### PR TITLE
fix(aws-amplify-react-native): Match withAuthenticator arguments with documentation

### DIFF
--- a/packages/aws-amplify-react-native/src/Auth/index.js
+++ b/packages/aws-amplify-react-native/src/Auth/index.js
@@ -69,6 +69,8 @@ export function withAuthenticator(
 					includeGreetings,
 					authenticatorComponents,
 					signUpConfig,
+					federated,
+					theme,
 				};
 			}
 		}
@@ -101,7 +103,7 @@ export function withAuthenticator(
 							authState={authState}
 							authData={authData}
 							onStateChange={this.handleAuthStateChange}
-							theme={theme}
+							theme={this.authConfig.theme}
 							usernameAttributes={this.authConfig.usernameAttributes}
 						/>
 						<Comp
@@ -125,7 +127,8 @@ export function withAuthenticator(
 					onStateChange={this.handleAuthStateChange}
 					children={this.authConfig.authenticatorComponents}
 					usernameAttributes={this.authConfig.usernameAttributes}
-					theme={theme}
+					federated={this.authConfig.federated}
+					theme={this.authConfig.theme}
 				/>
 			);
 		}


### PR DESCRIPTION
https://aws-amplify.github.io/docs/js/authentication#using-the-authenticator-component

_Issue #1949

_Description of changes:_

> Ideally, we'd be able to pass a theme into `withAuthenticator` for React Native as the docs suggest. Is there a reason not to?
Based on the current code
https://github.com/aws-amplify/amplify-js/blob/master/packages/aws-amplify-react-native/src/Auth/index.js

Documentation does not match the actual arguments. 
https://aws-amplify.github.io/docs/js/authentication#customize-ui-theme
```javascript
// Documentation
export default withAuthenticator(App, {
                // Render a sign out button once logged in
                includeGreetings: true, 
                // Show only certain components
                authenticatorComponents: [MyComponents],
                // display federation/social provider buttons 
                federated: {myFederatedConfig}, 
                // customize the UI/styling
                theme: {myCustomTheme}});

// So... You expect to work based on the documentation.
export default withAuthenticator(
  App,
  { 
     includeGreetings: true,
     theme: {myCustomTheme}
  }, // documentation says you can place federated and theme here, but it actually 
)

// What actually working at this moment
export default withAuthenticator(
  App,
  { includeGreetings: true, },  // documentation says you can place federated and theme here, but it actually wont work
  undefined, // placeholder for authenticatorComponents
  undefined, // placeholder for federated
  theme, // This is where the theme should be placed. the 5th argument
)
```




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
