### PR TITLE
Move tslib to devDependencies

### DIFF
--- a/packages/amplify-ui-angular/package.json
+++ b/packages/amplify-ui-angular/package.json
@@ -31,8 +31,7 @@
 		"dist/"
 	],
 	"dependencies": {
-		"@aws-amplify/ui-components": "*",
-		"tslib": "^1.9.3"
+		"@aws-amplify/ui-components": "*"
 	},
 	"devDependencies": {
 		"@angular/compiler-cli": "^7.2.1",
@@ -43,6 +42,7 @@
 		"tsickle": "^0.34.0",
 		"typescript": "3.2.4",
 		"zone.js": "^0.8.28",
+		"tslib": "^1.9.3",
 		"tslint": "^5.12.1"
 	}
 }


### PR DESCRIPTION
Troubleshooting issues with `@aws-amplify/ui-angular` and found this dependency should've been in `devDependencies`.

Related to https://github.com/aws-amplify/amplify-js-samples-staging/pull/42

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
