### PR TITLE
chore(@aws-amplify/ui-components): Check for user before authenticator loads

### DIFF
--- a/packages/amplify-ui-components/src/common/constants.ts
+++ b/packages/amplify-ui-components/src/common/constants.ts
@@ -89,6 +89,7 @@ export const SIGN_OUT = 'Sign Out';
 // Auth Keys
 export const AUTH_SOURCE_KEY = 'amplify-auth-source';
 export const SIGNING_IN_WITH_HOSTEDUI_KEY = 'amplify-signin-with-hostedUI';
+export const AUTHENTICATOR_AUTHSTATE = 'amplify-authenticator-authState';
 
 // Error message Common Constants
 export const PHONE_EMPTY_ERROR_MESSAGE = 'Phone number can not be empty';

--- a/packages/amplify-ui-components/src/common/constants.ts
+++ b/packages/amplify-ui-components/src/common/constants.ts
@@ -88,6 +88,7 @@ export const SIGN_OUT = 'Sign Out';
 
 // Auth Keys
 export const AUTH_SOURCE_KEY = 'amplify-auth-source';
+export const SIGNING_IN_WITH_HOSTEDUI_KEY = 'amplify-signin-with-hostedUI';
 
 // Error message Common Constants
 export const PHONE_EMPTY_ERROR_MESSAGE = 'Phone number can not be empty';

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
@@ -1,7 +1,7 @@
 import { Component, State, Prop, h } from '@stencil/core';
 import { AuthState, CognitoUserInterface, FederatedConfig } from '../../common/types/auth-types';
 import { AuthStateTunnel } from '../../data/auth-state';
-import { NO_AUTH_MODULE_FOUND, SIGNING_IN_WITH_HOSTEDUI_KEY } from '../../common/constants';
+import { NO_AUTH_MODULE_FOUND, SIGNING_IN_WITH_HOSTEDUI_KEY, AUTHENTICATOR_AUTHSTATE } from '../../common/constants';
 import { Auth } from '@aws-amplify/auth';
 import { Logger } from '@aws-amplify/core';
 
@@ -38,7 +38,7 @@ export class AmplifyAuthenticator {
     } catch (error) {
       let cachedAuthState = null;
       try {
-        cachedAuthState = localStorage.getItem('amplify-authenticator-authState');
+        cachedAuthState = localStorage.getItem(AUTHENTICATOR_AUTHSTATE);
       } catch (error) {
         logger.debug('Failed to get the auth state from local storage', error);
       }

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
@@ -1,7 +1,8 @@
 import { Component, State, Prop, h } from '@stencil/core';
 import { AuthState, CognitoUserInterface, FederatedConfig } from '../../common/types/auth-types';
 import { AuthStateTunnel } from '../../data/auth-state';
-
+import { NO_AUTH_MODULE_FOUND, SIGNING_IN_WITH_HOSTEDUI_KEY } from '../../common/constants';
+import { Auth } from '@aws-amplify/auth';
 import { Logger } from '@aws-amplify/core';
 
 const logger = new Logger('Authenticator');
@@ -20,8 +21,36 @@ export class AmplifyAuthenticator {
   /** Federated credentials & configuration. */
   @Prop() federated: FederatedConfig = {};
 
-  componentWillLoad() {
-    this.authState = this.initialAuthState;
+  async componentWillLoad() {
+    const byHostedUI = localStorage.getItem(SIGNING_IN_WITH_HOSTEDUI_KEY);
+    localStorage.removeItem(SIGNING_IN_WITH_HOSTEDUI_KEY);
+    if (byHostedUI !== 'true') await this.checkUser();
+  }
+
+  async checkUser() {
+    if (!Auth || typeof Auth.currentAuthenticatedUser !== 'function') {
+      throw new Error(NO_AUTH_MODULE_FOUND);
+    }
+
+    try {
+      const user = await Auth.currentAuthenticatedUser();
+      this.onAuthStateChange(AuthState.SignedIn, user);
+    } catch (error) {
+      let cachedAuthState = null;
+      try {
+        cachedAuthState = localStorage.getItem('amplify-authenticator-authState');
+      } catch (error) {
+        logger.debug('Failed to get the auth state from local storage', error);
+      }
+      try {
+        if (cachedAuthState === AuthState.SignedIn) {
+          await Auth.signOut();
+        }
+        this.onAuthStateChange(this.initialAuthState);
+      } catch (error) {
+        logger.debug('Failed to sign out', error);
+      }
+    }
   }
 
   onAuthStateChange = (nextAuthState: AuthState, data?: CognitoUserInterface) => {


### PR DESCRIPTION
_Description of changes:_
- Check user before Authenticator loads to determine if they are signed in or not

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
