### PR TITLE
fix(aws-amplify-react): Fix import statement

### DIFF
--- a/packages/aws-amplify-react/src/Auth/Authenticator.jsx
+++ b/packages/aws-amplify-react/src/Auth/Authenticator.jsx
@@ -12,7 +12,7 @@
  */
 
 import React, { Component } from 'react';
-import { Amplify, I18n, ConsoleLogger as Logger, Hub } from '@aws-amplify/core';
+import Amplify, { I18n, ConsoleLogger as Logger, Hub } from '@aws-amplify/core';
 import Auth from '@aws-amplify/auth';
 import Greetings from './Greetings';
 import SignIn from './SignIn';


### PR DESCRIPTION
Related to #1482 and #1484

*Issue #, if available:*
#1482 

*Description of changes:*
Fixes import statement (after a regression in 41d3184239b4087d750c86ae7401843afe6f6555) like in the PR #1484 by @yuth:

> After modularization of amplify library Amplify became the default export of @aws-amplify/core. The import statement in aws-amplify-react still used named import. Update code to use the default import

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
