### PR TITLE
Log error in Analytics API if not configured

### DIFF
--- a/packages/analytics/__tests__/Analytics-unit-test.ts
+++ b/packages/analytics/__tests__/Analytics-unit-test.ts
@@ -63,12 +63,20 @@ describe("Analytics test", () => {
             const analytics = new Analytics();
             const provider = new AWSAnalyticsProvider();
             analytics.addPluggable(provider);
+            analytics.configure({mock: "value"});
 
             await analytics.startSession();
             expect(record_spyon).toBeCalled();
         });
+        test('analytics not configured', async () => {
+            const analytics = new Analytics();
 
-
+            try {
+                await analytics.startSession();
+            } catch (e) {
+                expect(e).toBe('Analytics has not been configured');
+            }
+        });
     });
 
     describe('stopSession test', () => {
@@ -76,9 +84,19 @@ describe("Analytics test", () => {
             const analytics = new Analytics();
             const provider = new AWSAnalyticsProvider();
             analytics.addPluggable(provider);
+            analytics.configure({mock: "value"});
 
             await analytics.stopSession();
             expect(record_spyon).toBeCalled();
+        });
+        test('analytics not configured', async () => {
+            const analytics = new Analytics();
+
+            try {
+                await analytics.stopSession();
+            } catch (e) {
+                expect(e).toBe('Analytics has not been configured');
+            }
         });
     });
 
@@ -87,6 +105,7 @@ describe("Analytics test", () => {
             const analytics = new Analytics();
             const provider = new AWSAnalyticsProvider();
             analytics.addPluggable(provider);
+            analytics.configure({mock: "value"});
 
             await analytics.record({
                 name: 'event',
@@ -95,6 +114,15 @@ describe("Analytics test", () => {
             });
             expect(record_spyon).toBeCalled();
         });
+        test('analytics not configured', async () => {
+            const analytics = new Analytics();
+
+            try {
+                await analytics.record({});
+            } catch (e) {
+                expect(e).toBe('Analytics has not been configured');
+            }
+        });
     });
 
     describe('updateEndpoint test', () => {
@@ -102,11 +130,21 @@ describe("Analytics test", () => {
             const analytics = new Analytics();
             const provider = new AWSAnalyticsProvider();
             analytics.addPluggable(provider);
+            analytics.configure({mock: "value"});
 
             await analytics.updateEndpoint({
                 UserId: 'id'
             });
             expect(record_spyon).toBeCalled();
+        });
+        test('analytics not configured', async () => {
+            const analytics = new Analytics();
+
+            try {
+                await analytics.updateEndpoint({});
+            } catch (e) {
+                expect(e).toBe('Analytics has not been configured');
+            }
         });
     });
 

--- a/packages/analytics/__tests__/Analytics-unit-test.ts
+++ b/packages/analytics/__tests__/Analytics-unit-test.ts
@@ -74,8 +74,9 @@ describe("Analytics test", () => {
             try {
                 await analytics.startSession();
             } catch (e) {
-                expect(e).toBe('Analytics has not been configured');
+                expect(e.message).toBe('Analytics has not been configured');
             }
+            expect.assertions(1);
         });
     });
 
@@ -95,8 +96,9 @@ describe("Analytics test", () => {
             try {
                 await analytics.stopSession();
             } catch (e) {
-                expect(e).toBe('Analytics has not been configured');
+                expect(e.message).toBe('Analytics has not been configured');
             }
+            expect.assertions(1);
         });
     });
 
@@ -120,8 +122,9 @@ describe("Analytics test", () => {
             try {
                 await analytics.record({});
             } catch (e) {
-                expect(e).toBe('Analytics has not been configured');
+                expect(e.message).toBe('Analytics has not been configured');
             }
+            expect.assertions(1);
         });
     });
 
@@ -143,8 +146,9 @@ describe("Analytics test", () => {
             try {
                 await analytics.updateEndpoint({});
             } catch (e) {
-                expect(e).toBe('Analytics has not been configured');
+                expect(e.message).toBe('Analytics has not been configured');
             }
+            expect.assertions(1);
         });
     });
 

--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -204,7 +204,7 @@ export default class AnalyticsClass {
         if (!this.isAnalyticsConfigured()) {
             const errMsg = 'Analytics has not been configured';
             logger.debug(errMsg);
-            return Promise.reject(errMsg);
+            return Promise.reject(new Error(errMsg));
         }
 
         let params = null;
@@ -234,7 +234,7 @@ export default class AnalyticsClass {
         if (!this.isAnalyticsConfigured()) {
             const errMsg = 'Analytics has not been configured';
             logger.debug(errMsg);
-            return Promise.reject(errMsg);
+            return Promise.reject(new Error(errMsg));
         }
 
         if (this._disabled) {

--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -201,6 +201,12 @@ export default class AnalyticsClass {
      * @return - A promise which resolves if buffer doesn't overflow
      */
     public async record(event: string | object, provider? , metrics?: EventMetrics) {
+        if (!this.isAnalyticsConfigured()) {
+            const errMsg = 'Analytics has not been configured';
+            logger.debug(errMsg);
+            return Promise.reject(errMsg);
+        }
+
         let params = null;
         // this is just for compatibility, going to be deprecated
         if (typeof event === 'string') {
@@ -225,6 +231,12 @@ export default class AnalyticsClass {
     }
 
     private _sendEvent(params) {
+        if (!this.isAnalyticsConfigured()) {
+            const errMsg = 'Analytics has not been configured';
+            logger.debug(errMsg);
+            return Promise.reject(errMsg);
+        }
+
         if (this._disabled) {
             logger.debug('Analytics has been disabled');
             return Promise.resolve();
@@ -258,5 +270,9 @@ export default class AnalyticsClass {
         } else {
             tracker.configure(opts);
         }
+    }
+
+    private isAnalyticsConfigured() {
+        return this._config && Object.entries(this._config).length > 0;
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
fixes #2971 

*Description of changes:*
- Log debug error and reject promise if Analytics is not configured

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
