### PR TITLE
fix(aws-amplify-react): Fix import statement

### DIFF
--- a/packages/aws-amplify-react/src/Auth/AuthStateWrapper.jsx
+++ b/packages/aws-amplify-react/src/Auth/AuthStateWrapper.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
+import Amplify, { ConsoleLogger as Logger } from '@aws-amplify/core';
 import Auth from '@aws-amplify/auth';
 
 import AmplifyTheme from '../AmplifyTheme';

--- a/packages/aws-amplify-react/src/Auth/Authenticator.jsx
+++ b/packages/aws-amplify-react/src/Auth/Authenticator.jsx
@@ -12,7 +12,7 @@
  */
 
 import React, { Component } from 'react';
-import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
+import Amplify, { ConsoleLogger as Logger } from '@aws-amplify/core';
 
 import Greetings from './Greetings';
 import SignIn from './SignIn';


### PR DESCRIPTION
*Issue #, if available:*
Fixes #1482

*Description of changes:*
After modularization of amplify library Amplify became the default export of @aws-amplify/core. The import statement in aws-amplify-react still used named import. Update code to use the default import



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
