### PR TITLE
fix(spelling): Changes then to than

### DIFF
--- a/docs/media/authentication_guide.md
+++ b/docs/media/authentication_guide.md
@@ -1031,7 +1031,7 @@ The *Greetings* component has two states: signedIn, and signedOut. To customize 
 
 ### Customize `withAuthenticator`
 
-The `withAuthenticator` HOC gives you some nice default authentication screens out-of-box. If you want to use your own components rather then provided default components, you can pass the list of customized components to `withAuthenticator`:
+The `withAuthenticator` HOC gives you some nice default authentication screens out-of-box. If you want to use your own components rather than the provided default components, you can pass the list of customized components to `withAuthenticator`:
 
 ```js
 import React, { Component } from 'react';


### PR DESCRIPTION
Fixes incorrect usage of then.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
