### PR TITLE
fix(Vue-SignUp): check fields are non-empty prior to submitting them

### DIFF
--- a/packages/aws-amplify-vue/src/components/authenticator/SignUp.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/SignUp.vue
@@ -210,7 +210,7 @@ export default {
           user.password = e.value
         } else if (e.key === 'phone_number' && e.value) {
           user.attributes.phone_number = `+${this.countryCode}${e.value}`
-        } else {
+        } else if (e.value) {
           const newKey = `${this.needPrefix(e.key) ? 'custom:' : ''}${e.key}`;
           user.attributes[newKey] = e.value;
         };


### PR DESCRIPTION
Cognito does not accept empty attribute values so corresponding attributes cannot be submitted to avoid any error from returned API.

This pull request is fixes #3174.

*Description of changes:*
In Vue <amplify-sign-up> component, we now check that attributes are non-empty prior to submitting them.
No change on the validator has been made so rules for checking correct formatting and required values are not affected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
