### PR TITLE
feat(aws-amplify-react): add identityId prop to S3Album, S3Image, S3Text

### DIFF
--- a/packages/aws-amplify-react/__tests__/Storage/S3Album-test.js
+++ b/packages/aws-amplify-react/__tests__/Storage/S3Album-test.js
@@ -396,7 +396,8 @@ describe('S3Album test', () => {
             
             const props = {
                 path: 'path',
-                level: 'public'
+                level: 'public',
+                identityId: 'identityId'
             };
 
             const wrapper = shallow(<S3Album/>);
@@ -412,7 +413,7 @@ describe('S3Album test', () => {
 
             await s3Album.list();
 
-            expect(spyon3).toBeCalledWith('path', {level: 'public'});
+            expect(spyon3).toBeCalledWith('path', {level: 'public',identityId: 'identityId'});
 
             spyon.mockClear();
             spyon2.mockClear();

--- a/packages/aws-amplify-react/__tests__/Storage/S3Image-test.js
+++ b/packages/aws-amplify-react/__tests__/Storage/S3Image-test.js
@@ -313,8 +313,8 @@ describe('S3Image', () => {
                 });
             });
 
-            s3Image.getImageSource('key', 'level', false);
-            expect(spyon).toBeCalledWith('key', {level: 'level', track: false});
+            s3Image.getImageSource('key', 'level', false, 'identityId');
+            expect(spyon).toBeCalledWith('key', {level: 'level', track: false, identityId: 'identityId'});
             spyon.mockClear();
         });
 

--- a/packages/aws-amplify-react/__tests__/Storage/S3Text-test.js
+++ b/packages/aws-amplify-react/__tests__/Storage/S3Text-test.js
@@ -313,8 +313,8 @@ describe('S3Text test', () => {
                 });
             });
 
-            s3Text.getText('key', 'level', false);
-            expect(spyon).toBeCalledWith('key', {"download": true, "level": "level", "track": false});
+            s3Text.getText('key', 'level', false, 'identityId');
+            expect(spyon).toBeCalledWith('key', {"download": true, "level": "level", "track": false, identityId: 'identityId'});
             spyon.mockClear();
         });
 

--- a/packages/aws-amplify-react/src/Storage/S3Album.js
+++ b/packages/aws-amplify-react/src/Storage/S3Album.js
@@ -146,12 +146,12 @@ export default class S3Album extends Component {
     }
 
     list() {
-        const { path, level, track } = this.props;
+        const { path, level, track, identityId } = this.props;
         logger.debug('Album path: ' + path);
         if (!Storage || typeof Storage.list !== 'function') {
             throw new Error('No Storage module found, please ensure @aws-amplify/storage is imported');
         }
-        return Storage.list(path, { level: level? level : 'public', track })
+        return Storage.list(path, { level: level? level : 'public', track, identityId })
             .then(data => {
                 logger.debug('album list', data);
                 this.marshal(data);
@@ -210,7 +210,7 @@ export default class S3Album extends Component {
     }
 
     render() {
-        const { picker, translateItem, level } = this.props;
+        const { picker, translateItem, level, identityId } = this.props;
         const { items, ts } = this.state;
 
         const pickerTitle = this.props.pickerTitle || 'Pick';
@@ -227,6 +227,7 @@ export default class S3Album extends Component {
                              selected={item.selected}
                              translate={translateItem}
                              level={level}
+                             identityId={identityId}
                              onClick={() => this.handleClick(item)}
                            />
                          : <S3Image
@@ -237,6 +238,7 @@ export default class S3Album extends Component {
                              selected={item.selected}
                              translate={translateItem}
                              level={level}
+                             identityId={identityId}
                              onClick={() => this.handleClick(item)}
                            />;
         });

--- a/packages/aws-amplify-react/src/Storage/S3Image.js
+++ b/packages/aws-amplify-react/src/Storage/S3Image.js
@@ -38,11 +38,11 @@ export default class S3Image extends Component {
         this.state = { src: initSrc };
     }
 
-    getImageSource(key, level, track) {
+    getImageSource(key, level, track, identityId) {
         if (!Storage || typeof Storage.get !== 'function') {
             throw new Error('No Storage module found, please ensure @aws-amplify/storage is imported');
         }
-        Storage.get(key, { level: level? level : 'public', track })
+        Storage.get(key, { level: level? level : 'public', track, identityId })
             .then(url => {
                 this.setState({
                     src: url
@@ -52,7 +52,7 @@ export default class S3Image extends Component {
     }
 
     load() {
-        const { imgKey, path, body, contentType, level, track } = this.props;
+        const { imgKey, path, body, contentType, level, track, identityId } = this.props;
         if (!imgKey && !path) {
             logger.debug('empty imgKey and path');
             return ;
@@ -73,11 +73,11 @@ export default class S3Image extends Component {
             });
             ret.then(data => {
                 logger.debug(data);
-                that.getImageSource(key, level, track);
+                that.getImageSource(key, level, track, identityId);
             })
             .catch(err => logger.debug(err));
         } else {
-            that.getImageSource(key, level, track);
+            that.getImageSource(key, level, track, identityId);
         }
     }
 
@@ -95,7 +95,7 @@ export default class S3Image extends Component {
         const that = this;
 
         const path = this.props.path || '';
-        const { imgKey, level, fileToKey, track } = this.props;
+        const { imgKey, level, fileToKey, track, identityId } = this.props;
         const { file, name, size, type } = data;
         const key = imgKey || (path + calcKey(data, fileToKey));
         if (!Storage || typeof Storage.put !== 'function') {
@@ -108,7 +108,7 @@ export default class S3Image extends Component {
         })
             .then(data => {
                 logger.debug('handle pick data', data);
-                that.getImageSource(key, level, track);
+                that.getImageSource(key, level, track, identityId);
             })
             .catch(err => logger.debug('handle pick error', err));
     }

--- a/packages/aws-amplify-react/src/Storage/S3Text.js
+++ b/packages/aws-amplify-react/src/Storage/S3Text.js
@@ -39,11 +39,11 @@ export default class S3Text extends Component {
         };
     }
 
-    getText(key, level, track) {
+    getText(key, level, track, identityId) {
         if (!Storage || typeof Storage.get !== 'function') {
             throw new Error('No Storage module found, please ensure @aws-amplify/storage is imported');
         }
-        Storage.get(key, { download: true, level: level? level : 'public', track })
+        Storage.get(key, { download: true, level: level? level : 'public', track, identityId })
             .then(data => {
                 logger.debug(data);
                 const text = data.Body.toString('utf8');
@@ -57,7 +57,7 @@ export default class S3Text extends Component {
     }
 
     load() {
-        const { path, textKey, body, contentType, level, track } = this.props;
+        const { path, textKey, body, contentType, level, track, identityId } = this.props;
         if (!textKey && !path) {
             logger.debug('empty textKey and path');
             return ;
@@ -78,11 +78,11 @@ export default class S3Text extends Component {
             });
             ret.then(data => {
                 logger.debug(data);
-                that.getText(key, level, track);
+                that.getText(key, level, track, identityId);
             })
             .catch(err => logger.debug(err));
         } else {
-            that.getText(key, level, track);
+            that.getText(key, level, track, identityId);
         }
     }
 
@@ -100,7 +100,7 @@ export default class S3Text extends Component {
         const that = this;
 
         const path = this.props.path || '';
-        const { textKey, level, fileToKey, track } = this.props;
+        const { textKey, level, fileToKey, track, identityId } = this.props;
         const { file, name, size, type } = data;
         const key = textKey || (path + calcKey(data, fileToKey));
         if (!Storage || typeof Storage.put !== 'function') {
@@ -113,7 +113,7 @@ export default class S3Text extends Component {
         })
             .then(data => {
                 logger.debug('handle pick data', data);
-                that.getText(key, level, track);
+                that.getText(key, level, track, identityId);
             })
             .catch(err => logger.debug('handle pick error', err));
     }


### PR DESCRIPTION
Surfacing the identityId option from the Storage class
as a prop of the S3* React components allows viewing protected files
of other users in a social app. The identityId values for other users
must be provided out-of-band, e.g. via GraphQL.

Resolves #2424

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
