### PR TITLE
fix(@aws-amplify/api): Content-Type header on init options

### DIFF
--- a/packages/api/src/RestClient.ts
+++ b/packages/api/src/RestClient.ts
@@ -84,19 +84,19 @@ export class RestClient {
             };
         }
 
-        const extraParams = Object.assign({}, init);
-        const isAllResponse = init ? init.response : null;
-        if (extraParams.body) {
-            libraryHeaders['content-type'] = 'application/json; charset=UTF-8';
-            params.data = JSON.stringify(extraParams.body);
+        const initParams = Object.assign({}, init);
+        const isAllResponse = initParams.response;
+        if (initParams.body) {
+            libraryHeaders['Content-Type'] = 'application/json; charset=UTF-8';
+            params.data = JSON.stringify(initParams.body);
         }
 
-        params['signerServiceInfo'] = extraParams.signerServiceInfo;
+        params['signerServiceInfo'] = initParams.signerServiceInfo;
 
         // custom_header callback
         const custom_header = this._custom_header ? await this._custom_header() : undefined;
         
-        params.headers = { ...libraryHeaders, ...(custom_header),...extraParams.headers };
+        params.headers = { ...libraryHeaders, ...(custom_header),...initParams.headers };
 
         // Intentionally discarding search
         const { search, ...parsedUrl } = urlLib.parse(url, true, true);
@@ -104,7 +104,7 @@ export class RestClient {
             ...parsedUrl,
             query: {
                 ...parsedUrl.query,
-                ...(extraParams.queryStringParameters || {})
+                ...(initParams.queryStringParameters || {})
             }
         });
 
@@ -260,7 +260,6 @@ export class RestClient {
         logger.debug('Signed Request: ', signed_params);
 
         delete signed_params.headers['host'];
-
         return axios(signed_params)
             .then(response => isAllResponse ? response : response.data)
             .catch((error) => {


### PR DESCRIPTION
*Issue #, if available:*
#1646 1646
*Description of changes:*
updating Content-Type name on libraryHeaders

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
