### PR TITLE
fix(aws-amplify-vue/storage): Fixed PhotoPicker input element not usi…

### DIFF
--- a/packages/aws-amplify-vue/src/components/storage/PhotoPicker.vue
+++ b/packages/aws-amplify-vue/src/components/storage/PhotoPicker.vue
@@ -19,7 +19,7 @@
       <input
         ref="file_input"  
         type="file"
-        accept="options.accept"
+        :accept="options.accept"
         @change="pick"
       />
     </div>
@@ -68,7 +68,7 @@ export default {
     }
   },
   methods: {
-    upload() {
+    upload: function() {
       this.$Amplify.Storage.put(
         this.s3ImagePath,
         this.file, 
@@ -79,7 +79,7 @@ export default {
       })
       .catch(e => this.setError(e));
     },
-    pick(evt) {
+    pick: function(evt) {
       this.file = evt.target.files[0];
       if (!this.file) { return ;};
       if (!this.options.storageOptions.contentType) {
@@ -96,7 +96,7 @@ export default {
       }
       reader.readAsDataURL(this.file);
     },
-    completeFileUpload(img) {
+    completeFileUpload: function(img) {
       this.file = null;
       this.s3ImageFile = null;
       this.$refs.file_input.value = null;


### PR DESCRIPTION
…ng the given accept attribute

*Issue #, if available:*

*Description of changes:*
The PhotoPicker component was not using the the given accept attribute in the config object due to not binding the attribute in the template. So i added the appropriate binding. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
