### PR TITLE
Fix for negative BigIntegers (toString())

### DIFF
--- a/packages/amazon-cognito-identity-js/src/BigInteger.js
+++ b/packages/amazon-cognito-identity-js/src/BigInteger.js
@@ -219,7 +219,7 @@ function bnpClamp() {
 
 // (public) return string representation in given radix
 function bnToString(b) {
-	if (this.s < 0) return '-' + this.negate().toString();
+	if (this.s < 0) return '-' + this.negate().toString(b);
 	var k;
 	if (b == 16) k = 4;
 	else if (b == 8) k = 3;


### PR DESCRIPTION
Without this fix, a negative bigint will always end up throwing `new Error('Only radix 2, 4, 8, 16, 32 are supported')` because b is undefined.  This same fix is present in the original code from which this file was derived: http://www-cs-students.stanford.edu/~tjw/jsbn/jsbn.js

_Issue #, if available:_
None, trivial change.

_Description of changes:_
The first line of `bnToString` calls toString() with no radix parameter, when the number is negative.  The toString function is set equal to bnToString, which requires a radix parameter.  This fix adds the radix parameter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
