### PR TITLE
Prevent console error when using guest creds with Storage

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1075,7 +1075,8 @@ export default class AuthClass {
     public currentSession(): Promise<CognitoUserSession> {
         const that = this;
         logger.debug('Getting current session');
-        if (!this.userPool) { return this.rejectNoUserPool(); }
+        // Purposely not calling the reject method here because we don't need a console error
+        if (!this.userPool) { return Promise.reject(); }
 
         return new Promise((res, rej) => {
             that.currentUserPoolUser().then(user => {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/3983

*Description of changes:*
Return empty `Promise.reject()` to prevent error from showing up in the console

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
