### PR TITLE
feat(aws-amplify-react): Add validationData prop for SignIn and SignUp component

### DIFF
--- a/packages/aws-amplify-react/__tests__/Auth/SignIn-test.js
+++ b/packages/aws-amplify-react/__tests__/Auth/SignIn-test.js
@@ -89,8 +89,11 @@ describe('SignIn', () => {
             await Promise.resolve();
            
             expect(spyon.mock.calls.length).toBe(1);
-            expect(spyon.mock.calls[0][0]).toBe(event_username.target.value);
-            expect(spyon.mock.calls[0][1]).toBe(event_password.target.value);
+            expect(spyon.mock.calls[0][0]).toEqual({ 
+                username: event_username.target.value, 
+                password: event_password.target.value,
+                validationData: undefined
+            });
 
             expect(spyon_changeState).toBeCalled();
             expect(spyon_changeState.mock.calls[0][0]).toBe('requireNewPassword');

--- a/packages/aws-amplify-react/src/Auth/SignIn.jsx
+++ b/packages/aws-amplify-react/src/Auth/SignIn.jsx
@@ -69,13 +69,14 @@ export default class SignIn extends AuthPiece {
         // avoid submitting the form
         event.preventDefault();
         
+        const { validationData } = this.props;
         const { username='', password } = this.inputs;
         if (!Auth || typeof Auth.signIn !== 'function') {
             throw new Error('No Auth module found, please ensure @aws-amplify/auth is imported');
         }
         this.setState({loading: true});
         try {
-            const user = await Auth.signIn(username, password);
+            const user = await Auth.signIn({ username, password, validationData });
             logger.debug(user);
             if (user.challengeName === 'SMS_MFA' || user.challengeName === 'SOFTWARE_TOKEN_MFA') {
                 logger.debug('confirm user with ' + user.challengeName);

--- a/packages/aws-amplify-react/src/Auth/SignUp.jsx
+++ b/packages/aws-amplify-react/src/Auth/SignUp.jsx
@@ -180,7 +180,8 @@ export default class SignUp extends AuthPiece {
             password: this.inputs.password,
             attributes: {
                 
-            }
+            },
+            validationData: this.props.validationData
         };
 
         const inputKeys = Object.keys(this.inputs);


### PR DESCRIPTION
*Issue #, if available:*
closes #3323

*Description of changes:*
Add validationData prop for SignIn and SignUp component to provide data for the PreAuthentication Lambda trigger

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
