### PR TITLE
Fixes "In this environment the sources for assign MUST be an object" for PubSub

### DIFF
--- a/packages/core/src/Signer.ts
+++ b/packages/core/src/Signer.ts
@@ -307,8 +307,8 @@ const signUrl = function(urlToSign: String, accessInfo: any, serviceInfo?: any, 
         'X-Amz-Algorithm': DEFAULT_ALGORITHM,
         'X-Amz-Credential': [accessInfo.access_key, credentialScope].join('/'),
         'X-Amz-Date': now.substr(0, 16),
-        ...(sessionTokenRequired && { 'X-Amz-Security-Token': `${accessInfo.session_token}` }),
-        ...(expiration && { 'X-Amz-Expires': `${expiration}` }),
+        ...(sessionTokenRequired ? { 'X-Amz-Security-Token': `${accessInfo.session_token}` } : {}),
+        ...(expiration ? { 'X-Amz-Expires': `${expiration}` } : {}),
         'X-Amz-SignedHeaders': Object.keys(signedHeaders).join(','),
     };
 


### PR DESCRIPTION
Fixes https://github.com/aws-amplify/amplify-js/issues/750

*Issue #, if available: 750*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
