### PR TITLE
Handle Pinpoint error without "message"

### DIFF
--- a/packages/analytics/__tests__/Providers/AWSPinpointProvider-unit-test.ts
+++ b/packages/analytics/__tests__/Providers/AWSPinpointProvider-unit-test.ts
@@ -749,6 +749,28 @@ describe('AnalyticsProvider test', () => {
 				expect(reject).toBeCalledWith(mockError);
 				spyon.mockRestore();
 			});
+
+			test('BAD_REQUEST_CODE without message rejects error', async () => {
+				const analytics = new AnalyticsProvider();
+				const mockError = { debug: 'error', statusCode: 400 };
+
+				analytics.configure(options);
+				const spyon = jest
+					.spyOn(Pinpoint.prototype, 'updateEndpoint')
+					.mockImplementationOnce(params => ({
+						promise: jest.fn().mockRejectedValue(mockError),
+					}));
+
+				jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+					return Promise.resolve(credentials);
+				});
+
+				const params = { event: { name: '_update_endpoint', immediate: true } };
+
+				await analytics.record(params, { resolve, reject });
+				expect(reject).toBeCalledWith(mockError);
+				spyon.mockRestore();
+			});
 		});
 	});
 });

--- a/packages/analytics/__tests__/Providers/AWSPinpointProvider-unit-test.ts
+++ b/packages/analytics/__tests__/Providers/AWSPinpointProvider-unit-test.ts
@@ -730,12 +730,14 @@ describe('AnalyticsProvider test', () => {
 
 			test('error case', async () => {
 				const analytics = new AnalyticsProvider();
+				const mockError = { message: 'error' };
+
 				analytics.configure(options);
 				const spyon = jest
 					.spyOn(Pinpoint.prototype, 'updateEndpoint')
-					.mockImplementationOnce((params, callback) => {
-						callback({ message: 'error' }, null);
-					});
+					.mockImplementationOnce(params => ({
+						promise: jest.fn().mockRejectedValue(mockError),
+					}));
 
 				jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
 					return Promise.resolve(credentials);
@@ -744,7 +746,7 @@ describe('AnalyticsProvider test', () => {
 				const params = { event: { name: '_update_endpoint', immediate: true } };
 
 				await analytics.record(params, { resolve, reject });
-				expect(reject).toBeCalled();
+				expect(reject).toBeCalledWith(mockError);
 				spyon.mockRestore();
 			});
 		});

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -447,7 +447,7 @@ export default class AWSPinpointProvider implements AnalyticsProvider {
 		failureData: EndpointFailureData
 	) {
 		const { err, update_params, endpointObject } = failureData;
-		const { message } = err;
+		const { message = '' } = err;
 		const { ApplicationId, EndpointRequest } = update_params;
 
 		if (!message.startsWith('Exceeded maximum endpoint per user count')) {

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -445,10 +445,12 @@ export default class AWSPinpointProvider implements AnalyticsProvider {
 		failureData: EndpointFailureData
 	) {
 		const { err, update_params, endpointObject } = failureData;
-		const { message = '' } = err;
+		const { message } = err;
 		const { ApplicationId, EndpointRequest } = update_params;
 
-		if (!message.startsWith('Exceeded maximum endpoint per user count')) {
+		if (
+			!String(message).startsWith('Exceeded maximum endpoint per user count')
+		) {
 			return endpointObject.handlers.reject(err);
 		}
 

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -372,9 +372,7 @@ export default class AWSPinpointProvider implements AnalyticsProvider {
 			typeof params.resendLimit === 'number' ? params.resendLimit : resendLimit;
 		if (params.resendLimit-- > 0) {
 			logger.debug(
-				`resending event ${params.eventName} with ${
-					params.resendLimit
-				} retry times left`
+				`resending event ${params.eventName} with ${params.resendLimit} retry times left`
 			);
 			this._pinpointPutEvents(params, handlers);
 		} else {
@@ -494,9 +492,7 @@ export default class AWSPinpointProvider implements AnalyticsProvider {
 
 		if (params.resendLimit-- > 0) {
 			logger.debug(
-				`resending endpoint update ${params.event.eventId} with ${
-					params.resendLimit
-				} retry attempts remaining`
+				`resending endpoint update ${params.event.eventId} with ${params.resendLimit} retry attempts remaining`
 			);
 			// insert at the front of endpointBuffer
 			this._endpointBuffer.unshift(endpointObject);
@@ -504,9 +500,7 @@ export default class AWSPinpointProvider implements AnalyticsProvider {
 		}
 
 		logger.warn(
-			`resending endpoint update ${params.event.eventId} failed after ${
-				params.config.resendLimit
-			} attempts`
+			`resending endpoint update ${params.event.eventId} failed after ${params.config.resendLimit} attempts`
 		);
 
 		if (this._endpointGenerating) {


### PR DESCRIPTION
_Issue #, if available:_ #4485

@mariotsi discovered in #4485:
> From our remote logs we saw errors coming from this line `TypeError: Cannot read property 'startsWith' of undefined`. We are unable to check more deeply what was the response because we do not not log payloads. I'm making this change in order to make the code more failsafe

This PR fixes a unit test that was incorrectly asserting that a rejection happened, _not what got rejected_, and adds a test case for the behavior @mariotsi is seeing.

The primary difference between aa8e3de and this PR is that `message` is cast as a `String` to defensively catch `undefined`, `null`, booleans, numbers, or any other valid, non-String JSON responses.  It also avoids defaulting `message` to `"", so that the original value of `undefined` is preserved for future changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
