### PR TITLE
fix(aws-amplify-react):Hide Forgot Password/Singup conditionally

### DIFF
--- a/packages/aws-amplify-react/__tests__/Auth/__snapshots__/Authenticator-test.js.snap
+++ b/packages/aws-amplify-react/__tests__/Auth/__snapshots__/Authenticator-test.js.snap
@@ -4995,6 +4995,7 @@ exports[`Authenticator normal case render if no error with children 1`] = `
   />
   <div
     authState="signIn"
+    hide={Array []}
     key="aws-amplify-authenticator-props-children-0/.0"
     messageMap={[Function]}
     onAuthEvent={[Function]}

--- a/packages/aws-amplify-react/__tests__/Auth/__snapshots__/index-test.js.snap
+++ b/packages/aws-amplify-react/__tests__/Auth/__snapshots__/index-test.js.snap
@@ -4,7 +4,9 @@ exports[`AuthenticatorWrapper test render test render correctly 1`] = `
 <div>
   <Authenticator
     onStateChange={[Function]}
-  />
+  >
+    <Component />
+  </Authenticator>
 </div>
 `;
 

--- a/packages/aws-amplify-react/__tests__/Widget/__snapshots__/TextPicker-test.js.snap
+++ b/packages/aws-amplify-react/__tests__/Widget/__snapshots__/TextPicker-test.js.snap
@@ -34,7 +34,9 @@ exports[`TextPicker test render test render with previewSrc 1`] = `
           "wordWrap": "break-word",
         }
       }
-    />
+    >
+      <Component />
+    </pre>
   </div>
   <Picker
     accept="text/*"

--- a/packages/aws-amplify-react/src/Auth/Authenticator.jsx
+++ b/packages/aws-amplify-react/src/Auth/Authenticator.jsx
@@ -79,8 +79,7 @@ export default class Authenticator extends Component {
         const theme = this.props.theme || AmplifyTheme;
         const messageMap = this.props.errorMessage || AmplifyMessageMap;
 
-        let { hideDefault, hide, federated } = this.props;
-        if (!hide) { hide = []; }
+        let { hideDefault, hide = [], federated } = this.props;
         if (hideDefault) {
             hide = hide.concat([
                 Greetings,
@@ -95,6 +94,7 @@ export default class Authenticator extends Component {
             ]);
         }
         const props_children = this.props.children || [];
+
         const default_children = [
             <Greetings/>,
             <SignIn federated={federated}/>,
@@ -107,6 +107,8 @@ export default class Authenticator extends Component {
             <TOTPSetup/>
         ];
 
+        const props_children_names  = React.Children.map(props_children, child => child.type.name)
+        hide = hide.filter((component) =>!props_children_names.includes(component.name))
         const render_props_children = React.Children.map(props_children, (child, index) => {
             return React.cloneElement(child, {
                     key: 'aws-amplify-authenticator-props-children-' + index,
@@ -115,11 +117,12 @@ export default class Authenticator extends Component {
                     authState: auth,
                     authData: authData,
                     onStateChange: this.handleStateChange,
-                    onAuthEvent: this.handleAuthEvent
+                    onAuthEvent: this.handleAuthEvent,
+                    hide: hide
                 });
         });
-        
-        const render_default_children = React.Children.map(default_children, (child, index) => {
+       
+        const render_default_children = hideDefault ? [] : React.Children.map(default_children, (child, index) => {
                 return React.cloneElement(child, {
                     key: 'aws-amplify-authenticator-default-children-' + index,
                     theme: theme,
@@ -133,7 +136,6 @@ export default class Authenticator extends Component {
             });
 
         const render_children = render_default_children.concat(render_props_children);
-
         const errorRenderer = this.props.errorRenderer || this.errorRenderer;
         const error = this.state.error;
         return (

--- a/packages/aws-amplify-react/src/Auth/SignIn.jsx
+++ b/packages/aws-amplify-react/src/Auth/SignIn.jsx
@@ -106,9 +106,10 @@ export default class SignIn extends AuthPiece {
     }
 
     showComponent(theme) {
-        const { authState, hide, federated, onStateChange } = this.props;
+        const { authState, hide = [], federated, onStateChange } = this.props;
         if (hide && hide.includes(SignIn)) { return null; }
-
+        const hideSingUp = hide.some(component => component.name === 'SignUp')
+        const hideForgotPassword = hide.some(component => component.name === 'ForgotPassword')
         return (
             <FormSection theme={theme}>
                 <SectionHeader theme={theme}>{I18n.get('Sign In Account')}</SectionHeader>
@@ -141,14 +142,18 @@ export default class SignIn extends AuthPiece {
                 </SectionBody>
                 <SectionFooter theme={theme}>
                     <div style={theme.col6}>
-                        <Link theme={theme} onClick={() => this.changeState('forgotPassword')}>
-                            {I18n.get('Forgot Password')}
-                        </Link>
+                        {
+                            !hideForgotPassword && <Link theme={theme} onClick={() => this.changeState('forgotPassword')}>
+                                {I18n.get('Forgot Password')}
+                            </Link>
+                        }
                     </div>
                     <div style={Object.assign({textAlign: 'right'}, theme.col6)}>
-                        <Link theme={theme} onClick={() => this.changeState('signUp')}>
-                            {I18n.get('Sign Up')}
-                        </Link>
+                        {
+                            !hideSingUp && <Link theme={theme} onClick={() => this.changeState('signUp')}>
+                                {I18n.get('Sign Up')}
+                            </Link>
+                        }
                     </div>
                 </SectionFooter>
             </FormSection>

--- a/packages/aws-amplify-react/src/Auth/SignIn.jsx
+++ b/packages/aws-amplify-react/src/Auth/SignIn.jsx
@@ -108,7 +108,7 @@ export default class SignIn extends AuthPiece {
     showComponent(theme) {
         const { authState, hide = [], federated, onStateChange } = this.props;
         if (hide && hide.includes(SignIn)) { return null; }
-        const hideSingUp = hide.some(component => component.name === 'SignUp')
+        const hideSignUp = hide.some(component => component.name === 'SignUp')
         const hideForgotPassword = hide.some(component => component.name === 'ForgotPassword')
         return (
             <FormSection theme={theme}>
@@ -150,7 +150,7 @@ export default class SignIn extends AuthPiece {
                     </div>
                     <div style={Object.assign({textAlign: 'right'}, theme.col6)}>
                         {
-                            !hideSingUp && <Link theme={theme} onClick={() => this.changeState('signUp')}>
+                            !hideSignUp && <Link theme={theme} onClick={() => this.changeState('signUp')}>
                                 {I18n.get('Sign Up')}
                             </Link>
                         }


### PR DESCRIPTION
Users can pass a list of components to withAuthenticator and it would render only the passed list. If the user does not pass SignUp or Forgot password the SignIn form will not render the links
for SignUp and Forgot password

*Issue #, if available:*
Fixes issue #1467
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
