### PR TITLE
fix(@aws-amplify/auth): Encode customState when storing to compare ag…

### DIFF
--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -72,7 +72,7 @@ export default class OAuth {
     const generatedState = this._generateState(32);
     const state = customState ? `${generatedState}-${customState}` : generatedState;
 
-    oAuthStorage.setState(state);
+    oAuthStorage.setState(encodeURIComponent(state));
 
     const pkce_key = this._generateRandom(128);
     oAuthStorage.setPKCE(pkce_key);


### PR DESCRIPTION
…ainst incoming state for federated sign in

*Issue #, if available:* #3783 

*Description of changes:*
Encode customState so validation compares like with like.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
