### PR TITLE
fix: Pinpoint analytics stopSession event

### DIFF
--- a/packages/analytics/__tests__/trackers/SessionTracker-test.ts
+++ b/packages/analytics/__tests__/trackers/SessionTracker-test.ts
@@ -98,6 +98,11 @@ describe('SessionTracker test', () => {
                 value: true
             });
 
+            Object.defineProperty(window.document, 'visibilityState', {
+                writable: true,
+                value: 'hidden'
+            });
+
             await sessionTracker._trackFunc();
 
             expect(tracker).toBeCalledWith({
@@ -115,6 +120,11 @@ describe('SessionTracker test', () => {
             Object.defineProperty(window.document, 'hidden', {
                 writable: true,
                 value: false
+            });
+
+            Object.defineProperty(window.document, 'visibilityState', {
+                writable: true,
+                value: 'visible'
             });
 
             await sessionTracker._trackFunc();

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -10,8 +10,10 @@
   },
   "scripts": {
     "test": "tslint 'src/**/*.ts' && jest --coverage",
+    "test:watch": "tslint 'src/**/*.ts' && jest --watch",
     "build-with-test": "npm run clean && npm test && tsc && webpack",
     "build": "npm run clean && tsc && webpack",
+    "build:watch": "npm run clean && tsc --watch",
     "clean": "rimraf lib lib-esm dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts'"
@@ -79,6 +81,9 @@
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/"
+    ],
+    "setupFiles": [
+      "<rootDir>/src/setupTests.ts"
     ]
   }
 }

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -27,7 +27,6 @@ import Cache from '@aws-amplify/cache';
 
 import { AnalyticsProvider, PromiseHandlers } from '../types';
 import { v1 as uuid } from 'uuid';
-import { RequestParams } from './AmazonPersonalizeHelper/DataType';
 
 const AMPLIFY_SYMBOL = ((typeof Symbol !== 'undefined' && typeof Symbol.for === 'function') ?
     Symbol.for('amplify_default') : '@@amplify_default') as Symbol;

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -16,7 +16,6 @@ import {
     ClientDevice,
     Platform,
     Credentials,
-    Constants,
     Signer,
     JS,
     Hub
@@ -28,8 +27,6 @@ import Cache from '@aws-amplify/cache';
 
 import { AnalyticsProvider, PromiseHandlers } from '../types';
 import { v1 as uuid } from 'uuid';
-import { SSL_OP_TLS_BLOCK_PADDING_BUG } from 'constants';
-import { resolve } from 'url';
 
 const AMPLIFY_SYMBOL = ((typeof Symbol !== 'undefined' && typeof Symbol.for === 'function') ?
     Symbol.for('amplify_default') : '@@amplify_default') as Symbol;

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -331,7 +331,7 @@ export default class AWSPinpointProvider implements AnalyticsProvider {
             method,
         };
 
-        const serviceInfo = { region, service: SERVICE_NAME };
+        const serviceInfo = { region, service: MOBILE_SERVICE_NAME };
 
         const requestUrl: string = Signer.signUrl(request, accessInfo, serviceInfo, null);
 

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -27,6 +27,7 @@ import Cache from '@aws-amplify/cache';
 
 import { AnalyticsProvider, PromiseHandlers } from '../types';
 import { v1 as uuid } from 'uuid';
+import { RequestParams } from './AmazonPersonalizeHelper/DataType';
 
 const AMPLIFY_SYMBOL = ((typeof Symbol !== 'undefined' && typeof Symbol.for === 'function') ?
     Symbol.for('amplify_default') : '@@amplify_default') as Symbol;
@@ -325,9 +326,15 @@ export default class AWSPinpointProvider implements AnalyticsProvider {
         const body = JSON.stringify(EventsRequest);
         const method = 'POST';
 
+        const request = {
+            url,
+            body,
+            method,
+        };
+
         const serviceInfo = { region, service: SERVICE_NAME };
 
-        const requestUrl: string = Signer.signUrl(url, accessInfo, serviceInfo, null, body, method);
+        const requestUrl: string = Signer.signUrl(request, accessInfo, serviceInfo, null);
 
         const success: boolean = navigator.sendBeacon(requestUrl, body);
 

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -312,8 +312,8 @@ export default class AWSPinpointProvider implements AnalyticsProvider {
     private _pinpointSendStopSession(params, handlers): Promise<string> {
         const eventParams = this._generateBatchItemContext(params);
         
-        const {region} = this._config;
-        const {ApplicationId, EventsRequest} = eventParams;
+        const { region } = this._config;
+        const { ApplicationId, EventsRequest } = eventParams;
 
         const accessInfo = {
             secret_key: this._config.credentials.secretAccessKey,
@@ -340,7 +340,7 @@ export default class AWSPinpointProvider implements AnalyticsProvider {
         if (success) {
             return handlers.resolve('sendBeacon success');
         }
-        return handlers.reject("sendBeacon failure");
+        return handlers.reject('sendBeacon failure');
     }
 
     private _retry(params, handlers) {

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -38,7 +38,7 @@ const dispatchAnalyticsEvent = (event, data) => {
 const logger = new Logger('AWSPinpointProvider');
 const RETRYABLE_CODES = [429, 500];
 const ACCEPTED_CODES = [202];
-const SERVICE_NAME = "mobiletargeting";
+const MOBILE_SERVICE_NAME = "mobiletargeting";
 
 // events buffer
 const BUFFER_SIZE = 1000;

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -322,18 +322,12 @@ export default class AWSPinpointProvider implements AnalyticsProvider {
         };
 
         const url = `https://pinpoint.${region}.amazonaws.com/v1/apps/${ApplicationId}/events`;
-
         const body = JSON.stringify(EventsRequest);
-
-        const reqOptions: any = {
-            url,
-            method: 'POST',
-            body,
-        };
+        const method = 'POST';
 
         const serviceInfo = { region, service: SERVICE_NAME };
 
-        const requestUrl: string = Signer.signUrlWithBody(reqOptions, accessInfo, serviceInfo, null, 'POST');
+        const requestUrl: string = Signer.signUrl(url, accessInfo, serviceInfo, null, body, method);
 
         const success: boolean = navigator.sendBeacon(requestUrl, body);
 

--- a/packages/analytics/src/setupTests.ts
+++ b/packages/analytics/src/setupTests.ts
@@ -1,0 +1,4 @@
+const anyGlobal = (global as any);
+
+anyGlobal.navigator = anyGlobal.navigator || {}; 
+anyGlobal.navigator.sendBeacon = anyGlobal.navigator.sendBeacon || jest.fn();

--- a/packages/analytics/src/trackers/SessionTracker.ts
+++ b/packages/analytics/src/trackers/SessionTracker.ts
@@ -13,7 +13,7 @@
 
 // the session tracker for web
 
-import { ConsoleLogger as Logger, Hub, JS } from '@aws-amplify/core';
+import { ConsoleLogger as Logger, Hub, JS, Constants } from '@aws-amplify/core';
 import { SessionTrackOpts } from '../types';
 
 const logger = new Logger('SessionTracker');
@@ -40,8 +40,8 @@ export default class SessionTracker {
         this._hasEnabled = false;
         this._trackFunc = this._trackFunc.bind(this);
         this._trackBeforeUnload = this._trackBeforeUnload.bind(this);
+        
         this.configure(this._config);
-
     }
 
     private _envCheck() {
@@ -79,7 +79,7 @@ export default class SessionTracker {
             customAttrs
         );
 
-        if (document[this._hidden]) {
+        if (document.visibilityState === this._hidden) {
             this._tracker(
                 {
                     name: '_session.stop',
@@ -102,8 +102,9 @@ export default class SessionTracker {
         }
     }
 
-    private _trackBeforeUnload() {
+    private _trackBeforeUnload(event) {
         // before unload callback cannot be async => https://github.com/aws-amplify/amplify-js/issues/2088
+
         const customAttrs = typeof this._config.attributes === 'function' ?
             Promise.resolve(this._config.attributes()) : Promise.resolve(this._config.attributes);
 
@@ -124,7 +125,6 @@ export default class SessionTracker {
                 logger.debug('record session stop event failed.', e);
             });
         });
-
     }
 
     // to keep configure a synchronized function
@@ -136,8 +136,10 @@ export default class SessionTracker {
             initialEventSent = true;
         }
 
-        const customAttrs = typeof this._config.attributes === 'function' ?
-            await this._config.attributes() : this._config.attributes;
+        const customAttrs = typeof this._config.attributes === 'function' 
+            ? await this._config.attributes() 
+            : this._config.attributes;
+        
         const attributes = Object.assign(
             {},
             customAttrs

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -27,5 +27,8 @@
     },
     "include": [
         "src/**/*"
+    ],
+    "exclude": [
+        "src/setupTests.ts"
     ]
 }

--- a/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ForgotPassword-test.js.snap
+++ b/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ForgotPassword-test.js.snap
@@ -4691,6 +4691,7 @@ exports[`forgotPassword normal case render correctly with state delivery set 1`]
            *
         </Component>
         <Component
+          autoComplete="off"
           key="password"
           name="password"
           onChange={[Function]}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
     "test": "jest --coverage",
     "build-with-test": "npm run clean && npm test && tsc && webpack",
     "build": "npm run clean && tsc && webpack",
+    "build:watch": "npm run clean && tsc --watch",
     "clean": "rimraf lib lib-esm dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts'"

--- a/packages/core/src/Signer.ts
+++ b/packages/core/src/Signer.ts
@@ -333,9 +333,9 @@ export default class Signer {
     static signUrl(request: any, accessInfo: any, serviceInfo?: any, expiration?: number): string;
     static signUrl(urlOrRequest: string | any, accessInfo: any, serviceInfo?: any, expiration?: number): string {
 
-        const urlToSign: string = typeof urlOrRequest === 'string' ? urlOrRequest : urlOrRequest.url;
-        const method: string = typeof urlOrRequest === 'string' ? 'GET' : urlOrRequest.method;
-        const body: any = typeof urlOrRequest === 'string' ? undefined : urlOrRequest.body;
+        const urlToSign: string = typeof urlOrRequest === ‘object' ? urlOrRequest.url : urlOrRequest;
+        const method: string = typeof urlOrRequest === ‘object' ? urlOrRequest.method : 'GET';
+        const body: any = typeof urlOrRequest === 'object' ? urlOrRequest.body : undefined;
 
         const now = new Date().toISOString().replace(/[:\-]|\.\d{3}/g, '');
         const today = now.substr(0, 8);

--- a/packages/core/src/Signer.ts
+++ b/packages/core/src/Signer.ts
@@ -333,8 +333,8 @@ export default class Signer {
     static signUrl(request: any, accessInfo: any, serviceInfo?: any, expiration?: number): string;
     static signUrl(urlOrRequest: string | any, accessInfo: any, serviceInfo?: any, expiration?: number): string {
 
-        const urlToSign: string = typeof urlOrRequest === ‘object' ? urlOrRequest.url : urlOrRequest;
-        const method: string = typeof urlOrRequest === ‘object' ? urlOrRequest.method : 'GET';
+        const urlToSign: string = typeof urlOrRequest === 'object' ? urlOrRequest.url : urlOrRequest;
+        const method: string = typeof urlOrRequest === 'object' ? urlOrRequest.method : 'GET';
         const body: any = typeof urlOrRequest === 'object' ? urlOrRequest.body : undefined;
 
         const now = new Date().toISOString().replace(/[:\-]|\.\d{3}/g, '');


### PR DESCRIPTION
utilize `navigator.sendBeacon()` to reliably send _session.stop events on `beforunload`

closes issues #3786 and #3042




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
