### PR TITLE
delete useless npm install (react native project)

### DIFF
--- a/docs/media/react_native_guide.md
+++ b/docs/media/react_native_guide.md
@@ -21,7 +21,6 @@ Install following npm packages into your React Native app.
 
 ```bash
 $ npm install aws-amplify
-$ npm install aws-amplify-react
 $ npm install aws-amplify-react-native
 ```
 


### PR DESCRIPTION
Delete npm install aws-amplify-react, is not needed on react native app and is confusing.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
