### PR TITLE
chore:(stale bot updates) Add label for to-be-reproduced

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ exemptLabels:
   - security
   - feature-request
   - to-be-triaged
+  - to-be-reproduced
   - bug
   - tracked
   - question


### PR DESCRIPTION
_Description of changes:_
As part of OE, we need to adjust the current label `to-be-triaged` to `to-be-reproduced`. This is the first Pull Request of two to add the new label and the second PR will be to remove `to-be-triaged`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
