### PR TITLE
chore: Use await for async function Signer.sign in SumerianProvider

### DIFF
--- a/packages/xr/src/Providers/SumerianProvider.ts
+++ b/packages/xr/src/Providers/SumerianProvider.ts
@@ -141,7 +141,7 @@ export class SumerianProvider extends AbstractXRProvider {
 				region: sceneRegion,
 				service: SUMERIAN_SERVICE_NAME,
 			};
-			const request = Signer.sign(
+			const request = await Signer.sign(
 				{ method: 'GET', url: sceneUrl },
 				accessInfo,
 				serviceInfo


### PR DESCRIPTION
_Description of changes:_
* `Signer.sign` is an async function now, use `await` in the SumerianProvider.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
