### PR TITLE
Fixes alert element not being centered on small screens

### DIFF
--- a/packages/amplify-ui/src/Angular.css
+++ b/packages/amplify-ui/src/Angular.css
@@ -273,7 +273,7 @@ border: 0px solid var(--color-white) !important;
 }
 
 /************************************
-** Input Groups 
+** Input Groups
 ************************************/
 
 .amplify-input-group {
@@ -565,6 +565,8 @@ margin-left: 0.5em;
 .amplify-alert {
     width: 92%;
     margin-top: 1em;
+    margin-left: 4%;
+    margin-right: 4%;
 }
 }
 
@@ -595,7 +597,7 @@ z-index: 1;
 .tooltip:hover .tooltip-text {
 visibility: visible;
 }
-  
+
 /************************************
 ** Ionic
 ************************************/


### PR DESCRIPTION
Description of changes:
The alert element was not centered like it was on larger screens. I added left/right margins that makes it centered again.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
