### PR TITLE
feat(aws-amplify-angular): provide singletone amplify service

### DIFF
--- a/packages/aws-amplify-angular/src/aws-amplify-angular.module.ts
+++ b/packages/aws-amplify-angular/src/aws-amplify-angular.module.ts
@@ -12,7 +12,7 @@
  */
 
 
-import { NgModule , forwardRef} from '@angular/core';
+import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -46,6 +46,7 @@ import { FormComponent } from './components/common/form.component';
 import { SumerianSceneComponent } from './components/xr/sumerian-scene-component/sumerian-scene.factory';
 import { SumerianSceneComponentCore } from './components/xr/sumerian-scene-component/sumerian-scene.component.core';
 import { SumerianSceneLoadingComponentCore } from './components/xr/sumerian-scene-component/sumerian-scene-loading.component.core';
+import { AMPLIFY_SERVICE_PROVIDER } from './providers';
 // tslint:enable:max-line-length
 
 const components = [
@@ -91,7 +92,9 @@ const components = [
   entryComponents: [
     ...components
   ],
-  providers: [ ],
+  providers: [
+    AMPLIFY_SERVICE_PROVIDER
+  ],
   exports: [
     ...components,
   ]

--- a/packages/aws-amplify-angular/src/providers/amplify-service.provider.ts
+++ b/packages/aws-amplify-angular/src/providers/amplify-service.provider.ts
@@ -1,0 +1,24 @@
+import { Optional, FactoryProvider , SkipSelf } from '@angular/core';
+
+import { AmplifyService } from './amplify.service';
+
+/**
+ * Ensure a single global service provider
+ * @deprecated
+ * @deletion-target once the module depends on angular v6
+ */
+export function AMPLIFY_SERVIDE_PROVIDER_FACTORY(parentService: AmplifyService) {
+    return parentService || new AmplifyService();
+}
+
+
+/**
+* Export provider that uses a global service factory (above)
+* @deprecated
+* @deletion-target once the module depends on angular v6
+*/
+export const AMPLIFY_SERVICE_PROVIDER: FactoryProvider = {
+    provide: AmplifyService,
+    deps: [[new Optional(), new SkipSelf(), AmplifyService]],
+    useFactory: AMPLIFY_SERVIDE_PROVIDER_FACTORY
+};

--- a/packages/aws-amplify-angular/src/providers/index.ts
+++ b/packages/aws-amplify-angular/src/providers/index.ts
@@ -1,2 +1,3 @@
 export { AmplifyService } from './amplify.service';
 export { AuthState } from './auth.state';
+export { AMPLIFY_SERVICE_PROVIDER } from './amplify-service.provider';


### PR DESCRIPTION
*Description of changes:*

Provide the amplify service through a
factory provider in the angular module.
Currently, consumers of the library are obligated
to provide the service at root module level.
With this change, this is no longer required.

Furthermore, its ensured that the service is singletone
even when the aws module is imported by lazy modules
or imported/exported by shared ones.

Sidenote: the docs currently state that registering
a provider for the service is an optional step
isnt accurate, as angular will throw an InjectionError
when there is no provider for the service registered.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Note: [the docs file](https://github.com/aws-amplify/docs/blob/master/js/ionic.md) for this module should be updated once this lands