### PR TITLE
The second parameter should be optional for I18n.get()

### DIFF
--- a/packages/core/src/I18n/index.ts
+++ b/packages/core/src/I18n/index.ts
@@ -74,7 +74,7 @@ class I18n {
      * @param {String} key 
      * @param {String} defVal - Default value
      */
-    static get(key, defVal) {
+    static get(key, defVal?) {
         if (!I18n.checkConfig()) { return (typeof defVal === 'undefined')? key : defVal; }
 
         return _i18n.get(key, defVal); 


### PR DESCRIPTION
*Issue #, if available:*

 #1028

*Description of changes:*

While doing the TypeScript conversion I noticed that I18n.get() is called in many places without the second parameter. Looking at the code it seems like this should be an optional parameter so I've added the `?` to make it optional.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
