### PR TITLE
feat (@aws-amplify/api): Added support for timeout in the init parameters supplied to API

### DIFF
--- a/packages/api/__tests__/API-test.ts
+++ b/packages/api/__tests__/API-test.ts
@@ -1033,7 +1033,7 @@ describe('API test', () => {
                 timeout: 2500
             }
             await api.get('apiName', '/items', init);
-            const expectedParams = {"data": null, "headers": {}, "host": undefined, "method": "GET", "path": "/", "responseType": "json", "url": "endpoint/items?ke%3Ay3=val%3Aue%203", "timeout": 2500};
+            const expectedParams = {"data": null, "headers": {}, "host": undefined, "method": "GET", "path": "/", "responseType": "json", "url": "endpoint/items", "timeout": 2500};
             expect(spyonSigner).toBeCalledWith( expectedParams, creds2 , { region: 'us-east-1', service: 'execute-api'});
         });
 

--- a/packages/api/__tests__/API-test.ts
+++ b/packages/api/__tests__/API-test.ts
@@ -1030,7 +1030,7 @@ describe('API test', () => {
             });
 
             const init = {
-                timout: 2500
+                timeout: 2500
             }
             await api.get('apiName', '/items', init);
             const expectedParams = {"data": null, "headers": {}, "host": undefined, "method": "GET", "path": "/", "responseType": "json", "url": "endpoint/items?ke%3Ay3=val%3Aue%203", "timeout": 2500};

--- a/packages/api/__tests__/API-test.ts
+++ b/packages/api/__tests__/API-test.ts
@@ -983,7 +983,48 @@ describe('API test', () => {
                 "path": "/",
                 "responseType": "json",
                 "signerServiceInfo": undefined, 
-                "url": "https://www.amazonaws.compath/"
+                "url": "https://www.amazonaws.compath/",
+                "timeout": 0
+            }, undefined);
+
+        });
+
+        test('non-default timeout', async () => {
+            const custom_config = {
+                API: {
+                    endpoints: [
+                        {
+                            name: 'apiName',
+                            endpoint: 'https://www.amazonaws.com'
+                        }
+                    ]
+                }
+            };
+            const api = new API({});
+            api.configure(custom_config);
+            const spyon = jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+                return new Promise((res, rej) => {
+                    res('cred');
+                });
+            });
+
+            const spyonRequest = jest.spyOn(RestClient.prototype, '_request').mockImplementationOnce(() => {
+                return new Promise((res, rej) => {
+                    res({});
+                });
+            });
+            await api.get('apiName', 'path', {timeout: 2500});
+
+            expect(spyonRequest).toBeCalledWith({
+                "data": null, 
+                "headers": {}, 
+                "host": "www.amazonaws.compath", 
+                "method": "GET", 
+                "path": "/",
+                "responseType": "json",
+                "signerServiceInfo": undefined, 
+                "url": "https://www.amazonaws.compath/",
+                "timeout": 2500
             }, undefined);
 
         });
@@ -1034,7 +1075,7 @@ describe('API test', () => {
                 }
             }
             await api.get('apiName', '/items', init);
-            const expectedParams = {"data": null, "headers": {}, "host": undefined, "method": "GET", "path": "/", "responseType": "json", "url": "endpoint/items?ke%3Ay3=val%3Aue%203"};
+            const expectedParams = {"data": null, "headers": {}, "host": undefined, "method": "GET", "path": "/", "responseType": "json", "url": "endpoint/items?ke%3Ay3=val%3Aue%203", "timeout": 0};
             expect(spyonSigner).toBeCalledWith( expectedParams, creds2 , { region: 'us-east-1', service: 'execute-api'});
         });
 
@@ -1087,7 +1128,7 @@ describe('API test', () => {
                 }
             }
             await api.get('apiName', '/items', init);
-            const expectedParams = {"data": null, "headers": {"Authorization": "apikey"}, "host": undefined, "method": "GET", "path": "/", "responseType": "json", "signerServiceInfo": undefined, "url": "endpoint/items?ke%3Ay3=val%3Aue%203"};
+            const expectedParams = {"data": null, "headers": {"Authorization": "apikey"}, "host": undefined, "method": "GET", "path": "/", "responseType": "json", "signerServiceInfo": undefined, "url": "endpoint/items?ke%3Ay3=val%3Aue%203", "timeout": 0};
             expect(spyonRequest).toBeCalledWith( expectedParams, undefined );
         });
         test('query-string on init and url', async () => {
@@ -1136,7 +1177,7 @@ describe('API test', () => {
                 }
             }
             await api.get('apiName', '/items?key1=value1&key2=value', init);
-            const expectedParams = {"data": null, "headers": {}, "host": undefined, "method": "GET", "path": "/", "responseType": "json", "url": "endpoint/items?key1=value1&key2=value2_real"};
+            const expectedParams = {"data": null, "headers": {}, "host": undefined, "method": "GET", "path": "/", "responseType": "json", "url": "endpoint/items?key1=value1&key2=value2_real", "timeout": 0};
             expect(spyonSigner).toBeCalledWith( expectedParams, creds2 , { region: 'us-east-1', service: 'execute-api'});
         });
 

--- a/packages/api/src/RestClient.ts
+++ b/packages/api/src/RestClient.ts
@@ -73,7 +73,8 @@ export class RestClient {
             path: parsed_url.path,
             headers: {},
             data: null,
-            responseType: 'json'
+            responseType: 'json',
+            timeout: 0
         };
 
         let libraryHeaders = {};
@@ -93,6 +94,9 @@ export class RestClient {
         }
         if (initParams.responseType) {
             params.responseType = initParams.responseType;
+        }
+        if (initParams.timeout) {
+            params.timeout = initParams.timeout;
         }
 
         params['signerServiceInfo'] = initParams.signerServiceInfo;


### PR DESCRIPTION
Fixes #368 

*Description of changes:*
- Added support for timeout in the init parameters supplied to API.[get/post/put/patch/del/head] requests
- Set default timeout to 0 in line with Axios's default timeout.

Usage example:
```
let params = {
   timeout: 2500 // OPTIONAL
};
API.get('apiName, '/path', params);
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
