### PR TITLE
fix(@aws-amplify/auth): NotAuthorizedException

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1086,7 +1086,8 @@ export default class AuthClass {
 										// Make sure the user is still valid
 										if (
 											err.message === 'User is disabled' ||
-											err.message === 'User does not exist.'
+											err.message === 'User does not exist.' ||
+											err.message === 'Access Token has been revoked' // Session revoked by another app
 										) {
 											rej(err);
 										} else {


### PR DESCRIPTION
reject if NotAuthorizedException was thrown caused by session revoking by another SSO app.

_Issue #, if available:_
#3594 

_Description of changes:_
Add NotAuthorizedException catcher caused by SSO logout.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
