### PR TITLE
fix(@aws-amplify/core): fix aws-sdk version to 2.329.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "webpack": "^3.5.5"
   },
   "dependencies": {
-    "aws-sdk": "^2.312.0",
+    "aws-sdk": "2.329.0",
     "url": "^0.11.0"
   },
   "jest": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fixing aws-sdk version to be the same as aws-appsync-sdk

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
