### PR TITLE
fix(@aws-amplify/auth): avoid `Cannot read property` error

### DIFF
--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -673,15 +673,31 @@ describe('auth unit test', () => {
             spyon.mockClear();
         });
 
-        test('no username', async () => {
+        test('null username', async () => {
             const spyon = jest.spyOn(CognitoUser.prototype, 'authenticateUser');
             const auth = new Auth(authOptions);
 
-            expect.assertions(1);
+            expect.assertions(2);
             try {
                 await auth.signIn(null, 'password');
             } catch (e) {
                 expect(e).not.toBeNull();
+                expect(e.message).not.toEqual(expect.stringMatching(/.*Cannot read property 'username'.*/));
+            }
+
+            spyon.mockClear();
+        });
+
+        test('undefined username', async () => {
+            const spyon = jest.spyOn(CognitoUser.prototype, 'authenticateUser');
+            const auth = new Auth(authOptions);
+
+            expect.assertions(2);
+            try {
+                await auth.signIn(undefined, 'password');
+            } catch (e) {
+                expect(e).not.toBeNull();
+                expect(e.message).not.toEqual(expect.stringMatching(/.*Cannot read property 'username'.*/));
             }
 
             spyon.mockClear();

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -110,5 +110,5 @@ export type UsernamePasswordOpts = {
 export type SignInOpts = UsernamePasswordOpts;
 
 export function isUsernamePasswordOpts(obj: any): obj is UsernamePasswordOpts {
-    return !!(obj as UsernamePasswordOpts).username;
+    return !!obj && !!(obj as UsernamePasswordOpts).username;
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

When no `username` is provided `obj`'s value is undefined. The error thrown is then the default JS error: `Cannot read property 'username' of undefined`.

This change first checks if `obj`'s value is a true-ish before reading the `username` value from it.

This is my first PR for a Typescript project, I hope it's correct. Please review and comment. I'll be more than happy to change anything.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.