### PR TITLE
defValue is required, it should be optional

### DIFF
--- a/packages/core/src/I18n/index.ts
+++ b/packages/core/src/I18n/index.ts
@@ -74,7 +74,7 @@ class I18n {
      * @param {String} key 
      * @param {String} defVal - Default value
      */
-    static get(key, defVal) {
+    static get(key, defVal=undefined) {
         if (!I18n.checkConfig()) { return (typeof defVal === 'undefined')? key : defVal; }
 
         return _i18n.get(key, defVal); 


### PR DESCRIPTION
typescript currently generates this 
```ts
static get(key: any, defVal: any): any;
```
but def value should be optional/undefined


this means you need to add
```ts
{I18n.get('Password',"Password")}
``` 
but you should just be able to do
```ts
{I18n.get('Password')}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
