### PR TITLE
fix(aws-amplify-angular): moves rxjs-compat to dependencies

### DIFF
--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -59,7 +59,6 @@
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-uglify": "^4.0.0",
     "rxjs": "^6.2.1",
-    "rxjs-compat": "^6.2.1",
     "source-map-explorer": "^1.3.3",
     "to-string-loader": "^1.1.5",
     "uglify-js": "^3.4.7",
@@ -68,6 +67,7 @@
   },
   "dependencies": {
     "@aws-amplify/ui": "1.0.19-unstable.0",
-    "@types/lodash": "^4.14.106"
+    "@types/lodash": "^4.14.106",
+    "rxjs-compat": "^6.0.0"
   }
 }

--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -68,6 +68,6 @@
   "dependencies": {
     "@aws-amplify/ui": "1.0.19-unstable.0",
     "@types/lodash": "^4.14.106",
-    "rxjs-compat": "^6.0.0"
+    "rxjs-compat": "^6.2.1"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
#3075 

*Description of changes:*
Moves rxjs-compat to dependencies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
