### PR TITLE
Throw an error to prevent returning undefined as auth response

### DIFF
--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -224,6 +224,7 @@ export default class OAuth {
 			}
 		} catch (e) {
 			logger.error(`Error handling auth response.`, e);
+			throw e;
 		}
 	}
 


### PR DESCRIPTION
_Issue #, if available: Potentially fixes #4375, but should provide further visibility into further errors._

**tldr;** If a duplicate or invalid `?code=...` is in the URL, Cognito returns an error that is caught, logged but not thrown. `undefined` is returned, causing run-time errors when trying to destructuring `accessToken` from it.
> https://github.com/aws-amplify/amplify-js/issues/4375#issuecomment-569963165

This fix was recommended here: https://github.com/aws-amplify/amplify-js/issues/4375#issuecomment-570270373

We could potentially unwrap the entire `try/catch` block, but doing so would make it more difficult to catch any other run-time errors within this code (that's primarily happy-path).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
