### PR TITLE
fix(@aws-amplify/core): Edge browser misidentified as Chrome

### DIFF
--- a/packages/core/src/ClientDevice/browser.ts
+++ b/packages/core/src/ClientDevice/browser.ts
@@ -71,11 +71,11 @@ function browserType(userAgent) {
     const operaMatch = /.+(Opera[\s[A-Z]*|OPR[\sA-Z]*)\/([0-9\.]+).*/i.exec(userAgent);
     if (operaMatch) { return { type: operaMatch[1], version: operaMatch[2]}; }
 
-    const cfMatch = /.+(Chrome|Firefox|FxiOS)\/([0-9\.]+).*/i.exec(userAgent);
-    if (cfMatch) { return { type: cfMatch[1], version: cfMatch[2]}; }
-
     const ieMatch = /.+(Trident|Edge)\/([0-9\.]+).*/i.exec(userAgent);
     if (ieMatch) { return { type: ieMatch[1], version: ieMatch[2]}; }
+    
+    const cfMatch = /.+(Chrome|Firefox|FxiOS)\/([0-9\.]+).*/i.exec(userAgent);
+    if (cfMatch) { return { type: cfMatch[1], version: cfMatch[2]}; }
 
     const sMatch = /.+(Safari)\/([0-9\.]+).*/i.exec(userAgent);
     if (sMatch) { return { type: sMatch[1], version: sMatch[2]}; }


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3192 

*Description of changes:*
Move the Trident|Edge check above the Chrome one

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
