### PR TITLE
feat(@aws-amplify/storage) list/get objects from protected

### DIFF
--- a/packages/storage/__tests__/Providers/AWSS3Provider-unit-test.ts
+++ b/packages/storage/__tests__/Providers/AWSS3Provider-unit-test.ts
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import  StorageProvider  from '../../src/Providers/AWSS3Provider';
+import  StorageProvider, { S3OptionsIdentityId }  from '../../src/Providers/AWSS3Provider';
 import { Hub, Credentials } from '@aws-amplify/core';
 import * as S3 from 'aws-sdk/clients/s3';
 
@@ -687,7 +687,7 @@ describe('StorageProvider test', () => {
             curCredSpyOn.mockClear();
         });
 
-        test('list object protected level, withoutIdentityId successfully', async () => {
+        test('list object protected level, S3OptionsIdentityId NONE successfully', async () => {
             const curCredSpyOn = jest.spyOn(Credentials, 'get')
                 .mockImplementationOnce(() => {
                     return new Promise((res, rej) => {
@@ -702,7 +702,7 @@ describe('StorageProvider test', () => {
             const spyon = jest.spyOn(S3.prototype, 'listObjects');
 
             expect.assertions(2);
-            expect(await storage.list('path', {level: 'protected', withoutIdentityId:true})).toEqual([{
+            expect(await storage.list('path', {level: 'protected', identityId: S3OptionsIdentityId.NONE})).toEqual([{
                 "eTag": "etag",
                  "key": "identityId/path/itemsKey",
                 "lastModified": "lastmodified",

--- a/packages/storage/src/Providers/AWSS3Provider.ts
+++ b/packages/storage/src/Providers/AWSS3Provider.ts
@@ -335,23 +335,50 @@ export default class AWSS3Provider implements StorageProvider{
      * @private
      */
     private _prefix(config) {
-        const { credentials, level } = config;
-
-        const customPrefix = config.customPrefix || {};
-        const identityId = config.identityId || credentials.identityId;
-        const privatePath = (customPrefix.private !== undefined ? customPrefix.private : 'private/') + identityId + '/';
-        const protectedPath = (customPrefix.protected !== undefined ?
-            customPrefix.protected : 'protected/') + identityId + '/';
-        const publicPath = customPrefix.public !== undefined ? customPrefix.public : 'public/';
+        const { level } = config;
 
         switch (level) {
             case 'private':
-                return privatePath;
+                return this._privatePath(config);
             case 'protected':
-                return protectedPath;
+                return this._protectedPath(config);
             default:
-                return publicPath;
+                return this._publicPath(config);
         }
+    }
+
+    /**
+     * @private
+     */
+    private _publicPath(config) {
+        const customPrefix = config.customPrefix || {};
+        
+        return customPrefix.public !== undefined ? customPrefix.public : 'public/';
+    }
+
+    /**
+     * @private
+     */
+    private _privatePath(config) {
+        const { credentials = {}, customPrefix = {} } = config;
+        const identityIdPath = credentials.identityId;
+        
+        return (customPrefix.private !== undefined ? customPrefix.private : 'private/') + identityIdPath + '/';
+    }
+
+    /**
+     * @private
+     */
+    private _protectedPath(config) {
+        const { credentials = {}, customPrefix = {} } = config;
+
+        let identityIdPath = '';
+        if (!config.withoutIdentityId) {
+            identityIdPath = (config.identityId || credentials.identityId) + '/';
+        }
+
+        return (customPrefix.protected !== undefined ?
+            customPrefix.protected : 'protected/') + identityIdPath;
     }
 
     /**

--- a/packages/storage/src/Providers/AWSS3Provider.ts
+++ b/packages/storage/src/Providers/AWSS3Provider.ts
@@ -27,6 +27,11 @@ const dispatchStorageEvent = (track, attrs, metrics) => {
     }
 };
 
+export enum S3OptionsIdentityId {
+    CURRENT = "@@Current",
+    NONE = "@@None"
+}
+
 /**
  * Provide storage methods to use AWS S3
  */
@@ -373,7 +378,7 @@ export default class AWSS3Provider implements StorageProvider{
         const { credentials = {}, customPrefix = {} } = config;
 
         let identityIdPath = '';
-        if (!config.withoutIdentityId) {
+        if (config.identityId !== S3OptionsIdentityId.NONE) {
             identityIdPath = (config.identityId || credentials.identityId) + '/';
         }
 

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -13,6 +13,7 @@
 
 import StorageClass from './Storage';
 import { StorageProvider } from './types';
+import { S3OptionsIdentityId } from './Providers/AWSS3Provider';
 
 import Amplify, { ConsoleLogger as Logger } from '@aws-amplify/core';
 
@@ -47,4 +48,5 @@ Amplify.register(Storage);
 export default Storage;
 export { StorageClass };
 export { StorageProvider };
+export { S3OptionsIdentityId };
 export * from './Providers';


### PR DESCRIPTION
list/get objects from protected prefix without identityId
*Issue #, if available:*
#2203
*Description of changes:*
To list/get objects from protected prefix without identityId. That means from the root path of `protected` you can do it like this.

```javascript
import { S3OptionsIdentityId } from '@aws-amplify/storage';
...

Storage.list('path', { config: 'protected', identityId: S3OptionsIdentityId.NONE })
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
