### PR TITLE
feat(@aws-amplify/ui-components): amplify-auth0-button

### DIFF
--- a/packages/amplify-ui-components/src/common/types/auth-types.ts
+++ b/packages/amplify-ui-components/src/common/types/auth-types.ts
@@ -23,9 +23,13 @@ export enum AuthState {
 
 export interface FederatedConfig {
   auth0Config?: {
+    audience?: string;
     clientID: string;
     domain: string;
-    [key: string]: any;
+    responseType: string;
+    redirectUri: string;
+    returnTo?: string;
+    scope?: string;
   };
   amazonClientId?: string;
   facebookAppId?: string;
@@ -63,7 +67,7 @@ export interface CognitoUserInterface {
   userSub?: string;
   challengeName: string;
   challengeParam: { [key: string]: any };
-};
+}
 
 export type AuthStateHandler = (nextAuthState: AuthState, data?: object) => void;
 
@@ -82,5 +86,5 @@ export enum ChallengeName {
 }
 
 export enum AuthFormField {
-  Password = 'password'
+  Password = 'password',
 }

--- a/packages/amplify-ui-components/src/components.d.ts
+++ b/packages/amplify-ui-components/src/components.d.ts
@@ -5,864 +5,841 @@
  * It contains typing information for all components that exist in this project.
  */
 
-
 import { HTMLStencilElement, JSXBase } from '@stencil/core/internal';
-import {
-  AuthState,
-  AuthStateHandler,
-  CognitoUserInterface,
-  FederatedConfig,
-} from './common/types/auth-types';
-import {
-  FormFieldTypes,
-} from './components/amplify-auth-fields/amplify-auth-fields-interface';
-import {
-  ButtonTypes,
-  TextFieldTypes,
-} from './common/types/ui-types';
-import {
-  FunctionalComponent,
-} from '@stencil/core';
-import {
-  CountryCodeDialOptions,
-} from './components/amplify-country-dial-code/amplify-country-dial-code-interface';
-import {
-  IconNameType,
-} from './components/amplify-icon/icons';
-import {
-  AmplifySceneError,
-} from './components/amplify-scene/amplify-scene-interface';
-import {
-  SelectOptionsNumber,
-  SelectOptionsString,
-} from './components/amplify-select/amplify-select-interface';
+import { AuthState, AuthStateHandler, CognitoUserInterface, FederatedConfig } from './common/types/auth-types';
+import { FormFieldTypes } from './components/amplify-auth-fields/amplify-auth-fields-interface';
+import { ButtonTypes, TextFieldTypes } from './common/types/ui-types';
+import { FunctionalComponent } from '@stencil/core';
+import { CountryCodeDialOptions } from './components/amplify-country-dial-code/amplify-country-dial-code-interface';
+import { IconNameType } from './components/amplify-icon/icons';
+import { AmplifySceneError } from './components/amplify-scene/amplify-scene-interface';
+import { SelectOptionsNumber, SelectOptionsString } from './components/amplify-select/amplify-select-interface';
 
 export namespace Components {
   interface AmplifyAmazonButton {
     /**
-    * App-specific client ID from Google
-    */
-    'clientId': FederatedConfig['amazonClientId'];
+     * App-specific client ID from Google
+     */
+    clientId: FederatedConfig['amazonClientId'];
     /**
-    * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
-    */
-    'handleAuthStateChange': AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
+     */
+    handleAuthStateChange: AuthStateHandler;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
   }
   interface AmplifyAuthFields {
     /**
-    * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
-    */
-    'formFields': FormFieldTypes | string[];
+     * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
+     */
+    formFields: FormFieldTypes | string[];
   }
   interface AmplifyAuth0Button {
     /**
-    * See: https://auth0.com/docs/libraries/auth0js/v9#available-parameters
-    */
-    'config': FederatedConfig['auth0Config'];
+     * See: https://auth0.com/docs/libraries/auth0js/v9#available-parameters
+     */
+    config: FederatedConfig['auth0Config'];
+    handleAuthStateChange: AuthStateHandler;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
   }
   interface AmplifyAuthenticator {
     /**
-    * Federated credentials & configuration.
-    */
-    'federated': FederatedConfig;
+     * Federated credentials & configuration.
+     */
+    federated: FederatedConfig;
     /**
-    * Initial starting state of the Authenticator component. E.g. If `signup` is passed the default component is set to AmplifySignUp
-    */
-    'initialAuthState': AuthState;
+     * Initial starting state of the Authenticator component. E.g. If `signup` is passed the default component is set to AmplifySignUp
+     */
+    initialAuthState: AuthState;
   }
   interface AmplifyButton {
     /**
-    * (Optional) Callback called when a user clicks on the button
-    */
-    'handleButtonClick': (evt: Event) => void;
+     * (Optional) Callback called when a user clicks on the button
+     */
+    handleButtonClick: (evt: Event) => void;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
     /**
-    * Type of the button: 'button', 'submit' or 'reset'
-    */
-    'type': ButtonTypes;
+     * Type of the button: 'button', 'submit' or 'reset'
+     */
+    type: ButtonTypes;
   }
   interface AmplifyCheckbox {
     /**
-    * If `true`, the checkbox is selected.
-    */
-    'checked': boolean;
+     * If `true`, the checkbox is selected.
+     */
+    checked: boolean;
     /**
-    * If `true`, the checkbox is disabled
-    */
-    'disabled': boolean;
+     * If `true`, the checkbox is disabled
+     */
+    disabled: boolean;
     /**
-    * Field ID used for the 'htmlFor' in the label
-    */
-    'fieldId': string;
+     * Field ID used for the 'htmlFor' in the label
+     */
+    fieldId: string;
     /**
-    * Label for the checkbox
-    */
-    'label': string;
+     * Label for the checkbox
+     */
+    label: string;
     /**
-    * Name of the checkbox
-    */
-    'name'?: string;
+     * Name of the checkbox
+     */
+    name?: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle: boolean;
     /**
-    * Value of the checkbox
-    */
-    'value'?: string;
+     * Value of the checkbox
+     */
+    value?: string;
   }
   interface AmplifyCodeField {
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * Based on the type of field e.g. sign in, sign up, forgot password, etc.
-    */
-    'fieldId': string;
+     * Based on the type of field e.g. sign in, sign up, forgot password, etc.
+     */
+    fieldId: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * Used as the hint in case you forgot your confirmation code, etc.
-    */
-    'hint': string | FunctionalComponent | null;
+     * Used as the hint in case you forgot your confirmation code, etc.
+     */
+    hint: string | FunctionalComponent | null;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * Used for the code label
-    */
-    'label': string;
+     * Used for the code label
+     */
+    label: string;
     /**
-    * Used for the placeholder label
-    */
-    'placeholder': string;
+     * Used for the placeholder label
+     */
+    placeholder: string;
     /**
-    * The required flag in order to make an input required prior to submitting a form
-    */
-    'required': boolean;
+     * The required flag in order to make an input required prior to submitting a form
+     */
+    required: boolean;
     /**
-    * The value of the content inside of the input field
-    */
-    'value'?: string;
+     * The value of the content inside of the input field
+     */
+    value?: string;
   }
   interface AmplifyConfirmSignIn {
     /**
-    * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
-    */
-    'formFields': FormFieldTypes | string[];
+     * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
+     */
+    formFields: FormFieldTypes | string[];
     /**
-    * Passed from the Authenticator component in order to change Authentication state
-    */
-    'handleAuthStateChange': AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state
+     */
+    handleAuthStateChange: AuthStateHandler;
     /**
-    * Fires when confirm sign in form is submitted
-    */
-    'handleSubmit': (Event) => void;
+     * Fires when confirm sign in form is submitted
+     */
+    handleSubmit: (Event) => void;
     /**
-    * Used for header text in confirm sign in component
-    */
-    'headerText': string;
+     * Used for header text in confirm sign in component
+     */
+    headerText: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle: boolean;
     /**
-    * Used for the submit button text in confirm sign in component
-    */
-    'submitButtonText': string;
+     * Used for the submit button text in confirm sign in component
+     */
+    submitButtonText: string;
     /**
-    * Cognito user signing in
-    */
-    'user': CognitoUserInterface;
+     * Cognito user signing in
+     */
+    user: CognitoUserInterface;
     /**
-    * Engages when invalid actions occur, such as missing field, etc.
-    */
-    'validationErrors': string;
+     * Engages when invalid actions occur, such as missing field, etc.
+     */
+    validationErrors: string;
   }
   interface AmplifyConfirmSignUp {
     /**
-    * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
-    */
-    'formFields': FormFieldTypes | string[];
+     * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
+     */
+    formFields: FormFieldTypes | string[];
     /**
-    * Passed from the Authenticator component in order to change Authentication states e.g. SignIn -> 'Create Account' link -> SignUp
-    */
-    'handleAuthStateChange': AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication states e.g. SignIn -> 'Create Account' link -> SignUp
+     */
+    handleAuthStateChange: AuthStateHandler;
     /**
-    * Fires when sign up form is submitted
-    */
-    'handleSubmit': (submitEvent: Event) => void;
+     * Fires when sign up form is submitted
+     */
+    handleSubmit: (submitEvent: Event) => void;
     /**
-    * Used for header text in confirm sign up component
-    */
-    'headerText': string;
+     * Used for header text in confirm sign up component
+     */
+    headerText: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle: boolean;
     /**
-    * Used for the submit button text in confirm sign up component
-    */
-    'submitButtonText': string;
+     * Used for the submit button text in confirm sign up component
+     */
+    submitButtonText: string;
     /**
-    * Used for the username to be passed to resend code
-    */
-    'user': CognitoUserInterface;
+     * Used for the username to be passed to resend code
+     */
+    user: CognitoUserInterface;
     /**
-    * Engages when invalid actions occur, such as missing field, etc.
-    */
-    'validationErrors': string;
+     * Engages when invalid actions occur, such as missing field, etc.
+     */
+    validationErrors: string;
   }
   interface AmplifyCountryDialCode {
     /**
-    * The ID of the field.  Should match with its corresponding input's ID.
-    */
-    'fieldId': string;
+     * The ID of the field.  Should match with its corresponding input's ID.
+     */
+    fieldId: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * The options of the country dial code select input.
-    */
-    'options': CountryCodeDialOptions;
+     * The options of the country dial code select input.
+     */
+    options: CountryCodeDialOptions;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle: boolean;
   }
   interface AmplifyEmailField {
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * Based on the type of field e.g. sign in, sign up, forgot password, etc.
-    */
-    'fieldId': string;
+     * Based on the type of field e.g. sign in, sign up, forgot password, etc.
+     */
+    fieldId: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * Used for the EMAIL label
-    */
-    'label': string;
+     * Used for the EMAIL label
+     */
+    label: string;
     /**
-    * Used for the placeholder label
-    */
-    'placeholder': string;
+     * Used for the placeholder label
+     */
+    placeholder: string;
     /**
-    * The required flag in order to make an input required prior to submitting a form
-    */
-    'required': boolean;
+     * The required flag in order to make an input required prior to submitting a form
+     */
+    required: boolean;
     /**
-    * The value of the content inside of the input field
-    */
-    'value'?: string;
+     * The value of the content inside of the input field
+     */
+    value?: string;
   }
   interface AmplifyExamples {}
   interface AmplifyFacebookButton {
     /**
-    * App-specific client ID from Facebook
-    */
-    'appId': FederatedConfig['facebookAppId'];
+     * App-specific client ID from Facebook
+     */
+    appId: FederatedConfig['facebookAppId'];
     /**
-    * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
-    */
-    'handleAuthStateChange': AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
+     */
+    handleAuthStateChange: AuthStateHandler;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
   }
   interface AmplifyFederatedButtons {
     /**
-    * The current authentication state.
-    */
-    'authState': AuthState;
+     * The current authentication state.
+     */
+    authState: AuthState;
     /**
-    * Federated credentials & configuration.
-    */
-    'federated': FederatedConfig;
+     * Federated credentials & configuration.
+     */
+    federated: FederatedConfig;
     /**
-    * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
-    */
-    'handleAuthStateChange': AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
+     */
+    handleAuthStateChange: AuthStateHandler;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
   }
   interface AmplifyFederatedSignIn {
     /**
-    * The current authentication state.
-    */
-    'authState': AuthState;
+     * The current authentication state.
+     */
+    authState: AuthState;
     /**
-    * Federated credentials & configuration.
-    */
-    'federated': any;
+     * Federated credentials & configuration.
+     */
+    federated: any;
   }
   interface AmplifyForgotPassword {
     /**
-    * The form fields displayed inside of the forgot password form
-    */
-    'formFields': FormFieldTypes;
+     * The form fields displayed inside of the forgot password form
+     */
+    formFields: FormFieldTypes;
     /**
-    * Passed from the Authenticator component in order to change Authentication state
-    */
-    'handleAuthStateChange': AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state
+     */
+    handleAuthStateChange: AuthStateHandler;
     /**
-    * The function called when making a request to reset password
-    */
-    'handleSend': (event: Event) => void;
+     * The function called when making a request to reset password
+     */
+    handleSend: (event: Event) => void;
     /**
-    * The function called when submitting a new password
-    */
-    'handleSubmit': (event: Event) => void;
+     * The function called when submitting a new password
+     */
+    handleSubmit: (event: Event) => void;
     /**
-    * The header text of the forgot password section
-    */
-    'headerText': string;
+     * The header text of the forgot password section
+     */
+    headerText: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle: boolean;
     /**
-    * The text displayed inside of the submit button for the form
-    */
-    'submitButtonText': string;
+     * The text displayed inside of the submit button for the form
+     */
+    submitButtonText: string;
   }
   interface AmplifyFormField {
     /**
-    * The text of the description.  Goes between the label and the input.
-    */
-    'description': string | null;
+     * The text of the description.  Goes between the label and the input.
+     */
+    description: string | null;
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * The ID of the field.  Should match with its corresponding input's ID.
-    */
-    'fieldId': string;
+     * The ID of the field.  Should match with its corresponding input's ID.
+     */
+    fieldId: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * The text of a hint to the user as to how to fill out the input.  Goes just below the input.
-    */
-    'hint': string | FunctionalComponent | null;
+     * The text of a hint to the user as to how to fill out the input.  Goes just below the input.
+     */
+    hint: string | FunctionalComponent | null;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * The text of the label.  Goes above the input. Ex: 'First name'
-    */
-    'label': string | null;
+     * The text of the label.  Goes above the input. Ex: 'First name'
+     */
+    label: string | null;
     /**
-    * (Optional) String value for the name of the input.
-    */
-    'name'?: string;
+     * (Optional) String value for the name of the input.
+     */
+    name?: string;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * (Optional) The placeholder for the input element.  Using hints is recommended, but placeholders can also be useful to convey information to users.
-    */
-    'placeholder'?: string;
+     * (Optional) The placeholder for the input element.  Using hints is recommended, but placeholders can also be useful to convey information to users.
+     */
+    placeholder?: string;
     /**
-    * The required flag in order to make an input required prior to submitting a form
-    */
-    'required': boolean;
+     * The required flag in order to make an input required prior to submitting a form
+     */
+    required: boolean;
     /**
-    * The input type.  Can be any HTML input type.
-    */
-    'type'?: TextFieldTypes;
+     * The input type.  Can be any HTML input type.
+     */
+    type?: TextFieldTypes;
     /**
-    * The value of the content inside of the input field
-    */
-    'value': string;
+     * The value of the content inside of the input field
+     */
+    value: string;
   }
   interface AmplifyFormSection {
     /**
-    * (Required) Function called upon submission of form
-    */
-    'handleSubmit': (inputEvent: Event) => void;
+     * (Required) Function called upon submission of form
+     */
+    handleSubmit: (inputEvent: Event) => void;
     /**
-    * Used for form section header
-    */
-    'headerText': string;
+     * Used for form section header
+     */
+    headerText: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle'?: boolean;
-    'primaryFooterContent': string | FunctionalComponent;
-    'secondaryFooterContent': string | FunctionalComponent | null;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle?: boolean;
+    primaryFooterContent: string | FunctionalComponent;
+    secondaryFooterContent: string | FunctionalComponent | null;
     /**
-    * (Optional) Used as a the default value within the default footer slot
-    */
-    'submitButtonText'?: string;
+     * (Optional) Used as a the default value within the default footer slot
+     */
+    submitButtonText?: string;
   }
   interface AmplifyGoogleButton {
     /**
-    * App-specific client ID from Google
-    */
-    'clientId': FederatedConfig['googleClientId'];
+     * App-specific client ID from Google
+     */
+    clientId: FederatedConfig['googleClientId'];
     /**
-    * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
-    */
-    'handleAuthStateChange': AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
+     */
+    handleAuthStateChange: AuthStateHandler;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
   }
   interface AmplifyGreetings {
     /**
-    * Passed from the Authenticator component in order to change Authentication state
-    */
-    'handleAuthStateChange': AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state
+     */
+    handleAuthStateChange: AuthStateHandler;
     /**
-    * Logo displayed inside of the header
-    */
-    'logo': FunctionalComponent | null;
+     * Logo displayed inside of the header
+     */
+    logo: FunctionalComponent | null;
     /**
-    * Override default styling
-    */
-    'overrideStyle': boolean;
+     * Override default styling
+     */
+    overrideStyle: boolean;
     /**
-    * Used for the username to be passed to resend code
-    */
-    'user': CognitoUserInterface;
+     * Used for the username to be passed to resend code
+     */
+    user: CognitoUserInterface;
   }
   interface AmplifyHint {
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
   }
   interface AmplifyIcon {
     /**
-    * (Required) Name of icon used to determine the icon rendered
-    */
-    'name': IconNameType;
+     * (Required) Name of icon used to determine the icon rendered
+     */
+    name: IconNameType;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
   }
   interface AmplifyIconButton {
-    'autoShowTooltip': boolean;
-    'name': IconNameType;
+    autoShowTooltip: boolean;
+    name: IconNameType;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
-    'tooltip': string | null;
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
+    tooltip: string | null;
   }
   interface AmplifyInput {
     /**
-    * The text of the description.  Goes just below the label.
-    */
-    'description': string | null;
+     * The text of the description.  Goes just below the label.
+     */
+    description: string | null;
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * The ID of the field.  Should match with its corresponding input's ID.
-    */
-    'fieldId': string;
+     * The ID of the field.  Should match with its corresponding input's ID.
+     */
+    fieldId: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * (Optional) String value for the name of the input.
-    */
-    'name'?: string;
+     * (Optional) String value for the name of the input.
+     */
+    name?: string;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
     /**
-    * (Optional) The placeholder for the input element.  Using hints is recommended, but placeholders can also be useful to convey information to users.
-    */
-    'placeholder'?: string;
+     * (Optional) The placeholder for the input element.  Using hints is recommended, but placeholders can also be useful to convey information to users.
+     */
+    placeholder?: string;
     /**
-    * The input type.  Can be any HTML input type.
-    */
-    'type'?: TextFieldTypes;
+     * The input type.  Can be any HTML input type.
+     */
+    type?: TextFieldTypes;
     /**
-    * The value of the content inside of the input field
-    */
-    'value': string;
+     * The value of the content inside of the input field
+     */
+    value: string;
   }
   interface AmplifyLabel {
-    'htmlFor': string;
-    'overrideStyle': boolean;
+    htmlFor: string;
+    overrideStyle: boolean;
   }
   interface AmplifyLink {
-    'overrideStyle': boolean;
-    'role': string;
+    overrideStyle: boolean;
+    role: string;
   }
   interface AmplifyNav {}
   interface AmplifyOauthButton {
-    'config': FederatedConfig['oauthConfig'];
+    config: FederatedConfig['oauthConfig'];
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
   }
   interface AmplifyPasswordField {
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * Based on the type of field e.g. sign in, sign up, forgot password, etc.
-    */
-    'fieldId': string;
+     * Based on the type of field e.g. sign in, sign up, forgot password, etc.
+     */
+    fieldId: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * Used as the hint in case you forgot your password, etc.
-    */
-    'hint': string | FunctionalComponent | null;
+     * Used as the hint in case you forgot your password, etc.
+     */
+    hint: string | FunctionalComponent | null;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * Used for the password label
-    */
-    'label': string;
+     * Used for the password label
+     */
+    label: string;
     /**
-    * Used for the placeholder label
-    */
-    'placeholder': string;
+     * Used for the placeholder label
+     */
+    placeholder: string;
     /**
-    * The required flag in order to make an input required prior to submitting a form
-    */
-    'required': boolean;
+     * The required flag in order to make an input required prior to submitting a form
+     */
+    required: boolean;
     /**
-    * The value of the content inside of the input field
-    */
-    'value'?: string;
+     * The value of the content inside of the input field
+     */
+    value?: string;
   }
   interface AmplifyPhoneField {
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * Based on the type of field e.g. sign in, sign up, forgot password, etc.
-    */
-    'fieldId': string;
+     * Based on the type of field e.g. sign in, sign up, forgot password, etc.
+     */
+    fieldId: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * Used as the hint in case you forgot your confirmation code, etc.
-    */
-    'hint': string | FunctionalComponent | null;
+     * Used as the hint in case you forgot your confirmation code, etc.
+     */
+    hint: string | FunctionalComponent | null;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * Used for the Phone label
-    */
-    'label': string;
+     * Used for the Phone label
+     */
+    label: string;
     /**
-    * Used for the placeholder label
-    */
-    'placeholder': string;
+     * Used for the placeholder label
+     */
+    placeholder: string;
     /**
-    * The required flag in order to make an input required prior to submitting a form
-    */
-    'required': boolean;
+     * The required flag in order to make an input required prior to submitting a form
+     */
+    required: boolean;
     /**
-    * The value of the content inside of the input field
-    */
-    'value': string;
+     * The value of the content inside of the input field
+     */
+    value: string;
   }
   interface AmplifyRadioButton {
     /**
-    * If `true`, the radio button is selected.
-    */
-    'checked': boolean;
+     * If `true`, the radio button is selected.
+     */
+    checked: boolean;
     /**
-    * If `true`, the checkbox is disabled
-    */
-    'disabled': boolean;
+     * If `true`, the checkbox is disabled
+     */
+    disabled: boolean;
     /**
-    * Field ID used for the 'for' in the label
-    */
-    'fieldId': string;
+     * Field ID used for the 'for' in the label
+     */
+    fieldId: string;
     /**
-    * Label for the radio button
-    */
-    'label': string;
+     * Label for the radio button
+     */
+    label: string;
     /**
-    * (Optional) Name of radio button
-    */
-    'name'?: string;
+     * (Optional) Name of radio button
+     */
+    name?: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle: boolean;
     /**
-    * (Optional) Value of radio button
-    */
-    'value'?: string;
+     * (Optional) Value of radio button
+     */
+    value?: string;
   }
   interface AmplifyRequireNewPassword {
     /**
-    * The form fields displayed inside of the forgot password form
-    */
-    'formFields': FormFieldTypes;
+     * The form fields displayed inside of the forgot password form
+     */
+    formFields: FormFieldTypes;
     /**
-    * Passed from the Authenticator component in order to change Authentication state
-    */
-    'handleAuthStateChange': AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state
+     */
+    handleAuthStateChange: AuthStateHandler;
     /**
-    * The function called when submitting a new password
-    */
-    'handleSubmit': (event: Event) => void;
+     * The function called when submitting a new password
+     */
+    handleSubmit: (event: Event) => void;
     /**
-    * The header text of the forgot password section
-    */
-    'headerText': string;
+     * The header text of the forgot password section
+     */
+    headerText: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle: boolean;
     /**
-    * The text displayed inside of the submit button for the form
-    */
-    'submitButtonText': string;
+     * The text displayed inside of the submit button for the form
+     */
+    submitButtonText: string;
     /**
-    * Used for the username to be passed to resend code
-    */
-    'user': CognitoUserInterface;
+     * Used for the username to be passed to resend code
+     */
+    user: CognitoUserInterface;
   }
   interface AmplifyScene {
-    'sceneName': string;
+    sceneName: string;
   }
   interface AmplifySceneLoading {
-    'loadPercentage': number;
-    'sceneError': AmplifySceneError | null;
-    'sceneName': string;
+    loadPercentage: number;
+    sceneError: AmplifySceneError | null;
+    sceneName: string;
   }
   interface AmplifySection {
-    'overrideStyle'?: boolean;
-    'role': string;
+    overrideStyle?: boolean;
+    role: string;
   }
   interface AmplifySelect {
     /**
-    * Used for id field
-    */
-    'fieldId': string;
+     * Used for id field
+     */
+    fieldId: string;
     /**
-    * The callback, called when the select is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the select is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * The options of the select input. Must be an Array of Objects with an Object shape of {label: string, value: string|number}
-    */
-    'options': SelectOptionsString | SelectOptionsNumber;
+     * The options of the select input. Must be an Array of Objects with an Object shape of {label: string, value: string|number}
+     */
+    options: SelectOptionsString | SelectOptionsNumber;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle: boolean;
   }
   interface AmplifySignIn {
     /**
-    * Federated credentials & configuration.
-    */
-    'federated': FederatedConfig;
+     * Federated credentials & configuration.
+     */
+    federated: FederatedConfig;
     /**
-    * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
-    */
-    'formFields': FormFieldTypes | string[];
+     * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
+     */
+    formFields: FormFieldTypes | string[];
     /**
-    * Passed from the Authenticator component in order to change Authentication state
-    */
-    'handleAuthStateChange': AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state
+     */
+    handleAuthStateChange: AuthStateHandler;
     /**
-    * Fires when sign in form is submitted
-    */
-    'handleSubmit': (Event) => void;
+     * Fires when sign in form is submitted
+     */
+    handleSubmit: (Event) => void;
     /**
-    * Used for header text in sign in component
-    */
-    'headerText': string;
+     * Used for header text in sign in component
+     */
+    headerText: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle: boolean;
     /**
-    * Used for the submit button text in sign in component
-    */
-    'submitButtonText': string;
+     * Used for the submit button text in sign in component
+     */
+    submitButtonText: string;
     /**
-    * Engages when invalid actions occur, such as missing field, etc.
-    */
-    'validationErrors': string;
+     * Engages when invalid actions occur, such as missing field, etc.
+     */
+    validationErrors: string;
   }
   interface AmplifySignInButton {
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
-    'provider': 'amazon' | 'auth0' | 'facebook' | 'google' | 'oauth';
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
+    provider: 'amazon' | 'auth0' | 'facebook' | 'google' | 'oauth';
   }
   interface AmplifySignOut {
     /**
-    * Text inside of the Sign Out button
-    */
-    'buttonText': string;
+     * Text inside of the Sign Out button
+     */
+    buttonText: string;
     /**
-    * Passed from the Authenticator component in order to change Authentication state
-    */
-    'handleAuthStateChange': AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state
+     */
+    handleAuthStateChange: AuthStateHandler;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle: boolean;
   }
   interface AmplifySignUp {
     /**
-    * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
-    */
-    'formFields': FormFieldTypes | string[];
+     * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
+     */
+    formFields: FormFieldTypes | string[];
     /**
-    * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
-    */
-    'handleAuthStateChange': AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
+     */
+    handleAuthStateChange: AuthStateHandler;
     /**
-    * Fires when sign up form is submitted
-    */
-    'handleSubmit': (submitEvent: Event) => void;
+     * Fires when sign up form is submitted
+     */
+    handleSubmit: (submitEvent: Event) => void;
     /**
-    * Used for the submit button text in sign up component
-    */
-    'haveAccountText': string;
+     * Used for the submit button text in sign up component
+     */
+    haveAccountText: string;
     /**
-    * Used for header text in sign up component
-    */
-    'headerText': string;
+     * Used for header text in sign up component
+     */
+    headerText: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle: boolean;
     /**
-    * Used for the submit button text in sign up component
-    */
-    'signInText': string;
+     * Used for the submit button text in sign up component
+     */
+    signInText: string;
     /**
-    * Used for the submit button text in sign up component
-    */
-    'submitButtonText': string;
+     * Used for the submit button text in sign up component
+     */
+    submitButtonText: string;
     /**
-    * Engages when invalid actions occur, such as missing field, etc.
-    */
-    'validationErrors': string;
+     * Engages when invalid actions occur, such as missing field, etc.
+     */
+    validationErrors: string;
   }
   interface AmplifyStrike {
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
   }
   interface AmplifyTooltip {
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle': boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle: boolean;
     /**
-    * (Optional) Whether or not the tooltip should be automatically shown, i.e. not disappear when not hovered
-    */
-    'shouldAutoShow': boolean;
+     * (Optional) Whether or not the tooltip should be automatically shown, i.e. not disappear when not hovered
+     */
+    shouldAutoShow: boolean;
     /**
-    * (Required) The text in the tooltip
-    */
-    'text': string;
+     * (Required) The text in the tooltip
+     */
+    text: string;
   }
   interface AmplifyUsernameField {
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * Based on the type of field e.g. sign in, sign up, forgot password, etc.
-    */
-    'fieldId': string;
+     * Based on the type of field e.g. sign in, sign up, forgot password, etc.
+     */
+    fieldId: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * Used for the username label
-    */
-    'label': string;
+     * Used for the username label
+     */
+    label: string;
     /**
-    * Used for the placeholder label
-    */
-    'placeholder': string;
+     * Used for the placeholder label
+     */
+    placeholder: string;
     /**
-    * The required flag in order to make an input required prior to submitting a form
-    */
-    'required': boolean;
+     * The required flag in order to make an input required prior to submitting a form
+     */
+    required: boolean;
     /**
-    * The value of the content inside of the input field
-    */
-    'value'?: string;
+     * The value of the content inside of the input field
+     */
+    value?: string;
   }
   interface RockPaperScissor {
-    'icon': Function;
+    icon: Function;
   }
 }
 
 declare global {
-
-
   interface HTMLAmplifyAmazonButtonElement extends Components.AmplifyAmazonButton, HTMLStencilElement {}
   var HTMLAmplifyAmazonButtonElement: {
     prototype: HTMLAmplifyAmazonButtonElement;
@@ -1177,824 +1154,825 @@ declare global {
 declare namespace LocalJSX {
   interface AmplifyAmazonButton {
     /**
-    * App-specific client ID from Google
-    */
-    'clientId'?: FederatedConfig['amazonClientId'];
+     * App-specific client ID from Google
+     */
+    clientId?: FederatedConfig['amazonClientId'];
     /**
-    * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
-    */
-    'handleAuthStateChange'?: AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
+     */
+    handleAuthStateChange?: AuthStateHandler;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
   }
   interface AmplifyAuthFields {
     /**
-    * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
-    */
-    'formFields'?: FormFieldTypes | string[];
+     * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
+     */
+    formFields?: FormFieldTypes | string[];
   }
   interface AmplifyAuth0Button {
     /**
-    * See: https://auth0.com/docs/libraries/auth0js/v9#available-parameters
-    */
-    'config'?: FederatedConfig['auth0Config'];
+     * See: https://auth0.com/docs/libraries/auth0js/v9#available-parameters
+     */
+    config?: FederatedConfig['auth0Config'];
+    handleAuthStateChange?: AuthStateHandler;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
   }
   interface AmplifyAuthenticator {
     /**
-    * Federated credentials & configuration.
-    */
-    'federated'?: FederatedConfig;
+     * Federated credentials & configuration.
+     */
+    federated?: FederatedConfig;
     /**
-    * Initial starting state of the Authenticator component. E.g. If `signup` is passed the default component is set to AmplifySignUp
-    */
-    'initialAuthState'?: AuthState;
+     * Initial starting state of the Authenticator component. E.g. If `signup` is passed the default component is set to AmplifySignUp
+     */
+    initialAuthState?: AuthState;
   }
   interface AmplifyButton {
     /**
-    * (Optional) Callback called when a user clicks on the button
-    */
-    'handleButtonClick'?: (evt: Event) => void;
+     * (Optional) Callback called when a user clicks on the button
+     */
+    handleButtonClick?: (evt: Event) => void;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * Type of the button: 'button', 'submit' or 'reset'
-    */
-    'type'?: ButtonTypes;
+     * Type of the button: 'button', 'submit' or 'reset'
+     */
+    type?: ButtonTypes;
   }
   interface AmplifyCheckbox {
     /**
-    * If `true`, the checkbox is selected.
-    */
-    'checked'?: boolean;
+     * If `true`, the checkbox is selected.
+     */
+    checked?: boolean;
     /**
-    * If `true`, the checkbox is disabled
-    */
-    'disabled'?: boolean;
+     * If `true`, the checkbox is disabled
+     */
+    disabled?: boolean;
     /**
-    * Field ID used for the 'htmlFor' in the label
-    */
-    'fieldId'?: string;
+     * Field ID used for the 'htmlFor' in the label
+     */
+    fieldId?: string;
     /**
-    * Label for the checkbox
-    */
-    'label'?: string;
+     * Label for the checkbox
+     */
+    label?: string;
     /**
-    * Name of the checkbox
-    */
-    'name'?: string;
+     * Name of the checkbox
+     */
+    name?: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * Value of the checkbox
-    */
-    'value'?: string;
+     * Value of the checkbox
+     */
+    value?: string;
   }
   interface AmplifyCodeField {
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * Based on the type of field e.g. sign in, sign up, forgot password, etc.
-    */
-    'fieldId'?: string;
+     * Based on the type of field e.g. sign in, sign up, forgot password, etc.
+     */
+    fieldId?: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * Used as the hint in case you forgot your confirmation code, etc.
-    */
-    'hint'?: string | FunctionalComponent | null;
+     * Used as the hint in case you forgot your confirmation code, etc.
+     */
+    hint?: string | FunctionalComponent | null;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * Used for the code label
-    */
-    'label'?: string;
+     * Used for the code label
+     */
+    label?: string;
     /**
-    * Used for the placeholder label
-    */
-    'placeholder'?: string;
+     * Used for the placeholder label
+     */
+    placeholder?: string;
     /**
-    * The required flag in order to make an input required prior to submitting a form
-    */
-    'required'?: boolean;
+     * The required flag in order to make an input required prior to submitting a form
+     */
+    required?: boolean;
     /**
-    * The value of the content inside of the input field
-    */
-    'value'?: string;
+     * The value of the content inside of the input field
+     */
+    value?: string;
   }
   interface AmplifyConfirmSignIn {
     /**
-    * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
-    */
-    'formFields'?: FormFieldTypes | string[];
+     * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
+     */
+    formFields?: FormFieldTypes | string[];
     /**
-    * Passed from the Authenticator component in order to change Authentication state
-    */
-    'handleAuthStateChange'?: AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state
+     */
+    handleAuthStateChange?: AuthStateHandler;
     /**
-    * Fires when confirm sign in form is submitted
-    */
-    'handleSubmit'?: (Event) => void;
+     * Fires when confirm sign in form is submitted
+     */
+    handleSubmit?: (Event) => void;
     /**
-    * Used for header text in confirm sign in component
-    */
-    'headerText'?: string;
+     * Used for header text in confirm sign in component
+     */
+    headerText?: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * Used for the submit button text in confirm sign in component
-    */
-    'submitButtonText'?: string;
+     * Used for the submit button text in confirm sign in component
+     */
+    submitButtonText?: string;
     /**
-    * Cognito user signing in
-    */
-    'user'?: CognitoUserInterface;
+     * Cognito user signing in
+     */
+    user?: CognitoUserInterface;
     /**
-    * Engages when invalid actions occur, such as missing field, etc.
-    */
-    'validationErrors'?: string;
+     * Engages when invalid actions occur, such as missing field, etc.
+     */
+    validationErrors?: string;
   }
   interface AmplifyConfirmSignUp {
     /**
-    * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
-    */
-    'formFields'?: FormFieldTypes | string[];
+     * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
+     */
+    formFields?: FormFieldTypes | string[];
     /**
-    * Passed from the Authenticator component in order to change Authentication states e.g. SignIn -> 'Create Account' link -> SignUp
-    */
-    'handleAuthStateChange'?: AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication states e.g. SignIn -> 'Create Account' link -> SignUp
+     */
+    handleAuthStateChange?: AuthStateHandler;
     /**
-    * Fires when sign up form is submitted
-    */
-    'handleSubmit'?: (submitEvent: Event) => void;
+     * Fires when sign up form is submitted
+     */
+    handleSubmit?: (submitEvent: Event) => void;
     /**
-    * Used for header text in confirm sign up component
-    */
-    'headerText'?: string;
+     * Used for header text in confirm sign up component
+     */
+    headerText?: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * Used for the submit button text in confirm sign up component
-    */
-    'submitButtonText'?: string;
+     * Used for the submit button text in confirm sign up component
+     */
+    submitButtonText?: string;
     /**
-    * Used for the username to be passed to resend code
-    */
-    'user'?: CognitoUserInterface;
+     * Used for the username to be passed to resend code
+     */
+    user?: CognitoUserInterface;
     /**
-    * Engages when invalid actions occur, such as missing field, etc.
-    */
-    'validationErrors'?: string;
+     * Engages when invalid actions occur, such as missing field, etc.
+     */
+    validationErrors?: string;
   }
   interface AmplifyCountryDialCode {
     /**
-    * The ID of the field.  Should match with its corresponding input's ID.
-    */
-    'fieldId'?: string;
+     * The ID of the field.  Should match with its corresponding input's ID.
+     */
+    fieldId?: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * The options of the country dial code select input.
-    */
-    'options'?: CountryCodeDialOptions;
+     * The options of the country dial code select input.
+     */
+    options?: CountryCodeDialOptions;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle?: boolean;
   }
   interface AmplifyEmailField {
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * Based on the type of field e.g. sign in, sign up, forgot password, etc.
-    */
-    'fieldId'?: string;
+     * Based on the type of field e.g. sign in, sign up, forgot password, etc.
+     */
+    fieldId?: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * Used for the EMAIL label
-    */
-    'label'?: string;
+     * Used for the EMAIL label
+     */
+    label?: string;
     /**
-    * Used for the placeholder label
-    */
-    'placeholder'?: string;
+     * Used for the placeholder label
+     */
+    placeholder?: string;
     /**
-    * The required flag in order to make an input required prior to submitting a form
-    */
-    'required'?: boolean;
+     * The required flag in order to make an input required prior to submitting a form
+     */
+    required?: boolean;
     /**
-    * The value of the content inside of the input field
-    */
-    'value'?: string;
+     * The value of the content inside of the input field
+     */
+    value?: string;
   }
   interface AmplifyExamples {}
   interface AmplifyFacebookButton {
     /**
-    * App-specific client ID from Facebook
-    */
-    'appId'?: FederatedConfig['facebookAppId'];
+     * App-specific client ID from Facebook
+     */
+    appId?: FederatedConfig['facebookAppId'];
     /**
-    * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
-    */
-    'handleAuthStateChange'?: AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
+     */
+    handleAuthStateChange?: AuthStateHandler;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
   }
   interface AmplifyFederatedButtons {
     /**
-    * The current authentication state.
-    */
-    'authState'?: AuthState;
+     * The current authentication state.
+     */
+    authState?: AuthState;
     /**
-    * Federated credentials & configuration.
-    */
-    'federated'?: FederatedConfig;
+     * Federated credentials & configuration.
+     */
+    federated?: FederatedConfig;
     /**
-    * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
-    */
-    'handleAuthStateChange'?: AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
+     */
+    handleAuthStateChange?: AuthStateHandler;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
   }
   interface AmplifyFederatedSignIn {
     /**
-    * The current authentication state.
-    */
-    'authState'?: AuthState;
+     * The current authentication state.
+     */
+    authState?: AuthState;
     /**
-    * Federated credentials & configuration.
-    */
-    'federated'?: any;
+     * Federated credentials & configuration.
+     */
+    federated?: any;
   }
   interface AmplifyForgotPassword {
     /**
-    * The form fields displayed inside of the forgot password form
-    */
-    'formFields'?: FormFieldTypes;
+     * The form fields displayed inside of the forgot password form
+     */
+    formFields?: FormFieldTypes;
     /**
-    * Passed from the Authenticator component in order to change Authentication state
-    */
-    'handleAuthStateChange'?: AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state
+     */
+    handleAuthStateChange?: AuthStateHandler;
     /**
-    * The function called when making a request to reset password
-    */
-    'handleSend'?: (event: Event) => void;
+     * The function called when making a request to reset password
+     */
+    handleSend?: (event: Event) => void;
     /**
-    * The function called when submitting a new password
-    */
-    'handleSubmit'?: (event: Event) => void;
+     * The function called when submitting a new password
+     */
+    handleSubmit?: (event: Event) => void;
     /**
-    * The header text of the forgot password section
-    */
-    'headerText'?: string;
+     * The header text of the forgot password section
+     */
+    headerText?: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * The text displayed inside of the submit button for the form
-    */
-    'submitButtonText'?: string;
+     * The text displayed inside of the submit button for the form
+     */
+    submitButtonText?: string;
   }
   interface AmplifyFormField {
     /**
-    * The text of the description.  Goes between the label and the input.
-    */
-    'description'?: string | null;
+     * The text of the description.  Goes between the label and the input.
+     */
+    description?: string | null;
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * The ID of the field.  Should match with its corresponding input's ID.
-    */
-    'fieldId'?: string;
+     * The ID of the field.  Should match with its corresponding input's ID.
+     */
+    fieldId?: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * The text of a hint to the user as to how to fill out the input.  Goes just below the input.
-    */
-    'hint'?: string | FunctionalComponent | null;
+     * The text of a hint to the user as to how to fill out the input.  Goes just below the input.
+     */
+    hint?: string | FunctionalComponent | null;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * The text of the label.  Goes above the input. Ex: 'First name'
-    */
-    'label'?: string | null;
+     * The text of the label.  Goes above the input. Ex: 'First name'
+     */
+    label?: string | null;
     /**
-    * (Optional) String value for the name of the input.
-    */
-    'name'?: string;
+     * (Optional) String value for the name of the input.
+     */
+    name?: string;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * (Optional) The placeholder for the input element.  Using hints is recommended, but placeholders can also be useful to convey information to users.
-    */
-    'placeholder'?: string;
+     * (Optional) The placeholder for the input element.  Using hints is recommended, but placeholders can also be useful to convey information to users.
+     */
+    placeholder?: string;
     /**
-    * The required flag in order to make an input required prior to submitting a form
-    */
-    'required'?: boolean;
+     * The required flag in order to make an input required prior to submitting a form
+     */
+    required?: boolean;
     /**
-    * The input type.  Can be any HTML input type.
-    */
-    'type'?: TextFieldTypes;
+     * The input type.  Can be any HTML input type.
+     */
+    type?: TextFieldTypes;
     /**
-    * The value of the content inside of the input field
-    */
-    'value'?: string;
+     * The value of the content inside of the input field
+     */
+    value?: string;
   }
   interface AmplifyFormSection {
     /**
-    * (Required) Function called upon submission of form
-    */
-    'handleSubmit'?: (inputEvent: Event) => void;
+     * (Required) Function called upon submission of form
+     */
+    handleSubmit?: (inputEvent: Event) => void;
     /**
-    * Used for form section header
-    */
-    'headerText'?: string;
+     * Used for form section header
+     */
+    headerText?: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle'?: boolean;
-    'primaryFooterContent'?: string | FunctionalComponent;
-    'secondaryFooterContent'?: string | FunctionalComponent | null;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle?: boolean;
+    primaryFooterContent?: string | FunctionalComponent;
+    secondaryFooterContent?: string | FunctionalComponent | null;
     /**
-    * (Optional) Used as a the default value within the default footer slot
-    */
-    'submitButtonText'?: string;
+     * (Optional) Used as a the default value within the default footer slot
+     */
+    submitButtonText?: string;
   }
   interface AmplifyGoogleButton {
     /**
-    * App-specific client ID from Google
-    */
-    'clientId'?: FederatedConfig['googleClientId'];
+     * App-specific client ID from Google
+     */
+    clientId?: FederatedConfig['googleClientId'];
     /**
-    * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
-    */
-    'handleAuthStateChange'?: AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
+     */
+    handleAuthStateChange?: AuthStateHandler;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
   }
   interface AmplifyGreetings {
     /**
-    * Passed from the Authenticator component in order to change Authentication state
-    */
-    'handleAuthStateChange'?: AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state
+     */
+    handleAuthStateChange?: AuthStateHandler;
     /**
-    * Logo displayed inside of the header
-    */
-    'logo'?: FunctionalComponent | null;
+     * Logo displayed inside of the header
+     */
+    logo?: FunctionalComponent | null;
     /**
-    * Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * Override default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * Used for the username to be passed to resend code
-    */
-    'user'?: CognitoUserInterface;
+     * Used for the username to be passed to resend code
+     */
+    user?: CognitoUserInterface;
   }
   interface AmplifyHint {
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
   }
   interface AmplifyIcon {
     /**
-    * (Required) Name of icon used to determine the icon rendered
-    */
-    'name'?: IconNameType;
+     * (Required) Name of icon used to determine the icon rendered
+     */
+    name?: IconNameType;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
   }
   interface AmplifyIconButton {
-    'autoShowTooltip'?: boolean;
-    'name'?: IconNameType;
+    autoShowTooltip?: boolean;
+    name?: IconNameType;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
-    'tooltip'?: string | null;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
+    tooltip?: string | null;
   }
   interface AmplifyInput {
     /**
-    * The text of the description.  Goes just below the label.
-    */
-    'description'?: string | null;
+     * The text of the description.  Goes just below the label.
+     */
+    description?: string | null;
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * The ID of the field.  Should match with its corresponding input's ID.
-    */
-    'fieldId'?: string;
+     * The ID of the field.  Should match with its corresponding input's ID.
+     */
+    fieldId?: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * (Optional) String value for the name of the input.
-    */
-    'name'?: string;
+     * (Optional) String value for the name of the input.
+     */
+    name?: string;
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * (Optional) The placeholder for the input element.  Using hints is recommended, but placeholders can also be useful to convey information to users.
-    */
-    'placeholder'?: string;
+     * (Optional) The placeholder for the input element.  Using hints is recommended, but placeholders can also be useful to convey information to users.
+     */
+    placeholder?: string;
     /**
-    * The input type.  Can be any HTML input type.
-    */
-    'type'?: TextFieldTypes;
+     * The input type.  Can be any HTML input type.
+     */
+    type?: TextFieldTypes;
     /**
-    * The value of the content inside of the input field
-    */
-    'value'?: string;
+     * The value of the content inside of the input field
+     */
+    value?: string;
   }
   interface AmplifyLabel {
-    'htmlFor'?: string;
-    'overrideStyle'?: boolean;
+    htmlFor?: string;
+    overrideStyle?: boolean;
   }
   interface AmplifyLink {
-    'overrideStyle'?: boolean;
-    'role'?: string;
+    overrideStyle?: boolean;
+    role?: string;
   }
   interface AmplifyNav {}
   interface AmplifyOauthButton {
-    'config'?: FederatedConfig['oauthConfig'];
+    config?: FederatedConfig['oauthConfig'];
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
   }
   interface AmplifyPasswordField {
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * Based on the type of field e.g. sign in, sign up, forgot password, etc.
-    */
-    'fieldId'?: string;
+     * Based on the type of field e.g. sign in, sign up, forgot password, etc.
+     */
+    fieldId?: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * Used as the hint in case you forgot your password, etc.
-    */
-    'hint'?: string | FunctionalComponent | null;
+     * Used as the hint in case you forgot your password, etc.
+     */
+    hint?: string | FunctionalComponent | null;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * Used for the password label
-    */
-    'label'?: string;
+     * Used for the password label
+     */
+    label?: string;
     /**
-    * Used for the placeholder label
-    */
-    'placeholder'?: string;
+     * Used for the placeholder label
+     */
+    placeholder?: string;
     /**
-    * The required flag in order to make an input required prior to submitting a form
-    */
-    'required'?: boolean;
+     * The required flag in order to make an input required prior to submitting a form
+     */
+    required?: boolean;
     /**
-    * The value of the content inside of the input field
-    */
-    'value'?: string;
+     * The value of the content inside of the input field
+     */
+    value?: string;
   }
   interface AmplifyPhoneField {
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * Based on the type of field e.g. sign in, sign up, forgot password, etc.
-    */
-    'fieldId'?: string;
+     * Based on the type of field e.g. sign in, sign up, forgot password, etc.
+     */
+    fieldId?: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * Used as the hint in case you forgot your confirmation code, etc.
-    */
-    'hint'?: string | FunctionalComponent | null;
+     * Used as the hint in case you forgot your confirmation code, etc.
+     */
+    hint?: string | FunctionalComponent | null;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * Used for the Phone label
-    */
-    'label'?: string;
+     * Used for the Phone label
+     */
+    label?: string;
     /**
-    * Used for the placeholder label
-    */
-    'placeholder'?: string;
+     * Used for the placeholder label
+     */
+    placeholder?: string;
     /**
-    * The required flag in order to make an input required prior to submitting a form
-    */
-    'required'?: boolean;
+     * The required flag in order to make an input required prior to submitting a form
+     */
+    required?: boolean;
     /**
-    * The value of the content inside of the input field
-    */
-    'value'?: string;
+     * The value of the content inside of the input field
+     */
+    value?: string;
   }
   interface AmplifyRadioButton {
     /**
-    * If `true`, the radio button is selected.
-    */
-    'checked'?: boolean;
+     * If `true`, the radio button is selected.
+     */
+    checked?: boolean;
     /**
-    * If `true`, the checkbox is disabled
-    */
-    'disabled'?: boolean;
+     * If `true`, the checkbox is disabled
+     */
+    disabled?: boolean;
     /**
-    * Field ID used for the 'for' in the label
-    */
-    'fieldId'?: string;
+     * Field ID used for the 'for' in the label
+     */
+    fieldId?: string;
     /**
-    * Label for the radio button
-    */
-    'label'?: string;
+     * Label for the radio button
+     */
+    label?: string;
     /**
-    * (Optional) Name of radio button
-    */
-    'name'?: string;
+     * (Optional) Name of radio button
+     */
+    name?: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * (Optional) Value of radio button
-    */
-    'value'?: string;
+     * (Optional) Value of radio button
+     */
+    value?: string;
   }
   interface AmplifyRequireNewPassword {
     /**
-    * The form fields displayed inside of the forgot password form
-    */
-    'formFields'?: FormFieldTypes;
+     * The form fields displayed inside of the forgot password form
+     */
+    formFields?: FormFieldTypes;
     /**
-    * Passed from the Authenticator component in order to change Authentication state
-    */
-    'handleAuthStateChange'?: AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state
+     */
+    handleAuthStateChange?: AuthStateHandler;
     /**
-    * The function called when submitting a new password
-    */
-    'handleSubmit'?: (event: Event) => void;
+     * The function called when submitting a new password
+     */
+    handleSubmit?: (event: Event) => void;
     /**
-    * The header text of the forgot password section
-    */
-    'headerText'?: string;
+     * The header text of the forgot password section
+     */
+    headerText?: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * The text displayed inside of the submit button for the form
-    */
-    'submitButtonText'?: string;
+     * The text displayed inside of the submit button for the form
+     */
+    submitButtonText?: string;
     /**
-    * Used for the username to be passed to resend code
-    */
-    'user'?: CognitoUserInterface;
+     * Used for the username to be passed to resend code
+     */
+    user?: CognitoUserInterface;
   }
   interface AmplifyScene {
-    'sceneName'?: string;
+    sceneName?: string;
   }
   interface AmplifySceneLoading {
-    'loadPercentage'?: number;
-    'sceneError'?: AmplifySceneError | null;
-    'sceneName'?: string;
+    loadPercentage?: number;
+    sceneError?: AmplifySceneError | null;
+    sceneName?: string;
   }
   interface AmplifySection {
-    'overrideStyle'?: boolean;
-    'role'?: string;
+    overrideStyle?: boolean;
+    role?: string;
   }
   interface AmplifySelect {
     /**
-    * Used for id field
-    */
-    'fieldId'?: string;
+     * Used for id field
+     */
+    fieldId?: string;
     /**
-    * The callback, called when the select is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the select is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * The options of the select input. Must be an Array of Objects with an Object shape of {label: string, value: string|number}
-    */
-    'options'?: SelectOptionsString | SelectOptionsNumber;
+     * The options of the select input. Must be an Array of Objects with an Object shape of {label: string, value: string|number}
+     */
+    options?: SelectOptionsString | SelectOptionsNumber;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle?: boolean;
   }
   interface AmplifySignIn {
     /**
-    * Federated credentials & configuration.
-    */
-    'federated'?: FederatedConfig;
+     * Federated credentials & configuration.
+     */
+    federated?: FederatedConfig;
     /**
-    * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
-    */
-    'formFields'?: FormFieldTypes | string[];
+     * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
+     */
+    formFields?: FormFieldTypes | string[];
     /**
-    * Passed from the Authenticator component in order to change Authentication state
-    */
-    'handleAuthStateChange'?: AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state
+     */
+    handleAuthStateChange?: AuthStateHandler;
     /**
-    * Fires when sign in form is submitted
-    */
-    'handleSubmit'?: (Event) => void;
+     * Fires when sign in form is submitted
+     */
+    handleSubmit?: (Event) => void;
     /**
-    * Used for header text in sign in component
-    */
-    'headerText'?: string;
+     * Used for header text in sign in component
+     */
+    headerText?: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * Used for the submit button text in sign in component
-    */
-    'submitButtonText'?: string;
+     * Used for the submit button text in sign in component
+     */
+    submitButtonText?: string;
     /**
-    * Engages when invalid actions occur, such as missing field, etc.
-    */
-    'validationErrors'?: string;
+     * Engages when invalid actions occur, such as missing field, etc.
+     */
+    validationErrors?: string;
   }
   interface AmplifySignInButton {
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
-    'provider'?: 'amazon' | 'auth0' | 'facebook' | 'google' | 'oauth';
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
+    provider?: 'amazon' | 'auth0' | 'facebook' | 'google' | 'oauth';
   }
   interface AmplifySignOut {
     /**
-    * Text inside of the Sign Out button
-    */
-    'buttonText'?: string;
+     * Text inside of the Sign Out button
+     */
+    buttonText?: string;
     /**
-    * Passed from the Authenticator component in order to change Authentication state
-    */
-    'handleAuthStateChange'?: AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state
+     */
+    handleAuthStateChange?: AuthStateHandler;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle?: boolean;
   }
   interface AmplifySignUp {
     /**
-    * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
-    */
-    'formFields'?: FormFieldTypes | string[];
+     * Form fields allows you to utilize our pre-built components such as username field, code field, password field, email field, etc. by passing an array of strings that you would like the order of the form to be in. If you need more customization, such as changing text for a label or adjust a placeholder, you can follow the structure below in order to do just that. ``` [   {     type: 'username'|'password'|'email'|'code'|'default',     label: string,     placeholder: string,     hint: string | Functional Component | null,     required: boolean   } ] ```
+     */
+    formFields?: FormFieldTypes | string[];
     /**
-    * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
-    */
-    'handleAuthStateChange'?: AuthStateHandler;
+     * Passed from the Authenticator component in order to change Authentication state e.g. SignIn -> 'Create Account' link -> SignUp
+     */
+    handleAuthStateChange?: AuthStateHandler;
     /**
-    * Fires when sign up form is submitted
-    */
-    'handleSubmit'?: (submitEvent: Event) => void;
+     * Fires when sign up form is submitted
+     */
+    handleSubmit?: (submitEvent: Event) => void;
     /**
-    * Used for the submit button text in sign up component
-    */
-    'haveAccountText'?: string;
+     * Used for the submit button text in sign up component
+     */
+    haveAccountText?: string;
     /**
-    * Used for header text in sign up component
-    */
-    'headerText'?: string;
+     * Used for header text in sign up component
+     */
+    headerText?: string;
     /**
-    * (Optional) Overrides default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Overrides default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * Used for the submit button text in sign up component
-    */
-    'signInText'?: string;
+     * Used for the submit button text in sign up component
+     */
+    signInText?: string;
     /**
-    * Used for the submit button text in sign up component
-    */
-    'submitButtonText'?: string;
+     * Used for the submit button text in sign up component
+     */
+    submitButtonText?: string;
     /**
-    * Engages when invalid actions occur, such as missing field, etc.
-    */
-    'validationErrors'?: string;
+     * Engages when invalid actions occur, such as missing field, etc.
+     */
+    validationErrors?: string;
   }
   interface AmplifyStrike {
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
   }
   interface AmplifyTooltip {
     /**
-    * (Optional) Override default styling
-    */
-    'overrideStyle'?: boolean;
+     * (Optional) Override default styling
+     */
+    overrideStyle?: boolean;
     /**
-    * (Optional) Whether or not the tooltip should be automatically shown, i.e. not disappear when not hovered
-    */
-    'shouldAutoShow'?: boolean;
+     * (Optional) Whether or not the tooltip should be automatically shown, i.e. not disappear when not hovered
+     */
+    shouldAutoShow?: boolean;
     /**
-    * (Required) The text in the tooltip
-    */
-    'text'?: string;
+     * (Required) The text in the tooltip
+     */
+    text?: string;
   }
   interface AmplifyUsernameField {
     /**
-    * Will disable the input if set to true
-    */
-    'disabled'?: boolean;
+     * Will disable the input if set to true
+     */
+    disabled?: boolean;
     /**
-    * Based on the type of field e.g. sign in, sign up, forgot password, etc.
-    */
-    'fieldId'?: string;
+     * Based on the type of field e.g. sign in, sign up, forgot password, etc.
+     */
+    fieldId?: string;
     /**
-    * The callback, called when the input is modified by the user.
-    */
-    'handleInputChange'?: (inputEvent: Event) => void;
+     * The callback, called when the input is modified by the user.
+     */
+    handleInputChange?: (inputEvent: Event) => void;
     /**
-    * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
-    */
-    'inputProps'?: object;
+     * Attributes places on the input element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
+     */
+    inputProps?: object;
     /**
-    * Used for the username label
-    */
-    'label'?: string;
+     * Used for the username label
+     */
+    label?: string;
     /**
-    * Used for the placeholder label
-    */
-    'placeholder'?: string;
+     * Used for the placeholder label
+     */
+    placeholder?: string;
     /**
-    * The required flag in order to make an input required prior to submitting a form
-    */
-    'required'?: boolean;
+     * The required flag in order to make an input required prior to submitting a form
+     */
+    required?: boolean;
     /**
-    * The value of the content inside of the input field
-    */
-    'value'?: string;
+     * The value of the content inside of the input field
+     */
+    value?: string;
   }
   interface RockPaperScissor {
-    'icon'?: Function;
-    'onIconChange'?: (event: CustomEvent<any>) => void;
+    icon?: Function;
+    onIconChange?: (event: CustomEvent<any>) => void;
   }
 
   interface IntrinsicElements {
@@ -2047,8 +2025,7 @@ declare namespace LocalJSX {
 
 export { LocalJSX as JSX };
 
-
-declare module "@stencil/core" {
+declare module '@stencil/core' {
   export namespace JSX {
     interface IntrinsicElements {
       'amplify-amazon-button': LocalJSX.AmplifyAmazonButton & JSXBase.HTMLAttributes<HTMLAmplifyAmazonButtonElement>;
@@ -2058,15 +2035,22 @@ declare module "@stencil/core" {
       'amplify-button': LocalJSX.AmplifyButton & JSXBase.HTMLAttributes<HTMLAmplifyButtonElement>;
       'amplify-checkbox': LocalJSX.AmplifyCheckbox & JSXBase.HTMLAttributes<HTMLAmplifyCheckboxElement>;
       'amplify-code-field': LocalJSX.AmplifyCodeField & JSXBase.HTMLAttributes<HTMLAmplifyCodeFieldElement>;
-      'amplify-confirm-sign-in': LocalJSX.AmplifyConfirmSignIn & JSXBase.HTMLAttributes<HTMLAmplifyConfirmSignInElement>;
-      'amplify-confirm-sign-up': LocalJSX.AmplifyConfirmSignUp & JSXBase.HTMLAttributes<HTMLAmplifyConfirmSignUpElement>;
-      'amplify-country-dial-code': LocalJSX.AmplifyCountryDialCode & JSXBase.HTMLAttributes<HTMLAmplifyCountryDialCodeElement>;
+      'amplify-confirm-sign-in': LocalJSX.AmplifyConfirmSignIn &
+        JSXBase.HTMLAttributes<HTMLAmplifyConfirmSignInElement>;
+      'amplify-confirm-sign-up': LocalJSX.AmplifyConfirmSignUp &
+        JSXBase.HTMLAttributes<HTMLAmplifyConfirmSignUpElement>;
+      'amplify-country-dial-code': LocalJSX.AmplifyCountryDialCode &
+        JSXBase.HTMLAttributes<HTMLAmplifyCountryDialCodeElement>;
       'amplify-email-field': LocalJSX.AmplifyEmailField & JSXBase.HTMLAttributes<HTMLAmplifyEmailFieldElement>;
       'amplify-examples': LocalJSX.AmplifyExamples & JSXBase.HTMLAttributes<HTMLAmplifyExamplesElement>;
-      'amplify-facebook-button': LocalJSX.AmplifyFacebookButton & JSXBase.HTMLAttributes<HTMLAmplifyFacebookButtonElement>;
-      'amplify-federated-buttons': LocalJSX.AmplifyFederatedButtons & JSXBase.HTMLAttributes<HTMLAmplifyFederatedButtonsElement>;
-      'amplify-federated-sign-in': LocalJSX.AmplifyFederatedSignIn & JSXBase.HTMLAttributes<HTMLAmplifyFederatedSignInElement>;
-      'amplify-forgot-password': LocalJSX.AmplifyForgotPassword & JSXBase.HTMLAttributes<HTMLAmplifyForgotPasswordElement>;
+      'amplify-facebook-button': LocalJSX.AmplifyFacebookButton &
+        JSXBase.HTMLAttributes<HTMLAmplifyFacebookButtonElement>;
+      'amplify-federated-buttons': LocalJSX.AmplifyFederatedButtons &
+        JSXBase.HTMLAttributes<HTMLAmplifyFederatedButtonsElement>;
+      'amplify-federated-sign-in': LocalJSX.AmplifyFederatedSignIn &
+        JSXBase.HTMLAttributes<HTMLAmplifyFederatedSignInElement>;
+      'amplify-forgot-password': LocalJSX.AmplifyForgotPassword &
+        JSXBase.HTMLAttributes<HTMLAmplifyForgotPasswordElement>;
       'amplify-form-field': LocalJSX.AmplifyFormField & JSXBase.HTMLAttributes<HTMLAmplifyFormFieldElement>;
       'amplify-form-section': LocalJSX.AmplifyFormSection & JSXBase.HTMLAttributes<HTMLAmplifyFormSectionElement>;
       'amplify-google-button': LocalJSX.AmplifyGoogleButton & JSXBase.HTMLAttributes<HTMLAmplifyGoogleButtonElement>;
@@ -2082,7 +2066,8 @@ declare module "@stencil/core" {
       'amplify-password-field': LocalJSX.AmplifyPasswordField & JSXBase.HTMLAttributes<HTMLAmplifyPasswordFieldElement>;
       'amplify-phone-field': LocalJSX.AmplifyPhoneField & JSXBase.HTMLAttributes<HTMLAmplifyPhoneFieldElement>;
       'amplify-radio-button': LocalJSX.AmplifyRadioButton & JSXBase.HTMLAttributes<HTMLAmplifyRadioButtonElement>;
-      'amplify-require-new-password': LocalJSX.AmplifyRequireNewPassword & JSXBase.HTMLAttributes<HTMLAmplifyRequireNewPasswordElement>;
+      'amplify-require-new-password': LocalJSX.AmplifyRequireNewPassword &
+        JSXBase.HTMLAttributes<HTMLAmplifyRequireNewPasswordElement>;
       'amplify-scene': LocalJSX.AmplifyScene & JSXBase.HTMLAttributes<HTMLAmplifySceneElement>;
       'amplify-scene-loading': LocalJSX.AmplifySceneLoading & JSXBase.HTMLAttributes<HTMLAmplifySceneLoadingElement>;
       'amplify-section': LocalJSX.AmplifySection & JSXBase.HTMLAttributes<HTMLAmplifySectionElement>;
@@ -2098,5 +2083,3 @@ declare module "@stencil/core" {
     }
   }
 }
-
-

--- a/packages/amplify-ui-components/src/components/amplify-auth0-button/__snapshots__/amplify-auth0-button.spec.tsx.snap
+++ b/packages/amplify-ui-components/src/components/amplify-auth0-button/__snapshots__/amplify-auth0-button.spec.tsx.snap
@@ -1,10 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`amplify-auth0-button stories defaults 1`] = `
-<amplify-auth0-button>
-  <amplify-sign-in-button provider="auth0">
-    <script src="https://cdn.auth0.com/js/auth0/9.11/auth0.min.js"></script>
-    Sign In with Auth0
-  </amplify-sign-in-button>
-</amplify-auth0-button>
-`;
+exports[`amplify-auth0-button stories defaults 1`] = `null`;

--- a/packages/amplify-ui-components/src/components/amplify-auth0-button/__snapshots__/amplify-auth0-button.spec.tsx.snap
+++ b/packages/amplify-ui-components/src/components/amplify-auth0-button/__snapshots__/amplify-auth0-button.spec.tsx.snap
@@ -1,3 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`amplify-auth0-button stories defaults 1`] = `null`;
+exports[`amplify-auth0-button stories defaults 1`] = `
+<amplify-auth0-button>
+  <amplify-sign-in-button provider="auth0">
+    <script src="https://cdn.auth0.com/js/auth0/9.11/auth0.min.js"></script>
+    Sign In with Auth0
+  </amplify-sign-in-button>
+</amplify-auth0-button>
+`;

--- a/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.spec.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.spec.tsx
@@ -5,16 +5,16 @@ import * as stories from './amplify-auth0-button.stories';
 
 const {
   default: { title },
-  ...specs
+  ...templates
 } = stories;
 
 const components = [AmplifyAuth0Button];
 
 describe(title, () => {
   describe('stories', () => {
-    Object.entries(specs).forEach(([name, spec]) => {
+    Object.entries(templates).forEach(([name, template]) => {
       it(name, async () => {
-        const page = await newSpecPage({ components, html: spec() });
+        const page = await newSpecPage({ components, template });
 
         expect(page.root).toMatchSnapshot();
       });

--- a/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.stories.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.stories.tsx
@@ -1,5 +1,18 @@
+import { h } from '@stencil/core';
+import * as knobs from '@storybook/addon-knobs';
+
 export default {
   title: 'amplify-auth0-button',
 };
 
-export const defaults = () => `<amplify-auth0-button />`;
+export const defaults = () => (
+  <amplify-auth0-button
+    config={{
+      clientID: knobs.text('Auth0 client ID', 'auth0_client_id'),
+      domain: knobs.text('Auth0 account domain', 'example.auth0.com'),
+      redirectUri: knobs.text('App URL', 'http://localhost:3000/'),
+      responseType: 'token id_token',
+      scope: knobs.text('Scope', 'openid profile email'),
+    }}
+  />
+);

--- a/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.tsx
@@ -35,13 +35,6 @@ export class AmplifyAuth0Button {
 
     if (!this._auth0) {
       this._auth0 = new window['auth0'].WebAuth(config);
-      // TODO Do we need this?
-      window['auth0_client'] = this._auth0;
-    }
-
-    if (!this._auth0) {
-      logger.error('Auth0 instance was not initialized');
-      return;
     }
 
     this._auth0.parseHash((err, authResult) => {

--- a/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.tsx
@@ -1,7 +1,11 @@
+import { Auth } from '@aws-amplify/auth';
+import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import { Component, h, Prop } from '@stencil/core';
 
-import { SIGN_IN_WITH_AUTH0 } from '../../common/constants';
-import { FederatedConfig } from '../../common/types/auth-types';
+import { AUTH_SOURCE_KEY, SIGN_IN_WITH_AUTH0 } from '../../common/constants';
+import { AuthStateHandler, FederatedConfig, AuthState } from '../../common/types/auth-types';
+
+const logger = new Logger('amplify-auth0-button');
 
 @Component({
   tag: 'amplify-auth0-button',
@@ -12,11 +16,94 @@ export class AmplifyAuth0Button {
   @Prop() config: FederatedConfig['auth0Config'];
   /** (Optional) Override default styling */
   @Prop() overrideStyle: boolean = false;
+  @Prop() handleAuthStateChange: AuthStateHandler;
+
+  _auth0: any;
+
+  handleLoad = () => {
+    // @ts-ignore Property 'auth0' does not exist on type '{}'.
+    const { oauth = {} } = Auth.configure({});
+    // @ts-ignore Property 'auth0' does not exist on type '{}'.
+    const { config = oauth.auth0 } = this;
+
+    if (!config) {
+      logger.debug('Auth0 is not configured');
+      return;
+    }
+
+    logger.debug('auth0 configuration', config);
+
+    if (!this._auth0) {
+      this._auth0 = new window['auth0'].WebAuth(config);
+      // TODO Do we need this?
+      window['auth0_client'] = this._auth0;
+    }
+
+    if (!this._auth0) {
+      logger.error('Auth0 instance was not initialized');
+      return;
+    }
+
+    this._auth0.parseHash((err, authResult) => {
+      if (err) {
+        logger.debug('Failed to parse the url for Auth0', err);
+        return;
+      }
+
+      if (!authResult) {
+        logger.debug('Auth0 found no authResult in hash');
+        return;
+      }
+
+      const payload = {
+        provider: 'auth0',
+        opts: {
+          returnTo: config.returnTo,
+          clientID: config.clientID,
+          federated: config.federated,
+        },
+      };
+
+      try {
+        localStorage.setItem(AUTH_SOURCE_KEY, JSON.stringify(payload));
+      } catch (e) {
+        logger.debug('Failed to cache auth source into localStorage', e);
+      }
+
+      this._auth0.client.userInfo(authResult.accessToken, async (err, user) => {
+        let username = undefined;
+        let email = undefined;
+        if (err) {
+          logger.debug('Failed to get the user info', err);
+        } else {
+          username = user.name;
+          email = user.email;
+        }
+
+        await Auth.federatedSignIn(
+          config.domain,
+          {
+            token: authResult.idToken,
+            expires_at: authResult.expiresIn * 1000 + new Date().getTime(),
+          },
+          { name: username, email },
+        );
+
+        const authenticatedUser = await Auth.currentAuthenticatedUser();
+
+        this.handleAuthStateChange(AuthState.SignedIn, authenticatedUser);
+      });
+    });
+  };
 
   signInWithAuth0(event) {
     event.preventDefault();
 
-    throw new Error('Not implemented');
+    if (!this._auth0) {
+      throw new Error('the auth0 client is not configured');
+    }
+
+    this._auth0.authorize();
   }
 
   render() {
@@ -26,7 +113,7 @@ export class AmplifyAuth0Button {
         overrideStyle={this.overrideStyle}
         provider="auth0"
       >
-        <script src="https://cdn.auth0.com/js/auth0/9.11/auth0.min.js"></script>
+        <script onLoad={this.handleLoad} src="https://cdn.auth0.com/js/auth0/9.11/auth0.min.js"></script>
         {SIGN_IN_WITH_AUTH0}
       </amplify-sign-in-button>
     );

--- a/packages/amplify-ui-components/src/components/amplify-auth0-button/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-auth0-button/readme.md
@@ -2,26 +2,26 @@
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property        | Attribute        | Description                                                           | Type                                                        | Default     |
-| --------------- | ---------------- | --------------------------------------------------------------------- | ----------------------------------------------------------- | ----------- |
-| `config`        | --               | See: https://auth0.com/docs/libraries/auth0js/v9#available-parameters | `{ [key: string]: any; clientID: string; domain: string; }` | `undefined` |
-| `overrideStyle` | `override-style` | (Optional) Override default styling                                   | `boolean`                                                   | `false`     |
-
+| Property                | Attribute        | Description                                                           | Type                                                                                                                                     | Default     |
+| ----------------------- | ---------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `config`                | --               | See: https://auth0.com/docs/libraries/auth0js/v9#available-parameters | `{ audience?: string; clientID: string; domain: string; responseType: string; redirectUri: string; returnTo?: string; scope?: string; }` | `undefined` |
+| `handleAuthStateChange` | --               |                                                                       | `(nextAuthState: AuthState, data?: object) => void`                                                                                      | `undefined` |
+| `overrideStyle`         | `override-style` | (Optional) Override default styling                                   | `boolean`                                                                                                                                | `false`     |
 
 ## Dependencies
 
 ### Used by
 
- - [amplify-federated-buttons](../amplify-federated-buttons)
+- [amplify-federated-buttons](../amplify-federated-buttons)
 
 ### Depends on
 
 - [amplify-sign-in-button](../amplify-sign-in-button)
 
 ### Graph
+
 ```mermaid
 graph TD;
   amplify-auth0-button --> amplify-sign-in-button
@@ -30,6 +30,6 @@ graph TD;
   style amplify-auth0-button fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.stories.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.stories.tsx
@@ -14,6 +14,8 @@ export const withFederated = () => (
       auth0Config: {
         clientID: knobs.text('Auth0 client ID', 'auth0_client_id'),
         domain: knobs.text('Auth0 account domain', 'example.auth0.com'),
+        redirectUri: 'http://localhost:3000/',
+        responseType: 'token id_token',
       },
       facebookAppId: knobs.text('Facebook app ID', 'facebook_app_id'),
       googleClientId: knobs.text('Google client ID', 'google_client_id'),

--- a/packages/amplify-ui-components/src/components/amplify-federated-buttons/amplify-federated-buttons.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-federated-buttons/amplify-federated-buttons.tsx
@@ -65,13 +65,21 @@ export class AmplifyFederatedButtons {
 
         {facebookAppId && (
           <div>
-            <amplify-facebook-button appId={facebookAppId} overrideStyle={this.overrideStyle} />
+            <amplify-facebook-button
+              appId={facebookAppId}
+              handleAuthStateChange={this.handleAuthStateChange}
+              overrideStyle={this.overrideStyle}
+            />
           </div>
         )}
 
         {amazonClientId && (
           <div>
-            <amplify-amazon-button clientId={amazonClientId} overrideStyle={this.overrideStyle} />
+            <amplify-amazon-button
+              clientId={amazonClientId}
+              handleAuthStateChange={this.handleAuthStateChange}
+              overrideStyle={this.overrideStyle}
+            />
           </div>
         )}
 
@@ -83,7 +91,11 @@ export class AmplifyFederatedButtons {
 
         {auth0Config && (
           <div>
-            <amplify-auth0-button config={auth0Config} overrideStyle={this.overrideStyle} />
+            <amplify-auth0-button
+              config={auth0Config}
+              handleAuthStateChange={this.handleAuthStateChange}
+              overrideStyle={this.overrideStyle}
+            />
           </div>
         )}
       </div>

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.stories.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.stories.tsx
@@ -14,6 +14,9 @@ export const withFederated = () => (
       auth0Config: {
         clientID: knobs.text('Auth0 client ID', 'auth0_client_id'),
         domain: knobs.text('Auth0 account domain', 'example.auth0.com'),
+        redirectUri: knobs.text('App URL', 'http://localhost:3000/'),
+        responseType: 'token id_token',
+        scope: knobs.text('Scope', 'openid profile email'),
       },
       facebookAppId: knobs.text('Facebook app ID', 'facebook_app_id'),
       googleClientId: knobs.text('Google client ID', 'google_client_id'),
@@ -29,6 +32,9 @@ export const withFederatedAndOverrideStyle = () => (
       auth0Config: {
         clientID: knobs.text('Auth0 client ID', 'auth0_client_id'),
         domain: knobs.text('Auth0 account domain', 'example.auth0.com'),
+        redirectUri: knobs.text('App URL', 'http://localhost:3000/'),
+        responseType: 'token id_token',
+        scope: knobs.text('Scope', 'openid profile email'),
       },
       facebookAppId: knobs.text('Facebook app ID', 'facebook_app_id'),
       googleClientId: knobs.text('Google client ID', 'google_client_id'),


### PR DESCRIPTION
[Delivers #169928296]

A placeholder was implemented in #4249, but wasn't functional.  This PR adds that functionality:

> ![auth0](https://user-images.githubusercontent.com/15182/70668939-d7530300-1c29-11ea-95a2-8ad143c6e196.gif)

(View commits for overview)

1. Followed instructions at:

	> https://aws-amplify.github.io/docs/js/authentication#federated-with-auth0
	and
	> https://auth0.com/docs/integrations/integrating-auth0-amazon-cognito-mobile-apps

1. Setup Identity Provider + Identity Pool to match existing `aws-exports.js` file
1. Updated `amplify-examples/authenticator-example.tsx` to look like:

```diff
diff --git a/packages/amplify-ui-components/src/components/amplify-examples/authenticator-example.tsx b/packages/amplify-ui-components/src/components/amplify-examples/authenticator-example.tsx
index 8858123e..84a7a540 100644
--- a/packages/amplify-ui-components/src/components/amplify-examples/authenticator-example.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-examples/authenticator-example.tsx
@@ -1,7 +1,19 @@
 import { h } from '@stencil/core';

 const Authenticator = () => (
-  <amplify-authenticator>
+  <amplify-authenticator
+    federated={{
+      auth0Config: {
+        domain: 'aws-amplify-test.auth0.com',
+        clientID: '•••••••••••••••••••••••••',
+        redirectUri: window.location.origin,
+        responseType: 'token id_token',
+        scope: 'openid profile email',
+      },
+    }}
+  >
     <h1>My App</h1>
   </amplify-authenticator>
 );
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
