### PR TITLE
[Fix] Handle form input on Android-Web

### DIFF
--- a/packages/aws-amplify-vue/src/components/authenticator/PhoneField.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/PhoneField.vue
@@ -31,6 +31,7 @@
             :placeholder="$Amplify.I18n.get(getPlaceholder)"
             autofocus 
             v-on:keyup="emitPhoneNumberChanged" 
+            v-on:input="local_phone_number = $event.target.value"
             v-bind:data-test="auth.genericAttrs.phoneNumberInput"
         />
     </div>

--- a/packages/aws-amplify-vue/src/components/authenticator/UsernameField.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/UsernameField.vue
@@ -21,6 +21,7 @@
                 :placeholder="$Amplify.I18n.get(`Enter your ${getUsernameLabel()}`)" 
                 autofocus 
                 v-on:keyup="usernameChanged" 
+                v-on:input="username = $event.target.value"
                 v-bind:data-test="auth.genericAttrs.usernameInput"
             />
         </div>
@@ -32,6 +33,7 @@
                 :placeholder="$Amplify.I18n.get('Enter your email')" 
                 autofocus 
                 v-on:keyup="emailChanged" 
+                v-on:input="email = $event.target.value"
                 v-bind:data-test="auth.genericAttrs.emailInput"
             />
         </div>


### PR DESCRIPTION
Addresses issue #3598 

_Description of changes:_
On Android-Web, `v-model` is not updated with keyboards using IME, unless a space is typed as described in https://github.com/vuejs/vue/issues/8231 and https://github.com/vuejs/vue/issues/8723
Which leads to `this.signInUsername` to stay empty in `components/authenticator/SignIn.vue` 

Adding `v-on:input` as suggested by https://github.com/vuejs/vue/issues/8231#issuecomment-416585972 fixes the issue for Android-Web without any impact on Desktop.

Tested on Chrome-Android and Chrome Desktop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
