### PR TITLE
Adding support for push notifications in iOS for React Native 0.60+

### DIFF
--- a/packages/pushnotification/package.json
+++ b/packages/pushnotification/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "devDependencies": {
+    "@react-native-community/push-notification-ios": "^1.0.2",
     "@types/jest": "^20.0.8",
     "@types/node": "^8.10.15",
     "awesome-typescript-loader": "^3.2.2",
@@ -51,7 +52,8 @@
     "@aws-amplify/core": "^2.1.0"
   },
   "peerdependencies": {
-    "react-native": "^0.55.0"
+    "react-native": "^0.55.0",
+    "@react-native-community/push-notification-ios": "^1.0.2"
   },
   "jest": {
     "transform": {

--- a/packages/pushnotification/package.json
+++ b/packages/pushnotification/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "devDependencies": {
-    "@react-native-community/push-notification-ios": "^1.0.2",
     "@types/jest": "^20.0.8",
     "@types/node": "^8.10.15",
     "awesome-typescript-loader": "^3.2.2",
@@ -49,11 +48,11 @@
     "webpack": "^3.5.5"
   },
   "dependencies": {
-    "@aws-amplify/core": "^2.1.0"
+    "@aws-amplify/core": "^2.1.0",
+    "@react-native-community/push-notification-ios": "^1.0.2"
   },
   "peerdependencies": {
-    "react-native": "^0.55.0",
-    "@react-native-community/push-notification-ios": "^1.0.2"
+    "react-native": "^0.55.0"
   },
   "jest": {
     "transform": {

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -15,10 +15,10 @@ import {
 	NativeModules,
 	DeviceEventEmitter,
 	AsyncStorage,
-	PushNotificationIOS,
 	Platform,
 	AppState,
 } from 'react-native';
+import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import Amplify, { ConsoleLogger as Logger } from '@aws-amplify/core';
 
 const logger = new Logger('Notification');

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -18,7 +18,7 @@ import {
 	Platform,
 	AppState,
 } from 'react-native';
-import * as PushNotificationIOS from '@react-native-community/push-notification-ios';
+import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import Amplify, { ConsoleLogger as Logger } from '@aws-amplify/core';
 
 const logger = new Logger('Notification');

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -18,7 +18,7 @@ import {
 	Platform,
 	AppState,
 } from 'react-native';
-import PushNotificationIOS from '@react-native-community/push-notification-ios';
+import * as PushNotificationIOS from '@react-native-community/push-notification-ios';
 import Amplify, { ConsoleLogger as Logger } from '@aws-amplify/core';
 
 const logger = new Logger('Notification');

--- a/packages/pushnotification/tsconfig.json
+++ b/packages/pushnotification/tsconfig.json
@@ -1,29 +1,20 @@
 //WARNING: If you are manually specifying files to compile then the tsconfig.json is completely ignored, you must use command line flags
 {
-    "compilerOptions": {
-        "outDir": "./lib/",
-        "target": "es5",
-        "noImplicitAny": false,
-        "lib": [
-            "es5",
-            "es2015",
-            "dom",
-            "esnext.asynciterable",
-            "es2017.object"
-        ],
-        "sourceMap": true,
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "allowJs": false,
-        "declaration": true,
-        "typeRoots": [
-            "./node_modules/@types",
-            "../../node_modules/@types"
-        ],
-        // temporary fix
-        "types": ["node", "lodash"]
-    },
-    "include": [
-        "src/**/*"
-    ]
+	"compilerOptions": {
+		"outDir": "./lib/",
+		"target": "es5",
+		"noImplicitAny": false,
+		"lib": ["es5", "es2015", "dom", "esnext.asynciterable", "es2017.object"],
+		"sourceMap": true,
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"allowJs": false,
+		"declaration": true,
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+		"typeRoots": ["./node_modules/@types", "../../node_modules/@types"],
+		// temporary fix
+		"types": ["node", "lodash"]
+	},
+	"include": ["src/**/*"]
 }


### PR DESCRIPTION
_Issue #:_
#3995
#4089

_Description of changes:_
Adding support for push notifications in iOS for React Native 0.60+

Tested these changes on an iPhone running iOS 12.x and a React Native 0.61.x app. Was able to receive push notifications through a pinpoint campaign and log the notification data in the onNotification handler.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
