### PR TITLE
allow custom authentication flow type for Auth.signIn

### DIFF
--- a/packages/aws-amplify/src/Auth/Auth.ts
+++ b/packages/aws-amplify/src/Auth/Auth.ts
@@ -264,12 +264,17 @@ export default class AuthClass {
      * @param {String} password - The password of the username
      * @return - A promise resolves the CognitoUser
      */
-    public signIn(username: string, password: string): Promise<any> {
+    public signIn(username: string, password: string, authenticationFlowType: Maybe<string>): Promise<any> {
         if (!this.userPool) { return Promise.reject('No userPool'); }
         if (!username) { return Promise.reject('Username cannot be empty'); }
         if (!password) { return Promise.reject('Password cannot be empty'); }
 
         const user = this.createCognitoUser(username);
+
+        if (authenticationFlowType) {
+          user.setAuthenticationFlowType(authenticationFlowType);
+        }
+
         const authDetails = new AuthenticationDetails({
             Username: username,
             Password: password


### PR DESCRIPTION
Hey, would you be open to merging something like this? We're trying to use `Auth.signIn` from Amplify with a user migration lambda. Seems it isn't possible right now as we need to specify the user authentication flow type:

```
user.setAuthenticationFlowType('USER_PASSWORD_AUTH');
```

We have got this working using `amazon-cognito-identity-js` directly, but we'd really rather use Amplify throughout our app.

Sorry for lack of tests, wasn't able to get the tests running, had lots of unhandled promise rejections...