### PR TITLE
fix(@aws-amplify/ui): Add padding to caret for SignUp component

### DIFF
--- a/packages/amplify-ui/src/SelectInput.css
+++ b/packages/amplify-ui/src/SelectInput.css
@@ -1,42 +1,36 @@
 @import './Theme.css';
 
 .selectInput {
-  display: flex;
+	display: flex;
 }
 
 .selectInput > input {
-  flex: 1;
-  border-radius: 0 3px 3px 0 !important;
+	flex: 1;
+	border-radius: 0 3px 3px 0 !important;
 }
 
 .selectInput > select {
-  padding: 16px;
-  font-size: 14px;
-  color: var(--deepSquidInk);
-  background-color: #fff;
-  background-image: none;
-  border: 1px solid var(--lightGrey);
-  border-right: none;
-  border-radius: 3px 0 0 3px;
-  box-sizing: border-box;
-  margin-bottom: 10px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  flex-basis: 22%;
-  width: 1%;
+	padding: 16px 20px 16px 16px;
+	font-size: 14px;
+	color: var(--deepSquidInk);
+	background-color: #fff;
+	background-image: none;
+	border: 1px solid var(--lightGrey);
+	border-right: none;
+	border-radius: 3px 0 0 3px;
+	box-sizing: border-box;
+	margin-bottom: 10px;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+	flex-basis: 22%;
+	width: 1%;
 
-  background-image:
-    linear-gradient(45deg, transparent 50%, gray 50%),
-    linear-gradient(135deg, gray 50%, transparent 50%),
-    linear-gradient(to right, #ccc, #ccc);
-  background-position:
-    calc(100% - 20px) calc(1em + 8px),
-    calc(100% - 15px) calc(1em + 8px),
-    calc(100% - 2.5em) 0.5em;
-  background-size:
-    6px 5px,
-    6px 5px,
-    0px 1.5em;
-  background-repeat: no-repeat;
+	background-image: linear-gradient(45deg, transparent 50%, gray 50%),
+		linear-gradient(135deg, gray 50%, transparent 50%),
+		linear-gradient(to right, #ccc, #ccc);
+	background-position: calc(100% - 10px) calc(1em + 8px),
+		calc(100% - 4px) calc(1em + 8px), calc(100% - 2.5em) 0.5em;
+	background-size: 6px 5px, 6px 5px, 0px 1.5em;
+	background-repeat: no-repeat;
 }


### PR DESCRIPTION
_Issue #, if available:_ Fixes #3944

Before, the caret encroaches upon the country code:
> <img width="572" alt="Screen Shot 2020-01-22 at 12 57 50 PM" src="https://user-images.githubusercontent.com/15182/72934187-09bb4a00-3d18-11ea-9825-873f5f7767a0.png">

With this change (thanks to @gsans), it can breath:
> ![72844426-57b94a80-3c51-11ea-8ef1-57e87194e933](https://user-images.githubusercontent.com/15182/72844426-57b94a80-3c51-11ea-8ef1-57e87194e933.png)

See #3944 for more research.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
