### PR TITLE
fix(@aws-amplify/pubsub): sending connection error  to observable on …

### DIFF
--- a/packages/pubsub/src/Providers/AWSAppSyncProvider.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncProvider.ts
@@ -136,9 +136,9 @@ export class AWSAppSyncProvider extends MqttOverWSProvider {
                             url,
                         });
                     } catch (err) {
-                        observer.error('Fail to connect');
+                        observer.error('Failed to connect');
                         observer.complete();
-                        return Promise.resolve(undefined)
+                        return undefined;
                     }
 
                     // subscribe to all topics for this client

--- a/packages/pubsub/src/Providers/AWSAppSyncProvider.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncProvider.ts
@@ -136,7 +136,7 @@ export class AWSAppSyncProvider extends MqttOverWSProvider {
                             url,
                         });
                     } catch (err) {
-                        observer.error('Failed to connect');
+                        observer.error({ message: 'Failed to connect', error: err });
                         observer.complete();
                         return undefined;
                     }

--- a/packages/pubsub/src/Providers/AWSAppSyncProvider.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncProvider.ts
@@ -129,10 +129,17 @@ export class AWSAppSyncProvider extends MqttOverWSProvider {
                 // reconnect everything we have in the map
                 await Promise.all(map.map(async ([clientId, { url, topics }]) => {
                     // connect to new client
-                    const client = await this.connect(clientId, {
-                        clientId,
-                        url,
-                    });
+                    let client = null;
+                    try {
+                        client = await this.connect(clientId, {
+                            clientId,
+                            url,
+                        });
+                    } catch (err) {
+                        observer.error('Fail to connect');
+                        observer.complete();
+                        return Promise.resolve(undefined)
+                    }
 
                     // subscribe to all topics for this client
                     // store topic-client mapping


### PR DESCRIPTION
sending connection error  to observable on AWSAppSyncProvider

*Issue #, if available:*
fixes: #3727 
*Description of changes:*
Adding try catch and sending 'Fail to connect' on `observer.error`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
