### PR TITLE
fix: image will reload when level is changed

### DIFF
--- a/packages/aws-amplify-react/src/Storage/S3Image.js
+++ b/packages/aws-amplify-react/src/Storage/S3Image.js
@@ -133,7 +133,8 @@ export default class S3Image extends Component {
     componentDidUpdate(prevProps) {
         const update = prevProps.path !== this.props.path ||
             prevProps.imgKey !== this.props.imgKey ||
-            prevProps.body !== this.props.body;
+            prevProps.body !== this.props.body ||
+            prevProps.level !== this.props.level;
         if (update) {
             this.load();
         }


### PR DESCRIPTION
Add the level change check in update method so that the S3Image will reload when the level is changed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
