### PR TITLE
feat(aws-amplify-react/oauth): add Hosted UI URL pathing

### DIFF
--- a/packages/aws-amplify-react/src/Auth/Provider/withOAuth.jsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/withOAuth.jsx
@@ -48,12 +48,13 @@ export default function withOAuth(Comp, options) {
                 domain, 
                 redirectSignIn,
                 redirectSignOut,
-                responseType
+                responseType,
+                options
             } = config;
 
             const options = config.options || {};
             const url = 'https://' + domain 
-                + '/login?redirect_uri=' + redirectSignIn 
+                + (options.ProviderHostedUIFlag ? '/oauth2/authorize?redirect_uri=' : '/login?redirect_uri=') + redirectSignIn
                 + '&response_type=' + responseType 
                 + '&client_id=' + (options.ClientId || Auth.configure().userPoolWebClientId);
 


### PR DESCRIPTION
This feature will allow the callout to bypass the Universal Login page and head straight to the Provider's Hosted UI. 
This will improve the UX by lowering the number of clicks to sign in.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
