### PR TITLE
fix(@aws-amplify/analytics): Search with event userId + credentials Identity ID while removing unused endpoints.

### DIFF
--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -379,7 +379,8 @@ export default class AWSPinpointProvider implements AnalyticsProvider {
                 if (err) {
                     logger.debug('updateEndpoint failed', err);
                     if (err.message === 'Exceeded maximum endpoint per user count 10') {
-                        this._removeUnusedEndpoints(appId, credentials.identityId)
+                        const { userId = credentials.identityId } = event;
+                        this._removeUnusedEndpoints(appId, userId)
                         .then(() => {
                             logger.debug('Remove the unused endpoints successfully');
                             return res(false);


### PR DESCRIPTION
*Issue:*
Amazon Pinpoint limits User IDs to 10 unique endpoints. As such, when an endpoint update fails due to a user exceeding their limit, Amplify attempts to delete unused endpoints registered to the user. The problem is, it only searches for endpoints bearing Identity ID obtained from Cognito Identity Pool, leaving applications that use Cognito User Pool Sub (or anything else) as User ID in a jam.  See screenshot below.

![screen shot 2019-01-09 at 12 31 35 am](https://user-images.githubusercontent.com/8375739/50888509-725cb080-13bb-11e9-9069-0932e1e37714.png)

*Description of changes:*
This commit checks for a userId in the update event. If it finds one, it queries Pinpoint with the userId, otherwise it defaults to Cognito Identity ID from credentials.

![screen shot 2019-01-09 at 1 25 28 am](https://user-images.githubusercontent.com/8375739/50888552-902a1580-13bb-11e9-8073-5c8da025fab2.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.