### PR TITLE
Phone number invalid format.

### DIFF
--- a/packages/aws-amplify-react-native/src/Auth/SignUp.js
+++ b/packages/aws-amplify-react-native/src/Auth/SignUp.js
@@ -238,7 +238,7 @@ export default class SignUp extends AuthPiece {
                                     placeholder={I18n.get(field.placeholder)}
                                     keyboardType="phone-pad"
                                     required={field.required}
-                                    defaultDialCode={this.getDefaultDialCode}
+                                    defaultDialCode={this.getDefaultDialCode()}
                                 />
                             )
                         })


### PR DESCRIPTION
getDefaultDialCode was returning a function.  Fixes invalid phone number error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
