### PR TITLE
fix(@aws-amplify/auth): Adding theme support to the FederatedButtons "or" Strike

### DIFF
--- a/packages/aws-amplify-react/src/Auth/FederatedSignIn.jsx
+++ b/packages/aws-amplify-react/src/Auth/FederatedSignIn.jsx
@@ -119,7 +119,7 @@ export class FederatedButtons extends Component {
                 <div>
                 {this.auth0(auth0)}
                 </div>
-                <Strike>{I18n.get('or')}</Strike>
+                <Strike theme={theme}>{I18n.get('or')}</Strike>
             </div>
         );
     }


### PR DESCRIPTION
*No Issue Number*
This is a trivial change, no issue was created.

*Description of changes:*
Adding support to the `FederatedButtons` to theme the `Strike` containing "or". `Strike` is a theme able element in Amplify UI and should be supported in this use case as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.