### PR TITLE
Fixing yarn create syntax

### DIFF
--- a/docs/media/react_guide.md
+++ b/docs/media/react_guide.md
@@ -16,8 +16,7 @@ If you're using Windows, we recommend the [Windows Subsystem for Linux](https://
 
 - Ensure you have [Create React App](https://github.com/facebook/create-react-app) installed. 
 - Create a new project as follows:<br>
-  `yarn create-react-app -g`<br>
-  `create-react-app myapp`<br>
+  `yarn create react-app myapp`<br>
   `cd myapp`<br>
   **Note** This example uses `yarn`, but you can use `npm` instead.
 


### PR DESCRIPTION
Adding the new yarn create react-app syntax

*Issue #, if available:*

*Description of changes: Updating the create-react-app syntax to mach it's current documentation found at https://github.com/facebook/create-react-app under the Yarn section*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
