### PR TITLE
[Delivers #168673124] Migrate S3 client to aws sdk V3

### DIFF
--- a/packages/storage/__tests__/Providers/AWSS3Provider-unit-test.ts
+++ b/packages/storage/__tests__/Providers/AWSS3Provider-unit-test.ts
@@ -22,9 +22,9 @@ import { ListObjectsCommand } from '@aws-sdk/client-s3-browser/commands/ListObje
  * actually be using dispatchStorageEvent from Storage
  */
 
-S3Client.prototype.send = jest.fn((command, callback) => {
+S3Client.prototype.send = jest.fn(async command => {
 	if (command instanceof ListObjectsCommand) {
-		callback(null, {
+		return {
 			Contents: [
 				{
 					Key: 'public/path/itemsKey',
@@ -33,10 +33,10 @@ S3Client.prototype.send = jest.fn((command, callback) => {
 					Size: 'size',
 				},
 			],
-		});
+		};
 	}
-	callback(null, 'data');
-}) as any;
+	return 'data';
+});
 
 S3RequestPresigner.prototype.presignRequest = jest.fn((request, expires) => {
 	return new Promise<any>((res, rej) => {
@@ -185,8 +185,8 @@ describe('StorageProvider test', () => {
 			storage.configure(options_with_download);
 			const spyon = jest
 				.spyOn(S3Client.prototype, 'send')
-				.mockImplementationOnce((params, callback) => {
-					callback(null, { Body: [1, 2] } as any);
+				.mockImplementationOnce(async params => {
+					return { Body: [1, 2] };
 				});
 
 			expect.assertions(2);
@@ -210,8 +210,8 @@ describe('StorageProvider test', () => {
 			storage.configure(options);
 			jest
 				.spyOn(S3Client.prototype, 'send')
-				.mockImplementationOnce((params, callback) => {
-					callback('err', null);
+				.mockImplementationOnce(async params => {
+					throw 'err';
 				});
 
 			expect.assertions(1);
@@ -474,8 +474,8 @@ describe('StorageProvider test', () => {
 			storage.configure(options);
 			const spyon = jest
 				.spyOn(S3Client.prototype, 'send')
-				.mockImplementationOnce((params, callback) => {
-					callback('err', null);
+				.mockImplementationOnce(async params => {
+					throw 'err';
 				});
 
 			expect.assertions(1);
@@ -596,8 +596,8 @@ describe('StorageProvider test', () => {
 			storage.configure(options);
 			const spyon = jest
 				.spyOn(S3Client.prototype, 'send')
-				.mockImplementationOnce((params, callback) => {
-					callback('err', null);
+				.mockImplementationOnce(async params => {
+					throw 'err';
 				});
 
 			expect.assertions(1);
@@ -727,8 +727,8 @@ describe('StorageProvider test', () => {
 			storage.configure(options);
 			const spyon = jest
 				.spyOn(S3Client.prototype, 'send')
-				.mockImplementationOnce((params, callback) => {
-					callback('err', null);
+				.mockImplementationOnce(async params => {
+					throw 'err';
 				});
 
 			expect.assertions(1);

--- a/packages/storage/__tests__/Providers/AWSS3Provider-unit-test.ts
+++ b/packages/storage/__tests__/Providers/AWSS3Provider-unit-test.ts
@@ -39,9 +39,7 @@ S3Client.prototype.send = jest.fn(async command => {
 });
 
 S3RequestPresigner.prototype.presignRequest = jest.fn((request, expires) => {
-	return new Promise<any>((res, rej) => {
-		res();
-	});
+	return (Promise as any).resolve();
 });
 
 const credentials = {
@@ -414,9 +412,9 @@ describe('StorageProvider test', () => {
 			const spyon = jest.spyOn(S3Client.prototype, 'send');
 
 			expect.assertions(2);
-			expect(await storage.put('key', 'obejct', {})).toEqual({ key: 'key' });
+			expect(await storage.put('key', 'object', {})).toEqual({ key: 'key' });
 			expect(spyon.mock.calls[0][0].input).toEqual({
-				Body: 'obejct',
+				Body: 'object',
 				Bucket: 'bucket',
 				ContentType: 'binary/octet-stream',
 				Key: 'public/key',
@@ -436,11 +434,11 @@ describe('StorageProvider test', () => {
 			const spyon2 = jest.spyOn(Hub, 'dispatch');
 
 			expect.assertions(3);
-			expect(await storage.put('key', 'obejct', { track: true })).toEqual({
+			expect(await storage.put('key', 'object', { track: true })).toEqual({
 				key: 'key',
 			});
 			expect(spyon.mock.calls[0][0].input).toEqual({
-				Body: 'obejct',
+				Body: 'object',
 				Bucket: 'bucket',
 				ContentType: 'binary/octet-stream',
 				Key: 'public/key',
@@ -480,7 +478,7 @@ describe('StorageProvider test', () => {
 
 			expect.assertions(1);
 			try {
-				await storage.put('key', 'obejct', {});
+				await storage.put('key', 'object', {});
 			} catch (e) {
 				expect(e).toBe('err');
 			}
@@ -501,13 +499,13 @@ describe('StorageProvider test', () => {
 
 			expect.assertions(2);
 			expect(
-				await storage.put('key', 'obejct', {
+				await storage.put('key', 'object', {
 					level: 'private',
 					contentType: 'text/plain',
 				})
 			).toEqual({ key: 'key' });
 			expect(spyon.mock.calls[0][0].input).toEqual({
-				Body: 'obejct',
+				Body: 'object',
 				Bucket: 'bucket',
 				ContentType: 'text/plain',
 				Key: 'private/id/key',

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -36,7 +36,11 @@
     "typescript": "^3.2.2"
   },
   "dependencies": {
-    "@aws-amplify/core": "^1.1.2"
+    "@aws-amplify/core": "^1.1.2",
+    "@aws-sdk/client-s3-browser": "^0.1.0-preview.2",
+    "@aws-sdk/s3-request-presigner": "^0.1.0-preview.2",
+    "@aws-sdk/util-create-request": "^0.1.0-preview.2",
+    "@aws-sdk/util-format-url": "^0.1.0-preview.1"
   },
   "jest": {
     "globals": {

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -144,7 +144,7 @@ export class AWSS3Provider implements StorageProvider {
 					`Download success for ${key}`
 				);
 				return response;
-			} catch (err) {
+			} catch (error) {
 				dispatchStorageEvent(
 					track,
 					'download',
@@ -153,9 +153,9 @@ export class AWSS3Provider implements StorageProvider {
 						result: 'failed',
 					},
 					null,
-					`Download failed with ${err.message}`
+					`Download failed with ${error.message}`
 				);
-				throw err;
+				throw error;
 			}
 		}
 
@@ -177,8 +177,8 @@ export class AWSS3Provider implements StorageProvider {
 				`Signed URL: ${url}`
 			);
 			return url;
-		} catch (e) {
-			logger.warn('get signed url error', e);
+		} catch (error) {
+			logger.warn('get signed url error', error);
 			dispatchStorageEvent(
 				track,
 				'getSignedUrl',
@@ -186,7 +186,7 @@ export class AWSS3Provider implements StorageProvider {
 				null,
 				`Could not get a signed URL for ${key}`
 			);
-			throw e;
+			throw error;
 		}
 	}
 
@@ -279,8 +279,8 @@ export class AWSS3Provider implements StorageProvider {
 			return {
 				key,
 			};
-		} catch (err) {
-			logger.warn('error uploading', err);
+		} catch (error) {
+			logger.warn('error uploading', error);
 			dispatchStorageEvent(
 				track,
 				'upload',
@@ -288,7 +288,7 @@ export class AWSS3Provider implements StorageProvider {
 				null,
 				`Error uploading ${key}`
 			);
-			throw err;
+			throw error;
 		}
 		// This functionality is not available in V3 SDK. Amplify needs to implement it.
 		// .on('httpUploadProgress', progress => {
@@ -339,15 +339,15 @@ export class AWSS3Provider implements StorageProvider {
 				`Deleted ${key} successfully`
 			);
 			return response;
-		} catch (err) {
+		} catch (error) {
 			dispatchStorageEvent(
 				track,
 				'delete',
 				{ method: 'remove', result: 'failed' },
 				null,
-				`Deletion of ${key} failed with ${err}`
+				`Deletion of ${key} failed with ${error}`
 			);
-			throw err;
+			throw error;
 		}
 	}
 
@@ -397,16 +397,16 @@ export class AWSS3Provider implements StorageProvider {
 			);
 			logger.debug('list', list);
 			return list;
-		} catch (err) {
-			logger.warn('list error', err);
+		} catch (error) {
+			logger.warn('list error', error);
 			dispatchStorageEvent(
 				track,
 				'list',
 				{ method: 'list', result: 'failed' },
 				null,
-				`Listing items failed: ${err.message}`
+				`Listing items failed: ${error.message}`
 			);
-			throw err;
+			throw error;
 		}
 	}
 
@@ -423,8 +423,8 @@ export class AWSS3Provider implements StorageProvider {
 
 				return true;
 			})
-			.catch(err => {
-				logger.warn('ensure credentials error', err);
+			.catch(error => {
+				logger.warn('ensure credentials error', error);
 				return false;
 			});
 	}

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -16,13 +16,20 @@ import {
 	Credentials,
 	Parser,
 } from '@aws-amplify/core';
-import * as S3 from 'aws-sdk/clients/s3';
+import { S3Client } from '@aws-sdk/client-s3-browser/S3Client';
+import { formatUrl } from '@aws-sdk/util-format-url';
+import { createRequest } from '@aws-sdk/util-create-request';
+import { GetObjectCommand } from '@aws-sdk/client-s3-browser/commands/GetObjectCommand';
+import { PutObjectCommand } from '@aws-sdk/client-s3-browser/commands/PutObjectCommand';
+import { DeleteObjectCommand } from '@aws-sdk/client-s3-browser/commands/DeleteObjectCommand';
+import { ListObjectsCommand } from '@aws-sdk/client-s3-browser/commands/ListObjectsCommand';
+import { S3RequestPresigner } from '@aws-sdk/s3-request-presigner';
 import { StorageOptions, StorageProvider } from '../types';
 
 const logger = new Logger('AWSS3Provider');
 
 const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' &&
-	typeof Symbol.for === 'function'
+typeof Symbol.for === 'function'
 	? Symbol.for('amplify_default')
 	: '@@amplify_default') as Symbol;
 
@@ -117,7 +124,7 @@ export class AWSS3Provider implements StorageProvider {
 		const { bucket, download, track, expires } = opt;
 		const prefix = this._prefix(opt);
 		const final_key = prefix + key;
-		const s3 = this._createS3(opt);
+		const s3 = this._createNewS3Client(opt);
 		logger.debug('get ' + key + ' from ' + final_key);
 
 		const params: any = {
@@ -127,7 +134,8 @@ export class AWSS3Provider implements StorageProvider {
 
 		if (download === true) {
 			return new Promise<any>((res, rej) => {
-				s3.getObject(params, (err, data) => {
+				const getObjectCommand = new GetObjectCommand(params);
+				s3.send(getObjectCommand, (err, data) => {
 					if (err) {
 						dispatchStorageEvent(
 							track,
@@ -154,13 +162,17 @@ export class AWSS3Provider implements StorageProvider {
 			});
 		}
 
-		if (expires) {
-			params.Expires = expires;
-		}
+		params.Expires = expires || 900; // Default is 15 mins as defined in V2 AWS SDK
+		params.Expires = new Date(Date.now() + params.Expires * 1000); // expires is in secs
 
-		return new Promise<string>((res, rej) => {
+		return new Promise<string>(async (res, rej) => {
 			try {
-				const url = s3.getSignedUrl('getObject', params);
+				const signer = new S3RequestPresigner({ ...s3.config });
+				const request = await createRequest(s3, new GetObjectCommand(params));
+				const url = formatUrl((await signer.presignRequest(
+					request,
+					params.Expires
+				)) as any);
 				dispatchStorageEvent(
 					track,
 					'getSignedUrl',
@@ -218,7 +230,7 @@ export class AWSS3Provider implements StorageProvider {
 
 		const prefix = this._prefix(opt);
 		const final_key = prefix + key;
-		const s3 = this._createS3(opt);
+		const s3 = this._createNewS3Client(opt);
 		logger.debug('put ' + key + ' to ' + final_key);
 
 		const params: any = {
@@ -257,46 +269,44 @@ export class AWSS3Provider implements StorageProvider {
 				params.SSEKMSKeyId = SSEKMSKeyId;
 			}
 		}
-
-		try {
-			const upload = s3.upload(params).on('httpUploadProgress', progress => {
-				if (progressCallback) {
-					if (typeof progressCallback === 'function') {
-						progressCallback(progress);
-					} else {
-						logger.warn(
-							'progressCallback should be a function, not a ' +
-							typeof progressCallback
-						);
-					}
+		return new Promise<any>((res, rej) => {
+			const putObjectCommand = new PutObjectCommand(params);
+			s3.send(putObjectCommand, (err, data) => {
+				if (err) {
+					logger.warn('error uploading', err);
+					dispatchStorageEvent(
+						track,
+						'upload',
+						{ method: 'put', result: 'failed' },
+						null,
+						`Error uploading ${key}`
+					);
+					rej(err);
+				} else {
+					logger.debug('upload result', data);
+					dispatchStorageEvent(
+						track,
+						'upload',
+						{ method: 'put', result: 'success' },
+						null,
+						`Upload success for ${key}`
+					);
+					res({
+						key,
+					});
 				}
 			});
-			const data = await upload.promise();
-
-			logger.debug('upload result', data);
-			dispatchStorageEvent(
-				track,
-				'upload',
-				{ method: 'put', result: 'success' },
-				null,
-				`Upload success for ${key}`
-			);
-
-			return {
-				key: data.Key.substr(prefix.length),
-			};
-		} catch (e) {
-			logger.warn('error uploading', e);
-			dispatchStorageEvent(
-				track,
-				'upload',
-				{ method: 'put', result: 'failed' },
-				null,
-				`Error uploading ${key}`
-			);
-
-			throw e;
-		}
+			// This functionality is not available in V3 SDK. Amplify needs to implement it.
+			// .on('httpUploadProgress', progress => {
+			//     if (progressCallback) {
+			//         if (typeof progressCallback === 'function') {
+			//             progressCallback(progress);
+			//         } else {
+			//             logger.warn('progressCallback should be a function, not a ' + typeof progressCallback);
+			//         }
+			//     }
+			// });
+		});
 	}
 
 	/**
@@ -316,7 +326,7 @@ export class AWSS3Provider implements StorageProvider {
 
 		const prefix = this._prefix(opt);
 		const final_key = prefix + key;
-		const s3 = this._createS3(opt);
+		const s3 = this._createNewS3Client(opt);
 		logger.debug('remove ' + key + ' from ' + final_key);
 
 		const params = {
@@ -324,8 +334,10 @@ export class AWSS3Provider implements StorageProvider {
 			Key: final_key,
 		};
 
+		const deleteObjectCommand = new DeleteObjectCommand(params);
+
 		return new Promise<any>((res, rej) => {
-			s3.deleteObject(params, (err, data) => {
+			s3.send(deleteObjectCommand, (err, data) => {
 				if (err) {
 					dispatchStorageEvent(
 						track,
@@ -366,7 +378,7 @@ export class AWSS3Provider implements StorageProvider {
 
 		const prefix = this._prefix(opt);
 		const final_path = prefix + path;
-		const s3 = this._createS3(opt);
+		const s3 = this._createNewS3Client(opt);
 		logger.debug('list ' + path + ' from ' + final_path);
 
 		const params = {
@@ -374,8 +386,10 @@ export class AWSS3Provider implements StorageProvider {
 			Prefix: final_path,
 		};
 
+		const listObjectsCommand = new ListObjectsCommand(params);
+
 		return new Promise<any>((res, rej) => {
-			s3.listObjects(params, (err, data) => {
+			s3.send(listObjectsCommand, (err, data) => {
 				if (err) {
 					logger.warn('list error', err);
 					dispatchStorageEvent(
@@ -460,11 +474,10 @@ export class AWSS3Provider implements StorageProvider {
 	}
 
 	/**
-	 * @private
+	 * @private creates an S3 client with new V3 aws sdk
 	 */
-	private _createS3(config) {
+	private _createNewS3Client(config) {
 		const {
-			bucket,
 			region,
 			credentials,
 			dangerouslyConnectToHttpEndpointForTesting,
@@ -479,10 +492,7 @@ export class AWSS3Provider implements StorageProvider {
 			};
 		}
 
-		return new S3({
-			apiVersion: '2006-03-01',
-			params: { Bucket: bucket },
-			signatureVersion: 'v4',
+		return new S3Client({
 			region,
 			credentials,
 			...localTestingConfig,


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws-amplify/amplify-js/issues/3365

_Description of changes:_ This PR upgrades the S3 client from aws sdk V2 to V3 client to achieve modularization at the AWS clients level.

[Delivers #168673124]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
