### PR TITLE
feat(aws-amplify-react-native): enable typescript

### DIFF
--- a/packages/aws-amplify-react-native/package.json
+++ b/packages/aws-amplify-react-native/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "jest --coverage --maxWorkers 2",
-    "build": "npm run clean && babel src --out-dir dist --copy-files",
-    "watch": "npm run clean && babel src --out-dir dist --copy-files --watch",
+    "build": "npm run clean && tsc -p .",
+    "build:watch": "npm run clean && tsc -p . --watch",
     "generate-docs": "rimraf docs && jsdoc -c ./jsDoc.config.json --readme ../../media/api_reference_home.md ./src -r  -d ./docs",
     "clean": "rimraf dist"
   },

--- a/packages/aws-amplify-react-native/src/API/GraphQL/Connect.js
+++ b/packages/aws-amplify-react-native/src/API/GraphQL/Connect.js
@@ -1,5 +1,5 @@
 import 'regenerator-runtime/runtime';
-import React, { Component } from 'react';
+import * as React from 'react';
 import { parse } from 'graphql/language/parser';
 
 import { API } from "aws-amplify";
@@ -11,7 +11,7 @@ const getOperationType = operation => {
     return operationType;
 }
 
-export default class Connect extends Component {
+export default class Connect extends React.Component {
 
     constructor(props) {
         super(props);

--- a/packages/aws-amplify-react-native/src/AmplifyI18n.js
+++ b/packages/aws-amplify-react-native/src/AmplifyI18n.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-export default dict = {
+const dict = {
     'fr': {
         'Loading...': "S'il vous plaît, attendez",
         'Sign In': "Se connecter",
@@ -106,3 +106,5 @@ Utilice el formato de número de teléfono +12345678900`
         'Invalid phone number format': "电话格式错误，请使用格式 +12345678900"
     }
 }
+
+export default dict;

--- a/packages/aws-amplify-react-native/src/AmplifyMessageMap.js
+++ b/packages/aws-amplify-react-native/src/AmplifyMessageMap.js
@@ -25,7 +25,7 @@ export const MapEntries = [
     ]
 ];
 
-export default AmplifyMessageMap = (message) => {
+const AmplifyMessageMap = (message) => {
     const match = MapEntries.filter(entry => entry[1].test(message));
     if (match.length === 0) {
         return message;
@@ -36,3 +36,5 @@ export default AmplifyMessageMap = (message) => {
 
     return I18n.get(entry[0], msg);
 }
+
+export default AmplifyMessageMap;

--- a/packages/aws-amplify-react-native/src/AmplifyTheme.js
+++ b/packages/aws-amplify-react-native/src/AmplifyTheme.js
@@ -19,7 +19,7 @@ export const linkUnderlayColor = '#FFF';
 export const errorIconColor = '#DD3F5B';
 
 // Theme
-export default AmplifyTheme = StyleSheet.create({
+const AmplifyTheme = StyleSheet.create({
     container: {
         flex: 1,
         flexDirection: 'column',
@@ -133,3 +133,4 @@ export default AmplifyTheme = StyleSheet.create({
     },
 });
 
+export default AmplifyTheme;

--- a/packages/aws-amplify-react-native/src/AmplifyUI.js
+++ b/packages/aws-amplify-react-native/src/AmplifyUI.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React, { Component } from 'react';
+import * as React from 'react';
 import { View, Text, TextInput, TouchableHighlight, TouchableOpacity, Picker } from 'react-native';
 import { I18n } from 'aws-amplify';
 import AmplifyTheme, { linkUnderlayColor, errorIconColor } from './AmplifyTheme';
@@ -33,7 +33,7 @@ export const FormField = (props) => {
     )
 }
 
-export class PhoneField extends Component {
+export class PhoneField extends React.Component {
     constructor(props) {
         super(props);
 

--- a/packages/aws-amplify-react-native/src/Auth/AuthPiece.js
+++ b/packages/aws-amplify-react-native/src/Auth/AuthPiece.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {
     Auth,

--- a/packages/aws-amplify-react-native/src/Auth/Authenticator.js
+++ b/packages/aws-amplify-react-native/src/Auth/Authenticator.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React from 'react';
+import * as React from 'react';
 import { View } from 'react-native';
 import { 
     Auth, 

--- a/packages/aws-amplify-react-native/src/Auth/ConfirmSignIn.js
+++ b/packages/aws-amplify-react-native/src/Auth/ConfirmSignIn.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React from 'react';
+import * as React from 'react';
 import { 
     View, 
     TouchableWithoutFeedback,

--- a/packages/aws-amplify-react-native/src/Auth/ConfirmSignUp.js
+++ b/packages/aws-amplify-react-native/src/Auth/ConfirmSignUp.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React from 'react';
+import * as React from 'react';
 import { 
     View, 
     TouchableWithoutFeedback,

--- a/packages/aws-amplify-react-native/src/Auth/ForgotPassword.js
+++ b/packages/aws-amplify-react-native/src/Auth/ForgotPassword.js
@@ -10,8 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-
-import React from 'react';
+import * as React from 'react';
 import { 
     View, 
     TouchableWithoutFeedback,

--- a/packages/aws-amplify-react-native/src/Auth/Greetings.js
+++ b/packages/aws-amplify-react-native/src/Auth/Greetings.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React from 'react';
+import * as React from 'react';
 import { 
     View, 
     Text, 

--- a/packages/aws-amplify-react-native/src/Auth/Loading.js
+++ b/packages/aws-amplify-react-native/src/Auth/Loading.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React from 'react';
+import * as React from 'react';
 import { View, Text } from 'react-native';
 import { I18n } from 'aws-amplify';
 import AuthPiece from './AuthPiece';

--- a/packages/aws-amplify-react-native/src/Auth/RequireNewPassword.js
+++ b/packages/aws-amplify-react-native/src/Auth/RequireNewPassword.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React from 'react';
+import * as React from 'react';
 import {
     View,
     TouchableWithoutFeedback,

--- a/packages/aws-amplify-react-native/src/Auth/SignIn.js
+++ b/packages/aws-amplify-react-native/src/Auth/SignIn.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React from 'react';
+import * as React from 'react';
 import {
     View,
     TouchableWithoutFeedback,

--- a/packages/aws-amplify-react-native/src/Auth/SignUp.js
+++ b/packages/aws-amplify-react-native/src/Auth/SignUp.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React from 'react';
+import * as React from 'react';
 import {
     View,
     Text,

--- a/packages/aws-amplify-react-native/src/Auth/VerifyContact.js
+++ b/packages/aws-amplify-react-native/src/Auth/VerifyContact.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React from 'react';
+import * as React from 'react';
 import { 
     View, 
     Picker, 

--- a/packages/aws-amplify-react-native/src/Auth/index.js
+++ b/packages/aws-amplify-react-native/src/Auth/index.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React from 'react';
+import * as React from 'react';
 import { View } from 'react-native';
 import { Logger } from 'aws-amplify';
 import Authenticator from './Authenticator';

--- a/packages/aws-amplify-react-native/src/Interactions/ChatBot.js
+++ b/packages/aws-amplify-react-native/src/Interactions/ChatBot.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import * as React from 'react';
 import { View, TextInput, Text, KeyboardAvoidingView, ScrollView } from "react-native";
 import Interactions from '@aws-amplify/interactions';
 import { I18n } from "aws-amplify";
@@ -72,7 +72,7 @@ const MIC_BUTTON_TEXT = {
 
 let timer = null;
 
-export class ChatBot extends Component {
+export class ChatBot extends React.Component {
     constructor(props) {
         super(props);
         this.state = {

--- a/packages/aws-amplify-react-native/src/Storage/S3Album.js
+++ b/packages/aws-amplify-react-native/src/Storage/S3Album.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React, { Component } from 'react';
+import * as React from 'react';
 import { 
     ScrollView, 
     Dimensions, 
@@ -26,7 +26,7 @@ import S3Image from './S3Image';
 
 const logger = new Logger('Storage.S3Album');
 
-export default class S3Album extends Component {
+export default class S3Album extends React.Component {
     constructor(props) {
         super(props);
 

--- a/packages/aws-amplify-react-native/src/Storage/S3Image.js
+++ b/packages/aws-amplify-react-native/src/Storage/S3Image.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import React, { Component } from 'react';
+import * as React from 'react';
 import { 
     Image, 
     StyleSheet 
@@ -24,7 +24,7 @@ import AmplifyTheme from '../AmplifyTheme';
 
 const logger = new Logger('Storage.S3Image');
 
-export default class S3Image extends Component {
+export default class S3Image extends React.Component {
     constructor(props) {
         super(props);
 

--- a/packages/aws-amplify-react-native/tsconfig.json
+++ b/packages/aws-amplify-react-native/tsconfig.json
@@ -1,0 +1,67 @@
+{
+    "compilerOptions": {
+      /* Basic Options */
+      "target": "es5", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+      "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+      "lib": [
+        "es5",
+        "es2015",
+        "dom",
+        "esnext.asynciterable",
+        "es2017.object"
+      ], /* Specify library files to be included in the compilation. */
+      "allowJs": true, /* Allow javascript files to be compiled. */
+      // "checkJs": true,                       /* Report errors in .js files. */
+      "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+      // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+      // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+      "sourceMap": true, /* Generates corresponding '.map' file. */
+      // "outFile": "./",                       /* Concatenate and emit output to single file. */
+      "outDir": "./dist", /* Redirect output structure to the directory. */
+      // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+      // "composite": true,                     /* Enable project compilation */
+      // "removeComments": true,                /* Do not emit comments to output. */
+      // "noEmit": true,                        /* Do not emit outputs. */
+      // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+      // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+      // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+      /* Strict Type-Checking Options */
+      "strict": false, /* Enable all strict type-checking options. */
+      // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+      // "strictNullChecks": true,              /* Enable strict null checks. */
+      // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+      // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+      // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+      // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+      /* Additional Checks */
+      // "noUnusedLocals": true,                /* Report errors on unused locals. */
+      // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+      // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+      // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+      /* Module Resolution Options */
+      "moduleResolution": "node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+      // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+      // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+      // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+      "typeRoots": [
+        "./node_modules/@types",
+        "../../node_modules/@types"
+      ], /* List of folders to include type definitions from. */
+      // "types": [],                           /* Type declaration files to be included in compilation. */
+      "allowSyntheticDefaultImports": true, /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+      // "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+      // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+      /* Source Map Options */
+      // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+      // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+      // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+      // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+      /* Experimental Options */
+      // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+      // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+      "skipLibCheck": true
+    },
+    "include": [
+      "src/**/*"
+    ]
+  }


### PR DESCRIPTION
*Issue #, if available:*
The `aws-amplify-react-native` is not written in Typescript. This pr is the first step to transform it into a Typescript project.
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
