### PR TITLE
Hint fix

### DIFF
--- a/packages/amplify-ui-components/src/common/constants.ts
+++ b/packages/amplify-ui-components/src/common/constants.ts
@@ -2,9 +2,7 @@
 export const AMPLIFY_UI_PREFIX = 'amplify-ui';
 
 // Classnames
-export const AMPLIFY_UI_HINT = `${AMPLIFY_UI_PREFIX}-hint`;
 export const AMPLIFY_UI_LINK = `${AMPLIFY_UI_PREFIX}-link`;
-export const AMPLIFY_UI_FORM_FIELD = `${AMPLIFY_UI_PREFIX}-form-field`;
 export const AMPLIFY_UI_TEXT_INPUT = `${AMPLIFY_UI_PREFIX}-text-input`;
 export const AMPLIFY_UI_SCENE = `${AMPLIFY_UI_PREFIX}-scene`;
 export const AMPLIFY_UI_SCENE_LOADING = `${AMPLIFY_UI_PREFIX}-scene-loading`;

--- a/packages/amplify-ui-components/src/components/amplify-hint/__snapshots__/amplify-hint.spec.ts.snap
+++ b/packages/amplify-ui-components/src/components/amplify-hint/__snapshots__/amplify-hint.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`amplify-hint spec: Render logic -> renders with hint text FOO 1`] = `
 <amplify-hint>
   <!---->
-  <div class="amplify-ui-hint css-1qzfaa1">
+  <div class="amplify-ui--hint css-1qzfaa1">
     FOO
   </div>
 </amplify-hint>
@@ -12,14 +12,14 @@ exports[`amplify-hint spec: Render logic -> renders with hint text FOO 1`] = `
 exports[`amplify-hint spec: Render logic -> renders with no hint text 1`] = `
 <amplify-hint>
   <!---->
-  <div class="amplify-ui-hint css-1qzfaa1"></div>
+  <div class="amplify-ui--hint css-1qzfaa1"></div>
 </amplify-hint>
 `;
 
 exports[`amplify-hint spec: Render logic -> renders without Emotion CSS class when overrideStyle is true 1`] = `
 <amplify-hint override-style="true">
   <!---->
-  <div class="amplify-ui-hint">
+  <div class="amplify-ui--hint">
     FOO
   </div>
 </amplify-hint>

--- a/packages/amplify-ui-components/src/components/amplify-hint/amplify-hint.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-hint/amplify-hint.tsx
@@ -1,7 +1,10 @@
 import { Component, h, Prop } from '@stencil/core';
 import { hint } from './amplify-hint.style';
 import { styleNuker } from '../../common/helpers';
-import { AMPLIFY_UI_HINT } from '../../common/constants';
+import { AMPLIFY_UI_PREFIX } from '../../common/constants';
+
+const STATIC_HINT_CLASS_NAME = `${AMPLIFY_UI_PREFIX}--hint`;
+
 @Component({
   tag: 'amplify-hint',
   shadow: false,
@@ -12,7 +15,7 @@ export class AmplifyHint {
 
   render() {
     return (
-      <div class={styleNuker(this.overrideStyle, AMPLIFY_UI_HINT, hint)}>
+      <div class={styleNuker(this.overrideStyle, STATIC_HINT_CLASS_NAME, hint)}>
         <slot />
       </div>
     );


### PR DESCRIPTION
Hint component should use AMPLIFY_UI_PREFIX
- also removed AMPLIFY_UI_FORM_FIELD since it's not used either

not sure how I missed these tbh...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
