### PR TITLE
LGTM configuration file

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,5 @@
+extraction:
+  javascript:
+    index:
+      filters:
+        - exclude: "docs"


### PR DESCRIPTION
Introduce LGTM config file to optimize extraction times. The vanilla setup for LGTM.com analyzes the folder 'docs' which includes the files located in docs/api, where there is ~177KB of minified JS in each html file. If we can avoid this folder during extraction, then there is a huge speedup in analysis time. It does not appear like the code in this folder is of interest for scanning.

[ci skip]

*Issue #, if available:*
Internal email communications with Michael.

*Description of changes:*
Exclude /docs folder from extraction by LGTM using LGTM.yml config file. For further documentation on yml file configuration for LGTM, please see here: https://help.semmle.com/lgtm-enterprise/user/help/lgtm.yml-configuration-file.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
