### PR TITLE
Add tracked for exempt labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,6 +7,7 @@ exemptLabels:
   - feature-request
   - to-be-triaged
   - bug
+  - tracked
 staleLabel: pending-close-response-required
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
*Description of changes:*
- Adding `tracked` to the exemptLabels for stale bot not to add a pending closed to.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
