### PR TITLE
print a console error if no user pool

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -973,6 +973,10 @@ export default class AuthClass {
             try {
                 user = await this.currentUserPoolUser(params);
             } catch (e) {
+                if (e === 'No userPool') {
+                    logger.error('Cannot get the current user because the user pool is missing. ' +
+                        'Please make sure the Auth module is configured with a valid Cognito User Pool ID');
+                }
                 logger.debug('The user is not authenticated by the error', e);
                 throw ('not authenticated');
             }


### PR DESCRIPTION
*Issue #, if available:*
To give more info when `Auth.currentAuthenticatedUser()` failed.
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
