### PR TITLE
fix(@aws-amplify/xr)  Fixing a bug in XR::SumerianProvider where headers were not correctly being passed to one fetch command.

### DIFF
--- a/packages/xr/src/Providers/SumerianProvider.ts
+++ b/packages/xr/src/Providers/SumerianProvider.ts
@@ -123,7 +123,7 @@ export class SumerianProvider extends AbstractXRProvider {
     
     // Get bundle data from scene api response
     const sceneBundleData = apiResponseJson.bundleData[sceneId];
-    const sceneBundle = await fetch(sceneBundleData.url, sceneBundleData.headers);
+    const sceneBundle = await fetch(sceneBundleData.url, { headers : sceneBundleData.headers });
     const sceneBundleJson = await sceneBundle.json();
 
     try {


### PR DESCRIPTION

The Sumerian service does not yet use this header object, which is why this was not noticed earlier.

Testing:

This code was successfully tested against a non-production stage of the Sumerian service

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
