### PR TITLE
feature(@aws-amplify/aws-amplify-angular): added abilty to display a …

### DIFF
--- a/packages/amplify-ui/src/Angular.css
+++ b/packages/amplify-ui/src/Angular.css
@@ -408,6 +408,12 @@ border: 0px solid var(--color-white) !important;
   margin: 0.5em;
 }
 
+.amplify-form-extra-details {
+  margin: 0.5em;
+  font-size: 12px;
+  color: var(--color-gray);
+}
+
 /** Ionic styles for material design */
 .md .amplify-form-input {
   border: none;

--- a/packages/aws-amplify-angular/src/components/authenticator/sign-up-component/sign-up.component.core.ts
+++ b/packages/aws-amplify-angular/src/components/authenticator/sign-up-component/sign-up.component.core.ts
@@ -38,7 +38,9 @@ const template = `
             type={{field.type}}
             placeholder={{field.label}}
             [(ngModel)]="user[field.key]" name="field.key" />
+            <div *ngIf="field.key === 'password'" class="amplify-form-extra-details">{{passwordPolicy}}</div>
         </div>
+            
         <div *ngIf="field.key === 'phone_number'">
           <label class="amplify-input-label">
             {{field.label}} 
@@ -131,7 +133,7 @@ export class SignUpComponentCore implements OnInit {
   errorMessage: string;
   amplifyService: AmplifyService;
   hiddenFields: any = [];
-
+  passwordPolicy: string;
 
   constructor(@Inject(AmplifyService) amplifyService: AmplifyService) {
     this.countries = countrylist;
@@ -155,6 +157,9 @@ export class SignUpComponentCore implements OnInit {
       }
       if (this._signUpConfig.hiddenDefaults) {
         this.hiddenFields = this._signUpConfig.hiddenDefaults;
+      }
+      if (this._signUpConfig.passwordPolicy) {
+        this.passwordPolicy = this._signUpConfig.passwordPolicy;
       }
     }
   }
@@ -180,6 +185,9 @@ export class SignUpComponentCore implements OnInit {
       }
       if (this._signUpConfig.hiddenDefaults) {
         this.hiddenFields = this._signUpConfig.hiddenDefaults;
+      }
+      if (this._signUpConfig.passwordPolicy) {
+        this.passwordPolicy = this._signUpConfig.passwordPolicy;
       }
     }
   }


### PR DESCRIPTION
…password policy for signup

*Issue #, if available:*
[#2576](https://github.com/aws-amplify/amplify-js/issues/2576)

*Description of changes:*
signUpConfig now takes a field `passwordPolicy: string`

If present will render to view the string below the password input (new stylings).

If not present, nothing will be rendered and view will look the same as current.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
