### PR TITLE
fix(aws-amplify-react): removing duplicate property

### DIFF
--- a/packages/aws-amplify-react/src/Interactions/ChatBot.jsx
+++ b/packages/aws-amplify-react/src/Interactions/ChatBot.jsx
@@ -327,7 +327,6 @@ export class ChatBot extends Component {
                         inputDisabled={this.state.inputDisabled}
                         micButtonDisabled={this.state.micButtonDisabled}
                         handleMicButton={this.micButtonHandler}
-                        micText={this.state.micText}
                         currentVoiceState={this.state.currentVoiceState}>
                     </ChatBotInputs>
                 </SectionFooter>


### PR DESCRIPTION
Removing duplicate property which causes errors in strict mode on IE11

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
