### PR TITLE
fix(@aws-amplify/core): add zen-observable dependency

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -80,5 +80,8 @@
     "coveragePathIgnorePatterns": [
       "/node_modules/"
     ]
+  },
+  "devDependencies": {
+    "rimraf": "^3.0.0"
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -80,8 +80,5 @@
     "coveragePathIgnorePatterns": [
       "/node_modules/"
     ]
-  },
-  "devDependencies": {
-    "rimraf": "^3.0.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "aws-sdk": "2.518.0",
     "url": "^0.11.0",
-    "zen-observable": "^0.8.15"
+    "zen-observable": "^0.8.6"
   },
   "jest": {
     "globals": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,8 @@
   },
   "dependencies": {
     "aws-sdk": "2.518.0",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "zen-observable": "^0.8.15"
   },
   "jest": {
     "globals": {


### PR DESCRIPTION
_Issue #, if available:_ #4506

`core` uses `zen-observable`:

https://github.com/aws-amplify/amplify-js/blob/8d2ba6e85031a7880d2b573e1f68108d22a7de54/packages/core/src/Util/Reachability.ts#L1

But it isn't declared as a dependency:
https://github.com/aws-amplify/amplify-js/blob/8d2ba6e85031a7880d2b573e1f68108d22a7de54/packages/core/package.json#L39-L46

Users who had multiple packages installed (such as API/PubSub) would get this as a  transitive dependency, which hid the error.

See this demo repo: https://github.com/ericclemmons/amplify-js-issues-4506

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
