### PR TITLE
feat(@aws-amplify/auth): Add create session using refresh token for SSO

### DIFF
--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -2595,6 +2595,34 @@ describe('auth unit test', () => {
             spyon.mockClear();
         });
     });
+
+    describe('createSession test', () => {
+        test('happy case', async () => {
+            const spyon = jest.spyOn(CognitoUser.prototype, 'refreshSession')
+                .mockImplementation((refreshToken, callback) => {
+                    return callback(null, 'cognitoSession');
+                });
+            const auth = new Auth(authOptions);
+            expect.assertions(1);
+            expect(await auth.createSession('username', 'refreshToken')).toBe('cognitoSession');
+            spyon.mockClear();
+        });
+
+        test('error case: token expired', async () => {
+            const spyon = jest.spyOn(CognitoUser.prototype, 'refreshSession')
+                .mockImplementation((refreshToken, callback) => {
+                    return callback('token expired');
+                });
+            const auth = new Auth(authOptions);
+            expect.assertions(1);
+            try {
+                await auth.createSession('username', 'refreshToken');
+            } catch (e) {
+                expect(e).toBe('token expired');
+            }
+            spyon.mockClear();
+        });
+    });
 });
 
 

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1517,6 +1517,28 @@ export default class AuthClass {
     }
 
     /**
+     * Creates the user session using refreshToken.
+     * In case of SSO, we can pass the refresh token to another app to create new session in that app.
+     * @param {String} username 
+     * @param {String} refreshToken 
+     * @return - A promise resolves to session object if success
+     */
+    public createSession(username: string, refreshToken: string): Promise<CognitoUserSession | any> {
+        const cognitoUser = this.createCognitoUser(username);
+        const cognitoRefreshToken = new CognitoRefreshToken({ RefreshToken: refreshToken });
+        return new Promise((res, rej) => {
+            cognitoUser.refreshSession(cognitoRefreshToken, (error, data) => {
+                if (error) {
+                    logger.debug('refreshSession failed', error);
+                    rej(error);
+                } else {
+                    res(data);
+                }
+            });
+        });
+    }
+
+    /**
      * Used to complete the OAuth flow with or without the Cognito Hosted UI
      * @param {String} URL - optional parameter for customers to pass in the response URL
      */


### PR DESCRIPTION
*Issue #, if available:*
#2095
*Description of changes:*
We have a requirement of passing refresh token to a different app hosted in a different domain and that app should be able to create CognitoUserSession using the refreshToken.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
