### PR TITLE
clear federated info from storage at signOut

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1422,6 +1422,7 @@ export default class AuthClass {
 	public async signOut(opts?: SignOutOpts): Promise<any> {
 		try {
 			await this.cleanCachedItems();
+			this._storage.removeItem('aws-amplify-federatedInfo');
 		} catch (e) {
 			logger.debug('failed to clear cached items');
 		}


### PR DESCRIPTION
_Issue:_
Issue: #4210 

_Description of changes:_

clear the `aws-amplify-federatedInfo` key from storage upon signOut

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
