### PR TITLE
feat(auth i18n french)

### DIFF
--- a/packages/aws-amplify-react/src/AmplifyI18n.js
+++ b/packages/aws-amplify-react/src/AmplifyI18n.js
@@ -44,7 +44,21 @@ const dict = {
         'Invalid password format': "format de mot de passe invalide",
         'Invalid phone number format':
 `Format de numéro de téléphone invalide.
-Veuillez utiliser un format de numéro de téléphone du +12345678900`
+Veuillez utiliser un format de numéro de téléphone du +12345678900`,
+        'Sign in to your account': "Connectez-vous à votre compte",
+        'Forget your password? ': "Mot de passe oublié ? ",
+        'Reset password': "Réinitialisez votre mot de passe",
+        'No account? ': "Pas de compte ? ",
+        'Create account': "Créer un compte",
+        'Create Account': "Créer un compte",
+        'Have an account? ': "Déjà un compte ? ",
+        'Sign in': "Se connecter",
+        'Create a new account': "Créer un nouveau compte",
+        'Reset your password': "Réinitialisez votre mot de passe",
+        'Enter your username': "Saisissez votre nom d'utilisateur",
+        'Enter your password': "Saisissez votre mot de passe",
+        'An account with the given email already exists.': "Un utilisateur avec cette adresse email existe déjà.",
+        'Username cannot be empty': "Le nom d'utilisateur doit être renseigné"
     },
 
     'es': {


### PR DESCRIPTION
*Description of changes:*
I've added a bunch of French translation for React Auth.
## Sign in
![image](https://user-images.githubusercontent.com/1325474/56097657-b8b03700-5ef7-11e9-9f6c-0c85cdf3feb2.png)
## Reset password
![image](https://user-images.githubusercontent.com/1325474/56097668-ccf43400-5ef7-11e9-9f82-96463a5b1dbb.png)
## Create account
![image](https://user-images.githubusercontent.com/1325474/56097670-da112300-5ef7-11e9-8248-f45f33bf2ffb.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
