### PR TITLE
Parody for each framework to use hideAllDefaults in SignUp

### DIFF
--- a/packages/aws-amplify-react/__tests__/Auth/SignUp-test.js
+++ b/packages/aws-amplify-react/__tests__/Auth/SignUp-test.js
@@ -373,7 +373,7 @@ describe('signUp with signUpConfig', () => {
         expect(addressElementFound.props().name).toEqual(addressChildFound.props().name);
     });
 
-    test('expect 5 fields to be present if hideDefaults is undefined', () => {
+    test('expect 5 fields to be present if hideAllDefaults is undefined', () => {
         wrapper.setProps({
             authState: 'signUp',
             theme: AmplifyTheme,
@@ -391,7 +391,7 @@ describe('signUp with signUpConfig', () => {
         expect(wrapper.find(Input).length).toEqual(5);
     });
 
-    test('expect 5 fields to be present if hideDefaults is false', () => {
+    test('expect 5 fields to be present if hideAllDefaults is false', () => {
         wrapper.setProps({
             authState: 'signUp',
             theme: AmplifyTheme,
@@ -410,7 +410,7 @@ describe('signUp with signUpConfig', () => {
         expect(wrapper.find(Input).length).toEqual(5);
     });
 
-    test('expect custom field to be the only field if hideDefaults is true', () => {
+    test('expect custom field to be the only field if hideAllDefaults is true', () => {
         wrapper.setProps({
             authState: 'signUp',
             theme: AmplifyTheme,

--- a/packages/aws-amplify-vue/src/components/authenticator/SignUp.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/SignUp.vue
@@ -128,7 +128,7 @@ export default {
 
       // begin looping through signUpFields
       if (this.signUpConfig && this.signUpConfig.signUpFields && this.signUpConfig.signUpFields.length > 0) {
-        // if hideAllDefaults or hideDefaults is not present on props...
+        // if hideAllDefaults and hideDefaults are not present on props...
         if (!this.signUpConfig.hideAllDefaults && !this.signUpConfig.hideDefaults) {
           // ...add default fields to signUpField array unless user has passed in custom field with matching key
           defaults.signUpFields.forEach((f, i) => {

--- a/packages/aws-amplify-vue/src/components/authenticator/SignUp.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/SignUp.vue
@@ -128,8 +128,8 @@ export default {
 
       // begin looping through signUpFields
       if (this.signUpConfig && this.signUpConfig.signUpFields && this.signUpConfig.signUpFields.length > 0) {
-        // if hideDefaults is not present on props...
-        if (!this.signUpConfig.hideDefaults) {
+        // if hideAllDefaults or hideDefaults is not present on props...
+        if (!this.signUpConfig.hideAllDefaults || !this.signUpConfig.hideDefaults) {
           // ...add default fields to signUpField array unless user has passed in custom field with matching key
           defaults.signUpFields.forEach((f, i) => {
             const matchKey = this.signUpConfig.signUpFields.findIndex((d) => {

--- a/packages/aws-amplify-vue/src/components/authenticator/SignUp.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/SignUp.vue
@@ -129,7 +129,7 @@ export default {
       // begin looping through signUpFields
       if (this.signUpConfig && this.signUpConfig.signUpFields && this.signUpConfig.signUpFields.length > 0) {
         // if hideAllDefaults or hideDefaults is not present on props...
-        if (!this.signUpConfig.hideAllDefaults || !this.signUpConfig.hideDefaults) {
+        if (!this.signUpConfig.hideAllDefaults && !this.signUpConfig.hideDefaults) {
           // ...add default fields to signUpField array unless user has passed in custom field with matching key
           defaults.signUpFields.forEach((f, i) => {
             const matchKey = this.signUpConfig.signUpFields.findIndex((d) => {


### PR DESCRIPTION
*Issue #, if available:*
Related to: https://github.com/aws-amplify/docs/pull/458
Fixes: #3166 

*Description of changes:*
- Use hideDefaults or hideAllDefaults to hide default SignUp fields
- hideAllDefaults is what is listed in the docs for each framework

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
