### PR TITLE
Update Android Gradle Config

### DIFF
--- a/packages/pushnotification/android/build.gradle
+++ b/packages/pushnotification/android/build.gradle
@@ -21,13 +21,17 @@ allprojects {
 
 apply plugin: "com.android.library"
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.3"
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    buildToolsVersion safeExtGet('buildToolsVersion', "26.0.3")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
 Define and use a `safeExtGet` Gradle function that checks the
  parent project configuration before specifying a hard definition.
  This suppresses build warnings for android with version 3.2.1
  of the Android Gradle Plugin.

see https://github.com/aws-amplify/amplify-js/commit/a08f100306dc1bb2310abb72a3dbc168a60ce1c5

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
