### PR TITLE
fix(@aws-amplify/api): change type of GraphQLOptions.authMode to be string literal

### DIFF
--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -69,7 +69,7 @@ export interface apiOptions {
 export interface GraphQLOptions {
 	query: string | DocumentNode;
 	variables?: object;
-	authMode?: GRAPHQL_AUTH_MODE;
+	authMode?: keyof typeof GRAPHQL_AUTH_MODE;
 }
 
 export enum GRAPHQL_AUTH_MODE {


### PR DESCRIPTION
_Issue #, if available:_
Fixes #4361

_Description of changes:_
TypeScript users are getting a compilation error when using a string literal as a value for `authMode` in the `API.graphql()` options parameter: 

```
Type '"AMAZON_COGNITO_USER_POOLS"' is not assignable to type 'GRAPHQL_AUTH_MODE'.ts(2322)
index.d.ts(47, 5): The expected type comes from property 'authMode' which is declared here on type 'GraphQLOptions'
```

This pull request actually makes the type of `authMode` to be a string literal instead of requiring the actual GRAPHQL_AUTH_MODE enum.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.