### PR TITLE
fix(@aws-amplify/core): AWS.config.systemClockOffset for signing requ…

### DIFF
--- a/packages/core/__tests__/Signer-test.ts
+++ b/packages/core/__tests__/Signer-test.ts
@@ -1,5 +1,5 @@
 jest.mock('../src/Facet', () => {
-	let ret = { util: { crypto: { lib: {} } } };
+	let ret = { util: { crypto: { lib: {} }, date: {} } };
 	ret['util']['crypto']['lib']['createHmac'] = () => {
 		const update = () => {
 			return {
@@ -20,13 +20,15 @@ jest.mock('../src/Facet', () => {
 		};
 		return { update };
 	};
+	ret['util']['date']['getDate'] = () => new Date();
+
 	return {
 		AWS: ret,
 	};
 });
 
 import Signer from '../src/Signer';
-import AWS from '../src';
+import { AWS } from '../src/Facet';
 
 describe('Signer test', () => {
 	describe('sign test', () => {
@@ -45,6 +47,8 @@ describe('Signer test', () => {
 				.spyOn(Date.prototype, 'toISOString')
 				.mockReturnValueOnce('0');
 
+			const getDateSpy = jest.spyOn(AWS['util']['date'], 'getDate');
+
 			const res = {
 				headers: {
 					Authorization:
@@ -56,6 +60,7 @@ describe('Signer test', () => {
 				url: url,
 			};
 			expect(Signer.sign(request, access_info)).toEqual(res);
+			expect(getDateSpy).toHaveBeenCalledTimes(1);
 
 			spyon.mockClear();
 		});

--- a/packages/core/src/Signer.ts
+++ b/packages/core/src/Signer.ts
@@ -299,7 +299,7 @@ export default class Signer {
 		request.headers = request.headers || {};
 
 		// datetime string and date string
-		const dt = new Date(),
+		const dt = AWS['util']['date'].getDate(),
 			dt_str = dt.toISOString().replace(/[:\-]|\.\d{3}/g, ''),
 			d_str = dt_str.substr(0, 8);
 
@@ -370,7 +370,10 @@ export default class Signer {
 		const body: any =
 			typeof urlOrRequest === 'object' ? urlOrRequest.body : undefined;
 
-		const now = new Date().toISOString().replace(/[:\-]|\.\d{3}/g, '');
+		const now = AWS['util']['date']
+			.getDate()
+			.toISOString()
+			.replace(/[:\-]|\.\d{3}/g, '');
 		const today = now.substr(0, 8);
 		// Intentionally discarding search
 		const { search, ...parsedUrl } = url.parse(urlToSign, true, true);


### PR DESCRIPTION
…ests

_Issue #, if available:_
#2014  #3719 #3699

_Description of changes:_
Signer calls `AWS.util.date.getDate()` instead of `new Date()` - making it possible to correct the signature and headers for the correct date when the system time is wrong by:

```
import { AWS } from '@aws-amplify/core'
AWS.config = new AWS.Config({
    systemClockOffset: CLOCK_OFFSET
})
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
