### PR TITLE
chore: use npxinfo to simplify bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,14 +29,14 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 <details>
-  <summary><strong>Environment></strong>
+  <summary><strong>Environment></strong></summary>
 
 <!-- Please run the following command inside your project and copy/paste the output into the codeblock: -->
 ```
-npx envinfo --system --binaries --npmPackages @angular/core,react,react-dom,react-native,vue,aws-amplify,aws-amplilfy-angular,aws-amplify-react,aws-amplify-vue,aws-amplify-react-native,@aws-amplify/cli --markdown
+npx envinfo --system --binaries --browsers --npmPackages --npmGlobalPackages
 ```
 
-</summary>
+</details>
 
 
 **Smartphone (please complete the following information):**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 <details>
-  <summary><strong>Environment></strong></summary>
+  <summary><strong>Environment</strong></summary>
 
 <!-- Please run the following command inside your project and copy/paste the output into the codeblock: -->
 ```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,13 +28,16 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Environment**:
+<details>
+  <summary><strong>Environment></strong>
 
-<!--
-  Please run the following command inside your project and copy/paste its contents here:
+<!-- Please run the following command inside your project and copy/paste the output into the codeblock: -->
+```
+npx envinfo --system --binaries --npmPackages @angular/core,react,react-dom,react-native,vue,aws-amplify,aws-amplilfy-angular,aws-amplify-react,aws-amplify-vue,aws-amplify-react-native,@aws-amplify/cli --markdown
+```
 
-  npx envinfo --system --binaries --npmPackages @angular/core,react,react-dom,react-native,vue,aws-amplify,aws-amplilfy-angular,aws-amplify-react,aws-amplify-vue,aws-amplify-react-native,@aws-amplify/cli --markdown
--->
+</summary>
+
 
 **Smartphone (please complete the following information):**
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,11 +28,13 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+**Environment**:
 
-- OS: [e.g. iOS]
-- Browser [e.g. chrome, safari]
-- Version [e.g. 22]
+<!--
+  Please run the following command inside your project and copy/paste its contents here:
+
+  npx envinfo --system --binaries --npmPackages @angular/core,react,react-dom,react-native,vue,aws-amplify,aws-amplilfy-angular,aws-amplify-react,aws-amplify-vue,aws-amplify-react-native,@aws-amplify/cli --markdown
+-->
 
 **Smartphone (please complete the following information):**
 
@@ -40,10 +42,6 @@ If applicable, add screenshots to help explain your problem.
 - OS: [e.g. iOS8.1]
 - Browser [e.g. stock browser, safari]
 - Version [e.g. 22]
-
-**Amplify context**
-- Framework (e.g. React, Angular, Vue, React Native)
-- Versions of Amplify you are using
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: to-be-triaged
 assignees: ''
 
 ---


### PR DESCRIPTION
Projects like [styled-components](https://github.com/styled-components/styled-components/issues/new) leverage [envinfo](https://github.com/tabrindle/envinfo) to simplify getting environment/dependency data for reproducing bugs.

Ideally, I would like to see this handled via `amplify --info` or part of `amplify status`, similar to [`npx create-react-app --info`](https://github.com/facebook/create-react-app/blob/master/packages/create-react-app/createReactApp.js#L157-L174), which allows for greater control for us & a simpler command for users:

<details>
<summary><code>npx create-react-app --info</code></summary>

```
Environment Info:

  System:
    OS: macOS 10.14.6
    CPU: (4) x64 Intel(R) Core(TM) i7-7660U CPU @ 2.50GHz
  Binaries:
    Node: 12.12.0 - /usr/local/bin/node
    Yarn: 1.19.1 - /usr/local/bin/yarn
    npm: 6.11.3 - /usr/local/bin/npm
  Browsers:
    Chrome: 78.0.3904.70
    Firefox: 68.2.0
    Safari: 13.0.2
  npmPackages:
    react: Not Found
    react-dom: Not Found
    react-scripts: Not Found
  npmGlobalPackages:
    create-react-app: Not Found
```
</details>

In the meantime, our bug reports will end up having:

<details>
<summary>
 Environment
</summary>

```
  System:
    OS: macOS Mojave 10.14.6
    CPU: (4) x64 Intel(R) Core(TM) i7-7660U CPU @ 2.50GHz
    Memory: 880.84 MB / 16.00 GB
    Shell: 3.0.2 - /usr/local/bin/fish
  Binaries:
    Node: 12.12.0 - /usr/local/bin/node
    Yarn: 1.19.1 - /usr/local/bin/yarn
    npm: 6.11.3 - /usr/local/bin/npm
  Browsers:
    Chrome: 78.0.3904.70
    Firefox: 68.2.0
    Safari: 13.0.2
  npmPackages:
    @angular-devkit/build-angular: ~0.13.0 => 0.13.9
    @angular/animations: ~7.2.0 => 7.2.15
    @angular/cli: ~7.3.8 => 7.3.9
    @angular/common: ~7.2.0 => 7.2.15
    @angular/compiler: ~7.2.0 => 7.2.15
    @angular/compiler-cli: ~7.2.0 => 7.2.15
    @angular/core: ^7.2.14 => 7.2.15
    @angular/forms: ~7.2.0 => 7.2.15
    @angular/language-service: ~7.2.0 => 7.2.15
    @angular/platform-browser: ~7.2.0 => 7.2.15
    @angular/platform-browser-dynamic: ~7.2.0 => 7.2.15
    @angular/router: ~7.2.0 => 7.2.15
    @types/jasmine: ~2.8.8 => 2.8.16
    @types/jasminewd2: ~2.0.3 => 2.0.6
    @types/node: ~8.9.4 => 8.9.5
    aws-amplify: unstable => 1.1.38-unstable.0+057c8131
    aws-amplify-angular: unstable => 3.0.14-unstable.1+072694f6
    codelyzer: ~4.5.0 => 4.5.0
    core-js: ^2.5.4 => 2.6.9
    jasmine-core: ~2.99.1 => 2.99.1
    jasmine-spec-reporter: ~4.2.1 => 4.2.1
    karma: ~4.0.0 => 4.0.1
    karma-chrome-launcher: ~2.2.0 => 2.2.0
    karma-coverage-istanbul-reporter: ~2.0.1 => 2.0.6
    karma-jasmine: ~1.1.2 => 1.1.2
    karma-jasmine-html-reporter: ^0.2.2 => 0.2.2
    protractor: ~5.4.0 => 5.4.2
    rxjs: ^6.5.1 => 6.5.3
    ts-node: ~7.0.0 => 7.0.1
    tslib: ^1.9.0 => 1.10.0
    tslint: ~5.11.0 => 5.11.0
    typescript: ~3.2.2 => 3.2.4
    zone.js: ~0.8.26 => 0.8.29
  npmGlobalPackages:
    npm: 6.11.3
```

</details>

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
