### PR TITLE
[Delivers #168789986] Migrate Interactions category to use aws-sdk v3 clients

### DIFF
--- a/packages/interactions/__tests__/Interactions-unit-test.ts
+++ b/packages/interactions/__tests__/Interactions-unit-test.ts
@@ -1,66 +1,70 @@
-jest.mock('aws-sdk/clients/lexruntime', () => {
-	const LexRuntime = () => {};
-	LexRuntime.prototype.postText = (params, callback) => {
-		if (params.inputText === 'done') {
-			callback(null, {
-				message: 'echo:' + params.inputText,
+import { LexRuntimeServiceClient } from '@aws-sdk/client-lex-runtime-service-browser/LexRuntimeServiceClient';
+import Interactions from '../src/Interactions';
+import { findInterfacesAddedToObjectTypes } from 'graphql/utilities/findBreakingChanges';
+import { AWSLexProvider, AbstractInteractionsProvider } from '../src/Providers';
+import { Credentials } from '@aws-amplify/core';
+import { PostContentCommand } from '@aws-sdk/client-lex-runtime-service-browser/commands/PostContentCommand';
+import { PostTextCommand } from '@aws-sdk/client-lex-runtime-service-browser/commands/PostTextCommand';
+
+LexRuntimeServiceClient.prototype.send = jest.fn((command, callback) => {
+	if (command instanceof PostTextCommand) {
+		if (command.input.inputText === 'done') {
+			const result = {
+				message: 'echo:' + command.input.inputText,
 				dialogState: 'ReadyForFulfillment',
 				slots: {
 					m1: 'hi',
 					m2: 'done',
 				},
-			});
+			};
+			return Promise.resolve(result);
 		} else {
-			callback(null, {
-				message: 'echo:' + params.inputText,
+			const result = {
+				message: 'echo:' + command.input.inputText,
 				dialogState: 'ElicitSlot',
-			});
+			};
+			return Promise.resolve(result);
 		}
-	};
-
-	LexRuntime.prototype.postContent = (params, callback) => {
-		if (params.contentType === 'audio/x-l16; sample-rate=16000') {
-			if (params.inputStream === 'voice:done') {
-				callback(null, {
-					message: 'voice:echo:' + params.inputStream,
+	} else if (command instanceof PostContentCommand) {
+		if (command.input.contentType === 'audio/x-l16; sample-rate=16000') {
+			if (command.input.inputStream === 'voice:done') {
+				const result = {
+					message: 'voice:echo:' + command.input.inputStream,
 					dialogState: 'ReadyForFulfillment',
 					slots: {
 						m1: 'voice:hi',
 						m2: 'voice:done',
 					},
-				});
+				};
+				return Promise.resolve(result);
 			} else {
-				callback(null, {
-					message: 'voice:echo:' + params.inputStream,
+				const result = {
+					message: 'voice:echo:' + command.input.inputStream,
 					dialogState: 'ElicitSlot',
-				});
+				};
+				return Promise.resolve(result);
 			}
 		} else {
-			if (params.inputStream === 'done') {
-				callback(null, {
-					message: 'echo:' + params.inputStream,
+			if (command.input.inputStream === 'done') {
+				const result = {
+					message: 'echo:' + command.input.inputStream,
 					dialogState: 'ReadyForFulfillment',
 					slots: {
 						m1: 'hi',
 						m2: 'done',
 					},
-				});
+				};
+				return Promise.resolve(result);
 			} else {
-				callback(null, {
-					message: 'echo:' + params.inputStream,
+				const result = {
+					message: 'echo:' + command.input.inputStream,
 					dialogState: 'ElicitSlot',
-				});
+				};
+				return Promise.resolve(result);
 			}
 		}
-	};
-
-	return LexRuntime;
-});
-
-import Interactions from '../src/Interactions';
-import { findInterfacesAddedToObjectTypes } from 'graphql/utilities/findBreakingChanges';
-import { AWSLexProvider, AbstractInteractionsProvider } from '../src/Providers';
-import { Credentials } from '@aws-amplify/core';
+	}
+}) as any;
 
 class AWSLexProvider2 extends AWSLexProvider {
 	getProviderName() {
@@ -81,7 +85,7 @@ class AWSLexProviderWrong extends AbstractInteractionsProvider {
 	}
 
 	sendMessage(message: string | Object): Promise<Object> {
-		return new Promise(async (res, rej) => {});
+		return new Promise(async (res, rej) => { });
 	}
 
 	async onComplete() {
@@ -732,7 +736,7 @@ describe('Interactions', () => {
 				});
 
 				try {
-					await interactions.onComplete('BookTrip', () => {});
+					await interactions.onComplete('BookTrip', () => { });
 				} catch (err) {
 					expect(err.message).toEqual('Bot BookTrip does not exist');
 				}

--- a/packages/interactions/__tests__/Interactions-unit-test.ts
+++ b/packages/interactions/__tests__/Interactions-unit-test.ts
@@ -1,6 +1,5 @@
 import { LexRuntimeServiceClient } from '@aws-sdk/client-lex-runtime-service-browser/LexRuntimeServiceClient';
 import Interactions from '../src/Interactions';
-import { findInterfacesAddedToObjectTypes } from 'graphql/utilities/findBreakingChanges';
 import { AWSLexProvider, AbstractInteractionsProvider } from '../src/Providers';
 import { Credentials } from '@aws-amplify/core';
 import { PostContentCommand } from '@aws-sdk/client-lex-runtime-service-browser/commands/PostContentCommand';

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -1,79 +1,80 @@
 {
-  "name": "@aws-amplify/interactions",
-  "version": "1.0.37",
-  "description": "Interactions category of aws-amplify",
-  "main": "./index.js",
-  "module": "./lib-esm/index.js",
-  "typings": "./lib-esm/index.d.ts",
-  "react-native": {
-    "./index": "./lib-esm/index.js"
-  },
-  "sideEffects": false,
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest --coverage",
-    "build-with-test": "npm run clean && npm test && tsc && webpack",
-    "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
-    "build:esm": "node ./build es6",
-    "build": "npm run clean && npm run build:esm && npm run build:cjs",
-    "clean": "rimraf lib-esm lib dist",
-    "format": "tsfmt --useTsfmt tsfmt.json -r src/**/*.ts",
-    "lint": "tslint 'src/**/*.ts'"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/aws/aws-amplify.git"
-  },
-  "author": "Amazon Web Services",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/aws/aws-amplify/issues"
-  },
-  "homepage": "https://github.com/aws/aws-amplify#readme",
-  "dependencies": {
-    "@aws-amplify/core": "^1.1.2"
-  },
-  "jest": {
-    "globals": {
-      "ts-jest": {
-        "diagnostics": false,
-        "tsConfig": {
-          "lib": [
-            "es5",
-            "es2015",
-            "dom",
-            "esnext.asynciterable",
-            "es2017.object"
-          ],
-          "allowJs": true
-        }
-      }
-    },
-    "transform": {
-      "^.+\\.(js|jsx|ts|tsx)$": "ts-jest"
-    },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "json",
-      "jsx"
-    ],
-    "testEnvironment": "jsdom",
-    "testURL": "http://localhost/",
-    "coverageThreshold": {
-      "global": {
-        "branches": 0,
-        "functions": 0,
-        "lines": 0,
-        "statements": 0
-      }
-    },
-    "coveragePathIgnorePatterns": [
-      "/node_modules/"
-    ]
-  }
+	"name": "@aws-amplify/interactions",
+	"version": "1.0.37",
+	"description": "Interactions category of aws-amplify",
+	"main": "./index.js",
+	"module": "./lib-esm/index.js",
+	"typings": "./lib-esm/index.d.ts",
+	"react-native": {
+		"./index": "./lib-esm/index.js"
+	},
+	"sideEffects": false,
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"test": "tslint 'src/**/*.ts' && jest --coverage",
+		"build-with-test": "npm run clean && npm test && tsc && webpack",
+		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
+		"build:esm": "node ./build es6",
+		"build": "npm run clean && npm run build:esm && npm run build:cjs",
+		"clean": "rimraf lib-esm lib dist",
+		"format": "tsfmt --useTsfmt tsfmt.json -r src/**/*.ts",
+		"lint": "tslint 'src/**/*.ts'"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/aws/aws-amplify.git"
+	},
+	"author": "Amazon Web Services",
+	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://github.com/aws/aws-amplify/issues"
+	},
+	"homepage": "https://github.com/aws/aws-amplify#readme",
+	"dependencies": {
+		"@aws-amplify/core": "^1.1.2",
+		"@aws-sdk/client-lex-runtime-service-browser": "^0.1.0-preview.2"
+	},
+	"jest": {
+		"globals": {
+			"ts-jest": {
+				"diagnostics": false,
+				"tsConfig": {
+					"lib": [
+						"es5",
+						"es2015",
+						"dom",
+						"esnext.asynciterable",
+						"es2017.object"
+					],
+					"allowJs": true
+				}
+			}
+		},
+		"transform": {
+			"^.+\\.(js|jsx|ts|tsx)$": "ts-jest"
+		},
+		"testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+		"moduleFileExtensions": [
+			"ts",
+			"tsx",
+			"js",
+			"json",
+			"jsx"
+		],
+		"testEnvironment": "jsdom",
+		"testURL": "http://localhost/",
+		"coverageThreshold": {
+			"global": {
+				"branches": 0,
+				"functions": 0,
+				"lines": 0,
+				"statements": 0
+			}
+		},
+		"coveragePathIgnorePatterns": [
+			"/node_modules/"
+		]
+	}
 }

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -12,153 +12,151 @@
  */
 
 import { AbstractInteractionsProvider } from './InteractionsProvider';
-import {
-	InteractionsOptions,
-	InteractionsMessage,
-	InteractionsResponse,
-} from '../types';
-import * as LexRuntime from 'aws-sdk/clients/lexruntime';
+import { InteractionsOptions, InteractionsMessage } from '../types';
+import { LexRuntimeServiceClient } from '@aws-sdk/client-lex-runtime-service-browser/LexRuntimeServiceClient';
+import { PostTextCommand } from '@aws-sdk/client-lex-runtime-service-browser/commands/PostTextCommand';
+import { PostContentCommand } from '@aws-sdk/client-lex-runtime-service-browser/commands/PostContentCommand';
 import { ConsoleLogger as Logger, AWS, Credentials } from '@aws-amplify/core';
-import { registerHelper } from 'handlebars';
 
 const logger = new Logger('AWSLexProvider');
 
 export class AWSLexProvider extends AbstractInteractionsProvider {
-	private aws_lex: LexRuntime;
-	private _botsCompleteCallback: object;
+    private lexRuntimeServiceClient: LexRuntimeServiceClient;
+    private _botsCompleteCallback: object;
 
-	constructor(options: InteractionsOptions = {}) {
-		super(options);
-		this.aws_lex = new LexRuntime({ region: this._config.region });
-		this._botsCompleteCallback = {};
-	}
+    constructor(options: InteractionsOptions = {}) {
+        super(options);
+        this._botsCompleteCallback = {};
+    }
 
-	getProviderName() {
-		return 'AWSLexProvider';
-	}
+    getProviderName() {
+        return 'AWSLexProvider';
+    }
 
-	responseCallback(err, data, res, rej, botname) {
-		if (err) {
-			rej(err);
-			return;
-		} else {
-			// Check if state is fulfilled to resolve onFullfilment promise
-			logger.debug('postContent state', data.dialogState);
-			if (
-				data.dialogState === 'ReadyForFulfillment' ||
-				data.dialogState === 'Fulfilled'
-			) {
-				if (typeof this._botsCompleteCallback[botname] === 'function') {
-					setTimeout(
-						() =>
-							this._botsCompleteCallback[botname](null, { slots: data.slots }),
-						0
-					);
-				}
+    responseCallback(data, botname) {
+        // Check if state is fulfilled to resolve onFullfilment promise
+        logger.debug('postContent state', data.dialogState);
+        if (
+            data.dialogState === 'ReadyForFulfillment' ||
+            data.dialogState === 'Fulfilled'
+        ) {
+            if (typeof this._botsCompleteCallback[botname] === 'function') {
+                setTimeout(
+                    () =>
+                        this._botsCompleteCallback[botname](null, { slots: data.slots }),
+                    0
+                );
+            }
 
-				if (
-					this._config &&
-					typeof this._config[botname].onComplete === 'function'
-				) {
-					setTimeout(
-						() => this._config[botname].onComplete(null, { slots: data.slots }),
-						0
-					);
-				}
-			}
+            if (
+                this._config &&
+                typeof this._config[botname].onComplete === 'function'
+            ) {
+                setTimeout(
+                    () => this._config[botname].onComplete(null, { slots: data.slots }),
+                    0
+                );
+            }
+        }
 
-			res(data);
-			if (data.dialogState === 'Failed') {
-				if (typeof this._botsCompleteCallback[botname] === 'function') {
-					setTimeout(
-						() =>
-							this._botsCompleteCallback[botname]('Bot conversation failed'),
-						0
-					);
-				}
+        if (data.dialogState === 'Failed') {
+            if (typeof this._botsCompleteCallback[botname] === 'function') {
+                setTimeout(
+                    () =>
+                        this._botsCompleteCallback[botname]('Bot conversation failed'),
+                    0
+                );
+            }
 
-				if (
-					this._config &&
-					typeof this._config[botname].onComplete === 'function'
-				) {
-					setTimeout(
-						() => this._config[botname].onComplete('Bot conversation failed'),
-						0
-					);
-				}
-			}
-		}
-	}
+            if (
+                this._config &&
+                typeof this._config[botname].onComplete === 'function'
+            ) {
+                setTimeout(
+                    () => this._config[botname].onComplete('Bot conversation failed'),
+                    0
+                );
+            }
+        }
+    }
 
-	sendMessage(
-		botname: string,
-		message: string | InteractionsMessage
-	): Promise<object> {
-		return new Promise(async (res, rej) => {
-			if (!this._config[botname]) {
-				return rej('Bot ' + botname + ' does not exist');
-			}
-			const credentials = await Credentials.get();
-			if (!credentials) {
-				return rej('No credentials');
-			}
-			AWS.config.update({
-				credentials,
-			});
+    async sendMessage(
+        botname: string,
+        message: string | InteractionsMessage
+    ): Promise<object> {
+        if (!this._config[botname]) {
+            return Promise.reject('Bot ' + botname + ' does not exist');
+        }
+        const credentials = await Credentials.get();
+        if (!credentials) {
+            return Promise.reject('No credentials');
+        }
+        AWS.config.update({
+            credentials,
+        });
 
-			this.aws_lex = new LexRuntime({
-				region: this._config[botname].region,
-				credentials,
-			});
+        this.lexRuntimeServiceClient = new LexRuntimeServiceClient({
+            region: this._config[botname].region,
+            credentials,
+        });
 
-			let params;
-			if (typeof message === 'string') {
-				params = {
-					botAlias: this._config[botname].alias,
-					botName: botname,
-					inputText: message,
-					userId: credentials.identityId,
-				};
+        let params;
+        if (typeof message === 'string') {
+            params = {
+                botAlias: this._config[botname].alias,
+                botName: botname,
+                inputText: message,
+                userId: credentials.identityId,
+            };
 
-				logger.debug('postText to lex', message);
+            logger.debug('postText to lex', message);
 
-				this.aws_lex.postText(params, (err, data) => {
-					this.responseCallback(err, data, res, rej, botname);
-				});
-			} else {
-				if (message.options['messageType'] === 'voice') {
-					params = {
-						botAlias: this._config[botname].alias,
-						botName: botname,
-						contentType: 'audio/x-l16; sample-rate=16000',
-						inputStream: message.content,
-						userId: credentials.identityId,
-						accept: 'audio/mpeg',
-					};
-				} else {
-					params = {
-						botAlias: this._config[botname].alias,
-						botName: botname,
-						contentType: 'text/plain; charset=utf-8',
-						inputStream: message.content,
-						userId: credentials.identityId,
-						accept: 'audio/mpeg',
-					};
-				}
+            try {
+                const postTextCommand = new PostTextCommand(params);
+                const data = this.lexRuntimeServiceClient.send(postTextCommand);
+                this.responseCallback(data, botname);
+                return data;
+            } catch (err) {
+                return Promise.reject(err);
+            }
+        } else {
+            if (message.options['messageType'] === 'voice') {
+                params = {
+                    botAlias: this._config[botname].alias,
+                    botName: botname,
+                    contentType: 'audio/x-l16; sample-rate=16000',
+                    inputStream: message.content,
+                    userId: credentials.identityId,
+                    accept: 'audio/mpeg',
+                };
+            } else {
+                params = {
+                    botAlias: this._config[botname].alias,
+                    botName: botname,
+                    contentType: 'text/plain; charset=utf-8',
+                    inputStream: message.content,
+                    userId: credentials.identityId,
+                    accept: 'audio/mpeg',
+                };
+            }
 
-				logger.debug('postContent to lex', message);
+            logger.debug('postContent to lex', message);
 
-				this.aws_lex.postContent(params, (err, data) => {
-					this.responseCallback(err, data, res, rej, botname);
-				});
-			}
-		});
-	}
+            try {
+                const postContentCommand = new PostContentCommand(params);
+                const data = this.lexRuntimeServiceClient.send(postContentCommand);
+                this.responseCallback(data, botname);
+                return data;
+            } catch (err) {
+                return Promise.reject(err);
+            }
+        }
+    }
 
-	onComplete(botname: string, callback) {
-		if (!this._config[botname]) {
-			throw new ErrorEvent('Bot ' + botname + ' does not exist');
-		}
-		this._botsCompleteCallback[botname] = callback;
-	}
+    onComplete(botname: string, callback) {
+        if (!this._config[botname]) {
+            throw new ErrorEvent('Bot ' + botname + ' does not exist');
+        }
+        this._botsCompleteCallback[botname] = callback;
+    }
 }

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -33,7 +33,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
         return 'AWSLexProvider';
     }
 
-    responseCallback(data, botname) {
+    reportBotStatus(data, botname) {
         // Check if state is fulfilled to resolve onFullfilment promise
         logger.debug('postContent state', data.dialogState);
         if (
@@ -111,7 +111,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
             try {
                 const postTextCommand = new PostTextCommand(params);
                 const data = await this.lexRuntimeServiceClient.send(postTextCommand);
-                this.responseCallback(data, botname);
+                this.reportBotStatus(data, botname);
                 return data;
             } catch (err) {
                 return Promise.reject(err);
@@ -142,7 +142,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
             try {
                 const postContentCommand = new PostContentCommand(params);
                 const data = await this.lexRuntimeServiceClient.send(postContentCommand);
-                this.responseCallback(data, botname);
+                this.reportBotStatus(data, botname);
                 return data;
             } catch (err) {
                 return Promise.reject(err);

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -16,7 +16,7 @@ import { InteractionsOptions, InteractionsMessage } from '../types';
 import { LexRuntimeServiceClient } from '@aws-sdk/client-lex-runtime-service-browser/LexRuntimeServiceClient';
 import { PostTextCommand } from '@aws-sdk/client-lex-runtime-service-browser/commands/PostTextCommand';
 import { PostContentCommand } from '@aws-sdk/client-lex-runtime-service-browser/commands/PostContentCommand';
-import { ConsoleLogger as Logger, AWS, Credentials } from '@aws-amplify/core';
+import { ConsoleLogger as Logger, Credentials } from '@aws-amplify/core';
 
 const logger = new Logger('AWSLexProvider');
 
@@ -91,9 +91,6 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
         if (!credentials) {
             return Promise.reject('No credentials');
         }
-        AWS.config.update({
-            credentials,
-        });
 
         this.lexRuntimeServiceClient = new LexRuntimeServiceClient({
             region: this._config[botname].region,
@@ -113,7 +110,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 
             try {
                 const postTextCommand = new PostTextCommand(params);
-                const data = this.lexRuntimeServiceClient.send(postTextCommand);
+                const data = await this.lexRuntimeServiceClient.send(postTextCommand);
                 this.responseCallback(data, botname);
                 return data;
             } catch (err) {
@@ -144,7 +141,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 
             try {
                 const postContentCommand = new PostContentCommand(params);
-                const data = this.lexRuntimeServiceClient.send(postContentCommand);
+                const data = await this.lexRuntimeServiceClient.send(postContentCommand);
                 this.responseCallback(data, botname);
                 return data;
             } catch (err) {


### PR DESCRIPTION
Related to #3365

Description of changes:
This PR upgrades the aws-sdk v2 clients used in the Interactions category to aws-sdk V3 client. This helps achieve modularization at the AWS clients level in Interactions.

[Delivers #168789986]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
