### PR TITLE
Add input labels

### DIFF
--- a/packages/aws-amplify-react/src/Auth/ForgotPassword.jsx
+++ b/packages/aws-amplify-react/src/Auth/ForgotPassword.jsx
@@ -92,22 +92,28 @@ export default class ForgotPassword extends AuthPiece {
         const theme = this.props.theme || AmplifyTheme;
         return (
             <div>
-                <Input
-                    placeholder={I18n.get('Code')}
-                    theme={theme}
-                    key="code"
-                    name="code"
-                    autoComplete="off"
-                    onChange={this.handleInputChange}
-                />
-                <Input
-                    placeholder={I18n.get('New Password')}
-                    theme={theme}
-                    type="password"
-                    key="password"
-                    name="password"
-                    onChange={this.handleInputChange}
-                />
+                <FormField theme={theme}>
+                    <InputLabel theme={theme}>{I18n.get('Code')} *</InputLabel>
+                    <Input
+                        placeholder={I18n.get('Code')}
+                        theme={theme}
+                        key="code"
+                        name="code"
+                        autoComplete="off"
+                        onChange={this.handleInputChange}
+                    />
+                </FormField>
+                <FormField theme={theme}>
+                    <InputLabel theme={theme}>{I18n.get('New Password')} *</InputLabel>
+                    <Input
+                        placeholder={I18n.get('New Password')}
+                        theme={theme}
+                        type="password"
+                        key="password"
+                        name="password"
+                        onChange={this.handleInputChange}
+                    />
+                </FormField>
             </div>
         );
     }


### PR DESCRIPTION

*Issue #, if available:*
The Inputs in the ForgotPassword doesn't have input label!


*Description of changes:*
The other component has Input labels, Adding it here also to make it consistent with other places.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
