### PR TITLE
remove import of CSS files in JSX

### DIFF
--- a/packages/aws-amplify-react/src/Amplify-UI/Amplify-UI-Components-React.jsx
+++ b/packages/aws-amplify-react/src/Amplify-UI/Amplify-UI-Components-React.jsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { JS } from '@aws-amplify/core';
 
-import "@aws-amplify/ui/dist/style.css";
 import * as AmplifyUI from '@aws-amplify/ui';
 
 import AmplifyTheme from './Amplify-UI-Theme';


### PR DESCRIPTION
The css can be prepackaged and explicitly imported via Webpack or
another way. The explicit inclusion of css styles requires a CSS
processor in dependant aplications that use the amplify-react library.
This PR removes that hard dependency for people that do not wish to use
the CSS processor (e.g. CSS in JS)

*Issue #, if available:* #3348

*Description of changes:*

This removes the inclusion of a CSS file in a `jsx` file, thereby removing the need for dependant applications that use the `amplify-react` package of a CSS processor in their webpack config.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
