### PR TITLE
@aws-amplify/interactions Support structured objects when sending text

### DIFF
--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -48,7 +48,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
             //  TODO: Implement for content
             let params = {
                 botAlias: this._config[botname].alias,
-                botName: botname,
+                botName: this._config[botname].name,
                 userId: credentials.identityId
             };
             if (typeof message === 'string') {


### PR DESCRIPTION
The object structure is just a passthrough for postText call. This is
useful for setting other parameters like sessionAttributes.

*Issue #, if available:*
While using the Interactions module, I found it rather limiting what information I can send to a Lex chatbot. I need to be able to set session attributes alongside my slot information. 

*Description of changes:*
After reviewing the default AWSLexProvider, I think the most straight forward approach would be to just passthrough the parameters available in the LexRuntime SDK. For consistency, the botname, bot alias, and userId cannot be provided in the request object. If they are, they will be overwritten with the information provided in the interactions configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
