### PR TITLE
fix: correct Czech Republic phone country code

### DIFF
--- a/packages/aws-amplify-angular/src/assets/countries.ts
+++ b/packages/aws-amplify-angular/src/assets/countries.ts
@@ -68,7 +68,7 @@ const countrylist = [
 	{ countryCode: 'CW', value: '599', label: 'Curacao (+599)' },
 	{ countryCode: 'CY', value: '90392', label: 'Cyprus North (+90392)' },
 	{ countryCode: 'CY', value: '357', label: 'Cyprus South (+357)' },
-	{ countryCode: 'CZ', value: '42', label: 'Czech Republic (+42)' },
+	{ countryCode: 'CZ', value: '420', label: 'Czech Republic (+420)' },
 	{ countryCode: 'DK', value: '45', label: 'Denmark (+45)' },
 	{ countryCode: 'DJ', value: '253', label: 'Djibouti (+253)' },
 	{ countryCode: 'DM', value: '1809', label: 'Dominica (+1809)' },

--- a/packages/aws-amplify-vue/src/assets/countries.js
+++ b/packages/aws-amplify-vue/src/assets/countries.js
@@ -48,7 +48,7 @@ const countries = [
 	{ countryCode: 'CW', value: '599', label: 'Curacao (+599)' },
 	{ countryCode: 'CY', value: '90392', label: 'Cyprus North (+90392)' },
 	{ countryCode: 'CY', value: '357', label: 'Cyprus South (+357)' },
-	{ countryCode: 'CZ', value: '42', label: 'Czech Republic (+42)' },
+	{ countryCode: 'CZ', value: '420', label: 'Czech Republic (+420)' },
 	{ countryCode: 'DK', value: '45', label: 'Denmark (+45)' },
 	{ countryCode: 'DJ', value: '253', label: 'Djibouti (+253)' },
 	{ countryCode: 'DM', value: '1809', label: 'Dominica (+1809)' },


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/issues/4693

_Description of changes:_
Corrected phone country code for Czech Republic to `+420`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
