### PR TITLE
fix: Downgrade TS to ~3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"tslint": "^5.7.0",
 		"tslint-config-airbnb": "^5.8.0",
 		"typedoc": "^0.11.0",
-		"typescript": "^3.7.2",
+		"typescript": "~3.6.4",
 		"uglifyjs-webpack-plugin": "^0.4.6",
 		"webpack": "^4.32.0",
 		"webpack-bundle-analyzer": "^3.3.2",

--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -420,7 +420,7 @@ export default class APIClass {
 			},
 		};
 
-		const endpoint = customGraphqlEndpoint ?? appSyncGraphqlEndpoint;
+		const endpoint = customGraphqlEndpoint || appSyncGraphqlEndpoint;
 
 		if (!endpoint) {
 			const error = new GraphQLError('No graphql endpoint provided.');


### PR DESCRIPTION
_Issue #, if available:_
Fixes: https://github.com/aws-amplify/amplify-js/issues/4389

_Description of changes:_
TypeScript 3.7 introduced a feature change to declaration files which broke support with Angular versions supported by AmplifyJS. 

Downgrading the version to `~3.6.4` thereby floating the patch version but pinning the major and minor version to 3.6.

Reverting change to `packages/api/src/API.ts` that utilized nullish coalescing operator `??`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
