### PR TITLE
fix(@aws-amplify-react/Auth)

### DIFF
--- a/packages/aws-amplify-react/__tests__/Auth/SignUp-test.js
+++ b/packages/aws-amplify-react/__tests__/Auth/SignUp-test.js
@@ -716,4 +716,48 @@ describe('signUp with signUpConfig', () => {
         expect(spyon).toBeCalled();
 
     });
+
+    test('signUp should complete even if phone field is hidden', async () => {
+        wrapper.setProps({
+            authState: 'signUp',
+            signUpConfig: {
+                hiddenDefaults: ["phone_number"]
+            }
+        });
+
+        const spyon = jest.spyOn(Auth, 'signUp')
+        .mockImplementationOnce((user, password) => {
+            return new Promise((res, rej) => {
+                res(mockResult);
+            });
+        });
+
+        const event_username = {
+            target: {
+                name: 'username',
+                value: 'user1'
+            }
+        }
+
+        const event_password = {
+            target: {
+                name: 'password',
+                value: 'abc'
+            }
+        }
+
+        const event_email = {
+            target: {
+                name: 'email',
+                value: 'email@amazon.com'
+            }
+        }
+
+        wrapper.find(Input).at(0).simulate('change', event_username);
+        wrapper.find(Input).at(1).simulate('change', event_password);
+        wrapper.find(Input).at(2).simulate('change', event_email);
+        await wrapper.find(Button).simulate('click');
+
+        expect(spyon).toBeCalled();
+    });
 });

--- a/packages/aws-amplify-react/src/Auth/SignUp.jsx
+++ b/packages/aws-amplify-react/src/Auth/SignUp.jsx
@@ -185,7 +185,7 @@ export default class SignUp extends AuthPiece {
         const inputVals = Object.values(this.inputs);
 
         inputKeys.forEach((key, index) => {
-            if (!['username', 'password', 'checkedValue'].includes(key)) {
+            if (!['username', 'password', 'checkedValue', 'dial_code'].includes(key)) {
               if (key !== 'phone_line_number' && key !== 'dial_code' && key !== 'error') {
                 const newKey = `${this.needPrefix(key) ? 'custom:' : ''}${key}`;
                 signup_info.attributes[newKey] = inputVals[index];


### PR DESCRIPTION
Fixes bug where hiding phone number input would case an error see issue #2160

*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/2160 
There are multiple things going on in that issue, this addresses one of them, number 2 in the summary of mrcoles

*Description of changes:*
When adding the attributes to the `signup_info`, the current code creates the `phone_number` attribute both for the `phone_line_number` and the `dial_code` inputs. The second assignment just overrides the first with the same value.
The problem occurs if the phone number default is hidden as the `dial_code` is still added as an input, causing a reference error when calling `replace` on `phone_line_number` which is undefined. 

The fix only adds the `phone_number` attribute for the `phone_line_number` input and ignores the `dial_code` input. 

The test fails without the fix in the code when it tries to call `replace` on an undefined object.

An alternative fix could be in line 165 to extend the if clause to also check that `phone_line_number` is not hidden.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
