### PR TITLE
Fix typo in docs/media/analytics_guide

### DIFF
--- a/docs/media/analytics_guide.md
+++ b/docs/media/analytics_guide.md
@@ -466,6 +466,7 @@ Analytics.autoTrack('event', {
     //        myAttr: attr
     //    }
     // }
+});
 ```
 
 For example:


### PR DESCRIPTION
*Description of changes:*
This fixes a typo in `docs/media/analytics_guide`.
A closing `})` has been missing in the example code snippet.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
