### PR TITLE
Add theme to button for SignUp and SignIn

### DIFF
--- a/packages/aws-amplify-react-native/src/Auth/ConfirmSignIn.js
+++ b/packages/aws-amplify-react-native/src/Auth/ConfirmSignIn.js
@@ -71,6 +71,7 @@ export default class ConfirmSignIn extends AuthPiece {
                             required={true}
                         />
                         <AmplifyButton
+                            theme={theme}
                             text={I18n.get('Confirm')}
                             onPress={this.confirm}
                             disabled={!this.state.code}

--- a/packages/aws-amplify-react-native/src/Auth/ConfirmSignUp.js
+++ b/packages/aws-amplify-react-native/src/Auth/ConfirmSignUp.js
@@ -91,6 +91,7 @@ export default class ConfirmSignUp extends AuthPiece {
                             required={true}
                         />
                         <AmplifyButton
+                            theme={theme}
                             text={I18n.get('Confirm')}
                             onPress={this.confirm}
                             disabled={!this.state.username || !this.state.code}


### PR DESCRIPTION
*Issue #, if available:*
#1882

*Description of changes:*
Pass theme to AmplifyButton in React Native ConfirmSignIn and ConfirmSignUp components.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
