### PR TITLE
fixes #4186 add type information in the map so typescript doesn't try…

### DIFF
--- a/packages/aws-amplify-react/src/Auth/AuthPiece.tsx
+++ b/packages/aws-amplify-react/src/Auth/AuthPiece.tsx
@@ -142,7 +142,9 @@ export default class AuthPiece<
 
 	getUsernameLabel() {
 		const { usernameAttributes = UsernameAttributes.USERNAME } = this.props;
-		return labelMap[usernameAttributes] || usernameAttributes;
+		return (
+			labelMap[usernameAttributes as UsernameAttributes] || usernameAttributes
+		);
 	}
 
 	// extract username from authData


### PR DESCRIPTION
… to auto generate bad type

_Issue #, if available:_ #4186

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
