### PR TITLE
fix(aws-amplify): use method get instead of getPromise for credentials

### DIFF
--- a/packages/api/__tests__/API-test.ts
+++ b/packages/api/__tests__/API-test.ts
@@ -115,10 +115,8 @@ describe('API test', () => {
                 });
             });
 
-            const cognitoCredentialSpyon = jest.spyOn(CognitoIdentityCredentials.prototype, 'getPromise').mockImplementation(() => {
-                return new Promise((res, rej) => {
-                    res('cred');
-                });
+            const cognitoCredentialSpyon = jest.spyOn(CognitoIdentityCredentials.prototype, 'get').mockImplementation((callback) => {
+                callback(null);
             })
 
             const cache_config = {

--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -191,10 +191,8 @@ const session = new CognitoUserSession({
     AccessToken: accessToken
 });
 
-const cognitoCredentialSpyon = jest.spyOn(CognitoIdentityCredentials.prototype, 'getPromise').mockImplementation(() => {
-    return new Promise((res, rej) => {
-        res('cred');
-    });
+const cognitoCredentialSpyon = jest.spyOn(CognitoIdentityCredentials.prototype, 'get').mockImplementation((callback) => {
+    callback(null);
 });
 
 describe('auth unit test', () => {
@@ -1422,10 +1420,8 @@ describe('auth unit test', () => {
         test('get guest credentials failed', async() => {
             const auth = new Auth(authOptionsWithNoUserPoolId);
 
-            const cognitoCredentialSpyon = jest.spyOn(CognitoIdentityCredentials.prototype, 'getPromise').mockImplementation(() => {
-                return new Promise((res, rej) => {
-                    rej('err');
-                });
+            const cognitoCredentialSpyon = jest.spyOn(CognitoIdentityCredentials.prototype, 'get').mockImplementation((callback) => {
+                callback(null);
             });
 
             expect(await auth.signOut()).toBeUndefined();     

--- a/packages/auth/__tests__/cred-unit-test-rn.ts
+++ b/packages/auth/__tests__/cred-unit-test-rn.ts
@@ -165,10 +165,8 @@ const session = new CognitoUserSession({
     AccessToken: accessToken
 });
 
-const cognitoCredentialSpyon = jest.spyOn(CognitoIdentityCredentials.prototype, 'getPromise').mockImplementation(() => {
-    return new Promise((res, rej) => {
-        res('cred');
-    });
+const cognitoCredentialSpyon = jest.spyOn(CognitoIdentityCredentials.prototype, 'get').mockImplementation((callback) => {
+   callback(null);
 })
 
 describe('for react native', () => {

--- a/packages/core/__tests__/Credentials-test.ts
+++ b/packages/core/__tests__/Credentials-test.ts
@@ -21,10 +21,8 @@ const cacheClass = {
     }
 }
 
-const cognitoCredentialSpyon = jest.spyOn(CognitoIdentityCredentials.prototype, 'getPromise').mockImplementation(() => {
-    return new Promise((res, rej) => {
-        res('cred');
-    });
+const cognitoCredentialSpyon = jest.spyOn(CognitoIdentityCredentials.prototype, 'get').mockImplementation((callback) => {
+    callback(null);
 })
 
 const options = {


### PR DESCRIPTION
*Issue #, if available:*
fixes #1280 
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
