### PR TITLE
fix(aws-amplify-react) #2301

### DIFF
--- a/packages/aws-amplify-react/src/Auth/Greetings.jsx
+++ b/packages/aws-amplify-react/src/Auth/Greetings.jsx
@@ -28,7 +28,9 @@ export default class Greetings extends AuthPiece {
         super(props);
         this.state = {};
         Hub.listen('auth', this);
-        this.onHubCapsule = this.onHubCapsule.bind(this)
+        this.onHubCapsule = this.onHubCapsule.bind(this);
+        this._validAuthStates = ['signedIn'];
+
     }
 
     componentDidMount() {

--- a/packages/aws-amplify-react/src/Auth/index.jsx
+++ b/packages/aws-amplify-react/src/Auth/index.jsx
@@ -73,12 +73,6 @@ export function withAuthenticator(Comp, includeGreetings = false, authenticatorC
             if (signedIn) {
                 return (
                     <React.Fragment>
-                        <Comp
-                            {...this.props}
-                            authState={authState}
-                            authData={authData}
-                            onStateChange={this.handleAuthStateChange}
-                        />
                         <Authenticator
                             {...this.props}
                             theme={this.authConfig.theme}
@@ -87,6 +81,12 @@ export function withAuthenticator(Comp, includeGreetings = false, authenticatorC
                             signUpConfig={this.authConfig.signUpConfig}
                             onStateChange={this.handleAuthStateChange}
                             children={this.authConfig.authenticatorComponents || []}
+                        />
+                        <Comp
+                            {...this.props}
+                            authState={authState}
+                            authData={authData}
+                            onStateChange={this.handleAuthStateChange}
                         />;
                     </React.Fragment>
                 );

--- a/packages/aws-amplify-react/src/Auth/index.jsx
+++ b/packages/aws-amplify-react/src/Auth/index.jsx
@@ -73,23 +73,21 @@ export function withAuthenticator(Comp, includeGreetings = false, authenticatorC
             if (signedIn) {
                 return (
                     <React.Fragment>
-                        {
-                            this.authConfig.includeGreetings?
-                            <Greetings
-                                authState={authState}
-                                authData={authData}
-                                federated={this.authConfig.federated || this.props.federated || {} }
-                                onStateChange={this.handleAuthStateChange}
-                                theme={theme}
-                            />
-                            : null
-                        }
                         <Comp
                             {...this.props}
                             authState={authState}
                             authData={authData}
                             onStateChange={this.handleAuthStateChange}
                         />
+                        <Authenticator
+                            {...this.props}
+                            theme={this.authConfig.theme}
+                            federated={this.authConfig.federated || this.props.federated}
+                            hideDefault={this.authConfig.authenticatorComponents && this.authConfig.authenticatorComponents.length > 0}
+                            signUpConfig={this.authConfig.signUpConfig}
+                            onStateChange={this.handleAuthStateChange}
+                            children={this.authConfig.authenticatorComponents || []}
+                        />;
                     </React.Fragment>
                 );
             }

--- a/packages/aws-amplify-react/src/Auth/index.jsx
+++ b/packages/aws-amplify-react/src/Auth/index.jsx
@@ -73,15 +73,17 @@ export function withAuthenticator(Comp, includeGreetings = false, authenticatorC
             if (signedIn) {
                 return (
                     <React.Fragment>
-                        <Authenticator
-                            {...this.props}
-                            theme={this.authConfig.theme}
-                            federated={this.authConfig.federated || this.props.federated}
-                            hideDefault={this.authConfig.authenticatorComponents && this.authConfig.authenticatorComponents.length > 0}
-                            signUpConfig={this.authConfig.signUpConfig}
-                            onStateChange={this.handleAuthStateChange}
-                            children={this.authConfig.authenticatorComponents || []}
-                        />
+                        { this.authConfig.includeGreetings ? 
+                            <Authenticator
+                                {...this.props}
+                                theme={this.authConfig.theme}
+                                federated={this.authConfig.federated || this.props.federated}
+                                hideDefault={this.authConfig.authenticatorComponents && this.authConfig.authenticatorComponents.length > 0}
+                                signUpConfig={this.authConfig.signUpConfig}
+                                onStateChange={this.handleAuthStateChange}
+                                children={this.authConfig.authenticatorComponents || []}
+                            /> : null
+                        }
                         <Comp
                             {...this.props}
                             authState={authState}


### PR DESCRIPTION
*Issue #, if available:*
#2701 

*Description of changes:*
Uses Authenticator in HOC signedIn state instead of Greetings only, and adds validAuth state to greetings component to make this possible

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
