### PR TITLE
Use specific Cypress spec file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
           name: "Run cypress tests for React Authenticator Sample"
           command: |
             cd amplify-js-samples-staging
-            yarn cypress:react
+            yarn cypress:react --spec "cypress/integration/auth/authenticator.spec.js"
       - store_artifacts:
           path: amplify-js-samples-staging/cypress/videos
       - store_artifacts:
@@ -151,7 +151,7 @@ jobs:
           name: "Run cypress tests for Vue Authenticator Sample"
           command: |
             cd amplify-js-samples-staging
-            yarn cypress:vue
+            yarn cypress:vue --spec "cypress/integration/auth/authenticator.spec.js"
       - store_artifacts:
           path: amplify-js-samples-staging/cypress/videos
       - store_artifacts:
@@ -191,6 +191,7 @@ workflows:
           filters:
             branches:
               only:
+                - cypress-spec
                 - release
                 - master
           requires:
@@ -199,6 +200,7 @@ workflows:
           filters:
             branches:
               only:
+                - cypress-spec
                 - release
                 - master
           requires:
@@ -207,6 +209,7 @@ workflows:
           filters:
             branches:
               only:
+                - cypress-spec
                 - release
                 - master
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,6 @@ workflows:
           filters:
             branches:
               only:
-                - cypress-spec
                 - release
                 - master
           requires:
@@ -200,7 +199,6 @@ workflows:
           filters:
             branches:
               only:
-                - cypress-spec
                 - release
                 - master
           requires:
@@ -209,7 +207,6 @@ workflows:
           filters:
             branches:
               only:
-                - cypress-spec
                 - release
                 - master
           requires:


### PR DESCRIPTION
*Description of changes:*
- Use specific cypress [spec](https://docs.cypress.io/guides/guides/command-line.html#cypress-run-spec-lt-spec-gt) for specific sample app running

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
