### PR TITLE
Auto-label PRs based on files changed

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,14 +17,6 @@ Analytics:
 
 API:
   - packages/api/**/*
-  - packages/api-graphql/**/*
-  - packages/api-rest/**/*
-
-GraphQL:
-  - packages/api-graphql/**/*
-
-REST:
-  - packages/api-rest/**/*
 
 Auth:
   - packages/auth/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,81 @@
+# See https://github.com/actions/labeler for usage
+
+needs-review:
+  - ./**/*
+
+Cognito:
+  - packages/amazon-cognito-identity-js/**/*
+
+amplify-ui:
+  - packages/amplify-ui/**/*
+
+UI:
+  - packages/amplify-ui-components/**/*
+
+Analytics:
+  - packages/analytics/**/*
+
+API:
+  - packages/api/**/*
+  - packages/api-graphql/**/*
+  - packages/api-rest/**/*
+
+GraphQL:
+  - packages/api-graphql/**/*
+
+REST:
+  - packages/api-rest/**/*
+
+Auth:
+  - packages/auth/**/*
+
+Core:
+  - packages/aws-amplify/**/*
+  - packages/core/**/*
+
+Angular:
+  - packages/aws-amplify-angular/**/*
+
+React:
+  - packages/aws-amplify-react/**/*
+
+React Native:
+  - packages/aws-amplify-react-native/**/*
+
+Vue:
+  - packages/aws-amplify-vue/**/*
+
+Caching:
+  - packages/cache/**/*
+
+DataStore:
+  - packages/datastore/**/*
+
+Interactions:
+  - packages/interactions/**/*
+
+Predictions:
+  - packages/predictions/**/*
+
+PubSub:
+  - packages/pubsub/**/*
+
+Push Notification:
+  - packages/pushnotification/**/*
+
+Storage:
+  - packages/storage/**/*
+
+XR:
+  - packages/xr/**/*
+
+Tests:
+  - ./**/__tests__/**/*
+  - ./**/*.spec.*
+  - ./**/*.test.*
+
+Tooling:
+  - scripts/**/*
+
+TypeScript:
+  - ./**/types/**/*.ts

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,17 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler/blob/master/README.md
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
From https://github.com/actions/labeler, this GitHub action automates away manual label (e.g. <kbd>Analytics</kbd>, <kbd>Auth</kbd>, <kbd>API</kbd>, etc.) attribution for PRs to help streamline on-call duties and issue organization.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
