### PR TITLE
fix(@aws-amplify/core) fix(@aws-amplify/storage) Fix credentials issue with storage and aws config credentials

### DIFF
--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -178,7 +178,7 @@ export class Credentials {
         logger.debug('setting credentials from aws');
         const that = this;
         if (credentials instanceof AWS.Credentials){
-            return this._loadCredentials(credentials, 'aws', undefined, null);
+            return Promise.resolve(credentials);
         } else {
             logger.debug('AWS.config.credentials is not an instance of AWS Credentials');
             return Promise.reject('AWS.config.credentials is not an instance of AWS Credentials');

--- a/packages/storage/src/Providers/AWSS3Provider.ts
+++ b/packages/storage/src/Providers/AWSS3Provider.ts
@@ -11,7 +11,6 @@
  * and limitations under the License.
  */
 import {
-    AWS,
     ConsoleLogger as Logger,
     Hub,
     Credentials,
@@ -359,15 +358,13 @@ export default class AWSS3Provider implements StorageProvider{
      */
     private _createS3(config) {
         const { bucket, region, credentials } = config;
-        AWS.config.update({
-            region,
-            credentials
-        });
+        
         return new S3({
             apiVersion: '2006-03-01',
             params: { Bucket: bucket },
             signatureVersion: 'v4',
-            region
+            region,
+            credentials
         });
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#2397
*Description of changes:*
Core/Credentials
Return aws credentials instead of calling load credentials

Storage/AWSS3Provider
Configure credentials on S3 instead of AWS.config
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
