### PR TITLE
fix(amazon-cognito-identity-js): publish a forked version of crypto-browserify package to fix webpack build error

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -62,7 +62,7 @@
   "types": "./index.d.ts",
   "dependencies": {
     "buffer": "4.9.1",
-    "crypto-browserify": "1.0.9",
+    "amplify-crypto-browserify": "1.0.10",
     "js-cookie": "^2.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
*Issue #, if available:*
fixes #891 
fixes #888 

related #1679

Published a forked version of crypto-browserify which made a patch to `rng.js` to pass the webpack build
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
