### PR TITLE
Lift authState up when using withAuthenticator HOC

### DIFF
--- a/packages/aws-amplify-react-native/src/Auth/index.js
+++ b/packages/aws-amplify-react-native/src/Auth/index.js
@@ -94,6 +94,7 @@ export function withAuthenticator(Comp, includeGreetings=false, authenticatorCom
                 hideDefault={authenticatorComponents.length > 0}
                 onStateChange={this.handleAuthStateChange}
                 children={authenticatorComponents}
+                authState={authState}
             />
         }
     }


### PR DESCRIPTION
*Fixes #1012*

*Description of changes: When using `withAuthenticator` HOC at the time of signing out the `<Authenticator/>` component was using its own authState and this was causing conflict with the updated authState fo the `<Wrapper />` Component because it was not being lift up as a prop at the creation time by `withAuthenticator` HOC*.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
