### PR TITLE
fix(build): Prevent tree-shaking of crypto-js/lib-typedarrays

### DIFF
--- a/packages/amazon-cognito-identity-js/src/AuthenticationHelper.js
+++ b/packages/amazon-cognito-identity-js/src/AuthenticationHelper.js
@@ -17,7 +17,7 @@
 
 import { Buffer } from 'buffer/';
 import CryptoJS from 'crypto-js/core';
-import TypedArrays from 'crypto-js/lib-typedarrays'; // necessary for crypto js
+import 'crypto-js/lib-typedarrays'; // necessary for crypto js
 import SHA256 from 'crypto-js/sha256';
 import HmacSHA256 from 'crypto-js/hmac-sha256';
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes #1181 

*Description of changes:*
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Import_a_module_for_its_side_effects_only

> Import a module for its side effects onlySection
Import an entire module for side effects only, without importing anything. This runs the module's global code, but doesn't actually import any values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
