### PR TITLE
perf(@aws-amplify/api,graphql): support GraphQL source with DocumentN…

### DIFF
--- a/packages/api/__tests__/API-test.ts
+++ b/packages/api/__tests__/API-test.ts
@@ -171,7 +171,7 @@ describe('API test', () => {
                 }
             };
 
-            await api.graphql(graphqlOperation(doc, variables));
+            await api.graphql(graphqlOperation(doc, variables, query));
 
             expect(spyon).toBeCalledWith(url, init);
         });

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -69,6 +69,7 @@ export interface apiOptions {
 export interface GraphQLOptions {
     query: string | DocumentNode,
     variables?: object,
+    source?: string,
 }
 
 export interface GraphQLResult {


### PR DESCRIPTION
…ode for performance

*Issue #, if available:*

*Description of changes:*

`API.graphql()` method calls `parse()` with the given GraphQL source to get a `DocumentNode`,
and then `print()` it to get a clean version of the GraphQL source.

With this modification, you can pass a parsed `DocumentNode` and a printed GraphQL source to the method for better performance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
