### PR TITLE
fix(@aws-amplify-vue/api): Connect import

### DIFF
--- a/packages/aws-amplify-vue/src/Amplify.vue
+++ b/packages/aws-amplify-vue/src/Amplify.vue
@@ -18,7 +18,8 @@ import {
   S3Album,
   S3Image,
   SumerianScene,
-  RequireNewPassword
+  RequireNewPassword,
+  Connect
 } from './components';
 import AmplifyPlugin from './plugins/AmplifyPlugin';
 import AmplifyEventBus from './events/AmplifyEventBus';
@@ -39,7 +40,8 @@ export default {
     S3Album,
     S3Image,
     SumerianScene,
-    RequireNewPassword
+    RequireNewPassword,
+    Connect
   },
   AmplifyPlugin,
   AmplifyEventBus,


### PR DESCRIPTION
*Issue #, if available:*
Closes #2633

*Description of changes:*
Allow the Connect Vue component to be imported from the top level like the other components.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
