### PR TITLE
Fix couldn't play custom sound for notification on Android Oreo & later

### DIFF
--- a/packages/pushnotification/android/src/main/java/com/amazonaws/amplify/pushnotification/modules/RNPushNotificationHelper.java
+++ b/packages/pushnotification/android/src/main/java/com/amazonaws/amplify/pushnotification/modules/RNPushNotificationHelper.java
@@ -26,6 +26,7 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
+import android.media.AudioAttributes;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
@@ -184,14 +185,6 @@ public class RNPushNotificationHelper {
 
             NotificationManager notificationManager = notificationManager();
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                int importance = NotificationManager.IMPORTANCE_HIGH;
-                NotificationChannel notificationChannel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, NOTIFICATION_CHANNEL_NAME, importance);
-                notificationChannel.enableLights(true);
-                notificationChannel.enableVibration(true);
-                notificationManager.createNotificationChannel(notificationChannel);
-            }
-
             NotificationCompat.Builder notification = new NotificationCompat.Builder(context)
                     .setContentTitle(title)
                     .setTicker(bundle.getString("ticker"))
@@ -270,8 +263,8 @@ public class RNPushNotificationHelper {
             intent.putExtra("notification", bundle);
             intent.setAction(NOTIFICATION_OPENED);
 
+            Uri soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
             if (!bundle.containsKey("playSound") || bundle.getBoolean("playSound")) {
-                Uri soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
                 String soundName = bundle.getString("pinpoint.notification.sound");
                 if (soundName != null) {
                     if (!"default".equalsIgnoreCase(soundName)) {
@@ -292,6 +285,21 @@ public class RNPushNotificationHelper {
                     }
                 }
                 notification.setSound(soundUri);
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                notification.setSound(null);
+                AudioAttributes audioAttributes = new AudioAttributes.Builder()
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                    .build();
+
+                int importance = NotificationManager.IMPORTANCE_HIGH;
+                NotificationChannel notificationChannel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, NOTIFICATION_CHANNEL_NAME, importance);
+                notificationChannel.enableLights(true);
+                notificationChannel.enableVibration(true);
+                notificationChannel.setSound(soundUri, audioAttributes);
+                notificationManager.createNotificationChannel(notificationChannel);
             }
 
             if (bundle.containsKey("ongoing") || bundle.getBoolean("ongoing")) {

--- a/packages/pushnotification/android/src/main/java/com/amazonaws/amplify/pushnotification/modules/RNPushNotificationHelper.java
+++ b/packages/pushnotification/android/src/main/java/com/amazonaws/amplify/pushnotification/modules/RNPushNotificationHelper.java
@@ -272,7 +272,7 @@ public class RNPushNotificationHelper {
 
             if (!bundle.containsKey("playSound") || bundle.getBoolean("playSound")) {
                 Uri soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
-                String soundName = bundle.getString("soundName");
+                String soundName = bundle.getString("pinpoint.notification.sound");
                 if (soundName != null) {
                     if (!"default".equalsIgnoreCase(soundName)) {
 


### PR DESCRIPTION
The custom sound from notification payload is not used correctly.

*Description of changes:*
The actual payload is:
```
2018-09-13 17:44:11.207 5370-5370/app I/RNPushNotificationMessagingService: sendNotification: Bundle[{pinpoint.openApp=true, userInteraction=false, pinpoint.notification.sound=notification.caf, pinpoint.notification.title=Title, pinpoint.notification.body=Body, id=-727273900, pinpoint.campaign.campaign_id=_DIRECT, pinpoint.notification.silentPush=0}]
```

So we should retrieve the custom sound name by `pinpoint.notification.sound`

And for Android O or later, custom sound is not applied.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
