### PR TITLE
fix(#4001)

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1694,9 +1694,13 @@ export default class AuthClass {
 			const provider = providerOrOptions;
 			// To check if the user is already logged in
 			try {
-				const loggedInUser = await this.currentAuthenticatedUser();
-				logger.warn(`There is already a signed in user: ${loggedInUser} in your app.
-                You should not call Auth.federatedSignIn method again as it may cause unexpected behavior.`);
+				const loggedInUser = JSON.stringify(
+					JSON.parse(this._storage.getItem('aws-amplify-federatedInfo')).user
+				);
+				if (loggedInUser) {
+					logger.warn(`There is already a signed in user: ${loggedInUser} in your app.
+																	You should not call Auth.federatedSignIn method again as it may cause unexpected behavior.`);
+				}
 			} catch (e) {}
 
 			const { token, identity_id, expires_at } = response;


### PR DESCRIPTION
_Issue #, if available:_
#4001 

_Description of changes:_
Removes call to `currentAuthenticatedUser` in `federatedSignIn` function, and instead checks local storage directly in order to avoid logging of error from `currentAuthenticatedUser`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
