### PR TITLE
Fix not picking up existing credentials

### DIFF
--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -60,7 +60,6 @@ export class Credentials {
         logger.debug('picking up credentials');
         if (!this._gettingCredPromise || !this._gettingCredPromise.isPending()) {
             logger.debug('getting new cred promise');
-            console.log('AWS.config.credentials instanceof AWS.Credentials', AWS.config.credentials instanceof AWS.Credentials);
             if (AWS.config && AWS.config.credentials && AWS.config.credentials instanceof AWS.Credentials) {
                 this._gettingCredPromise = JS.makeQuerablePromise(this._setCredentialsFromAWS());
             } else {

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -60,7 +60,8 @@ export class Credentials {
         logger.debug('picking up credentials');
         if (!this._gettingCredPromise || !this._gettingCredPromise.isPending()) {
             logger.debug('getting new cred promise');
-            if (AWS.config && AWS.config.credentials && AWS.config.credentials instanceof Credentials) {
+            console.log('AWS.config.credentials instanceof AWS.Credentials', AWS.config.credentials instanceof AWS.Credentials);
+            if (AWS.config && AWS.config.credentials && AWS.config.credentials instanceof AWS.Credentials) {
                 this._gettingCredPromise = JS.makeQuerablePromise(this._setCredentialsFromAWS());
             } else {
                 this._gettingCredPromise = JS.makeQuerablePromise(this._keepAlive());


### PR DESCRIPTION
*Issue #1382*

*Description of changes:*
This is a one line change to fix the conditional statement while verifying the type of the object stored in `AWS.config.credentials`.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
