### PR TITLE
Reject functions throw an error object instead of a string.

### DIFF
--- a/packages/aws-amplify-react-native/docs/Auth_auth.js.html
+++ b/packages/aws-amplify-react-native/docs/Auth_auth.js.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="utf-8">
     <title>JSDoc: Source: Auth/Auth.js</title>
@@ -15,18 +16,18 @@
 
 <body>
 
-<div id="main">
+    <div id="main">
 
-    <h1 class="page-title">Source: Auth/Auth.js</h1>
-
-    
+        <h1 class="page-title">Source: Auth/Auth.js</h1>
 
 
 
-    
-    <section>
-        <article>
-            <pre class="prettyprint source linenums"><code>/*
+
+
+
+        <section>
+            <article>
+                <pre class="prettyprint source linenums"><code>/*
  * Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
@@ -133,7 +134,7 @@ class AuthClass {
      * @return {Promise} - A promise resolves callback data if success
      */
     signUp(username, password, email, phone_number) {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
+        if (!this.userPool) { return Promise.reject(new Error('No userPool')); }
         if (!username) { return Promise.reject('Username cannot be empty'); }
         if (!password) { return Promise.reject('Password cannot be empty'); }
 
@@ -155,7 +156,7 @@ class AuthClass {
      * @return {Promise} - A promise resolves callback data if success
      */
     confirmSignUp(username, code) {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
+        if (!this.userPool) { return Promise.reject(new Error('No userPool')); }
         if (!username) { return Promise.reject('Username cannot be empty'); }
         if (!code) { return Promise.reject('Code cannot be empty'); }
 
@@ -176,7 +177,7 @@ class AuthClass {
      * @return {Promise} - A promise resolves data if success
      */
     resendSignUp(username) {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
+        if (!this.userPool) { return Promise.reject(new Error('No userPool')); }
         if (!username) { return Promise.reject('Username cannot be empty'); }
 
         const user = new CognitoUser({
@@ -192,12 +193,12 @@ class AuthClass {
 
     /**
      * Sign in
-     * @param {String} username - The username to be signed in 
+     * @param {String} username - The username to be signed in
      * @param {String} password - The password of the username
      * @return {Promise} - A promise resolves the CognitoUser object if success or mfa required
      */
     signIn(username, password) {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
+        if (!this.userPool) { return Promise.reject(new Error('No userPool')); }
         if (!username) { return Promise.reject('Username cannot be empty'); }
         if (!password) { return Promise.reject('Password cannot be empty'); }
 
@@ -321,7 +322,7 @@ class AuthClass {
      * @return {Promise} - A promise resolves to curret CognitoUser if success
      */
     currentUser() {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
+        if (!this.userPool) { return Promise.reject(new Error('No userPool')); }
 
         const user = this.userPool.getCurrentUser();
         return user? Promise.resolve(user) : Promise.reject('UserPool doesnot have current user');
@@ -332,7 +333,7 @@ class AuthClass {
      * @return {Promise} - A promise resolves to curret authenticated CognitoUser if success
      */
     currentAuthenticatedUser() {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
+        if (!this.userPool) { return Promise.reject(new Error('No userPool')); }
 
         const user = this.userPool.getCurrentUser();
         if (!user) { return Promise.reject('No current user'); }
@@ -346,10 +347,10 @@ class AuthClass {
 
     /**
      * Get current user's session
-     * @return {Promise} - A promise resolves to session object if success 
+     * @return {Promise} - A promise resolves to session object if success
      */
     currentUserSession() {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
+        if (!this.userPool) { return Promise.reject(new Error('No userPool')); }
 
         const user = this.userPool.getCurrentUser();
         if (!user) { return Promise.reject('No current user'); }
@@ -464,7 +465,7 @@ class AuthClass {
      * @return {Promise} - A promise resolved if success
      */
     signOut() {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
+        if (!this.userPool) { return Promise.reject(new Error('No userPool')); }
 
         const user = this.userPool.getCurrentUser();
         if (!user) { return Promise.resolve(); }
@@ -482,10 +483,10 @@ class AuthClass {
     /**
      * Initiate a forgot password request
      * @param {String} username - the username to change password
-     * @return {Promise} - A promise resolves if success 
+     * @return {Promise} - A promise resolves if success
      */
     forgotPassword(username) {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
+        if (!this.userPool) { return Promise.reject(new Error('No userPool')); }
         if (!username) { return Promise.reject('Username cannot be empty'); }
 
         const user = new CognitoUser({
@@ -508,13 +509,13 @@ class AuthClass {
 
     /**
      * Confirm a new password using a confirmation Code
-     * @param {String} username - The username 
+     * @param {String} username - The username
      * @param {String} code - The confirmation code
      * @param {String} password - The new password
      * @return {Promise} - A promise that resolves if success
      */
     forgotPasswordSubmit(username, code, password) {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
+        if (!this.userPool) { return Promise.reject(new Error('No userPool')); }
         if (!username) { return Promise.reject('Username cannot be empty'); }
         if (!code) { return Promise.reject('Code cannot be empty'); }
         if (!password) { return Promise.reject('Password cannot be empty'); }
@@ -619,7 +620,7 @@ class AuthClass {
 
     /**
      * Compact version of credentials
-     * @param {Object} credentials 
+     * @param {Object} credentials
      * @return {Object} - Credentials
      */
     essentialCredentials(credentials) {
@@ -646,25 +647,62 @@ class AuthClass {
 
 export default AuthClass;
 </code></pre>
-        </article>
-    </section>
+            </article>
+        </section>
 
 
 
 
-</div>
+    </div>
 
-<nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="AnalyticsClass.html">AnalyticsClass</a></li><li><a href="API.html">API</a></li><li><a href="AsyncStorageCache.html">AsyncStorageCache</a></li><li><a href="AuthClass.html">AuthClass</a></li><li><a href="ConsoleLogger.html">ConsoleLogger</a></li><li><a href="I18nClass.html">I18nClass</a></li><li><a href="RestClient.html">RestClient</a></li><li><a href="Signer.html">Signer</a></li><li><a href="StorageCache.html">StorageCache</a></li><li><a href="StorageClass.html">StorageClass</a></li></ul>
-</nav>
+    <nav>
+        <h2>
+            <a href="index.html">Home</a>
+        </h2>
+        <h3>Classes</h3>
+        <ul>
+            <li>
+                <a href="AnalyticsClass.html">AnalyticsClass</a>
+            </li>
+            <li>
+                <a href="API.html">API</a>
+            </li>
+            <li>
+                <a href="AsyncStorageCache.html">AsyncStorageCache</a>
+            </li>
+            <li>
+                <a href="AuthClass.html">AuthClass</a>
+            </li>
+            <li>
+                <a href="ConsoleLogger.html">ConsoleLogger</a>
+            </li>
+            <li>
+                <a href="I18nClass.html">I18nClass</a>
+            </li>
+            <li>
+                <a href="RestClient.html">RestClient</a>
+            </li>
+            <li>
+                <a href="Signer.html">Signer</a>
+            </li>
+            <li>
+                <a href="StorageCache.html">StorageCache</a>
+            </li>
+            <li>
+                <a href="StorageClass.html">StorageClass</a>
+            </li>
+        </ul>
+    </nav>
 
-<br class="clear">
+    <br class="clear">
 
-<footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Tue Nov 21 2017 10:31:36 GMT-0800 (PST)
-</footer>
+    <footer>
+        Documentation generated by
+        <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Tue Nov 21 2017 10:31:36 GMT-0800 (PST)
+    </footer>
 
-<script> prettyPrint(); </script>
-<script src="scripts/linenumber.js"> </script>
+    <script> prettyPrint(); </script>
+    <script src="scripts/linenumber.js"> </script>
 </body>
+
 </html>

--- a/packages/aws-amplify/__tests__/Auth/auth-unit-test.ts
+++ b/packages/aws-amplify/__tests__/Auth/auth-unit-test.ts
@@ -1,2125 +1,2310 @@
-jest.mock('aws-sdk/clients/pinpoint', () => {
-    const Pinpoint = () => {
-        const pinpoint = null;
-        return pinpoint;
-    };
+jest.mock("aws-sdk/clients/pinpoint", () => {
+  const Pinpoint = () => {
+    const pinpoint = null;
+    return pinpoint;
+  };
 
-    Pinpoint.prototype.updateEndpoint = (params, callback) => {
-        callback(null, 'data');
-    };
+  Pinpoint.prototype.updateEndpoint = (params, callback) => {
+    callback(null, "data");
+  };
 
-    return Pinpoint;
+  return Pinpoint;
 });
 
-jest.mock('amazon-cognito-identity-js/lib/CognitoUserSession', () => {
-    const CognitoUserSession = () => {};
+jest.mock("amazon-cognito-identity-js/lib/CognitoUserSession", () => {
+  const CognitoUserSession = () => {};
 
-    CognitoUserSession.prototype.CognitoUserSession = (options) => {
-        CognitoUserSession.prototype.options = options;
-        return CognitoUserSession;
-    };
-
-    CognitoUserSession.prototype.getIdToken = () => {
-        return {
-            getJwtToken: () => {
-                return null;
-            }
-        };
-    };
-
-    CognitoUserSession.prototype.isValid = () => {
-        return true;
-    }
-
-    CognitoUserSession.prototype.getRefreshToken = () => {
-        return 'refreshToken';
-    }
-
+  CognitoUserSession.prototype.CognitoUserSession = options => {
+    CognitoUserSession.prototype.options = options;
     return CognitoUserSession;
+  };
+
+  CognitoUserSession.prototype.getIdToken = () => {
+    return {
+      getJwtToken: () => {
+        return null;
+      }
+    };
+  };
+
+  CognitoUserSession.prototype.isValid = () => {
+    return true;
+  };
+
+  CognitoUserSession.prototype.getRefreshToken = () => {
+    return "refreshToken";
+  };
+
+  return CognitoUserSession;
 });
 
-jest.mock('amazon-cognito-identity-js/lib/CognitoIdToken', () => {
-    const CognitoIdToken = () => {};
+jest.mock("amazon-cognito-identity-js/lib/CognitoIdToken", () => {
+  const CognitoIdToken = () => {};
 
-    CognitoIdToken.prototype.CognitoIdToken = (value) => {
-        CognitoIdToken.prototype.idToken = value;
-        return CognitoIdToken;
-    };
-
-    CognitoIdToken.prototype.getJwtToken = () => {
-        return 'jwtToken';
-    };
-
-
+  CognitoIdToken.prototype.CognitoIdToken = value => {
+    CognitoIdToken.prototype.idToken = value;
     return CognitoIdToken;
+  };
+
+  CognitoIdToken.prototype.getJwtToken = () => {
+    return "jwtToken";
+  };
+
+  return CognitoIdToken;
 });
 
-jest.mock('amazon-cognito-identity-js/lib/CognitoUserPool', () => {
-    const CognitoUserPool = () => {};
+jest.mock("amazon-cognito-identity-js/lib/CognitoUserPool", () => {
+  const CognitoUserPool = () => {};
 
-    CognitoUserPool.prototype.CognitoUserPool = (options) => {
-        CognitoUserPool.prototype.options = options;
-        return CognitoUserPool;
-    };
-
-    CognitoUserPool.prototype.getCurrentUser = () => {
-        return "currentUser";
-    };
-
-    CognitoUserPool.prototype.signUp = (username, password, signUpAttributeList, validationData, callback) => {
-        callback(null, 'signUpResult');
-    };
-
+  CognitoUserPool.prototype.CognitoUserPool = options => {
+    CognitoUserPool.prototype.options = options;
     return CognitoUserPool;
+  };
+
+  CognitoUserPool.prototype.getCurrentUser = () => {
+    return "currentUser";
+  };
+
+  CognitoUserPool.prototype.signUp = (
+    username,
+    password,
+    signUpAttributeList,
+    validationData,
+    callback
+  ) => {
+    callback(null, "signUpResult");
+  };
+
+  return CognitoUserPool;
 });
 
-jest.mock('amazon-cognito-identity-js/lib/CognitoUser', () => {
-    const CognitoUser = () => { };
+jest.mock("amazon-cognito-identity-js/lib/CognitoUser", () => {
+  const CognitoUser = () => {};
 
-    CognitoUser.prototype.CognitoUser = (options) => {
-        CognitoUser.prototype.options = options;
-        return CognitoUser;
-    };
-
-    CognitoUser.prototype.getSession = (callback) => {
-       // throw 3;
-        callback(null, "session");
-    };
-
-    CognitoUser.prototype.getUserAttributes = (callback) => {
-        callback(null, "attributes");
-    };
-
-    CognitoUser.prototype.getAttributeVerificationCode = (attr, callback) => {
-        callback.onSuccess("success");
-    };
-
-    CognitoUser.prototype.verifyAttribute = (attr, code, callback) => {
-        callback.onSuccess("success");
-    };
-
-    CognitoUser.prototype.authenticateUser = (authenticationDetails, callback) => {
-        callback.onSuccess('session');
-    };
-
-    CognitoUser.prototype.sendMFACode = (code, callback) => {
-        callback.onSuccess('session');
-    };
-
-    CognitoUser.prototype.resendConfirmationCode = (callback) => {
-        callback(null, 'result');
-    };
-
-    CognitoUser.prototype.changePassword = (oldPassword, newPassword, callback) => {
-        callback(null, 'SUCCESS');
-    };
-
-    CognitoUser.prototype.forgotPassword = (callback) => {
-        callback.onSuccess();
-    };
-
-    CognitoUser.prototype.confirmPassword = (code, password, callback) => {
-        callback.onSuccess();
-    };
-
-    CognitoUser.prototype.signOut = () => {
-
-    };
-
-    CognitoUser.prototype.confirmRegistration = (confirmationCode, forceAliasCreation, callback) => {
-        callback(null, 'Success');
-    };
-
-    CognitoUser.prototype.completeNewPasswordChallenge = (password, requiredAttributes, callback) => {
-        callback.onSuccess('session');
-    };
-
-    CognitoUser.prototype.updateAttributes = (attributeList, callback) => {
-        callback(null, 'SUCCESS');
-    };
-
-    CognitoUser.prototype.setAuthenticationFlowType = (type) => {
-
-    };
-
-    CognitoUser.prototype.initiateAuth = (authenticationDetails, callback) => {
-        callback.customChallenge('challengeParam');
-    };
-
-    CognitoUser.prototype.sendCustomChallengeAnswer = (challengeAnswer, callback) => {
-        callback.onSuccess('session');
-    };
-
-    CognitoUser.prototype.refreshSession = (refreshToken, callback) => {
-        callback(null, 'session');
-    }
-
+  CognitoUser.prototype.CognitoUser = options => {
+    CognitoUser.prototype.options = options;
     return CognitoUser;
+  };
+
+  CognitoUser.prototype.getSession = callback => {
+    // throw 3;
+    callback(null, "session");
+  };
+
+  CognitoUser.prototype.getUserAttributes = callback => {
+    callback(null, "attributes");
+  };
+
+  CognitoUser.prototype.getAttributeVerificationCode = (attr, callback) => {
+    callback.onSuccess("success");
+  };
+
+  CognitoUser.prototype.verifyAttribute = (attr, code, callback) => {
+    callback.onSuccess("success");
+  };
+
+  CognitoUser.prototype.authenticateUser = (
+    authenticationDetails,
+    callback
+  ) => {
+    callback.onSuccess("session");
+  };
+
+  CognitoUser.prototype.sendMFACode = (code, callback) => {
+    callback.onSuccess("session");
+  };
+
+  CognitoUser.prototype.resendConfirmationCode = callback => {
+    callback(null, "result");
+  };
+
+  CognitoUser.prototype.changePassword = (
+    oldPassword,
+    newPassword,
+    callback
+  ) => {
+    callback(null, "SUCCESS");
+  };
+
+  CognitoUser.prototype.forgotPassword = callback => {
+    callback.onSuccess();
+  };
+
+  CognitoUser.prototype.confirmPassword = (code, password, callback) => {
+    callback.onSuccess();
+  };
+
+  CognitoUser.prototype.signOut = () => {};
+
+  CognitoUser.prototype.confirmRegistration = (
+    confirmationCode,
+    forceAliasCreation,
+    callback
+  ) => {
+    callback(null, "Success");
+  };
+
+  CognitoUser.prototype.completeNewPasswordChallenge = (
+    password,
+    requiredAttributes,
+    callback
+  ) => {
+    callback.onSuccess("session");
+  };
+
+  CognitoUser.prototype.updateAttributes = (attributeList, callback) => {
+    callback(null, "SUCCESS");
+  };
+
+  CognitoUser.prototype.setAuthenticationFlowType = type => {};
+
+  CognitoUser.prototype.initiateAuth = (authenticationDetails, callback) => {
+    callback.customChallenge("challengeParam");
+  };
+
+  CognitoUser.prototype.sendCustomChallengeAnswer = (
+    challengeAnswer,
+    callback
+  ) => {
+    callback.onSuccess("session");
+  };
+
+  CognitoUser.prototype.refreshSession = (refreshToken, callback) => {
+    callback(null, "session");
+  };
+
+  return CognitoUser;
 });
 
-jest.mock('amazon-cognito-auth-js/lib/CognitoAuth', () => {
-    const CognitoAuth = () => {};
+jest.mock("amazon-cognito-auth-js/lib/CognitoAuth", () => {
+  const CognitoAuth = () => {};
 
-    CognitoAuth.prototype.parseCognitoWebResponse = () => {
-        CognitoAuth.prototype.userhandler.onSuccess();
-        throw 'err';
-    }
+  CognitoAuth.prototype.parseCognitoWebResponse = () => {
+    CognitoAuth.prototype.userhandler.onSuccess();
+    throw "err";
+  };
 
-    return CognitoAuth;
+  return CognitoAuth;
 });
 
-import { AuthOptions, SignUpParams } from '../../src/Auth/types';
-import Auth from '../../src/Auth/Auth';
-import Cache from '../../src/Cache';
-import { CookieStorage, CognitoUserPool, CognitoUser, CognitoUserSession, CognitoIdToken, CognitoAccessToken } from 'amazon-cognito-identity-js';
-import { CognitoIdentityCredentials } from 'aws-sdk';
-import GoogleOAuth from '../../src/Common/OAuthHelper/GoogleOAuth';
-import { Credentials } from '../../src/Common';
+import { AuthOptions, SignUpParams } from "../../src/Auth/types";
+import Auth from "../../src/Auth/Auth";
+import Cache from "../../src/Cache";
+import {
+  CookieStorage,
+  CognitoUserPool,
+  CognitoUser,
+  CognitoUserSession,
+  CognitoIdToken,
+  CognitoAccessToken
+} from "amazon-cognito-identity-js";
+import { CognitoIdentityCredentials } from "aws-sdk";
+import GoogleOAuth from "../../src/Common/OAuthHelper/GoogleOAuth";
+import { Credentials } from "../../src/Common";
 
-const authOptions : AuthOptions = {
-    userPoolId: "awsUserPoolsId",
-    userPoolWebClientId: "awsUserPoolsWebClientId",
-    region: "region",
-    identityPoolId: "awsCognitoIdentityPoolId",
-    mandatorySignIn: false
-}
+const authOptions: AuthOptions = {
+  userPoolId: "awsUserPoolsId",
+  userPoolWebClientId: "awsUserPoolsWebClientId",
+  region: "region",
+  identityPoolId: "awsCognitoIdentityPoolId",
+  mandatorySignIn: false
+};
 
-const authOptionsWithNoUserPoolId : AuthOptions = {
-    userPoolId: null,
-    userPoolWebClientId: "awsUserPoolsWebClientId",
-    region: "region",
-    identityPoolId: "awsCognitoIdentityPoolId",
-    mandatorySignIn: false
-}
+const authOptionsWithNoUserPoolId: AuthOptions = {
+  userPoolId: null,
+  userPoolWebClientId: "awsUserPoolsWebClientId",
+  region: "region",
+  identityPoolId: "awsCognitoIdentityPoolId",
+  mandatorySignIn: false
+};
 
 const userPool = new CognitoUserPool({
-    UserPoolId: authOptions.userPoolId,
-    ClientId: authOptions.userPoolWebClientId
+  UserPoolId: authOptions.userPoolId,
+  ClientId: authOptions.userPoolWebClientId
 });
 
-const idToken = new CognitoIdToken({ IdToken: 'idToken' });
-const accessToken = new CognitoAccessToken({ AccessToken: 'accessToken' });
+const idToken = new CognitoIdToken({ IdToken: "idToken" });
+const accessToken = new CognitoAccessToken({ AccessToken: "accessToken" });
 
 const session = new CognitoUserSession({
-    IdToken: idToken,
-    AccessToken: accessToken
+  IdToken: idToken,
+  AccessToken: accessToken
 });
 
-const cognitoCredentialSpyon = jest.spyOn(CognitoIdentityCredentials.prototype, 'getPromise').mockImplementation(() => {
+const cognitoCredentialSpyon = jest
+  .spyOn(CognitoIdentityCredentials.prototype, "getPromise")
+  .mockImplementation(() => {
     return new Promise((res, rej) => {
-        res('cred');
+      res("cred");
     });
+  });
+
+describe("auth unit test", () => {
+  describe("signUp", () => {
+    test("happy case with string attrs", async () => {
+      const spyon = jest.spyOn(CognitoUserPool.prototype, "signUp");
+      const auth = new Auth(authOptions);
+      expect(await auth.signUp("username", "password", "email", "phone")).toBe(
+        "signUpResult"
+      );
+
+      spyon.mockClear();
+    });
+
+    test("happy case with object attr", async () => {
+      const spyon = jest.spyOn(CognitoUserPool.prototype, "signUp");
+      const auth = new Auth(authOptions);
+
+      const attrs = {
+        username: "username",
+        password: "password",
+        attributes: {
+          email: "email",
+          phone_number: "phone_number",
+          otherAttrs: "otherAttrs"
+        }
+      };
+      expect.assertions(1);
+      expect(await auth.signUp(attrs)).toBe("signUpResult");
+
+      spyon.mockClear();
+    });
+
+    test("object attr with null username", async () => {
+      const auth = new Auth(authOptions);
+
+      const attrs = {
+        username: null,
+        password: "password",
+        attributes: {
+          email: "email",
+          phone_number: "phone_number",
+          otherAttrs: "otherAttrs"
+        }
+      };
+      expect.assertions(1);
+      try {
+        await auth.signUp(attrs);
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+    });
+
+    test("callback error", async () => {
+      const spyon = jest
+        .spyOn(CognitoUserPool.prototype, "signUp")
+        .mockImplementationOnce(
+          (
+            username,
+            password,
+            signUpAttributeList,
+            validationData,
+            callback
+          ) => {
+            callback("err", null);
+          }
+        );
+
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.signUp("username", "password", "email", "phone");
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+    });
+
+    test("no user pool", async () => {
+      // @ts-ignore
+      const auth = new Auth(authOptionsWithNoUserPoolId);
+
+      expect.assertions(1);
+      try {
+        await auth.signUp("username", "password", "email", "phone");
+      } catch (e) {
+        console.log(typeof e);
+        expect(e.message).toBe("No userPool");
+      }
+    });
+
+    test("no username", async () => {
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.signUp(null, "password", "email", "phone");
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+    });
+
+    test("no password", async () => {
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.signUp("username", null, "email", "phone");
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+    });
+
+    test("only username", async () => {
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.signUp("username");
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+    });
+  });
+
+  describe("confirmSignUp", () => {
+    test("happy case", async () => {
+      const spyon = jest.spyOn(CognitoUser.prototype, "confirmRegistration");
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      expect(await auth.confirmSignUp("username", "code")).toBe("Success");
+
+      spyon.mockClear();
+    });
+
+    test("with options", async () => {
+      const spyon = jest.spyOn(CognitoUser.prototype, "confirmRegistration");
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      expect(
+        await auth.confirmSignUp("username", "code", {
+          forceAliasCreation: false
+        })
+      ).toBe("Success");
+
+      spyon.mockClear();
+    });
+
+    test("callback err", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "confirmRegistration")
+        .mockImplementationOnce(
+          (confirmationCode, forceAliasCreation, callback) => {
+            callback("err", null);
+          }
+        );
+
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.confirmSignUp("username", "code");
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+    });
+
+    test("no user pool", async () => {
+      // @ts-ignore
+      const auth = new Auth(authOptionsWithNoUserPoolId);
+
+      expect.assertions(1);
+      try {
+        await auth.confirmSignUp("username", "code");
+      } catch (e) {
+        expect(e.message).toBe("No userPool");
+      }
+    });
+
+    test("no user name", async () => {
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.confirmSignUp(null, "code");
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+    });
+
+    test("no code", async () => {
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.confirmSignUp("username", null);
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+    });
+  });
+
+  describe("resendSignUp", () => {
+    test("happy case", async () => {
+      const spyon = jest.spyOn(CognitoUser.prototype, "resendConfirmationCode");
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      expect(await auth.resendSignUp("username")).toBe("result");
+
+      spyon.mockClear();
+    });
+
+    test("callback err", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "resendConfirmationCode")
+        .mockImplementationOnce(callback => {
+          callback("err", null);
+        });
+
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.resendSignUp("username");
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+    });
+
+    test("no user pool", async () => {
+      // @ts-ignore
+      const auth = new Auth(authOptionsWithNoUserPoolId);
+
+      expect.assertions(1);
+      try {
+        await auth.resendSignUp("username");
+      } catch (e) {
+        expect(e.message).toBe("No userPool");
+      }
+    });
+
+    test("no username", async () => {
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.resendSignUp(null);
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+    });
+  });
+
+  describe("signIn", () => {
+    test("happy case with password", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "authenticateUser")
+        .mockImplementationOnce((authenticationDetails, callback) => {
+          callback.onSuccess(session);
+        });
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      expect(await auth.signIn("username", "password")).toEqual(user);
+
+      spyon.mockClear();
+    });
+
+    test("happy case using cookie storage", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "authenticateUser")
+        .mockImplementationOnce((authenticationDetails, callback) => {
+          callback.onSuccess(session);
+        });
+
+      const auth = new Auth({
+        ...authOptions,
+        cookieStorage: { domain: ".example.com" }
+      });
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool,
+        Storage: new CookieStorage({ domain: ".yourdomain.com" })
+      });
+
+      expect.assertions(1);
+      expect(await auth.signIn("username", "password")).toEqual(user);
+
+      spyon.mockClear();
+    });
+
+    test("onFailure", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "authenticateUser")
+        .mockImplementationOnce((authenticationDetails, callback) => {
+          callback.onFailure("err");
+        });
+
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.signIn("username", "password");
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+    });
+
+    test("mfaRequired", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "authenticateUser")
+        .mockImplementationOnce((authenticationDetails, callback) => {
+          callback.mfaRequired("challengeName", "challengeParam");
+        });
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      const userAfterSignedIn = Object.assign({}, user, {
+        challengeName: "challengeName",
+        challengeParam: "challengeParam"
+      });
+
+      expect.assertions(1);
+      expect(await auth.signIn("username", "password")).toEqual(
+        userAfterSignedIn
+      );
+
+      spyon.mockClear();
+    });
+
+    test("mfaSetup", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "authenticateUser")
+        .mockImplementationOnce((authenticationDetails, callback) => {
+          callback.mfaSetup("challengeName", "challengeParam");
+        });
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      const userAfterSignedIn = Object.assign({}, user, {
+        challengeName: "challengeName",
+        challengeParam: "challengeParam"
+      });
+
+      expect.assertions(1);
+      expect(await auth.signIn("username", "password")).toEqual(
+        userAfterSignedIn
+      );
+
+      spyon.mockClear();
+    });
+
+    test("totpRequired", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "authenticateUser")
+        .mockImplementationOnce((authenticationDetails, callback) => {
+          callback.totpRequired("challengeName", "challengeParam");
+        });
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      const userAfterSignedIn = Object.assign({}, user, {
+        challengeName: "challengeName",
+        challengeParam: "challengeParam"
+      });
+
+      expect.assertions(1);
+      expect(await auth.signIn("username", "password")).toEqual(
+        userAfterSignedIn
+      );
+
+      spyon.mockClear();
+    });
+
+    test("selectMFAType", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "authenticateUser")
+        .mockImplementationOnce((authenticationDetails, callback) => {
+          callback.selectMFAType("challengeName", "challengeParam");
+        });
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      const userAfterSignedIn = Object.assign({}, user, {
+        challengeName: "challengeName",
+        challengeParam: "challengeParam"
+      });
+
+      expect.assertions(1);
+      expect(await auth.signIn("username", "password")).toEqual(
+        userAfterSignedIn
+      );
+
+      spyon.mockClear();
+    });
+
+    test("newPasswordRequired", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "authenticateUser")
+        .mockImplementationOnce((authenticationDetails, callback) => {
+          callback.newPasswordRequired("userAttributes", "requiredAttributes");
+        });
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      const userAfterSignedIn = Object.assign({}, user, {
+        challengeName: "NEW_PASSWORD_REQUIRED",
+        challengeParam: {
+          requiredAttributes: "requiredAttributes",
+          userAttributes: "userAttributes"
+        }
+      });
+
+      expect.assertions(1);
+      expect(await auth.signIn("username", "password")).toEqual(
+        userAfterSignedIn
+      );
+
+      spyon.mockClear();
+    });
+
+    test("customChallenge", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "authenticateUser")
+        .mockImplementationOnce((authenticationDetails, callback) => {
+          callback.customChallenge("challengeParam");
+        });
+      const spyon2 = jest
+        .spyOn(CognitoUser.prototype, "setAuthenticationFlowType")
+        .mockImplementationOnce(type => {});
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      const userAfterSignedIn = Object.assign({}, user, {
+        challengeName: "CUSTOM_CHALLENGE",
+        challengeParam: "challengeParam"
+      });
+
+      expect.assertions(2);
+      expect(await auth.signIn("username")).toEqual(userAfterSignedIn);
+      expect(spyon2).toBeCalledWith("CUSTOM_AUTH");
+
+      spyon2.mockClear();
+      spyon.mockClear();
+    });
+
+    test("no userPool", async () => {
+      const spyon = jest.spyOn(CognitoUser.prototype, "authenticateUser");
+
+      // @ts-ignore
+      const auth = new Auth(authOptionsWithNoUserPoolId);
+
+      expect.assertions(1);
+      try {
+        await auth.signIn("username", "password");
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+
+      spyon.mockClear();
+    });
+
+    test("no username", async () => {
+      const spyon = jest.spyOn(CognitoUser.prototype, "authenticateUser");
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.signIn(null, "password");
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+
+      spyon.mockClear();
+    });
+  });
+
+  describe("confirmSignIn", () => {
+    test("happy case", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "sendMFACode")
+        .mockImplementationOnce((code, callback) => {
+          callback.onSuccess(session);
+        });
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      expect(await auth.confirmSignIn(user, "code", null)).toEqual(user);
+
+      spyon.mockClear();
+    });
+
+    test("onFailure", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "sendMFACode")
+        .mockImplementationOnce((code, callback) => {
+          callback.onFailure("err");
+        });
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      try {
+        await auth.confirmSignIn(user, "code", null);
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+    });
+
+    test("no code", async () => {
+      const spyon = jest.spyOn(CognitoUser.prototype, "sendMFACode");
+      const auth = new Auth(authOptions);
+
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      try {
+        await auth.confirmSignIn(user, null, null);
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+
+      spyon.mockClear();
+    });
+  });
+
+  describe("completeNewPassword", () => {
+    test("happy case", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "completeNewPasswordChallenge")
+        .mockImplementationOnce((password, requiredAttributes, callback) => {
+          callback.onSuccess(session);
+        });
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      expect(await auth.completeNewPassword(user, "password", {})).toEqual(
+        user
+      );
+
+      spyon.mockClear();
+    });
+
+    test("on Failure", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "completeNewPasswordChallenge")
+        .mockImplementationOnce((password, requiredAttributes, callback) => {
+          callback.onFailure("err");
+        });
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      try {
+        await auth.completeNewPassword(user, "password", {});
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+    });
+
+    test("mfaRequired", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "completeNewPasswordChallenge")
+        .mockImplementationOnce((password, requiredAttributes, callback) => {
+          callback.mfaRequired("challengeName", "challengeParam");
+        });
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      expect(await auth.completeNewPassword(user, "password", {})).toBe(user);
+
+      spyon.mockClear();
+    });
+
+    test("mfaSetup", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "completeNewPasswordChallenge")
+        .mockImplementationOnce((password, requiredAttributes, callback) => {
+          callback.mfaSetup("challengeName", "challengeParam");
+        });
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      expect(await auth.completeNewPassword(user, "password", {})).toBe(user);
+
+      spyon.mockClear();
+    });
+
+    test("no password", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      try {
+        await auth.completeNewPassword(user, null, {});
+      } catch (e) {
+        expect(e).toBe("Password cannot be empty");
+      }
+    });
+  });
+
+  describe("userAttributes", () => {
+    test("happy case", async () => {
+      const spyon = jest
+        .spyOn(Auth.prototype, "userSession")
+        .mockImplementationOnce(user => {
+          return new Promise((res, rej) => {
+            res("session");
+          });
+        });
+
+      const spyon2 = jest.spyOn(CognitoUser.prototype, "getUserAttributes");
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      expect(await auth.userAttributes(user)).toBe("attributes");
+
+      spyon.mockClear();
+      spyon2.mockClear();
+    });
+
+    test("get userattributes failed", async () => {
+      const spyon = jest
+        .spyOn(Auth.prototype, "userSession")
+        .mockImplementationOnce(user => {
+          return new Promise((res, rej) => {
+            res("session");
+          });
+        });
+
+      const spyon2 = jest
+        .spyOn(CognitoUser.prototype, "getUserAttributes")
+        .mockImplementationOnce(callback => {
+          callback("err");
+        });
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      try {
+        await auth.userAttributes(user);
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+      spyon2.mockClear();
+    });
+  });
+
+  describe("currentSession", () => {
+    test("happy case", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      const spyon = jest
+        .spyOn(CognitoUserPool.prototype, "getCurrentUser")
+        .mockImplementationOnce(() => {
+          return user;
+        });
+
+      const spyon2 = jest
+        .spyOn(Auth.prototype, "userSession")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            res(session);
+          });
+        });
+      expect.assertions(1);
+      expect(await auth.currentSession()).toEqual(session);
+
+      spyon.mockClear();
+      spyon2.mockClear();
+    });
+
+    test("callback failure", async () => {
+      const auth = new Auth(authOptions);
+
+      const spyon = jest
+        .spyOn(CognitoUserPool.prototype, "getCurrentUser")
+        .mockImplementationOnce(() => {
+          return null;
+        });
+
+      expect.assertions(1);
+      try {
+        await auth.currentSession();
+      } catch (e) {
+        expect(e).toBe("No current user");
+      }
+
+      spyon.mockClear();
+    });
+
+    test("no UserPool", async () => {
+      const auth = new Auth({
+        userPoolId: undefined,
+        userPoolWebClientId: "awsUserPoolsWebClientId",
+        region: "region",
+        identityPoolId: "awsCognitoIdentityPoolId",
+        mandatorySignIn: false
+      });
+
+      expect.assertions(1);
+      try {
+        await auth.currentSession();
+      } catch (e) {
+        expect(e.message).toBe("No userPool");
+      }
+    });
+  });
+
+  describe("currentAuthenticatedUser", () => {
+    test("happy case with source userpool", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      const spyon = jest
+        .spyOn(Auth.prototype, "currentUserPoolUser")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            res(user);
+          });
+        });
+
+      const spyon2 = jest
+        .spyOn(Auth.prototype, "userAttributes")
+        .mockImplementationOnce(() => {
+          return Promise.resolve([
+            {
+              Name: "name",
+              Value: "val"
+            }
+          ]);
+        });
+      expect.assertions(1);
+      expect(await auth.currentAuthenticatedUser()).toEqual({
+        attributes: { name: "val" }
+      });
+
+      spyon.mockClear();
+    });
+
+    test("happy case with source federation", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      const spyon = jest.spyOn(Cache, "getItem").mockImplementationOnce(() => {
+        return {
+          user: "federated_user"
+        };
+      });
+
+      expect.assertions(1);
+      expect(await auth.currentAuthenticatedUser()).toBe("federated_user");
+
+      spyon.mockClear();
+    });
+  });
+
+  describe("userSession test", () => {
+    test("happy case", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "getSession")
+        .mockImplementationOnce(callback => {
+          callback(null, session);
+        });
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      expect(await auth.userSession(user)).toEqual(session);
+
+      spyon.mockClear();
+    });
+
+    test("CognitoSession not valid and refresh successfully", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "getSession")
+        .mockImplementationOnce(callback => {
+          callback(null, session);
+        });
+
+      const spyon2 = jest
+        .spyOn(CognitoUserSession.prototype, "isValid")
+        .mockImplementationOnce(() => {
+          return false;
+        });
+
+      const spyon3 = jest
+        .spyOn(CognitoUser.prototype, "refreshSession")
+        .mockImplementationOnce((refreshToken, callback) => {
+          callback(null, session);
+        });
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      expect(await auth.userSession(user)).toEqual(session);
+
+      spyon.mockClear();
+      spyon2.mockClear();
+      spyon3.mockClear();
+    });
+
+    test("CognitoSession not valid and refresh fails", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "getSession")
+        .mockImplementationOnce(callback => {
+          callback(null, session);
+        });
+
+      const spyon2 = jest
+        .spyOn(CognitoUserSession.prototype, "isValid")
+        .mockImplementationOnce(() => {
+          return false;
+        });
+
+      const spyon3 = jest
+        .spyOn(CognitoUser.prototype, "refreshSession")
+        .mockImplementationOnce((refreshToken, callback) => {
+          callback("err", null);
+        });
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      try {
+        await auth.userSession(user);
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+
+      spyon.mockClear();
+      spyon2.mockClear();
+      spyon3.mockClear();
+    });
+
+    test("callback error", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "getSession")
+        .mockImplementationOnce(callback => {
+          callback("err", null);
+        });
+
+      expect.assertions(1);
+      try {
+        await auth.userSession(user);
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+    });
+  });
+
+  describe("currentUserCredentials test", () => {
+    test("with federated info", async () => {
+      const auth = new Auth(authOptions);
+
+      const spyon = jest.spyOn(Cache, "getItem").mockImplementationOnce(() => {
+        return {
+          provider: "google",
+          token: "token"
+        };
+      });
+
+      const spyon2 = jest
+        .spyOn(Credentials, "refreshFederatedToken")
+        .mockImplementationOnce(() => {
+          return Promise.resolve("cred");
+        });
+
+      expect.assertions(1);
+      expect(await auth.currentUserCredentials()).toBe("cred");
+
+      spyon.mockClear();
+      spyon2.mockClear();
+    });
+
+    test("with cognito session", async () => {
+      const auth = new Auth(authOptions);
+
+      const spyon = jest.spyOn(Cache, "getItem").mockImplementationOnce(() => {
+        return null;
+      });
+
+      const spyon2 = jest
+        .spyOn(auth, "currentSession")
+        .mockImplementationOnce(() => {
+          return Promise.resolve("session");
+        });
+
+      const spyon3 = jest
+        .spyOn(Credentials, "set")
+        .mockImplementationOnce(() => {
+          return Promise.resolve("cred");
+        });
+
+      expect.assertions(1);
+      expect(await auth.currentUserCredentials()).toBe("cred");
+
+      spyon.mockClear();
+      spyon2.mockClear();
+      spyon3.mockClear();
+    });
+
+    test("with guest", async () => {
+      const auth = new Auth(authOptions);
+
+      const spyon = jest.spyOn(Cache, "getItem").mockImplementationOnce(() => {
+        return null;
+      });
+
+      const spyon2 = jest
+        .spyOn(auth, "currentSession")
+        .mockImplementationOnce(() => {
+          return Promise.reject("err");
+        });
+
+      const spyon3 = jest
+        .spyOn(Credentials, "set")
+        .mockImplementationOnce(() => {
+          return Promise.resolve("cred");
+        });
+
+      expect.assertions(1);
+      expect(await auth.currentUserCredentials()).toBe("cred");
+
+      spyon.mockClear();
+      spyon2.mockClear();
+      spyon3.mockClear();
+    });
+  });
+
+  describe("currentCrendentials", () => {
+    const spyon = jest.spyOn(Credentials, "get").mockImplementationOnce(() => {
+      return;
+    });
+
+    const auth = new Auth(authOptions);
+
+    auth.currentCredentials();
+    expect(spyon).toBeCalled();
+    spyon.mockClear();
+  });
+
+  describe("verifyUserAttribute test", () => {
+    test("happy case", async () => {
+      const spyon = jest.spyOn(
+        CognitoUser.prototype,
+        "getAttributeVerificationCode"
+      );
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      expect(await auth.verifyUserAttribute(user, {})).toBe("success");
+
+      spyon.mockClear();
+    });
+
+    test("onFailure", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "getAttributeVerificationCode")
+        .mockImplementationOnce((attr, callback) => {
+          callback.onFailure("err");
+        });
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      try {
+        await auth.verifyUserAttribute(user, {});
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+    });
+  });
+
+  describe("verifyUserAttributeSubmit", () => {
+    test("happy case", async () => {
+      const spyon = jest.spyOn(CognitoUser.prototype, "verifyAttribute");
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      expect(await auth.verifyUserAttributeSubmit(user, {}, "code")).toBe(
+        "success"
+      );
+
+      spyon.mockClear();
+    });
+
+    test("onFailure", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "verifyAttribute")
+        .mockImplementationOnce((attr, code, callback) => {
+          callback.onFailure("err");
+        });
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      try {
+        await auth.verifyUserAttributeSubmit(user, {}, "code");
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+    });
+
+    test("code empty", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      try {
+        await auth.verifyUserAttributeSubmit(user, {}, null);
+      } catch (e) {
+        expect(e).toBe("Code cannot be empty");
+      }
+    });
+  });
+
+  describe("verifyCurrentUserAttribute test", () => {
+    test("happy case", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      const spyon = jest
+        .spyOn(Auth.prototype, "currentUserPoolUser")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            res(user);
+          });
+        });
+
+      const spyon2 = jest
+        .spyOn(Auth.prototype, "verifyUserAttribute")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            res();
+          });
+        });
+
+      await auth.verifyCurrentUserAttribute("attr");
+
+      expect.assertions(2);
+      expect(spyon).toBeCalled();
+      expect(spyon2).toBeCalledWith(user, "attr");
+
+      spyon.mockClear();
+      spyon2.mockClear();
+    });
+  });
+
+  describe("verifyCurrentUserAttributeSubmit test", () => {
+    test("happy case", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      const spyon = jest
+        .spyOn(Auth.prototype, "currentUserPoolUser")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            res(user);
+          });
+        });
+
+      const spyon2 = jest
+        .spyOn(Auth.prototype, "verifyUserAttributeSubmit")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            res();
+          });
+        });
+
+      await auth.verifyCurrentUserAttributeSubmit("attr", "code");
+
+      expect.assertions(2);
+      expect(spyon).toBeCalled();
+      expect(spyon2).toBeCalledWith(user, "attr", "code");
+
+      spyon.mockClear();
+      spyon2.mockClear();
+    });
+  });
+
+  describe("signOut", () => {
+    test("happy case", async () => {
+      const auth = new Auth(authOptions);
+
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      const spyon = jest.spyOn(
+        CognitoIdentityCredentials.prototype,
+        "clearCachedId"
+      );
+      const spyon2 = jest.spyOn(Cache, "removeItem");
+      const spyon3 = jest
+        .spyOn(CognitoUserPool.prototype, "getCurrentUser")
+        .mockImplementationOnce(() => {
+          return user;
+        });
+
+      await auth.signOut();
+
+      expect.assertions(2);
+      expect(spyon).toBeCalled();
+      expect(spyon2).toBeCalledWith("federatedInfo");
+
+      spyon.mockClear();
+      spyon2.mockClear();
+      spyon3.mockClear();
+    });
+
+    test("happy case for source userpool", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      auth["credentials_source"] = "aws";
+      auth["credentials"] = new CognitoIdentityCredentials({
+        IdentityPoolId: "identityPoolId"
+      });
+
+      const spyonAuth = jest
+        .spyOn(Auth.prototype, "currentUserCredentials")
+        .mockImplementationOnce(() => {
+          return new Promise((resolve, reject) => {
+            resolve();
+          });
+        });
+      const spyon = jest
+        .spyOn(CognitoUserPool.prototype, "getCurrentUser")
+        .mockImplementationOnce(() => {
+          return user;
+        });
+      const spyon2 = jest.spyOn(CognitoUser.prototype, "signOut");
+      // @ts-ignore
+
+      await auth.signOut();
+
+      expect.assertions(1);
+      expect(spyon2).toBeCalled();
+
+      spyonAuth.mockClear();
+      spyon.mockClear();
+      spyon2.mockClear();
+    });
+
+    test("happy case for no userpool", async () => {
+      // @ts-ignore
+      const auth = new Auth(authOptionsWithNoUserPoolId);
+
+      expect(await auth.signOut()).toBeUndefined();
+    });
+
+    test("no User in userpool", async () => {
+      const auth = new Auth(authOptions);
+
+      const spyon = jest
+        .spyOn(CognitoUserPool.prototype, "getCurrentUser")
+        .mockImplementationOnce(() => {
+          return null;
+        });
+      expect(await auth.signOut()).toBeUndefined();
+
+      spyon.mockClear();
+    });
+
+    test("get guest credentials failed", async () => {
+      const auth = new Auth(authOptionsWithNoUserPoolId);
+
+      const cognitoCredentialSpyon = jest
+        .spyOn(CognitoIdentityCredentials.prototype, "getPromise")
+        .mockImplementation(() => {
+          return new Promise((res, rej) => {
+            rej("err");
+          });
+        });
+
+      expect(await auth.signOut()).toBeUndefined();
+
+      cognitoCredentialSpyon.mockClear();
+    });
+  });
+
+  describe("changePassword", () => {
+    test("happy case", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      const oldPassword = "oldPassword1";
+      const newPassword = "newPassword1.";
+
+      const spyon = jest
+        .spyOn(Auth.prototype, "userSession")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            res(session);
+          });
+        });
+
+      expect.assertions(1);
+      expect(await auth.changePassword(user, oldPassword, newPassword)).toBe(
+        "SUCCESS"
+      );
+
+      spyon.mockClear();
+    });
+  });
+
+  describe("forgotPassword", () => {
+    test("happy case", async () => {
+      const spyon = jest.spyOn(CognitoUser.prototype, "forgotPassword");
+
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      expect(await auth.forgotPassword("username")).toBeUndefined();
+
+      spyon.mockClear();
+    });
+
+    test("onFailue", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "forgotPassword")
+        .mockImplementationOnce(callback => {
+          callback.onFailure("err");
+        });
+
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.forgotPassword("username");
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+    });
+
+    test("inputVerficationCode", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "forgotPassword")
+        .mockImplementationOnce(callback => {
+          callback.inputVerificationCode("data");
+        });
+
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      expect(await auth.forgotPassword("username")).toBe("data");
+
+      spyon.mockClear();
+    });
+
+    test("no user pool id", async () => {
+      const spyon = jest.spyOn(CognitoUser.prototype, "forgotPassword");
+
+      // @ts-ignore
+      const auth = new Auth(authOptionsWithNoUserPoolId);
+
+      expect.assertions(1);
+      try {
+        await auth.forgotPassword("username");
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+      spyon.mockClear();
+    });
+
+    test("no username", async () => {
+      const spyon = jest.spyOn(CognitoUser.prototype, "forgotPassword");
+
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.forgotPassword(null);
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+      spyon.mockClear();
+    });
+  });
+
+  describe("forgotPasswordSubmit", () => {
+    test("happy case", async () => {
+      const spyon = jest.spyOn(CognitoUser.prototype, "confirmPassword");
+
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      expect(
+        await auth.forgotPasswordSubmit("username", "code", "password")
+      ).toBeUndefined();
+
+      spyon.mockClear();
+    });
+
+    test("confirmPassword failed", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "confirmPassword")
+        .mockImplementationOnce((code, password, callback) => {
+          callback.onFailure("err");
+        });
+
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.forgotPasswordSubmit("username", "code", "password");
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+    });
+
+    test("no user pool", async () => {
+      // @ts-ignore
+      const auth = new Auth(authOptionsWithNoUserPoolId);
+
+      expect.assertions(1);
+      try {
+        await auth.forgotPasswordSubmit("username", "code", "password");
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+    });
+
+    test("no username", async () => {
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.forgotPasswordSubmit(null, "code", "password");
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+    });
+
+    test("no code", async () => {
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.forgotPasswordSubmit("username", null, "password");
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+    });
+
+    test("no password", async () => {
+      const auth = new Auth(authOptions);
+
+      expect.assertions(1);
+      try {
+        await auth.forgotPasswordSubmit("username", "code", null);
+      } catch (e) {
+        expect(e).not.toBeNull();
+      }
+    });
+  });
+
+  describe("currentUserInfo test", () => {
+    test("happy case with aws or userpool source", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      const spyon = jest
+        .spyOn(Auth.prototype, "currentUserPoolUser")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            res({
+              username: "username"
+            });
+          });
+        });
+
+      const spyon2 = jest
+        .spyOn(Auth.prototype, "userAttributes")
+        .mockImplementationOnce(() => {
+          auth["credentials"] = new CognitoIdentityCredentials({
+            IdentityPoolId: "identityPoolId",
+            IdentityId: "identityId"
+          });
+          auth["credentials"]["identityId"] = "identityId";
+          return new Promise((res, rej) => {
+            res([
+              { Name: "email", Value: "email" },
+              { Name: "phone_number", Value: "phone_number" },
+              { Name: "email_verified", Value: "false" },
+              { Name: "phone_number_verified", Value: "true" },
+              { Name: "sub", Value: "fefefe" }
+            ]);
+          });
+        });
+
+      const spyon3 = jest
+        .spyOn(Auth.prototype, "currentCredentials")
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            identityId: "identityId"
+          });
+        });
+
+      const spyon4 = jest
+        .spyOn(Credentials, "getCredSource")
+        .mockImplementationOnce(() => {
+          return "aws";
+        });
+
+      expect.assertions(1);
+      expect(await auth.currentUserInfo()).toEqual({
+        username: "username",
+        id: "identityId",
+        attributes: {
+          email: "email",
+          phone_number: "phone_number",
+          email_verified: false,
+          phone_number_verified: true
+        }
+      });
+
+      spyon.mockClear();
+      spyon2.mockClear();
+      spyon3.mockClear();
+      spyon4.mockClear();
+    });
+
+    test("return empty object if error happens", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      const spyon = jest
+        .spyOn(Auth.prototype, "currentUserPoolUser")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            res({
+              username: "username"
+            });
+          });
+        });
+
+      const spyon2 = jest
+        .spyOn(Auth.prototype, "userAttributes")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            rej("err");
+          });
+        });
+
+      const spyon3 = jest
+        .spyOn(Auth.prototype, "currentCredentials")
+        .mockImplementationOnce(() => {
+          return Promise.resolve({
+            IdentityPoolId: "identityPoolId",
+            identityId: "identityId"
+          });
+        });
+
+      const spyon4 = jest
+        .spyOn(Credentials, "getCredSource")
+        .mockImplementationOnce(() => {
+          return "aws";
+        });
+
+      expect.assertions(1);
+      expect(await auth.currentUserInfo()).toEqual({});
+
+      spyon.mockClear();
+      spyon2.mockClear();
+      spyon3.mockClear();
+      spyon4.mockClear();
+    });
+
+    test("no credentials source", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      const spyon = jest
+        .spyOn(Credentials, "getCredSource")
+        .mockImplementationOnce(() => {
+          return null;
+        });
+
+      expect.assertions(1);
+      expect(await auth.currentUserInfo()).toEqual(null);
+
+      spyon.mockClear();
+    });
+
+    test("no current userpool user", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      auth["credentials_source"] = "aws";
+
+      const spyon = jest
+        .spyOn(Auth.prototype, "currentUserPoolUser")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            res(null);
+          });
+        });
+
+      const spyon2 = jest
+        .spyOn(Credentials, "getCredSource")
+        .mockImplementationOnce(() => {
+          return "aws";
+        });
+
+      expect.assertions(1);
+      expect(await auth.currentUserInfo()).toBeNull();
+
+      spyon.mockClear();
+      spyon2.mockClear();
+    });
+
+    test("federated user", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      auth["user"] = "federated_user";
+
+      const spyon = jest
+        .spyOn(Credentials, "getCredSource")
+        .mockImplementationOnce(() => {
+          return "federated";
+        });
+
+      expect.assertions(1);
+      expect(await auth.currentUserInfo()).toBe("federated_user");
+
+      spyon.mockClear();
+    });
+  });
+
+  describe("updateUserAttributes test", () => {
+    test("happy case", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      const attributes = {
+        email: "email",
+        phone_number: "phone_number",
+        sub: "sub"
+      };
+      const spyon = jest
+        .spyOn(Auth.prototype, "userSession")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            res(session);
+          });
+        });
+
+      expect.assertions(1);
+      expect(await auth.updateUserAttributes(user, attributes)).toBe("SUCCESS");
+
+      spyon.mockClear();
+    });
+  });
+
+  describe("federatedSignIn test", () => {
+    test("happy case", async () => {
+      const auth = new Auth(authOptions);
+
+      const spyon = jest
+        .spyOn(Credentials, "set")
+        .mockImplementationOnce(() => {
+          return Promise.resolve("cred");
+        });
+
+      auth.federatedSignIn(
+        "google",
+        { token: "token", expires_at: 1234 },
+        { user: "user" }
+      );
+
+      expect(spyon).toBeCalled();
+      spyon.mockClear();
+    });
+  });
+
+  describe("verifiedContact test", () => {
+    test("happy case with unverified", async () => {
+      const spyon = jest
+        .spyOn(Auth.prototype, "userAttributes")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            res([
+              {
+                Name: "email",
+                Value: "email@amazon.com"
+              },
+              {
+                Name: "phone_number",
+                Value: "+12345678901"
+              }
+            ]);
+          });
+        });
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect(await auth.verifiedContact(user)).toEqual({
+        unverified: { email: "email@amazon.com", phone_number: "+12345678901" },
+        verified: {}
+      });
+
+      spyon.mockClear();
+    });
+
+    test("happy case with unverified", async () => {
+      const spyon = jest
+        .spyOn(Auth.prototype, "userAttributes")
+        .mockImplementationOnce(() => {
+          return new Promise((res, rej) => {
+            res([
+              {
+                Name: "email",
+                Value: "email@amazon.com"
+              },
+              {
+                Name: "phone_number",
+                Value: "+12345678901"
+              },
+              {
+                Name: "email_verified",
+                Value: true
+              },
+              {
+                Name: "phone_number_verified",
+                Value: true
+              }
+            ]);
+          });
+        });
+
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect(await auth.verifiedContact(user)).toEqual({
+        unverified: {},
+        verified: { email: "email@amazon.com", phone_number: "+12345678901" }
+      });
+
+      spyon.mockClear();
+    });
+  });
+
+  describe("currentUserPoolUser test", () => {
+    test("happy case", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      const spyon = jest
+        .spyOn(CognitoUserPool.prototype, "getCurrentUser")
+        .mockImplementation(() => {
+          return user;
+        });
+      const spyon2 = jest
+        .spyOn(CognitoUser.prototype, "getSession")
+        .mockImplementation(callback => {
+          return callback(null, "session");
+        });
+
+      expect.assertions(1);
+      auth
+        .currentUserPoolUser()
+        .then(user => {
+          expect(user).toEqual(user);
+          spyon.mockClear();
+          spyon2.mockClear();
+        })
+        .catch(e => {
+          expect(e).toBe("No current user in userPool");
+        });
+
+      // expect(await auth.currentUserPoolUser()).toEqual(user);
+    });
+
+    test("no current user", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      const spyon = jest
+        .spyOn(CognitoUserPool.prototype, "getCurrentUser")
+        .mockImplementation(() => {
+          return null;
+        });
+
+      expect.assertions(1);
+      try {
+        await auth.currentUserPoolUser();
+      } catch (e) {
+        expect(e).toBe("No current user in userPool");
+      }
+
+      spyon.mockClear();
+    });
+
+    test("No userPool", async () => {
+      // @ts-ignore
+      const auth = new Auth(authOptionsWithNoUserPoolId);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      expect.assertions(1);
+      try {
+        await auth.currentUserPoolUser();
+      } catch (e) {
+        expect(e.message).toBe("No userPool");
+      }
+    });
+
+    test("get session error", async () => {
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+
+      const spyon = jest
+        .spyOn(CognitoUserPool.prototype, "getCurrentUser")
+        .mockImplementation(() => {
+          return user;
+        });
+      const spyon2 = jest
+        .spyOn(CognitoUser.prototype, "getSession")
+        .mockImplementation(callback => {
+          return callback("err", null);
+        });
+
+      expect.assertions(1);
+      try {
+        await auth.currentUserPoolUser();
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+      spyon2.mockClear();
+    });
+  });
+
+  describe("sendCustomChallengeAnswer", () => {
+    test("happy case", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "sendCustomChallengeAnswer")
+        .mockImplementationOnce((challengeResponses, callback) => {
+          callback.onSuccess(session);
+        });
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      const userAfterCustomChallengeAnswer = Object.assign(
+        new CognitoUser({
+          Username: "username",
+          Pool: userPool
+        }),
+        {
+          challengeName: "CUSTOM_CHALLENGE",
+          challengeParam: "challengeParam"
+        }
+      );
+
+      expect.assertions(1);
+      expect(
+        await auth.sendCustomChallengeAnswer(
+          userAfterCustomChallengeAnswer,
+          "challengeResponse"
+        )
+      ).toEqual(user);
+
+      spyon.mockClear();
+    });
+
+    test("customChallenge", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "sendCustomChallengeAnswer")
+        .mockImplementationOnce((challengeResponses, callback) => {
+          callback.customChallenge("challengeParam");
+        });
+      const auth = new Auth(authOptions);
+      const user = new CognitoUser({
+        Username: "username",
+        Pool: userPool
+      });
+      const userAfterCustomChallengeAnswer = Object.assign(
+        new CognitoUser({
+          Username: "username",
+          Pool: userPool
+        }),
+        {
+          challengeName: "CUSTOM_CHALLENGE",
+          challengeParam: "challengeParam"
+        }
+      );
+
+      expect.assertions(1);
+      expect(
+        await auth.sendCustomChallengeAnswer(
+          userAfterCustomChallengeAnswer,
+          "challengeResponse"
+        )
+      ).toEqual(userAfterCustomChallengeAnswer);
+
+      spyon.mockClear();
+    });
+
+    test("onFailure", async () => {
+      const spyon = jest
+        .spyOn(CognitoUser.prototype, "sendCustomChallengeAnswer")
+        .mockImplementationOnce((challengeResponses, callback) => {
+          callback.onFailure("err");
+        });
+
+      const auth = new Auth(authOptions);
+      const userAfterCustomChallengeAnswer = Object.assign(
+        new CognitoUser({
+          Username: "username",
+          Pool: userPool
+        }),
+        {
+          challengeName: "CUSTOM_CHALLENGE",
+          challengeParam: "challengeParam"
+        }
+      );
+
+      expect.assertions(1);
+      try {
+        await auth.sendCustomChallengeAnswer(
+          userAfterCustomChallengeAnswer,
+          "challengeResponse"
+        );
+      } catch (e) {
+        expect(e).toBe("err");
+      }
+
+      spyon.mockClear();
+    });
+
+    test("no userPool", async () => {
+      const spyon = jest.spyOn(
+        CognitoUser.prototype,
+        "sendCustomChallengeAnswer"
+      );
+
+      // @ts-ignore
+      const auth = new Auth(authOptionsWithNoUserPoolId);
+      const userAfterCustomChallengeAnswer = Object.assign(
+        new CognitoUser({
+          Username: "username",
+          Pool: userPool
+        }),
+        {
+          challengeName: "CUSTOM_CHALLENGE",
+          challengeParam: "challengeParam"
+        }
+      );
+
+      expect.assertions(1);
+      try {
+        await auth.sendCustomChallengeAnswer(
+          userAfterCustomChallengeAnswer,
+          "challengeResponse"
+        );
+      } catch (e) {
+        expect(e.message).toBe("No userPool");
+      }
+
+      spyon.mockClear();
+    });
+  });
+
+  describe("hosted ui test", () => {
+    test("happy case", () => {
+      const oauth = {};
+
+      const authOptions = {
+        Auth: {
+          userPoolId: "awsUserPoolsId",
+          userPoolWebClientId: "awsUserPoolsWebClientId",
+          region: "region",
+          identityPoolId: "awsCognitoIdentityPoolId",
+          oauth
+        }
+      };
+      const spyon = jest
+        .spyOn(Auth.prototype, "currentAuthenticatedUser")
+        .mockImplementationOnce(() => {
+          return Promise.reject("err");
+        });
+
+      const auth = new Auth(authOptions);
+      expect(spyon).toBeCalled();
+
+      spyon.mockClear();
+    });
+  });
 });
-
-describe('auth unit test', () => {
-    describe('signUp', () => {
-        test('happy case with string attrs', async () => {
-            const spyon = jest.spyOn(CognitoUserPool.prototype, "signUp");
-            const auth = new Auth(authOptions);
-            expect(await auth.signUp('username', 'password', 'email','phone')).toBe('signUpResult');
-
-            spyon.mockClear();
-        });
-
-        test('happy case with object attr', async () => {
-            const spyon = jest.spyOn(CognitoUserPool.prototype, "signUp");
-            const auth = new Auth(authOptions);
-
-            const attrs = {
-                username: 'username',
-                password: 'password',
-                attributes: {
-                    email: 'email',
-                    phone_number: 'phone_number',
-                    otherAttrs: 'otherAttrs'
-                }
-            };
-            expect.assertions(1);
-            expect(await auth.signUp(attrs)).toBe('signUpResult');
-
-            spyon.mockClear();
-        });
-
-        test('object attr with null username', async () => {
-            const auth = new Auth(authOptions);
-
-            const attrs = {
-                username: null,
-                password: 'password',
-                attributes: {
-                    email: 'email',
-                    phone_number: 'phone_number',
-                    otherAttrs: 'otherAttrs'
-                }
-            };
-            expect.assertions(1);
-            try {
-                await auth.signUp(attrs);
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-        });
-
-        test('callback error', async () => {
-            const spyon = jest.spyOn(CognitoUserPool.prototype, "signUp")
-                .mockImplementationOnce((username, password, signUpAttributeList, validationData, callback) => {
-                    callback('err', null);
-                });
-
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.signUp('username', 'password', 'email', 'phone');
-            } catch (e) {
-                expect(e).toBe('err');
-            }
-
-            spyon.mockClear();
-        });
-
-        test('no user pool', async () => {
-            // @ts-ignore
-            const auth = new Auth(authOptionsWithNoUserPoolId);
-
-            expect.assertions(1);
-            try {
-                await auth.signUp('username', 'password', 'email', 'phone');
-            } catch (e) {
-                expect(e).toBe('No userPool');
-            }
-        });
-
-        test('no username', async () => {
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.signUp(null, 'password', 'email', 'phone');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-        });
-
-        test('no password', async () => {
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.signUp('username', null, 'email', 'phone');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-        });
-
-        test('only username', async () => {
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.signUp('username');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-        });
-    });
-
-    describe('confirmSignUp', () => {
-        test('happy case', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "confirmRegistration");
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            expect(await auth.confirmSignUp('username', 'code')).toBe('Success');
-
-            spyon.mockClear();
-        });
-
-        test('with options', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "confirmRegistration");
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            expect(await auth.confirmSignUp('username', 'code', {forceAliasCreation: false})).toBe('Success');
-
-            spyon.mockClear();
-        });
-
-        test('callback err', async () => {
-             const spyon = jest.spyOn(CognitoUser.prototype, "confirmRegistration")
-                .mockImplementationOnce((confirmationCode, forceAliasCreation, callback) => {
-                    callback('err', null);
-                });
-
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.confirmSignUp('username', 'code');
-            } catch (e) {
-                expect(e).toBe('err');
-            }
-
-            spyon.mockClear();
-        });
-
-        test('no user pool', async () => {
-            // @ts-ignore
-            const auth = new Auth(authOptionsWithNoUserPoolId);
-
-            expect.assertions(1);
-            try {
-                await auth.confirmSignUp('username', 'code');
-            } catch (e) {
-                expect(e).toBe('No userPool');
-            }
-        });
-
-        test('no user name', async () => {
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.confirmSignUp(null, 'code');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-        });
-
-        test('no code', async () => {
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.confirmSignUp('username', null);
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-        });
-    });
-
-    describe('resendSignUp', () => {
-        test('happy case', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "resendConfirmationCode");
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            expect(await auth.resendSignUp('username')).toBe('result');
-
-            spyon.mockClear();
-        });
-
-        test('callback err', async () => {
-             const spyon = jest.spyOn(CognitoUser.prototype, "resendConfirmationCode")
-                .mockImplementationOnce((callback) => {
-                    callback('err', null);
-                });
-
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.resendSignUp('username');
-            } catch (e) {
-                expect(e).toBe('err');
-            }
-
-            spyon.mockClear();
-        });
-
-        test('no user pool', async () => {
-            // @ts-ignore
-            const auth = new Auth(authOptionsWithNoUserPoolId);
-
-            expect.assertions(1);
-            try {
-                await auth.resendSignUp('username');
-            } catch (e) {
-                expect(e).toBe('No userPool');
-            }
-        });
-
-        test('no username', async () => {
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.resendSignUp(null);
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-        });
-    });
-
-    describe('signIn', () => {
-        test('happy case with password', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'authenticateUser')
-                .mockImplementationOnce((authenticationDetails, callback) => {
-                    callback.onSuccess(session);
-                });
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            expect(await auth.signIn('username', 'password')).toEqual(user);
-
-            spyon.mockClear();
-        });
-
-        test('happy case using cookie storage', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'authenticateUser')
-                .mockImplementationOnce((authenticationDetails, callback) => {
-                    callback.onSuccess(session);
-                });
-
-            const auth = new Auth({ ...authOptions, cookieStorage: { domain: ".example.com" } });
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool,
-                Storage: new CookieStorage({ domain: ".yourdomain.com" })
-            });
-
-            expect.assertions(1);
-            expect(await auth.signIn('username', 'password')).toEqual(user);
-
-            spyon.mockClear();
-        });
-
-        test('onFailure', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "authenticateUser")
-                .mockImplementationOnce((authenticationDetails, callback) => {
-                    callback.onFailure('err');
-                });
-
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.signIn('username', 'password');
-            } catch (e) {
-                expect(e).toBe('err');
-            }
-
-            spyon.mockClear();
-        });
-
-        test('mfaRequired', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "authenticateUser")
-                .mockImplementationOnce((authenticationDetails, callback) => {
-                    callback.mfaRequired('challengeName', 'challengeParam');
-                });
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            const userAfterSignedIn = Object.assign(
-                {},
-                user,
-                {
-                    "challengeName": "challengeName",
-                    "challengeParam": "challengeParam"
-                });
-
-            expect.assertions(1);
-            expect(await auth.signIn('username', 'password')).toEqual(userAfterSignedIn);
-
-            spyon.mockClear();
-        });
-
-        test('mfaSetup', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "authenticateUser")
-                .mockImplementationOnce((authenticationDetails, callback) => {
-                    callback.mfaSetup('challengeName', 'challengeParam');
-                });
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            const userAfterSignedIn = Object.assign(
-                {},
-                user,
-                {
-                    "challengeName": "challengeName",
-                    "challengeParam": "challengeParam"
-                });
-
-            expect.assertions(1);
-            expect(await auth.signIn('username', 'password')).toEqual(userAfterSignedIn);
-
-            spyon.mockClear();
-        });
-
-        test('totpRequired', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "authenticateUser")
-                .mockImplementationOnce((authenticationDetails, callback) => {
-                    callback.totpRequired('challengeName', 'challengeParam');
-                });
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            const userAfterSignedIn = Object.assign(
-                {},
-                user,
-                {
-                    "challengeName": "challengeName",
-                    "challengeParam": "challengeParam"
-                });
-
-            expect.assertions(1);
-            expect(await auth.signIn('username', 'password')).toEqual(userAfterSignedIn);
-
-            spyon.mockClear();
-        });
-
-        test('selectMFAType', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "authenticateUser")
-                .mockImplementationOnce((authenticationDetails, callback) => {
-                    callback.selectMFAType('challengeName', 'challengeParam');
-                });
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            const userAfterSignedIn = Object.assign(
-                {},
-                user,
-                {
-                    "challengeName": "challengeName",
-                    "challengeParam": "challengeParam"
-                });
-
-            expect.assertions(1);
-            expect(await auth.signIn('username', 'password')).toEqual(userAfterSignedIn);
-
-            spyon.mockClear();
-        });
-
-        test('newPasswordRequired', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "authenticateUser")
-                .mockImplementationOnce((authenticationDetails, callback) => {
-                    callback.newPasswordRequired('userAttributes', 'requiredAttributes');
-                });
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            const userAfterSignedIn = Object.assign(
-                {},
-                user,
-                {
-                    "challengeName": "NEW_PASSWORD_REQUIRED",
-                    "challengeParam": {
-                        "requiredAttributes": "requiredAttributes",
-                        "userAttributes": "userAttributes"
-                    }
-                });
-
-            expect.assertions(1);
-            expect(await auth.signIn('username', 'password')).toEqual(userAfterSignedIn);
-
-            spyon.mockClear();
-        });
-
-        test('customChallenge', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'authenticateUser')
-                .mockImplementationOnce((authenticationDetails, callback) => {
-                    callback.customChallenge('challengeParam');
-                });
-            const spyon2 = jest.spyOn(CognitoUser.prototype, 'setAuthenticationFlowType')
-                .mockImplementationOnce((type) => {
-
-                });
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            const userAfterSignedIn = Object.assign(
-                {},
-                user,
-                {
-                    "challengeName": "CUSTOM_CHALLENGE",
-                    "challengeParam": "challengeParam"
-                });
-
-            expect.assertions(2);
-            expect(await auth.signIn('username')).toEqual(userAfterSignedIn);
-            expect(spyon2).toBeCalledWith('CUSTOM_AUTH');
-
-            spyon2.mockClear();
-            spyon.mockClear();
-        });
-
-        test('no userPool', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'authenticateUser');
-
-            // @ts-ignore
-            const auth = new Auth(authOptionsWithNoUserPoolId);
-
-            expect.assertions(1);
-            try {
-                await auth.signIn('username', 'password');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-
-            spyon.mockClear();
-        });
-
-        test('no username', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'authenticateUser');
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.signIn(null, 'password');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-
-            spyon.mockClear();
-        });
-        });
-
-    describe("confirmSignIn", () => {
-        test('happy case', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "sendMFACode")
-                .mockImplementationOnce((code, callback) => {
-                    callback.onSuccess(session);
-                });
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            expect(await auth.confirmSignIn(user, 'code', null)).toEqual(user);
-
-            spyon.mockClear();
-        });
-
-        test('onFailure', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "sendMFACode")
-                .mockImplementationOnce((code, callback) => {
-                    callback.onFailure('err');
-                });
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            try {
-                await auth.confirmSignIn(user, 'code', null);
-            } catch (e) {
-                expect(e).toBe('err');
-            }
-
-            spyon.mockClear();
-        });
-
-        test('no code', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "sendMFACode");
-            const auth = new Auth(authOptions);
-
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            try {
-                await auth.confirmSignIn(user, null, null);
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-
-            spyon.mockClear();
-        });
-    });
-
-    describe('completeNewPassword', () => {
-        test('happy case', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'completeNewPasswordChallenge')
-                .mockImplementationOnce((password, requiredAttributes, callback) => {
-                    callback.onSuccess(session);
-                });
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            expect(await auth.completeNewPassword(user, 'password', {})).toEqual(user);
-
-            spyon.mockClear();
-        });
-
-        test('on Failure', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'completeNewPasswordChallenge')
-                .mockImplementationOnce((password, requiredAttributes, callback) => {
-                    callback.onFailure('err');
-                });
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            try {
-                await auth.completeNewPassword(user, 'password', {});
-            } catch (e) {
-                expect(e).toBe('err');
-            }
-
-            spyon.mockClear();
-        });
-
-        test('mfaRequired', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'completeNewPasswordChallenge')
-                .mockImplementationOnce((password, requiredAttributes, callback) => {
-                    callback.mfaRequired('challengeName', 'challengeParam');
-                });
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            expect(await auth.completeNewPassword(user, 'password', {})).toBe(user);
-
-            spyon.mockClear();
-        });
-
-        test('mfaSetup', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'completeNewPasswordChallenge')
-                .mockImplementationOnce((password, requiredAttributes, callback) => {
-                    callback.mfaSetup('challengeName', 'challengeParam');
-                });
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            expect(await auth.completeNewPassword(user, 'password', {})).toBe(user);
-
-            spyon.mockClear();
-        });
-
-        test('no password', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            try {
-                await auth.completeNewPassword(user, null, {});
-            } catch (e) {
-                expect(e).toBe('Password cannot be empty');
-            }
-        });
-    });
-
-    describe('userAttributes', () => {
-        test('happy case', async () => {
-            const spyon = jest.spyOn(Auth.prototype, 'userSession')
-                .mockImplementationOnce((user) => {
-                    return new Promise((res, rej) => {
-                        res('session');
-                    });
-                });
-
-            const spyon2 = jest.spyOn(CognitoUser.prototype, 'getUserAttributes');
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            expect(await auth.userAttributes(user)).toBe('attributes');
-
-            spyon.mockClear();
-            spyon2.mockClear();
-        });
-
-        test('get userattributes failed', async () => {
-            const spyon = jest.spyOn(Auth.prototype, 'userSession')
-                .mockImplementationOnce((user) => {
-                    return new Promise((res, rej) => {
-                        res('session');
-                    });
-                });
-
-            const spyon2 = jest.spyOn(CognitoUser.prototype, 'getUserAttributes')
-                .mockImplementationOnce((callback) => {
-                    callback('err');
-                });
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            try {
-                await auth.userAttributes(user);
-            } catch (e) {
-                expect(e).toBe('err');
-            }
-
-            spyon.mockClear();
-            spyon2.mockClear();
-        });
-    });
-
-    describe('currentSession', () => {
-        test('happy case', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            const spyon = jest.spyOn(CognitoUserPool.prototype, "getCurrentUser")
-                .mockImplementationOnce(() => {
-                    return user;
-                });
-
-            const spyon2 = jest.spyOn(Auth.prototype, 'userSession').mockImplementationOnce(() => {
-                return new Promise((res, rej) => {
-                    res(session);
-                })
-            });
-            expect.assertions(1);
-            expect(await auth.currentSession()).toEqual(session);
-
-            spyon.mockClear();
-            spyon2.mockClear();
-        });
-
-        test('callback failure', async () => {
-            const auth = new Auth(authOptions);
-
-            const spyon = jest.spyOn(CognitoUserPool.prototype, "getCurrentUser")
-                .mockImplementationOnce(() => {
-                    return null;
-                });
-
-            expect.assertions(1);
-            try {
-                await auth.currentSession();
-            } catch (e) {
-                expect(e).toBe('No current user');
-            }
-
-            spyon.mockClear();
-        });
-
-        test('no UserPool', async () => {
-            const auth = new Auth({
-                userPoolId: undefined,
-                userPoolWebClientId: "awsUserPoolsWebClientId",
-                region: "region",
-                identityPoolId: "awsCognitoIdentityPoolId",
-                mandatorySignIn: false
-            });
-
-            expect.assertions(1);
-            try {
-                await auth.currentSession();
-            } catch (e) {
-                expect(e).toBe('No userPool');
-            }
-        });
-    });
-
-    describe('currentAuthenticatedUser', () => {
-        test('happy case with source userpool', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            const spyon = jest.spyOn(Auth.prototype, 'currentUserPoolUser')
-                .mockImplementationOnce(() => {
-                    return new Promise((res, rej) => {
-                        res(user);
-                    });
-                });
-
-            const spyon2 = jest.spyOn(Auth.prototype, 'userAttributes').mockImplementationOnce(() => {
-                return Promise.resolve([{
-                    Name: 'name',
-                    Value: 'val' 
-                }]);
-            });
-            expect.assertions(1);
-            expect(await auth.currentAuthenticatedUser()).toEqual({"attributes": {"name": "val"}});
-
-            spyon.mockClear();
-
-        });
-
-        test('happy case with source federation', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            const spyon = jest.spyOn(Cache, 'getItem').mockImplementationOnce(() => {
-                return {
-                    user: 'federated_user'
-                };
-            });
-
-            expect.assertions(1);
-            expect(await auth.currentAuthenticatedUser()).toBe('federated_user');
-
-            spyon.mockClear();
-        });
-    });
-
-    describe('userSession test', () => {
-        test('happy case', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'getSession').mockImplementationOnce((callback) => {
-                callback(null, session);
-            });
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            expect(await auth.userSession(user)).toEqual(session);
-
-            spyon.mockClear();
-        });
-
-        test('CognitoSession not valid and refresh successfully', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'getSession').mockImplementationOnce((callback) => {
-                callback(null, session);
-            });
-
-            const spyon2 = jest.spyOn(CognitoUserSession.prototype, 'isValid').mockImplementationOnce(() => {
-                return false;
-            });
-
-            const spyon3 = jest.spyOn(CognitoUser.prototype, 'refreshSession').mockImplementationOnce((refreshToken, callback) => {
-                callback(null, session);
-            });
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            expect(await auth.userSession(user)).toEqual(session);
-
-            spyon.mockClear();
-            spyon2.mockClear();
-            spyon3.mockClear();
-        });
-
-        test('CognitoSession not valid and refresh fails', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'getSession').mockImplementationOnce((callback) => {
-                callback(null, session);
-            });
-
-            const spyon2 = jest.spyOn(CognitoUserSession.prototype, 'isValid').mockImplementationOnce(() => {
-                return false;
-            });
-
-            const spyon3 = jest.spyOn(CognitoUser.prototype, 'refreshSession').mockImplementationOnce((refreshToken, callback) => {
-                callback('err', null);
-            });
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            try {
-                await auth.userSession(user);
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-
-            spyon.mockClear();
-            spyon2.mockClear();
-            spyon3.mockClear();
-        });
-
-        test('callback error', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            const spyon = jest.spyOn(CognitoUser.prototype, "getSession")
-                .mockImplementationOnce((callback) => {
-                    callback('err', null);
-                });
-
-            expect.assertions(1);
-            try {
-                await auth.userSession(user);
-            } catch (e) {
-                expect(e).toBe('err');
-            }
-
-            spyon.mockClear();
-    });
-    });
-
-    describe('currentUserCredentials test', () => {
-        test('with federated info', async () => {
-            const auth = new Auth(authOptions);
-
-            const spyon = jest.spyOn(Cache, 'getItem')
-                .mockImplementationOnce(() => {
-                    return {
-                        provider: 'google',
-                        token: 'token'
-                    }
-                });
-
-            const spyon2 = jest.spyOn(Credentials, 'refreshFederatedToken').mockImplementationOnce(() => {
-                return Promise.resolve('cred');
-            });
-
-            expect.assertions(1);
-            expect(await auth.currentUserCredentials()).toBe('cred');
-
-            spyon.mockClear();
-            spyon2.mockClear();
-        });
-
-        test('with cognito session', async () => {
-            const auth = new Auth(authOptions);
-
-            const spyon = jest.spyOn(Cache, 'getItem')
-                .mockImplementationOnce(() => {
-                    return null;
-                });
-
-            const spyon2 = jest.spyOn(auth, 'currentSession').mockImplementationOnce(() => {
-                return Promise.resolve('session');
-            });
-
-            const spyon3 = jest.spyOn(Credentials, 'set').mockImplementationOnce(() => {
-                return Promise.resolve('cred');
-            });
-
-            expect.assertions(1);
-            expect(await auth.currentUserCredentials()).toBe('cred');
-
-            spyon.mockClear();
-            spyon2.mockClear();
-            spyon3.mockClear();
-        });
-
-        test('with guest', async () => {
-            const auth = new Auth(authOptions);
-
-            const spyon = jest.spyOn(Cache, 'getItem')
-                .mockImplementationOnce(() => {
-                    return null;
-                });
-
-            const spyon2 = jest.spyOn(auth, 'currentSession').mockImplementationOnce(() => {
-                return Promise.reject('err');
-            });
-
-            const spyon3 = jest.spyOn(Credentials, 'set').mockImplementationOnce(() => {
-                return Promise.resolve('cred');
-            });
-
-            expect.assertions(1);
-            expect(await auth.currentUserCredentials()).toBe('cred');
-
-            spyon.mockClear();
-            spyon2.mockClear();
-            spyon3.mockClear();
-        });
-    });
-
-    describe('currentCrendentials', () => {
-        const spyon = jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
-            return;
-        });
-
-        const auth = new Auth(authOptions);
-
-        auth.currentCredentials();
-        expect(spyon).toBeCalled();
-        spyon.mockClear();
-    });
-
-    describe('verifyUserAttribute test', () => {
-        test('happy case', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "getAttributeVerificationCode");
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            expect(await auth.verifyUserAttribute(user, {})).toBe("success");
-
-            spyon.mockClear();
-
-        });
-
-        test('onFailure', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "getAttributeVerificationCode")
-                .mockImplementationOnce((attr, callback) => {
-                    callback.onFailure('err');
-                });
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            try {
-                await auth.verifyUserAttribute(user, {});
-            } catch (e) {
-                expect(e).toBe("err");
-            }
-
-            spyon.mockClear();
-        });
-    });
-
-    describe('verifyUserAttributeSubmit', () => {
-        test('happy case', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "verifyAttribute");
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            expect(await auth.verifyUserAttributeSubmit(user, {}, 'code')).toBe("success");
-
-            spyon.mockClear();
-        });
-
-        test('onFailure', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "verifyAttribute")
-                .mockImplementationOnce((attr, code, callback) => {
-                    callback.onFailure('err');
-                });
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            try {
-                await auth.verifyUserAttributeSubmit(user, {}, 'code');
-            } catch (e) {
-                expect(e).toBe("err");
-            }
-
-            spyon.mockClear();
-        });
-
-        test('code empty', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            try {
-                await auth.verifyUserAttributeSubmit(user, {}, null);
-            } catch (e) {
-                expect(e).toBe('Code cannot be empty');
-            }
-        });
-    });
-
-    describe('verifyCurrentUserAttribute test', () => {
-        test('happy case', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            const spyon = jest.spyOn(Auth.prototype, 'currentUserPoolUser')
-                .mockImplementationOnce(() => {
-                    return new Promise((res, rej) => {
-                        res(user);
-                    });
-                });
-
-            const spyon2 = jest.spyOn(Auth.prototype, 'verifyUserAttribute')
-                .mockImplementationOnce(() => {
-                    return new Promise((res, rej) => {
-                        res();
-                    });
-                });
-
-            await auth.verifyCurrentUserAttribute('attr');
-
-            expect.assertions(2);
-            expect(spyon).toBeCalled();
-            expect(spyon2).toBeCalledWith(user, 'attr');
-
-            spyon.mockClear();
-            spyon2.mockClear();
-        });
-    });
-
-    describe('verifyCurrentUserAttributeSubmit test', () => {
-        test('happy case', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            const spyon = jest.spyOn(Auth.prototype, 'currentUserPoolUser')
-                .mockImplementationOnce(() => {
-                    return new Promise((res, rej) => {
-                        res(user);
-                    });
-                });
-
-            const spyon2 = jest.spyOn(Auth.prototype, 'verifyUserAttributeSubmit')
-                .mockImplementationOnce(() => {
-                    return new Promise((res, rej) => {
-                        res();
-                    });
-                });
-
-            await auth.verifyCurrentUserAttributeSubmit('attr', 'code');
-
-            expect.assertions(2);
-            expect(spyon).toBeCalled();
-            expect(spyon2).toBeCalledWith(user, 'attr', 'code');
-
-            spyon.mockClear();
-            spyon2.mockClear();
-        });
-    });
-
-    describe('signOut', () => {
-        test('happy case', async () => {
-            const auth = new Auth(authOptions);
-
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            const spyon = jest.spyOn(CognitoIdentityCredentials.prototype, "clearCachedId");
-            const spyon2 = jest.spyOn(Cache, 'removeItem');
-            const spyon3 = jest.spyOn(CognitoUserPool.prototype, "getCurrentUser")
-            .mockImplementationOnce(() => {
-                return user;
-            });
-
-            await auth.signOut();
-
-            expect.assertions(2);
-            expect(spyon).toBeCalled();
-            expect(spyon2).toBeCalledWith('federatedInfo');
-
-            spyon.mockClear();
-            spyon2.mockClear();
-            spyon3.mockClear();
-        });
-
-        test('happy case for source userpool', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            auth['credentials_source'] = 'aws';
-            auth['credentials'] = new CognitoIdentityCredentials({
-                IdentityPoolId: 'identityPoolId'
-            });
-
-            const spyonAuth = jest.spyOn(Auth.prototype, "currentUserCredentials")
-            .mockImplementationOnce(() => {
-                return new Promise((resolve, reject) => { resolve(); });
-            });
-            const spyon = jest.spyOn(CognitoUserPool.prototype, "getCurrentUser")
-            .mockImplementationOnce(() => {
-                return user;
-            });
-            const spyon2 = jest.spyOn(CognitoUser.prototype, "signOut");
-            // @ts-ignore
-
-            await auth.signOut();
-
-            expect.assertions(1);
-            expect(spyon2).toBeCalled();
-
-            spyonAuth.mockClear();
-            spyon.mockClear();
-            spyon2.mockClear();
-        });
-
-        test('happy case for no userpool', async () => {
-            // @ts-ignore
-            const auth = new Auth(authOptionsWithNoUserPoolId);
-
-            expect(await auth.signOut()).toBeUndefined();            
-        });
-
-        test('no User in userpool', async () => {
-            const auth = new Auth(authOptions);
-
-            const spyon = jest.spyOn(CognitoUserPool.prototype, 'getCurrentUser')
-                .mockImplementationOnce(() => {
-                    return null;
-                });
-            expect(await auth.signOut()).toBeUndefined();           
-
-            spyon.mockClear();
-        });
-
-        test('get guest credentials failed', async() => {
-            const auth = new Auth(authOptionsWithNoUserPoolId);
-
-            const cognitoCredentialSpyon = jest.spyOn(CognitoIdentityCredentials.prototype, 'getPromise').mockImplementation(() => {
-                return new Promise((res, rej) => {
-                    rej('err');
-                });
-            });
-
-            expect(await auth.signOut()).toBeUndefined();     
-
-            cognitoCredentialSpyon.mockClear();
-        });
-    });
-
-    describe('changePassword', () => {
-        test('happy case', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            const oldPassword = 'oldPassword1';
-            const newPassword = 'newPassword1.';
-
-            const spyon = jest.spyOn(Auth.prototype, 'userSession').mockImplementationOnce(() => {
-                return new Promise((res, rej) => {
-                    res(session);
-                })
-            });
-
-            expect.assertions(1);
-            expect(await auth.changePassword(user, oldPassword, newPassword)).toBe('SUCCESS');
-
-            spyon.mockClear();
-        });
-    });
-
-    describe('forgotPassword', () => {
-        test('happy case', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "forgotPassword");
-
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            expect(await auth.forgotPassword('username')).toBeUndefined();
-
-            spyon.mockClear();
-        });
-
-        test('onFailue', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "forgotPassword")
-                .mockImplementationOnce((callback) => {
-                    callback.onFailure('err');
-                });
-
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.forgotPassword('username');
-            } catch (e) {
-                expect(e).toBe('err');
-            }
-
-            spyon.mockClear();
-        });
-
-        test('inputVerficationCode', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "forgotPassword")
-                .mockImplementationOnce((callback) => {
-                    callback.inputVerificationCode('data');
-                });
-
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            expect(await auth.forgotPassword('username')).toBe('data');
-
-            spyon.mockClear();
-        });
-
-        test('no user pool id', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "forgotPassword");
-
-            // @ts-ignore
-            const auth = new Auth(authOptionsWithNoUserPoolId);
-
-            expect.assertions(1);
-            try {
-                await auth.forgotPassword('username');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-            spyon.mockClear();
-        });
-
-        test('no username', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "forgotPassword");
-
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.forgotPassword(null);
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-            spyon.mockClear();
-        });
-    });
-
-    describe('forgotPasswordSubmit', () => {
-        test('happy case', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "confirmPassword");
-
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            expect(await auth.forgotPasswordSubmit('username', 'code', 'password')).toBeUndefined();
-
-            spyon.mockClear();
-        });
-
-        test('confirmPassword failed', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, "confirmPassword")
-                .mockImplementationOnce((code, password, callback) => {
-                    callback.onFailure('err');
-                });
-
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.forgotPasswordSubmit('username', 'code', 'password');
-            } catch (e) {
-                expect(e).toBe('err');
-            }
-
-            spyon.mockClear();
-        });
-
-        test('no user pool', async () => {
-            // @ts-ignore
-            const auth = new Auth(authOptionsWithNoUserPoolId);
-
-            expect.assertions(1);
-            try {
-                await auth.forgotPasswordSubmit('username', 'code', 'password');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-        });
-
-        test('no username', async () => {
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.forgotPasswordSubmit(null, 'code', 'password');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-        });
-
-        test('no code', async () => {
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.forgotPasswordSubmit('username', null, 'password');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-        });
-
-        test('no password', async () => {
-            const auth = new Auth(authOptions);
-
-            expect.assertions(1);
-            try {
-                await auth.forgotPasswordSubmit('username', 'code', null);
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
-        });
-    });
-
-    describe('currentUserInfo test', () => {
-        test('happy case with aws or userpool source', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            const spyon = jest.spyOn(Auth.prototype, 'currentUserPoolUser')
-                .mockImplementationOnce(() => {
-                    return new Promise((res, rej) => {
-                        res({
-                            username: 'username'
-                        });
-                    });
-                });
-
-            const spyon2 = jest.spyOn(Auth.prototype, 'userAttributes')
-                .mockImplementationOnce(() => {
-                    auth['credentials'] = new CognitoIdentityCredentials({
-                        IdentityPoolId: 'identityPoolId',
-                        IdentityId: 'identityId'
-                    });
-                    auth['credentials']['identityId'] = 'identityId';
-                    return new Promise((res, rej) => {
-                        res([
-                            { Name: 'email', Value: 'email' },
-                            { Name: 'phone_number', Value: 'phone_number' },
-                            { Name: 'email_verified', Value: 'false' },
-                            { Name: 'phone_number_verified', Value: 'true' },
-                            { Name: 'sub', Value: 'fefefe' }
-                        ]);
-                    });
-                });
-
-            const spyon3 = jest.spyOn(Auth.prototype, 'currentCredentials').mockImplementationOnce(() => {
-                return Promise.resolve({
-                    identityId: 'identityId'
-                });
-            });
-
-            const spyon4 = jest.spyOn(Credentials, 'getCredSource').mockImplementationOnce(() => {
-                return 'aws';
-            });
-
-            expect.assertions(1);
-            expect(await auth.currentUserInfo()).toEqual({
-                username: 'username',
-                id: 'identityId',
-                attributes: {
-                    email: 'email',
-                    phone_number: 'phone_number',
-                    email_verified: false,
-                    phone_number_verified: true
-                }
-            });
-
-            spyon.mockClear();
-            spyon2.mockClear();
-            spyon3.mockClear();
-            spyon4.mockClear();
-        });
-
-        test('return empty object if error happens', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            const spyon = jest.spyOn(Auth.prototype, 'currentUserPoolUser')
-                .mockImplementationOnce(() => {
-                    return new Promise((res, rej) => {
-                        res({
-                            username: 'username'
-                        });
-                    });
-                });
-
-            const spyon2 = jest.spyOn(Auth.prototype, 'userAttributes')
-                .mockImplementationOnce(() => {
-                    return new Promise((res, rej) => {
-                        rej('err');
-                    });
-                });
-
-            const spyon3 = jest.spyOn(Auth.prototype, 'currentCredentials').mockImplementationOnce(() => {
-                return Promise.resolve({
-                    IdentityPoolId: 'identityPoolId',
-                    identityId: 'identityId'
-                });
-            });
-
-            const spyon4 = jest.spyOn(Credentials, 'getCredSource').mockImplementationOnce(() => {
-                return 'aws';
-            });
-
-            expect.assertions(1);
-            expect(await auth.currentUserInfo()).toEqual({});
-
-            spyon.mockClear();
-            spyon2.mockClear();
-            spyon3.mockClear();
-            spyon4.mockClear();
-        });
-
-        test('no credentials source', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            const spyon = jest.spyOn(Credentials, 'getCredSource').mockImplementationOnce(() => {
-                return null;
-            });
-
-            expect.assertions(1);
-            expect(await auth.currentUserInfo()).toEqual(null);
-
-            spyon.mockClear();
-        });
-
-        test('no current userpool user', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            auth['credentials_source'] = 'aws';
-
-            const spyon = jest.spyOn(Auth.prototype, 'currentUserPoolUser')
-                .mockImplementationOnce(() => {
-                    return new Promise((res, rej) => {
-                        res(null);
-                    });
-                });
-
-            const spyon2 = jest.spyOn(Credentials, 'getCredSource').mockImplementationOnce(() => {
-                return 'aws';
-            });
-
-            expect.assertions(1);
-            expect(await auth.currentUserInfo()).toBeNull();
-
-            spyon.mockClear();
-            spyon2.mockClear();
-        });
-
-        test('federated user', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            auth['user'] = 'federated_user';
-
-            const spyon = jest.spyOn(Credentials, 'getCredSource').mockImplementationOnce(() => {
-                return 'federated';
-            });
-
-            expect.assertions(1);
-            expect(await auth.currentUserInfo()).toBe('federated_user');
-
-            spyon.mockClear();
-        });
-    });
-
-    describe('updateUserAttributes test', () => {
-        test('happy case', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            const attributes = {
-                'email': 'email',
-                'phone_number': 'phone_number',
-                'sub': 'sub'
-            }
-            const spyon = jest.spyOn(Auth.prototype, 'userSession').mockImplementationOnce(() => {
-                return new Promise((res, rej) => {
-                    res(session);
-                })
-            });
-            
-            expect.assertions(1);
-            expect(await auth.updateUserAttributes(user,attributes)).toBe('SUCCESS');
-
-            spyon.mockClear();
-        });
-    });
-
-    describe('federatedSignIn test', () => {
-        test('happy case', async () => {
-            const auth = new Auth(authOptions);
-
-            const spyon = jest.spyOn(Credentials, 'set').mockImplementationOnce(() => {
-                return Promise.resolve('cred');
-            });
-
-            auth.federatedSignIn('google', { token: 'token', expires_at: 1234 }, { user: 'user' });
-
-            expect(spyon).toBeCalled();
-            spyon.mockClear();
-        });
-    });
-
-    describe('verifiedContact test', () => {
-        test('happy case with unverified', async () => {
-            const spyon = jest.spyOn(Auth.prototype, 'userAttributes')
-                .mockImplementationOnce(() => {
-                    return new Promise((res, rej) => {
-                        res([{
-                            Name: 'email',
-                            Value: 'email@amazon.com'
-                        },
-                        {
-                            Name: 'phone_number',
-                            Value: '+12345678901'
-                        }]);
-                    });
-                });
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect(await auth.verifiedContact(user)).toEqual({
-                "unverified": { "email": "email@amazon.com", "phone_number": "+12345678901" },
-                "verified": {}
-            });
-
-            spyon.mockClear();
-        });
-
-        test('happy case with unverified', async () => {
-            const spyon = jest.spyOn(Auth.prototype, 'userAttributes')
-                .mockImplementationOnce(() => {
-                    return new Promise((res, rej) => {
-                        res([{
-                            Name: 'email',
-                            Value: 'email@amazon.com'
-                        },
-                        {
-                            Name: 'phone_number',
-                            Value: '+12345678901'
-                        },
-                        {
-                            Name: 'email_verified',
-                            Value: true
-                        },
-                        {
-                            Name: 'phone_number_verified',
-                            Value: true
-                        }]);
-                    });
-                });
-
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect(await auth.verifiedContact(user)).toEqual({
-                "unverified": {},
-                "verified": { "email": "email@amazon.com", "phone_number": "+12345678901" }
-            });
-
-            spyon.mockClear();
-        });
-    });
-
-    describe('currentUserPoolUser test', () => {
-        test('happy case', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            const spyon = jest.spyOn(CognitoUserPool.prototype, 'getCurrentUser')
-                .mockImplementation(() => {
-                    return user;
-                });
-            const spyon2 = jest.spyOn(CognitoUser.prototype, 'getSession')
-                .mockImplementation((callback) => {
-                    return callback(null, 'session');
-                });
-
-            expect.assertions(1);
-            auth.currentUserPoolUser()
-                .then((user) => {
-                    expect(user).toEqual(user);
-                    spyon.mockClear();
-                    spyon2.mockClear();
-                })
-                .catch((e) => {
-                    expect(e).toBe('No current user in userPool');
-                });
-
-            // expect(await auth.currentUserPoolUser()).toEqual(user);
-        });
-
-        test('no current user', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            const spyon = jest.spyOn(CognitoUserPool.prototype, 'getCurrentUser')
-                .mockImplementation(() => {
-                    return null;
-                });
-
-            expect.assertions(1);
-            try {
-                await auth.currentUserPoolUser();
-            } catch (e) {
-                expect(e).toBe('No current user in userPool');
-            }
-
-            spyon.mockClear();
-        });
-
-        test('No userPool', async () => {
-            // @ts-ignore
-            const auth = new Auth(authOptionsWithNoUserPoolId);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            expect.assertions(1);
-            try {
-                await auth.currentUserPoolUser();
-            } catch (e) {
-                expect(e).toBe('No userPool');
-            }
-        });
-
-        test('get session error', async () => {
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-
-            const spyon = jest.spyOn(CognitoUserPool.prototype, 'getCurrentUser')
-                .mockImplementation(() => {
-                    return user;
-                });
-            const spyon2 = jest.spyOn(CognitoUser.prototype, 'getSession')
-                .mockImplementation((callback) => {
-                    return callback('err', null);
-                });
-
-            expect.assertions(1);
-            try {
-                await auth.currentUserPoolUser();
-            } catch (e) {
-                expect(e).toBe('err');
-            }
-
-            spyon.mockClear();
-            spyon2.mockClear();
-        });
-    });
-
-    describe('sendCustomChallengeAnswer', () => {
-        test('happy case', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'sendCustomChallengeAnswer')
-                .mockImplementationOnce((challengeResponses, callback) => {
-                    callback.onSuccess(session);
-                });
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            const userAfterCustomChallengeAnswer = Object.assign(
-                new CognitoUser({
-                    Username: 'username',
-                    Pool: userPool
-                }),
-                {
-                    "challengeName": "CUSTOM_CHALLENGE",
-                    "challengeParam": "challengeParam"
-                });
-
-            expect.assertions(1);
-            expect(await auth.sendCustomChallengeAnswer(userAfterCustomChallengeAnswer, 'challengeResponse')).toEqual(user);
-
-            spyon.mockClear();
-        });
-
-        test('customChallenge', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'sendCustomChallengeAnswer')
-                .mockImplementationOnce((challengeResponses, callback) => {
-                    callback.customChallenge('challengeParam');
-                });
-            const auth = new Auth(authOptions);
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool
-            });
-            const userAfterCustomChallengeAnswer = Object.assign(
-                new CognitoUser({
-                    Username: 'username',
-                    Pool: userPool
-                }),
-                {
-                    "challengeName": "CUSTOM_CHALLENGE",
-                    "challengeParam": "challengeParam"
-                });
-
-            expect.assertions(1);
-            expect(await auth.sendCustomChallengeAnswer(userAfterCustomChallengeAnswer, 'challengeResponse')).toEqual(userAfterCustomChallengeAnswer);
-
-            spyon.mockClear();
-        });
-
-        test('onFailure', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'sendCustomChallengeAnswer')
-                .mockImplementationOnce((challengeResponses, callback) => {
-                    callback.onFailure('err');
-                });
-
-            const auth = new Auth(authOptions);
-            const userAfterCustomChallengeAnswer = Object.assign(
-                new CognitoUser({
-                    Username: 'username',
-                    Pool: userPool
-                }),
-                {
-                    "challengeName": "CUSTOM_CHALLENGE",
-                    "challengeParam": "challengeParam"
-                });
-
-            expect.assertions(1);
-            try {
-                await auth.sendCustomChallengeAnswer(userAfterCustomChallengeAnswer, 'challengeResponse');
-            } catch (e) {
-                expect(e).toBe('err');
-            }
-
-            spyon.mockClear();
-        });
-
-        test('no userPool', async () => {
-            const spyon = jest.spyOn(CognitoUser.prototype, 'sendCustomChallengeAnswer');
-
-            // @ts-ignore
-            const auth = new Auth(authOptionsWithNoUserPoolId);
-            const userAfterCustomChallengeAnswer = Object.assign(
-                new CognitoUser({
-                    Username: 'username',
-                    Pool: userPool
-                }),
-                {
-                    "challengeName": "CUSTOM_CHALLENGE",
-                    "challengeParam": "challengeParam"
-                });
-
-            expect.assertions(1);
-            try {
-                await auth.sendCustomChallengeAnswer(userAfterCustomChallengeAnswer, 'challengeResponse');
-            } catch (e) {
-                expect(e).toBe('No userPool');
-            }
-
-            spyon.mockClear();
-        });
-    });
-
-    describe('hosted ui test', () => {
-        test('happy case', () => {
-            const oauth = {};
-
-            const authOptions = {
-                Auth: {
-                    userPoolId: "awsUserPoolsId",
-                    userPoolWebClientId: "awsUserPoolsWebClientId",
-                    region: "region",
-                    identityPoolId: "awsCognitoIdentityPoolId",
-                    oauth
-                }
-            };
-            const spyon = jest.spyOn(Auth.prototype, 'currentAuthenticatedUser').mockImplementationOnce(() => {
-                return Promise.reject('err');
-            });
-
-
-            const auth = new Auth(authOptions);
-            expect(spyon).toBeCalled();
-
-            spyon.mockClear();
-          
-        });
-    });
-});
-
-
-    
-

--- a/packages/aws-amplify/src/Auth/Auth.ts
+++ b/packages/aws-amplify/src/Auth/Auth.ts
@@ -11,1190 +11,1364 @@
  * and limitations under the License.
  */
 
-import { AuthOptions, FederatedResponse, ConfirmSignUpOptions } from './types';
+import { AuthOptions, FederatedResponse, ConfirmSignUpOptions } from "./types";
 
 import {
-    AWS,
-    Cognito,
-    CognitoHostedUI,
-    ConsoleLogger as Logger,
-    Constants,
-    Hub,
-    JS,
-    Parser,
-    Credentials,
-    StorageHelper
-} from '../Common';
-import Platform from '../Common/Platform';
-import Cache from '../Cache';
-import { ICognitoUserPoolData, ICognitoUserData } from 'amazon-cognito-identity-js';
-import '../Common/Polyfills';
+  AWS,
+  Cognito,
+  CognitoHostedUI,
+  ConsoleLogger as Logger,
+  Constants,
+  Hub,
+  JS,
+  Parser,
+  Credentials,
+  StorageHelper
+} from "../Common";
+import Platform from "../Common/Platform";
+import Cache from "../Cache";
+import {
+  ICognitoUserPoolData,
+  ICognitoUserData
+} from "amazon-cognito-identity-js";
+import "../Common/Polyfills";
 
-const logger = new Logger('AuthClass');
+const logger = new Logger("AuthClass");
 
 const { CognitoAuth } = CognitoHostedUI;
 
 const {
-    CookieStorage,
-    CognitoUserPool,
-    CognitoUserAttribute,
-    CognitoUser,
-    AuthenticationDetails,
+  CookieStorage,
+  CognitoUserPool,
+  CognitoUserAttribute,
+  CognitoUser,
+  AuthenticationDetails
 } = Cognito;
 
 const dispatchAuthEvent = (event, data) => {
-    Hub.dispatch('auth', { event, data }, 'Auth');
+  Hub.dispatch("auth", { event, data }, "Auth");
 };
 
 /**
-* Provide authentication steps
-*/
+ * Provide authentication steps
+ */
 export default class AuthClass {
-    private _config: AuthOptions;
-    private _userPoolStorageSync: Promise<any>;
-    private userPool = null;
-    private _cognitoAuthClient = null;
-    private user:any = null;
+  private _config: AuthOptions;
+  private _userPoolStorageSync: Promise<any>;
+  private userPool = null;
+  private _cognitoAuthClient = null;
+  private user: any = null;
 
-    private _gettingCredPromise = null;
+  private _gettingCredPromise = null;
 
-    /**
-     * Initialize Auth with AWS configurations
-     * @param {Object} config - Configuration of the Auth
-     */
-    constructor(config: AuthOptions) {
-        this.configure(config);
+  /**
+   * Initialize Auth with AWS configurations
+   * @param {Object} config - Configuration of the Auth
+   */
+  constructor(config: AuthOptions) {
+    this.configure(config);
 
-        this.currentUserCredentials = this.currentUserCredentials.bind(this);
+    this.currentUserCredentials = this.currentUserCredentials.bind(this);
 
-        if (AWS.config) {
-            AWS.config.update({customUserAgent: Constants.userAgent});
-        } else {
-            logger.warn('No AWS.config');
-        }
+    if (AWS.config) {
+      AWS.config.update({ customUserAgent: Constants.userAgent });
+    } else {
+      logger.warn("No AWS.config");
     }
+  }
 
-    configure(config) {
-        if (!config) return this._config || {};
-        logger.debug('configure Auth');
-        const conf = Object.assign({}, this._config, Parser.parseMobilehubConfig(config).Auth, config);
-        this._config = conf;
+  configure(config) {
+    if (!config) return this._config || {};
+    logger.debug("configure Auth");
+    const conf = Object.assign(
+      {},
+      this._config,
+      Parser.parseMobilehubConfig(config).Auth,
+      config
+    );
+    this._config = conf;
 
-        if (!this._config.identityPoolId) { logger.debug('Do not have identityPoolId yet.'); }
-        const { 
-            userPoolId, 
-            userPoolWebClientId, 
-            cookieStorage, 
-            oauth, 
-            region, 
-            identityPoolId, 
-            mandatorySignIn,
-            refreshHandlers
-        } = this._config;
-
-        if (userPoolId) {
-            const userPoolData: ICognitoUserPoolData = {
-                UserPoolId: userPoolId,
-                ClientId: userPoolWebClientId,
-            };
-            if (cookieStorage) {
-                userPoolData.Storage = new CookieStorage(cookieStorage);
-            }
-            this.userPool = new CognitoUserPool(userPoolData);
-            if (Platform.isReactNative) {
-                const that = this;
-                this._userPoolStorageSync = new Promise((resolve, reject) => {
-                    this.userPool.storage.sync((err, data) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(data);
-                        }
-                    });
-                });
-            }
-        }
-
-        Credentials.configure({
-            mandatorySignIn,
-            region,
-            userPoolId,
-            identityPoolId,
-            refreshHandlers
-        });
-
-        // initiailize cognitoauth client if hosted ui options provided
-        if (oauth) {
-            const that = this;
-
-            const cognitoAuthParams = Object.assign(
-                {
-                    ClientId: userPoolWebClientId,
-                    UserPoolId: userPoolId,
-                    AppWebDomain: oauth.domain,
-                    TokenScopesArray: oauth.scope,
-                    RedirectUriSignIn: oauth.redirectSignIn,
-                    RedirectUriSignOut: oauth.redirectSignOut,
-                    ResponseType: oauth.responseType,
-                    Storage: this.userPool.Storage
-                },
-                oauth.options
-            );
-
-            logger.debug('cognito auth params', cognitoAuthParams);
-            this._cognitoAuthClient = new CognitoAuth(cognitoAuthParams);
-            this._cognitoAuthClient.userhandler = {
-                // user signed in
-                onSuccess: (result) => {
-                    that.user = that.userPool.getCurrentUser();
-                    logger.debug("Cognito Hosted authentication result", result);
-                    that.currentSession().then(async (session) => {
-                        try {
-                            const cred = await Credentials.set(session, 'session');
-                            logger.debug('sign in succefully with', cred);
-                        } catch (e) {
-                            logger.debug('sign in without aws credentials', e);
-                        } finally {
-                            dispatchAuthEvent('signIn', that.user);
-                            dispatchAuthEvent('cognitoHostedUI', that.user);
-                        }
-                    });
-                },
-                onFailure: (err) => {
-                    logger.debug("Error in cognito hosted auth response", err);
-                }
-            };
-            // if not logged in, try to parse the url.
-            this.currentAuthenticatedUser().then(() => {
-                logger.debug('user already logged in');
-            }).catch(e => {
-                logger.debug('not logged in, try to parse the url');
-                const curUrl = window.location.href;
-                this._cognitoAuthClient.parseCognitoWebResponse(curUrl);
-            });
-        }
-
-        dispatchAuthEvent('configured', null);
-        return this._config;
+    if (!this._config.identityPoolId) {
+      logger.debug("Do not have identityPoolId yet.");
     }
+    const {
+      userPoolId,
+      userPoolWebClientId,
+      cookieStorage,
+      oauth,
+      region,
+      identityPoolId,
+      mandatorySignIn,
+      refreshHandlers
+    } = this._config;
 
-    /**
-     * Sign up with username, password and other attrbutes like phone, email
-     * @param {String | object} params - The user attirbutes used for signin
-     * @param {String[]} restOfAttrs - for the backward compatability
-     * @return - A promise resolves callback data if success
-     */
-    public signUp(params: string | object, ...restOfAttrs: string[]): Promise<any> {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
-
-        let username : string = null;
-        let password : string = null;
-        const attributes : object[] = [];
-        let validationData: object[] = null;
-        if (params && typeof params === 'string') {
-            username = params;
-            password = restOfAttrs? restOfAttrs[0] : null;
-            const email : string = restOfAttrs? restOfAttrs[1] : null;
-            const phone_number : string = restOfAttrs? restOfAttrs[2] : null;
-            if (email) attributes.push({Name: 'email', Value: email});
-            if (phone_number) attributes.push({Name: 'phone_number', Value: phone_number});
-        } else if (params && typeof params === 'object') {
-            username = params['username'];
-            password = params['password'];
-            const attrs = params['attributes'];
-            if (attrs) {
-                Object.keys(attrs).map(key => {
-                    const ele : object = { Name: key, Value: attrs[key] };
-                    attributes.push(ele);
-                });
-            }
-            validationData = params['validationData'] || null;
-        } else {
-            return Promise.reject('The first parameter should either be non-null string or object');
-        }
-
-        if (!username) { return Promise.reject('Username cannot be empty'); }
-        if (!password) { return Promise.reject('Password cannot be empty'); }
-
-        logger.debug('signUp attrs:', attributes);
-        logger.debug('signUp validation data:', validationData);
-
-        return new Promise((resolve, reject) => {
-            this.userPool.signUp(username, password, attributes, validationData, function(err, data) {
-                if (err) {
-                    dispatchAuthEvent('signUp_failure', err);
-                    reject(err);
-                } else {
-                    dispatchAuthEvent('signUp', data);
-                    resolve(data);
-                }
-            });
-        });
-    }
-
-    /**
-     * Send the verfication code to confirm sign up
-     * @param {String} username - The username to be confirmed
-     * @param {String} code - The verification code
-     * @param {ConfirmSignUpOptions} options - other options for confirm signup
-     * @return - A promise resolves callback data if success
-     */
-    public confirmSignUp(username: string, code: string, options?: ConfirmSignUpOptions): Promise<any> {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
-        if (!username) { return Promise.reject('Username cannot be empty'); }
-        if (!code) { return Promise.reject('Code cannot be empty'); }
-
-        const user = this.createCognitoUser(username);
-        const forceAliasCreation = options && typeof options.forceAliasCreation === 'boolean'
-            ? options.forceAliasCreation : true;
-
-        return new Promise((resolve, reject) => {
-            user.confirmRegistration(code, forceAliasCreation, function(err, data) {
-                if (err) { reject(err); } else { resolve(data); }
-            });
-        });
-    }
-
-    /**
-     * Resend the verification code
-     * @param {String} username - The username to be confirmed
-     * @return - A promise resolves data if success
-     */
-    public resendSignUp(username: string): Promise<any> {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
-        if (!username) { return Promise.reject('Username cannot be empty'); }
-
-        const user = this.createCognitoUser(username);
-        return new Promise((resolve, reject) => {
-            user.resendConfirmationCode(function(err, data) {
-                if (err) { reject(err); } else { resolve(data); }
-            });
-        });
-    }
-
-    /**
-     * Sign in
-     * @param {String} username - The username to be signed in
-     * @param {String} password - The password of the username
-     * @return - A promise resolves the CognitoUser
-     */
-    public signIn(username: string, password?: string): Promise<any> {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
-        if (!username) { return Promise.reject('Username cannot be empty'); }
-
-        if (password) {
-            return this.signInWithPassword(username, password);
-        } else {
-            return this.signInWithoutPassword(username);
-        }
-    }
-
-    /**
-     * Return an object with the authentication callbacks
-     * @param {CognitoUser} user - the cognito user object
-     * @param {} resolve - function called when resolving the current step
-     * @param {} reject - function called when rejecting the current step
-     * @return - an object with the callback methods for user authentication
-     */
-    private authCallbacks(user, resolve: (value?: any) => void, reject: (value?: any) => void) {
+    if (userPoolId) {
+      const userPoolData: ICognitoUserPoolData = {
+        UserPoolId: userPoolId,
+        ClientId: userPoolWebClientId
+      };
+      if (cookieStorage) {
+        userPoolData.Storage = new CookieStorage(cookieStorage);
+      }
+      this.userPool = new CognitoUserPool(userPoolData);
+      if (Platform.isReactNative) {
         const that = this;
-        return {
-            onSuccess: async (session) => {
-                logger.debug(session);
-                delete(user['challengeName']);
-                delete(user['challengeParam']);
-                try {
-                    const cred = await Credentials.set(session, 'session');
-                    logger.debug('succeed to get cognito credentials', cred);
-                } catch (e) {
-                    logger.debug('cannot get cognito credentials', e);
-                } finally {
-                    that.user = user;
-                    dispatchAuthEvent('signIn', user);
-                    resolve(user);
-                }
-            },
-        onFailure: (err) => {
-                logger.debug('signIn failure', err);
-                dispatchAuthEvent('signIn_failure', err);
-                reject(err);
-            },
-            customChallenge: (challengeParam) => {
-                logger.debug('signIn custom challenge answer required');
-                user['challengeName'] = 'CUSTOM_CHALLENGE';
-                user['challengeParam'] = challengeParam;
-                resolve(user);
-            },
-            mfaRequired: (challengeName, challengeParam) => {
-                logger.debug('signIn MFA required');
-                user['challengeName'] = challengeName;
-                user['challengeParam'] = challengeParam;
-                resolve(user);
-            },
-            mfaSetup: (challengeName, challengeParam) => {
-                logger.debug('signIn mfa setup', challengeName);
-                user['challengeName'] = challengeName;
-                user['challengeParam'] = challengeParam;
-                resolve(user);
-            },
-            newPasswordRequired: (userAttributes, requiredAttributes) => {
-                logger.debug('signIn new password');
-                user['challengeName'] = 'NEW_PASSWORD_REQUIRED';
-                user['challengeParam'] = {
-                    userAttributes,
-                    requiredAttributes
-                };
-                resolve(user);
-            },
-            totpRequired: (challengeName, challengeParam) => {
-                logger.debug('signIn totpRequired');
-                user['challengeName'] = challengeName;
-                user['challengeParam'] = challengeParam;
-                resolve(user);
-            },
-            selectMFAType: (challengeName, challengeParam) => {
-                logger.debug('signIn selectMFAType', challengeName);
-                user['challengeName'] = challengeName;
-                user['challengeParam'] = challengeParam;
-                resolve(user);
-            }
-        };
-    }
-
-    /**
-     * Sign in with a password
-     * @param {String} username - The username to be signed in
-     * @param {String} password - The password of the username
-     * @return - A promise resolves the CognitoUser object if success or mfa required
-     */
-    private signInWithPassword(username: string, password: string): Promise<any> {
-        const user = this.createCognitoUser(username);
-        const authDetails = new AuthenticationDetails({
-            Username: username,
-            Password: password
-        });
-
-        return new Promise((resolve, reject) => {
-            user.authenticateUser(authDetails, this.authCallbacks(user, resolve, reject));
-        });
-    }
-
-    /**
-     * Sign in without a password
-     * @param {String} username - The username to be signed in
-     * @return - A promise resolves the CognitoUser object if success or mfa required
-     */
-    private signInWithoutPassword(username: string): Promise<any> {
-        const user = this.createCognitoUser(username);
-        user.setAuthenticationFlowType('CUSTOM_AUTH');
-        const authDetails = new AuthenticationDetails({
-            Username: username,
-        });
-
-        return new Promise((resolve, reject) => {
-            user.initiateAuth(authDetails, this.authCallbacks(user, resolve, reject));
-        });
-    }
-
-    /**
-     * get user current preferred mfa option
-     * @param {CognitoUser} user - the current user
-     * @return - A promise resolves the current preferred mfa option if success
-     */
-    public getMFAOptions(user : any) : Promise<any> {
-        return new Promise((res, rej) => {
-            user.getMFAOptions((err, mfaOptions) => {
-                if (err) {
-                    logger.debug('get MFA Options failed', err);
-                    rej(err);
-                }
-                logger.debug('get MFA options success', mfaOptions);
-                res(mfaOptions);
-            });
-        });
-    }
-    
-    /**
-     * set preferred MFA method
-     * @param {CognitoUser} user - the current Cognito user
-     * @param {string} mfaMethod - preferred mfa method
-     * @return - A promise resolve if success
-     */
-    public setPreferredMFA(user : any, mfaMethod : string): Promise<any> {
-        let smsMfaSettings = null;
-        let totpMfaSettings = {
-            PreferredMfa : false,
-            Enabled : false
-        };
-
-        switch(mfaMethod) {
-            case 'TOTP':
-                totpMfaSettings = {
-                    PreferredMfa : true,
-                    Enabled : true
-                };
-                break;
-            case 'SMS':
-                smsMfaSettings = {
-                    PreferredMfa : true,
-                    Enabled : true
-                };
-                break;
-            case 'NOMFA':
-                break;
-            default:
-                logger.debug('no validmfa method provided');
-                return Promise.reject('no validmfa method provided');
-        }
-
-        const that = this;
-        const TOTP_NOT_VERIFED = 'User has not verified software token mfa';
-        const TOTP_NOT_SETUP = 'User has not set up software token mfa';
-        return new Promise((res, rej) => {
-            user.setUserMfaPreference(smsMfaSettings, totpMfaSettings, (err, result) => {
-                if (err) {
-                    // if totp not setup or verified and user want to set it, return error
-                    // otherwise igonre it
-                    if (err.message === TOTP_NOT_SETUP || err.message === TOTP_NOT_VERIFED) {
-                        if (mfaMethod === 'SMS') {
-                            that.enableSMS(user).then((data) => {
-                                logger.debug('Set user mfa success', data);
-                                res(data);
-                            }).catch(err => {
-                                logger.debug('Set user mfa preference error', err);
-                                rej(err);
-                            });
-                        } else if (mfaMethod === 'NOMFA') {
-                            // diable sms
-                            that.disableSMS(user).then((data) => {
-                                logger.debug('Set user mfa success', data);
-                                res(data);
-                            }).catch(err => {
-                                logger.debug('Set user mfa preference error', err);
-                                rej(err);
-                            });
-                        } else {
-                            logger.debug('Set user mfa preference error', err);
-                            rej(err);
-                        }
-                    } else {
-                        logger.debug('Set user mfa preference error', err);
-                        rej(err);
-                    }
-                }
-                logger.debug('Set user mfa success', result);
-                res(result);
-            });
-        });
-    }
-
-    /**
-     * diable SMS
-     * @param {CognitoUser} user - the current user
-     * @return - A promise resolves is success
-     */
-    public disableSMS(user : any) : Promise<any> {
-        return new Promise((res, rej) => {
-            user.disableMFA((err, data) => {
-                if (err) {
-                    logger.debug('disable mfa failed', err);
-                    rej(err);
-                }
-                logger.debug('disable mfa succeed', data);
-                res(data);
-            });
-        });
-    }
-
-    /**
-     * enable SMS
-     * @param {CognitoUser} user - the current user
-     * @return - A promise resolves is success
-     */
-    public enableSMS(user) {
-        return new Promise((res, rej) => {
-            user.enableMFA((err, data) => {
-                if (err) {
-                    logger.debug('enable mfa failed', err);
-                    rej(err);
-                }
-                logger.debug('enable mfa succeed', data);
-                res(data);
-            });
-        });
-    }
-
-    /**
-     * Setup TOTP
-     * @param {CognitoUser} user - the current user
-     * @return - A promise resolves with the secret code if success
-     */
-    public setupTOTP(user) {
-        return new Promise((res, rej) => {
-            user.associateSoftwareToken({
-                onFailure: (err) => {
-                    logger.debug('associateSoftwareToken failed', err);
-                    rej(err);
-                },
-                associateSecretCode: (secretCode) => {
-                    logger.debug('associateSoftwareToken sucess', secretCode);
-                    res(secretCode);
-                }
-            });
-        });
-    }
-
-    /**
-     * verify TOTP setup
-     * @param {CognitoUser} user - the current user
-     * @param {string} challengeAnswer - challenge answer
-     * @return - A promise resolves is success
-     */
-    public verifyTotpToken(user, challengeAnswer) {
-        logger.debug('verfication totp token', user, challengeAnswer);
-        return new Promise((res, rej) => {
-            user.verifySoftwareToken(challengeAnswer, 'My TOTP device', {
-                onFailure: (err) => {
-                    logger.debug('verifyTotpToken failed', err);
-                    rej(err);
-                },
-                onSuccess: (data) => {
-                    logger.debug('verifyTotpToken success', data);
-                    res(data);
-                }
-            });
-        });
-    }
-
-    /**
-     * Send MFA code to confirm sign in
-     * @param {Object} user - The CognitoUser object
-     * @param {String} code - The confirmation code
-     */
-    public confirmSignIn(user: any, code: string, mfaType: string | null): Promise<any> {
-        if (!code) { return Promise.reject('Code cannot be empty'); }
-
-        const that = this;
-        return new Promise((resolve, reject) => {
-            user.sendMFACode(
-                code, {
-                    onSuccess: async (session) => {
-                        logger.debug(session);
-                        try {
-                            const cred = await Credentials.set(session, 'session');
-                            logger.debug('succeed to get cognito credentials', cred);
-                        } catch (e) {
-                            logger.debug('cannot get cognito credentials', e);
-                        } finally {
-                            that.user = user;
-                            dispatchAuthEvent('signIn', user);
-                            resolve(user);
-                        }
-                    },
-                    onFailure: (err) => {
-                        logger.debug('confirm signIn failure', err);
-                        reject(err);
-                    }
-                }, 
-                mfaType);
-        });
-    }
-
-    public completeNewPassword(
-        user: any,
-        password: string,
-        requiredAttributes: any
-    ): Promise<any> {
-        if (!password) { return Promise.reject('Password cannot be empty'); }
-
-        const that = this;
-        return new Promise((resolve, reject) => {
-            user.completeNewPasswordChallenge(password, requiredAttributes, {
-                onSuccess: async (session) => {
-                    logger.debug(session);
-                    try {
-                        const cred = await Credentials.set(session, 'session');
-                        logger.debug('succeed to get cognito credentials', cred);
-                    } catch (e) {
-                        logger.debug('cannot get cognito credentials', e);
-                    } finally {
-                        that.user = user;
-                        dispatchAuthEvent('signIn', user);
-                        resolve(user);
-                    }
-                },
-                onFailure: (err) => {
-                    logger.debug('completeNewPassword failure', err);
-                    dispatchAuthEvent('completeNewPassword_failure', err);
-                    reject(err);
-                },
-                mfaRequired: (challengeName, challengeParam) => {
-                    logger.debug('signIn MFA required');
-                    user['challengeName'] = challengeName;
-                    user['challengeParam'] = challengeParam;
-                    resolve(user);
-                },
-                mfaSetup: (challengeName, challengeParam) => {
-                    logger.debug('signIn mfa setup', challengeName);
-                    user['challengeName'] = challengeName;
-                    user['challengeParam'] = challengeParam;
-                    resolve(user);
-                }
-            });
-        });
-    }
-
-    /**
-     * Send the answer to a custom challenge
-     * @param {CognitoUser} user - The CognitoUser object
-     * @param {String} challengeResponses - The confirmation code
-     */
-    public sendCustomChallengeAnswer(user, challengeResponses: string): Promise<any> {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
-        if (!challengeResponses) { return Promise.reject('Challenge response cannot be empty'); }
-
-        const that = this;
-        return new Promise((resolve, reject) => {
-            user.sendCustomChallengeAnswer(challengeResponses, this.authCallbacks(user, resolve, reject));
-        });
-    }
-
-    /**
-     * Update an authenticated users' attributes
-     * @param {CognitoUser} - The currently logged in user object
-     * @return {Promise}
-     **/
-    public updateUserAttributes(user, attributes:object): Promise<any> {
-        let attr:object = {};
-        const attributeList:Array<object> = [];
-        return this.userSession(user)
-            .then(session => {
-                return new Promise((resolve, reject) => {
-                    for (const key in attributes) {
-                        if ( key !== 'sub' &&
-                            key.indexOf('_verified') < 0) {
-                            attr = {
-                                'Name': key,
-                                'Value': attributes[key]
-                            };
-                            attributeList.push(attr);
-                        }
-                    }
-                    user.updateAttributes(attributeList, (err,result) => {
-                        if (err) { reject(err); } else { resolve(result); }
-                    });
-                });
-            });
-    }
-    /**
-     * Return user attributes
-     * @param {Object} user - The CognitoUser object
-     * @return - A promise resolves to user attributes if success
-     */
-    public userAttributes(user): Promise<any> {
-        return this.userSession(user)
-            .then(session => {
-                return new Promise((resolve, reject) => {
-                    user.getUserAttributes((err, attributes) => {
-                        if (err) { reject(err); } else { resolve(attributes); }
-                    });
-                });
-            });
-    }
-
-    public verifiedContact(user) {
-        const that = this;
-        return this.userAttributes(user)
-            .then(attributes => {
-                const attrs = that.attributesToObject(attributes);
-                const unverified = {};
-                const verified = {};
-                if (attrs['email']) {
-                    if (attrs['email_verified']) {
-                        verified['email'] = attrs['email'];
-                    } else {
-                        unverified['email'] = attrs['email'];
-                    }
-                }
-                if (attrs['phone_number']) {
-                    if (attrs['phone_number_verified']) {
-                        verified['phone_number'] = attrs['phone_number'];
-                    } else {
-                        unverified['phone_number'] = attrs['phone_number'];
-                    }
-                }
-                return {
-                    verified,
-                    unverified
-                };
-            });
-    }
-
-    /**
-     * Get current authenticated user
-     * @return - A promise resolves to curret authenticated CognitoUser if success
-     */
-    public currentUserPoolUser(): Promise<any> {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
-        let user = null;
-        if (Platform.isReactNative) {
-            const that = this;
-            return this.getSyncedUser().then(user => {
-                if (!user) { return Promise.reject('No current user in userPool'); }
-                return new Promise((resolve, reject) => {
-                    user.getSession(function(err, session) {
-                        if (err) { reject(err); } else { resolve(user); }
-                    });
-                });
-            });
-        } else {
-            user = this.userPool.getCurrentUser();
-            if (!user) { return Promise.reject('No current user in userPool'); }
-            return new Promise((resolve, reject) => {
-                user.getSession(function(err, session) {
-                    if (err) { reject(err); } else { resolve(user); }
-                });
-            });
-        }
-    }
-
-    /**
-     * Return the current user after synchornizing AsyncStorage
-     * @return - A promise with the current authenticated user
-     **/
-    private getSyncedUser(): Promise<any> {
-        const that = this;
-        return (this._userPoolStorageSync || Promise.resolve()).then(result => {
-            if (!that.userPool) {
-                return Promise.reject('No userPool');
-            }
-            return that.userPool.getCurrentUser();
-        });
-    }
-
-    /**
-     * Get current authenticated user
-     * @return - A promise resolves to curret authenticated CognitoUser if success
-     */
-    public async currentAuthenticatedUser(): Promise<any> {
-        logger.debug('getting current authenticted user');
-        let federatedUser = null;
-        try {
-            federatedUser = await Cache.getItem('federatedInfo').user;
-        } catch (e) {
-            logger.debug('cannot load federated user from cache');
-        }
-        
-        if (federatedUser) {
-            this.user = federatedUser;
-            logger.debug('get current authenticated federated user', this.user);
-            return this.user;
-        } else {
-            logger.debug('get current authenticated userpool user');
-            let user = null;
-            try {
-                user = await this.currentUserPoolUser();
-            } catch (e) {
-                throw 'not authenticated';
-            }
-            let attributes = {};
-            try {
-                attributes = this.attributesToObject(await this.userAttributes(user));
-            } catch (e) {
-                logger.debug('cannot get user attributes');
-            } finally {
-                this.user = Object.assign(user, { attributes });
-                return this.user;
-            }
-        }
-    }
-
-    /**
-     * Get current user's session
-     * @return - A promise resolves to session object if success
-     */
-    public currentSession() : Promise<any> {
-        let user:any;
-        const that = this;
-        logger.debug('Getting current session');
-        if (!this.userPool) { return Promise.reject('No userPool'); }
-        if (Platform.isReactNative) {
-            return this.getSyncedUser().then(user => {
-                if (!user) { 
-                    logger.debug('Failed to get user from user pool');
-                    return Promise.reject('No current user'); 
-                }
-                return that.userSession(user);
-            });
-        } else {
-            user = this.userPool.getCurrentUser();
-            if (!user) {
-                logger.debug('Failed to get user from user pool');
-                return Promise.reject('No current user'); 
-            }
-            return this.userSession(user);
-        }
-    }
-
-    /**
-     * Get the corresponding user session
-     * @param {Object} user - The CognitoUser object
-     * @return - A promise resolves to the session
-     */
-    public userSession(user) : Promise<any> {
-        return new Promise((resolve, reject) => {
-            logger.debug('Getting the session from this user:', user);
-            user.getSession(function(err, session) {
-                if (err) { 
-                    logger.debug('Failed to get the session from user', user);
-                    reject(err); 
-                } else {
-                    logger.debug('Succeed to get the user session', session);
-                    // check if session is expired
-                    if (!session.isValid()) {
-                        const refreshToken = session.getRefreshToken();
-                        logger.debug('Session is not valid, refreshing session with refreshToken', refreshToken);
-                        user.refreshSession(refreshToken, (err, newSession) => {
-                            if (err) {
-                                logger.debug('Refresh Cognito Session failed', err);
-                                reject(err);
-                            }
-                            logger.debug('Refresh Cognito Session success', newSession);
-                            resolve(newSession);
-                        });
-                    } else {
-                        logger.debug('Session is valid, directly return this session');
-                        resolve(session); 
-                    }
-                }
-            });
-        });
-    }
-
-    /**
-     * Get authenticated credentials of current user.
-     * @return - A promise resolves to be current user's credentials
-     */
-    public currentUserCredentials() {
-        const that = this;
-        logger.debug('Getting current user credentials');
-        if (Platform.isReactNative) {
-            // asyncstorage
-            return Cache.getItem('federatedInfo')
-                .then((federatedInfo) => {
-                    if (federatedInfo) {
-                        // refresh the jwt token here if necessary
-                        return Credentials.refreshFederatedToken(federatedInfo);
-                    } else {
-                        return that.currentSession()
-                            .then(session => {
-                                return Credentials.set(session, 'session');
-                            }).catch((error) => {
-                                return Credentials.set(null, 'guest');
-                            });
-                    }
-                }).catch((error) => {
-                    return Promise.reject(error);
-                });
-        } else {
-            // first to check whether there is federation info in the local storage
-            const federatedInfo = Cache.getItem('federatedInfo');
-            if (federatedInfo) {
-                // refresh the jwt token here if necessary
-                return Credentials.refreshFederatedToken(federatedInfo);
+        this._userPoolStorageSync = new Promise((resolve, reject) => {
+          this.userPool.storage.sync((err, data) => {
+            if (err) {
+              reject(err);
             } else {
-                return this.currentSession()
-                    .then(session => {
-                        logger.debug('getting session success', session);
-                        return Credentials.set(session, 'session');
-                    }).catch((error) => {
-                        logger.debug('getting session failed', error);
-                        return Credentials.set(null, 'guest');
-                    });
+              resolve(data);
             }
-        }
-    }
-
-
-    public currentCredentials(): Promise<any> {
-        logger.debug('getting current credntials');
-        return Credentials.get();
-    }
-
-    /**
-     * Initiate an attribute confirmation request
-     * @param {Object} user - The CognitoUser
-     * @param {Object} attr - The attributes to be verified
-     * @return - A promise resolves to callback data if success
-     */
-    public verifyUserAttribute(user, attr): Promise<any> {
-        return new Promise((resolve, reject) => {
-            user.getAttributeVerificationCode(attr, {
-                onSuccess(data) { resolve(data); },
-                onFailure(err) { reject(err); }
-            });
+          });
         });
+      }
     }
 
-    /**
-     * Confirm an attribute using a confirmation code
-     * @param {Object} user - The CognitoUser
-     * @param {Object} attr - The attribute to be verified
-     * @param {String} code - The confirmation code
-     * @return - A promise resolves to callback data if success
-     */
-    public verifyUserAttributeSubmit(user, attr, code): Promise<any> {
-        if (!code) { return Promise.reject('Code cannot be empty'); }
+    Credentials.configure({
+      mandatorySignIn,
+      region,
+      userPoolId,
+      identityPoolId,
+      refreshHandlers
+    });
 
-        return new Promise((resolve, reject) => {
-            user.verifyAttribute(attr, code, {
-                onSuccess(data) { resolve(data); },
-                onFailure(err) { reject(err); }
-            });
-        });
-    }
+    // initiailize cognitoauth client if hosted ui options provided
+    if (oauth) {
+      const that = this;
 
-    verifyCurrentUserAttribute(attr) {
-        const that = this;
-        return that.currentUserPoolUser()
-            .then(user => that.verifyUserAttribute(user, attr));
-    }
+      const cognitoAuthParams = Object.assign(
+        {
+          ClientId: userPoolWebClientId,
+          UserPoolId: userPoolId,
+          AppWebDomain: oauth.domain,
+          TokenScopesArray: oauth.scope,
+          RedirectUriSignIn: oauth.redirectSignIn,
+          RedirectUriSignOut: oauth.redirectSignOut,
+          ResponseType: oauth.responseType,
+          Storage: this.userPool.Storage
+        },
+        oauth.options
+      );
 
-    /**
-     * Confirm current user's attribute using a confirmation code
-     * @param {Object} attr - The attribute to be verified
-     * @param {String} code - The confirmation code
-     * @return - A promise resolves to callback data if success
-     */
-    verifyCurrentUserAttributeSubmit(attr, code) {
-        const that = this;
-        return that.currentUserPoolUser()
-            .then(user => that.verifyUserAttributeSubmit(user, attr, code));
-    }
-    /**
-     * Sign out method
-     * @return - A promise resolved if success
-     */
-    public async signOut(): Promise<any> {
-        try {
-            await this.cleanCachedItems();
-        } catch (e) {
-            logger.debug('failed to clear cached items');
-        }
-
-        if (this.userPool) { 
-            const user = this.userPool.getCurrentUser();
-            if (user) {
-                logger.debug('user sign out', user);
-                user.signOut();
-                if (this._cognitoAuthClient) {
-                    this._cognitoAuthClient.signOut();
-                }
-            }
-        } else {
-            logger.debug('no Congito User pool');
-        }
-        
-        const that = this;
-        return new Promise(async (resolve, reject) => {
+      logger.debug("cognito auth params", cognitoAuthParams);
+      this._cognitoAuthClient = new CognitoAuth(cognitoAuthParams);
+      this._cognitoAuthClient.userhandler = {
+        // user signed in
+        onSuccess: result => {
+          that.user = that.userPool.getCurrentUser();
+          logger.debug("Cognito Hosted authentication result", result);
+          that.currentSession().then(async session => {
             try {
-                await Credentials.set(null, 'guest');
+              const cred = await Credentials.set(session, "session");
+              logger.debug("sign in succefully with", cred);
             } catch (e) {
-                logger.debug('cannot load guest credentials for unauthenticated user', e);
+              logger.debug("sign in without aws credentials", e);
             } finally {
-                dispatchAuthEvent('signOut', that.user);
-                that.user = null;
-                resolve();
+              dispatchAuthEvent("signIn", that.user);
+              dispatchAuthEvent("cognitoHostedUI", that.user);
             }
+          });
+        },
+        onFailure: err => {
+          logger.debug("Error in cognito hosted auth response", err);
+        }
+      };
+      // if not logged in, try to parse the url.
+      this.currentAuthenticatedUser()
+        .then(() => {
+          logger.debug("user already logged in");
+        })
+        .catch(e => {
+          logger.debug("not logged in, try to parse the url");
+          const curUrl = window.location.href;
+          this._cognitoAuthClient.parseCognitoWebResponse(curUrl);
         });
     }
 
-    private async cleanCachedItems() {
-        // clear cognito cached item
-        await Credentials.clear();
+    dispatchAuthEvent("configured", null);
+    return this._config;
+  }
+
+  /**
+   * Sign up with username, password and other attrbutes like phone, email
+   * @param {String | object} params - The user attirbutes used for signin
+   * @param {String[]} restOfAttrs - for the backward compatability
+   * @return - A promise resolves callback data if success
+   */
+  public signUp(
+    params: string | object,
+    ...restOfAttrs: string[]
+  ): Promise<any> {
+    if (!this.userPool) {
+      return Promise.reject(new Error("No userPool"));
     }
 
-    /**
-     * Change a password for an authenticated user
-     * @param {Object} user - The CognitoUser object
-     * @param {String} oldPassword - the current password
-     * @param {String} newPassword - the requested new password
-     * @return - A promise resolves if success
-     */
-    public changePassword(user: any, oldPassword: string, newPassword: string): Promise<any> {
-        return this.userSession(user)
-            .then(session => {
-                return new Promise((resolve, reject) => {
-                    user.changePassword(oldPassword, newPassword, (err, data) => {
-                        if (err) {
-                            logger.debug('change password failure', err);
-                            reject(err);
-                        } else {
-                            resolve(data);
-                        }
-                    });
-                });
-            });
-    }
-
-    /**
-     * Initiate a forgot password request
-     * @param {String} username - the username to change password
-     * @return - A promise resolves if success
-     */
-    public forgotPassword(username: string): Promise<any> {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
-        if (!username) { return Promise.reject('Username cannot be empty'); }
-
-        const user = this.createCognitoUser(username);
-        return new Promise((resolve, reject) => {
-            user.forgotPassword({
-                onSuccess: () => { resolve(); },
-                onFailure: err => {
-                    logger.debug('forgot password failure', err);
-                    reject(err);
-                },
-                inputVerificationCode: data => {
-                    resolve(data);
-                }
-            });
+    let username: string = null;
+    let password: string = null;
+    const attributes: object[] = [];
+    let validationData: object[] = null;
+    if (params && typeof params === "string") {
+      username = params;
+      password = restOfAttrs ? restOfAttrs[0] : null;
+      const email: string = restOfAttrs ? restOfAttrs[1] : null;
+      const phone_number: string = restOfAttrs ? restOfAttrs[2] : null;
+      if (email) attributes.push({ Name: "email", Value: email });
+      if (phone_number)
+        attributes.push({ Name: "phone_number", Value: phone_number });
+    } else if (params && typeof params === "object") {
+      username = params["username"];
+      password = params["password"];
+      const attrs = params["attributes"];
+      if (attrs) {
+        Object.keys(attrs).map(key => {
+          const ele: object = { Name: key, Value: attrs[key] };
+          attributes.push(ele);
         });
+      }
+      validationData = params["validationData"] || null;
+    } else {
+      return Promise.reject(
+        "The first parameter should either be non-null string or object"
+      );
     }
 
-    /**
-     * Confirm a new password using a confirmation Code
-     * @param {String} username - The username
-     * @param {String} code - The confirmation code
-     * @param {String} password - The new password
-     * @return - A promise that resolves if success
-     */
-    public forgotPasswordSubmit(
-        username: string,
-        code: string,
-        password: string
-    ): Promise<any> {
-        if (!this.userPool) { return Promise.reject('No userPool'); }
-        if (!username) { return Promise.reject('Username cannot be empty'); }
-        if (!code) { return Promise.reject('Code cannot be empty'); }
-        if (!password) { return Promise.reject('Password cannot be empty'); }
-
-        const user = this.createCognitoUser(username);
-        return new Promise((resolve, reject) => {
-            user.confirmPassword(code, password, {
-                onSuccess: () => { resolve(); },
-                onFailure: err => { reject(err); }
-            });
-        });
+    if (!username) {
+      return Promise.reject("Username cannot be empty");
+    }
+    if (!password) {
+      return Promise.reject("Password cannot be empty");
     }
 
-    /**
-     * Get user information
-     * @async
-     * @return {Object }- current User's information
-     */
-    public async currentUserInfo() {
-        const source = Credentials.getCredSource();
+    logger.debug("signUp attrs:", attributes);
+    logger.debug("signUp validation data:", validationData);
 
-        if (!source || source === 'aws' || source === 'userPool') {
-            const user = await this.currentUserPoolUser()
-                .catch(err => logger.debug(err));
-            if (!user) { return null; }
+    return new Promise((resolve, reject) => {
+      this.userPool.signUp(
+        username,
+        password,
+        attributes,
+        validationData,
+        function(err, data) {
+          if (err) {
+            dispatchAuthEvent("signUp_failure", err);
+            reject(err);
+          } else {
+            dispatchAuthEvent("signUp", data);
+            resolve(data);
+          }
+        }
+      );
+    });
+  }
 
+  /**
+   * Send the verfication code to confirm sign up
+   * @param {String} username - The username to be confirmed
+   * @param {String} code - The verification code
+   * @param {ConfirmSignUpOptions} options - other options for confirm signup
+   * @return - A promise resolves callback data if success
+   */
+  public confirmSignUp(
+    username: string,
+    code: string,
+    options?: ConfirmSignUpOptions
+  ): Promise<any> {
+    if (!this.userPool) {
+      return Promise.reject(new Error("No userPool"));
+    }
+    if (!username) {
+      return Promise.reject("Username cannot be empty");
+    }
+    if (!code) {
+      return Promise.reject("Code cannot be empty");
+    }
+
+    const user = this.createCognitoUser(username);
+    const forceAliasCreation =
+      options && typeof options.forceAliasCreation === "boolean"
+        ? options.forceAliasCreation
+        : true;
+
+    return new Promise((resolve, reject) => {
+      user.confirmRegistration(code, forceAliasCreation, function(err, data) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      });
+    });
+  }
+
+  /**
+   * Resend the verification code
+   * @param {String} username - The username to be confirmed
+   * @return - A promise resolves data if success
+   */
+  public resendSignUp(username: string): Promise<any> {
+    if (!this.userPool) {
+      return Promise.reject(new Error("No userPool"));
+    }
+    if (!username) {
+      return Promise.reject("Username cannot be empty");
+    }
+
+    const user = this.createCognitoUser(username);
+    return new Promise((resolve, reject) => {
+      user.resendConfirmationCode(function(err, data) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      });
+    });
+  }
+
+  /**
+   * Sign in
+   * @param {String} username - The username to be signed in
+   * @param {String} password - The password of the username
+   * @return - A promise resolves the CognitoUser
+   */
+  public signIn(username: string, password?: string): Promise<any> {
+    if (!this.userPool) {
+      return Promise.reject(new Error("No userPool"));
+    }
+    if (!username) {
+      return Promise.reject("Username cannot be empty");
+    }
+
+    if (password) {
+      return this.signInWithPassword(username, password);
+    } else {
+      return this.signInWithoutPassword(username);
+    }
+  }
+
+  /**
+   * Return an object with the authentication callbacks
+   * @param {CognitoUser} user - the cognito user object
+   * @param {} resolve - function called when resolving the current step
+   * @param {} reject - function called when rejecting the current step
+   * @return - an object with the callback methods for user authentication
+   */
+  private authCallbacks(
+    user,
+    resolve: (value?: any) => void,
+    reject: (value?: any) => void
+  ) {
+    const that = this;
+    return {
+      onSuccess: async session => {
+        logger.debug(session);
+        delete user["challengeName"];
+        delete user["challengeParam"];
+        try {
+          const cred = await Credentials.set(session, "session");
+          logger.debug("succeed to get cognito credentials", cred);
+        } catch (e) {
+          logger.debug("cannot get cognito credentials", e);
+        } finally {
+          that.user = user;
+          dispatchAuthEvent("signIn", user);
+          resolve(user);
+        }
+      },
+      onFailure: err => {
+        logger.debug("signIn failure", err);
+        dispatchAuthEvent("signIn_failure", err);
+        reject(err);
+      },
+      customChallenge: challengeParam => {
+        logger.debug("signIn custom challenge answer required");
+        user["challengeName"] = "CUSTOM_CHALLENGE";
+        user["challengeParam"] = challengeParam;
+        resolve(user);
+      },
+      mfaRequired: (challengeName, challengeParam) => {
+        logger.debug("signIn MFA required");
+        user["challengeName"] = challengeName;
+        user["challengeParam"] = challengeParam;
+        resolve(user);
+      },
+      mfaSetup: (challengeName, challengeParam) => {
+        logger.debug("signIn mfa setup", challengeName);
+        user["challengeName"] = challengeName;
+        user["challengeParam"] = challengeParam;
+        resolve(user);
+      },
+      newPasswordRequired: (userAttributes, requiredAttributes) => {
+        logger.debug("signIn new password");
+        user["challengeName"] = "NEW_PASSWORD_REQUIRED";
+        user["challengeParam"] = {
+          userAttributes,
+          requiredAttributes
+        };
+        resolve(user);
+      },
+      totpRequired: (challengeName, challengeParam) => {
+        logger.debug("signIn totpRequired");
+        user["challengeName"] = challengeName;
+        user["challengeParam"] = challengeParam;
+        resolve(user);
+      },
+      selectMFAType: (challengeName, challengeParam) => {
+        logger.debug("signIn selectMFAType", challengeName);
+        user["challengeName"] = challengeName;
+        user["challengeParam"] = challengeParam;
+        resolve(user);
+      }
+    };
+  }
+
+  /**
+   * Sign in with a password
+   * @param {String} username - The username to be signed in
+   * @param {String} password - The password of the username
+   * @return - A promise resolves the CognitoUser object if success or mfa required
+   */
+  private signInWithPassword(username: string, password: string): Promise<any> {
+    const user = this.createCognitoUser(username);
+    const authDetails = new AuthenticationDetails({
+      Username: username,
+      Password: password
+    });
+
+    return new Promise((resolve, reject) => {
+      user.authenticateUser(
+        authDetails,
+        this.authCallbacks(user, resolve, reject)
+      );
+    });
+  }
+
+  /**
+   * Sign in without a password
+   * @param {String} username - The username to be signed in
+   * @return - A promise resolves the CognitoUser object if success or mfa required
+   */
+  private signInWithoutPassword(username: string): Promise<any> {
+    const user = this.createCognitoUser(username);
+    user.setAuthenticationFlowType("CUSTOM_AUTH");
+    const authDetails = new AuthenticationDetails({
+      Username: username
+    });
+
+    return new Promise((resolve, reject) => {
+      user.initiateAuth(authDetails, this.authCallbacks(user, resolve, reject));
+    });
+  }
+
+  /**
+   * get user current preferred mfa option
+   * @param {CognitoUser} user - the current user
+   * @return - A promise resolves the current preferred mfa option if success
+   */
+  public getMFAOptions(user: any): Promise<any> {
+    return new Promise((res, rej) => {
+      user.getMFAOptions((err, mfaOptions) => {
+        if (err) {
+          logger.debug("get MFA Options failed", err);
+          rej(err);
+        }
+        logger.debug("get MFA options success", mfaOptions);
+        res(mfaOptions);
+      });
+    });
+  }
+
+  /**
+   * set preferred MFA method
+   * @param {CognitoUser} user - the current Cognito user
+   * @param {string} mfaMethod - preferred mfa method
+   * @return - A promise resolve if success
+   */
+  public setPreferredMFA(user: any, mfaMethod: string): Promise<any> {
+    let smsMfaSettings = null;
+    let totpMfaSettings = {
+      PreferredMfa: false,
+      Enabled: false
+    };
+
+    switch (mfaMethod) {
+      case "TOTP":
+        totpMfaSettings = {
+          PreferredMfa: true,
+          Enabled: true
+        };
+        break;
+      case "SMS":
+        smsMfaSettings = {
+          PreferredMfa: true,
+          Enabled: true
+        };
+        break;
+      case "NOMFA":
+        break;
+      default:
+        logger.debug("no validmfa method provided");
+        return Promise.reject("no validmfa method provided");
+    }
+
+    const that = this;
+    const TOTP_NOT_VERIFED = "User has not verified software token mfa";
+    const TOTP_NOT_SETUP = "User has not set up software token mfa";
+    return new Promise((res, rej) => {
+      user.setUserMfaPreference(
+        smsMfaSettings,
+        totpMfaSettings,
+        (err, result) => {
+          if (err) {
+            // if totp not setup or verified and user want to set it, return error
+            // otherwise igonre it
+            if (
+              err.message === TOTP_NOT_SETUP ||
+              err.message === TOTP_NOT_VERIFED
+            ) {
+              if (mfaMethod === "SMS") {
+                that
+                  .enableSMS(user)
+                  .then(data => {
+                    logger.debug("Set user mfa success", data);
+                    res(data);
+                  })
+                  .catch(err => {
+                    logger.debug("Set user mfa preference error", err);
+                    rej(err);
+                  });
+              } else if (mfaMethod === "NOMFA") {
+                // diable sms
+                that
+                  .disableSMS(user)
+                  .then(data => {
+                    logger.debug("Set user mfa success", data);
+                    res(data);
+                  })
+                  .catch(err => {
+                    logger.debug("Set user mfa preference error", err);
+                    rej(err);
+                  });
+              } else {
+                logger.debug("Set user mfa preference error", err);
+                rej(err);
+              }
+            } else {
+              logger.debug("Set user mfa preference error", err);
+              rej(err);
+            }
+          }
+          logger.debug("Set user mfa success", result);
+          res(result);
+        }
+      );
+    });
+  }
+
+  /**
+   * diable SMS
+   * @param {CognitoUser} user - the current user
+   * @return - A promise resolves is success
+   */
+  public disableSMS(user: any): Promise<any> {
+    return new Promise((res, rej) => {
+      user.disableMFA((err, data) => {
+        if (err) {
+          logger.debug("disable mfa failed", err);
+          rej(err);
+        }
+        logger.debug("disable mfa succeed", data);
+        res(data);
+      });
+    });
+  }
+
+  /**
+   * enable SMS
+   * @param {CognitoUser} user - the current user
+   * @return - A promise resolves is success
+   */
+  public enableSMS(user) {
+    return new Promise((res, rej) => {
+      user.enableMFA((err, data) => {
+        if (err) {
+          logger.debug("enable mfa failed", err);
+          rej(err);
+        }
+        logger.debug("enable mfa succeed", data);
+        res(data);
+      });
+    });
+  }
+
+  /**
+   * Setup TOTP
+   * @param {CognitoUser} user - the current user
+   * @return - A promise resolves with the secret code if success
+   */
+  public setupTOTP(user) {
+    return new Promise((res, rej) => {
+      user.associateSoftwareToken({
+        onFailure: err => {
+          logger.debug("associateSoftwareToken failed", err);
+          rej(err);
+        },
+        associateSecretCode: secretCode => {
+          logger.debug("associateSoftwareToken sucess", secretCode);
+          res(secretCode);
+        }
+      });
+    });
+  }
+
+  /**
+   * verify TOTP setup
+   * @param {CognitoUser} user - the current user
+   * @param {string} challengeAnswer - challenge answer
+   * @return - A promise resolves is success
+   */
+  public verifyTotpToken(user, challengeAnswer) {
+    logger.debug("verfication totp token", user, challengeAnswer);
+    return new Promise((res, rej) => {
+      user.verifySoftwareToken(challengeAnswer, "My TOTP device", {
+        onFailure: err => {
+          logger.debug("verifyTotpToken failed", err);
+          rej(err);
+        },
+        onSuccess: data => {
+          logger.debug("verifyTotpToken success", data);
+          res(data);
+        }
+      });
+    });
+  }
+
+  /**
+   * Send MFA code to confirm sign in
+   * @param {Object} user - The CognitoUser object
+   * @param {String} code - The confirmation code
+   */
+  public confirmSignIn(
+    user: any,
+    code: string,
+    mfaType: string | null
+  ): Promise<any> {
+    if (!code) {
+      return Promise.reject("Code cannot be empty");
+    }
+
+    const that = this;
+    return new Promise((resolve, reject) => {
+      user.sendMFACode(
+        code,
+        {
+          onSuccess: async session => {
+            logger.debug(session);
             try {
-                const attributes = await this.userAttributes(user);
-                const userAttrs:object = this.attributesToObject(attributes);
-                let credentials = null;
-                try {
-                    credentials = await this.currentCredentials();
-                } catch (e) {
-                    logger.debug('Failed to retrieve credentials while getting current user info', e);
-                }
-                
-
-                const info = {
-                    'id': credentials? credentials.identityId : undefined,
-                    'username': user.username,
-                    'attributes': userAttrs
-                };
-                return info;
-            } catch(err) {
-                logger.debug('currentUserInfo error', err);
-                return {};
+              const cred = await Credentials.set(session, "session");
+              logger.debug("succeed to get cognito credentials", cred);
+            } catch (e) {
+              logger.debug("cannot get cognito credentials", e);
+            } finally {
+              that.user = user;
+              dispatchAuthEvent("signIn", user);
+              resolve(user);
             }
-        }
+          },
+          onFailure: err => {
+            logger.debug("confirm signIn failure", err);
+            reject(err);
+          }
+        },
+        mfaType
+      );
+    });
+  }
 
-        if (source === 'federated') {
-            const user = this.user;
-            return user? user : {};
-        }
+  public completeNewPassword(
+    user: any,
+    password: string,
+    requiredAttributes: any
+  ): Promise<any> {
+    if (!password) {
+      return Promise.reject("Password cannot be empty");
     }
 
-    /**
-     * For federated login
-     * @param {String} provider - federation login provider
-     * @param {FederatedResponse} response - response should have the access token
-     * the identity id (optional)
-     * and the expiration time (the universal time)
-     * @param {String} user - user info
-     */
-    public federatedSignIn(provider: string, response: FederatedResponse, user: object) {
-        const { token, identity_id, expires_at } = response;
-        const that = this;
-        return new Promise((res, rej) => {
-            Credentials.set({ provider, token, identity_id, user, expires_at }, 'federation').then((cred) => {
-                dispatchAuthEvent('signIn', that.user);
-                logger.debug('federated sign in credentials', cred);
-                res(cred);
-            }).catch(e => {
-                rej(e);
+    const that = this;
+    return new Promise((resolve, reject) => {
+      user.completeNewPasswordChallenge(password, requiredAttributes, {
+        onSuccess: async session => {
+          logger.debug(session);
+          try {
+            const cred = await Credentials.set(session, "session");
+            logger.debug("succeed to get cognito credentials", cred);
+          } catch (e) {
+            logger.debug("cannot get cognito credentials", e);
+          } finally {
+            that.user = user;
+            dispatchAuthEvent("signIn", user);
+            resolve(user);
+          }
+        },
+        onFailure: err => {
+          logger.debug("completeNewPassword failure", err);
+          dispatchAuthEvent("completeNewPassword_failure", err);
+          reject(err);
+        },
+        mfaRequired: (challengeName, challengeParam) => {
+          logger.debug("signIn MFA required");
+          user["challengeName"] = challengeName;
+          user["challengeParam"] = challengeParam;
+          resolve(user);
+        },
+        mfaSetup: (challengeName, challengeParam) => {
+          logger.debug("signIn mfa setup", challengeName);
+          user["challengeName"] = challengeName;
+          user["challengeParam"] = challengeParam;
+          resolve(user);
+        }
+      });
+    });
+  }
+
+  /**
+   * Send the answer to a custom challenge
+   * @param {CognitoUser} user - The CognitoUser object
+   * @param {String} challengeResponses - The confirmation code
+   */
+  public sendCustomChallengeAnswer(
+    user,
+    challengeResponses: string
+  ): Promise<any> {
+    if (!this.userPool) {
+      return Promise.reject(new Error("No userPool"));
+    }
+    if (!challengeResponses) {
+      return Promise.reject("Challenge response cannot be empty");
+    }
+
+    const that = this;
+    return new Promise((resolve, reject) => {
+      user.sendCustomChallengeAnswer(
+        challengeResponses,
+        this.authCallbacks(user, resolve, reject)
+      );
+    });
+  }
+
+  /**
+   * Update an authenticated users' attributes
+   * @param {CognitoUser} - The currently logged in user object
+   * @return {Promise}
+   **/
+  public updateUserAttributes(user, attributes: object): Promise<any> {
+    let attr: object = {};
+    const attributeList: Array<object> = [];
+    return this.userSession(user).then(session => {
+      return new Promise((resolve, reject) => {
+        for (const key in attributes) {
+          if (key !== "sub" && key.indexOf("_verified") < 0) {
+            attr = {
+              Name: key,
+              Value: attributes[key]
+            };
+            attributeList.push(attr);
+          }
+        }
+        user.updateAttributes(attributeList, (err, result) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(result);
+          }
+        });
+      });
+    });
+  }
+  /**
+   * Return user attributes
+   * @param {Object} user - The CognitoUser object
+   * @return - A promise resolves to user attributes if success
+   */
+  public userAttributes(user): Promise<any> {
+    return this.userSession(user).then(session => {
+      return new Promise((resolve, reject) => {
+        user.getUserAttributes((err, attributes) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(attributes);
+          }
+        });
+      });
+    });
+  }
+
+  public verifiedContact(user) {
+    const that = this;
+    return this.userAttributes(user).then(attributes => {
+      const attrs = that.attributesToObject(attributes);
+      const unverified = {};
+      const verified = {};
+      if (attrs["email"]) {
+        if (attrs["email_verified"]) {
+          verified["email"] = attrs["email"];
+        } else {
+          unverified["email"] = attrs["email"];
+        }
+      }
+      if (attrs["phone_number"]) {
+        if (attrs["phone_number_verified"]) {
+          verified["phone_number"] = attrs["phone_number"];
+        } else {
+          unverified["phone_number"] = attrs["phone_number"];
+        }
+      }
+      return {
+        verified,
+        unverified
+      };
+    });
+  }
+
+  /**
+   * Get current authenticated user
+   * @return - A promise resolves to curret authenticated CognitoUser if success
+   */
+  public currentUserPoolUser(): Promise<any> {
+    if (!this.userPool) {
+      return Promise.reject(new Error("No userPool"));
+    }
+    let user = null;
+    if (Platform.isReactNative) {
+      const that = this;
+      return this.getSyncedUser().then(user => {
+        if (!user) {
+          return Promise.reject("No current user in userPool");
+        }
+        return new Promise((resolve, reject) => {
+          user.getSession(function(err, session) {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(user);
+            }
+          });
+        });
+      });
+    } else {
+      user = this.userPool.getCurrentUser();
+      if (!user) {
+        return Promise.reject("No current user in userPool");
+      }
+      return new Promise((resolve, reject) => {
+        user.getSession(function(err, session) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(user);
+          }
+        });
+      });
+    }
+  }
+
+  /**
+   * Return the current user after synchornizing AsyncStorage
+   * @return - A promise with the current authenticated user
+   **/
+  private getSyncedUser(): Promise<any> {
+    const that = this;
+    return (this._userPoolStorageSync || Promise.resolve()).then(result => {
+      if (!that.userPool) {
+        return Promise.reject(new Error("No userPool"));
+      }
+      return that.userPool.getCurrentUser();
+    });
+  }
+
+  /**
+   * Get current authenticated user
+   * @return - A promise resolves to curret authenticated CognitoUser if success
+   */
+  public async currentAuthenticatedUser(): Promise<any> {
+    logger.debug("getting current authenticted user");
+    let federatedUser = null;
+    try {
+      federatedUser = await Cache.getItem("federatedInfo").user;
+    } catch (e) {
+      logger.debug("cannot load federated user from cache");
+    }
+
+    if (federatedUser) {
+      this.user = federatedUser;
+      logger.debug("get current authenticated federated user", this.user);
+      return this.user;
+    } else {
+      logger.debug("get current authenticated userpool user");
+      let user = null;
+      try {
+        user = await this.currentUserPoolUser();
+      } catch (e) {
+        throw "not authenticated";
+      }
+      let attributes = {};
+      try {
+        attributes = this.attributesToObject(await this.userAttributes(user));
+      } catch (e) {
+        logger.debug("cannot get user attributes");
+      } finally {
+        this.user = Object.assign(user, { attributes });
+        return this.user;
+      }
+    }
+  }
+
+  /**
+   * Get current user's session
+   * @return - A promise resolves to session object if success
+   */
+  public currentSession(): Promise<any> {
+    let user: any;
+    const that = this;
+    logger.debug("Getting current session");
+    if (!this.userPool) {
+      return Promise.reject(new Error("No userPool"));
+    }
+    if (Platform.isReactNative) {
+      return this.getSyncedUser().then(user => {
+        if (!user) {
+          logger.debug("Failed to get user from user pool");
+          return Promise.reject("No current user");
+        }
+        return that.userSession(user);
+      });
+    } else {
+      user = this.userPool.getCurrentUser();
+      if (!user) {
+        logger.debug("Failed to get user from user pool");
+        return Promise.reject("No current user");
+      }
+      return this.userSession(user);
+    }
+  }
+
+  /**
+   * Get the corresponding user session
+   * @param {Object} user - The CognitoUser object
+   * @return - A promise resolves to the session
+   */
+  public userSession(user): Promise<any> {
+    return new Promise((resolve, reject) => {
+      logger.debug("Getting the session from this user:", user);
+      user.getSession(function(err, session) {
+        if (err) {
+          logger.debug("Failed to get the session from user", user);
+          reject(err);
+        } else {
+          logger.debug("Succeed to get the user session", session);
+          // check if session is expired
+          if (!session.isValid()) {
+            const refreshToken = session.getRefreshToken();
+            logger.debug(
+              "Session is not valid, refreshing session with refreshToken",
+              refreshToken
+            );
+            user.refreshSession(refreshToken, (err, newSession) => {
+              if (err) {
+                logger.debug("Refresh Cognito Session failed", err);
+                reject(err);
+              }
+              logger.debug("Refresh Cognito Session success", newSession);
+              resolve(newSession);
             });
-        });    
-    }
-
-    /**
-     * Compact version of credentials
-     * @param {Object} credentials
-     * @return {Object} - Credentials
-     */
-    public essentialCredentials(credentials) {
-        return {
-            accessKeyId: credentials.accessKeyId,
-            sessionToken: credentials.sessionToken,
-            secretAccessKey: credentials.secretAccessKey,
-            identityId: credentials.identityId,
-            authenticated: credentials.authenticated
-        };
-    }
-
-    private attributesToObject(attributes) {
-        const obj = {};
-        if (attributes) {
-            attributes.map(attribute => {
-                if (attribute.Name === 'sub') return;
-
-                if (attribute.Value === 'true') {
-                    obj[attribute.Name] = true;
-                } else if (attribute.Value === 'false') {
-                    obj[attribute.Name] = false;
-                } else {
-                    obj[attribute.Name] = attribute.Value;
-                }
-            });
+          } else {
+            logger.debug("Session is valid, directly return this session");
+            resolve(session);
+          }
         }
-        return obj;
-    }
-    
-    private createCognitoUser(username: string): Cognito.CognitoUser {
-        const userData: ICognitoUserData = {
-            Username: username,
-            Pool: this.userPool,
-        };
+      });
+    });
+  }
 
-        const { cookieStorage } = this._config;
-        if (cookieStorage) {
-            userData.Storage = new CookieStorage(cookieStorage);
+  /**
+   * Get authenticated credentials of current user.
+   * @return - A promise resolves to be current user's credentials
+   */
+  public currentUserCredentials() {
+    const that = this;
+    logger.debug("Getting current user credentials");
+    if (Platform.isReactNative) {
+      // asyncstorage
+      return Cache.getItem("federatedInfo")
+        .then(federatedInfo => {
+          if (federatedInfo) {
+            // refresh the jwt token here if necessary
+            return Credentials.refreshFederatedToken(federatedInfo);
+          } else {
+            return that
+              .currentSession()
+              .then(session => {
+                return Credentials.set(session, "session");
+              })
+              .catch(error => {
+                return Credentials.set(null, "guest");
+              });
+          }
+        })
+        .catch(error => {
+          return Promise.reject(error);
+        });
+    } else {
+      // first to check whether there is federation info in the local storage
+      const federatedInfo = Cache.getItem("federatedInfo");
+      if (federatedInfo) {
+        // refresh the jwt token here if necessary
+        return Credentials.refreshFederatedToken(federatedInfo);
+      } else {
+        return this.currentSession()
+          .then(session => {
+            logger.debug("getting session success", session);
+            return Credentials.set(session, "session");
+          })
+          .catch(error => {
+            logger.debug("getting session failed", error);
+            return Credentials.set(null, "guest");
+          });
+      }
+    }
+  }
+
+  public currentCredentials(): Promise<any> {
+    logger.debug("getting current credntials");
+    return Credentials.get();
+  }
+
+  /**
+   * Initiate an attribute confirmation request
+   * @param {Object} user - The CognitoUser
+   * @param {Object} attr - The attributes to be verified
+   * @return - A promise resolves to callback data if success
+   */
+  public verifyUserAttribute(user, attr): Promise<any> {
+    return new Promise((resolve, reject) => {
+      user.getAttributeVerificationCode(attr, {
+        onSuccess(data) {
+          resolve(data);
+        },
+        onFailure(err) {
+          reject(err);
+        }
+      });
+    });
+  }
+
+  /**
+   * Confirm an attribute using a confirmation code
+   * @param {Object} user - The CognitoUser
+   * @param {Object} attr - The attribute to be verified
+   * @param {String} code - The confirmation code
+   * @return - A promise resolves to callback data if success
+   */
+  public verifyUserAttributeSubmit(user, attr, code): Promise<any> {
+    if (!code) {
+      return Promise.reject("Code cannot be empty");
+    }
+
+    return new Promise((resolve, reject) => {
+      user.verifyAttribute(attr, code, {
+        onSuccess(data) {
+          resolve(data);
+        },
+        onFailure(err) {
+          reject(err);
+        }
+      });
+    });
+  }
+
+  verifyCurrentUserAttribute(attr) {
+    const that = this;
+    return that
+      .currentUserPoolUser()
+      .then(user => that.verifyUserAttribute(user, attr));
+  }
+
+  /**
+   * Confirm current user's attribute using a confirmation code
+   * @param {Object} attr - The attribute to be verified
+   * @param {String} code - The confirmation code
+   * @return - A promise resolves to callback data if success
+   */
+  verifyCurrentUserAttributeSubmit(attr, code) {
+    const that = this;
+    return that
+      .currentUserPoolUser()
+      .then(user => that.verifyUserAttributeSubmit(user, attr, code));
+  }
+  /**
+   * Sign out method
+   * @return - A promise resolved if success
+   */
+  public async signOut(): Promise<any> {
+    try {
+      await this.cleanCachedItems();
+    } catch (e) {
+      logger.debug("failed to clear cached items");
+    }
+
+    if (this.userPool) {
+      const user = this.userPool.getCurrentUser();
+      if (user) {
+        logger.debug("user sign out", user);
+        user.signOut();
+        if (this._cognitoAuthClient) {
+          this._cognitoAuthClient.signOut();
+        }
+      }
+    } else {
+      logger.debug("no Congito User pool");
+    }
+
+    const that = this;
+    return new Promise(async (resolve, reject) => {
+      try {
+        await Credentials.set(null, "guest");
+      } catch (e) {
+        logger.debug(
+          "cannot load guest credentials for unauthenticated user",
+          e
+        );
+      } finally {
+        dispatchAuthEvent("signOut", that.user);
+        that.user = null;
+        resolve();
+      }
+    });
+  }
+
+  private async cleanCachedItems() {
+    // clear cognito cached item
+    await Credentials.clear();
+  }
+
+  /**
+   * Change a password for an authenticated user
+   * @param {Object} user - The CognitoUser object
+   * @param {String} oldPassword - the current password
+   * @param {String} newPassword - the requested new password
+   * @return - A promise resolves if success
+   */
+  public changePassword(
+    user: any,
+    oldPassword: string,
+    newPassword: string
+  ): Promise<any> {
+    return this.userSession(user).then(session => {
+      return new Promise((resolve, reject) => {
+        user.changePassword(oldPassword, newPassword, (err, data) => {
+          if (err) {
+            logger.debug("change password failure", err);
+            reject(err);
+          } else {
+            resolve(data);
+          }
+        });
+      });
+    });
+  }
+
+  /**
+   * Initiate a forgot password request
+   * @param {String} username - the username to change password
+   * @return - A promise resolves if success
+   */
+  public forgotPassword(username: string): Promise<any> {
+    if (!this.userPool) {
+      return Promise.reject(new Error("No userPool"));
+    }
+    if (!username) {
+      return Promise.reject("Username cannot be empty");
+    }
+
+    const user = this.createCognitoUser(username);
+    return new Promise((resolve, reject) => {
+      user.forgotPassword({
+        onSuccess: () => {
+          resolve();
+        },
+        onFailure: err => {
+          logger.debug("forgot password failure", err);
+          reject(err);
+        },
+        inputVerificationCode: data => {
+          resolve(data);
+        }
+      });
+    });
+  }
+
+  /**
+   * Confirm a new password using a confirmation Code
+   * @param {String} username - The username
+   * @param {String} code - The confirmation code
+   * @param {String} password - The new password
+   * @return - A promise that resolves if success
+   */
+  public forgotPasswordSubmit(
+    username: string,
+    code: string,
+    password: string
+  ): Promise<any> {
+    if (!this.userPool) {
+      return Promise.reject(new Error("No userPool"));
+    }
+    if (!username) {
+      return Promise.reject("Username cannot be empty");
+    }
+    if (!code) {
+      return Promise.reject("Code cannot be empty");
+    }
+    if (!password) {
+      return Promise.reject("Password cannot be empty");
+    }
+
+    const user = this.createCognitoUser(username);
+    return new Promise((resolve, reject) => {
+      user.confirmPassword(code, password, {
+        onSuccess: () => {
+          resolve();
+        },
+        onFailure: err => {
+          reject(err);
+        }
+      });
+    });
+  }
+
+  /**
+   * Get user information
+   * @async
+   * @return {Object }- current User's information
+   */
+  public async currentUserInfo() {
+    const source = Credentials.getCredSource();
+
+    if (!source || source === "aws" || source === "userPool") {
+      const user = await this.currentUserPoolUser().catch(err =>
+        logger.debug(err)
+      );
+      if (!user) {
+        return null;
+      }
+
+      try {
+        const attributes = await this.userAttributes(user);
+        const userAttrs: object = this.attributesToObject(attributes);
+        let credentials = null;
+        try {
+          credentials = await this.currentCredentials();
+        } catch (e) {
+          logger.debug(
+            "Failed to retrieve credentials while getting current user info",
+            e
+          );
         }
 
-        return new CognitoUser(userData);
+        const info = {
+          id: credentials ? credentials.identityId : undefined,
+          username: user.username,
+          attributes: userAttrs
+        };
+        return info;
+      } catch (err) {
+        logger.debug("currentUserInfo error", err);
+        return {};
+      }
     }
+
+    if (source === "federated") {
+      const user = this.user;
+      return user ? user : {};
+    }
+  }
+
+  /**
+   * For federated login
+   * @param {String} provider - federation login provider
+   * @param {FederatedResponse} response - response should have the access token
+   * the identity id (optional)
+   * and the expiration time (the universal time)
+   * @param {String} user - user info
+   */
+  public federatedSignIn(
+    provider: string,
+    response: FederatedResponse,
+    user: object
+  ) {
+    const { token, identity_id, expires_at } = response;
+    const that = this;
+    return new Promise((res, rej) => {
+      Credentials.set(
+        { provider, token, identity_id, user, expires_at },
+        "federation"
+      )
+        .then(cred => {
+          dispatchAuthEvent("signIn", that.user);
+          logger.debug("federated sign in credentials", cred);
+          res(cred);
+        })
+        .catch(e => {
+          rej(e);
+        });
+    });
+  }
+
+  /**
+   * Compact version of credentials
+   * @param {Object} credentials
+   * @return {Object} - Credentials
+   */
+  public essentialCredentials(credentials) {
+    return {
+      accessKeyId: credentials.accessKeyId,
+      sessionToken: credentials.sessionToken,
+      secretAccessKey: credentials.secretAccessKey,
+      identityId: credentials.identityId,
+      authenticated: credentials.authenticated
+    };
+  }
+
+  private attributesToObject(attributes) {
+    const obj = {};
+    if (attributes) {
+      attributes.map(attribute => {
+        if (attribute.Name === "sub") return;
+
+        if (attribute.Value === "true") {
+          obj[attribute.Name] = true;
+        } else if (attribute.Value === "false") {
+          obj[attribute.Name] = false;
+        } else {
+          obj[attribute.Name] = attribute.Value;
+        }
+      });
+    }
+    return obj;
+  }
+
+  private createCognitoUser(username: string): Cognito.CognitoUser {
+    const userData: ICognitoUserData = {
+      Username: username,
+      Pool: this.userPool
+    };
+
+    const { cookieStorage } = this._config;
+    if (cookieStorage) {
+      userData.Storage = new CookieStorage(cookieStorage);
+    }
+
+    return new CognitoUser(userData);
+  }
 }


### PR DESCRIPTION
*Description of changes:*
Changes requested for better error handling practices. `aws-amplify` currently rejects Promises with a [string](https://github.com/aws/aws-amplify/blob/c3cb5eae7718449a365ffe26d10c72a321bc5295/packages/aws-amplify-react-native/docs/Auth_auth.js.html#L136). This is the equivalent to using `throw` with a string, rather than an Error instance.  An error object makes it easier to manage how developers handle and debug errors. This is because when an error object is thrown the same two properties, name and message, will be available in all browsers. When a string is thrown, different browsers will handle the error in different ways. In some cases, the error string is not displayed but a browser error like "uncaught exception” will be displayed instead. 

Resources
 https://www.ecma-international.org/ecma-262/6.0/#sec-promise-executor
https://www.nczonline.net/blog/2009/03/10/the-art-of-throwing-javascript-errors-part-2/
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
