### PR TITLE
fix(@aws-amplify/core): reject promise on error

### DIFF
--- a/packages/core/src/ServiceWorker/ServiceWorker.ts
+++ b/packages/core/src/ServiceWorker/ServiceWorker.ts
@@ -126,6 +126,7 @@ class ServiceWorkerClass {
                                 resolve(subscription);
                             }).catch((error) => {
                                 this._logger.error(error);
+                                reject(error);
                             });
                         }
                     });


### PR DESCRIPTION
*Description of changes:*
Reject promise on error,
e.g. if browser asks for permission to enable push notifications but user declines this permission.
Right now the error is logged but the promise is never settled. Therefore one has no possibility to react to this error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
