### PR TITLE
CredentialsProvider was returning an object instead of a Promise. Fix…

### DIFF
--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -316,7 +316,7 @@ export class CredentialsClass {
 
 			Note: Retreive identityId from CredentialsProvider once aws-sdk-js v3 supports this.
 		*/
-		let credentialsProvider: CredentialProvider = async () => {
+		const credentialsProvider: CredentialProvider = async () => {
 			const { IdentityId } = await cognitoClient.send(
 				new GetIdCommand({
 					IdentityPoolId: identityPoolId,
@@ -331,9 +331,11 @@ export class CredentialsClass {
 				identityId: IdentityId,
 			};
 
-			credentialsProvider = fromCognitoIdentity(cognitoIdentityParams);
+			const credentialsFromCognitoIdentity = fromCognitoIdentity(
+				cognitoIdentityParams
+			);
 
-			return credentialsProvider();
+			return credentialsFromCognitoIdentity();
 		};
 
 		const credentials = credentialsProvider().catch(async err => {

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -316,7 +316,7 @@ export class CredentialsClass {
 
 			Note: Retreive identityId from CredentialsProvider once aws-sdk-js v3 supports this.
 		*/
-		let credentials: CredentialProvider = async () => {
+		let credentialsProvider: CredentialProvider = async () => {
 			const { IdentityId } = await cognitoClient.send(
 				new GetIdCommand({
 					IdentityPoolId: identityPoolId,
@@ -331,10 +331,14 @@ export class CredentialsClass {
 				identityId: IdentityId,
 			};
 
-			credentials = fromCognitoIdentity(cognitoIdentityParams);
+			credentialsProvider = fromCognitoIdentity(cognitoIdentityParams);
 
-			return credentials();
+			return credentialsProvider();
 		};
+
+		const credentials = credentialsProvider.catch(async err => {
+			throw err;
+		});
 
 		return this._loadCredentials(credentials, 'userPool', true, null);
 	}


### PR DESCRIPTION
_Description of changes:_
- CredentialProvider returned an object instead of a Promise. loadCredentials expects a Promise.
- We were missing this part of the code from `fromCognitoIdentityPool `:
https://github.com/aws/aws-sdk-js-v3/blob/04592b775d715c1f0313954a3f09a01ba5d229bd/packages/credential-provider-cognito-identity/src/fromCognitoIdentityPool.ts#L59-L66

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
