### PR TITLE
I18n support Vue Authenticator

### DIFF
--- a/packages/aws-amplify-vue/src/components/authenticator/ConfirmSignIn.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/ConfirmSignIn.vue
@@ -16,20 +16,20 @@
     <div v-bind:class="amplifyUI.sectionHeader">{{options.header}}</div>
     <div v-bind:class="amplifyUI.sectionBody">
       <div v-bind:class="amplifyUI.formField">
-        <div v-bind:class="amplifyUI.inputLabel">Code *</div>
-        <input v-bind:class="amplifyUI.input" v-model="code" placeholder="Code" />
+        <div v-bind:class="amplifyUI.inputLabel">{{$Amplify.I18n.get('Code')}} *</div>
+        <input v-bind:class="amplifyUI.input" v-model="code" placeholder="{{$Amplify.I18n.get('Code')}}" />
         <div v-bind:class="amplifyUI.hint">
-          Lost your code?
-          <a v-bind:class="amplifyUI.a" v-on:click="send">Resend Code</a>
+          {{$Amplify.I18n.get('Lost your code? ')}}
+          <a v-bind:class="amplifyUI.a" v-on:click="send">{{$Amplify.I18n.get('Resend Code')}}</a>
         </div>
       </div>
     </div>
     <div v-bind:class="amplifyUI.sectionFooter">
       <span v-bind:class="amplifyUI.sectionFooterPrimaryContent">
-        <button v-bind:class="amplifyUI.button" v-on:click="submit" :disabled="!code">Submit</button>
+        <button v-bind:class="amplifyUI.button" v-on:click="submit" :disabled="!code">{{$Amplify.I18n.get('Confirm')}}</button>
       </span>
       <span v-bind:class="amplifyUI.sectionFooterSecondaryContent">
-        <a v-bind:class="amplifyUI.a" v-on:click="signIn">Back to Sign In</a>      
+        <a v-bind:class="amplifyUI.a" v-on:click="signIn">{{$Amplify.I18n.get('Back to Sign In')}}</a>      
       </span>
     </div>
     <div class="error" v-if="error">
@@ -58,7 +58,7 @@ export default {
   computed: {
     options() {
       const defaults = {
-        header: 'Confirm Sign In',
+        header: this.$Amplify.I18n.get('Confirm Sign In'),
         user: {},
       }
       return Object.assign(defaults, this.confirmSignInConfig || {})

--- a/packages/aws-amplify-vue/src/components/authenticator/ConfirmSignUp.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/ConfirmSignUp.vue
@@ -16,25 +16,25 @@
     <div v-bind:class="amplifyUI.sectionHeader">{{options.header}}</div>
     <div v-bind:class="amplifyUI.sectionBody">
       <div v-bind:class="amplifyUI.formField">
-        <div v-bind:class="amplifyUI.inputLabel">Username *</div>
-        <input v-bind:class="amplifyUI.input" v-model="options.username" name="username" placeholder="Username" autofocus />
+        <div v-bind:class="amplifyUI.inputLabel">{{$Amplify.I18n.get('Username')}} *</div>
+        <input v-bind:class="amplifyUI.input" v-model="options.username" name="username" placeholder="{{$Amplify.I18n.get('Username')}}" autofocus />
       </div>
       <div v-bind:class="amplifyUI.formField">
-        <div v-bind:class="amplifyUI.inputLabel">Code *</div>
-        <input v-bind:class="amplifyUI.input" v-model="code" name="code" placeholder="Code" />
+        <div v-bind:class="amplifyUI.inputLabel">{{$Amplify.I18n.get('Confirmation Code')}} *</div>
+        <input v-bind:class="amplifyUI.input" v-model="code" name="code" placeholder="{{$Amplify.I18n.get('Confirmation Code')}}" />
         <div v-bind:class="amplifyUI.hint">
-          Lost your code?
-          <a v-bind:class="amplifyUI.a" v-on:click="resend">Resend Code</a>
+          {{$Amplify.I18n.get('Lost your code? ')}}
+          <a v-bind:class="amplifyUI.a" v-on:click="resend">{{$Amplify.I18n.get('Resend Code')}}</a>
         </div>
       </div>
     </div>
     <div v-bind:class="amplifyUI.sectionFooter">
       <span v-bind:class="amplifyUI.sectionFooterPrimaryContent">
-        <button v-bind:class="amplifyUI.button" v-on:click="confirm">Confirm</button>
+        <button v-bind:class="amplifyUI.button" v-on:click="confirm">{{$Amplify.I18n.get('Confirm')}}</button>
       </span>
       <span v-bind:class="amplifyUI.sectionFooterSecondaryContent">
-        Have an Account?
-        <a v-bind:class="amplifyUI.a" v-on:click="signIn">Sign In</a>
+        {{$Amplify.I18n.get('Have an account? ')}}
+        <a v-bind:class="amplifyUI.a" v-on:click="signIn">{{$Amplify.I18n.get('Back to Sign In')}}</a>
       </span>
     </div>
     <div class="error" v-if="error">
@@ -62,7 +62,7 @@ export default {
     options() {
       const defaults = {
         username: '',
-        header: 'Confirm Sign Up',
+        header: this.$Amplify.I18n.get('Confirm Sign Up'),
       }
       return Object.assign(defaults, this.confirmSignUpConfig || {})
     }

--- a/packages/aws-amplify-vue/src/components/authenticator/ForgotPassword.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/ForgotPassword.vue
@@ -16,27 +16,27 @@
     <div v-bind:class="amplifyUI.sectionHeader">{{options.header}}</div>
     <div v-bind:class="amplifyUI.sectionBody">
       <div v-bind:class="amplifyUI.formField">
-        <div v-bind:class="amplifyUI.inputLabel">Username *</div>
-        <input v-bind:class="amplifyUI.input" v-model="username" placeholder="Username" autofocus />
+        <div v-bind:class="amplifyUI.inputLabel">{{$Amplify.I18n.get('Username')}} *</div>
+        <input v-bind:class="amplifyUI.input" v-model="username" placeholder="{{$Amplify.I18n.get('Enter your username')}}" autofocus />
       </div>
       <div v-bind:class="amplifyUI.formField" v-if="sent">
-        <div v-bind:class="amplifyUI.inputLabel">Verification Code *</div>
-        <input v-bind:class="amplifyUI.input" v-model="code" placeholder="Verification Code" autofocus />
+        <div v-bind:class="amplifyUI.inputLabel">{{$Amplify.I18n.get('Code')}} *</div>
+        <input v-bind:class="amplifyUI.input" v-model="code" placeholder="{{$Amplify.I18n.get('Code')}}" autofocus />
       </div>
       <div v-bind:class="amplifyUI.formField" v-if="sent">
-        <div v-bind:class="amplifyUI.inputLabel">New Password *</div>
-        <input v-bind:class="amplifyUI.input" v-model="password" type="password" placeholder="New Password" autofocus />
+        <div v-bind:class="amplifyUI.inputLabel">{{$Amplify.I18n.get('New Password')}} *</div>
+        <input v-bind:class="amplifyUI.input" v-model="password" type="password" placeholder="{{$Amplify.I18n.get('New Password')}}" autofocus />
       </div>
     </div>
 
   <div v-bind:class="amplifyUI.sectionFooter">
       <span v-bind:class="amplifyUI.sectionFooterPrimaryContent">
-        <button v-if="!sent" v-bind:class="amplifyUI.button" v-on:click="submit" :disabled="!username">Submit</button>
-        <button v-if="sent" v-bind:class="amplifyUI.button" v-on:click="verify" :disabled="!username">Verify</button>
+        <button v-if="!sent" v-bind:class="amplifyUI.button" v-on:click="submit" :disabled="!username">{{$Amplify.I18n.get('Submit')}}</button>
+        <button v-if="sent" v-bind:class="amplifyUI.button" v-on:click="verify" :disabled="!username">{{$Amplify.I18n.get('Send Code')}}</button>
       </span>
       <span v-bind:class="amplifyUI.sectionFooterSecondaryContent">
-        <a v-if="!sent" v-bind:class="amplifyUI.a" v-on:click="signIn">Back to Sign In</a>
-        <a v-if="sent" v-bind:class="amplifyUI.a" v-on:click="submit">Resend Code</a>
+        <a v-if="!sent" v-bind:class="amplifyUI.a" v-on:click="signIn">{{$Amplify.I18n.get('Back to Sign In')}}</a>
+        <a v-if="sent" v-bind:class="amplifyUI.a" v-on:click="submit">{{$Amplify.I18n.get('Resend Code')}}</a>
       </span>
     </div>
     <div class="error" v-if="error">
@@ -66,7 +66,7 @@ export default {
   computed: {
     options() {
       const defaults = {
-        header: 'Forgot Password',
+        header: this.$Amplify.I18n.get('Reset your password'),
       }
       return Object.assign(defaults, this.forgotPasswordConfig || {})
     }

--- a/packages/aws-amplify-vue/src/components/authenticator/SetMFA.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/SetMFA.vue
@@ -18,7 +18,7 @@
         {{options.mfaDescription}}
       </div>
     </div>
-    <div v-bind:class="amplifyUI.sectionHeader" v-if="displayTotpSetup">Verify Authentication Token
+    <div v-bind:class="amplifyUI.sectionHeader" v-if="displayTotpSetup">{{$Amplify.I18n.get('Verify Authentication Token')}}
       <div style="font-size: 16px; color: #828282; margin-top: 10px;">
         {{options.tokenInstructions}}
       </div>
@@ -46,17 +46,17 @@
     <div v-bind:class="amplifyUI.sectionBody" v-if="displayTotpSetup">
       <qrcode-vue v-bind:class="amplifyUI.totpQrcode" :value="token" :size="300" level="H"></qrcode-vue>
       <div v-bind:class="amplifyUI.formField" >
-        <div v-bind:class="amplifyUI.inputLabel">Verification Code *</div>
-        <input v-bind:class="amplifyUI.input" v-model="code" placeholder="Verification Code" autofocus />
+        <div v-bind:class="amplifyUI.inputLabel">{{$Amplify.I18n.get('Verification Code')}} *</div>
+        <input v-bind:class="amplifyUI.input" v-model="code" placeholder="{{$Amplify.I18n.get('Verification Code')}}" autofocus />
       </div>
     </div>
     <div v-bind:class="amplifyUI.sectionFooter">
       <span v-bind:class="amplifyUI.sectionFooterPrimaryContent">
-        <button id="setMfa" v-bind:class="amplifyUI.button" v-on:click="setMFA" v-if="!displayTotpSetup">Set MFA</button>
-        <button id="verify" v-bind:class="amplifyUI.button" v-on:click="verifyTotpToken" v-if="displayTotpSetup">Verify Token</button>
+        <button id="setMfa" v-bind:class="amplifyUI.button" v-on:click="setMFA" v-if="!displayTotpSetup">{{$Amplify.I18n.get('Set MFA')}}</button>
+        <button id="verify" v-bind:class="amplifyUI.button" v-on:click="verifyTotpToken" v-if="displayTotpSetup">{{$Amplify.I18n.get('Verify Token')}}</button>
       </span>
       <span v-bind:class="amplifyUI.sectionFooterSecondaryContent">
-        <a v-bind:class="amplifyUI.a" v-on:click="cancel">Cancel</a>
+        <a v-bind:class="amplifyUI.a" v-on:click="cancel">{{$Amplify.I18n.get('Cancel')}}</a>
       </span>
     </div>
     <div class="error" v-if="error">

--- a/packages/aws-amplify-vue/src/components/authenticator/SignIn.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/SignIn.vue
@@ -16,25 +16,25 @@
     <div v-bind:class="amplifyUI.sectionHeader">{{options.header}}</div>
     <div v-bind:class="amplifyUI.sectionBody">
       <div v-bind:class="amplifyUI.formField">
-        <div v-bind:class="amplifyUI.inputLabel">Username *</div>
-        <input v-bind:class="amplifyUI.input"  v-model="options.username" placeholder="Username" autofocus v-on:keyup.enter="signIn" />
+        <div v-bind:class="amplifyUI.inputLabel">{{$Amplify.I18n.get('Username')}} *</div>
+        <input v-bind:class="amplifyUI.input"  v-model="options.username" placeholder="{{$Amplify.I18n.get('Enter your username')}}" autofocus v-on:keyup.enter="signIn" />
       </div>
       <div v-bind:class="amplifyUI.formField">
-        <div v-bind:class="amplifyUI.inputLabel">Password *</div>
-        <input  v-bind:class="amplifyUI.input" v-model="password" type="password" placeholder="Password" v-on:keyup.enter="signIn" />
+        <div v-bind:class="amplifyUI.inputLabel">{{$Amplify.I18n.get('Password')}} *</div>
+        <input  v-bind:class="amplifyUI.input" v-model="password" type="password" placeholder="{{$Amplify.I18n.get('Enter your password')}}" v-on:keyup.enter="signIn" />
         <div v-bind:class="amplifyUI.hint">
-          Forgot your password?
-          <a v-bind:class="amplifyUI.a" v-on:click="forgot">Reset</a>
+          {{$Amplify.I18n.get('Forget your password? ')}}
+          <a v-bind:class="amplifyUI.a" v-on:click="forgot">{{$Amplify.I18n.get('Reset password')}}</a>
         </div>
       </div>
     </div>
     <div v-bind:class="amplifyUI.sectionFooter">
       <span v-bind:class="amplifyUI.sectionFooterPrimaryContent">
-        <button v-bind:class="amplifyUI.button" v-on:click="signIn">Sign In</button>
+        <button v-bind:class="amplifyUI.button" v-on:click="signIn">{{$Amplify.I18n.get('Sign In')}}</button>
       </span>
       <span v-bind:class="amplifyUI.sectionFooterSecondaryContent">
-        No Account?
-        <a v-bind:class="amplifyUI.a" v-on:click="signUp">Sign Up</a>
+        {{$Amplify.I18n.get('No account? ')}}
+        <a v-bind:class="amplifyUI.a" v-on:click="signUp">{{$Amplify.I18n.get('Create account')}}</a>
       </span>
     </div>
     <div class="error" v-if="error">
@@ -63,7 +63,7 @@ export default {
   computed: {
     options() {
       const defaults = {
-        header: 'Sign In',
+        header: this.$Amplify.I18n.get('Sign In Account'),
         username: ''
       }
       return Object.assign(defaults, this.signInConfig || {})

--- a/packages/aws-amplify-vue/src/components/authenticator/SignOut.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/SignOut.vue
@@ -43,7 +43,7 @@ export default {
     options() {
       const defaults = {
         msg: null,
-        signOutButton: 'Sign Out'
+        signOutButton: this.$Amplify.I18n.get('Sign Out')
       }
       return Object.assign(defaults, this.signOutConfig || {})
     }

--- a/packages/aws-amplify-vue/src/components/authenticator/SignUp.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/SignUp.vue
@@ -45,11 +45,11 @@
     </div>
     <div v-bind:class="amplifyUI.sectionFooter">
       <span v-bind:class="amplifyUI.sectionFooterPrimaryContent">
-        <button v-bind:class="amplifyUI.button" v-on:click="signUp">Create Account</button>
+        <button v-bind:class="amplifyUI.button" v-on:click="signUp">{{$Amplify.I18n.get('Create account')}}</button>
       </span>
       <span v-bind:class="amplifyUI.sectionFooterSecondaryContent">
-        Have an Account?
-        <a v-bind:class="amplifyUI.a" v-on:click="signIn">Sign In</a>
+        {{$Amplify.I18n.get('Have an account? ')}}
+        <a v-bind:class="amplifyUI.a" v-on:click="signIn">{{$Amplify.I18n.get('Sign In')}}</a>
       </span>
     </div>
     <div class="error" v-if="error">
@@ -83,31 +83,31 @@ export default {
   computed: {
     options() {
       const defaults = {
-        header: 'Sign Up',
+        header: this.$Amplify.I18n.get('Sign Up Account'),
         signUpFields: [
           {
-            label: 'Username',
+            label: this.$Amplify.I18n.get('Username'),
             key: 'username',
             required: true,
             type: 'string',
             displayOrder: 1,
           },
           {
-            label: 'Password',
+            label: this.$Amplify.I18n.get('Password'),
             key: 'password',
             required: true,
             type: 'password',
             displayOrder: 2,
           },
           {
-            label: 'Email',
+            label: this.$Amplify.I18n.get('Email'),
             key: 'email',
             required: true,
             type: 'string',
             displayOrder: 3
           },
           {
-            label: 'Phone Number',
+            label: this.$Amplify.I18n.get('Phone Number'),
             key: 'phone_number',
             required: true,
             displayOrder: 4

--- a/packages/aws-amplify-vue/src/plugins/AmplifyPlugin.js
+++ b/packages/aws-amplify-vue/src/plugins/AmplifyPlugin.js
@@ -5,6 +5,7 @@
 const requiredModules = [
   'Auth',
   'AuthClass',
+  'I18n',
   'Logger',
 ];
 


### PR DESCRIPTION
*Issue #1865*

I would like to add I18n support to Vue.js version of authenticator components
 in the same way as the React version.

I replaced the fixed wording with *I18n.get(key)*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
