### PR TITLE
fix(aws-amplify-react): show the setup totp component if totp is not verified

### DIFF
--- a/packages/aws-amplify-react/src/Widget/SelectMFAType.jsx
+++ b/packages/aws-amplify-react/src/Widget/SelectMFAType.jsx
@@ -85,7 +85,7 @@ export default class SelectMFAType extends Component {
  
         }).catch(err => {
             const { message } = err;
-            if (message === 'User has not set up software token mfa') {
+            if (message === 'User has not set up software token mfa' || message === 'User has not verified software token mfa') {
                 this.setState({TOTPSetup: true});
                 this.setState({selectMessage: 'You need to setup TOTP'})
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
