### PR TITLE
Changed value type in EventAttribute interface

### DIFF
--- a/packages/aws-amplify/src/Analytics/types/Analytics.ts
+++ b/packages/aws-amplify/src/Analytics/types/Analytics.ts
@@ -23,7 +23,7 @@ export interface AnalyticsOptions {
 }
 
 export interface EventAttributes {
-    [key: string]: any;
+    [key: string]: string;
 }
 
 export interface EventMetrics {


### PR DESCRIPTION
Changed type from `any` to `string` on the value in the EventAttribute interface for the Analtyics lib.

Should resolve issue #734 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
