### PR TITLE
fix(@aws-amplify/amazon-cognito-identity): Add missing required param to string conversion fn for negative big integers

### DIFF
--- a/packages/amazon-cognito-identity-js/src/BigInteger.js
+++ b/packages/amazon-cognito-identity-js/src/BigInteger.js
@@ -219,7 +219,7 @@ function bnpClamp() {
 
 // (public) return string representation in given radix
 function bnToString(b) {
-	if (this.s < 0) return '-' + this.negate().toString();
+	if (this.s < 0) return '-' + this.negate().toString(b);
 	var k;
 	if (b == 16) k = 4;
 	else if (b == 8) k = 3;


### PR DESCRIPTION
The bnToString() function throws an exception when called without a radix value or given a radix outside of [2, 4, 8, 16, 32]. 

When bnToString() is called on a negative big int value, it's negated value is used to call bnToString() which then gets concatenated to a '-'. However, in the bnToString() call for the negated value, no radix value is passed in so it always throws an exception. 

This change will use the radix value argument from the initial bnToString() call on the negative big integer value when calling bnToString() for it's negated value so that it works as intended.

_Issue #, if available:_

_Description of changes:_
BigInteger.bnToString() throws errors on negative values. Include the radix param when calling bnToString() recursively for negative big ints.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
