### PR TITLE
fix(@aws-amplify/auth): User may not be fully signed out

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1244,9 +1244,10 @@ export default class AuthClass {
                         onSuccess: (data) => {
                             logger.debug('global sign out success');
                             if (isSignedInHostedUI) {
-                                this._oAuthHandler.signOut();
+                                return this._oAuthHandler.signOut().then(() => res());
+                            } else {
+                                return res();
                             }
-                            return res();
                         },
                         onFailure: (err) => {
                             logger.debug('global sign out failed', err);
@@ -1258,9 +1259,10 @@ export default class AuthClass {
                 logger.debug('user sign out', user);
                 user.signOut();
                 if (isSignedInHostedUI) {
-                    this._oAuthHandler.signOut();
+                    return this._oAuthHandler.signOut().then(() => res());
+                } else {
+                    return res();
                 }
-                return res();
             }
         });
     }


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3117

*Description of changes:*
By not awaiting for the url to open when signing out, a user may not be fully signed out.
This PR waits for the signout promise to be resolved.

These two snippets illustrate the issue:

```js
// the promise resolves immediately and the url is opened 3 seconds later
await new Promise(res => {setTimeout(() => {window.open('https://aws.amazon.com/')}, 3000); res('done');});
```

```js
// the promise is resolved after the url is opened
await new Promise(res => setTimeout(() => {window.open('https://aws.amazon.com/'); res('done')}, 3000));
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
