### PR TITLE
fix(aws-amplify-angular): hide the link of creating account or forgetting password in SignIn component if corresponding components are hidden

### DIFF
--- a/packages/aws-amplify-angular/src/components/authenticator/authenticator/authenticator.component.core.ts
+++ b/packages/aws-amplify-angular/src/components/authenticator/authenticator/authenticator.component.core.ts
@@ -21,6 +21,7 @@ const template = `
     <amplify-auth-sign-in-core
       *ngIf="!shouldHide('SignIn')"
       [authState]="authState"
+      [hide]="hide"
     ></amplify-auth-sign-in-core>
 
     <amplify-auth-sign-up-core

--- a/packages/aws-amplify-angular/src/components/authenticator/authenticator/authenticator.component.ionic.ts
+++ b/packages/aws-amplify-angular/src/components/authenticator/authenticator/authenticator.component.ionic.ts
@@ -24,6 +24,7 @@ const template = `
 <amplify-auth-sign-in-ionic
   *ngIf="!shouldHide('SignIn')"
   [authState]="authState"
+  [hide]="hide"
 ></amplify-auth-sign-in-ionic>
 
 <amplify-auth-sign-up-ionic

--- a/packages/aws-amplify-angular/src/components/authenticator/sign-in-component/sign-in.component.core.ts
+++ b/packages/aws-amplify-angular/src/components/authenticator/sign-in-component/sign-in.component.core.ts
@@ -51,7 +51,7 @@ const template = `
           required
           placeholder="{{ this.amplifyService.i18n().get('Enter your password') }}"
         />
-        <span class="amplify-form-action">{{ this.amplifyService.i18n().get('Forgot Password?') }}
+        <span class="amplify-form-action" *ngIf="!shouldHide('ForgotPassword')">{{ this.amplifyService.i18n().get('Forgot Password?') }}
         <a class="amplify-form-link"
             (click)="onForgotPassword()"
           >{{ this.amplifyService.i18n().get('Reset your password') }}</a></span>
@@ -63,7 +63,7 @@ const template = `
           >{{ this.amplifyService.i18n().get('Sign In') }}</button>
         </div>
         <div class="amplify-form-cell-left">
-          <div class="amplify-form-signup">
+          <div class="amplify-form-signup" *ngIf="!shouldHide('SignUp')">
             {{ this.amplifyService.i18n().get('No account?') }}
             <a class="amplify-form-link" (click)="onSignUp()">
               {{ this.amplifyService.i18n().get('Create account') }}
@@ -105,6 +105,9 @@ export class SignInComponentCore implements OnInit {
     this._show = includes(['signIn', 'signedOut', 'signedUp'], authState.state);
     this.username = authState.user? authState.user.username || '' : '';
   }
+
+  @Input()
+  hide: string[] = [];
 
   ngOnInit() {
     if (!this.amplifyService.auth()){
@@ -159,5 +162,10 @@ export class SignInComponentCore implements OnInit {
     }
     this.errorMessage = err.message || err;
     this.logger.error(this.errorMessage);
+  }
+
+  shouldHide(comp) {
+    return this.hide.filter(item => item === comp)
+      .length > 0;
   }
 }

--- a/packages/aws-amplify-angular/src/components/authenticator/sign-in-component/sign-in.component.factory.ts
+++ b/packages/aws-amplify-angular/src/components/authenticator/sign-in-component/sign-in.component.factory.ts
@@ -40,6 +40,7 @@ import { authDecorator } from '../../../providers/auth.decorator';
 export class SignInComponent implements OnInit, OnDestroy {
   @Input() framework: string;
   @Input() authState: AuthState;
+  @Input() hide: string[] = [];
   @ViewChild(DynamicComponentDirective) componentHost: DynamicComponentDirective;
 
   constructor(private componentFactoryResolver: ComponentFactoryResolver) { }
@@ -53,8 +54,8 @@ export class SignInComponent implements OnInit, OnDestroy {
   loadComponent() {
 
     const authComponent = this.framework && this.framework === 'ionic' ?
-    new ComponentMount(SignInComponentIonic,{authState: this.authState}) :
-    new ComponentMount(SignInComponentCore, {authState: this.authState});
+    new ComponentMount(SignInComponentIonic,{authState: this.authState, hide: this.hide}) :
+    new ComponentMount(SignInComponentCore, {authState: this.authState, hide: this.hide});
 
     const componentFactory = this.componentFactoryResolver
     .resolveComponentFactory(authComponent.component);

--- a/packages/aws-amplify-angular/src/components/authenticator/sign-in-component/sign-in.component.ionic.ts
+++ b/packages/aws-amplify-angular/src/components/authenticator/sign-in-component/sign-in.component.ionic.ts
@@ -58,13 +58,13 @@ const template = `
       </div>
 
       <div class="amplify-form-row">
-        <div class="amplify-form-signup">
+        <div class="amplify-form-signup" *ngIf="!shouldHide('SignUp')">
           {{ this.amplifyService.i18n().get('No account?') }}
           <a class="amplify-form-link" (click)="onSignUp()">
             {{ this.amplifyService.i18n().get('Create account') }}
           </a>
         </div>
-        <div class="amplify-form-signup">
+        <div class="amplify-form-signup" *ngIf="!shouldHide('ForgotPassword')">
           <a class="amplify-form-link" (click)="onForgotPassword()">
             {{ this.amplifyService.i18n().get('Reset Password') }}
           </a>


### PR DESCRIPTION
*Issue #, if available:*
fixes #2946 
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
