### PR TITLE
Update push_notifications_setup.md

### DIFF
--- a/docs/media/push_notifications_setup.md
+++ b/docs/media/push_notifications_setup.md
@@ -178,8 +178,9 @@ Setup instructions are provided for Android and iOS, and configuration for both 
     $ react-native init myapp
     $ cd myapp
     $ npm install
-    $ npm install aws-amplify --save
+    $ npm install aws-amplify --save && npm install @aws-amplify/pushnotification --save
     $ npm install aws-amplify-react-native --save
+    $ react-native link @aws-amplify/pushnotification
     $ react-native link aws-amplify-react-native
     ```
     Please note that linking `aws-amplify-react-native` but not completing the rest of the configuration steps could break your build process. Please be sure that you have completed all the steps before you build your app.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added `@aws-amplify/pushnotification` package to iOS setup requirements as it's not included in the core `aws-amplify` package. This missed step tripped me up for a while.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
