### PR TITLE
fix(@aws-amplify/analytics): Fix attributes and userAttributes case transform on updateEndpoint.

### DIFF
--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -364,7 +364,7 @@ export default class AWSPinpointProvider implements AnalyticsProvider {
         
         const request = this._endpointRequest(
             config, 
-            JS.transferKeyToLowerCase(event, [], ['Attributes', 'UserAttributes'])
+            JS.transferKeyToLowerCase(event, [], ['attributes', 'userAttributes', 'Attributes', 'UserAttributes'])
         );
         const update_params = {
             ApplicationId: appId,


### PR DESCRIPTION
Fixed a bug that transformed attributes and userAttributes object keys to lowercase while processing updateEndpoint requests.

*Issue:*
`_updateEndpoint()` transforms event object keys (such as eventId, name, session) to lowercase before sending to `_endpointRequest()` for request formatting. In the process, *attributes* and *userAttributes* object keys are inadvertently transformed.

Essentially, the whitelist variable supplied to the transform function is filtering out *Attributes* and *UserAttributes* which does not exist on the event object. Instead, it should filter out *attributes* and *userAttributes*.

*Description of changes:*
Changed values of the whitelist variable to `['attributes', 'userAttributes']`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.