### PR TITLE
Fix angular integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,7 @@ jobs:
             yarn
             yarn link aws-amplify
             yarn link aws-amplify-angular
+            yarn link @aws-amplify/analytics
       - run:
           name: 'Start Angular Authenticator Sample server in background'
           command: |

--- a/packages/analytics/webpack.config.js
+++ b/packages/analytics/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
 		'@aws-amplify/core',
 		'aws-sdk/clients/pinpoint',
 		'aws-sdk/clients/kinesis',
+		'aws-sdk/clients/firehose',
 	],
 	output: {
 		filename: '[name].js',


### PR DESCRIPTION
After adding a module to Analytics, the Angular Auth integ test is failing due to a linking issue with the analytics package (related to adding a new exported module, AWSKinesisFirehoseProvider)

See: https://circleci.com/gh/aws-amplify/amplify-js/9432

Manually linking @aws-amplify/analytics should allow this test to run successfully. A better long-term solution will need to be implemented to prevent this from happening with future module additions.

Also: adding aws-sdk/clients/firehose to `externals` in the webpack config to exclude it from the output bundle.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
