### PR TITLE
Update vue to use lodash orderBy

### DIFF
--- a/packages/aws-amplify-vue/package.json
+++ b/packages/aws-amplify-vue/package.json
@@ -13,6 +13,7 @@
     "debug": "node --debug-brk --inspect ./node_modules/.bin/jest -i"
   },
   "dependencies": {
+    "lodash.orderby": "^4.6.0",
     "qrcode.vue": "^1.6.0",
     "vue": "^2.5.17",
     "vue2-filters": "^0.3.0"

--- a/packages/aws-amplify-vue/src/components/authenticator/SignUp.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/SignUp.vue
@@ -16,7 +16,7 @@
     <div v-bind:class="amplifyUI.sectionHeader">{{this.options.header}}</div>
     <div v-bind:class="amplifyUI.sectionBody">
       <div v-bind:class="amplifyUI.formField"
-          v-for="signUpField in orderBy(this.options.signUpFields, 'displayOrder')"
+          v-for="signUpField in this.orderedSignUpFields"
           :signUpField="signUpField.key"
           v-bind:key="signUpField.key"
         >
@@ -61,6 +61,7 @@
 <script>
 import Vue from 'vue';
 import Vue2Filters from 'vue2-filters'
+import orderBy from 'lodash.orderby';
 import AmplifyEventBus from '../../events/AmplifyEventBus';
 import * as AmplifyUI from '@aws-amplify/ui';
 import countries from '../../assets/countries';
@@ -174,6 +175,9 @@ export default {
       }
       
       return Object.assign(defaults, this.signUpConfig || {})
+    },
+    orderedSignUpFields: function () {
+      return orderBy(this.options.signUpFields, 'displayOrder', 'name')
     }
   },
   mounted() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8886,6 +8886,11 @@ lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
 
+lodash.orderby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.orderby/-/lodash.orderby-4.6.0.tgz#e697f04ce5d78522f54d9338b32b81a3393e4eb3"
+  integrity sha1-5pfwTOXXhSL1TZM4syuBozk+TrM=
+
 lodash.pad@^4.1.0:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/lodash.pad/-/lodash.pad-4.5.1.tgz#4330949a833a7c8da22cc20f6a26c4d59debba70"


### PR DESCRIPTION
*Issue #, if available:*
fixes: #3032

*Description of changes:*
- Use lodash orderBy instead of mixin

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
