### PR TITLE
feat(@aws-amplify/auth): Error messaging

### DIFF
--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -179,6 +179,8 @@ import Cache from '@aws-amplify/cache';
 import { CookieStorage, CognitoUserPool, CognitoUser, CognitoUserSession, CognitoIdToken, CognitoAccessToken } from 'amazon-cognito-identity-js';
 import { CognitoIdentityCredentials } from 'aws-sdk';
 import { Credentials, GoogleOAuth, StorageHelper } from '@aws-amplify/core';
+import { AuthError, NoUserPoolError } from '../src/Errors';
+import { AuthErrorTypes } from '../src/types/Auth';
 
 const authOptions : AuthOptions = {
     userPoolId: "awsUserPoolsId",
@@ -278,49 +280,46 @@ describe('auth unit test', () => {
             spyon.mockClear();
         });
 
-        test('no user pool', async () => {
-            // @ts-ignore
-            const auth = new Auth(authOptionsWithNoUserPoolId);
+        test('no config', async () => {
+            const auth = new Auth(undefined);
+            const errorMessage = new NoUserPoolError(AuthErrorTypes.NoConfig);
 
-            expect.assertions(1);
-            try {
-                await auth.signUp('username', 'password', 'email', 'phone');
-            } catch (e) {
-                expect(e).toBe('No userPool');
-            }
+            expect.assertions(2);
+            expect(auth.signUp('username', 'password', 'email', 'phone').then()).rejects.toThrow(NoUserPoolError);
+            expect(auth.signUp('username', 'password', 'email', 'phone').then()).rejects.toEqual(errorMessage);
+        });
+
+        test('no user pool in config', async () => {
+            const auth = new Auth(authOptionsWithNoUserPoolId);
+            const errorMessage = new NoUserPoolError(AuthErrorTypes.MissingAuthConfig);
+
+            expect.assertions(2);
+            expect(auth.signUp('username', 'password', 'email', 'phone').then()).rejects.toThrow(NoUserPoolError);
+            expect(auth.signUp('username', 'password', 'email', 'phone').then()).rejects.toEqual(errorMessage);
         });
 
         test('no username', async () => {
             const auth = new Auth(authOptions);
-
             expect.assertions(1);
-            try {
-                await auth.signUp(null, 'password', 'email', 'phone');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
+            expect(auth.signUp(null, 'password', 'email', 'phone').then()).rejects.toThrow(AuthError);
         });
 
         test('no password', async () => {
             const auth = new Auth(authOptions);
+            const errorMessage = new AuthError(AuthErrorTypes.EmptyPassword);
 
-            expect.assertions(1);
-            try {
-                await auth.signUp('username', null, 'email', 'phone');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
+            expect.assertions(2);
+            expect(auth.signUp('username', null, 'email', 'phone').then()).rejects.toThrow(AuthError);
+            expect(auth.signUp('username', null, 'email', 'phone').then()).rejects.toEqual(errorMessage);
         });
 
         test('only username', async () => {
             const auth = new Auth(authOptions);
+            const errorMessage = new AuthError(AuthErrorTypes.EmptyPassword);
 
-            expect.assertions(1);
-            try {
-                await auth.signUp('username');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
+            expect.assertions(2);
+            expect(auth.signUp('username').then()).rejects.toThrow(AuthError);
+            expect(auth.signUp('username').then()).rejects.toEqual(errorMessage);
         });
     });
 
@@ -363,38 +362,31 @@ describe('auth unit test', () => {
             spyon.mockClear();
         });
 
-        test('no user pool', async () => {
-            // @ts-ignore
+        test('no user pool in config', async () => {
             const auth = new Auth(authOptionsWithNoUserPoolId);
+            const errorMessage = new NoUserPoolError(AuthErrorTypes.MissingAuthConfig);
 
-            expect.assertions(1);
-            try {
-                await auth.confirmSignUp('username', 'code');
-            } catch (e) {
-                expect(e).toBe('No userPool');
-            }
+            expect.assertions(2);
+            expect(auth.confirmSignUp('username', 'code').then()).rejects.toThrow(NoUserPoolError);
+            expect(auth.confirmSignUp('username', 'code').then()).rejects.toEqual(errorMessage);
         });
 
         test('no user name', async () => {
             const auth = new Auth(authOptions);
+            const errorMessage = new AuthError(AuthErrorTypes.EmptyUsername);
 
-            expect.assertions(1);
-            try {
-                await auth.confirmSignUp(null, 'code');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
+            expect.assertions(2);
+            expect(auth.confirmSignUp(null, 'code').then()).rejects.toThrow(AuthError);
+            expect(auth.confirmSignUp(null, 'code').then()).rejects.toEqual(errorMessage);
         });
 
         test('no code', async () => {
             const auth = new Auth(authOptions);
+            const errorMessage = new AuthError(AuthErrorTypes.EmptyCode);
 
-            expect.assertions(1);
-            try {
-                await auth.confirmSignUp('username', null);
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
+            expect.assertions(2);
+            expect(auth.confirmSignUp('username', null).then()).rejects.toThrow(AuthError);
+            expect(auth.confirmSignUp('username', null).then()).rejects.toEqual(errorMessage);
         });
     });
 
@@ -427,27 +419,22 @@ describe('auth unit test', () => {
             spyon.mockClear();
         });
 
-        test('no user pool', async () => {
-            // @ts-ignore
+        test('no user pool in config', async () => {
             const auth = new Auth(authOptionsWithNoUserPoolId);
+            const errorMessage = new NoUserPoolError(AuthErrorTypes.MissingAuthConfig);
 
-            expect.assertions(1);
-            try {
-                await auth.resendSignUp('username');
-            } catch (e) {
-                expect(e).toBe('No userPool');
-            }
+            expect.assertions(2);
+            expect(auth.resendSignUp('username').then()).rejects.toThrow(NoUserPoolError);
+            expect(auth.resendSignUp('username').then()).rejects.toEqual(errorMessage);
         });
 
         test('no username', async () => {
             const auth = new Auth(authOptions);
+            const errorMessage = new AuthError(AuthErrorTypes.EmptyUsername);
 
-            expect.assertions(1);
-            try {
-                await auth.resendSignUp(null);
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
+            expect.assertions(2);
+            expect(auth.resendSignUp(null).then()).rejects.toThrow(AuthError);
+            expect(auth.resendSignUp(null).then()).rejects.toEqual(errorMessage);
         });
     });
 
@@ -467,6 +454,7 @@ describe('auth unit test', () => {
             const spyon2 = jest.spyOn(auth, 'currentUserPoolUser').mockImplementationOnce(() => {
                 return Promise.resolve(user);
             });
+
             expect.assertions(2);
             expect(await auth.signIn('username', 'password')).toEqual(user);
             expect(spyon2).toBeCalled();
@@ -492,7 +480,7 @@ describe('auth unit test', () => {
             });
             expect.assertions(2);
             try {
-                await auth.signIn('username', 'password')
+                await auth.signIn('username', 'password');
             } catch (e) {
                 expect(e).toBe('User is disabled');
                 expect(spyon2).toBeCalled();
@@ -504,7 +492,7 @@ describe('auth unit test', () => {
 
         test('happy case using cookie storage', async () => {
             const spyon = jest.spyOn(CognitoUser.prototype, 'authenticateUser')
-                .mockImplementationOnce((authenticationDetails, callback) => {
+                .mockImplementationOnce((_authenticationDetails, callback) => {
                     callback.onSuccess(session);
                 });
 
@@ -870,12 +858,11 @@ describe('auth unit test', () => {
                 Pool: userPool
             });
 
-            expect.assertions(1);
-            try {
-                await auth.completeNewPassword(user, null, {});
-            } catch (e) {
-                expect(e).toBe('Password cannot be empty');
-            }
+            const error = new AuthError(AuthErrorTypes.EmptyPassword);
+
+            expect.assertions(2);
+            await expect(auth.completeNewPassword(user, null, {}).then()).rejects.toThrow(AuthError);
+            await expect(auth.completeNewPassword(user, null, {}).then()).rejects.toEqual(error);
         });
     });
 
@@ -1013,13 +1000,11 @@ describe('auth unit test', () => {
                 identityPoolId: "awsCognitoIdentityPoolId",
                 mandatorySignIn: false
             });
+            const errorMessage = new NoUserPoolError(AuthErrorTypes.MissingAuthConfig);
 
-            expect.assertions(1);
-            try {
-                await auth.currentSession();
-            } catch (e) {
-                expect(e).toBe('No userPool');
-            }
+            expect.assertions(2);
+            expect(auth.currentSession().then()).rejects.toThrow(NoUserPoolError);
+            expect(auth.currentSession().then()).rejects.toEqual(errorMessage);
         });
     });
 
@@ -1322,13 +1307,11 @@ describe('auth unit test', () => {
                 Username: 'username',
                 Pool: userPool
             });
+            const error = new AuthError(AuthErrorTypes.EmptyCode);
 
-            expect.assertions(1);
-            try {
-                await auth.verifyUserAttributeSubmit(user, {}, null);
-            } catch (e) {
-                expect(e).toBe('Code cannot be empty');
-            }
+            expect.assertions(2);
+            expect(auth.verifyUserAttributeSubmit(user, {}, null).then()).rejects.toThrow(AuthError);
+            expect(auth.verifyUserAttributeSubmit(user, {}, null).then()).rejects.toEqual(error);
         });
     });
 
@@ -1586,15 +1569,13 @@ describe('auth unit test', () => {
         test('no user pool id', async () => {
             const spyon = jest.spyOn(CognitoUser.prototype, "forgotPassword");
 
-            // @ts-ignore
             const auth = new Auth(authOptionsWithNoUserPoolId);
+            const errorMessage = new NoUserPoolError(AuthErrorTypes.MissingAuthConfig);
 
-            expect.assertions(1);
-            try {
-                await auth.forgotPassword('username');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
+            expect.assertions(2);
+            expect(auth.forgotPassword('username').then()).rejects.toThrow(NoUserPoolError);
+            expect(auth.forgotPassword('username').then()).rejects.toEqual(errorMessage);
+
             spyon.mockClear();
         });
 
@@ -1643,49 +1624,40 @@ describe('auth unit test', () => {
             spyon.mockClear();
         });
 
-        test('no user pool', async () => {
-            // @ts-ignore
+        test('no user pool in config', async () => {
             const auth = new Auth(authOptionsWithNoUserPoolId);
+            const errorMessage = new NoUserPoolError(AuthErrorTypes.MissingAuthConfig);
 
-            expect.assertions(1);
-            try {
-                await auth.forgotPasswordSubmit('username', 'code', 'password');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
+            expect.assertions(2);
+            expect(auth.forgotPasswordSubmit('username', 'code', 'password').then()).rejects.toThrow(NoUserPoolError);
+            expect(auth.forgotPasswordSubmit('username', 'code', 'password').then()).rejects.toEqual(errorMessage);
         });
 
         test('no username', async () => {
             const auth = new Auth(authOptions);
+            const errorMessage = new AuthError(AuthErrorTypes.EmptyUsername);
 
-            expect.assertions(1);
-            try {
-                await auth.forgotPasswordSubmit(null, 'code', 'password');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
+            expect.assertions(2);
+            expect(auth.forgotPasswordSubmit(null, 'code', 'password').then()).rejects.toThrow(AuthError);
+            expect(auth.forgotPasswordSubmit(null, 'code', 'password').then()).rejects.toEqual(errorMessage);
         });
 
         test('no code', async () => {
             const auth = new Auth(authOptions);
+            const errorMessage = new AuthError(AuthErrorTypes.EmptyCode);
 
-            expect.assertions(1);
-            try {
-                await auth.forgotPasswordSubmit('username', null, 'password');
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
+            expect.assertions(2);
+            expect(auth.forgotPasswordSubmit('username', null, 'password').then()).rejects.toThrow(AuthError);
+            expect(auth.forgotPasswordSubmit('username', null, 'password').then()).rejects.toEqual(errorMessage);
         });
 
         test('no password', async () => {
             const auth = new Auth(authOptions);
+            const errorMessage = new AuthError(AuthErrorTypes.EmptyPassword);
 
-            expect.assertions(1);
-            try {
-                await auth.forgotPasswordSubmit('username', 'code', null);
-            } catch (e) {
-                expect(e).not.toBeNull();
-            }
+            expect.assertions(2);
+            expect(auth.forgotPasswordSubmit('username', 'code', null).then()).rejects.toThrow(AuthError);
+            expect(auth.forgotPasswordSubmit('username', 'code', null).then()).rejects.toEqual(errorMessage);
         });
     });
 
@@ -2300,20 +2272,17 @@ describe('auth unit test', () => {
             spyon.mockClear();
         });
 
-        test('No userPool', async () => {
-            // @ts-ignore
+        test('No userPool in config', async () => {
             const auth = new Auth(authOptionsWithNoUserPoolId);
             const user = new CognitoUser({
                 Username: 'username',
                 Pool: userPool
             });
+            const errorMessage = new NoUserPoolError(AuthErrorTypes.EmptyCode);
 
-            expect.assertions(1);
-            try {
-                await auth.currentUserPoolUser();
-            } catch (e) {
-                expect(e).toBe('No userPool');
-            }
+            expect.assertions(2);
+            expect(auth.currentUserPoolUser().then()).rejects.toThrow(NoUserPoolError);
+            expect(auth.currentUserPoolUser().then()).rejects.toEqual(errorMessage);
         });
 
         test('get session error', async () => {
@@ -2573,7 +2542,6 @@ describe('auth unit test', () => {
         test('no userPool', async () => {
             const spyon = jest.spyOn(CognitoUser.prototype, 'sendCustomChallengeAnswer');
 
-            // @ts-ignore
             const auth = new Auth(authOptionsWithNoUserPoolId);
             const userAfterCustomChallengeAnswer = Object.assign(
                 new CognitoUser({
@@ -2584,13 +2552,14 @@ describe('auth unit test', () => {
                     "challengeName": "CUSTOM_CHALLENGE",
                     "challengeParam": "challengeParam"
                 });
+            const errorMessage = new NoUserPoolError(AuthErrorTypes.MissingAuthConfig);
 
-            expect.assertions(1);
-            try {
-                await auth.sendCustomChallengeAnswer(userAfterCustomChallengeAnswer, 'challengeResponse');
-            } catch (e) {
-                expect(e).toBe('No userPool');
-            }
+            expect.assertions(2);
+            expect(auth.sendCustomChallengeAnswer(userAfterCustomChallengeAnswer, 'challengeResponse')
+                .then()).rejects.toThrow(AuthError);
+
+            expect(auth.sendCustomChallengeAnswer(userAfterCustomChallengeAnswer, 'challengeResponse')
+                .then()).rejects.toEqual(errorMessage);
 
             spyon.mockClear();
         });

--- a/packages/auth/src/Errors.ts
+++ b/packages/auth/src/Errors.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { AuthErrorMessages, AuthErrorTypes } from './types';
+import { ConsoleLogger as Logger } from '@aws-amplify/core';
+
+const logger = new Logger('AuthError');
+const DEFAULT_MSG = 'Authentication Error';
+
+export class AuthError extends Error {
+    public log: string;
+    constructor(type: AuthErrorTypes) {
+        const { message, log } = authErrorMessages[type];
+        super(message);
+
+        // Hack for making the custom error class work when transpiled to es5
+        // TODO: Delete the following 2 lines after we change the build target to >= es2015
+        this.constructor = AuthError;
+        Object.setPrototypeOf(this, AuthError.prototype);
+
+        this.name = 'AuthError';
+        this.log = log || message;
+
+        logger.error(this.log);
+    }
+}
+
+export class NoUserPoolError extends AuthError {
+    constructor(type: AuthErrorTypes) {
+        super(type);
+
+        // Hack for making the custom error class work when transpiled to es5
+        // TODO: Delete the following 2 lines after we change the build target to >= es2015
+        this.constructor = NoUserPoolError;
+        Object.setPrototypeOf(this, NoUserPoolError.prototype);
+
+        this.name = 'NoUserPoolError';
+    }
+}
+
+export const authErrorMessages: AuthErrorMessages = {
+    noConfig: {
+        message: DEFAULT_MSG,
+        log: `
+            Error: Amplify has not been configured correctly. 
+            Please make sure you're passing the config object to Amplify.configure(). 
+            See https://aws-amplify.github.io/docs/js/authentication#configure-your-app for more information
+        `
+    },
+    missingAuthConfig: {
+        message: DEFAULT_MSG,
+        log: `
+            Error: Amplify has not been configured correctly. 
+            The configuration object is missing required auth properties. 
+            Did you run \`amplify push\` after adding auth via \`amplify add auth\`?
+            See https://aws-amplify.github.io/docs/js/authentication#amplify-project-setup for more information
+        `
+    },
+    emptyUsername: {
+        message: 'Username cannot be empty'
+    },
+    invalidUsername: {
+        message:
+            'The username should either be a string or one of the sign in types'
+    },
+    emptyPassword: {
+        message: 'Password cannot be empty'
+    },
+    emptyCode: {
+        message: 'Confirmation code cannot be empty'
+    },
+    signUpError: {
+        message: 'Error creating account',
+        log: 'The first parameter should either be non-null string or object'
+    },
+    noMFA: {
+        message: 'No valid MFA method provided'
+    },
+    invalidMFA: {
+        message: 'Invalid MFA type'
+    },
+    emptyChallengeResponse: {
+        message: 'Challenge response cannot be empty'
+    },
+    noUserSession: {
+        message: 'Failed to get the session because the user is empty'
+    },
+    default: {
+        message: DEFAULT_MSG
+    }
+};

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -11,76 +11,92 @@
  * and limitations under the License.
  */
 
- import { ICookieStorageData, ICognitoStorage, CognitoUserAttribute } from "amazon-cognito-identity-js";
+import {
+    ICookieStorageData,
+    ICognitoStorage,
+    CognitoUserAttribute
+} from 'amazon-cognito-identity-js';
 
 /**
-* Parameters for user sign up
-*/
+ * Parameters for user sign up
+ */
 export interface SignUpParams {
-    username: string,
-    password: string,
-    attributes?: object,
-    validationData?: CognitoUserAttribute[],
+    username: string;
+    password: string;
+    attributes?: object;
+    validationData?: CognitoUserAttribute[];
 }
 
 export interface AuthCache {
-    setItem(),
-    getItem(),
-    removeItem()
+    setItem();
+    getItem();
+    removeItem();
 }
 
 /**
  * Auth instance options
  */
 export interface AuthOptions {
-    userPoolId?: string,
-    userPoolWebClientId?: string,
-    identityPoolId?: string,
-    region?: string,
-    mandatorySignIn?: boolean
-    cookieStorage?: ICookieStorageData,
-    oauth?: OAuthOpts,
-    refreshHandlers?: object,
-    storage?: ICognitoStorage,
-    authenticationFlowType?: string,
-    identityPoolRegion?: string
+    userPoolId?: string;
+    userPoolWebClientId?: string;
+    identityPoolId?: string;
+    region?: string;
+    mandatorySignIn?: boolean;
+    cookieStorage?: ICookieStorageData;
+    oauth?: OAuthOpts;
+    refreshHandlers?: object;
+    storage?: ICognitoStorage;
+    authenticationFlowType?: string;
+    identityPoolRegion?: string;
 }
 
 export enum CognitoHostedUIIdentityProvider {
     Cognito = 'COGNITO',
     Google = 'Google',
     Facebook = 'Facebook',
-    Amazon = 'LoginWithAmazon',
+    Amazon = 'LoginWithAmazon'
 }
 
-export type LegacyProvider = 'google'|'facebook'|'amazon'|'developer'| string;
+export type LegacyProvider =
+    | 'google'
+    | 'facebook'
+    | 'amazon'
+    | 'developer'
+    | string;
 
 export type FederatedSignInOptions = {
-    provider: CognitoHostedUIIdentityProvider,
-    customState?: string
+    provider: CognitoHostedUIIdentityProvider;
+    customState?: string;
 };
 
 export type FederatedSignInOptionsCustom = {
-    customProvider: string,
-    customState?: string
+    customProvider: string;
+    customState?: string;
 };
 
-export function isFederatedSignInOptions(obj: any): obj is FederatedSignInOptions  {
+export function isFederatedSignInOptions(
+    obj: any
+): obj is FederatedSignInOptions {
     const keys: (keyof FederatedSignInOptions)[] = ['provider', 'customState'];
-    return obj && !!keys.find((k) => obj.hasOwnProperty(k));
+    return obj && !!keys.find(k => obj.hasOwnProperty(k));
 }
 
-export function isFederatedSignInOptionsCustom(obj:any): obj is FederatedSignInOptionsCustom  {
-    const keys: (keyof FederatedSignInOptionsCustom)[] = ['customProvider', 'customState'];
-    return obj && !!keys.find((k) => obj.hasOwnProperty(k));
+export function isFederatedSignInOptionsCustom(
+    obj: any
+): obj is FederatedSignInOptionsCustom {
+    const keys: (keyof FederatedSignInOptionsCustom)[] = [
+        'customProvider',
+        'customState'
+    ];
+    return obj && !!keys.find(k => obj.hasOwnProperty(k));
 }
 
 /**
  * Details for multi-factor authentication
  */
 export interface MfaRequiredDetails {
-    challengeName: any,
-    challengeParameters: any
+    challengeName: any;
+    challengeParameters: any;
 }
 
 /**
@@ -88,45 +104,46 @@ export interface MfaRequiredDetails {
  */
 export interface FederatedResponse {
     // access token
-    token: string,
+    token: string;
     // identity id
-    identity_id?: string,
+    identity_id?: string;
     // the universal time when token expired
-    expires_at: number
+    expires_at: number;
 }
 
 /**
  * interface for federatedUser
  */
 export interface FederatedUser {
-    name: string,
-    email?: string
+    name: string;
+    email?: string;
 }
 
 export interface AwsCognitoOAuthOpts {
-    domain: string,
-	scope: Array<string>,
-	redirectSignIn: string,
-	redirectSignOut: string,
-    responseType: string,
-    options?: object,
-    urlOpener?: (url:string, redirectUrl: string) => Promise<any>
+    domain: string;
+    scope: Array<string>;
+    redirectSignIn: string;
+    redirectSignOut: string;
+    responseType: string;
+    options?: object;
+    urlOpener?: (url: string, redirectUrl: string) => Promise<any>;
 }
 
-export function isCognitoHostedOpts(oauth: OAuthOpts): oauth is AwsCognitoOAuthOpts {
+export function isCognitoHostedOpts(
+    oauth: OAuthOpts
+): oauth is AwsCognitoOAuthOpts {
     return (<AwsCognitoOAuthOpts>oauth).redirectSignIn !== undefined;
 }
 
-
 export interface Auth0OAuthOpts {
-    domain: string,
-    clientID: string,
-	scope: string,
-    redirectUri: string,
-    audience: string,
-    responseType: string,
-    returnTo: string,
-    urlOpener?: (url:string, redirectUrl: string) => Promise<any>
+    domain: string;
+    clientID: string;
+    scope: string;
+    redirectUri: string;
+    audience: string;
+    responseType: string;
+    returnTo: string;
+    urlOpener?: (url: string, redirectUrl: string) => Promise<any>;
 }
 
 // Replacing to fix typings
@@ -138,26 +155,48 @@ export interface Auth0OAuthOpts {
 export type OAuthOpts = AwsCognitoOAuthOpts | Auth0OAuthOpts;
 
 export interface ConfirmSignUpOptions {
-    forceAliasCreation?: boolean
+    forceAliasCreation?: boolean;
 }
 
 export interface SignOutOpts {
-    global?: boolean
+    global?: boolean;
 }
 
 export interface CurrentUserOpts {
-    bypassCache: boolean
+    bypassCache: boolean;
 }
 
 export interface GetPreferredMFAOpts {
-    bypassCache: boolean
+    bypassCache: boolean;
 }
 
 export type UsernamePasswordOpts = {
-    username: string,
-    password: string,
-    validationData?: {[key:string]: any}
+    username: string;
+    password: string;
+    validationData?: { [key: string]: any };
 };
+
+export enum AuthErrorTypes {
+    NoConfig = 'noConfig',
+    MissingAuthConfig = 'missingAuthConfig',
+    EmptyUsername = 'emptyUsername',
+    InvalidUsername = 'invalidUsername',
+    EmptyPassword = 'emptyPassword',
+    EmptyCode = 'emptyCode',
+    SignUpError = 'signUpError',
+    NoMFA = 'noMFA',
+    InvalidMFA = 'invalidMFA',
+    EmptyChallengeResponse = 'emptyChallengeResponse',
+    NoUserSession = 'noUserSession',
+    Default = 'default'
+}
+
+export type AuthErrorMessages = { [key in AuthErrorTypes]?: AuthErrorMessage };
+
+export interface AuthErrorMessage {
+    message: string;
+    log?: string;
+}
 
 // We can extend this in the future if needed
 export type SignInOpts = UsernamePasswordOpts;


### PR DESCRIPTION
*Issue #, if available:*
https://www.pivotaltracker.com/story/show/159083701

*Description of changes:*

* Created custom classes to standardize error handling in Auth (`auth/src/Errors.ts`)
The class consists of `message` and `log` properties. The former gets displayed in the header to the end-user and `log` gets printed to the console.
* Added a dict containing error messages. 
* Detecting 2 different causes of the noUserpool error and offering solutions on how to fix them (in the console). 
* Will be adding a couple of additional noUserpool scenarios to the docs (couldn't detect them programmatically) 


Notes:
* I had prettier enabled, so there are some formatting changes (sorry!)
* docs will be done a bit later today 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
