### PR TITLE
chore:Prettier 1.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"jest": "^24.x.x",
 		"json-loader": "^0.5.7",
 		"lerna": "^3.13.1",
+		"prettier": "^1.19.0",
 		"pretty-quick": "^1.11.1",
 		"rimraf": "^2.6.2",
 		"rollup": "^0.67.4",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,9 +31,7 @@
     "url": "https://github.com/aws/aws-amplify/issues"
   },
   "homepage": "https://aws-amplify.github.io/",
-  "devDependencies": {
-    "prettier": "^1.7.4"
-  },
+  "devDependencies": {},
   "dependencies": {
     "@aws-amplify/auth": "^1.5.0",
     "@aws-amplify/cache": "^1.1.4",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,7 +31,6 @@
     "url": "https://github.com/aws/aws-amplify/issues"
   },
   "homepage": "https://aws-amplify.github.io/",
-  "devDependencies": {},
   "dependencies": {
     "@aws-amplify/auth": "^1.5.0",
     "@aws-amplify/cache": "^1.1.4",

--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -418,7 +418,7 @@ export default class APIClass {
 			},
 		};
 
-		const endpoint = customGraphqlEndpoint || appSyncGraphqlEndpoint;
+		const endpoint = customGraphqlEndpoint ?? appSyncGraphqlEndpoint;
 
 		if (!endpoint) {
 			const error = new GraphQLError('No graphql endpoint provided.');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,8 +36,7 @@
   "homepage": "https://aws-amplify.github.io/",
   "devDependencies": {
     "find": "^0.2.7",
-    "prepend-file": "^1.3.1",
-    "prettier": "^1.7.4"
+    "prepend-file": "^1.3.1"
   },
   "dependencies": {
     "aws-sdk": "2.518.0",


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Upgrade to prettier 1.19.0 so we can start using TypeScript 3.7 features without prettier complaining.

Tested with a small usage of `??` and verifying that the pre-commit hook handled it fine

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
