### PR TITLE
fixes #4309 add react native overrides for cache and core package

### DIFF
--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -6,7 +6,7 @@
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
   "react-native": {
-    "./lib/index.js": "./lib/reactnative.js"
+    "./index": "./lib/reactnative.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "lint": "tslint 'src/**/*.ts'"
   },
   "react-native": {
+    "./index": "./lib/index.js",
     "./lib/ClientDevice": "./lib/ClientDevice/reactnative.js",
     "./lib/RNComponents": "./lib/RNComponents/reactnative.js",
     "./lib/StorageHelper": "./lib/StorageHelper/reactnative.js"


### PR DESCRIPTION
_Issue #, if available:_ #4309

_Description of changes:_add react native overrides for cache and core package as index.js now points to a bundle in dist folder and not to modules.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
