### PR TITLE
Use React fragment instead of container div dom element

### DIFF
--- a/packages/aws-amplify-react/src/Auth/index.jsx
+++ b/packages/aws-amplify-react/src/Auth/index.jsx
@@ -72,7 +72,7 @@ export function withAuthenticator(Comp, includeGreetings = false, authenticatorC
             const signedIn = (authState === 'signedIn');
             if (signedIn) {
                 return (
-                    <div>
+                    <React.Fragment>
                         {
                             this.authConfig.includeGreetings?
                             <Greetings
@@ -90,7 +90,7 @@ export function withAuthenticator(Comp, includeGreetings = false, authenticatorC
                             authData={authData}
                             onStateChange={this.handleAuthStateChange}
                         />
-                    </div>
+                    </React.Fragment>
                 );
             }
 


### PR DESCRIPTION
*Issue #, if available:*
#1693 

*Description of changes:*
Use React.Fragment to wrap elements instead of legacy div dom element wrapper.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
