### PR TITLE
A bit of a head start on the sign-in component

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-authenticator/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/readme.md
@@ -37,10 +37,13 @@
 graph TD;
   amplify-authenticator --> amplify-sign-in
   amplify-authenticator --> context-consumer
-  amplify-sign-in --> amplify-section
+  amplify-sign-in --> amplify-form-section
   amplify-sign-in --> amplify-sign-in-username-field
   amplify-sign-in --> amplify-sign-in-password-field
-  amplify-sign-in --> amplify-button
+  amplify-sign-in --> amplify-tooltip
+  amplify-sign-in --> amplify-icon
+  amplify-form-section --> amplify-section
+  amplify-form-section --> amplify-button
   amplify-sign-in-username-field --> amplify-form-field
   amplify-sign-in-username-field --> context-consumer
   amplify-form-field --> amplify-label

--- a/packages/amplify-ui-components/src/components/amplify-button/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-button/readme.md
@@ -20,7 +20,6 @@
 
  - [amplify-examples](../amplify-examples)
  - [amplify-form-section](../amplify-form-section)
- - [amplify-sign-in](../amplify-sign-in)
  - [rock-paper-scissor](../amplify-examples/rock-paper-scissor)
 
 ### Graph
@@ -28,7 +27,6 @@
 graph TD;
   amplify-examples --> amplify-button
   amplify-form-section --> amplify-button
-  amplify-sign-in --> amplify-button
   rock-paper-scissor --> amplify-button
   style amplify-button fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/amplify-ui-components/src/components/amplify-examples/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-examples/readme.md
@@ -46,10 +46,11 @@ graph TD;
   amplify-form-field --> amplify-hint
   amplify-authenticator --> amplify-sign-in
   amplify-authenticator --> context-consumer
-  amplify-sign-in --> amplify-section
+  amplify-sign-in --> amplify-form-section
   amplify-sign-in --> amplify-sign-in-username-field
   amplify-sign-in --> amplify-sign-in-password-field
-  amplify-sign-in --> amplify-button
+  amplify-sign-in --> amplify-tooltip
+  amplify-sign-in --> amplify-icon
   amplify-sign-in-username-field --> amplify-form-field
   amplify-sign-in-username-field --> context-consumer
   amplify-sign-in-password-field --> amplify-form-field

--- a/packages/amplify-ui-components/src/components/amplify-form-section/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-form-section/readme.md
@@ -20,6 +20,7 @@
 ### Used by
 
  - [amplify-examples](../amplify-examples)
+ - [amplify-sign-in](../amplify-sign-in)
 
 ### Depends on
 
@@ -32,6 +33,7 @@ graph TD;
   amplify-form-section --> amplify-section
   amplify-form-section --> amplify-button
   amplify-examples --> amplify-form-section
+  amplify-sign-in --> amplify-form-section
   style amplify-form-section fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/amplify-ui-components/src/components/amplify-icon/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-icon/readme.md
@@ -13,6 +13,19 @@
 | `overrideStyle` | `override-style` | (Optional) Override default styling                         | `boolean`                                                                        | `false`     |
 
 
+## Dependencies
+
+### Used by
+
+ - [amplify-sign-in](../amplify-sign-in)
+
+### Graph
+```mermaid
+graph TD;
+  amplify-sign-in --> amplify-icon
+  style amplify-icon fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/amplify-ui-components/src/components/amplify-section/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-section/readme.md
@@ -18,13 +18,11 @@
 ### Used by
 
  - [amplify-form-section](../amplify-form-section)
- - [amplify-sign-in](../amplify-sign-in)
 
 ### Graph
 ```mermaid
 graph TD;
   amplify-form-section --> amplify-section
-  amplify-sign-in --> amplify-section
   style amplify-section fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.stories.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.stories.tsx
@@ -2,7 +2,7 @@ import { storiesOf } from '@storybook/html';
 import { knobs } from '../../common/testing';
 import { text as textKnob } from '@storybook/addon-knobs';
 
-const signInStories = storiesOf('mystery component...', module);
+const signInStories = storiesOf('amplify-sign-in', module);
 
 signInStories.add('default', () => {
   const override = knobs.overrideStyleKnob();

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.stories.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.stories.tsx
@@ -1,0 +1,11 @@
+import { storiesOf } from '@storybook/html';
+import { knobs } from '../../common/testing';
+import { text as textKnob } from '@storybook/addon-knobs';
+
+const signInStories = storiesOf('mystery component...', module);
+
+signInStories.add('default', () => {
+  const override = knobs.overrideStyleKnob();
+  const validationErrors = textKnob("Validation Errors", "");
+  return `<amplify-sign-in override-style=${override} validation-errors="${validationErrors}"></amplify-sign-in>`;
+});

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
@@ -10,15 +10,19 @@ export class AmplifySignIn {
 
   render() {
     return (
-      <amplify-section overrideStyle={this.overrideStyle}>
-        <amplify-section-header overrideStyle={this.overrideStyle}>Sign in to your account</amplify-section-header>
-        <form onSubmit={this.handleSubmit}>
-          <amplify-sign-in-username-field />
-          <amplify-sign-in-password-field />
-          {this.validationErrors && <p>{this.validationErrors}</p>}
-          <amplify-button type="submit" overrideStyle={this.overrideStyle}>Submit</amplify-button>
-        </form>
-      </amplify-section>
+      <amplify-form-section handleSubmit={this.handleSubmit} headerText="Sign into your account" overrideStyle={this.overrideStyle}>
+        <amplify-sign-in-username-field hint="Hint: it's the name of your user" />
+        <amplify-sign-in-password-field />
+        {this.validationErrors &&
+          <div style={{display: "flex"}}>
+            <p style={{margin: "0"}}>{this.validationErrors}</p>
+            <amplify-tooltip text="Listen up, this validation error is important!">
+              <amplify-icon name="sound" overrideStyle={true}>
+              </amplify-icon>
+            </amplify-tooltip>
+          </div>
+        }
+      </amplify-form-section>
     );
   }
 }

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/readme.md
@@ -22,18 +22,22 @@
 
 ### Depends on
 
-- [amplify-section](../amplify-section)
+- [amplify-form-section](../amplify-form-section)
 - [amplify-sign-in-username-field](../amplify-sign-in-username-field)
 - [amplify-sign-in-password-field](../amplify-sign-in-password-field)
-- [amplify-button](../amplify-button)
+- [amplify-tooltip](../amplify-tooltip)
+- [amplify-icon](../amplify-icon)
 
 ### Graph
 ```mermaid
 graph TD;
-  amplify-sign-in --> amplify-section
+  amplify-sign-in --> amplify-form-section
   amplify-sign-in --> amplify-sign-in-username-field
   amplify-sign-in --> amplify-sign-in-password-field
-  amplify-sign-in --> amplify-button
+  amplify-sign-in --> amplify-tooltip
+  amplify-sign-in --> amplify-icon
+  amplify-form-section --> amplify-section
+  amplify-form-section --> amplify-button
   amplify-sign-in-username-field --> amplify-form-field
   amplify-sign-in-username-field --> context-consumer
   amplify-form-field --> amplify-label

--- a/packages/amplify-ui-components/src/components/amplify-tooltip/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-tooltip/readme.md
@@ -14,6 +14,19 @@
 | `text`           | `text`             | (Required) The text in the tooltip                                                                       | `string`  | `undefined` |
 
 
+## Dependencies
+
+### Used by
+
+ - [amplify-sign-in](../amplify-sign-in)
+
+### Graph
+```mermaid
+graph TD;
+  amplify-sign-in --> amplify-tooltip
+  style amplify-tooltip fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION
- `<amplify-sign-in>` uses `<amplify-form-section>` now
- Small Storybook integration

This isn't the actual code change I'm doing before I go, but I thought I should at least put the sign-in component up before it's lost forever

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
