### PR TITLE
fix: Use paulfantom/periodic-labeler for labeling PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,12 +6,16 @@
 # https://github.com/actions/labeler/blob/master/README.md
 
 name: Labeler
-on: [pull_request]
+on:
+  schedule:
+    - cron: '*/30 * * * *' # Every 1st and 30th minute
 
 jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v2
+    - uses: paulfantom/periodic-labeler@v0.0.1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        LABEL_MAPPINGS_FILE: .github/labeler.yml


### PR DESCRIPTION
[Delivers #170288921]

The labeler runs successfully on PRs from `aws-amplify`, but **not on forks** with this error:

> ![70322537-a38f6c00-182a-11ea-9d7e-6fe8b7d54933](https://user-images.githubusercontent.com/15182/70822433-6549fd80-1d92-11ea-9eab-869cb3807824.png)
> https://github.com/actions/labeler/issues/16#issuecomment-562550042

This is known, but surprising behavior:
> https://github.com/yogstation13/Yogstation/pull/7203

The fix is to switch to `periodic-labeler`, which runs on a `cron` within the scope of `aws-amplify`, vs. a PR event which runs in the restricted context of the fork:
> https://github.com/actions/labeler/issues/12#issuecomment-555746868

https://github.com/marketplace/actions/periodic-labeler

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
