### PR TITLE
Add Authenticator option to start on a different screen

### DIFF
--- a/packages/aws-amplify-react-native/dist/Auth/Authenticator.js
+++ b/packages/aws-amplify-react-native/dist/Auth/Authenticator.js
@@ -72,7 +72,7 @@ export default class Authenticator extends React.Component {
         }
 
         if (state === 'signedOut') {
-            state = 'signIn';
+            state = this.props.initialSignedOutState;
         }
         this.setState({ authState: state, authData: data, error: null });
         if (this.props.onStateChange) {
@@ -91,10 +91,10 @@ export default class Authenticator extends React.Component {
 
     checkUser() {
         Auth.currentAuthenticatedUser().then(user => {
-            const state = user ? 'signedIn' : 'signIn';
+            const state = user ? 'signedIn' : this.props.initialSignedOutState;
             this.handleStateChange(state, user);
         }).catch(err => {
-            this.handleStateChange('signIn', null);
+            this.handleStateChange(this.props.initialSignedOutState, null);
             logger.error(err);
         });
     }
@@ -129,3 +129,7 @@ export default class Authenticator extends React.Component {
         );
     }
 }
+
+Authenticator.defaultProps = {
+    initialSignedOutState: 'signIn'
+};

--- a/packages/aws-amplify-react-native/dist/Auth/index.js
+++ b/packages/aws-amplify-react-native/dist/Auth/index.js
@@ -32,7 +32,7 @@ const logger = new Logger('auth components');
 
 export { Authenticator, AuthPiece, SignIn, ConfirmSignIn, SignUp, ConfirmSignUp, ForgotPassword, Loading, RequireNewPassword, VerifyContact, Greetings };
 
-export function withAuthenticator(Comp, includeGreetings = false, authenticatorComponents = []) {
+export function withAuthenticator(Comp, includeGreetings = false, authenticatorComponents = [], initialSignedOutState = 'signIn') {
     class Wrapper extends React.Component {
         constructor(props) {
             super(props);
@@ -80,6 +80,7 @@ export function withAuthenticator(Comp, includeGreetings = false, authenticatorC
             return React.createElement(Authenticator, _extends({}, this.props, {
                 hideDefault: authenticatorComponents.length > 0,
                 onStateChange: this.handleAuthStateChange,
+                initialSignedOutState: initialSignedOutState,
                 children: authenticatorComponents
             }));
         }

--- a/packages/aws-amplify-react-native/src/Auth/Authenticator.js
+++ b/packages/aws-amplify-react-native/src/Auth/Authenticator.js
@@ -75,7 +75,7 @@ export default class Authenticator extends React.Component {
         logger.debug('authenticator state change ' + state);
         if (state === this.state.authState) { return; }
 
-        if (state === 'signedOut') { state = 'signIn'; }
+        if (state === 'signedOut') { state = this.props.initialSignedOutState; }
         this.setState({ authState: state, authData: data, error: null });
         if (this.props.onStateChange) { this.props.onStateChange(state, data); }
 
@@ -92,11 +92,11 @@ export default class Authenticator extends React.Component {
     checkUser() {
         Auth.currentAuthenticatedUser()
             .then(user => {
-                const state = user? 'signedIn' : 'signIn';
+                const state = user? 'signedIn' : this.props.initialSignedOutState;
                 this.handleStateChange(state, user)
             })
             .catch(err => {
-                this.handleStateChange('signIn', null);
+                this.handleStateChange(this.props.initialSignedOutState, null);
                 logger.error(err);
             });
     }
@@ -140,4 +140,8 @@ export default class Authenticator extends React.Component {
             </TouchableWithoutFeedback>
         );
     }
+}
+
+Authenticator.defaultProps = {
+    initialSignedOutState: 'signIn'
 }

--- a/packages/aws-amplify-react-native/src/Auth/index.js
+++ b/packages/aws-amplify-react-native/src/Auth/index.js
@@ -42,7 +42,7 @@ export {
     Greetings
 };
 
-export function withAuthenticator(Comp, includeGreetings=false, authenticatorComponents = []) {
+export function withAuthenticator(Comp, includeGreetings=false, authenticatorComponents = [], initialSignedOutState = 'signIn') {
     class Wrapper extends React.Component {
         constructor(props) {
             super(props);
@@ -93,6 +93,7 @@ export function withAuthenticator(Comp, includeGreetings=false, authenticatorCom
                 {...this.props}
                 hideDefault={authenticatorComponents.length > 0}
                 onStateChange={this.handleAuthStateChange}
+                initialSignedOutState={initialSignedOutState}
                 children={authenticatorComponents}
             />
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is useful for things such as: a set of onboarding screens before
signup; landing on SignUp first instead of SignIn.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
