### PR TITLE
fix(@aws-amplify/core): guard for Symbol reference

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -12,7 +12,10 @@
  */
 
 /**
- * This Symbol is used to reference an internal-only PubSub provider that 
+ * This Symbol is used to reference an internal-only PubSub provider that
  * is used for AppSync/GraphQL subscriptions in the API category.
  */
-export const INTERNAL_AWS_APPSYNC_PUBSUB_PROVIDER = Symbol('INTERNAL_AWS_APPSYNC_PUBSUB_PROVIDER');
+const hasSymbol = (typeof(Symbol) !== 'undefined' && typeof(Symbol.for) === 'function');
+
+export const INTERNAL_AWS_APPSYNC_PUBSUB_PROVIDER = hasSymbol ?
+    Symbol.for('INTERNAL_AWS_APPSYNC_PUBSUB_PROVIDER') : '@@INTERNAL_AWS_APPSYNC_PUBSUB_PROVIDER';


### PR DESCRIPTION
*Issue #, if available:*

resolves: https://github.com/aws-amplify/amplify-js/issues/3233

*Description of changes:*

* Some JS interpreters don't natively support `Symbol` yet. An example is the version of JavaScriptCore that ships with React Native 0.58 on Android.
* Add a guard clause that checks for the existence of `Symbol`. If it's not available, substitute the value for a string prefixed with `@@`.
* I used the same pattern used in https://github.com/aws-amplify/amplify-js/pull/2992.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.