### PR TITLE
Fix For Error when using hideDefault={true}

### DIFF
--- a/packages/aws-amplify-react/src/Auth/Authenticator.jsx
+++ b/packages/aws-amplify-react/src/Auth/Authenticator.jsx
@@ -170,7 +170,7 @@ export default class Authenticator extends Component {
         ];
 
         const props_children_override =  React.Children.map(props_children, child => child.props.override);
-        hide = hide.filter((component) => !props_children.find(child => child.type === component));
+        hide = hide.filter((component) => !props_children_override.find(child => child.type === component));
         
         const render_props_children = React.Children.map(props_children, (child, index) => {
             return React.cloneElement(child, {


### PR DESCRIPTION
*Issue*
Using hideDefault={true} was throwing an error props_children does not have function find.
*Description of changes:*
looking into the changelog it appears to be a typographical mistake.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
