### PR TITLE
Reverting custom message for InvalidParameterException on signUp

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -296,10 +296,6 @@ export default class AuthClass {
 				validationData,
 				(err, data) => {
 					if (err) {
-						if (err.code === 'InvalidParameterException') {
-							err.message =
-								'Username could not be created. Please make sure that the username you have entered is between 1 and 128 characters.';
-						}
 						dispatchAuthEvent(
 							'signUp_failure',
 							err,


### PR DESCRIPTION
_Issue #, if available:_
fixes: #4175
_Description of changes:_
Reverting back custom messages before refactor is in place
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
