### PR TITLE
fix(@amazon-cognito-identity-js/Client): add polyfill for fetch call

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -63,7 +63,8 @@
   "dependencies": {
     "buffer": "4.9.1",
     "crypto-browserify": "1.0.9",
-    "js-cookie": "^2.1.4"
+    "js-cookie": "^2.1.4",
+    "whatwg-fetch": "^2.0.4"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/packages/amazon-cognito-identity-js/src/Client.js
+++ b/packages/amazon-cognito-identity-js/src/Client.js
@@ -1,3 +1,4 @@
+import 'whatwg-fetch';
 import UserAgent from './UserAgent';
 /** @class */
 export default class Client {


### PR DESCRIPTION
Issue:
On IE11 and fetch browser, using HOC UI components from amplify receiving 'fetch' is undefined error.

Fix:
Added browser polyfill and imported into Client.js where fetch is used
