### PR TITLE
Add getter for android fcm device token

### DIFF
--- a/packages/pushnotification/android/src/main/java/com/amazonaws/amplify/pushnotification/RNPushNotificationModule.java
+++ b/packages/pushnotification/android/src/main/java/com/amazonaws/amplify/pushnotification/RNPushNotificationModule.java
@@ -20,6 +20,7 @@ import android.content.IntentFilter;
 import android.content.BroadcastReceiver;
 
 import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -60,5 +61,10 @@ public class RNPushNotificationModule extends ReactContextBaseJavaModule {
             IntentFilter intentFilter = new IntentFilter("com.amazonaws.amplify.pushnotification.NOTIFICATION_OPENED");
             applicationContext.registerReceiver(receiver, intentFilter);
         }
+    }
+
+    @ReactMethod
+    public void getAndroidFCMDeviceToken(Promise promise) {
+        promise.resolve(FirebaseInstanceId.getInstance().getToken());
     }
 }

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -73,6 +73,12 @@ export default class PushNotification {
         }
     }
 
+    getAndroidFCMDeviceToken () {
+        if (Platform.OS === 'android' && !this._androidInitialized){
+            return RNPushNotification.getAndroidFCMDeviceToken();
+        }
+    }
+
     onNotification(handler) {
         if (typeof handler === 'function') {
             // check platform


### PR DESCRIPTION
*Description of changes:*
This adds ability to query device token on android devices for push notifications... currently the device token is provided only one time, after the app installation and if something goes wrong, there is no way how to discover that token...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
