### PR TITLE
@aws-amplify/auth: robust custom state encoding

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1857,7 +1857,7 @@ export default class AuthClass {
 				);
 
 				if (isCustomStateIncluded) {
-					const [, customState] = state.split('-');
+					const customState = this._decodeCustomState(state);
 
 					dispatchAuthEvent(
 						'customOAuthState',
@@ -1975,5 +1975,18 @@ export default class AuthClass {
 	private rejectNoUserPool(): Promise<never> {
 		const type = this.noUserPoolErrorHandler(this._config);
 		return Promise.reject(new NoUserPoolError(type));
+	}
+
+	private _decodeCustomState(str: string) {
+		// 1) Strip internal state prefix.
+		// 2) Reverse ./OAuth/OAuth.ts:_encodeCustomState().
+		return decodeURIComponent(
+			atob(
+				str
+					.replace(/^[^-]*-/, '')
+					.replace(/-/g, '+')
+					.replace(/_/g, '/')
+			)
+		);
 	}
 }

--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -70,10 +70,10 @@ export default class OAuth {
 	) {
 		const generatedState = this._generateState(32);
 		const state = customState
-			? `${generatedState}-${customState}`
+			? `${generatedState}-${this._encodeCustomState(customState)}`
 			: generatedState;
 
-		oAuthStorage.setState(encodeURIComponent(state));
+		oAuthStorage.setState(state);
 
 		const pkce_key = this._generateRandom(128);
 		oAuthStorage.setPKCE(pkce_key);
@@ -315,5 +315,14 @@ export default class OAuth {
 			state.push(CHARSET[index]);
 		}
 		return state.join('');
+	}
+
+	private _encodeCustomState(str: string) {
+		// 1) URI-encode to avoid the btoa() Unicode problem.
+		// 2) Base64URL-encode to avoid URL-parsing problems.
+		return btoa(encodeURIComponent(str))
+			.replace(/=/g, '')
+			.replace(/\+/g, '-')
+			.replace(/\\/g, '_');
 	}
 }


### PR DESCRIPTION
The custom state is encoded such that it is protected from issues
related to URL parsing anywhere in the OAuth workflow.

Besides issues with URL encoding, the old `state.split('-')` was also
incorrect in a different way: the custom state may include dashes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Steffen Prohaska <prohaska@zib.de>
