### PR TITLE
feat(amazon-cognito-identity-js): use hardtack instead of js-cookie

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "buffer": "4.9.1",
     "crypto-js": "^3.1.9-1",
-    "hardtack": "^2.1.0"
+    "hardtack": "4.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -85,6 +85,7 @@
     "react": "^16.0.0",
     "react-native": "^0.44.0",
     "rimraf": "^2.5.4",
+    "uglifyjs-webpack-plugin": "1.3.0",
     "webpack": "^3.5.5"
   }
 }

--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "buffer": "4.9.1",
     "crypto-js": "^3.1.9-1",
-    "js-cookie": "^2.1.4"
+    "hardtack": "^2.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/packages/amazon-cognito-identity-js/src/CookieStorage.js
+++ b/packages/amazon-cognito-identity-js/src/CookieStorage.js
@@ -1,5 +1,5 @@
 
-import * as Cookies from 'js-cookie';
+import * as hardtack from 'hardtack';
 
 /** @class */
 export default class CookieStorage {
@@ -20,9 +20,11 @@ export default class CookieStorage {
       this.path = '/';
     }
     if (Object.prototype.hasOwnProperty.call(data, 'expires')) {
-      this.expires = data.expires;
+      this.expires = new Date(
+        (new Date() * 1) + (data.expires * 864e5)
+      ).toUTCString();
     } else {
-      this.expires = 365;
+      this.expires = new Date((new Date() * 1) + (365 * 864e5)).toUTCString();
     }
     if (Object.prototype.hasOwnProperty.call(data, 'secure')) {
       this.secure = data.secure;
@@ -38,14 +40,14 @@ export default class CookieStorage {
    * @returns {string} value that was set
    */
   setItem(key, value) {
-    Cookies.set(key, value, {
+    hardtack.set(key, value, {
       path: this.path,
       expires: this.expires,
       domain: this.domain,
       secure: this.secure,
     }
     );
-    return Cookies.get(key);
+    return hardtack.get(key);
   }
 
   /**
@@ -55,7 +57,7 @@ export default class CookieStorage {
    * @returns {string} the data item
    */
   getItem(key) {
-    return Cookies.get(key);
+    return hardtack.get(key);
   }
 
   /**
@@ -64,7 +66,7 @@ export default class CookieStorage {
    * @returns {string} value - value that was deleted
    */
   removeItem(key) {
-    return Cookies.remove(key, {
+    return hardtack.remove(key, {
       path: this.path,
       domain: this.domain,
       secure: this.secure,
@@ -77,10 +79,10 @@ export default class CookieStorage {
    * @returns {string} nothing
    */
   clear() {
-    const cookies = Cookies.get();
+    const cookies = hardtack.get();
     let index;
     for (index = 0; index < cookies.length; ++index) {
-      Cookies.remove(cookies[index]);
+      hardtack.remove(cookies[index]);
     }
     return {};
   }

--- a/packages/amazon-cognito-identity-js/webpack.config.js
+++ b/packages/amazon-cognito-identity-js/webpack.config.js
@@ -37,7 +37,6 @@ var config = {
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.BannerPlugin({ banner, raw: true }),
     new UglifyJsPlugin({
-        minimize: true,
         sourceMap: true,
         include: /\.min\.js$/,
     }),
@@ -58,11 +57,6 @@ var config = {
          }
       }
     ]
-  },
-  resolve: {
-    alias: {
-      hardtack: '../../../node_modules/hardtack/dist/hardtack.min.js'
-    }
   }
 };
 

--- a/packages/amazon-cognito-identity-js/webpack.config.js
+++ b/packages/amazon-cognito-identity-js/webpack.config.js
@@ -58,6 +58,11 @@ var config = {
          }
       }
     ]
+  },
+  resolve: {
+    alias: {
+      hardtack: '../../../node_modules/hardtack/dist/hardtack.min.js'
+    }
   }
 };
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -46,7 +46,7 @@
     "tslint": "^5.7.0",
     "tslint-config-airbnb": "^5.8.0",
     "typescript-formatter": "^6.0.0",
-    "uglifyjs-webpack-plugin": "^0.4.6",
+    "uglifyjs-webpack-plugin": "1.3.0",
     "webpack": "^3.5.5"
   },
   "dependencies": {

--- a/packages/auth/webpack.config.js
+++ b/packages/auth/webpack.config.js
@@ -21,7 +21,6 @@ module.exports = {
     },
     plugins: [
         new UglifyJsPlugin({
-            minimize: true,
             sourceMap: true,
             include: /\.min\.js$/,
         }),
@@ -32,8 +31,8 @@ module.exports = {
     module: {
         rules: [
             // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
-            { 
-                test: /\.tsx?$/, 
+            {
+                test: /\.tsx?$/,
                 loader: 'awesome-typescript-loader',
                 exclude: /node_modules/,
                 query: {

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -43,7 +43,7 @@
     "tslint": "^5.7.0",
     "tslint-config-airbnb": "^5.8.0",
     "typescript-formatter": "^6.0.0",
-    "uglifyjs-webpack-plugin": "^0.4.6",
+    "uglifyjs-webpack-plugin": "1.3.0",
     "webpack": "^3.5.5"
   },
   "dependencies": {

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -6,8 +6,8 @@
   "typings": "./lib/index.d.ts",
   "scripts": {
     "test": "tslint 'src/**/*.ts' && jest --coverage --maxWorkers 2",
-    "build-with-test": "npm run clean && npm test && tsc && webpack -p",
-    "build": "npm run clean && tsc && webpack -p",
+    "build-with-test": "npm run clean && npm test && tsc && webpack",
+    "build": "npm run clean && tsc && webpack",
     "clean": "rimraf lib lib-esm dist",
     "format": "tsfmt --useTsfmt tsfmt.json -r src/**/*.ts",
     "lint": "tslint 'src/**/*.ts'",

--- a/packages/aws-amplify/webpack.config.js
+++ b/packages/aws-amplify/webpack.config.js
@@ -21,7 +21,6 @@ module.exports = {
     },
     plugins: [
         new UglifyJsPlugin({
-            minimize: true,
             sourceMap: true,
             include: /\.min\.js$/,
         }),
@@ -32,8 +31,8 @@ module.exports = {
     module: {
         rules: [
             // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
-            { 
-                test: /\.tsx?$/, 
+            {
+                test: /\.tsx?$/,
                 loader: 'awesome-typescript-loader',
                 exclude: /node_modules/,
                 query: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4221,6 +4221,11 @@ commander@^2.11.0, commander@^2.12.1, commander@^2.18.0, commander@^2.19.0, comm
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
+commander@~2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
+  integrity sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==
+
 commander@~2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
@@ -14511,7 +14516,7 @@ scheduler@^0.11.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-schema-utils@^0.4.0, schema-utils@^0.4.2, schema-utils@^0.4.4:
+schema-utils@^0.4.0, schema-utils@^0.4.2, schema-utils@^0.4.4, schema-utils@^0.4.5:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
   integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
@@ -16021,6 +16026,14 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
   integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
 
+uglify-es@^3.3.4:
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
+  integrity sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==
+  dependencies:
+    commander "~2.13.0"
+    source-map "~0.6.1"
+
 uglify-js@2.7.5, uglify-js@~2.7.3:
   version "2.7.5"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.5.tgz#4612c0c7baaee2ba7c487de4904ae122079f2ca8"
@@ -16053,6 +16066,20 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
   integrity sha1-bgkk1r2mta/jSeOabWMoUKD4grc=
+
+uglifyjs-webpack-plugin@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz#75f548160858163a08643e086d5fefe18a5d67de"
+  integrity sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==
+  dependencies:
+    cacache "^10.0.4"
+    find-cache-dir "^1.0.0"
+    schema-utils "^0.4.5"
+    serialize-javascript "^1.4.0"
+    source-map "^0.6.1"
+    uglify-es "^3.3.4"
+    webpack-sources "^1.1.0"
+    worker-farm "^1.5.2"
 
 uglifyjs-webpack-plugin@^0.4.6:
   version "0.4.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3544,6 +3544,14 @@ buffer@^3.0.3:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
+  integrity sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -7619,6 +7627,11 @@ har-validator@~5.1.0:
   dependencies:
     ajv "^6.5.5"
     har-schema "^2.0.0"
+
+hardtack@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hardtack/-/hardtack-2.1.0.tgz#621c92ae7ad4dc342e55ad274ddf703469e8dcba"
+  integrity sha512-J7RkzZnxPyTJSmlknFHISXAgwL0MgJMEFHrRGsdw8bIGbNsJ6FCKHg+ho4BVH7YUd9KGguI5XYFADkutN4W+MQ==
 
 has-ansi@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7633,10 +7633,10 @@ har-validator@~5.1.0:
     ajv "^6.5.5"
     har-schema "^2.0.0"
 
-hardtack@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/hardtack/-/hardtack-2.1.0.tgz#621c92ae7ad4dc342e55ad274ddf703469e8dcba"
-  integrity sha512-J7RkzZnxPyTJSmlknFHISXAgwL0MgJMEFHrRGsdw8bIGbNsJ6FCKHg+ho4BVH7YUd9KGguI5XYFADkutN4W+MQ==
+hardtack@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/hardtack/-/hardtack-4.0.0.tgz#e5ad0c069a9f03a2bb082edf2891102ba18e8646"
+  integrity sha512-RGuoWimYgTGw6xxuYaeAk3UdBhc2BsF/y6RsTC5LxM9Agqa0zsiFeC8sTQDoWdSdNORYLRLDs++MCtW6kci+TQ==
 
 has-ansi@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
hardtack easier js-cookie on 60%
https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js gzipped - **1105 bytes**
https://cdn.jsdelivr.net/npm/hardtack@2.1.0/dist/hardtack.min.js gzipped - **431 bytes**