### PR TITLE
dispatch auth event as soon as session has loaded or failed to do so

### DIFF
--- a/packages/aws-amplify/lib/Auth/Auth.js
+++ b/packages/aws-amplify/lib/Auth/Auth.js
@@ -940,9 +940,11 @@ var AuthClass = /** @class */ (function () {
                 return this.currentSession()
                     .then(function (session) {
                     logger.debug('getting session success', session);
+                    dispatchAuthEvent('signIn');
                     return _this._setCredentialsFromSession(session);
                 }).catch(function (error) {
                     logger.debug('getting session failed', error);
+                    dispatchAuthEvent('signOut');
                     return _this._setCredentialsForGuest();
                 });
             }


### PR DESCRIPTION
this would remove the need to put a function at the start of index.js in order to get the initial auth state
a listener will do all the job by itself instead
I'm a noob in coding so I'd recommend setting up a framework to simplify this even further
wrapping an already set up listener of auth states so that the user would just have to code what he wants to happen depending on the auth state instead of going through aws Logger, aws Auth and aws Hub modules to figure out how it works

this issue is related to https://github.com/aws/aws-amplify/issues/474

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.