### PR TITLE
fixes #4226 Remove ts-ignore and add typings to AuthPiece components

### DIFF
--- a/packages/aws-amplify-react/src/Auth/AuthPiece.tsx
+++ b/packages/aws-amplify-react/src/Auth/AuthPiece.tsx
@@ -12,19 +12,16 @@
  */
 
 import * as React from 'react';
-import { ConsoleLogger as Logger, I18n } from '@aws-amplify/core';
-import Auth from '@aws-amplify/auth';
-import AmplifyTheme from '../Amplify-UI/Amplify-UI-Theme';
-import countryDialCodes from './common/country-dial-codes';
+import { I18n } from '@aws-amplify/core';
 import {
 	FormField,
 	Input,
 	InputLabel,
-	SelectInput,
 } from '../Amplify-UI/Amplify-UI-Components-React';
 import { UsernameAttributes } from './common/types';
 import { PhoneField } from './PhoneField';
 import { auth } from '../Amplify-UI/data-test-attributes';
+import AmplifyTheme from '../Amplify-UI/Amplify-UI-Theme';
 
 const labelMap = {
 	[UsernameAttributes.EMAIL]: 'Email',
@@ -201,15 +198,12 @@ export default class AuthPiece<
 	handleInputChange(evt) {
 		this.inputs = this.inputs || {};
 		const { name, value, type, checked } = evt.target;
-		// @ts-ignore
 		const check_type = ['radio', 'checkbox'].includes(type);
 		this.inputs[name] = check_type ? checked : value;
 		this.inputs['checkedValue'] = check_type ? value : null;
 	}
 
-	// @ts-ignore
 	render() {
-		// @ts-ignore
 		if (!this._validAuthStates.includes(this.props.authState)) {
 			this._isHidden = true;
 			this.inputs = {};
@@ -226,7 +220,7 @@ export default class AuthPiece<
 		return this.showComponent(this.props.theme || AmplifyTheme);
 	}
 
-	showComponent(theme) {
+	showComponent(_theme?: any): React.ReactNode {
 		throw 'You must implement showComponent(theme) and don\'t forget to set this._validAuthStates.';
 	}
 }

--- a/packages/aws-amplify-react/src/Auth/AuthStateWrapper.tsx
+++ b/packages/aws-amplify-react/src/Auth/AuthStateWrapper.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Component } from 'react';
 import Amplify, { ConsoleLogger as Logger } from '@aws-amplify/core';
 import Auth from '@aws-amplify/auth';
 
@@ -20,7 +19,7 @@ export interface IAuthStateWrapperState {
 	error?: any;
 }
 
-export default class AuthStateWrapper extends Component<
+export default class AuthStateWrapper extends React.Component<
 	IAuthStateWrapperProps,
 	IAuthStateWrapperState
 > {

--- a/packages/aws-amplify-react/src/Auth/Authenticator.tsx
+++ b/packages/aws-amplify-react/src/Auth/Authenticator.tsx
@@ -12,7 +12,6 @@
  */
 
 import * as React from 'react';
-import { Component } from 'react';
 import Amplify, { I18n, ConsoleLogger as Logger, Hub } from '@aws-amplify/core';
 import Auth from '@aws-amplify/auth';
 import Greetings from './Greetings';
@@ -61,7 +60,7 @@ export interface IAuthenticatorState {
 	showToast?: boolean;
 }
 
-export default class Authenticator extends Component<
+export default class Authenticator extends React.Component<
 	IAuthenticatorProps,
 	IAuthenticatorState
 > {
@@ -243,27 +242,17 @@ export default class Authenticator extends Component<
 
 		const default_children = [
 			<Greetings federated={federated} />,
-			// @ts-ignore
 			<SignIn federated={federated} />,
-			// @ts-ignore
 			<ConfirmSignIn />,
-			// @ts-ignore
 			<RequireNewPassword />,
-			// @ts-ignore
 			<SignUp signUpConfig={signUpConfig} />,
-			// @ts-ignore
 			<ConfirmSignUp />,
-			// @ts-ignore
 			<VerifyContact />,
-			// @ts-ignore
 			<ForgotPassword />,
-			// @ts-ignore
 			<TOTPSetup />,
-			// @ts-ignore
 			<Loading />,
 		];
 
-		// @ts-ignore
 		const props_children_override = React.Children.map(
 			props_children,
 			child => child.props.override
@@ -275,7 +264,6 @@ export default class Authenticator extends Component<
 		const render_props_children = React.Children.map(
 			props_children,
 			(child, index) => {
-				// @ts-ignore
 				return React.cloneElement(child, {
 					key: 'aws-amplify-authenticator-props-children-' + index,
 					theme,
@@ -294,7 +282,6 @@ export default class Authenticator extends Component<
 		const render_default_children = hideDefault
 			? []
 			: React.Children.map(default_children, (child, index) => {
-					// @ts-ignore
 					return React.cloneElement(child, {
 						key: 'aws-amplify-authenticator-default-children-' + index,
 						theme,

--- a/packages/aws-amplify-react/src/Auth/ConfirmSignIn.tsx
+++ b/packages/aws-amplify-react/src/Auth/ConfirmSignIn.tsx
@@ -13,7 +13,7 @@
 
 import * as React from 'react';
 
-import { I18n, ConsoleLogger as Logger, JS } from '@aws-amplify/core';
+import { I18n, JS } from '@aws-amplify/core';
 import Auth from '@aws-amplify/auth';
 
 import AuthPiece, { IAuthPieceProps, IAuthPieceState } from './AuthPiece';
@@ -32,8 +32,6 @@ import {
 } from '../Amplify-UI/Amplify-UI-Components-React';
 
 import { auth } from '../Amplify-UI/data-test-attributes';
-
-const logger = new Logger('ConfirmSignIn');
 
 export interface IConfirmSignInState extends IAuthPieceState {
 	mfaType: string;
@@ -101,7 +99,7 @@ export default class ConfirmSignIn extends AuthPiece<
 	}
 
 	showComponent(theme) {
-		const { hide, authData } = this.props;
+		const { hide } = this.props;
 		if (hide && hide.includes(ConfirmSignIn)) {
 			return null;
 		}

--- a/packages/aws-amplify-react/src/Auth/FederatedSignIn.tsx
+++ b/packages/aws-amplify-react/src/Auth/FederatedSignIn.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Component } from 'react';
 
 import { JS, I18n, ConsoleLogger as Logger } from '@aws-amplify/core';
 import Auth from '@aws-amplify/auth';
@@ -31,7 +30,10 @@ export interface IFederatedButtonsProps {
 	theme: any;
 }
 
-export class FederatedButtons extends Component<IFederatedButtonsProps, {}> {
+export class FederatedButtons extends React.Component<
+	IFederatedButtonsProps,
+	{}
+> {
 	google(google_client_id) {
 		if (!google_client_id) {
 			return null;
@@ -96,7 +98,6 @@ export class FederatedButtons extends Component<IFederatedButtonsProps, {}> {
 			return null;
 		}
 		const { theme, onStateChange } = this.props;
-		// @ts-ignore
 		return (
 			<Auth0Button
 				label={auth0 ? auth0.label : undefined}
@@ -109,7 +110,6 @@ export class FederatedButtons extends Component<IFederatedButtonsProps, {}> {
 
 	render() {
 		const { authState } = this.props;
-		// @ts-ignore
 		if (!['signIn', 'signedOut', 'signedUp'].includes(authState)) {
 			return null;
 		}
@@ -169,7 +169,7 @@ export class FederatedButtons extends Component<IFederatedButtonsProps, {}> {
 	}
 }
 
-export default class FederatedSignIn extends Component<any, any> {
+export default class FederatedSignIn extends React.Component<any, any> {
 	render() {
 		const { authState, onStateChange } = this.props;
 		const federated = this.props.federated || {};

--- a/packages/aws-amplify-react/src/Auth/ForgotPassword.tsx
+++ b/packages/aws-amplify-react/src/Auth/ForgotPassword.tsx
@@ -84,7 +84,6 @@ export default class ForgotPassword extends AuthPiece<
 		Auth.forgotPasswordSubmit(username, code, password)
 			.then(data => {
 				logger.debug(data);
-				// @ts-ignore
 				this.changeState('signIn');
 				this.setState({ delivery: null });
 			})

--- a/packages/aws-amplify-react/src/Auth/Greetings.tsx
+++ b/packages/aws-amplify-react/src/Auth/Greetings.tsx
@@ -20,19 +20,11 @@ import {
 	Nav,
 	NavRight,
 	NavItem,
-	NavButton,
 } from '../Amplify-UI/Amplify-UI-Components-React';
 import { auth } from '../Amplify-UI/data-test-attributes';
 import AmplifyTheme from '../Amplify-UI/Amplify-UI-Theme';
-import Constants from './common/constants';
 import SignOut from './SignOut';
-import {
-	withGoogle,
-	withAmazon,
-	withFacebook,
-	withOAuth,
-	withAuth0,
-} from './Provider';
+import { withGoogle, withAmazon, withFacebook, withAuth0 } from './Provider';
 import { UsernameAttributes } from './common/types';
 
 const logger = new Logger('Greetings');
@@ -89,7 +81,7 @@ export default class Greetings extends AuthPiece<
 
 	onHubCapsule(capsule) {
 		if (this._isMounted) {
-			const { channel, payload, source } = capsule;
+			const { channel, payload } = capsule;
 			if (channel === 'auth' && payload.event === 'signIn') {
 				this.setState({
 					authState: 'signedIn',
@@ -149,7 +141,6 @@ export default class Greetings extends AuthPiece<
 		}
 
 		const message = typeof greeting === 'function' ? greeting(name) : greeting;
-		const { federated } = this.props;
 
 		return (
 			<span>

--- a/packages/aws-amplify-react/src/Auth/Loading.tsx
+++ b/packages/aws-amplify-react/src/Auth/Loading.tsx
@@ -12,18 +12,15 @@
  */
 
 import * as React from 'react';
-import { I18n, ConsoleLogger as Logger } from '@aws-amplify/core';
+import { I18n } from '@aws-amplify/core';
 
 import AuthPiece, { IAuthPieceProps, IAuthPieceState } from './AuthPiece';
-import AmplifyTheme from '../AmplifyTheme';
 import {
 	FormSection,
 	SectionBody,
 } from '../Amplify-UI/Amplify-UI-Components-React';
 
 import { auth } from '../Amplify-UI/data-test-attributes';
-
-const logger = new Logger('Loading');
 
 export default class Loading extends AuthPiece<
 	IAuthPieceProps,

--- a/packages/aws-amplify-react/src/Auth/Provider/index.tsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/index.tsx
@@ -12,7 +12,6 @@
  */
 
 import * as React from 'react';
-import { Component } from 'react';
 
 import withGoogle from './withGoogle';
 import withFacebook from './withFacebook';
@@ -27,12 +26,11 @@ export { default as withOAuth, OAuthButton } from './withOAuth';
 export { default as withAuth0, Auth0Button } from './withAuth0';
 
 export function withFederated(Comp) {
-	// @ts-ignore
 	const Federated = withAuth0(
 		withOAuth(withAmazon(withGoogle(withFacebook(Comp))))
 	);
 
-	return class extends Component {
+	return class extends React.Component {
 		render() {
 			// @ts-ignore
 			const federated = this.props.federated || {};

--- a/packages/aws-amplify-react/src/Auth/Provider/withAmazon.tsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/withAmazon.tsx
@@ -12,7 +12,6 @@
  */
 
 import * as React from 'react';
-import { Component } from 'react';
 
 import { I18n, ConsoleLogger as Logger } from '@aws-amplify/core';
 import Auth from '@aws-amplify/auth';
@@ -28,7 +27,7 @@ import Constants from '../common/constants';
 const logger = new Logger('withAmazon');
 
 export default function withAmazon(Comp) {
-	return class extends Component<any, any> {
+	return class extends React.Component<any, any> {
 		constructor(props: any) {
 			super(props);
 

--- a/packages/aws-amplify-react/src/Auth/Provider/withAuth0.tsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/withAuth0.tsx
@@ -12,7 +12,6 @@
  */
 
 import * as React from 'react';
-import { Component } from 'react';
 
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import Auth from '@aws-amplify/auth';
@@ -28,8 +27,8 @@ import Constants from '../common/constants';
 
 const logger = new Logger('withAuth0');
 
-export default function withAuth0(Comp, options) {
-	return class extends Component<any, any> {
+export default function withAuth0(Comp, options?) {
+	return class extends React.Component<any, any> {
 		public _auth0;
 
 		constructor(props: any) {
@@ -62,7 +61,7 @@ export default function withAuth0(Comp, options) {
 			const { oauth = {} } = Auth.configure();
 			// @ts-ignore
 			const config = this.props.auth0 || options || oauth.auth0;
-			const { onError, onStateChange, authState, onAuthEvent } = this.props;
+			const { onError, onStateChange, authState } = this.props;
 			if (!config) {
 				logger.debug('Auth0 is not configured');
 				return;
@@ -117,7 +116,7 @@ export default function withAuth0(Comp, options) {
 							},
 							{ name: username, email }
 						)
-							.then(cred => {
+							.then(() => {
 								if (onStateChange) {
 									Auth.currentAuthenticatedUser().then(user => {
 										onStateChange('signedIn', user);
@@ -155,7 +154,7 @@ export default function withAuth0(Comp, options) {
 			});
 		}
 
-		render() {
+		render(): React.ReactNode {
 			return (
 				<Comp
 					{...this.props}
@@ -194,5 +193,4 @@ const Button = props => (
 	</SignInButton>
 );
 
-// @ts-ignore
 export const Auth0Button = withAuth0(Button);

--- a/packages/aws-amplify-react/src/Auth/Provider/withFacebook.tsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/withFacebook.tsx
@@ -12,7 +12,6 @@
  */
 
 import * as React from 'react';
-import { Component } from 'react';
 
 import { I18n, ConsoleLogger as Logger } from '@aws-amplify/core';
 import Auth from '@aws-amplify/auth';
@@ -28,7 +27,7 @@ import Constants from '../common/constants';
 const logger = new Logger('withFacebook');
 
 export default function withFacebook(Comp) {
-	return class extends Component<any, any> {
+	return class extends React.Component<any, any> {
 		constructor(props: any) {
 			super(props);
 

--- a/packages/aws-amplify-react/src/Auth/Provider/withGoogle.tsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/withGoogle.tsx
@@ -12,7 +12,6 @@
  */
 
 import * as React from 'react';
-import { Component } from 'react';
 
 import { I18n, ConsoleLogger as Logger } from '@aws-amplify/core';
 import Auth from '@aws-amplify/auth';
@@ -28,7 +27,7 @@ import Constants from '../common/constants';
 const logger = new Logger('withGoogle');
 
 export default function withGoogle(Comp) {
-	return class extends Component<any, any> {
+	return class extends React.Component<any, any> {
 		constructor(props: any) {
 			super(props);
 
@@ -150,7 +149,7 @@ export default function withGoogle(Comp) {
 			});
 		}
 
-		render() {
+		render(): React.ReactNode {
 			const ga =
 				window.gapi && window.gapi.auth2
 					? window.gapi.auth2.getAuthInstance()

--- a/packages/aws-amplify-react/src/Auth/Provider/withOAuth.tsx
+++ b/packages/aws-amplify-react/src/Auth/Provider/withOAuth.tsx
@@ -12,9 +12,8 @@
  */
 
 import * as React from 'react';
-import { Component } from 'react';
 
-import { I18n, ConsoleLogger as Logger } from '@aws-amplify/core';
+import { I18n } from '@aws-amplify/core';
 import Auth from '@aws-amplify/auth';
 import AmplifyTheme from '../../Amplify-UI/Amplify-UI-Theme';
 import { oAuthSignInButton } from '@aws-amplify/ui';
@@ -24,7 +23,7 @@ import {
 } from '../../Amplify-UI/Amplify-UI-Components-React';
 
 export default function withOAuth(Comp) {
-	return class extends Component<any, any> {
+	return class extends React.Component<any, any> {
 		constructor(props: any) {
 			super(props);
 			this.signIn = this.signIn.bind(this);

--- a/packages/aws-amplify-react/src/Auth/RequireNewPassword.tsx
+++ b/packages/aws-amplify-react/src/Auth/RequireNewPassword.tsx
@@ -17,7 +17,6 @@ import { I18n, JS, ConsoleLogger as Logger } from '@aws-amplify/core';
 import Auth from '@aws-amplify/auth';
 
 import AuthPiece, { IAuthPieceProps, IAuthPieceState } from './AuthPiece';
-import AmplifyTheme from '../AmplifyTheme';
 import {
 	FormSection,
 	SectionHeader,

--- a/packages/aws-amplify-react/src/Auth/SignUp.tsx
+++ b/packages/aws-amplify-react/src/Auth/SignUp.tsx
@@ -25,7 +25,6 @@ import {
 	FormField,
 	Input,
 	InputLabel,
-	SelectInput,
 	Button,
 	Link,
 	SectionFooterPrimaryContent,
@@ -38,10 +37,9 @@ import countryDialCodes from './common/country-dial-codes';
 import signUpWithUsernameFields, {
 	signUpWithEmailFields,
 	signUpWithPhoneNumberFields,
+	ISignUpField,
 } from './common/default-sign-up-fields';
 import { UsernameAttributes } from './common/types';
-import { ISignUpField } from './common/default-sign-up-fields';
-import { valid } from 'semver';
 import { PhoneField } from './PhoneField';
 
 const logger = new Logger('SignUp');
@@ -117,7 +115,6 @@ export default class SignUp extends AuthPiece<ISignUpProps, IAuthPieceState> {
 			this.props.signUpConfig.hiddenDefaults.length > 0
 		) {
 			this.defaultSignUpFields = this.defaultSignUpFields.filter(d => {
-				// @ts-ignore
 				return !this.props.signUpConfig.hiddenDefaults.includes(d.key);
 			});
 		}
@@ -128,7 +125,7 @@ export default class SignUp extends AuthPiece<ISignUpProps, IAuthPieceState> {
 				!this.props.signUpConfig.hideAllDefaults
 			) {
 				// see if fields passed to component should override defaults
-				this.defaultSignUpFields.forEach((f, i) => {
+				this.defaultSignUpFields.forEach(f => {
 					const matchKey = this.signUpFields.findIndex(d => {
 						return d.key === f.key;
 					});
@@ -189,10 +186,9 @@ export default class SignUp extends AuthPiece<ISignUpProps, IAuthPieceState> {
 	getDefaultDialCode() {
 		return this.props.signUpConfig &&
 			this.props.signUpConfig.defaultCountryCode &&
-			// @ts-ignore
 			countryDialCodes.indexOf(
 				`+${this.props.signUpConfig.defaultCountryCode}`
-			) !== '-1'
+			) !== -1
 			? `+${this.props.signUpConfig.defaultCountryCode}`
 			: '+1';
 	}
@@ -232,7 +228,6 @@ export default class SignUp extends AuthPiece<ISignUpProps, IAuthPieceState> {
 
 		inputKeys.forEach((key, index) => {
 			if (
-				// @ts-ignore
 				!['username', 'password', 'checkedValue', 'dial_code'].includes(key)
 			) {
 				if (
@@ -274,7 +269,7 @@ export default class SignUp extends AuthPiece<ISignUpProps, IAuthPieceState> {
 			.catch(err => this.error(err));
 	}
 
-	showComponent(theme) {
+	showComponent(theme): React.ReactNode {
 		const { hide } = this.props;
 		if (hide && hide.includes(SignUp)) {
 			return null;

--- a/packages/aws-amplify-react/src/Auth/index.tsx
+++ b/packages/aws-amplify-react/src/Auth/index.tsx
@@ -12,7 +12,6 @@
  */
 
 import * as React from 'react';
-import { Component } from 'react';
 
 import Authenticator from './Authenticator';
 
@@ -36,8 +35,6 @@ export { default as Loading } from './Loading';
 
 export * from './Provider';
 
-import Greetings from './Greetings';
-
 export function withAuthenticator(
 	Comp,
 	includeGreetings = false,
@@ -46,7 +43,7 @@ export function withAuthenticator(
 	theme = null,
 	signUpConfig = {}
 ) {
-	return class extends Component<any, any> {
+	return class extends React.Component<any, any> {
 		public authConfig: any;
 
 		constructor(props) {
@@ -128,7 +125,7 @@ export function withAuthenticator(
 	};
 }
 
-export class AuthenticatorWrapper extends Component {
+export class AuthenticatorWrapper extends React.Component {
 	constructor(props) {
 		super(props);
 


### PR DESCRIPTION
_Issue #, if available:_ #4226 

_Description of changes:_ In Auth category of aws-amplify-react package
* Remove ts-ignores
* Add typings to AuthPiece and components
* Cleanup imports
* Remove unused variables

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
