### PR TITLE
bumping versions

### DIFF
--- a/packages/amplify-ui/package.json
+++ b/packages/amplify-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/ui",
-  "version": "1.0.9-unstable.0",
+  "version": "1.0.9",
   "main": "dist/aws-amplify-ui.js",
   "publishConfig": {
     "access": "public"

--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify-angular",
-  "version": "2.0.12-unstable.3",
+  "version": "2.1.0-unstable.0",
   "description": "AWS Amplify Angular Components",
   "main": "bundles/aws-amplify-angular.umd.js",
   "module": "dist/index.js",

--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify-angular",
-  "version": "2.1.0-unstable.0",
+  "version": "2.1.0",
   "description": "AWS Amplify Angular Components",
   "main": "bundles/aws-amplify-angular.umd.js",
   "module": "dist/index.js",

--- a/packages/aws-amplify-react-native/package.json
+++ b/packages/aws-amplify-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify-react-native",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "AWS Amplify is a JavaScript library for Frontend and mobile developers building cloud-enabled applications.",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/aws-amplify-react/package.json
+++ b/packages/aws-amplify-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify-react",
-  "version": "2.1.3-unstable.3",
+  "version": "2.2.0-unstable.0",
   "description": "AWS Amplify is a JavaScript library for Frontend and mobile developers building cloud-enabled applications.",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/aws-amplify-react/package.json
+++ b/packages/aws-amplify-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify-react",
-  "version": "2.2.0-unstable.0",
+  "version": "2.2.0",
   "description": "AWS Amplify is a JavaScript library for Frontend and mobile developers building cloud-enabled applications.",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/aws-amplify-react/src/Auth/SignUp.jsx
+++ b/packages/aws-amplify-react/src/Auth/SignUp.jsx
@@ -265,5 +265,4 @@ export default class SignUp extends AuthPiece {
         );
     }
 
-
 }

--- a/packages/aws-amplify-vue/package.json
+++ b/packages/aws-amplify-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify-vue",
-  "version": "0.1.6-unstable.0",
+  "version": "0.2.0-unstable.0",
   "license": "Apache-2.0",
   "private": false,
   "author": "Amazon Web Services",

--- a/packages/aws-amplify-vue/package.json
+++ b/packages/aws-amplify-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify-vue",
-  "version": "0.2.0-unstable.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "private": false,
   "author": "Amazon Web Services",


### PR DESCRIPTION
*Description of changes:*
Proper semantic versioning plus resolving lerna issue:

```
Changes:
 - @aws-amplify/ui: 1.0.9-unstable.0 => 1.0.9-beta.0
 - aws-amplify-angular: 2.0.12-unstable.3 => 2.0.12-beta.0
 - aws-amplify-react-native: 2.0.8 => 2.0.9-beta.0
 - aws-amplify-react: 2.1.3-unstable.3 => 2.1.3-beta.0
 - aws-amplify-vue: 0.1.6-unstable.0 => 0.1.6-beta.0

lerna info auto-confirmed 
lerna ERR! execute caught error
lerna ERR! Error: fatal: tag 'aws-amplify-angular@2.0.12-beta.0' already exists
lerna ERR! 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
