### PR TITLE
fix(@aws-amplify/auth): Valide OAuth state only when generated by Amlify

### DIFF
--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -212,6 +212,7 @@ export default class OAuth {
     const savedState = oAuthStorage.getState();
     const { state: returnedState } = urlParams;
 
+    // This is because savedState only exists if the flow was initiated by Amplify
     if (savedState && savedState !== returnedState) {
       throw new Error('Invalid state in OAuth flow');
     }

--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -127,7 +127,7 @@ export default class OAuth {
       code,
       client_id,
       redirect_uri,
-      code_verifier
+      ...(code_verifier ? { code_verifier } : {})
     };
 
     logger.debug(`Calling token endpoint: ${oAuthTokenEndpoint} with`, oAuthTokenBody);
@@ -212,7 +212,7 @@ export default class OAuth {
     const savedState = oAuthStorage.getState();
     const { state: returnedState } = urlParams;
 
-    if (savedState !== returnedState) {
+    if (savedState && savedState !== returnedState) {
       throw new Error('Invalid state in OAuth flow');
     }
   }

--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -66,7 +66,7 @@ export default class OAuth {
     domain: string,
     redirectSignIn: string,
     clientId: string,
-    provider: CognitoHostedUIIdentityProvider | string) {
+    provider: CognitoHostedUIIdentityProvider | string = CognitoHostedUIIdentityProvider.Cognito) {
 
     const state = this._generateState(32);
     oAuthStorage.setState(state);

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -63,12 +63,14 @@ export type FederatedSignInOptionsCustom = {
     customProvider: string
 };
 
-export function isFederatedSignInOptions(obj:any): obj is FederatedSignInOptions  {
-    return obj && typeof(obj as FederatedSignInOptions).provider !== 'undefined';
+export function isFederatedSignInOptions(obj: any): obj is FederatedSignInOptions  {
+    const key: keyof FederatedSignInOptions = 'provider';
+    return obj && obj.hasOwnProperty(key);
 }
 
 export function isFederatedSignInOptionsCustom(obj:any): obj is FederatedSignInOptionsCustom  {
-    return obj && typeof(obj as FederatedSignInOptionsCustom).customProvider !== 'undefined';
+    const key: keyof FederatedSignInOptionsCustom = 'customProvider';
+    return obj && obj.hasOwnProperty(key);
 }
 
 /**

--- a/packages/aws-amplify-react/__tests__/Auth/Provider/withOAuth-test.js
+++ b/packages/aws-amplify-react/__tests__/Auth/Provider/withOAuth-test.js
@@ -40,7 +40,7 @@ describe('withOAuth test', () => {
 
             comp.signIn();
 
-            expect(spyon).toBeCalledWith(undefined);
+            expect(spyon).toBeCalledWith({ provider: undefined });
             spyon.mockClear();
         });
 
@@ -57,7 +57,7 @@ describe('withOAuth test', () => {
             const wrapper = mount(<Comp/>);
             const comp = wrapper.instance();
 
-            comp.signIn('Facebook');
+            comp.signIn(expect.anything(), 'Facebook');
 
             expect(spyon).toBeCalledWith({"provider": "Facebook"});
             spyon.mockClear();

--- a/packages/aws-amplify-react/src/Auth/Provider/withOAuth.jsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/withOAuth.jsx
@@ -22,23 +22,16 @@ import {
     SignInButton, 
     SignInButtonContent
 } from '../../Amplify-UI/Amplify-UI-Components-React';
-import Constants from '../common/constants';
 
-const logger = new Logger('withOAuth');
-
-export default function withOAuth(Comp, options) {
+export default function withOAuth(Comp) {
     return class extends Component {
         constructor(props) {
             super(props);
             this.signIn = this.signIn.bind(this);
         }
 
-        signIn(provider) {
-            Auth.federatedSignIn(
-                provider
-                  ?{provider}
-                  :undefined
-            );
+        signIn(_e, provider) {
+            Auth.federatedSignIn({ provider });
         }
 
         render() {


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3054
Fixes #3055

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
