### PR TITLE
async storage -> community

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -67,6 +67,7 @@
     "js-cookie": "^2.1.4"
   },
   "devDependencies": {
+    "@react-native-community/async-storage": "^1.6.1",
     "babel-cli": "^6.23.0",
     "babel-core": "^6.13.2",
     "babel-loader": "^6.2.4",
@@ -84,7 +85,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "jsdoc": "^3.4.0",
     "react": "^16.0.0",
-    "react-native": "^0.44.0",
+    "react-native": "^0.60.0",
     "rimraf": "^2.5.4",
     "webpack": "^3.5.5"
   }

--- a/packages/amazon-cognito-identity-js/src/StorageHelper-rn.js
+++ b/packages/amazon-cognito-identity-js/src/StorageHelper-rn.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
 const MEMORY_KEY_PREFIX = '@MemoryStorage:';
 let dataMemory = {};

--- a/packages/aws-amplify-react-native/docs/Cache_AsyncStorageCache.js.html
+++ b/packages/aws-amplify-react-native/docs/Cache_AsyncStorageCache.js.html
@@ -41,7 +41,7 @@
 
 import StorageCache from './StorageCache';
 import {defaultConfig, getCurrTime} from './Utils/CacheUtils'
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
 import { ConsoleLogger as Logger } from '../Common';
 

--- a/packages/cache/src/AsyncStorageCache.ts
+++ b/packages/cache/src/AsyncStorageCache.ts
@@ -13,7 +13,7 @@
 
 import StorageCache from './StorageCache';
 import {defaultConfig, getCurrTime} from './Utils/CacheUtils';
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 import { ICache, CacheConfig, CacheItem, CacheItemOptions } from './types';
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 

--- a/packages/core/src/RNComponents/reactnative.ts
+++ b/packages/core/src/RNComponents/reactnative.ts
@@ -11,6 +11,7 @@
  * and limitations under the License.
  */
 
-import { Linking, AppState, AsyncStorage } from 'react-native';
+import { Linking, AppState } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
 export { Linking, AppState, AsyncStorage };

--- a/packages/core/src/StorageHelper/reactnative.ts
+++ b/packages/core/src/StorageHelper/reactnative.ts
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
 const MEMORY_KEY_PREFIX = '@MemoryStorage:';
 let dataMemory = {};

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -11,7 +11,8 @@
  * and limitations under the License.
  */
 
-import { NativeModules, DeviceEventEmitter, AsyncStorage, PushNotificationIOS, Platform, AppState } from 'react-native';
+import { NativeModules, DeviceEventEmitter, PushNotificationIOS, Platform, AppState } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 import Amplify, { ConsoleLogger as Logger } from '@aws-amplify/core';
 
 const logger = new Logger('Notification');


### PR DESCRIPTION
Attempt to fix #3422 by changing AsyncStorage dependency to use @react-native-community/async-storage.

I think a major release bump will be needed in order to separate support for >RN0.60 from <RN0.60.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
