### PR TITLE
Fix typo in Cognito-identity client

### DIFF
--- a/packages/amazon-cognito-identity-js/src/Client.js
+++ b/packages/amazon-cognito-identity-js/src/Client.js
@@ -64,7 +64,7 @@ export default class Client {
       })
       .catch(err => {
         // default to return 'UnknownError'
-        let error = { code: 'UnknownError', message: 'Unkown error' };
+        let error = { code: 'UnknownError', message: 'Unknown error' };
 
         // first check if we have a service error
         if (response && response.headers && response.headers.get('x-amzn-errortype')) {


### PR DESCRIPTION
I found a trivial typo in an error message of cognito-identity client and fixed it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
