### PR TITLE
Prevent setState warning on unmounted component

### DIFF
--- a/packages/aws-amplify-react/src/API/GraphQL/Connect.js
+++ b/packages/aws-amplify-react/src/API/GraphQL/Connect.js
@@ -79,7 +79,9 @@ export default class Connect extends Component {
                     next: ({ value: { data } }) => {
                         const { data: prevData } = this.state;
                         const newData = onSubscriptionMsg(prevData, data);
-                        this.setState({ data: newData });
+                        if (this.mounted) {
+                            this.setState({ data: newData });
+                        }
                     },
                     error: err => console.error(err),
                 });
@@ -99,10 +101,12 @@ export default class Connect extends Component {
 
     async componentDidMount() {
         this._fetchData();
+        this.mounted = true;
     }
 
     componentWillUnmount() {
         this._unsubscribe();
+        this.mounted = false;
     }
 
     componentDidUpdate(prevProps) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4249,10 +4249,6 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-crypto-browserify@1.0.9:
-  version "1.0.9"
-  resolved "http://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz#cc5449685dfb85eb11c9828acc7cb87ab5bbfcc0"
-
 crypto-browserify@3.3.0:
   version "3.3.0"
   resolved "http://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz#b9fc75bb4a0ed61dcf1cd5dae96eb30c9c3e506c"
@@ -4285,6 +4281,10 @@ crypto-browserify@~3.2.6:
     pbkdf2-compat "2.0.1"
     ripemd160 "0.2.0"
     sha.js "2.2.6"
+
+crypto-js@^3.1.9-1:
+  version "3.1.9-1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
 
 csrf@~3.0.0:
   version "3.0.6"


### PR DESCRIPTION
Addresses this issue - https://github.com/aws-amplify/amplify-js/issues/1771

*Description of changes:*
Setting a `mounted` flag in `componentDidMount`, removing the flag in `componentWillUnmount`. Then checking for this flag before setting state inside the subscription. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
