### PR TITLE
fix: Use exact version of the @aws-sdk V3 packages

### DIFF
--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -33,8 +33,8 @@
   "dependencies": {
     "@aws-amplify/core": "^1.2.3",
     "@aws-amplify/storage": "^1.2.3",
-    "@aws-sdk/eventstream-marshaller": "^0.1.0-preview.2",
-    "@aws-sdk/util-utf8-node": "^0.1.0-preview.1",
+    "@aws-sdk/eventstream-marshaller": "0.1.0-preview.2",
+    "@aws-sdk/util-utf8-node": "0.1.0-preview.1",
     "uuid": "^3.2.1"
   },
   "jest": {


### PR DESCRIPTION
_Issue #, if available:_ NA

_Description of changes:_ We are using few aws-sdk packages that are part of their V3 release. Since V3 is not in GA yet and aws-sdk team is expecting changes in their packages, locking the package versions of such packages so we don't break by their new changes inadvertently.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
