### PR TITLE
fix(aws-amplify-react): properly pass custom-children to Authenticator

### DIFF
--- a/packages/aws-amplify-react/src/Auth/index.jsx
+++ b/packages/aws-amplify-react/src/Auth/index.jsx
@@ -100,9 +100,9 @@ export function withAuthenticator(Comp, includeGreetings = false, authenticatorC
                 federated={this.authConfig.federated || this.props.federated}
                 hideDefault={this.authConfig.authenticatorComponents && this.authConfig.authenticatorComponents.length > 0}
                 signUpConfig={this.authConfig.signUpConfig}
-                onStateChange={this.handleAuthStateChange}
-                children={this.authConfig.authenticatorComponents || []}
-            />;
+                onStateChange={this.handleAuthStateChange}>
+                {this.authConfig.authenticatorComponents}
+            </Authenticator>;
         }
     };
 }


### PR DESCRIPTION
Fixes #1603

*Issue #, if available:* #1603

*Description of changes:* `children` property should not be passed explicitly. Children should be injected as JSX content. Otherwise, they are not treated as a React Element.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.