### PR TITLE
fix: sourcemaps for CSS, weird paths, /predictions

### DIFF
--- a/packages/amplify-ui/webpack.config.js
+++ b/packages/amplify-ui/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = {
 					{
 						loader: MiniCssExtractPlugin.loader,
 						options: {
+							sourceMap: true,
 							hmr: process.env.NODE_ENV === 'development',
 						},
 					},
@@ -48,10 +49,16 @@ module.exports = {
 						options: {
 							modules: true,
 							importLoaders: 1,
+							sourceMap: true,
 							localIdentName: '[name]__[local]___[hash:base64:5]',
 						},
 					},
-					'postcss-loader',
+					{
+						loader: 'postcss-loader',
+						options: {
+							sourceMap: true,
+						},
+					},
 				],
 			},
 		],

--- a/packages/aws-amplify-vue/babel.config.js
+++ b/packages/aws-amplify-vue/babel.config.js
@@ -1,3 +1,5 @@
 module.exports = {
 	presets: ['@vue/app'],
+	sourceMaps: true,
+	inputSourceMap: true,
 };

--- a/packages/aws-amplify-vue/vue.config.js
+++ b/packages/aws-amplify-vue/vue.config.js
@@ -23,4 +23,8 @@ module.exports = {
     */
 		extract: false,
 	},
+	configureWebpack: config => {
+		config.devtool = 'source-map';
+		config.output.devtoolModuleFilenameTemplate = require('../aws-amplify/webpack-utils').devtoolModuleFilenameTemplate;
+	},
 };

--- a/packages/aws-amplify/webpack-utils.js
+++ b/packages/aws-amplify/webpack-utils.js
@@ -40,6 +40,7 @@ const packageFolderMap = {
 	core: '@aws-amplify/core',
 	interactions: '@aws-amplify/interactions',
 	pubsub: '@aws-amplify/pubsub',
+	predictions: '@aws-amplify/predictions',
 	pushnotification: '@aws-amplify/pushnotification',
 	storage: '@aws-amplify/storage',
 	xr: '@aws-amplify/xr',
@@ -47,8 +48,7 @@ const packageFolderMap = {
 
 const folders = Object.keys(packageFolderMap);
 const nodeModules = '/node_modules/';
-const webpackPrefix = 'webpack:///';
-const webpackNodeModules = webpackPrefix + '.' + nodeModules;
+const webpackNodeModules = '~/';
 
 function devtoolModuleFilenameTemplate(info) {
 	const resource = info.resource;
@@ -59,8 +59,7 @@ function devtoolModuleFilenameTemplate(info) {
 		const after = start + nodeModules.length;
 		return webpackNodeModules + resource.substring(after);
 	} else if (resource.includes('../')) {
-		// handle relative paths to other packages in this monorepo by converting them into absolute
-		// paths pointing at node_modules
+		// handle relative paths to other packages in this monorepo
 		for (let i = 0; i < folders.length; i++) {
 			const folder = folders[i];
 			const relative = '../' + folder;
@@ -74,9 +73,22 @@ function devtoolModuleFilenameTemplate(info) {
 				);
 			}
 		}
+	} else if (resource.startsWith('./')) {
+		// The only time we get here is when there's a bug in the toolchain upstream from
+		// us that causes imported files (I've seen this only for CSS files and package.json)
+		// to have paths that are relative to the package root instead of being relative to
+		// the /dist or /lib output folder. Fix this by prefixing with an extra dot.
+		return '.' + resource;
 	}
-	// fall-through (e.g. relative paths in this package, webpack builtins, unknown package paths)
-	return webpackPrefix + resource;
+
+	// If we get here, the resource is one of these cases:
+	//   1) a relative path to a parent folder, e.g. '../src/foo.js'
+	//   2) a plain filename (no path), e.g. 'foo.min.js'
+	//   3) one of the invalid paths that webpack itself adds, e.g. 'webpack/universalModuleDefinition',
+	//      or 'webpack/bootstrap 21c2cca6cf7a65b395b7' (the space is actually included by webpack!)
+	//   4) node-only modules that are ignored on the browser, e.g. 'fs (ignored)'
+	// For all these cases, it's fine to just use the same input path. No transforms needed.
+	return resource;
 }
 
 module.exports = {


### PR DESCRIPTION
_Description of changes:_
 
This PR fixes a remaining handful of sourcemap issues remaining after my previous sourcemap-related PRs #3059 and #2680:
* CSS files in UI library - Currently, there's no source maps emitted for the CSS files in the amplify-ui package. This PR updates the amplify-ui package's webpack config to emit sourcemaps.
* CSS file paths - CSS files' sourcemap paths (both existing as well as the new ones added above) were invalid because they were relative to the package root, not to the /dist or /lib subdirectory where the sourcemap files were. This PR fixes these paths by prepending a `.` to these paths, e.g. `./src/foo.css` -> `../src/foo.css`
* Vue - enables source maps for the vue package via a `configureWebpack` setting in its config
* Weird webpath paths - Webpack emits some oddball paths like `webpack/universalModuleDefinition` or `webpack/bootstrap 21c2cca6cf7a65b395b7` or `fs (ignored)`. The logic in #3059 would pre-pend `webpack:///` to these paths which would trigger warnings in some sourcemap-consuming tools like https://github.com/Volune/source-map-loader/tree/fixes. This PR removes that prefix if a path is already a weird webpack path, which removes those warnings.
* relative URLs - The same code that fixes the "weird path" fix above also fixes a problem with #3059 where it would pre-pend `webpack:///` as a fall-through case, even when the path was already a valid relative URL and didn't need that prefix.  Also, according to @loganfsmyth (the most knowledgeable sourcemap expert I know), OSS library sourcemaps should always use relative URLs and should never use the webpack:/// prefix. Therefore, this PR removes that prefix.
* adds support for the new `predictions` library in this repo

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.