### PR TITLE
Allow dynamic region config for Sumerian scene provider

### DIFF
--- a/packages/xr/__tests__/XR-unit-test.ts
+++ b/packages/xr/__tests__/XR-unit-test.ts
@@ -41,7 +41,7 @@ describe('XR', () => {
     });
 
     describe('SumerianProvider', () => {
-        test('loadScene throws error on loadScene when no scenes are configured', async () => {
+        test('loadScene throws error when no scenes are configured', async () => {
             const xr = new XR({});
 
             // Mock dom
@@ -55,7 +55,7 @@ describe('XR', () => {
             }
         });
 
-        test('loadScene throws error on loadScene when dom element does not exist', async () => {
+        test('loadScene throws error when dom element does not exist', async () => {
             const xr = new XR({ scenes: { 'scene1': {} } });
 
             document.body.innerHTML = "";
@@ -68,7 +68,7 @@ describe('XR', () => {
             }
         });
 
-        test('loadScene throws error on loadScene when sceneName is not passed in', async () => {
+        test('loadScene throws error when sceneName is not passed in', async () => {
             const xr = new XR({ scenes: {} });
 
             // Mock dom
@@ -82,7 +82,7 @@ describe('XR', () => {
             }
         });
 
-        test('loadScene throws error on loadScene when scene is not configured', async () => {
+        test('loadScene throws error when scene is not configured', async () => {
             const xr = new XR({ scenes: {} });
 
             // Mock dom
@@ -92,6 +92,20 @@ describe('XR', () => {
                 await xr.loadScene('scene2', 'dom-element-id');
             } catch(e) {
                 expect(e.message).toEqual("Scene 'scene2' is not configured");
+                expect(e).toBeInstanceOf(Error);
+            }
+        });
+
+        test('loadScene throws error when region is not configured', async () => {
+            const xr = new XR({scenes:{scene2:{sceneConfig:{}}}});
+
+            // Mock dom
+            document.body.innerHTML = "<div id='dom-element-id'></div>";
+            expect.assertions(2);
+            try {
+                await xr.loadScene('scene2', 'dom-element-id');
+            } catch(e) {
+                expect(e.message).toEqual("No region configured for scene: scene2");
                 expect(e).toBeInstanceOf(Error);
             }
         });

--- a/packages/xr/src/Providers/SumerianProvider.ts
+++ b/packages/xr/src/Providers/SumerianProvider.ts
@@ -82,8 +82,22 @@ export class SumerianProvider extends AbstractXRProvider {
 
     const sceneUrl = scene.sceneConfig.url;
     const sceneId = scene.sceneConfig.sceneId;
+
+    let sceneRegion;
+    if(scene.sceneConfig.hasOwnProperty('region')) {
+      // Use the scene region on the Sumerian scene configuration
+      sceneRegion = scene.sceneConfig.region;
+    } else if (this.options.hasOwnProperty('region')) {
+      // Use the scene region on the XR category configuration
+      sceneRegion = this.options.region;
+    } else {
+      const errorMsg = `No region configured for scene: ${sceneName}`;
+      logger.error(errorMsg);
+      throw(new XRSceneLoadFailure(errorMsg));
+    }
+
     const awsSDKConfigOverride = {
-        region: this.options.region,
+        region: sceneRegion,
         // This is passed to the AWS clients created in
         // Sumerian's AwsSystem
         // This helps other services(like Lex and Polly) to track
@@ -113,7 +127,7 @@ export class SumerianProvider extends AbstractXRProvider {
         session_token: credentials.sessionToken,
       };
       
-      const serviceInfo = { region: this.options.region, service: SUMERIAN_SERVICE_NAME };
+      const serviceInfo = { region: sceneRegion, service: SUMERIAN_SERVICE_NAME };
       url = Signer.signUrl(sceneUrl, accessInfo, serviceInfo);
     } catch (e) {
       logger.debug('No credentials available, the request will be unsigned');


### PR DESCRIPTION
*Issue #, if available:*
#2366 

*Description of changes:*
- Use Sumerian scene configured region (from downloaded Sumerian json config)
- As a fallback use the XR configured region
- If neither is defined throw an Error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
