### PR TITLE
fix(@aws-amplify/pubsub): call observer.error on disconnect for MqttO…

### DIFF
--- a/packages/pubsub/__tests__/PubSub-unit-test.ts
+++ b/packages/pubsub/__tests__/PubSub-unit-test.ts
@@ -213,6 +213,22 @@ describe('PubSub', () => {
                     provider: 'AWSIoTProvider',
             })).rejects.toMatchObject({error: new Error('Failed to connect to the network')});
         });
+
+        test('trigger observer error when disconnected', (done) => {
+            const pubsub = new PubSub();
+
+            const awsIotProvider = new AWSIoTProvider({
+                aws_pubsub_region: 'region',
+                aws_pubsub_endpoint: 'wss://iot.mymockendpoint.org:443/notrealmqtt'
+            });
+            pubsub.addPluggable(awsIotProvider);
+
+            pubsub.subscribe('topic').subscribe({
+                error: () => done()
+            });
+
+            awsIotProvider.onDisconnect({ errorCode: 1, clientId: '123' });
+        });
     });
 
     describe('MqttOverWSProvider local testing config', () => {

--- a/packages/pubsub/src/Providers/MqttOverWSProvider.ts
+++ b/packages/pubsub/src/Providers/MqttOverWSProvider.ts
@@ -89,7 +89,14 @@ export class MqttOverWSProvider extends AbstractPubSubProvider {
     public onDisconnect({ clientId, errorCode, ...args }) {
         if (errorCode !== 0) {
             logger.warn(clientId, JSON.stringify({ errorCode, ...args }, null, 2));
+            this._topicObservers.forEach((observerForTopic, _observerTopic) => {
+                observerForTopic.forEach(observer => {
+                    observer.error('Disconnected, error code: ' + errorCode);
+                    observer.complete();
+                });
+            });
         }
+        this._topicObservers = new Map();
     }
 
     public async newClient({ url, clientId }: MqttProvidertOptions): Promise<any> {


### PR DESCRIPTION
call observer.error on disconnect for MqttOverWSProvider

*Issue #, if available:*
#2692
*Description of changes:*
implementation + unit test for calling `observer.error` on disconnect because of connection error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
