### PR TITLE
API init accepts raw data (text/plain)

### DIFF
--- a/packages/api/src/RestClient.ts
+++ b/packages/api/src/RestClient.ts
@@ -89,6 +89,9 @@ export class RestClient {
         if (initParams.body) {
             libraryHeaders['Content-Type'] = 'application/json; charset=UTF-8';
             params.data = JSON.stringify(initParams.body);
+        } else if (initParams.data) {
+            libraryHeaders['Content-Type'] = 'text/plain; charset=UTF-8';
+            params.data = initParams.data;
         }
 
         params['signerServiceInfo'] = initParams.signerServiceInfo;


### PR DESCRIPTION
https://github.com/aws-amplify/amplify-js/issues/2083

Added the ability to pass text/plain strings to `API.post('api', 'endpoint', { data })`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
