### PR TITLE
fix: lerna linking for unstable and beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
 		"lint": "lerna run lint",
 		"link-all": "yarn unlink-all && lerna exec --parallel yarn link",
 		"unlink-all": "lerna exec --parallel --bail=false yarn unlink",
-		"publish:master": "lerna publish --canary --yes --dist-tag=unstable --preid=unstable  --exact",
-		"publish:beta": "lerna publish --canary --yes --dist-tag=beta --preid=beta  --exact",
+		"publish:master": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=unstable --preid=unstable  --exact",
+		"publish:beta": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=beta --preid=beta  --exact",
 		"publish:release": "lerna publish --conventional-commits --yes --message 'chore(release): Publish [ci skip]'"
 	},
 	"husky": {


### PR DESCRIPTION
This is a workaround for the following issue when using lerna with the `--canary` option:
https://github.com/lerna/lerna/issues/2060




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
