### PR TITLE
feat(@aws-amplify/xr): Changing signing logic in SumerianProvider to use Auth Headers instead of Query Params. 

### DIFF
--- a/packages/xr/src/Providers/SumerianProvider.ts
+++ b/packages/xr/src/Providers/SumerianProvider.ts
@@ -128,7 +128,9 @@ export class SumerianProvider extends AbstractXRProvider {
       };
       
       const serviceInfo = { region: sceneRegion, service: SUMERIAN_SERVICE_NAME };
-      url = Signer.signUrl(sceneUrl, accessInfo, serviceInfo);
+      const request = Signer.sign({ method: "GET", url: sceneUrl }, accessInfo, serviceInfo);
+      fetchOptions.headers = {...fetchOptions.headers, ...request.headers};
+      url = request.url;
     } catch (e) {
       logger.debug('No credentials available, the request will be unsigned');
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This makes it easier for caching libraries like Workbox to cache requests which enable offline PWA Sumerian apps.
Using Signer.sign to sign the request and passing in the results as a header to fetchOptions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
