### PR TITLE
fix(aws-amplify): delete unused AmazonAIPredictionsProvider import

### DIFF
--- a/packages/aws-amplify/src/index.ts
+++ b/packages/aws-amplify/src/index.ts
@@ -27,9 +27,7 @@ import Cache from '@aws-amplify/cache';
 import Interactions, { InteractionsClass } from '@aws-amplify/interactions';
 import * as UI from '@aws-amplify/ui';
 import XR, { XRClass } from '@aws-amplify/xr';
-import Predictions, {
-	AmazonAIPredictionsProvider,
-} from '@aws-amplify/predictions';
+import Predictions from '@aws-amplify/predictions';
 
 import Amplify, {
 	ConsoleLogger as Logger,


### PR DESCRIPTION
_Description of changes:_
`AmazonAIPredictionsProvider` is unused in `packages/aws-amplify/src/index.ts`. It is likely to have been meant to be exported.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
