### PR TITLE
Fix/pubsub mqtt unsubscribe issue

### DIFF
--- a/packages/pubsub/__tests__/PubSub-unit-test.ts
+++ b/packages/pubsub/__tests__/PubSub-unit-test.ts
@@ -6,13 +6,13 @@ import {
 	mqttTopicMatch,
 } from '../src/Providers';
 // import Amplify from '../../src/';
-import { Credentials } from '@aws-amplify/core';
+import { Credentials, ConsoleLogger as Logger } from '@aws-amplify/core';
 import { INTERNAL_AWS_APPSYNC_PUBSUB_PROVIDER } from '@aws-amplify/core/lib/constants';
 import * as Paho from '../src/vendor/paho-mqtt';
 
 const pahoClientMockCache = {};
 
-const mockConnect = jest.fn(options => {
+const mockConnect = jest.fn((options, callback) => {
 	options.onSuccess();
 });
 
@@ -347,5 +347,49 @@ describe('PubSub', () => {
 				pubsub.publish('topicA', 'my message AWSIoTProvider')
 			).rejects.toThrowError('Failed to publish');
 		});
+
+		test(
+			'For multiple observers, client should not be disconnected if there are ' +
+				'other observers connected when unsubscribing',
+			async () => {
+				const pubsub = new PubSub();
+
+				const spyDisconnect = jest.spyOn(
+					MqttOverWSProvider.prototype,
+					'disconnect'
+				);
+				const mqttOverWSProvider = new MqttOverWSProvider({
+					aws_pubsub_endpoint: 'wss://iot.mock-endpoint.org:443/mqtt',
+				});
+				pubsub.addPluggable(mqttOverWSProvider);
+
+				const subscription1 = pubsub.subscribe(['topic1', 'topic2']).subscribe({
+					next: _data => {
+						console.log({ _data });
+					},
+					complete: () => console.log('done'),
+					error: error => console.log('error', error),
+				});
+
+				pubsub.subscribe(['topic3', 'topic4']).subscribe({
+					next: _data => {
+						console.log({ _data });
+					},
+					complete: () => console.log('done'),
+					error: error => console.log('error', error),
+				});
+
+				// TODO: we should now when the connection is established to wait for that first
+				await (() => {
+					return new Promise(res => {
+						setTimeout(res, 100);
+					});
+				})();
+
+				subscription1.unsubscribe();
+				expect(spyDisconnect).not.toHaveBeenCalled();
+				// setTimeout(async () => await pubsub.publish('topic4', 'my message'), 100);
+			}
+		);
 	});
 });


### PR DESCRIPTION
_Issue #, if available:_
Fixes: #4064
_Description of changes:_
Adding `clientId` map for observers on `MqttOverWSProvider` to avoid disconnecting other observers that are listening to the same `clientId`
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
