### PR TITLE
fix(aws-amplify-vue) - import JS core for JS.isEmpty() to fix #2158

### DIFF
--- a/packages/aws-amplify-vue/package.json
+++ b/packages/aws-amplify-vue/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "qrcode.vue": "^1.6.0",
     "vue": "^2.5.17",
-    "vue2-filters": "^0.3.0"
+    "vue2-filters": "^0.3.0",
+    "@aws-amplify/core": "^1.0.22"
   },
   "devDependencies": {
     "@aws-amplify/ui": "1.0.10-unstable.0",

--- a/packages/aws-amplify-vue/src/components/authenticator/RequireNewPassword.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/RequireNewPassword.vue
@@ -47,6 +47,8 @@
  <script>
 import AmplifyEventBus from '../../events/AmplifyEventBus';
 import * as AmplifyUI from '@aws-amplify/ui';
+import { JS } from '@aws-amplify/core';
+
  export default {
   name: 'RequireNewPassword',
   props: ['requireNewPasswordConfig'],


### PR DESCRIPTION
Fixes #2158 

I just added the import to have it available in the code


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
