### PR TITLE
fix(@aws-amplify/core): Await for cache.setItem when setting federatedInfo

### DIFF
--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -314,7 +314,7 @@ export class Credentials {
                     // the Cache module no longer stores federated info
                     // this is just for backward compatibility
                     if (Amplify.Cache && typeof Amplify.Cache.setItem === 'function'){
-                        Amplify.Cache.setItem(
+                        await Amplify.Cache.setItem(
                             'federatedInfo', 
                             { 
                                 provider, 


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3296

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
