### PR TITLE
Fix #4342: move @types/zen-observable to devDependencies

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "devDependencies": {
-    "@types/zen-observable": "^0.5.3"
+    "@types/zen-observable": "^0.8.0"
   },
   "dependencies": {
     "@aws-amplify/auth": "^2.1.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,11 +33,13 @@
     "url": "https://github.com/aws/aws-amplify/issues"
   },
   "homepage": "https://aws-amplify.github.io/",
+  "devDependencies": {
+    "@types/zen-observable": "^0.5.3"
+  },
   "dependencies": {
     "@aws-amplify/auth": "^2.1.0",
     "@aws-amplify/cache": "^2.1.0",
     "@aws-amplify/core": "^2.1.0",
-    "@types/zen-observable": "^0.5.3",
     "axios": "^0.19.0",
     "graphql": "14.0.0",
     "uuid": "^3.2.1",

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "devDependencies": {
-    "@types/zen-observable": "^0.5.3",
+    "@types/zen-observable": "^0.8.0",
     "cpx": "^1.5.0"
   },
   "dependencies": {

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -34,13 +34,13 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "devDependencies": {
+    "@types/zen-observable": "^0.5.3",
     "cpx": "^1.5.0"
   },
   "dependencies": {
     "@aws-amplify/auth": "^2.1.0",
     "@aws-amplify/cache": "^2.1.0",
     "@aws-amplify/core": "^2.1.0",
-    "@types/zen-observable": "^0.5.3",
     "graphql": "14.0.0",
     "paho-mqtt": "^1.1.0",
     "uuid": "^3.2.1",


### PR DESCRIPTION
_Issue #, if available:_ #4342

Moves `@types/zen-observable` to `devDependencies` and updates to `^0.8.0`.

This is a regression of #3529 when #4007 was merged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
