### PR TITLE
feature(@aws-amplify/aws-amplify-vue): Add ability to omit sign up fi…

### DIFF
--- a/packages/aws-amplify-vue/__tests__/SignUp.test.js
+++ b/packages/aws-amplify-vue/__tests__/SignUp.test.js
@@ -187,6 +187,14 @@ describe('SignUp', () => {
         type: 'string',
       },
     ];
+
+    const omitFields = [
+      {
+        key: 'phone_number',
+        displayOrder: -1
+      }
+    ]
+
     beforeEach(() => {
       header = 'TestHeader';
       wrapper = shallowMount(SignUp, {
@@ -222,5 +230,37 @@ describe('SignUp', () => {
       const email = wrapper.vm.options.signUpFields.find(x => x.key === 'email');
       expect(email.label).toEqual('Test Email');
     });
+  });
+
+  describe('...when signUpFields are omitted...', () => {
+
+    const signUpFields = [
+      {
+        key: 'phone_number',
+        displayOrder: -1
+      }
+    ]
+
+    beforeEach(() => {
+      wrapper = shallowMount(SignUp, {
+        methods: {
+          signUp: mockSignUp
+        },
+        propsData: {
+          signUpConfig: {
+            signUpFields,
+          },
+        },
+      });
+    });
+
+    afterEach(() => {
+      mockSignUp.mockReset();
+    });
+
+    it('...should omit the signUpFields given a displayOrder of -1', () => {
+      expect(wrapper.vm.options.signUpFields.length).toEqual(3);
+    });
+
   });
 });


### PR DESCRIPTION
…elds by giving them a negative number as a displayOrder value.

issue #1901

*Description of changes:*
Add logic to remove fields that have been given a negative displayOrder, so that when the returned options are iterated through a 'v-for' directive, the omitted fields are not rendered to the ui. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
