### PR TITLE
Use Lerna's --exact when publishing prereleases

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "lint": "lerna run -- lint",
     "link": "lerna exec yarn link",
     "publish:master": "lerna publish --conventional-commits --cd-version=prerelease --yes --independent --npm-tag=unstable --preid=unstable --message 'chore(release): Publish [ci skip]'",
-    "publish:beta": "lerna publish --conventional-commits --cd-version=prerelease --yes --independent --npm-tag=beta --preid=beta --message 'chore(release): Publish [ci skip]'",
-    "publish:release": "lerna publish --conventional-commits --yes --independent --message 'chore(release): Publish [ci skip]'"
+    "publish:beta": "lerna publish --conventional-commits --cd-version=prerelease --yes --independent --npm-tag=beta --preid=beta --message 'chore(release): Publish [ci skip]' --exact",
+    "publish:release": "lerna publish --conventional-commits --yes --independent --message 'chore(release): Publish [ci skip]' --exact"
   },
   "pre-commit": [
     "pre-commit"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://github.com/lerna/lerna/tree/2.x#--exact

This will force pre-releases and betas to use an exact match of dependencies from the monorepo.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
