### PR TITLE
fixes #4259 revert back to use commonJs modules for react native

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -20,8 +20,8 @@
     "lint": "tslint 'src/**/*.ts'"
   },
   "react-native": {
-    "./index": "./lib-esm/index.js",
-    "./lib-esm/trackers": "./lib-esm/trackers/reactnative.js"
+    "./index": "./lib/index.js",
+    "./lib/trackers": "./lib/trackers/reactnative.js"
   },
   "repository": {
     "type": "git",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,7 +6,7 @@
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
   "react-native": {
-    "./index": "./lib-esm/index.js"
+    "./index": "./lib/index.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -6,7 +6,7 @@
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
   "react-native": {
-    "./index": "./lib-esm/index.js"
+    "./index": "./lib/index.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -6,7 +6,7 @@
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
   "react-native": {
-    "./index": "./lib-esm/index.js"
+    "./index": "./lib/index.js"
   },
   "scripts": {
     "test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2",

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -5,6 +5,9 @@
   "main": "./index.js",
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
+  "react-native": {
+    "./index": "./lib/index.js"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -6,7 +6,7 @@
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
   "react-native": {
-    "./index": "./lib-esm/index.js"
+    "./index": "./lib/index.js"
   },
   "scripts": {
     "test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2",

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -6,7 +6,7 @@
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
   "react-native": {
-    "./index": "./lib-esm/index.js"
+    "./index": "./lib/index.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -6,7 +6,7 @@
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
   "react-native": {
-    "./index": "./lib-esm/index.js"
+    "./index": "./lib/index.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -6,7 +6,7 @@
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
   "react-native": {
-    "./index": "./lib-esm/index.js"
+    "./index": "./lib/index.js"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
_Issue #, if available:_#4259 
fixes #4261 
_Description of changes:_
React native has issues with the ES modules where we are using wildcard imports from aws-sdk instead of using the default import (which is a class and has constructors we use). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
