### PR TITLE
Pass theme to AmplifyButton instances

### DIFF
--- a/packages/aws-amplify-react-native/src/Auth/ForgotPassword.js
+++ b/packages/aws-amplify-react-native/src/Auth/ForgotPassword.js
@@ -81,7 +81,7 @@ export default class ForgotPassword extends AuthPiece {
                 />
                 <AmplifyButton
                     text={I18n.get('Send').toUpperCase()}
-                    style={theme.button}
+                    theme={theme}
                     onPress={this.send}
                     disabled={!this.state.username}
                 />
@@ -109,7 +109,7 @@ export default class ForgotPassword extends AuthPiece {
                 />
                 <AmplifyButton
                     text={I18n.get('Submit')}
-                    style={theme.button}
+                    theme={theme}
                     onPress={this.submit}
                     disabled={!this.state.username}
                 />

--- a/packages/aws-amplify-react-native/src/Auth/Greetings.js
+++ b/packages/aws-amplify-react-native/src/Auth/Greetings.js
@@ -62,6 +62,7 @@ export default class Greetings extends AuthPiece {
             <View style={theme.navBar}>
                 <Text>{message}</Text>
                 <AmplifyButton
+                    theme={theme}
                     text={I18n.get('Sign Out')}
                     onPress={this.signOut}
                     style={theme.navButton}

--- a/packages/aws-amplify-react-native/src/Auth/VerifyContact.js
+++ b/packages/aws-amplify-react-native/src/Auth/VerifyContact.js
@@ -128,6 +128,7 @@ export default class VerifyContact extends AuthPiece {
             <View style={theme.sectionBody}>
                 {this.createPicker(unverified)}
                 <AmplifyButton
+                    theme={theme}
                     text={I18n.get('Verify')}
                     onPress={this.verify}
                     disabled={!this.state.pickAttr}
@@ -147,6 +148,7 @@ export default class VerifyContact extends AuthPiece {
                     required={true}
                 />
                 <AmplifyButton
+                    theme={theme}
                     text={I18n.get('Submit')}
                     onPress={this.submit}
                     disabled={!this.state.code}


### PR DESCRIPTION
*Issue #, if available:*
#2465 

*Description of changes:*
Pass theme into AmplifyButton instance that previously did not have a theme prop or used style prop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
