### PR TITLE
Add OAuthSignUp to withOAuth HOC

### DIFF
--- a/packages/aws-amplify-react/src/Auth/Provider/withOAuth.jsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/withOAuth.jsx
@@ -34,6 +34,14 @@ export default function withOAuth(Comp, options) {
         }
 
         signIn() {
+          return this._authAction('/login');
+        }
+
+        signUp() {
+          return this._authAction('/signup')
+        }
+
+        _authAction(urlPath) {
             if (!Auth || typeof Auth.configure !== 'function') {
                 throw new Error('No Auth module found, please ensure @aws-amplify/auth is imported');
             }
@@ -53,7 +61,7 @@ export default function withOAuth(Comp, options) {
 
             const options = config.options || {};
             const url = 'https://' + domain 
-                + '/login?redirect_uri=' + redirectSignIn 
+                + urlPath + '?redirect_uri=' + redirectSignIn
                 + '&response_type=' + responseType 
                 + '&client_id=' + (options.ClientId || Auth.configure().userPoolWebClientId);
 
@@ -67,7 +75,10 @@ export default function withOAuth(Comp, options) {
 
         render() {
             return (
-                <Comp {...this.props} OAuthSignIn={this.signIn} />
+                <Comp {...this.props}
+                      OAuthSignIn={this.signIn}
+                      OAuthSignUp={this.signUp}
+                />
             );
         }
     };

--- a/packages/aws-amplify-react/src/Auth/Provider/withOAuth.jsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/withOAuth.jsx
@@ -31,6 +31,7 @@ export default function withOAuth(Comp, options) {
         constructor(props) {
             super(props);
             this.signIn = this.signIn.bind(this);
+            this.signUp = this.signUp.bind(this);
         }
 
         signIn() {


### PR DESCRIPTION
Currently, the `withOAuth` HOC injects an `OAuthSignIn` function into the props of whatever react component it wraps. This appears to be the best component to use to connect with the Cognito hosted UI from a react app.

This component only provides a function to send someone to the "sign in" experience and not to the "sign up" experience. In various instances a UI would want to send someone directly to "sign up" instead of the other.

This change turns the old "signIn" method into a genericized "_authAction" method that takes a URL path and then updates the existing `signIn` method to use it with "/login" and adds a `signUp` method to use it with "/signup". It then adds an "OAuthSignUp" prop to the props that are passed through to the underlying `Comp` value.

I recognized that this change could go further to create a SignUpButton too. Such a change would look like the bottom snippet, but I assume that it would want to use a different `id` than `oAuthSignInButton`:

```
const SignUpButton = (props) => (
    <SignInButton
        id={oAuthSignInButton}
        onClick={props.OAuthSignUp}
        theme={props.theme || AmplifyTheme}
        variant={'oAuthSignInButton'}
    >
        <SignInButtonContent theme={props.theme || AmplifyTheme}>
            {I18n.get(props.label || 'Sign up with AWS')}
        </SignInButtonContent>
    </SignInButton>
);

export const OAuthSignUpButton = withOAuth(SignUpButton);
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
