### PR TITLE
chore: (aws-amplify@2.0.0) Moving AWS Amplify JS to 2.0.0

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/analytics",
-  "version": "1.3.4",
+  "version": "2.0.0",
   "description": "Analytics category of aws-amplify",
   "main": "./index.js",
   "module": "./lib-esm/index.js",
@@ -36,8 +36,8 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/cache": "^1.1.4",
-    "@aws-amplify/core": "^1.2.4",
+    "@aws-amplify/cache": "^2.0.0",
+    "@aws-amplify/core": "^2.0.0",
     "uuid": "^3.2.1"
   },
   "jest": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/api",
-  "version": "1.2.4",
+  "version": "2.0.0",
   "description": "Api category of aws-amplify",
   "main": "./index.js",
   "module": "./lib-esm/index.js",
@@ -34,9 +34,9 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/auth": "^1.5.0",
-    "@aws-amplify/cache": "^1.1.4",
-    "@aws-amplify/core": "^1.2.4",
+    "@aws-amplify/auth": "^2.0.0",
+    "@aws-amplify/cache": "^2.0.0",
+    "@aws-amplify/core": "^2.0.0",
     "@types/zen-observable": "^0.5.3",
     "axios": "^0.19.0",
     "graphql": "14.0.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/auth",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "Auth category of aws-amplify",
   "main": "./index.js",
   "module": "./lib-esm/index.js",
@@ -34,8 +34,8 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/cache": "^1.1.4",
-    "@aws-amplify/core": "^1.2.4",
+    "@aws-amplify/cache": "^2.0.0",
+    "@aws-amplify/core": "^2.0.0",
     "amazon-cognito-identity-js": "^3.2.0",
     "crypto-js": "^3.1.9-1"
   },

--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify-angular",
-  "version": "3.1.4",
+  "version": "4.0.0",
   "description": "AWS Amplify Angular Components",
   "main": "bundles/aws-amplify-angular.umd.js",
   "module": "dist/index.js",
@@ -39,7 +39,7 @@
     "@types/zen-observable": "^0.5.3",
     "angular2-template-loader": "^0.6.2",
     "awesome-typescript-loader": "^4.0.1",
-    "aws-amplify": "^1.2.4",
+    "aws-amplify": "^2.0.0",
     "babel-core": "^6.26.3",
     "babel-plugin-lodash": "^3.3.4",
     "babel-preset-env": "^1.7.0",

--- a/packages/aws-amplify-react-native/package.json
+++ b/packages/aws-amplify-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify-react-native",
-  "version": "2.2.3",
+  "version": "3.0.0",
   "description": "AWS Amplify is a JavaScript library for Frontend and mobile developers building cloud-enabled applications.",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/aws-amplify-react/package.json
+++ b/packages/aws-amplify-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify-react",
-  "version": "2.5.4",
+  "version": "3.0.0",
   "description": "AWS Amplify is a JavaScript library for Frontend and mobile developers building cloud-enabled applications.",
   "main": "./index.js",
   "module": "./lib-esm/index.js",
@@ -25,7 +25,7 @@
     "@types/enzyme-adapter-react-16": "^1.0.3",
     "@types/react": "^16.0.41",
     "@types/react-dom": "^16.0.11",
-    "aws-amplify": "^1.2.4",
+    "aws-amplify": "^2.0.0",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.0.3",
     "enzyme-to-json": "^3.2.1",

--- a/packages/aws-amplify-vue/package.json
+++ b/packages/aws-amplify-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify-vue",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "private": false,
   "author": "Amazon Web Services",

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify",
-  "version": "1.2.4",
+  "version": "2.0.0",
   "description": "AWS Amplify is a JavaScript library for Frontend and mobile developers building cloud-enabled applications.",
   "main": "./index.js",
   "module": "./lib-esm/index.js",
@@ -33,16 +33,16 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/analytics": "^1.3.4",
-    "@aws-amplify/api": "^1.2.4",
-    "@aws-amplify/auth": "^1.5.0",
-    "@aws-amplify/cache": "^1.1.4",
-    "@aws-amplify/core": "^1.2.4",
-    "@aws-amplify/interactions": "^1.1.4",
-    "@aws-amplify/predictions": "^1.1.4",
-    "@aws-amplify/pubsub": "^1.2.4",
-    "@aws-amplify/storage": "^1.2.4",
+    "@aws-amplify/analytics": "^2.0.0",
+    "@aws-amplify/api": "^2.0.0",
+    "@aws-amplify/auth": "^2.0.0",
+    "@aws-amplify/cache": "^2.0.0",
+    "@aws-amplify/core": "^2.0.0",
+    "@aws-amplify/interactions": "^2.0.0",
+    "@aws-amplify/predictions": "^2.0.0",
+    "@aws-amplify/pubsub": "^2.0.0",
+    "@aws-amplify/storage": "^2.0.0",
     "@aws-amplify/ui": "^1.1.3",
-    "@aws-amplify/xr": "^0.2.4"
+    "@aws-amplify/xr": "^1.0.0"
   }
 }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/cache",
-  "version": "1.1.4",
+  "version": "2.0.0",
   "description": "Cache category of aws-amplify",
   "main": "./index.js",
   "module": "./lib-esm/index.js",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/core": "^1.2.4"
+    "@aws-amplify/core": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/core",
-  "version": "1.2.4",
+  "version": "2.0.0",
   "description": "Core category of aws-amplify",
   "main": "./index.js",
   "module": "./lib-esm/index.js",

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/interactions",
-  "version": "1.1.4",
+  "version": "2.0.0",
   "description": "Interactions category of aws-amplify",
   "main": "./index.js",
   "module": "./lib-esm/index.js",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/core": "^1.2.4"
+    "@aws-amplify/core": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/predictions",
-  "version": "1.1.4",
+  "version": "2.0.0",
   "description": "Machine learning category of aws-amplify",
   "main": "./index.js",
   "module": "./lib-esm/index.js",
@@ -33,8 +33,8 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/core": "^1.2.4",
-    "@aws-amplify/storage": "^1.2.4",
+    "@aws-amplify/core": "^2.0.0",
+    "@aws-amplify/storage": "^2.0.0",
     "@aws-sdk/eventstream-marshaller": "0.1.0-preview.2",
     "@aws-sdk/util-utf8-node": "0.1.0-preview.1",
     "uuid": "^3.2.1"

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/pubsub",
-  "version": "1.2.4",
+  "version": "2.0.0",
   "description": "Pubsub category of aws-amplify",
   "main": "./index.js",
   "module": "./lib-esm/index.js",
@@ -37,9 +37,9 @@
     "cpx": "^1.5.0"
   },
   "dependencies": {
-    "@aws-amplify/auth": "^1.5.0",
-    "@aws-amplify/cache": "^1.1.4",
-    "@aws-amplify/core": "^1.2.4",
+    "@aws-amplify/auth": "^2.0.0",
+    "@aws-amplify/cache": "^2.0.0",
+    "@aws-amplify/core": "^2.0.0",
     "@types/zen-observable": "^0.5.3",
     "graphql": "14.0.0",
     "paho-mqtt": "^1.1.0",

--- a/packages/pushnotification/package.json
+++ b/packages/pushnotification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/pushnotification",
-  "version": "1.1.4",
+  "version": "2.0.0",
   "description": "Push notifications category of aws-amplify",
   "main": "./lib/index.js",
   "module": "./lib/index.js",
@@ -48,7 +48,7 @@
     "webpack": "^3.5.5"
   },
   "dependencies": {
-    "@aws-amplify/core": "^1.2.4"
+    "@aws-amplify/core": "^2.0.0"
   },
   "peerdependencies": {
     "react-native": "^0.55.0"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/storage",
-  "version": "1.2.4",
+  "version": "2.0.0",
   "description": "Storage category of aws-amplify",
   "main": "./index.js",
   "module": "./lib-esm/index.js",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/core": "^1.2.4"
+    "@aws-amplify/core": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-amplify/xr",
-  "version": "0.2.4",
+  "version": "1.0.0",
   "description": "XR category of aws-amplify",
   "main": "./index.js",
   "module": "./lib-esm/index.js",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/core": "^1.2.4"
+    "@aws-amplify/core": "^2.0.0"
   },
   "jest": {
     "globals": {


### PR DESCRIPTION
_Description of changes:_
Moving packages to 2.0.0 as follows:
 - @aws-amplify/analytics@2.0.0
 - @aws-amplify/api@2.0.0
 - @aws-amplify/auth@2.0.0
 - aws-amplify-angular@4.0.0
 - aws-amplify-react-native@3.0.0
 - aws-amplify-react@3.0.0
 - aws-amplify-vue@1.0.0
 - aws-amplify@2.0.0
 - @aws-amplify/cache@2.0.0
 - @aws-amplify/core@2.0.0
 - @aws-amplify/interactions@2.0.0
 - @aws-amplify/predictions@2.0.0
 - @aws-amplify/pubsub@2.0.0
 - @aws-amplify/pushnotification@2.0.0
 - @aws-amplify/storage@2.0.0
 - @aws-amplify/xr@1.0.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
