### PR TITLE
ability to set custom classNames on Amplify-UI-Components-React

### DIFF
--- a/packages/aws-amplify-react/src/Amplify-UI/Amplify-UI-Components-React.jsx
+++ b/packages/aws-amplify-react/src/Amplify-UI/Amplify-UI-Components-React.jsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { JS } from '@aws-amplify/core';
 
-import "@aws-amplify/ui/dist/style.css";
+import '@aws-amplify/ui/dist/style.css';
 import * as AmplifyUI from '@aws-amplify/ui';
 
 import AmplifyTheme from './Amplify-UI-Theme';
@@ -13,7 +13,11 @@ export const Container = (props) => {
     const p = JS.objectLessAttributes(props, 'theme');
 
     return beforeAfter(
-        <div {...p} className={AmplifyUI.container} style={style}>
+        <div
+            {...p}
+            className={_cls(p.className, AmplifyUI.container)}
+            style={style}
+        >
             {props.children}
         </div>
     );
@@ -22,7 +26,10 @@ export const Container = (props) => {
 export const FormContainer = (props) => {
     const theme = props.theme || AmplifyTheme;
     return beforeAfter(
-        <div className={AmplifyUI.formContainer} style={theme.formContainer}>
+        <div
+            className={_cls(p.className, AmplifyUI.formContainer)}
+            style={theme.formContainer}
+        >
             {props.children}
         </div>
     );
@@ -34,7 +41,10 @@ export const FormSection = (props) => {
     return (
         <FormContainer theme={theme}>
             {beforeAfter(
-                <div className={AmplifyUI.formSection} style={style}>
+                <div
+                    className={_cls(p.className, AmplifyUI.formSection)}
+                    style={style}
+                >
                     {props.children}
                 </div>
             )}
@@ -47,14 +57,18 @@ export const SectionHeader = (props) => {
     const style = propStyle(props, theme.sectionHeader);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <div {...p} className={AmplifyUI.sectionHeader} style={style}>
+        <div
+            {...p}
+            className={_cls(p.className, AmplifyUI.sectionHeader)}
+            style={style}
+        >
             <SectionHeaderContent theme={theme}>
                 {props.children}
-                {props.hint &&
+                {props.hint && (
                     <div className={AmplifyUI.sectionHeaderHint}>
                         {props.hint}
                     </div>
-                }
+                )}
             </SectionHeaderContent>
         </div>
     );
@@ -64,7 +78,10 @@ export const SectionHeaderContent = (props) => {
     const theme = props.theme || AmplifyTheme;
     const style = propStyle(props, theme.sectionHeaderContent);
     return beforeAfter(
-        <span className={AmplifyUI.sectionHeaderContent} style={style}>
+        <span
+            className={_cls(p.className, AmplifyUI.sectionHeaderContent)}
+            style={style}
+        >
             {props.children}
         </span>
     );
@@ -75,7 +92,11 @@ export const SectionFooter = (props) => {
     const style = propStyle(props, theme.sectionFooter);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <div {...p} className={AmplifyUI.sectionFooter} style={style}>
+        <div
+            {...p}
+            className={_cls(p.className, AmplifyUI.sectionFooter)}
+            style={style}
+        >
             {props.children}
         </div>
     );
@@ -85,7 +106,10 @@ export const SectionFooterPrimaryContent = (props) => {
     const theme = props.theme || AmplifyTheme;
     const style = propStyle(props, theme.sectionFooterPrimaryContent);
     return beforeAfter(
-        <span className={AmplifyUI.sectionFooterPrimaryContent} style={style}>
+        <span
+            className={_cls(p.className, AmplifyUI.sectionFooterPrimaryContent)}
+            style={style}
+        >
             {props.children}
         </span>
     );
@@ -95,7 +119,13 @@ export const SectionFooterSecondaryContent = (props) => {
     const theme = props.theme || AmplifyTheme;
     const style = propStyle(props, theme.sectionFooterSecondaryContent);
     return beforeAfter(
-        <span className={AmplifyUI.sectionFooterSecondaryContent} style={style}>
+        <span
+            className={_cls(
+                p.className,
+                AmplifyUI.sectionFooterSecondaryContent
+            )}
+            style={style}
+        >
             {props.children}
         </span>
     );
@@ -106,7 +136,11 @@ export const SectionBody = (props) => {
     const style = propStyle(props, theme.sectionBody);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <div {...p} className={AmplifyUI.sectionBody} style={style}>
+        <div
+            {...p}
+            className={_cls(p.className, AmplifyUI.sectionBody)}
+            style={style}
+        >
             {props.children}
         </div>
     );
@@ -127,7 +161,7 @@ export const Strike = (props) => {
     const theme = props.theme || AmplifyTheme;
     const style = propStyle(props, theme.strike);
     return beforeAfter(
-        <div className={AmplifyUI.strike} style={style}>
+        <div className={_cls(p.className, AmplifyUI.strike)} style={style}>
             <StrikeContent theme={theme}>{props.children}</StrikeContent>
         </div>
     );
@@ -136,7 +170,10 @@ export const Strike = (props) => {
 export const StrikeContent = (props) => {
     const theme = props.theme || AmplifyTheme;
     return beforeAfter(
-        <span className={AmplifyUI.strikeContent} style={theme.strikeContent}>
+        <span
+            className={_cls(p.className, AmplifyUI.strikeContent)}
+            style={theme.strikeContent}
+        >
             {props.children}
         </span>
     );
@@ -147,7 +184,11 @@ export const FormRow = (props) => {
     const style = propStyle(props, theme.formRow);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <div {...p} className={AmplifyUI.formRow} style={style}>
+        <div
+            {...p}
+            className={_cls(p.className, AmplifyUI.formRow)}
+            style={style}
+        >
             {props.children}
         </div>
     );
@@ -158,14 +199,10 @@ export const RadioRow = (props) => {
     const theme = props.theme || AmplifyTheme;
     return (
         <FormRow theme={theme}>
-            <Radio
-                {...props}
-                id={id}
-            />
-            <Label
-                htmlFor={id}
-                theme={theme}
-            >{props.placeholder}</Label>
+            <Radio {...props} id={id} />
+            <Label htmlFor={id} theme={theme}>
+                {props.placeholder}
+            </Label>
         </FormRow>
     );
 };
@@ -175,12 +212,12 @@ export const Radio = (props) => {
     const style = propStyle(props, theme.radio);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-            <input
-                {...p}
-                type="radio"
-                className={AmplifyUI.radio}
-                style={style}
-            />
+        <input
+            {...p}
+            type="radio"
+            className={_cls(p.className, AmplifyUI.radio)}
+            style={style}
+        />
     );
 };
 
@@ -191,7 +228,11 @@ export const InputRow = (props) => {
     return (
         <FormRow theme={theme}>
             {beforeAfter(
-                <input {...p} className={AmplifyUI.input} style={style} />
+                <input
+                    {...p}
+                    className={_cls(p.className, AmplifyUI.input)}
+                    style={style}
+                />
             )}
         </FormRow>
     );
@@ -202,7 +243,11 @@ export const Input = (props) => {
     const style = propStyle(props, theme.input);
     const p = JS.objectLessAttributes(props, 'theme');
     return (
-        <input {...p} className={AmplifyUI.input} style={style} />
+        <input
+            {...p}
+            className={_cls(p.className, AmplifyUI.input)}
+            style={style}
+        />
     );
 };
 
@@ -210,7 +255,7 @@ export const SelectInput = (props) => {
     const theme = props.theme || AmplifyTheme;
     const style = propStyle(props, theme.selectInput);
     return (
-        <div className={AmplifyUI.selectInput} style={style}>
+        <div className={_cls(p.className, AmplifyUI.selectInput)} style={style}>
             {props.children}
         </div>
     );
@@ -221,7 +266,11 @@ export const FormField = (props) => {
     const style = propStyle(props, theme.formField);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <div {...p} className={AmplifyUI.formField} style={style}>
+        <div
+            {...p}
+            className={_cls(p.className, AmplifyUI.formField)}
+            style={style}
+        >
             {props.children}
         </div>
     );
@@ -233,7 +282,12 @@ export const Button = (props) => {
     const disabled = props.disabled || false;
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <button {...p} className={AmplifyUI.button} style={style} disabled={disabled}>
+        <button
+            {...p}
+            className={_cls(p.className, AmplifyUI.button)}
+            style={style}
+            disabled={disabled}
+        >
             {props.children}
         </button>
     );
@@ -244,7 +298,14 @@ export const PhotoPickerButton = (props) => {
     const style = propStyle(props, theme.photoPickerButton);
     const p = JS.objectLessAttributes(props, 'theme');
     return (
-        <button {...p} className={[AmplifyUI.photoPickerButton, AmplifyUI.button].join(' ')} style={style}>
+        <button
+            {...p}
+            className={_cls(
+                p.className,
+                [AmplifyUI.photoPickerButton, AmplifyUI.button].join(' ')
+            )}
+            style={style}
+        >
             {props.children}
         </button>
     );
@@ -256,7 +317,11 @@ export const SignInButton = (props) => {
     const p = JS.objectLessAttributes(props, 'theme');
 
     return beforeAfter(
-        <button {...p} className={AmplifyUI.signInButton} style={styles}>
+        <button
+            {...p}
+            className={_cls(p.className, AmplifyUI.signInButton)}
+            style={styles}
+        >
             {props.children}
         </button>
     );
@@ -267,7 +332,11 @@ export const SignInButtonIcon = (props) => {
     const style = propStyle(props, theme.signInButtonIcon);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <span {...p} className={AmplifyUI.signInButtonIcon} style={style}>
+        <span
+            {...p}
+            className={_cls(p.className, AmplifyUI.signInButtonIcon)}
+            style={style}
+        >
             {props.children}
         </span>
     );
@@ -277,7 +346,10 @@ export const SignInButtonContent = (props) => {
     const theme = props.theme || AmplifyTheme;
     const style = propStyle(props, theme.signInButtonContent);
     return beforeAfter(
-        <span className={AmplifyUI.signInButtonContent} style={style}>
+        <span
+            className={_cls(p.className, AmplifyUI.signInButtonContent)}
+            style={style}
+        >
             {props.children}
         </span>
     );
@@ -288,7 +360,9 @@ export const Link = (props) => {
     const style = propStyle(props, theme.a);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <a {...p} className={AmplifyUI.a} style={style}>{props.children}</a>
+        <a {...p} className={_cls(p.className, AmplifyUI.a)} style={style}>
+            {props.children}
+        </a>
     );
 };
 
@@ -297,7 +371,13 @@ export const Label = (props) => {
     const style = propStyle(props, theme.label);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <label {...p} className={AmplifyUI.label} style={style}>{props.children}</label>
+        <label
+            {...p}
+            className={_cls(p.className, AmplifyUI.label)}
+            style={style}
+        >
+            {props.children}
+        </label>
     );
 };
 
@@ -305,7 +385,7 @@ export const Hint = (props) => {
     const theme = props.theme || AmplifyTheme;
     const style = propStyle(props, theme.hint);
     return beforeAfter(
-        <div className={AmplifyUI.hint} style={style}>
+        <div className={_cls(p.className, AmplifyUI.hint)} style={style}>
             {props.children}
         </div>
     );
@@ -315,7 +395,7 @@ export const InputLabel = (props) => {
     const theme = props.theme || AmplifyTheme;
     const style = propStyle(props, theme.inputLabel);
     return beforeAfter(
-        <div className={AmplifyUI.inputLabel} style={style}>
+        <div className={_cls(p.className, AmplifyUI.inputLabel)} style={style}>
             {props.children}
         </div>
     );
@@ -326,7 +406,11 @@ export const NavBar = (props) => {
     const style = propStyle(props, theme.navBar);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <div {...p} className={AmplifyUI.navBar} style={style}>
+        <div
+            {...p}
+            className={_cls(p.className, AmplifyUI.navBar)}
+            style={style}
+        >
             {props.children}
         </div>
     );
@@ -337,7 +421,7 @@ export const Nav = (props) => {
     const style = propStyle(props, theme.nav);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <div {...p} className={AmplifyUI.nav} style={style}>
+        <div {...p} className={_cls(p.className, AmplifyUI.nav)} style={style}>
             {props.children}
         </div>
     );
@@ -348,7 +432,11 @@ export const NavRight = (props) => {
     const style = propStyle(props, theme.navRight);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <div {...p} className={AmplifyUI.navRight} style={style}>
+        <div
+            {...p}
+            className={_cls(p.className, AmplifyUI.navRight)}
+            style={style}
+        >
             {props.children}
         </div>
     );
@@ -359,7 +447,11 @@ export const NavItem = (props) => {
     const style = propStyle(props, theme.navItem);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <div {...p} className={AmplifyUI.navItem} style={style}>
+        <div
+            {...p}
+            className={_cls(p.className, AmplifyUI.navItem)}
+            style={style}
+        >
             {props.children}
         </div>
     );
@@ -370,10 +462,12 @@ export const NavButton = (props) => {
     const style = propStyle(props, theme.navButton);
     const p = JS.objectLessAttributes(props, 'theme');
     return beforeAfter(
-        <button {...p} className={AmplifyUI.button} style={style}>
-            {beforeAfter(
-                <span>{props.children}</span>
-            )}
+        <button
+            {...p}
+            className={_cls(p.className, AmplifyUI.button)}
+            style={style}
+        >
+            {beforeAfter(<span>{props.children}</span>)}
         </button>
     );
 };
@@ -383,28 +477,39 @@ export const Toast = (props) => {
     const theme = props.theme || AmplifyTheme;
 
     return (
-        <div theme={theme} className={AmplifyUI.toast} style={theme.toast}>
+        <div
+            theme={theme}
+            className={_cls(p.className, AmplifyUI.toast)}
+            style={theme.toast}
+        >
             <span>{props.children}</span>
-            <a className={AmplifyUI.toastClose} onClick={onClose}/>
+            <a className={AmplifyUI.toastClose} onClick={onClose} />
         </div>
     );
 };
 
 Toast.defaultProps = {
-    onClose: () => void(0)
+    onClose: () => void 0
 };
 
 export const PhotoPlaceholder = (props) => {
     const theme = props.theme || AmplifyTheme;
     const style = propStyle(props, theme.photoPlaceholder);
     return (
-        <div className={AmplifyUI.photoPlaceholder} style={style}>
+        <div
+            className={_cls(p.className, AmplifyUI.photoPlaceholder)}
+            style={style}
+        >
             <div className={AmplifyUI.photoPlaceholderIcon}>
-                <svg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 24 24'>
-                    <circle cx='12' cy='12' r='3.2' />
-                    <path d='M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z'
-                    />
-                    <path d='M0 0h24v24H0z' fill='none' />
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="64"
+                    height="64"
+                    viewBox="0 0 24 24"
+                >
+                    <circle cx="12" cy="12" r="3.2" />
+                    <path d="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z" />
+                    <path d="M0 0h24v24H0z" fill="none" />
                 </svg>
             </div>
         </div>
@@ -414,7 +519,9 @@ export const PhotoPlaceholder = (props) => {
 export const beforeAfter = (el) => {
     const style = el.props.style || {};
     const { before, after } = style;
-    if (!before && !after) { return el; }
+    if (!before && !after) {
+        return el;
+    }
 
     return (
         <span style={{ position: 'relative' }}>
@@ -428,9 +535,14 @@ export const beforeAfter = (el) => {
 export const propStyle = (props, themeStyle) => {
     const { id, style } = props;
     const styl = Object.assign({}, style, themeStyle);
-    if (!id) { return styl; }
+    if (!id) {
+        return styl;
+    }
 
     const selector = '#' + id;
     Object.assign(styl, styl[selector]);
     return styl;
 };
+
+const _cls = (cls1, cls2) =>
+    (cls1 || '') + (cls1 && clas2 ? ' ' : '') + (cls2 || '');


### PR DESCRIPTION
*Description of changes:*

This allows me to set a custom className (in addition to the default ones) on Amplify-UI-Components-React elements. The previous way they worked would overwrite any `className` that you pass in.

```jsx
<Input
  type="text"
  name="name"
  theme={theme}
  value={this.state.name}
  placeholder={I18n.get('Cardholder Name')}
  onChange={this.handleInputChange}
  className={classNames({
    'has-error': errorFields.name
  })}
  />
```

I would like to do this, because I’m currently using some of these components in custom ways in my app, building off of this idea: https://github.com/aws-amplify/amplify-js/issues/2272

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
