### PR TITLE
Fix default dial code

### DIFF
--- a/packages/aws-amplify-react-native/src/Auth/SignUp.js
+++ b/packages/aws-amplify-react-native/src/Auth/SignUp.js
@@ -238,7 +238,7 @@ export default class SignUp extends AuthPiece {
                                     placeholder={I18n.get(field.placeholder)}
                                     keyboardType="phone-pad"
                                     required={field.required}
-                                    defaultDialCode={this.getDefaultDialCode}
+                                    defaultDialCode={this.getDefaultDialCode()}
                                 />
                             )
                         })


### PR DESCRIPTION
***Issue #, if available:***

Refs #3292 (fixup)
TBA

***Description of changes:***

In #3292, the default dial code used was changed to be:

https://github.com/aws-amplify/amplify-js/blob/b07ce9613d1680533c715ac13eb339e98646e3e6/packages/aws-amplify-react-native/src/Auth/SignUp.js#L241

Which is defined as:

https://github.com/aws-amplify/amplify-js/blob/b07ce9613d1680533c715ac13eb339e98646e3e6/packages/aws-amplify-react-native/src/Auth/SignUp.js#L51

`this.getDefaultDialCode` is a function, and so the default dial code will be returned by `this.getDefaultDialCode()` (and not simply `this.getDefaultDialCode`, like which is currently used).

// cc @dabit3 @gsans

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.