### PR TITLE
add support for `onUploadProgress` option on RestClient

### DIFF
--- a/packages/api/__tests__/RestClient-unit-test.ts
+++ b/packages/api/__tests__/RestClient-unit-test.ts
@@ -73,7 +73,7 @@ describe('RestClient test', () => {
             try {
                 await restClient.ajax('url', 'method', { headers: { reject: true } });
             } catch (error) {
-                expect(error).toEqual({ data: 'error' });
+                expect(error).toMatchObject({ data: 'error' });
             }
         });
 

--- a/packages/api/__tests__/RestClient-unit-test.ts
+++ b/packages/api/__tests__/RestClient-unit-test.ts
@@ -14,16 +14,19 @@ jest.mock('axios', () => {
             return new Promise((res, rej) => {
                 if (signed_params && signed_params.headers && signed_params.headers.reject) {
                     rej({
+                        config: signed_params,
                         data: 'error'
                     });
                 }
                 else if (signed_params && signed_params.responseType === 'blob') {
                     res({
+                        config: signed_params,
                         data: 'blob'
                     });
                 }
                 else {
                     res({
+                        config: signed_params,
                         data: 'data'
                     });
                 }
@@ -151,6 +154,26 @@ describe('RestClient test', () => {
             const restClient = new RestClient(apiOptions);
 
             expect(await restClient.ajax('url', 'method', { headers: { Authorization: 'authorization' } })).toEqual('data');
+        });
+
+        test('ajax with onUploadProgress', async () => {
+            const apiOptions = {
+                headers: {},
+                endpoints: {},
+                credentials: {
+                    accessKeyId: 'accessKeyId',
+                    secretAccessKey: 'secretAccessKey',
+                    sessionToken: 'sessionToken'
+                }
+            };
+            const handleUploadProgress = jest.fn();
+
+            const restClient = new RestClient(apiOptions);
+
+            expect((await restClient.ajax('url', 'method', {
+                response: 'allResponse',
+                onUploadProgress: handleUploadProgress
+            })).config.onUploadProgress).toEqual(handleUploadProgress);
         });
     });
 

--- a/packages/api/src/RestClient.ts
+++ b/packages/api/src/RestClient.ts
@@ -73,6 +73,7 @@ export class RestClient {
             path: parsed_url.path,
             headers: {},
             data: null,
+            onUploadProgress: undefined,
             responseType: 'json'
         };
 
@@ -93,6 +94,9 @@ export class RestClient {
         }
         if (initParams.responseType) {
             params.responseType = initParams.responseType;
+        }
+        if (initParams.onUploadProgress) {
+            params.onUploadProgress = initParams.onUploadProgress;
         }
 
         params['signerServiceInfo'] = initParams.signerServiceInfo;


### PR DESCRIPTION
*Issue #, if available:*
#2911 

*Description of changes:*
Add support for `onUploadProgress` option on the RestClient as per [axios's configuration](https://github.com/axios/axios#request-config).

Also added a test to validate that `axios` does actually receive this option. In order to test that, I needed access to the configuration options that were passed to the `axios` mock. For this reason, I extended the mock to allow that, while fully conforming with the keys found in the [actual response schema of axios](https://github.com/axios/axios#response-schema).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
