### PR TITLE
aws-amplify-react: specify custom Authenticator container component

### DIFF
--- a/packages/aws-amplify-react/__tests__/Auth/Authenticator-test.js
+++ b/packages/aws-amplify-react/__tests__/Auth/Authenticator-test.js
@@ -1,6 +1,6 @@
 import Auth from '@aws-amplify/auth';
 import * as React from 'react';
-import Authenticator from '../../src/Auth/Authenticator';
+import Authenticator, { EmptyContainer } from '../../src/Auth/Authenticator';
 import SignIn from '../../src/Auth/SignIn';
 import AmplifyTheme  from '../../src/AmplifyTheme';
 import { Button, InputRow } from '../../src/Amplify-UI/Amplify-UI-Components-React';
@@ -142,5 +142,24 @@ describe('Authenticator', () => {
             expect(spyon).toBeCalled();
         });
     });
-        
+
+    describe('container component', () => {
+        test("use provided Container component if this.props.container is truthy", () => {
+            const CustomContainer = ({ children }) => {
+                return <div className="custom-container">{children}</div>;
+            };
+            const wrapper = mount(<Authenticator container={CustomContainer} />);
+            expect(wrapper.childAt(0).type()).toBe(CustomContainer);
+        });
+
+        test("use AWS Amplify UI Container if this.props.container is undefined", () => {
+            const wrapper = mount(<Authenticator />);
+            expect(wrapper.childAt(0).type()).toBe(Container);
+        });
+
+        test("use EmptyContainer if this.props.container is falsey", () => {
+            const wrapper = mount(<Authenticator container="" />);
+            expect(wrapper.childAt(0).type()).toBe(EmptyContainer);
+        });
+    });
 });

--- a/packages/aws-amplify-react/__tests__/Auth/Authenticator-test.js
+++ b/packages/aws-amplify-react/__tests__/Auth/Authenticator-test.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Authenticator, { EmptyContainer } from '../../src/Auth/Authenticator';
 import SignIn from '../../src/Auth/SignIn';
 import AmplifyTheme  from '../../src/AmplifyTheme';
-import { Button, InputRow } from '../../src/Amplify-UI/Amplify-UI-Components-React';
+import { Button, InputRow, Container } from '../../src/Amplify-UI/Amplify-UI-Components-React';
 
 const waitForResolve = Promise.resolve();
 

--- a/packages/aws-amplify-react/src/Auth/Authenticator.jsx
+++ b/packages/aws-amplify-react/src/Auth/Authenticator.jsx
@@ -35,6 +35,8 @@ import { Container, Toast } from '../Amplify-UI/Amplify-UI-Components-React';
 const logger = new Logger('Authenticator');
 const AUTHENTICATOR_AUTHSTATE = 'amplify-authenticator-authState';
 
+export const EmptyContainer = ({ children }) => <>{children}</>;
+
 export default class Authenticator extends Component {
     constructor(props) {
         super(props);
@@ -147,6 +149,10 @@ export default class Authenticator extends Component {
         const { authState, authData } = this.state;
         const theme = this.props.theme || AmplifyTheme;
         const messageMap = this.props.errorMessage || AmplifyMessageMap;
+        // If container prop is undefined, default to AWS Amplify UI Container
+        // otherwise if truthy, use the supplied render prop
+        // otherwise if falsey, use EmptyContainer
+        const Wrapper = this.props.container === undefined ? Container : this.props.container || EmptyContainer;
 
         let { hideDefault, hide = [], federated, signUpConfig } = this.props;
         if (hideDefault) {
@@ -221,14 +227,14 @@ export default class Authenticator extends Component {
         const error = this.state.error;        
 
         return (
-            <Container theme={theme}>
+            <Wrapper theme={theme}>
                 {this.state.showToast && 
                     <Toast theme={theme} onClose={() => this.setState({showToast: false})}>
                         { I18n.get(error) }
                     </Toast>
                 }
                 {render_children}
-            </Container>
+            </Wrapper>
         );
     }
 }


### PR DESCRIPTION
Enable passing through a custom container, or using an empty container in the Authenticator component.

*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/2877

*Description of changes:*
Enabled opt-in behaviour of using the Amplify UI `Container` component for wrapping the `Authenticator`'s children:
- If `Authenticator`'s `container === undefined`, it will default to using the AWS UI `Container` component (retains existing behaviour).
- If `Authenticator`'s `container` prop is falsey (i.e. `container === ""`), it will use an `EmptyContainer` component which wraps `Authenticator`'s components with a `React.Fragment` instead of a `div`.
- Any other custom `Container` component can be passed to `Authenticator` via the `container` prop.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._