### PR TITLE
fix(@aws-amplify/pubsub): MqttProvidertOptions typescript definition …

### DIFF
--- a/packages/pubsub/src/Providers/MqttOverWSProvider.ts
+++ b/packages/pubsub/src/Providers/MqttOverWSProvider.ts
@@ -37,6 +37,8 @@ export function mqttTopicMatch(filter: string, topic: string) {
 export interface MqttProvidertOptions extends ProvidertOptions {
     clientId?: string,
     url?: string,
+    aws_pubsub_region?: string,
+    aws_pubsub_endpoint?: string,
 }
 
 class ClientsQueue {


### PR DESCRIPTION
…reported in https://github.com/aws-amplify/amplify-js/issues/783

*Issue #, if available:*
#783 

*Description of changes:*
added in pubsub keys in MqttProvidertOptions definition 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
