### PR TITLE
Fix repository path in amazon-cognito-identity-js package README.md

### DIFF
--- a/packages/amazon-cognito-identity-js/README.md
+++ b/packages/amazon-cognito-identity-js/README.md
@@ -4,7 +4,7 @@ You can now use Amazon Cognito to easily add user sign-up and sign-in to your mo
 
 We welcome developer feedback on this project. You can reach us by creating an issue on the
 GitHub repository or posting to the Amazon Cognito Identity forums and the below blog post:
-* https://github.com/aws/amazon-cognito-identity-js
+* https://github.com/aws-amplify/amplify-js
 * https://forums.aws.amazon.com/forum.jspa?forumID=173
 * https://aws.amazon.com/blogs/mobile/accessing-your-user-pools-using-the-amazon-cognito-identity-sdk-for-javascript/
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating the path of the repo in the README.md of `/amazon-cognito-identity-js` package. That session has a call to action for the developer engage on feedback in this project, it is quite annoying clicking on `https://github.com/aws/amazon-cognito-identity-js` being redirected to `https://github.com/amazon-archives/amazon-cognito-identity-js` to read the description and then be redirected to `https://github.com/aws-amplify/amplify-js/tree/master/packages/amazon-cognito-identity-js`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
