### PR TITLE
fix(aws-amplify-react): transfer the children object to array

### DIFF
--- a/packages/aws-amplify-react/src/Auth/Authenticator.jsx
+++ b/packages/aws-amplify-react/src/Auth/Authenticator.jsx
@@ -154,7 +154,15 @@ export default class Authenticator extends Component {
                 Loading
             ]);
         }
-        const props_children = this.props.children || [];
+
+        let props_children = [];
+        if (typeof this.props.children === 'object') {
+            if (Array.isArray(this.props.children)){
+                props_children = this.props.children;
+            } else {
+                props_children.push(this.props.children);
+            }
+        } 
 
         const default_children = [
             <Greetings federated={federated}/>,


### PR DESCRIPTION
*Issue #, if available:*
Related to #2318 

> Using hideDefault={true} was throwing an error props_children does not have function find.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
