### PR TITLE
fix: update .prettierignore ignore files in subdirs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,6 @@
-node_modules
-dist
-package.json
-yarn.lock
-package-lock.json
-.eslintrc.js
+**/node_modules
+**/dist
+**/package.json
+**/yarn.lock
+**/package-lock.json
+**/.eslintrc.js


### PR DESCRIPTION
Mostly opening this to test the changes Sam made to codecov but this can get merged afterward (since currently, Prettier tries to format those those files in subdirs and it shouldn't)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
