### PR TITLE
Fix SignIn not signing in onKeyDown

### DIFF
--- a/packages/aws-amplify-react/src/Auth/SignIn.jsx
+++ b/packages/aws-amplify-react/src/Auth/SignIn.jsx
@@ -56,10 +56,11 @@ export default class SignIn extends AuthPiece {
     }
 
     onKeyDown(e) {
-        if (this.props.authState === 'signIn' && !this.props.hide) {
-            if (e.keyCode === 13) { // when press enter
-                this.signIn();
-            }
+        if (e.keyCode !== 13) return;
+
+        const { hide = [] } = this.props;
+        if (this.props.authState === 'signIn' && !hide.includes(SignIn)) {
+            this.signIn();
         }
     }
 
@@ -104,7 +105,7 @@ export default class SignIn extends AuthPiece {
                 if (err.code === 'UserNotConfirmedException') {
                     logger.debug('the user is not confirmed');
                     this.changeState('confirmSignUp', { username });
-                } 
+                }
                 else if (err.code === 'PasswordResetRequiredException') {
                     logger.debug('the user requires a new password');
                     this.changeState('requireNewPassword', { username });
@@ -160,7 +161,7 @@ export default class SignIn extends AuthPiece {
                             </Hint>
                         }
                     </FormField>
-                    
+
                 </SectionBody>
                 <SectionFooter theme={theme}>
                     <SectionFooterPrimaryContent theme={theme}>


### PR DESCRIPTION
*Issue #:* None

*Description of changes:* Fixes `SignIn` component not calling `signIn()` when Enter key is pressed.

The check for `!this.props.hide` didn't make sense, because `this.props.hide` is an array that contains components. The breaking change was introduced [here](https://github.com/aws-amplify/amplify-js/commit/bc6e54c3618ae38deee8e77f970066a8e2c851cc) .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.