### PR TITLE
make sure to call `preventDefault` only if `event` is defined

### DIFF
--- a/packages/aws-amplify-react/src/Auth/SignIn.jsx
+++ b/packages/aws-amplify-react/src/Auth/SignIn.jsx
@@ -67,7 +67,9 @@ export default class SignIn extends AuthPiece {
 
     async signIn(event) {
         // avoid submitting the form
-        event.preventDefault();
+        if (event) {
+            event.preventDefault();
+        }
 
         const username = this.getUsernameFromInput() || '';
         const password = this.inputs.password;


### PR DESCRIPTION
*Issue #, if available:*
#3211 

*Description of changes:*
Made sure to call `preventDefault` in the `signIn` method, only if an `event` is present


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
