### PR TITLE
fix(dependencies): pin version for push-notification-ios

### DIFF
--- a/packages/pushnotification/package.json
+++ b/packages/pushnotification/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@aws-amplify/core": "^2.2.1",
-    "@react-native-community/push-notification-ios": "^1.0.2"
+    "@react-native-community/push-notification-ios": "1.0.2"
   },
   "peerdependencies": {
     "react-native": "^0.55.0"

--- a/packages/pushnotification/package.json
+++ b/packages/pushnotification/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@aws-amplify/core": "^2.2.1",
-    "@react-native-community/push-notification-ios": "1.0.2"
+    "@react-native-community/push-notification-ios": "1.0.3"
   },
   "peerdependencies": {
     "react-native": "^0.55.0"


### PR DESCRIPTION
pinning latest known working version - 1.0.3 to resolve the build error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
