### PR TITLE
Use Array.some instead of Array.find to support IE11

### DIFF
--- a/packages/aws-amplify/src/Interactions/Interactions.ts
+++ b/packages/aws-amplify/src/Interactions/Interactions.ts
@@ -23,7 +23,7 @@ export default class Interactions {
 
     /**
      * Initialize PubSub with AWS configurations
-     * 
+     *
      * @param {InteractionsOptions} options - Configuration object for Interactions
      */
     constructor(options: InteractionsOptions) {
@@ -33,7 +33,7 @@ export default class Interactions {
     }
 
     /**
-     * 
+     *
      * @param {InteractionsOptions} options - Configuration object for Interactions
      * @return {Object} - The current configuration
      */
@@ -58,7 +58,7 @@ export default class Interactions {
         if (!this._pluggables.AWSLexProvider && bots_config &&
             Object.keys(bots_config).
                 map(key => bots_config[key]).
-                find(bot => !bot.providerName || bot.providerName === 'AWSLexProvider')) {
+                some(bot => !bot.providerName || bot.providerName === 'AWSLexProvider')) {
             this._pluggables.AWSLexProvider = new AWSLexProvider();
         }
 

--- a/packages/aws-amplify/src/PubSub/PubSub.ts
+++ b/packages/aws-amplify/src/PubSub/PubSub.ts
@@ -28,7 +28,7 @@ export default class PubSub {
 
     /**
      * Initialize PubSub with AWS configurations
-     * 
+     *
      * @param {PubSubOptions} options - Configuration object for PubSub
      */
     constructor(options: PubSubOptions) {
@@ -39,7 +39,7 @@ export default class PubSub {
 
     /**
      * Configure PubSub part with configurations
-     * 
+     *
      * @param {PubSubOptions} config - Configuration for PubSub
      * @return {Object} - The current configuration
      */
@@ -50,7 +50,7 @@ export default class PubSub {
         this._options = Object.assign({}, this._options, opt);
 
         if (this._options.aws_appsync_graphqlEndpoint && this._options.aws_appsync_region &&
-            !this._pluggables.find(p => p.getProviderName() === 'AWSAppSyncProvider')) {
+            !this._pluggables.some(p => p.getProviderName() === 'AWSAppSyncProvider')) {
             this.addPluggable(new AWSAppSyncProvider());
         }
 


### PR DESCRIPTION
Hello guys,

Today I faced the issue that aws-amplify fails on IE11 with an error saying that [Array.prototype.find](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Browser_compatibility) not available. I checked the code and see that in two cases `find` can be swapped with `some` ([that is present on IE9+](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some#Browser_compatibility)).

Please let me know if these changes make sense.

Thanks

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
