### PR TITLE
Include @aws-amplify/ui-components/loader in package

### DIFF
--- a/packages/amplify-ui-components/package.json
+++ b/packages/amplify-ui-components/package.json
@@ -10,7 +10,8 @@
   "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "files": [
-    "dist/"
+    "dist/",
+    "loader"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
When consuming `@aws-amplify/ui-react`, `@aws-amplify/ui-components/loader` cannot be resolved because it's not included in the package:

See: https://unpkg.com/browse/@aws-amplify/ui-components@0.1.1-ui-preview.3/

> <img width="1025" alt="Screen Shot 2020-01-16 at 10 25 54 AM" src="https://user-images.githubusercontent.com/15182/72551999-d75aaa00-384a-11ea-8752-e7e4ac7c22fa.png">

This adds it for publishing so this resolves correctly.

Related to https://github.com/aws-amplify/amplify-js-samples-staging/pull/42.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
