### PR TITLE
"wether" typo

### DIFF
--- a/packages/cache/src/InMemoryCache.ts
+++ b/packages/cache/src/InMemoryCache.ts
@@ -80,7 +80,7 @@ export class InMemoryCache extends StorageCache implements ICache {
     }
 
     /**
-     * check wether item is expired
+     * check whether item is expired
      * 
      * @param key - the key of the item
      * 


### PR DESCRIPTION
wether->whether

*Issue #, if available:*
Simple comment typo.

*Description of changes:*
Changed "wether" to "whether" in comment in cache memory implementation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
