### PR TITLE
feat(@aws-amplify/auth): Add device remembering methods for current auth user

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1332,6 +1332,51 @@ export default class AuthClass {
         };
     }
 
+    /**
+     * Set device status as remembered for the current cognito user
+     * @return - A promise resolve if success
+     */
+    public async setDeviceStatusRemembered() {
+      const user = await this.currentUserPoolUser();
+
+      return new Promise((resolve, reject) => {
+        user.setDeviceStatusRemembered({
+          onSuccess: resolve,
+          onFailure: reject,
+        });
+      });
+    }
+
+    /**
+     * Set device status as not remembered for the current cognito user
+     * @return - A promise resolve if success
+     */
+    public async setDeviceStatusNotRemembered() {
+      const user = await this.currentUserPoolUser();
+
+      return new Promise((resolve, reject) => {
+        user.setDeviceStatusNotRemembered({
+          onSuccess: resolve,
+          onFailure: reject,
+        });
+      });
+    }
+
+    /**
+     * Set device status as not forgotten for the current cognito user
+     * @return - A promise resolve if success
+     */
+    public async forgetDevice() {
+      const user = await this.currentUserPoolUser();
+
+      return new Promise((resolve, reject) => {
+        user.forgetDevice({
+          onSuccess: resolve,
+          onFailure: reject,
+        });
+      });
+    }
+
     private attributesToObject(attributes) {
         const obj = {};
         if (attributes) {

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1336,7 +1336,7 @@ export default class AuthClass {
      * Set device status as remembered for the current cognito user
      * @return - A promise resolve if success
      */
-    public async setDeviceStatusRemembered() {
+    public async setDeviceStatusRemembered(): Promise<string> {
       const user = await this.currentUserPoolUser();
 
       return new Promise((resolve, reject) => {
@@ -1351,7 +1351,7 @@ export default class AuthClass {
      * Set device status as not remembered for the current cognito user
      * @return - A promise resolve if success
      */
-    public async setDeviceStatusNotRemembered() {
+    public async setDeviceStatusNotRemembered(): Promise<string> {
       const user = await this.currentUserPoolUser();
 
       return new Promise((resolve, reject) => {
@@ -1366,7 +1366,7 @@ export default class AuthClass {
      * Set device status as not forgotten for the current cognito user
      * @return - A promise resolve if success
      */
-    public async forgetDevice() {
+    public async forgetDevice(): Promise<string> {
       const user = await this.currentUserPoolUser();
 
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
Resolves #137 (at least in part).

*Description of changes:*
This wraps the remember/forget methods for the current auth user's device with the AWS Amplify Auth API / promises.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.