### PR TITLE
feat(aws-amplify-react-native): Pass `track` and `identityId` prop to Storage.get/put options

### DIFF
--- a/packages/aws-amplify-react-native/src/Storage/S3Album.js
+++ b/packages/aws-amplify-react-native/src/Storage/S3Album.js
@@ -34,9 +34,9 @@ export default class S3Album extends Component {
     }
 
     componentDidMount() {
-        const { path, level, filter } = this.props;
+        const { path, level, filter, track, identityId } = this.props;
         logger.debug(path);
-        Storage.list(path, { level: level? level : 'public' })
+        Storage.list(path, { level: level? level : 'public', track, identityId })
             .then(data => {
                 logger.debug(data);
                 if (filter) { data = filter(data); }

--- a/packages/aws-amplify-react-native/src/Storage/S3Image.js
+++ b/packages/aws-amplify-react-native/src/Storage/S3Image.js
@@ -32,8 +32,8 @@ export default class S3Image extends Component {
     }
 
     getImageSource() {
-        const { imgKey, level } = this.props;
-        Storage.get(imgKey, { level : level? level : 'public'})
+        const { imgKey, level, identityId, track } = this.props;
+        Storage.get(imgKey, { level : level? level : 'public', identityId, track })
             .then(url => {
                 logger.debug(url);
                 this.setState({
@@ -44,7 +44,7 @@ export default class S3Image extends Component {
     }
 
     load() {
-        const { imgKey, body, contentType, level } = this.props;
+        const { imgKey, body, contentType, level, track } = this.props;
         if (!imgKey) {
             logger.debug('empty imgKey');
             return ;
@@ -56,7 +56,8 @@ export default class S3Image extends Component {
             const type = contentType? contentType : 'binary/octet-stream';
             const opt = {
                 contentType: type,
-                level: level? level : 'public'
+                level: level? level : 'public',
+                track
             }
             const ret = Storage.put(imgKey, body, opt);
             ret.then(data => {


### PR DESCRIPTION
*Issue #, if available:*

fixes https://github.com/aws-amplify/amplify-js/issues/3433


*Description of changes:*

Add missing Storage options to `get/put` calls

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
