### PR TITLE
feature(amazon-cognito-identity-js) allow custom auth

### DIFF
--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -195,7 +195,7 @@ export default class CognitoUser {
   authenticateUser(authDetails, callback) {
     if (this.authenticationFlowType === 'USER_PASSWORD_AUTH') {
       return this.authenticateUserPlainUsernamePassword(authDetails, callback);
-    } else if (this.authenticationFlowType === 'USER_SRP_AUTH') {
+    } else if (this.authenticationFlowType === 'USER_SRP_AUTH' || this.authenticationFlowType === 'CUSTOM_AUTH') {
       return this.authenticateUserDefaultAuth(authDetails, callback);
     }
     return callback.onFailure(new Error('Authentication flow type is invalid.'));


### PR DESCRIPTION
*Issue #, if available:*
#525 

*Description of changes:*
Allow custom auth flow type as an extension of normal signin with username/password.

A user should be able to start a signin by entering username and password, and when that passes, be prompted for additional challenges (like custom MFA).  Cognito supports that workflow.  Amplify doesn't.  This solves that.  I have tested this change by making it locally, and everything works following that -> the user is launched into the custom auth flow in Cognito, invoking the correct triggers within.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
