### PR TITLE
Pin webpack version to 4.39.3

### DIFF
--- a/packages/amplify-ui/package.json
+++ b/packages/amplify-ui/package.json
@@ -24,7 +24,7 @@
     "rimraf": "^2.6.3",
     "style-loader": "^0.23.1",
     "ts-loader": "^5.4.4",
-    "webpack": "^4.30.0",
+    "webpack": "4.39.3",
     "webpack-cli": "^3.3.1"
   },
   "postcss": {


### PR DESCRIPTION
4.40.0 broke our release

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
