### PR TITLE
feat(aws-amplify-react): disable sign in button while loading

### DIFF
--- a/packages/amplify-ui/src/Button.css
+++ b/packages/amplify-ui/src/Button.css
@@ -33,6 +33,12 @@
   opacity: 0.8;
 }
 
+.button:disabled {
+  opacity: 1;
+  cursor: auto;
+  background-color: var(--ion-color-primary-tint);
+}
+
 .signInButton {
   position: relative;
   width: 100%;

--- a/packages/aws-amplify-react/__tests__/Auth/SignIn-test.js
+++ b/packages/aws-amplify-react/__tests__/Auth/SignIn-test.js
@@ -80,8 +80,9 @@ describe('SignIn', () => {
 
             wrapper.find(Input).at(0).simulate('change', event_username);
             wrapper.find(Input).at(1).simulate('change', event_password);
-            await wrapper.find(Button).simulate('click');
+            wrapper.find(Button).simulate('click');
 
+            await Promise.resolve(); // await for all other promises to resolve
 
             expect(spyon.mock.calls.length).toBe(1);
             expect(spyon.mock.calls[0][0]).toBe(event_username.target.value);

--- a/packages/aws-amplify-react/src/Amplify-UI/Amplify-UI-Components-React.jsx
+++ b/packages/aws-amplify-react/src/Amplify-UI/Amplify-UI-Components-React.jsx
@@ -230,9 +230,10 @@ export const FormField = (props) => {
 export const Button = (props) => {
     const theme = props.theme || AmplifyTheme;
     const style = propStyle(props, theme.button);
+    const disabled = props.disabled || false;
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <button {...p} className={AmplifyUI.button} style={style}>
+        <button {...p} className={AmplifyUI.button} style={style} disabled={disabled}>
             {props.children}
         </button>
     );


### PR DESCRIPTION
**Issue**
Sign in button was not disabled when loading.
This makes the UI look like nothing is happening after submitting user credentials, specially when using the keyboard Enter key for submission.

**Description of changes:**
1. Added `disabled` state to `Button` component on `Amplify-UI`
2. Making `disabled=true` when signing in on `aws-amplify-react -> Auth`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.