### PR TITLE
fix(aws-amplify-react): Change the position of <form/> element in the <SignIn/> component

### DIFF
--- a/packages/aws-amplify-react/src/Auth/SignIn.jsx
+++ b/packages/aws-amplify-react/src/Auth/SignIn.jsx
@@ -109,16 +109,17 @@ export default class SignIn extends AuthPiece {
         const hideForgotPassword = !override.includes('ForgotPassword') && hide.some(component => component === ForgotPassword);
         return (
             <FormSection theme={theme}>
-                <form onSubmit={this.signIn}>
                 <SectionHeader theme={theme}>{I18n.get('Sign in to your account')}</SectionHeader>
-                <SectionBody theme={theme}>
-                    <FederatedButtons
+                <FederatedButtons
                         federated={federated}
                         theme={theme}
                         authState={authState}
                         onStateChange={onStateChange}
                         onAuthEvent={onAuthEvent}
                     />
+                <form onSubmit={this.signIn}>
+                <SectionBody theme={theme}>
+                    
                     <FormField theme={theme}>
                         <InputLabel theme={theme}>{I18n.get('Username')} *</InputLabel>
                         <Input


### PR DESCRIPTION
*Issue #, if available:*

When clicking federated buttons, the signIn method will be false triggered. This is because the <form/> element also includes the federated buttons.

*Description of changes:*
Adjust the position of <FederatedButtons/> and <form/>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
