### PR TITLE
currentUserPoolUser waits to getUserData until getSession succeeds

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -856,33 +856,33 @@ export default class AuthClass {
                 user.getSession(function(err, session) {
                     if (err) {
                         logger.debug('Failed to get the user session', err);
-                        rej(err); 
-                        return;
-                    }
-                });
-
-                // get user data from Cognito, also to make sure the user is still valid
-                user.getUserData((err, data) => {
-                    if (err) {
-                        logger.debug('getting user data failed', err);
                         rej(err);
                         return;
                     }
-                    const preferredMFA = data.PreferredMfaSetting || 'NOMFA';
-                    const attributeList = [];
 
-                    for (let i = 0; i < data.UserAttributes.length; i++) {
-                        const attribute = {
-                            Name: data.UserAttributes[i].Name,
-                            Value: data.UserAttributes[i].Value,
-                        };
-                        const userAttribute = new CognitoUserAttribute(attribute);
-                        attributeList.push(userAttribute);
-                    }
+                    // get user data from Cognito, also to make sure the user is still valid
+                    user.getUserData((err, data) => {
+                        if (err) {
+                            logger.debug('getting user data failed', err);
+                            rej(err);
+                            return;
+                        }
+                        const preferredMFA = data.PreferredMfaSetting || 'NOMFA';
+                        const attributeList = [];
 
-                    const attributes = this.attributesToObject(attributeList);
-                    Object.assign(user, {attributes, preferredMFA});
-                    res(user);
+                        for (let i = 0; i < data.UserAttributes.length; i++) {
+                            const attribute = {
+                                Name: data.UserAttributes[i].Name,
+                                Value: data.UserAttributes[i].Value,
+                            };
+                            const userAttribute = new CognitoUserAttribute(attribute);
+                            attributeList.push(userAttribute);
+                        }
+
+                        const attributes = this.attributesToObject(attributeList);
+                        Object.assign(user, {attributes, preferredMFA});
+                        res(user);
+                    });
                 });
             });
         });

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -879,7 +879,7 @@ export default class AuthClass {
                             attributeList.push(userAttribute);
                         }
 
-                        const attributes = this.attributesToObject(attributeList);
+                        const attributes = that.attributesToObject(attributeList);
                         Object.assign(user, {attributes, preferredMFA});
                         res(user);
                     });


### PR DESCRIPTION
Fixes #1390 

When `Auth.currentUserPoolUser` is called:

1. The auth data is synced from storage
2. The user is retrieved using `userPool.getCurrentUser()`
3. The session is retrieved and refreshed using `user.getSession()`
4. The user's attributes are retrieved using `user.getUserData()`

This PR fixes the flow between steps 3 and 4 by ensuring the `user.getUserData` is called after `user.getSession` success. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
