### PR TITLE
fix(@aws-amplify/storage): private by default

### DIFF
--- a/packages/storage/__tests__/Storage-unit-test.ts
+++ b/packages/storage/__tests__/Storage-unit-test.ts
@@ -238,7 +238,23 @@ describe('Storage', () => {
             storage.configure({ Storage: { level: "public"} });
         });
 
-        test('backwards compatible issue, third configure call track', () => {
+        test('normal storage level is public by default', () => {
+          const storage = StorageCategory;
+
+          storage.configure({
+            region: 'region',
+            bucket: 'bucket',
+          });
+
+          expect(storage['_config']).toEqual({
+            AWSS3: {
+              bucket: 'bucket',
+              region: 'region'
+            }
+          });
+        });
+
+      test('backwards compatible issue, third configure call track', () => {
             const storage = new Storage();
 
             const aws_options = {

--- a/packages/storage/__tests__/Storage-unit-test.ts
+++ b/packages/storage/__tests__/Storage-unit-test.ts
@@ -249,6 +249,7 @@ describe('Storage', () => {
           expect(storage['_config']).toEqual({
             AWSS3: {
               bucket: 'bucket',
+              level: 'public',
               region: 'region'
             }
           });

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -28,7 +28,7 @@ if (!_instance) {
     const old_configure = _instance.configure;
     _instance.configure = (options) => {
         logger.debug('storage configure called');
-        const vaultConfig = old_configure.call(_instance, options);
+        const vaultConfig = {...old_configure.call(_instance, options)};
 
         // set level private for each provider for the vault
         Object.keys(vaultConfig).forEach((providerName) => {


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3207

*Description of changes:*
This fixes a problem where the global Storage instance (the one
gotten from the Amplify registry) would be private by default, and adds
a test for it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
