### PR TITLE
fix(@aws-amplify/api): specify result error type

### DIFF
--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -73,6 +73,13 @@ export interface GraphQLOptions {
 
 export interface GraphQLResult {
     data?: object,
-    errors?: [object],
+    errors?: [{
+        message: string,
+        locations?: [{
+            line: number,
+            column: number
+        }],
+        path?: [string | number]
+    }],
     extensions?: { [key: string]: any },
 }


### PR DESCRIPTION
*Description of changes:*

`GraphQLResult.error` has currently a type of `object` which was changed to `Error`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
