### PR TITLE
Remove unnecessary URLSearchParams, it breaks React Native  0.59+

### DIFF
--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -141,7 +141,7 @@ export default class OAuth {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded'
         },
-        body: typeof URLSearchParams !== 'undefined' ? new URLSearchParams(body) : body
+        body
       }) as any).json();
 
       if (error) {


### PR DESCRIPTION
Issue #3399

In React Native 0.59 a light implementation of `URLSearchParams` has been included as a global. This breaks the amplify federated login flow. As I don't see/know any reason for using it I suggest removing it. This works fine on web, iOS and Android.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
