### PR TITLE
fixes: #4666 Remove externals from amplify's root webpack build

### DIFF
--- a/packages/aws-amplify/webpack.config.js
+++ b/packages/aws-amplify/webpack.config.js
@@ -2,18 +2,6 @@ module.exports = {
 	entry: {
 		'aws-amplify.min': './lib-esm/index.js',
 	},
-	externals: [
-		'@aws-amplify/analytics',
-		'@aws-amplify/api',
-		'@aws-amplify/auth',
-		'@aws-amplify/cache',
-		'@aws-amplify/core',
-		'@aws-amplify/interactions',
-		'@aws-amplify/pubsub',
-		'@aws-amplify/storage',
-		'@aws-amplify/ui',
-		'@aws-amplify/xr',
-	],
 	output: {
 		filename: '[name].js',
 		path: __dirname + '/dist',
@@ -27,7 +15,7 @@ module.exports = {
 	// Enable sourcemaps for debugging webpack's output.
 	devtool: 'source-map',
 	resolve: {
-		extensions: ['.js', '.json'],
+		extensions: ['.mjs', '.js', '.json'],
 	},
 	mode: 'production',
 	module: {


### PR DESCRIPTION
_Issue #, if available:_ #4666

_Description of changes:_ fixes: #4666 Remove externals from amplify's root webpack build

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
