### PR TITLE
fix(@aws-amplify/auth): react-native - guard for window reference

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -185,8 +185,8 @@ export default class AuthClass {
 
         // initiailize cognitoauth client if hosted ui options provided
         // to keep backward compatibility:
-        const cognitoHostedUIConfig = oauth? (isCognitoHostedOpts(this._config.oauth) 
-            ? oauth : (<any>oauth).awsCognito) 
+        const cognitoHostedUIConfig = oauth? (isCognitoHostedOpts(this._config.oauth)
+            ? oauth : (<any>oauth).awsCognito)
             : undefined;
 
         if (cognitoHostedUIConfig) {
@@ -218,7 +218,7 @@ export default class AuthClass {
         }
 
         dispatchAuthEvent(
-            'configured', 
+            'configured',
             null,
             `The Auth category has been configured successfully`
         );
@@ -271,14 +271,14 @@ export default class AuthClass {
             this.userPool.signUp(username, password, attributes, validationData, (err, data) => {
                 if (err) {
                     dispatchAuthEvent(
-                        'signUp_failure', 
+                        'signUp_failure',
                         err,
                         `${username} failed to signup`
                     );
                     reject(err);
                 } else {
                     dispatchAuthEvent(
-                        'signUp', 
+                        'signUp',
                         data,
                         `${username} has signed up successfully`
                     );
@@ -396,7 +396,7 @@ export default class AuthClass {
                         const currentUser = await this.currentUserPoolUser();
                         that.user = currentUser;
                         dispatchAuthEvent(
-                        'signIn', 
+                        'signIn',
                         currentUser,
                         `A user ${user.getUsername()} has been signed in`
                     );
@@ -794,10 +794,10 @@ export default class AuthClass {
                             logger.debug('cannot get cognito credentials', e);
                         } finally {
                             that.user = user;
-                            
+
                             dispatchAuthEvent(
-                                'signIn', 
-                                user, 
+                                'signIn',
+                                user,
                                 `${user} has signed in`
                             );
                             resolve(user);
@@ -833,7 +833,7 @@ export default class AuthClass {
                     } finally {
                         that.user = user;
                         dispatchAuthEvent(
-                            'signIn', 
+                            'signIn',
                             user, `${user} has signed in`
                         );
                         resolve(user);
@@ -842,7 +842,7 @@ export default class AuthClass {
                 onFailure: (err) => {
                     logger.debug('completeNewPassword failure', err);
                     dispatchAuthEvent(
-                        'completeNewPassword_failure', 
+                        'completeNewPassword_failure',
                         err,
                         `${this.user} failed to complete the new password flow`
                     );
@@ -1227,7 +1227,7 @@ export default class AuthClass {
             throw e;
         }
 
-        const isSignedInHostedUI = this._oAuthHandler 
+        const isSignedInHostedUI = this._oAuthHandler
             && this._storage.getItem('amplify-signin-with-hostedUI') === 'true';
 
         return new Promise((res, rej) => {
@@ -1290,15 +1290,15 @@ export default class AuthClass {
             logger.debug('no Congito User pool');
         }
 
-        /** 
+        /**
          * Note for future refactor - no reliable way to get username with
          * Cognito User Pools vs Identity when federating with Social Providers
          * This is why we need a well structured session object that can be inspected
          * and information passed back in the message below for Hub dispatch
         */
         dispatchAuthEvent(
-            'signOut', 
-            this.user, 
+            'signOut',
+            this.user,
             `A user has been signed out`
         );
         this.user = null;
@@ -1465,7 +1465,7 @@ export default class AuthClass {
         if (isFederatedSignInOptions(providerOrOptions)
             || isFederatedSignInOptionsCustom(providerOrOptions)
             || typeof providerOrOptions === 'undefined') {
-            
+
             const options = providerOrOptions || { provider: CognitoHostedUIIdentityProvider.Cognito };
             const provider = isFederatedSignInOptions(options)
                 ? options.provider
@@ -1526,7 +1526,7 @@ export default class AuthClass {
             throw new Error(`OAuth responses require a User Pool defined in config`);
         }
 
-        const currentUrl = URL || window.location.href;
+        const currentUrl = URL || (JS.browserOrNode().isBrowser ? window.location.href : null);
 
         const hasCodeOrError = !!(parse(currentUrl).query || '')
             .split('&')
@@ -1538,18 +1538,18 @@ export default class AuthClass {
             .split('&')
             .map(entry => entry.split('='))
             .find(([k]) => k === 'access_token' || k === 'error');
-        
+
 
         if (hasCodeOrError || hasTokenOrError) {
             try {
-                
+
                 const { accessToken, idToken, refreshToken } = await this._oAuthHandler.handleAuthResponse(currentUrl);
                 const session = new CognitoUserSession({
                     IdToken: new CognitoIdToken({ IdToken: idToken }),
                     RefreshToken: new CognitoRefreshToken({ RefreshToken: refreshToken }),
                     AccessToken: new CognitoAccessToken({ AccessToken: accessToken })
                 });
-                
+
                 let credentials;
                 // Get AWS Credentials & store if Identity Pool is defined
                 if (this._config.identityPoolId) {
@@ -1559,19 +1559,19 @@ export default class AuthClass {
 
                 /*The following is to create a user for the Cognito Identity SDK to store the tokens
                   When we remove this SDK later that logic will have to be centralized in our new version*/
-                //#region 
+                //#region
                 const currentUser = this.createCognitoUser(session.getIdToken().decodePayload()['cognito:username']);
                 dispatchAuthEvent(
-                    'signIn', 
+                    'signIn',
                     currentUser,
                     `A user ${currentUser.getUsername()} has been signed in`
                 );
                 dispatchAuthEvent(
-                    'cognitoHostedUI', 
+                    'cognitoHostedUI',
                     currentUser,
                     `A user ${currentUser.getUsername()} has been signed in via Cognito Hosted UI`
                 );
-                
+
                 // This calls cacheTokens() in Cognito SDK
                 currentUser.setSignInUserSession(session);
                 //#endregion
@@ -1579,17 +1579,17 @@ export default class AuthClass {
                 if (window && typeof window.history !== 'undefined') {
                     window.history.replaceState({}, null, (this._config.oauth as AwsCognitoOAuthOpts).redirectSignIn);
                 }
-                
+
                 return credentials;
             } catch (err) {
                 logger.debug("Error in cognito hosted auth response", err);
                 dispatchAuthEvent(
-                    'signIn_failure', 
+                    'signIn_failure',
                     err,
                     `The OAuth response flow failed`
                 );
                 dispatchAuthEvent(
-                    'cognitoHostedUI_failure', 
+                    'cognitoHostedUI_failure',
                     err,
                     `A failure occurred when returning to the Cognito Hosted UI`
                 );


### PR DESCRIPTION
*Issue #, if available:* 

- resolves: https://github.com/aws-amplify/amplify-js/issues/3057

*Description of changes:*

In a non-browser environment, the `window` global object will likely not be available. Currently, the latest versions of `aws-amplify` throw a YellowBox warning when using authentication in React Native:

```
Possible Unhandled Promise Rejection (id: 0)
TypeError: undefined is not an object (evaluating 'window.location.href')
```
 
- Use the `browserOrNode` JS helper function to determine the runtime environment. Guard against the case when not running in a browser by providing a `null` value.
- My text editor caught some trailing whitespace throughout the file - I've committed these changes as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.