### PR TITLE
 fixes #4305 check type of navigator to be undefined

### DIFF
--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -42,7 +42,9 @@ const RETRYABLE_CODES = [429, 500];
 const ACCEPTED_CODES = [202];
 const MOBILE_SERVICE_NAME = 'mobiletargeting';
 const BEACON_SUPPORTED =
-	navigator && typeof navigator.sendBeacon === 'function';
+	typeof navigator !== 'undefined' &&
+	navigator &&
+	typeof navigator.sendBeacon === 'function';
 
 // events buffer
 const BUFFER_SIZE = 1000;


### PR DESCRIPTION
 fixes #4305 check type of `navigator` to be `undefined` instead of only checking the value `undefined` since the variable `navigator` is not in scope.

_Issue #, if available:_ #4305

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
