### PR TITLE
Adding support for push notifications in iOS for React Native 0.60+(#…

### DIFF
--- a/packages/pushnotification/package.json
+++ b/packages/pushnotification/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "devDependencies": {
+    "@react-native-community/push-notification-ios": "^1.0.2",
     "@types/jest": "^20.0.8",
     "@types/node": "^8.10.15",
     "awesome-typescript-loader": "^3.2.2",
@@ -51,7 +52,8 @@
     "@aws-amplify/core": "^1.2.2"
   },
   "peerdependencies": {
-    "react-native": "^0.55.0"
+    "react-native": "^0.55.0",
+    "@react-native-community/push-notification-ios": "^1.0.2"
   },
   "jest": {
     "transform": {

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -15,10 +15,10 @@ import {
 	NativeModules,
 	DeviceEventEmitter,
 	AsyncStorage,
-	PushNotificationIOS,
 	Platform,
 	AppState,
 } from 'react-native';
+import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import Amplify, { ConsoleLogger as Logger } from '@aws-amplify/core';
 
 const logger = new Logger('Notification');


### PR DESCRIPTION
…4215)

_Issue #:_
#3995
#4089

_Description of changes:_
Adding support for push notifications in iOS for React Native 0.60+

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
