### PR TITLE
fixes #3654 and bug in react url search params check

### DIFF
--- a/packages/aws-amplify-angular/src/components/authenticator/sign-in-component/sign-in.component.core.ts
+++ b/packages/aws-amplify-angular/src/components/authenticator/sign-in-component/sign-in.component.core.ts
@@ -169,8 +169,6 @@ export class SignInComponentCore implements OnInit {
           user.challengeParam.trigger === 'true'
         ) {
           this.amplifyService.setAuthState({ state: 'customConfirmSignIn', user });
-        } else {
-          this.amplifyService.setAuthState({ state: 'signedIn', user });
         }
       })
       .catch((err) => {

--- a/packages/aws-amplify-react/src/Auth/AuthPiece.jsx
+++ b/packages/aws-amplify-react/src/Auth/AuthPiece.jsx
@@ -88,7 +88,7 @@ export default class AuthPiece extends React.Component {
             );
         } else {
             let value;
-            if (window && window.location && window.search) {
+            if (window && window.location && window.location.search) {
                 const searchParams = new URLSearchParams(window.location.search);
                 value = searchParams ? searchParams.get('username') : undefined
             }


### PR DESCRIPTION
*Issue #, if available:*
#3654 

*Description of changes:*
Prevents authStateChange from firing twice.  It does this be removing the setAuthState call from the signIn component, which isn't needed because of the decorateSignIn decorator.  Also fixes checks on URLSearchParams in react.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
