### PR TITLE
Remove import of deprecated AsyncStorage from 'react-native' and change to '@react-native-community/async-storage'

### DIFF
--- a/packages/core/src/StorageHelper/reactnative.ts
+++ b/packages/core/src/StorageHelper/reactnative.ts
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import { AsyncStorage } from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-community/async-storage';
 
 const MEMORY_KEY_PREFIX = '@MemoryStorage:';
 let dataMemory = {};

--- a/packages/core/src/StorageHelper/reactnative.ts
+++ b/packages/core/src/StorageHelper/reactnative.ts
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import { AsyncStorage } from '@react-native-community/async-storage'
+import { AsyncStorage } from '@react-native-community/async-storage';
 
 const MEMORY_KEY_PREFIX = '@MemoryStorage:';
 let dataMemory = {};

--- a/packages/core/src/StorageHelper/reactnative.ts
+++ b/packages/core/src/StorageHelper/reactnative.ts
@@ -10,98 +10,102 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import { AsyncStorage } from 'react-native';
+import { AsyncStorage } from '@react-native-community/async-storage';
 
 const MEMORY_KEY_PREFIX = '@MemoryStorage:';
 let dataMemory = {};
 
 /** @class */
 class MemoryStorage {
-    static syncPromise = null;
-    /**
-     * This is used to set a specific item in storage
-     * @param {string} key - the key for the item
-     * @param {object} value - the value
-     * @returns {string} value that was set
-     */
-    static setItem(key, value) {
-        AsyncStorage.setItem(MEMORY_KEY_PREFIX + key, value);
-        dataMemory[key] = value;
-        return dataMemory[key];
-    }
+  static syncPromise = null;
+  /**
+   * This is used to set a specific item in storage
+   * @param {string} key - the key for the item
+   * @param {object} value - the value
+   * @returns {string} value that was set
+   */
+  static setItem(key, value) {
+    AsyncStorage.setItem(MEMORY_KEY_PREFIX + key, value);
+    dataMemory[key] = value;
+    return dataMemory[key];
+  }
 
-    /**
-     * This is used to get a specific key from storage
-     * @param {string} key - the key for the item
-     * This is used to clear the storage
-     * @returns {string} the data item
-     */
-    static getItem(key) {
-        return Object.prototype.hasOwnProperty.call(dataMemory, key) ? dataMemory[key] : undefined;
-    }
+  /**
+   * This is used to get a specific key from storage
+   * @param {string} key - the key for the item
+   * This is used to clear the storage
+   * @returns {string} the data item
+   */
+  static getItem(key) {
+    return Object.prototype.hasOwnProperty.call(dataMemory, key)
+      ? dataMemory[key]
+      : undefined;
+  }
 
-    /**
-     * This is used to remove an item from storage
-     * @param {string} key - the key being set
-     * @returns {string} value - value that was deleted
-     */
-    static removeItem(key) {
-        AsyncStorage.removeItem(MEMORY_KEY_PREFIX + key);
-        return delete dataMemory[key];
-    }
+  /**
+   * This is used to remove an item from storage
+   * @param {string} key - the key being set
+   * @returns {string} value - value that was deleted
+   */
+  static removeItem(key) {
+    AsyncStorage.removeItem(MEMORY_KEY_PREFIX + key);
+    return delete dataMemory[key];
+  }
 
-    /**
-     * This is used to clear the storage
-     * @returns {string} nothing
-     */
-    static clear() {
-        dataMemory = {};
-        return dataMemory;
-    }
+  /**
+   * This is used to clear the storage
+   * @returns {string} nothing
+   */
+  static clear() {
+    dataMemory = {};
+    return dataMemory;
+  }
 
-    /**
-     * Will sync the MemoryStorage data from AsyncStorage to storageWindow MemoryStorage
-    * @returns {void}
-    */
-    static sync() {
-        if (!MemoryStorage.syncPromise) {
-            MemoryStorage.syncPromise =  new Promise((res, rej) => {
-                AsyncStorage.getAllKeys((errKeys, keys) => {
-                    if (errKeys) rej(errKeys);
-                    const memoryKeys = keys.filter((key) => key.startsWith(MEMORY_KEY_PREFIX));
-                    AsyncStorage.multiGet(memoryKeys, (err, stores) => {
-                        if (err) rej(err);
-                        stores.map((result, index, store) => {
-                            const key = store[index][0];
-                            const value = store[index][1];
-                            const memoryKey = key.replace(MEMORY_KEY_PREFIX, '');
-                            dataMemory[memoryKey] = value;
-                        });
-                        res();
-                    });
-                });
+  /**
+   * Will sync the MemoryStorage data from AsyncStorage to storageWindow MemoryStorage
+   * @returns {void}
+   */
+  static sync() {
+    if (!MemoryStorage.syncPromise) {
+      MemoryStorage.syncPromise = new Promise((res, rej) => {
+        AsyncStorage.getAllKeys((errKeys, keys) => {
+          if (errKeys) rej(errKeys);
+          const memoryKeys = keys.filter(key =>
+            key.startsWith(MEMORY_KEY_PREFIX)
+          );
+          AsyncStorage.multiGet(memoryKeys, (err, stores) => {
+            if (err) rej(err);
+            stores.map((result, index, store) => {
+              const key = store[index][0];
+              const value = store[index][1];
+              const memoryKey = key.replace(MEMORY_KEY_PREFIX, '');
+              dataMemory[memoryKey] = value;
             });
-        }
-        return MemoryStorage.syncPromise;
+            res();
+          });
+        });
+      });
     }
+    return MemoryStorage.syncPromise;
+  }
 }
 
 /** @class */
 export default class StorageHelper {
-    private storageWindow;
-    /**
-     * This is used to get a storage object
-     * @returns {object} the storage
-     */
-    constructor() {
-        this.storageWindow = MemoryStorage;
-    }
+  private storageWindow;
+  /**
+   * This is used to get a storage object
+   * @returns {object} the storage
+   */
+  constructor() {
+    this.storageWindow = MemoryStorage;
+  }
 
-    /**
-     * This is used to return the storage
-     * @returns {object} the storage
-     */
-    getStorage() {
-        return this.storageWindow;
-    }
+  /**
+   * This is used to return the storage
+   * @returns {object} the storage
+   */
+  getStorage() {
+    return this.storageWindow;
+  }
 }

--- a/packages/core/src/StorageHelper/reactnative.ts
+++ b/packages/core/src/StorageHelper/reactnative.ts
@@ -10,102 +10,98 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import { AsyncStorage } from '@react-native-community/async-storage';
+import { AsyncStorage } from '@react-native-community/async-storage'
 
 const MEMORY_KEY_PREFIX = '@MemoryStorage:';
 let dataMemory = {};
 
 /** @class */
 class MemoryStorage {
-  static syncPromise = null;
-  /**
-   * This is used to set a specific item in storage
-   * @param {string} key - the key for the item
-   * @param {object} value - the value
-   * @returns {string} value that was set
-   */
-  static setItem(key, value) {
-    AsyncStorage.setItem(MEMORY_KEY_PREFIX + key, value);
-    dataMemory[key] = value;
-    return dataMemory[key];
-  }
-
-  /**
-   * This is used to get a specific key from storage
-   * @param {string} key - the key for the item
-   * This is used to clear the storage
-   * @returns {string} the data item
-   */
-  static getItem(key) {
-    return Object.prototype.hasOwnProperty.call(dataMemory, key)
-      ? dataMemory[key]
-      : undefined;
-  }
-
-  /**
-   * This is used to remove an item from storage
-   * @param {string} key - the key being set
-   * @returns {string} value - value that was deleted
-   */
-  static removeItem(key) {
-    AsyncStorage.removeItem(MEMORY_KEY_PREFIX + key);
-    return delete dataMemory[key];
-  }
-
-  /**
-   * This is used to clear the storage
-   * @returns {string} nothing
-   */
-  static clear() {
-    dataMemory = {};
-    return dataMemory;
-  }
-
-  /**
-   * Will sync the MemoryStorage data from AsyncStorage to storageWindow MemoryStorage
-   * @returns {void}
-   */
-  static sync() {
-    if (!MemoryStorage.syncPromise) {
-      MemoryStorage.syncPromise = new Promise((res, rej) => {
-        AsyncStorage.getAllKeys((errKeys, keys) => {
-          if (errKeys) rej(errKeys);
-          const memoryKeys = keys.filter(key =>
-            key.startsWith(MEMORY_KEY_PREFIX)
-          );
-          AsyncStorage.multiGet(memoryKeys, (err, stores) => {
-            if (err) rej(err);
-            stores.map((result, index, store) => {
-              const key = store[index][0];
-              const value = store[index][1];
-              const memoryKey = key.replace(MEMORY_KEY_PREFIX, '');
-              dataMemory[memoryKey] = value;
-            });
-            res();
-          });
-        });
-      });
+    static syncPromise = null;
+    /**
+     * This is used to set a specific item in storage
+     * @param {string} key - the key for the item
+     * @param {object} value - the value
+     * @returns {string} value that was set
+     */
+    static setItem(key, value) {
+        AsyncStorage.setItem(MEMORY_KEY_PREFIX + key, value);
+        dataMemory[key] = value;
+        return dataMemory[key];
     }
-    return MemoryStorage.syncPromise;
-  }
+
+    /**
+     * This is used to get a specific key from storage
+     * @param {string} key - the key for the item
+     * This is used to clear the storage
+     * @returns {string} the data item
+     */
+    static getItem(key) {
+        return Object.prototype.hasOwnProperty.call(dataMemory, key) ? dataMemory[key] : undefined;
+    }
+
+    /**
+     * This is used to remove an item from storage
+     * @param {string} key - the key being set
+     * @returns {string} value - value that was deleted
+     */
+    static removeItem(key) {
+        AsyncStorage.removeItem(MEMORY_KEY_PREFIX + key);
+        return delete dataMemory[key];
+    }
+
+    /**
+     * This is used to clear the storage
+     * @returns {string} nothing
+     */
+    static clear() {
+        dataMemory = {};
+        return dataMemory;
+    }
+
+    /**
+     * Will sync the MemoryStorage data from AsyncStorage to storageWindow MemoryStorage
+    * @returns {void}
+    */
+    static sync() {
+        if (!MemoryStorage.syncPromise) {
+            MemoryStorage.syncPromise =  new Promise((res, rej) => {
+                AsyncStorage.getAllKeys((errKeys, keys) => {
+                    if (errKeys) rej(errKeys);
+                    const memoryKeys = keys.filter((key) => key.startsWith(MEMORY_KEY_PREFIX));
+                    AsyncStorage.multiGet(memoryKeys, (err, stores) => {
+                        if (err) rej(err);
+                        stores.map((result, index, store) => {
+                            const key = store[index][0];
+                            const value = store[index][1];
+                            const memoryKey = key.replace(MEMORY_KEY_PREFIX, '');
+                            dataMemory[memoryKey] = value;
+                        });
+                        res();
+                    });
+                });
+            });
+        }
+        return MemoryStorage.syncPromise;
+    }
 }
 
 /** @class */
 export default class StorageHelper {
-  private storageWindow;
-  /**
-   * This is used to get a storage object
-   * @returns {object} the storage
-   */
-  constructor() {
-    this.storageWindow = MemoryStorage;
-  }
+    private storageWindow;
+    /**
+     * This is used to get a storage object
+     * @returns {object} the storage
+     */
+    constructor() {
+        this.storageWindow = MemoryStorage;
+    }
 
-  /**
-   * This is used to return the storage
-   * @returns {object} the storage
-   */
-  getStorage() {
-    return this.storageWindow;
-  }
+    /**
+     * This is used to return the storage
+     * @returns {object} the storage
+     */
+    getStorage() {
+        return this.storageWindow;
+    }
 }


### PR DESCRIPTION

related to #3956 

*Description of changes:*
change AsyncStorage import path from `react-native` to `@react-native-community/async-storage`. This will only work if the user already has `@react-native-community/async-storage` as a dependency in their project (or installed in their node_modules folder), I wasn't sure where to put that dependency (dev dependency, peer etc) so please correct me.

Because AsyncStorage from `react-native` is deprecated (https://facebook.github.io/react-native/docs/asyncstorage) and exported to a different library, saving auth state no longer works with react native, meaning that if a user exists the application, when he will open it again he will be logged out, this should be fixed as soon as possible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
