### PR TITLE
Storage configure fix

### DIFF
--- a/packages/storage/__tests__/Storage-unit-test.ts
+++ b/packages/storage/__tests__/Storage-unit-test.ts
@@ -1,20 +1,21 @@
 
 import AWSStorageProvider from '../src/Providers/AWSS3Provider';
 import { default as Storage } from "../src/Storage";
+import StorageCategory from "../src";
 
 const credentials = {
-        accessKeyId: 'accessKeyId',
-        sessionToken: 'sessionToken',
-        secretAccessKey: 'secretAccessKey',
-        identityId: 'identityId',
-        authenticated: true
+    accessKeyId: 'accessKeyId',
+    sessionToken: 'sessionToken',
+    secretAccessKey: 'secretAccessKey',
+    identityId: 'identityId',
+    authenticated: true
 };
-    
+
 const options = {
-            bucket: 'bucket',
-            region: 'region',
-            credentials,
-            level: 'level'
+    bucket: 'bucket',
+    region: 'region',
+    credentials,
+    level: 'level'
 };
 
 describe('Storage', () => {
@@ -49,28 +50,239 @@ describe('Storage', () => {
     });
 
     describe('configure test', () => {
-        test('happy case', () => {
+        test('configure with aws-exports file', () => {
             const storage = new Storage();
-            
+
             const aws_options = {
                 aws_user_files_s3_bucket: 'bucket',
                 aws_user_files_s3_bucket_region: 'region'
             };
 
             const config = storage.configure(aws_options);
+
             expect(config).toEqual({
-                AWSS3:{
+                AWSS3: {
                     bucket: 'bucket',
                     region: 'region'
+                }
+            });
+        });
+
+        test('configure with bucket and region', () => {
+            const storage = new Storage();
+
+            const aws_options = {
+                bucket: 'bucket',
+                region: 'region'
+            };
+
+            const config = storage.configure(aws_options);
+
+            expect(config).toEqual({
+                AWSS3: {
+                    bucket: 'bucket',
+                    region: 'region'
+                }
+            });
+        });
+
+        test('Configure with Storage object', () => {
+            const storage = new Storage();
+
+            const aws_options = {
+                Storage: {
+                    bucket: 'bucket',
+                    region: 'region'
+                }
+            };
+
+            const config = storage.configure(aws_options);
+
+            expect(config).toEqual({
+                AWSS3: {
+                    bucket: 'bucket',
+                    region: 'region'
+                }
+            });
+        });
+
+        test('Configure with Provider object', () => {
+            const storage = new Storage();
+
+            const aws_options = {
+                AWSS3: {
+                    bucket: 'bucket',
+                    region: 'region'
+                }
+            };
+
+            const config = storage.configure(aws_options);
+
+            expect(config).toEqual({
+                AWSS3: {
+                    bucket: 'bucket',
+                    region: 'region'
+                }
+            });
+        });
+
+        test('Configure with Storage and Provider object', () => {
+            const storage = new Storage();
+
+            const aws_options = {
+                Storage: {
+                    AWSS3: {
+                        bucket: 'bucket',
+                        region: 'region'
+                    }
+                }
+            };
+
+            const config = storage.configure(aws_options);
+
+            expect(config).toEqual({
+                AWSS3: {
+                    bucket: 'bucket',
+                    region: 'region'
+                }
+            });
+        });
+
+        test('Second configure call changing bucket name only', () => {
+            const storage = new Storage();
+
+            const aws_options = {
+                aws_user_files_s3_bucket: 'bucket',
+                aws_user_files_s3_bucket_region: 'region'
+            };
+
+            storage.configure(aws_options);
+            const config = storage.configure({ bucket: "another-bucket" })
+            expect(config).toEqual({
+                AWSS3: {
+                    bucket: 'another-bucket',
+                    region: 'region',
+                }
+            });
+        });
+
+        test('Second configure call changing bucket, region and with Storage attribute', () => {
+            const storage = new Storage();
+
+            const aws_options = {
+                aws_user_files_s3_bucket: 'bucket',
+                aws_user_files_s3_bucket_region: 'region'
+            };
+
+            storage.configure(aws_options);
+            const config = storage.configure({ Storage: { bucket: "another-bucket", region: "another-region" } })
+            expect(config).toEqual({
+                AWSS3: {
+                    bucket: 'another-bucket',
+                    region: 'another-region',
+                }
+            });
+        });
+
+        test('Second configure call changing bucket, region and with Provider attribute', () => {
+            const storage = new Storage();
+
+            const aws_options = {
+                aws_user_files_s3_bucket: 'bucket',
+                aws_user_files_s3_bucket_region: 'region'
+            };
+
+            storage.configure(aws_options);
+            const config = storage.configure({ AWSS3: { bucket: "another-s3-bucket", region: "another-s3-region" } })
+            expect(config).toEqual({
+                AWSS3: {
+                    bucket: 'another-s3-bucket',
+                    region: 'another-s3-region',
+                }
+            });
+        });
+        test('backwards compatible issue, second configure call', () => {
+            const storage = new Storage();
+
+            const aws_options = {
+                aws_user_files_s3_bucket: 'bucket',
+                aws_user_files_s3_bucket_region: 'region'
+            };
+
+            storage.configure(aws_options);
+            const config = storage.configure({ level: "private" })
+            expect(config).toEqual({
+                AWSS3: {
+                    bucket: 'bucket',
+                    region: 'region',
+                    level: 'private'
+                }
+            });
+        });
+
+        test('vault level is always private', () => {
+
+            const storage = StorageCategory;
+            expect.assertions(3);
+            storage.vault.configure = jest.fn().mockImplementation((configure) => {
+                expect(configure).toEqual({"AWSS3": {"bucket": "bucket", "level": "private", "region": "region"}});
+            });
+            const aws_options = {
+                aws_user_files_s3_bucket: 'bucket',
+                aws_user_files_s3_bucket_region: 'region'
+            };
+
+
+            storage.configure(aws_options);
+            storage.configure({ Storage: { level: "protected"} });
+            storage.configure({ Storage: { level: "public"} });
+        });
+
+        test('backwards compatible issue, third configure call track', () => {
+            const storage = new Storage();
+
+            const aws_options = {
+                aws_user_files_s3_bucket: 'bucket',
+                aws_user_files_s3_bucket_region: 'region'
+            };
+
+            storage.configure(aws_options);
+            storage.configure({ level: "protected" })
+            const config = storage.configure({ track: true })
+            expect(config).toEqual({
+                AWSS3: {
+                    bucket: 'bucket',
+                    region: 'region',
+                    level: 'protected',
+                    track: true
+                }
+            });
+        });
+
+        test('backwards compatible issue, third configure to update level', () => {
+            const storage = new Storage();
+            const aws_options = {
+                aws_user_files_s3_bucket: 'bucket',
+                aws_user_files_s3_bucket_region: 'region'
+            };
+
+            storage.configure(aws_options);
+            storage.configure({ level: "private" })
+            const config = storage.configure({ level: "protected" })
+            expect(config).toEqual({
+                AWSS3: {
+                    bucket: 'bucket',
+                    region: 'region',
+                    level: 'protected',
                 }
             });
         });
     });
 
     describe('get test', async () => {
-        test('get object without download', async () => { 
+        test('get object without download', async () => {
             const get_spyon = jest.spyOn(AWSStorageProvider.prototype, 'get').mockImplementation(() => {
-                return ;
+                return;
             });
             const storage = new Storage();
             const provider = new AWSStorageProvider();
@@ -79,34 +291,34 @@ describe('Storage', () => {
             await storage.get('key', {
                 Storage: {
                     AWSS3: {
-                    bucket: 'bucket', 
-                    region: 'us-east-1', 
+                        bucket: 'bucket',
+                        region: 'us-east-1',
+                    }
                 }
-            }
-            }) ;
+            });
             expect(get_spyon).toBeCalled();
             get_spyon.mockClear();
         });
     });
-    
+
 
     describe('put test', () => {
         test('put object succefully', async () => {
             const put_spyon = jest.spyOn(AWSStorageProvider.prototype, 'put').mockImplementation(() => {
-                return ;
+                return;
             });
             const storage = new Storage();
             const provider = new AWSStorageProvider();
             storage.addPluggable(provider);
             storage.configure(options);
-            await storage.put('key','object',{
+            await storage.put('key', 'object', {
                 Storage: {
                     AWSS3: {
-                    bucket: 'bucket', 
-                    region: 'us-east-1', 
+                        bucket: 'bucket',
+                        region: 'us-east-1',
+                    }
                 }
-            }
-            }) ;
+            });
             expect(put_spyon).toBeCalled();
             put_spyon.mockClear();
         });
@@ -115,7 +327,7 @@ describe('Storage', () => {
     describe('remove test', () => {
         test('remove object successfully', async () => {
             const remove_spyon = jest.spyOn(AWSStorageProvider.prototype, 'remove').mockImplementation(() => {
-                return ;
+                return;
             });
             const storage = new Storage();
             const provider = new AWSStorageProvider();
@@ -124,11 +336,11 @@ describe('Storage', () => {
             await storage.remove('key', {
                 Storage: {
                     AWSS3: {
-                    bucket: 'bucket', 
-                    region: 'us-east-1', 
+                        bucket: 'bucket',
+                        region: 'us-east-1',
+                    }
                 }
-            }
-            }) ;
+            });
             expect(remove_spyon).toBeCalled();
             remove_spyon.mockClear();
         });
@@ -137,7 +349,7 @@ describe('Storage', () => {
     describe('list test', () => {
         test('list object successfully', async () => {
             const list_spyon = jest.spyOn(AWSStorageProvider.prototype, 'list').mockImplementation(() => {
-                return ;
+                return;
             });
             const storage = new Storage();
             const provider = new AWSStorageProvider();
@@ -146,11 +358,11 @@ describe('Storage', () => {
             await storage.list('path', {
                 Storage: {
                     AWSS3: {
-                    bucket: 'bucket', 
-                    region: 'us-east-1', 
+                        bucket: 'bucket',
+                        region: 'us-east-1',
+                    }
                 }
-            }
-            }) ;
+            });
             expect(list_spyon).toBeCalled();
             list_spyon.mockClear();
         });

--- a/packages/storage/src/Storage.ts
+++ b/packages/storage/src/Storage.ts
@@ -61,12 +61,9 @@ export default class StorageClass {
         if (pluggable && pluggable.getCategory() === 'Storage') {
             this._pluggables.push(pluggable);
             let config = {};
-            // for backward compatibility
-            if (pluggable.getProviderName() === DEFAULT_PROVIDER && !this._config[DEFAULT_PROVIDER]) {
-                config = pluggable.configure(this._config);
-            } else {
-                config = pluggable.configure(this._config[pluggable.getProviderName()]);
-            }
+            
+            config = pluggable.configure(this._config[pluggable.getProviderName()]);
+            
             return config;
         }
     }
@@ -77,7 +74,7 @@ export default class StorageClass {
      */
     public getPluggable(providerName: string) {
         const pluggable = this._pluggables.find(pluggable => pluggable.getProviderName() === providerName);
-        if(pluggable === undefined) {
+        if (pluggable === undefined) {
             logger.debug('No plugin found with providerName', providerName);
             return null;
         } else
@@ -88,8 +85,8 @@ export default class StorageClass {
      * Remove the plugin object
      * @param providerName - the name of the plugin
      */
-    public removePluggable(providerName:string) {
-        this._pluggables = this._pluggables.filter(pluggable=> pluggable.getProviderName() !== providerName);
+    public removePluggable(providerName: string) {
+        this._pluggables = this._pluggables.filter(pluggable => pluggable.getProviderName() !== providerName);
         return;
     }
 
@@ -101,17 +98,40 @@ export default class StorageClass {
     configure(config?) {
         logger.debug('configure Storage');
         if (!config) return this._config;
+
         const amplifyConfig = Parser.parseMobilehubConfig(config);
-        this._config = Object.assign({}, this._config, amplifyConfig.Storage);
-        if (!this._config.bucket) { logger.debug('Do not have bucket yet'); }
+        const { bucket, region, level, track } = amplifyConfig.Storage as any;
+        // Update DEFAULT_PROVIDER with defined attributes bucket, region, level, track if exists 
+        // on amplifyConfig.Storage, backwards compatible issue 
+        if ((bucket || region || level || track) && !amplifyConfig.Storage[DEFAULT_PROVIDER]) {
+            amplifyConfig.Storage[DEFAULT_PROVIDER] = {};
+        }
+        if (bucket) {
+            amplifyConfig.Storage[DEFAULT_PROVIDER].bucket = bucket;
+            delete amplifyConfig.Storage['bucket'];
+        }
+        if (region) {
+            amplifyConfig.Storage[DEFAULT_PROVIDER].region = region;
+            delete amplifyConfig.Storage['region'];
+        }
+        if (level) {
+            amplifyConfig.Storage[DEFAULT_PROVIDER].level = level;
+            delete amplifyConfig.Storage['level'];
+        }
+        if (track) {
+            amplifyConfig.Storage[DEFAULT_PROVIDER].track = track;
+            delete amplifyConfig.Storage['track'];
+        }
+
+        // only update new values for each provider
+        Object.keys(amplifyConfig.Storage).forEach((providerName) => {
+            if (typeof amplifyConfig.Storage[providerName] !== 'string') {
+                this._config[providerName] = { ...this._config[providerName], ...amplifyConfig.Storage[providerName] };
+            }
+        });
 
         this._pluggables.forEach((pluggable) => {
-            // for backward compatibility
-            if (pluggable.getProviderName() === DEFAULT_PROVIDER && !this._config[DEFAULT_PROVIDER]) {
-                pluggable.configure(this._config);
-            } else {
-                pluggable.configure(this._config[pluggable.getProviderName()]);
-            }
+            pluggable.configure(this._config[pluggable.getProviderName()]);
         });
 
         if (this._pluggables.length === 0) {
@@ -128,11 +148,11 @@ export default class StorageClass {
     * @param {Object} [config] - { level : private|protected|public, download: true|false }
     * @return - A promise resolves to either a presigned url or the object
     */
-    public async get(key: string, config?): Promise<String|Object> {
+    public async get(key: string, config?): Promise<String | Object> {
 
         const { provider = DEFAULT_PROVIDER } = config || {};
         const prov = this._pluggables.find(pluggable => pluggable.getProviderName() === provider);
-        if(prov === undefined) {
+        if (prov === undefined) {
             logger.debug('No plugin found with providerName', provider);
             Promise.reject('No plugin found in Storage for the provider');
         }
@@ -147,14 +167,14 @@ export default class StorageClass {
      *  progressCallback: function }
      * @return - promise resolves to object on success
      */
-    public async put(key: string, object, config?):Promise<Object> {
+    public async put(key: string, object, config?): Promise<Object> {
         const { provider = DEFAULT_PROVIDER } = config || {};
         const prov = this._pluggables.find(pluggable => pluggable.getProviderName() === provider);
-        if(prov === undefined) {
+        if (prov === undefined) {
             logger.debug('No plugin found with providerName', provider);
             Promise.reject('No plugin found in Storage for the provider');
         }
-        return prov.put(key,object,config);
+        return prov.put(key, object, config);
     }
 
     /**
@@ -166,11 +186,11 @@ export default class StorageClass {
     public async remove(key: string, config?): Promise<any> {
         const { provider = DEFAULT_PROVIDER } = config || {};
         const prov = this._pluggables.find(pluggable => pluggable.getProviderName() === provider);
-        if(prov === undefined) {
+        if (prov === undefined) {
             logger.debug('No plugin found with providerName', provider);
             Promise.reject('No plugin found in Storage for the provider');
         }
-        return prov.remove(key,config);
+        return prov.remove(key, config);
     }
 
     /**
@@ -182,10 +202,10 @@ export default class StorageClass {
     public async list(path, config?): Promise<any> {
         const { provider = DEFAULT_PROVIDER } = config || {};
         const prov = this._pluggables.find(pluggable => pluggable.getProviderName() === provider);
-        if(prov === undefined) {
+        if (prov === undefined) {
             logger.debug('No plugin found with providerName', provider);
             Promise.reject('No plugin found in Storage for the provider');
         }
-        return prov.list(path,config);
+        return prov.list(path, config);
     }
 }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -14,7 +14,7 @@
 import StorageClass from './Storage';
 import { StorageProvider } from './types';
 
-import Amplify, { ConsoleLogger as Logger, Parser } from '@aws-amplify/core';
+import Amplify, { ConsoleLogger as Logger } from '@aws-amplify/core';
 
 const logger = new Logger('Storage');
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -14,7 +14,7 @@
 import StorageClass from './Storage';
 import { StorageProvider } from './types';
 
-import Amplify, { ConsoleLogger as Logger } from '@aws-amplify/core';
+import Amplify, { ConsoleLogger as Logger, Parser } from '@aws-amplify/core';
 
 const logger = new Logger('Storage');
 
@@ -24,15 +24,20 @@ if (!_instance) {
     logger.debug('Create Storage Instance');
     _instance = new StorageClass();
     _instance.vault = new StorageClass();
-    _instance.vault.configure({ level: 'private' });
-
+    
     const old_configure = _instance.configure;
     _instance.configure = (options) => {
-        logger.debug('configure called');
-        old_configure.call(_instance, options);
+        logger.debug('storage configure called');
+        const vaultConfig = old_configure.call(_instance, options);
 
-        const vault_options = Object.assign({}, options, { level: 'private' });
-        _instance.vault.configure(vault_options);
+        // set level private for each provider for the vault
+        Object.keys(vaultConfig).forEach((providerName) => {
+            if (typeof vaultConfig[providerName] !== 'string') {
+                vaultConfig[providerName] = { ...vaultConfig[providerName], level: "private" };
+            }
+        });
+        logger.debug('storage vault configure called');
+        _instance.vault.configure(vaultConfig);
     };
 }
 


### PR DESCRIPTION
*Issue #, if available:*
#2693 
*Description of changes:*
Update Storage.configure and Storage.vault.configure to support backwards compatibility (without using provider configuration) added unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
