### PR TITLE
Allowing passing endpoint through to CognitoUserPool

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -147,7 +147,6 @@ export default class AuthClass {
 			userPoolWebClientId,
 			cookieStorage,
 			oauth,
-			endpoint,
 			region,
 			identityPoolId,
 			mandatorySignIn,
@@ -178,7 +177,7 @@ export default class AuthClass {
 			const userPoolData: ICognitoUserPoolData = {
 				UserPoolId: userPoolId,
 				ClientId: userPoolWebClientId,
-				endpoint: endpoint,
+				endpoint: this._config.endpoint,
 			};
 			userPoolData.Storage = this._storage;
 

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -147,6 +147,7 @@ export default class AuthClass {
 			userPoolWebClientId,
 			cookieStorage,
 			oauth,
+			endpoint,
 			region,
 			identityPoolId,
 			mandatorySignIn,
@@ -177,6 +178,7 @@ export default class AuthClass {
 			const userPoolData: ICognitoUserPoolData = {
 				UserPoolId: userPoolId,
 				ClientId: userPoolWebClientId,
+				endpoint: endpoint,
 			};
 			userPoolData.Storage = this._storage;
 


### PR DESCRIPTION
It is useful in our environment (for testing purposes) to direct the call to the cognito-idp endpoint to one that we control. When using `Amplify.configure({Auth: {...}})`, allow this endpoint to passed through to the CognitoUserPool instance created by the call to configure.

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
