### PR TITLE
Prevent setState warning on unmounted component

### DIFF
--- a/packages/aws-amplify-react/src/API/GraphQL/Connect.js
+++ b/packages/aws-amplify-react/src/API/GraphQL/Connect.js
@@ -89,7 +89,9 @@ export default class Connect extends Component {
                     next: ({ value: { data } }) => {
                         const { data: prevData } = this.state;
                         const newData = onSubscriptionMsg(prevData, data);
-                        this.setState({ data: newData });
+                        if (this.mounted) {
+                            this.setState({ data: newData });
+                        }
                     },
                     error: err => console.error(err),
                 });
@@ -109,10 +111,12 @@ export default class Connect extends Component {
 
     async componentDidMount() {
         this._fetchData();
+        this.mounted = true;
     }
 
     componentWillUnmount() {
         this._unsubscribe();
+        this.mounted = false;
     }
 
     componentDidUpdate(prevProps) {


### PR DESCRIPTION
@alebiavati

Updated version of https://github.com/aws-amplify/amplify-js/pull/1828, as original fork was deleted

Addresses https://github.com/aws-amplify/amplify-js/issues/1771

Description of changes:
Setting a mounted flag in componentDidMount, removing the flag in componentWillUnmount. Then checking for this flag before setting state inside the subscription.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.