### PR TITLE
fix(aws-amplify-react): Fix peer dependencies

### DIFF
--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -73,6 +73,6 @@
     "rxjs-compat": "^6.2.1"
   },
   "peerDependencies": {
-    "aws-amplify": "^1.x"
+    "aws-amplify": "^2.0.0"
   }
 }

--- a/packages/aws-amplify-react-native/package.json
+++ b/packages/aws-amplify-react-native/package.json
@@ -29,7 +29,7 @@
     "react-native-vector-icons": "^5.0.0"
   },
   "peerDependencies": {
-    "aws-amplify": "^1.x",
+    "aws-amplify": "^2.0.0",
     "graphql": "0.13.0",
     "react-native-fs": "^2.12.1",
     "react-native-sound": "^0.10.9",

--- a/packages/aws-amplify-react/package.json
+++ b/packages/aws-amplify-react/package.json
@@ -95,6 +95,12 @@
     "regenerator-runtime": "^0.11.1"
   },
   "peerDependencies": {
-    "aws-amplify": "^1.x"
+    "@aws-amplify/analytics": "^2.0.0",
+    "@aws-amplify/api": "^2.0.0",
+    "@aws-amplify/auth": "^2.0.0",
+    "@aws-amplify/core": "^2.0.0",
+    "@aws-amplify/interactions": "^2.0.0",
+    "@aws-amplify/storage": "^2.0.0",
+    "@aws-amplify/ui": "^2.0.0"
   }
 }


### PR DESCRIPTION
Also fix peer dependencies for `aws-amplify-react-native` and `aws-amplify-angular`.

Matched packages used in `aws-amplify-react` to peerDependencies in order to more precisely express dependencies.

Also, looks like some peer dependencies were not updated when migrating versions to 2.x.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
