### PR TITLE
Fix customState parsing to include all text past the first hyphen

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1857,7 +1857,10 @@ export default class AuthClass {
 				);
 
 				if (isCustomStateIncluded) {
-					const [, customState] = state.split('-');
+					const customState = state
+						.split('-')
+						.splice(1)
+						.join('-');
 
 					dispatchAuthEvent(
 						'customOAuthState',


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Amplify oAuth knows if there’s a customeOAuth state parameter only if theres a ‘-‘ in the URL, but what if my state parameter itself contains a ‘-‘?
For instance:
My:custome:state-this-information-is-lost

This causes the “customeOAuthState’ to publish everything up to the first ‘-‘, so in this example it would give:
My:custome:state

In this PR, we're updating the parsing to include everything after the first '-', including dashes themselves.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
