### PR TITLE
fix: remove stray semicolon after app wrapper

### DIFF
--- a/packages/aws-amplify-react/src/Auth/index.jsx
+++ b/packages/aws-amplify-react/src/Auth/index.jsx
@@ -89,7 +89,7 @@ export function withAuthenticator(Comp, includeGreetings = false, authenticatorC
                             authState={authState}
                             authData={authData}
                             onStateChange={this.handleAuthStateChange}
-                        />;
+                        />
                     </React.Fragment>
                 );
             }


### PR DESCRIPTION
This semicolon gets rendered as HTML text.

:heavy_check_mark: By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
