### PR TITLE
fix(@aws-amplify/pushnotification): upgrade react-native version and …

### DIFF
--- a/packages/pushnotification/package.json
+++ b/packages/pushnotification/package.json
@@ -48,10 +48,11 @@
     "webpack": "^3.5.5"
   },
   "dependencies": {
-    "@aws-amplify/core": "^1.1.2"
+    "@aws-amplify/core": "^1.1.2",
+    "@react-native-community/push-notification-ios": "^1.0.2"
   },
   "peerdependencies": {
-    "react-native": "^0.55.0"
+    "react-native": "^0.60.5"
   },
   "jest": {
     "transform": {

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -11,7 +11,8 @@
  * and limitations under the License.
  */
 
-import { NativeModules, DeviceEventEmitter, AsyncStorage, PushNotificationIOS, Platform, AppState } from 'react-native';
+import { NativeModules, DeviceEventEmitter, AsyncStorage, Platform, AppState } from 'react-native';
+import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import Amplify, { ConsoleLogger as Logger } from '@aws-amplify/core';
 
 const logger = new Logger('Notification');


### PR DESCRIPTION
upgrade react-native version and use community framework for PushNotificationIOS

*Issue #, if available: https://github.com/aws-amplify/amplify-js/issues/3995

*Description of changes: Upgraded the PushNotificationIOS to use "@react-native-community/push-notification-ios" module.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
