### PR TITLE
Fix inconsistent component state updates found by LGTM

### DIFF
--- a/packages/aws-amplify-react-native/src/Interactions/ChatBot.js
+++ b/packages/aws-amplify-react-native/src/Interactions/ChatBot.js
@@ -77,22 +77,22 @@ export class ChatBot extends Component {
             return;
         }
 
-        await new Promise(resolve => this.setState({
+        await new Promise(resolve => this.setState(prevState => ({
             dialog: [
-                ...this.state.dialog,
-                { message: this.state.inputText, from: 'me' },
+                ...prevState.dialog,
+                { message: prevState.inputText, from: 'me' },
             ]
-        }, resolve));
+        }), resolve));
 
         const response = await Interactions.send(this.props.botName, this.state.inputText);
 
-        this.setState({
+        this.setState(prevState => ({
             dialog: [
-                ...this.state.dialog,
+                ...prevState.dialog,
                 response && response.message && { from: 'bot', message: response.message }
             ].filter(Boolean),
             inputText: ''
-        }, () => {
+        }), () => {
             setTimeout(() => {
                 this.listItemsRef.current.scrollToEnd();
             }, 50);
@@ -105,12 +105,12 @@ export class ChatBot extends Component {
             const { clearOnComplete } = this.props;
             const message = fn(...args);
 
-            this.setState({
+            this.setState(prevState => ({
                 dialog: [
-                    ...(!clearOnComplete && this.state.dialog),
+                    ...(!clearOnComplete && prevState.dialog),
                     message && { from: 'bot', message }
                 ].filter(Boolean),
-            }, () => {
+            }), () => {
                 setTimeout(() => {
                     this.listItemsRef.current.scrollToEnd();
                 }, 50);

--- a/packages/aws-amplify-react/src/Interactions/ChatBot.jsx
+++ b/packages/aws-amplify-react/src/Interactions/ChatBot.jsx
@@ -65,12 +65,12 @@ export class ChatBot extends Component {
             return;
         }
 
-        await new Promise(resolve => this.setState({
+        await new Promise(resolve => this.setState(prevState => ({
             dialog: [
-                ...this.state.dialog,
-                { message: this.state.inputText, from: 'me' },
+                ...prevState.dialog,
+                { message: prevState.inputText, from: 'me' },
             ]
-        }, resolve));
+        }), resolve));
 
         if (!Interactions || typeof Interactions.send !== 'function') {
             throw new Error('No Interactions module found, please ensure @aws-amplify/interactions is imported');
@@ -78,10 +78,10 @@ export class ChatBot extends Component {
 
         const response = await Interactions.send(this.props.botName, this.state.inputText);
 
-        await this.setState({
-            dialog: [...this.state.dialog, response && { from: 'bot', message: response.message }],
+        await this.setState(prevState => ({
+            dialog: [...prevState.dialog, response && { from: 'bot', message: response.message }],
             inputText: ''
-        });
+        }));
         this.listItemsRef.current.scrollTop = this.listItemsRef.current.scrollHeight;
 
     }
@@ -95,13 +95,13 @@ export class ChatBot extends Component {
             const { clearOnComplete } = this.props;
             const message = fn(...args);
 
-            this.setState(
-                {
+            this.setState(prevState =>
+                ({
                     dialog: [
-                        ...(!clearOnComplete && this.state.dialog),
+                        ...(!clearOnComplete && prevState.dialog),
                         message && { from: 'bot', message }
                     ].filter(Boolean),
-                },
+                }),
                 () => {
                     this.listItemsRef.current.scrollTop = this.listItemsRef.current.scrollHeight;
                 }

--- a/packages/aws-amplify-react/src/Storage/S3Album.js
+++ b/packages/aws-amplify-react/src/Storage/S3Album.js
@@ -110,7 +110,7 @@ export default class S3Album extends Component {
         if (!select) { return; }
 
         item.selected = !item.selected;
-        this.setState({ items: this.state.items.slice() });
+        this.setState(prevState => ({ items: prevState.items.slice() }));
 
         if (!onSelect) { return; }
 


### PR DESCRIPTION
React component state updates using `setState` may asynchronously update `this.props` and `this.state`, thus it is not safe to use either of the two when calculating the new state passed to `setState`, and instead the callback-based variant should be used instead. ([details here](https://lgtm.com/rules/1819283066/)).

These were all found on LGTM.com, and there are [a bunch of other alerts](https://lgtm.com/projects/g/aws-amplify/amplify-js/alerts) for this project that would probably also be good to fix.

*(Full disclosure: I'm part of the team behind LGTM.com)*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
