### PR TITLE
removing references to changing aws-exports.js to .ts

### DIFF
--- a/docs/media/ionic_guide.md
+++ b/docs/media/ionic_guide.md
@@ -42,13 +42,6 @@ $ awsmobile push # Update your backend
 
 After creating your backend, the configuration file is copied to `/awsmobilejs/#current-backend-info/aws-exports.js`, and the source folder you have identified in the `awmobile init` command.
 
-To import the configuration file to your Ionic app, you will need to rename `aws_exports.js` to `aws_exports.ts`. Alternatively, you can create a `yarn start` command in your `package.json`.
-```js
-"scripts": {
-    "start": "[ -f src/aws-exports.js ] && mv src/aws-exports.js src/aws-exports.ts || ng serve; ng serve",
-    "build": "[ -f src/aws-exports.js ] && mv src/aws-exports.js src/aws-exports.ts || ng build --prod; ng build --prod"
-}
-```
 
 Import the configuration file and load it in your `main.ts`, which is the entry point of your Angular application. 
 

--- a/docs/media/tutorials/building-ionic-4-apps/index.md
+++ b/docs/media/tutorials/building-ionic-4-apps/index.md
@@ -661,9 +661,7 @@ Please tell us about your project:
 
 After answering the prompt, you should now see the *awsmobilejs* directory in your project root, as well as an *aws-exports.js* file in your */src* directory. The *aws-exports*file stores all of your project’s AWS related resource configuration. Again, do NOT check in the *awsmobilejs* directory or *aws-exports* file into source control.
 
-Since we are using TypeScript, change the name of the aws-exports file to *aws-exports.ts*.
-
-Please note that *aws-exports.js* (or *aws-exports.ts*. if you are using TypeScript) file should be located in the root of your source directory. If your source directory is different from */src* and you did not enter the folder name in the previous prompt, copy your *aws-exports.js* file to your source directory. You can find the updated copy of *aws-exports.js* file under *awsmobilejs/#current-backend-info/* directory.
+Please note that *aws-exports.js* file should be located in the root of your source directory. If your source directory is different from */src* and you did not enter the folder name in the previous prompt, copy your *aws-exports.js* file to your source directory. You can find the updated copy of *aws-exports.js* file under *awsmobilejs/#current-backend-info/* directory.
 {: .callout .callout--info}
 
 AWS resources for your application can be generated using:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fixes ionic documentation so that they aren't changing final extension, as CLI does not support .ts.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
