### PR TITLE
fix(@aws-amplify/predictions): Logger should be configured with corre…

### DIFF
--- a/packages/predictions/src/index.ts
+++ b/packages/predictions/src/index.ts
@@ -21,7 +21,7 @@ import {
 } from './Providers';
 
 import { InterpretTextCategories } from './types';
-const logger = new Logger('PubSub');
+const logger = new Logger('Predictions');
 
 let _instance: PredictionsClass = null;
 


### PR DESCRIPTION
…ct category name

_Description of changes:_
The Logger for Predictions was being incorrectly configured with the name 'PubSub'. This commit fixes that by using the correct category name 'Predictions'.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
