### PR TITLE
Track visibility via _session.pause & _session.resume

### DIFF
--- a/packages/analytics/__tests__/trackers/SessionTracker-test.ts
+++ b/packages/analytics/__tests__/trackers/SessionTracker-test.ts
@@ -114,7 +114,7 @@ describe('SessionTracker test', () => {
 
 			expect(tracker).toBeCalledWith(
 				{
-					name: '_session.stop',
+					name: '_session.pause',
 					attributes: {},
 				},
 				'AWSPinpoint'
@@ -141,7 +141,7 @@ describe('SessionTracker test', () => {
 
 			expect(tracker).toBeCalledWith(
 				{
-					name: '_session.start',
+					name: '_session.resume',
 					attributes: {},
 				},
 				'AWSPinpoint'

--- a/packages/analytics/src/trackers/SessionTracker.ts
+++ b/packages/analytics/src/trackers/SessionTracker.ts
@@ -81,22 +81,22 @@ export default class SessionTracker {
 		if (document.visibilityState === this._hidden) {
 			this._tracker(
 				{
-					name: '_session.stop',
+					name: '_session.pause',
 					attributes,
 				},
 				this._config.provider
 			).catch(e => {
-				logger.debug('record session stop event failed.', e);
+				logger.debug('record session pause event failed.', e);
 			});
 		} else {
 			this._tracker(
 				{
-					name: '_session.start',
+					name: '_session.resume',
 					attributes,
 				},
 				this._config.provider
 			).catch(e => {
-				logger.debug('record session start event failed.', e);
+				logger.debug('record session resume event failed.', e);
 			});
 		}
 	}


### PR DESCRIPTION
_Issue #, if available:_ #4517

@germain-receeve has been receiving noisy `_session.start` and `_session.stop` data, due to page visibility also sending those same events.

The initial suggestion was to introduce an option (e.g. `trackVisibilityChange`) to filter these events out entirely:

> An option for the autotrack feature that would allow us to disable this behaviour.
Could be for example trackVisibilityChange option which would not add the event listener if set to false.
> ...
> I would say it's more that it's making noise since in our case we are mainly interested by the user starting to use the site and effectively quitting it.
If we could differentiate those events like you suggested, that would work for us as well 👍

This PR opts for differentiating the `_session.start` / `_session.stop` with **new** `_session.pause` `_session.resume` visbility events, rather then removing data entirely.

These event names seem to be based on convention vs. a contract:
> https://docs.aws.amazon.com/mobileanalytics/latest/ug/managing-sessions.html

**However, if reporting depends on these events (e.g. for calculating DAU), then this would be a backwards incompatible change**. If that's the case, then adding an option for users to opt into is the best course of action.

---


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
