### PR TITLE
fix@amplify-js/docs: Fix typo: 'pallette' to 'palette' in ui_library.md

### DIFF
--- a/docs/media/ui_library.md
+++ b/docs/media/ui_library.md
@@ -6,7 +6,7 @@ layout: ui_library
 ## Colors
 
 ### UI Colors
-<span class="excerpt">UI Color for AWS amplify are derived from Amazon’s primary color pallette and examples commonly used through the current AWS websites. Most primary actions are wrapped in Amazon Orange. Dark backgrounds and darker treatments will typically receive the Squid Ink Amazon color treatment.</span>
+<span class="excerpt">UI Color for AWS amplify are derived from Amazon’s primary color palette and examples commonly used through the current AWS websites. Most primary actions are wrapped in Amazon Orange. Dark backgrounds and darker treatments will typically receive the Squid Ink Amazon color treatment.</span>
 
 <span class="title">Primary Colors</span>
 <span class="inline-img">![Amazon Orange]({%if jekyll.environment == 'production'%}{{site.amplify.baseurl}}{%endif%}/images/Style_Guide/pc_amazon_orange.png)</span>


### PR DESCRIPTION
*Issue #, if available:*

N/A, trivial fix.

*Description of changes:*

Fix typo: 'pallette' to 'palette' in ui_library.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
