### PR TITLE
Remove unused props in Greetings

### DIFF
--- a/packages/aws-amplify-react/src/Auth/Greetings.jsx
+++ b/packages/aws-amplify-react/src/Auth/Greetings.jsx
@@ -119,10 +119,6 @@ export default class Greetings extends AuthPiece {
 
         return <SignOut 
             {...stateAndProps} 
-            google_client_id={google_client_id} 
-            facebook_app_id={facebook_app_id} 
-            amazon_client_id={amazon_client_id}
-            auth0={auth0_config}
             />;
     }
 


### PR DESCRIPTION
*Issue #, if available:*
Those client ids are not used in `SignOut` component. Related to #2436 
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
