### PR TITLE
Amplify ui windows build fix

### DIFF
--- a/packages/amplify-ui/package.json
+++ b/packages/amplify-ui/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "webpack",
     "start": "webpack-dev-server",
-    "clean": "rimraf dist",
+    "clean": "rm -rf dist",
     "build": "npm run clean && webpack"
   },
   "license": "MIT",
@@ -27,7 +27,6 @@
     "raw-loader": "^0.5.1",
     "react": "^0.13.3",
     "react-to-html-webpack-plugin": "^2.2.0",
-    "rimraf": "^2.5.4",
     "style-loader": "^0.12.3",
     "url-loader": "^0.5.6",
     "webpack": "^1.9.10",


### PR DESCRIPTION
Description of changes:
Changed package.json to use cpx instead of cp to support building locally on Windows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
