### PR TITLE
fix(@aws-amplify/auth): throw error when failed to sync items from AsyncStorage into Memory

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -907,6 +907,9 @@ export default class AuthClass {
                         res(user);
                     });
                 });
+            }).catch(e => {
+                logger.debug('Failed to sync cache info into memory', e);
+                return rej(e);
             });
         });
     }

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -153,8 +153,13 @@ export class Credentials {
             return Promise.reject('No Cognito Federated Identity pool provided');
         }
         
-        await this._storageSync;
-        const identityId = this._storage.getItem('CognitoIdentityId-' + identityPoolId);
+        let identityId = undefined;
+        try {
+            await this._storageSync;
+            identityId = this._storage.getItem('CognitoIdentityId-' + identityPoolId);
+        } catch (e) {
+            logger.debug('Failed to get the cached identityId', e);
+        }
         
         const credentials = new AWS.CognitoIdentityCredentials(
             {


### PR DESCRIPTION
*Issue #, if available:*
fixes #1002 
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
