### PR TITLE
Fix/input tel

### DIFF
--- a/packages/aws-amplify-angular/src/components/authenticator/phone-field-component/phone-field.component.core.ts
+++ b/packages/aws-amplify-angular/src/components/authenticator/phone-field-component/phone-field.component.core.ts
@@ -47,7 +47,7 @@ const template = `
                 class="amplify-form-input"
                 placeholder="{{ this.amplifyService.i18n().get(this.getPlaceholder()) }}"
                 name="local_phone_number"
-                type="text"
+                type="tel"
                 (keyup)="setLocalPhoneNumber($event.target.value)"
                 data-test="${auth.genericAttrs.phoneNumberInput}"
             />

--- a/packages/aws-amplify-angular/src/components/authenticator/phone-field-component/phone-field.component.ionic.ts
+++ b/packages/aws-amplify-angular/src/components/authenticator/phone-field-component/phone-field.component.ionic.ts
@@ -48,7 +48,7 @@ const template = `
             class="amplify-form-input-phone-ionic"
             placeholder="{{ this.amplifyService.i18n().get(this.getPlaceholder()) }}"
             name="local_phone_number"
-            type="text"
+            type="tel"
             (ionChange)="setLocalPhoneNumber($event.target.value)"
             data-test="${auth.genericAttrs.phoneNumberInput}"
             ></ion-input>

--- a/packages/aws-amplify-vue/src/components/authenticator/PhoneField.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/PhoneField.vue
@@ -25,6 +25,7 @@
                >{{_country.label}}</option> 
         </select>
         <input
+            type="tel"
             v-model="local_phone_number"
             v-bind:class="[amplifyUI.input, isInvalid ? 'invalid': '']"
             :placeholder="$Amplify.I18n.get(getPlaceholder)"


### PR DESCRIPTION
*Issue #4009*

*Description of changes:*
Input fields taking phone numbers be `input type="tel"` rather than just `input type="text"` inputs?
To keep consistency between frameworks, the following has been updated. 

- [x] Vue
- [x] Angular 

React already output the input type as `tel`, React Native doesn't seem to support tel natively. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
