### PR TITLE
fix Auth.verifyCurrentUserAttribute typo

### DIFF
--- a/docs/media/authentication_guide.md
+++ b/docs/media/authentication_guide.md
@@ -209,7 +209,7 @@ Auth.forgotPasswordSubmit(username, code, new_password)
 Either the phone number or the email address is required for account recovery. You can let the user verify those attributes by:
 ```js
 // To initiate the process of verifying the attribute like 'phone_number' or 'email'
-Auth.verifyCurrentUserAttributes(attr)
+Auth.verifyCurrentUserAttribute(attr)
 .then(() => {
      console.log('a verification code is sent');
 }).catch(e) => {


### PR DESCRIPTION
Auth.verifyCurrentUserAttributes does not exist

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
