### PR TITLE
chore: (aws-amplify-vue) Pin vue test utils version

### DIFF
--- a/packages/aws-amplify-vue/package.json
+++ b/packages/aws-amplify-vue/package.json
@@ -23,7 +23,7 @@
     "@vue/cli-plugin-babel": "^3.0.1",
     "@vue/cli-plugin-unit-jest": "^3.0.1",
     "@vue/cli-service": "^3.0.1",
-    "@vue/test-utils": "^1.0.0-beta.20",
+    "@vue/test-utils": "1.0.0-beta.29",
     "babel-core": "7.0.0-bridge.0",
     "postcss-loader": "^2.1.6",
     "vue-template-compiler": "^2.5.17"


### PR DESCRIPTION
_Description of changes:_
Pinning version of vue-test-utils version to beta.29 in order to resolve unit test failure. New vue-test-utils [version](https://www.npmjs.com/package/@vue/test-utils) was released four days ago.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
