### PR TITLE
Improve next.js integration. Call getInitialProps from HOC.

### DIFF
--- a/packages/aws-amplify-react/src/Auth/index.jsx
+++ b/packages/aws-amplify-react/src/Auth/index.jsx
@@ -63,6 +63,12 @@ export function withAuthenticator(Comp, includeGreetings = false, authenticatorC
             }
         }
 
+        static getInitialProps = async (appCtx) => {
+          if (Comp.getInitialProps) {
+            return Comp.getInitialProps(appCtx)
+          }
+        };
+
         handleAuthStateChange(state, data) {
             this.setState({ authState: state, authData: data });
         }


### PR DESCRIPTION
Pass `getInitialProps` through to the child component.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.