### PR TITLE
add @aws-amplify/ui as the dependent of aws-amplify

### DIFF
--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -69,7 +69,6 @@
     "aws-amplify": "^1.x"
   },
   "dependencies": {
-    "@aws-amplify/ui": "^1.0.10-unstable.1",
     "@types/lodash": "^4.14.106"
   }
 }

--- a/packages/aws-amplify-react/package.json
+++ b/packages/aws-amplify-react/package.json
@@ -65,7 +65,6 @@
     }
   },
   "dependencies": {
-    "@aws-amplify/ui": "^1.0.10-unstable.1",
     "qrcode.react": "^0.8.0",
     "regenerator-runtime": "^0.11.1"
   },

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -55,6 +55,7 @@
     "@aws-amplify/interactions": "^1.0.19-unstable.4",
     "@aws-amplify/pubsub": "^1.0.19-unstable.4",
     "@aws-amplify/storage": "^1.0.20-unstable.5",
-    "@aws-amplify/xr": "^0.1.9-unstable.4"
+    "@aws-amplify/xr": "^0.1.9-unstable.4",
+    "@aws-amplify/ui": "^1.0.10-unstable.1"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Add @aws-amplify/ui into the dependencies of `aws-amplify` and remove it from `aws-amplify-angular` and `aws-amplify-react`.
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
