### PR TITLE
remove youtube-iframe and move the impl into MediaAutoTrack

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -55,8 +55,7 @@
   "dependencies": {
     "@aws-amplify/cache": "^1.0.28",
     "@aws-amplify/core": "^1.0.28",
-    "uuid": "^3.2.1",
-    "youtube-iframe": "^1.0.3"
+    "uuid": "^3.2.1"
   },
   "jest": {
     "transform": {

--- a/packages/analytics/src/Providers/AmazonPersonalizeHelper/MediaAutoTrack.ts
+++ b/packages/analytics/src/Providers/AmazonPersonalizeHelper/MediaAutoTrack.ts
@@ -67,18 +67,18 @@ export class MediaAutoTrack {
             loaded: false,
             listeners: [],
 
-            load: function(callback) {
+            load(callback) {
                 const _this = this;
                 this.listeners.push(callback);
 
-                if(this.loaded) {
+                if (this.loaded) {
                     setTimeout(function() {
                         _this.done();
                     });
                     return;
                 }
 
-                if(this.loading) {
+                if (this.loading) {
                     return;
                 }
 
@@ -95,10 +95,10 @@ export class MediaAutoTrack {
                 document.body.appendChild(script);
             },
 
-            done: function() {
+            done() {
                 delete window['onYouTubeIframeAPIReady'];
 
-                while(this.listeners.length) {
+                while (this.listeners.length) {
                     this.listeners.pop()(window['YT']);
                 }
             }

--- a/packages/analytics/src/Providers/AmazonPersonalizeHelper/MediaAutoTrack.ts
+++ b/packages/analytics/src/Providers/AmazonPersonalizeHelper/MediaAutoTrack.ts
@@ -12,8 +12,6 @@
  */
 import {RequestParams, SessionInfo} from './DataType';
 
-
-
 enum HTML5_MEDIA_EVENT {
         "PLAY" = "play",
         "PAUSE" = "pause",

--- a/packages/analytics/src/Providers/AmazonPersonalizeHelper/MediaAutoTrack.ts
+++ b/packages/analytics/src/Providers/AmazonPersonalizeHelper/MediaAutoTrack.ts
@@ -10,8 +10,9 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import * as YouTubeIframeLoader from 'youtube-iframe';
 import {RequestParams, SessionInfo} from './DataType';
+
+
 
 enum HTML5_MEDIA_EVENT {
         "PLAY" = "play",
@@ -42,6 +43,8 @@ export class MediaAutoTrack {
             [EVENT_TYPE.PAUSE]: this.pauseEventAction.bind(this)
         };
 
+    private _youTubeIframeLoader;
+
     constructor(params: RequestParams, provider) {
         const { eventData } = params;
         this._params = params;
@@ -55,6 +58,53 @@ export class MediaAutoTrack {
         };
 
         mediaTrackFunMapping[this._mediaElement.tagName].bind(this)();
+
+        this._initYoutubeFrame();
+    }
+
+    private _initYoutubeFrame() {
+        this._youTubeIframeLoader = {
+            src: 'https://www.youtube.com/iframe_api',
+            loading: false,
+            loaded: false,
+            listeners: [],
+
+            load: function(callback) {
+                const _this = this;
+                this.listeners.push(callback);
+
+                if(this.loaded) {
+                    setTimeout(function() {
+                        _this.done();
+                    });
+                    return;
+                }
+
+                if(this.loading) {
+                    return;
+                }
+
+                this.loading = true;
+
+                window['onYouTubeIframeAPIReady'] = function() {
+                    _this.loaded = true;
+                    _this.done();
+                };
+
+                const script = document.createElement('script');
+                script.type = 'text/javascript';
+                script.src = this.src;
+                document.body.appendChild(script);
+            },
+
+            done: function() {
+                delete window['onYouTubeIframeAPIReady'];
+
+                while(this.listeners.length) {
+                    this.listeners.pop()(window['YT']);
+                }
+            }
+        };
     }
 
     private _iframeMediaTracker() : void {
@@ -67,7 +117,7 @@ export class MediaAutoTrack {
             },
             3*1000
         );
-          YouTubeIframeLoader.load(function(YT) {
+        this._youTubeIframeLoader.load(function(YT) {
             that._iframePlayer = new YT.Player(that._mediaElement.id, {
                 events: {'onStateChange': that._onPlayerStateChange.bind(that)}
             });


### PR DESCRIPTION
*Issue #, if available:*
fixes #3477 
*Description of changes:*
The issue is that when the library running in non-browser environment, the `window` object in the `node_modules/youtube-iframe/index.js` will be `undefined`.

To fix this issue, I moved the code in the index js into `MediaAutoTrack.ts` and remove `youtube-iframe` from the `package.json`. Because `MediaAutoTrack` is not exposed to public and will only be initiated in browser env, so it will be safe to run the `youtube-iframe` code there.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
