### PR TITLE
fix(@aws-amplify/storage): Explicitly declare signatureVersion 'v4'

### DIFF
--- a/packages/storage/src/Providers/AWSS3Provider.ts
+++ b/packages/storage/src/Providers/AWSS3Provider.ts
@@ -366,6 +366,7 @@ export default class AWSS3Provider implements StorageProvider{
         return new S3({
             apiVersion: '2006-03-01',
             params: { Bucket: bucket },
+            signatureVersion: 'v4',
             region
         });
     }


### PR DESCRIPTION
*Issue #, if available:* Fixes #2378

*Description of changes:*
Add explicit signature version when creating S3 object. This allows generating a presigned URL for AWS KMS–managed encrypted files. From docs:
"When creating a presigned URL for an object encrypted using an AWS KMS–managed encryption key, you must explicitly specify Signature Version 4."

See https://docs.aws.amazon.com/AmazonS3/latest/dev/kms-using-sdks.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.