### PR TITLE
Make all HOCs accept generics for props & state.

### DIFF
--- a/packages/aws-amplify-react/src/Auth/AuthPiece.tsx
+++ b/packages/aws-amplify-react/src/Auth/AuthPiece.tsx
@@ -46,15 +46,15 @@ export interface IAuthPieceState {
 }
 
 export default class AuthPiece<
-	Props extends IAuthPieceProps,
-	State extends IAuthPieceState
-> extends React.Component<Props, State> {
+	P extends IAuthPieceProps,
+	S extends IAuthPieceState
+> extends React.Component<P, S> {
 	public _validAuthStates: string[];
 	public _isHidden: boolean;
 	public inputs: any;
 	public phone_number: any;
 
-	constructor(props) {
+	constructor(props: P) {
 		super(props);
 
 		this.inputs = {};

--- a/packages/aws-amplify-react/src/Auth/AuthStateWrapper.tsx
+++ b/packages/aws-amplify-react/src/Auth/AuthStateWrapper.tsx
@@ -19,18 +19,20 @@ export interface IAuthStateWrapperState {
 	error?: any;
 }
 
-export default class AuthStateWrapper extends React.Component<
-	IAuthStateWrapperProps,
-	IAuthStateWrapperState
-> {
-	constructor(props) {
+export default class AuthStateWrapper<
+	P extends IAuthStateWrapperProps,
+	S extends IAuthStateWrapperState
+> extends React.Component<P, S> {
+	constructor(props: P) {
 		super(props);
 
 		this.handleStateChange = this.handleStateChange.bind(this);
 		this.handleAuthEvent = this.handleAuthEvent.bind(this);
 		this.checkUser = this.checkUser.bind(this);
 
-		this.state = { authState: props.authState || 'signIn' };
+		this.state = {
+			authState: props.authState || 'signIn',
+		} as S;
 	}
 
 	componentWillMount() {

--- a/packages/aws-amplify-react/src/Auth/Authenticator.tsx
+++ b/packages/aws-amplify-react/src/Auth/Authenticator.tsx
@@ -60,14 +60,14 @@ export interface IAuthenticatorState {
 	showToast?: boolean;
 }
 
-export default class Authenticator extends React.Component<
-	IAuthenticatorProps,
-	IAuthenticatorState
-> {
+export default class Authenticator<
+	P extends IAuthenticatorProps,
+	S extends IAuthenticatorState
+> extends React.Component<P, S> {
 	public _initialAuthState: string;
 	public _isMounted: boolean;
 
-	constructor(props) {
+	public constructor(props: P) {
 		super(props);
 
 		this.handleStateChange = this.handleStateChange.bind(this);
@@ -75,7 +75,9 @@ export default class Authenticator extends React.Component<
 		this.onHubCapsule = this.onHubCapsule.bind(this);
 
 		this._initialAuthState = this.props.authState || 'signIn';
-		this.state = { authState: 'loading' };
+		this.state = {
+			authState: 'loading',
+		} as S;
 		Hub.listen('auth', this.onHubCapsule);
 	}
 

--- a/packages/aws-amplify-react/src/Auth/ConfirmSignIn.tsx
+++ b/packages/aws-amplify-react/src/Auth/ConfirmSignIn.tsx
@@ -37,11 +37,11 @@ export interface IConfirmSignInState extends IAuthPieceState {
 	mfaType: string;
 }
 
-export default class ConfirmSignIn extends AuthPiece<
-	IAuthPieceProps,
-	IConfirmSignInState
-> {
-	constructor(props: IAuthPieceProps) {
+export default class ConfirmSignIn<
+	P extends IAuthPieceProps,
+	S extends IConfirmSignInState
+> extends AuthPiece<P, S> {
+	constructor(props: P) {
 		super(props);
 
 		this._validAuthStates = ['confirmSignIn'];
@@ -49,7 +49,7 @@ export default class ConfirmSignIn extends AuthPiece<
 		this.checkContact = this.checkContact.bind(this);
 		this.state = {
 			mfaType: 'SMS',
-		};
+		} as S;
 	}
 
 	checkContact(user) {

--- a/packages/aws-amplify-react/src/Auth/ConfirmSignUp.tsx
+++ b/packages/aws-amplify-react/src/Auth/ConfirmSignUp.tsx
@@ -35,11 +35,11 @@ import { auth } from '../Amplify-UI/data-test-attributes';
 
 const logger = new Logger('ConfirmSignUp');
 
-export default class ConfirmSignUp extends AuthPiece<
-	IAuthPieceProps,
-	IAuthPieceState
-> {
-	constructor(props: IAuthPieceProps) {
+export default class ConfirmSignUp<
+	P extends IAuthPieceProps,
+	S extends IAuthPieceState
+> extends AuthPiece<P, S> {
+	constructor(props: P) {
 		super(props);
 
 		this._validAuthStates = ['confirmSignUp'];

--- a/packages/aws-amplify-react/src/Auth/FederatedSignIn.tsx
+++ b/packages/aws-amplify-react/src/Auth/FederatedSignIn.tsx
@@ -30,10 +30,10 @@ export interface IFederatedButtonsProps {
 	theme: any;
 }
 
-export class FederatedButtons extends React.Component<
-	IFederatedButtonsProps,
-	{}
-> {
+export class FederatedButtons<
+	P extends IFederatedButtonsProps,
+	S extends {}
+> extends React.Component<P, S> {
 	google(google_client_id) {
 		if (!google_client_id) {
 			return null;

--- a/packages/aws-amplify-react/src/Auth/ForgotPassword.tsx
+++ b/packages/aws-amplify-react/src/Auth/ForgotPassword.tsx
@@ -41,18 +41,18 @@ export interface IForgotPasswordState extends IAuthPieceState {
 	delivery: any;
 }
 
-export default class ForgotPassword extends AuthPiece<
-	IAuthPieceProps,
-	IForgotPasswordState
-> {
-	constructor(props: IAuthPieceProps) {
+export default class ForgotPassword<
+	P extends IAuthPieceProps,
+	S extends IForgotPasswordState
+> extends AuthPiece<P, S> {
+	constructor(props: P) {
 		super(props);
 
 		this.send = this.send.bind(this);
 		this.submit = this.submit.bind(this);
 
 		this._validAuthStates = ['forgotPassword'];
-		this.state = { delivery: null };
+		this.state = { delivery: null } as S;
 	}
 
 	send() {

--- a/packages/aws-amplify-react/src/Auth/Greetings.tsx
+++ b/packages/aws-amplify-react/src/Auth/Greetings.tsx
@@ -41,15 +41,15 @@ export interface IGreetingsState extends IAuthPieceState {
 	stateFromStorage?: boolean;
 }
 
-export default class Greetings extends AuthPiece<
-	IGreetingsProps,
-	IGreetingsState
-> {
+export default class Greetings<
+	P extends IGreetingsProps,
+	S extends IGreetingsState
+> extends AuthPiece<P, S> {
 	private _isMounted: boolean;
 
-	constructor(props: IGreetingsProps) {
+	constructor(props: P) {
 		super(props);
-		this.state = {};
+		this.state = {} as S;
 		this.onHubCapsule = this.onHubCapsule.bind(this);
 		this.inGreeting = this.inGreeting.bind(this);
 		Hub.listen('auth', this.onHubCapsule);

--- a/packages/aws-amplify-react/src/Auth/Loading.tsx
+++ b/packages/aws-amplify-react/src/Auth/Loading.tsx
@@ -22,11 +22,11 @@ import {
 
 import { auth } from '../Amplify-UI/data-test-attributes';
 
-export default class Loading extends AuthPiece<
-	IAuthPieceProps,
-	IAuthPieceState
-> {
-	constructor(props: IAuthPieceProps) {
+export default class Loading<
+	P extends IAuthPieceProps,
+	S extends IAuthPieceState
+> extends AuthPiece<P, S> {
+	constructor(props: P) {
 		super(props);
 
 		this._validAuthStates = ['loading'];

--- a/packages/aws-amplify-react/src/Auth/PhoneField.tsx
+++ b/packages/aws-amplify-react/src/Auth/PhoneField.tsx
@@ -21,10 +21,13 @@ interface IPhoneFieldProps {
 
 interface IPhoneFieldState {}
 
-class PhoneField extends React.Component<IPhoneFieldProps, IPhoneFieldState> {
+class PhoneField<
+	P extends IPhoneFieldProps,
+	S extends IPhoneFieldState
+> extends React.Component<P, S> {
 	private inputs: any;
 
-	constructor(props) {
+	constructor(props: P) {
 		super(props);
 		this.handleInputChange = this.handleInputChange.bind(this);
 		this.composePhoneNumber = this.composePhoneNumber.bind(this);

--- a/packages/aws-amplify-react/src/Auth/RequireNewPassword.tsx
+++ b/packages/aws-amplify-react/src/Auth/RequireNewPassword.tsx
@@ -33,11 +33,11 @@ import { auth } from '../Amplify-UI/data-test-attributes';
 
 const logger = new Logger('RequireNewPassword');
 
-export default class RequireNewPassword extends AuthPiece<
-	IAuthPieceProps,
-	IAuthPieceState
-> {
-	constructor(props: IAuthPieceProps) {
+export default class RequireNewPassword<
+	P extends IAuthPieceProps,
+	S extends IAuthPieceState
+> extends AuthPiece<P, S> {
+	constructor(props: P) {
 		super(props);
 
 		this._validAuthStates = ['requireNewPassword'];

--- a/packages/aws-amplify-react/src/Auth/SignIn.tsx
+++ b/packages/aws-amplify-react/src/Auth/SignIn.tsx
@@ -48,15 +48,18 @@ export interface ISignInState extends IAuthPieceState {
 	loading?: boolean;
 }
 
-export default class SignIn extends AuthPiece<ISignInProps, ISignInState> {
-	constructor(props: ISignInProps) {
+export default class SignIn<
+	P extends ISignInProps,
+	S extends ISignInState
+> extends AuthPiece<P, S> {
+	constructor(props: P) {
 		super(props);
 
 		this.checkContact = this.checkContact.bind(this);
 		this.signIn = this.signIn.bind(this);
 
 		this._validAuthStates = ['signIn', 'signedOut', 'signedUp'];
-		this.state = {};
+		this.state = {} as S;
 	}
 
 	checkContact(user) {

--- a/packages/aws-amplify-react/src/Auth/SignOut.tsx
+++ b/packages/aws-amplify-react/src/Auth/SignOut.tsx
@@ -39,16 +39,19 @@ export interface ISignOutState extends IAuthPieceState {
 	stateFromStorage?: any;
 }
 
-export default class SignOut extends AuthPiece<ISignOutProps, ISignOutState> {
+export default class SignOut<
+	P extends ISignOutProps,
+	S extends ISignOutState
+> extends AuthPiece<P, S> {
 	public _isMounted: boolean;
 
-	constructor(props: ISignOutProps) {
+	constructor(props: P) {
 		super(props);
 
 		this.signOut = this.signOut.bind(this);
 		this.onHubCapsule = this.onHubCapsule.bind(this);
 		Hub.listen('auth', this.onHubCapsule);
-		this.state = {};
+		this.state = {} as S;
 	}
 
 	componentDidMount() {

--- a/packages/aws-amplify-react/src/Auth/SignUp.tsx
+++ b/packages/aws-amplify-react/src/Auth/SignUp.tsx
@@ -56,14 +56,17 @@ export interface ISignUpProps extends IAuthPieceProps {
 	signUpConfig?: ISignUpConfig;
 }
 
-export default class SignUp extends AuthPiece<ISignUpProps, IAuthPieceState> {
+export default class SignUp<
+	P extends ISignUpProps,
+	S extends IAuthPieceState
+> extends AuthPiece<P, S> {
 	public defaultSignUpFields: ISignUpField[];
 	public header: string;
 	public signUpFields: ISignUpField[];
 
-	constructor(props: ISignUpProps) {
+	constructor(props: P) {
 		super(props);
-		this.state = { requestPending: false };
+		this.state = { requestPending: false } as S;
 
 		this._validAuthStates = ['signUp'];
 		this.signUp = this.signUp.bind(this);
@@ -136,7 +139,7 @@ export default class SignUp extends AuthPiece<ISignUpProps, IAuthPieceState> {
 				});
 			}
 
-			/* 
+			/*
             sort fields based on following rules:
             1. Fields with displayOrder are sorted before those without displayOrder
             2. Fields with conflicting displayOrder are sorted alphabetically by key

--- a/packages/aws-amplify-react/src/Auth/TOTPSetup.tsx
+++ b/packages/aws-amplify-react/src/Auth/TOTPSetup.tsx
@@ -21,11 +21,11 @@ import { auth } from '../Amplify-UI/data-test-attributes';
 
 const logger = new Logger('TOTPSetup');
 
-export default class TOTPSetup extends AuthPiece<
-	IAuthPieceProps,
-	IAuthPieceState
-> {
-	constructor(props: IAuthPieceProps) {
+export default class TOTPSetup<
+	P extends IAuthPieceProps,
+	S extends IAuthPieceState
+> extends AuthPiece<P, S> {
+	constructor(props: P) {
 		super(props);
 
 		this._validAuthStates = ['TOTPSetup'];
@@ -33,7 +33,7 @@ export default class TOTPSetup extends AuthPiece<
 		this.checkContact = this.checkContact.bind(this);
 	}
 
-	checkContact(user) {
+	checkContact(user): void {
 		if (!Auth || typeof Auth.verifiedContact !== 'function') {
 			throw new Error(
 				'No Auth module found, please ensure @aws-amplify/auth is imported'
@@ -49,7 +49,7 @@ export default class TOTPSetup extends AuthPiece<
 		});
 	}
 
-	onTOTPEvent(event, data, user) {
+	onTOTPEvent(event, data, user): void {
 		logger.debug('on totp event', event, data);
 		// const user = this.props.authData;
 		if (event === 'Setup TOTP') {
@@ -59,7 +59,7 @@ export default class TOTPSetup extends AuthPiece<
 		}
 	}
 
-	showComponent(theme) {
+	showComponent(theme): React.ReactNode {
 		const { hide } = this.props;
 		if (hide && hide.includes(TOTPSetup)) {
 			return null;

--- a/packages/aws-amplify-react/src/Auth/VerifyContact.tsx
+++ b/packages/aws-amplify-react/src/Auth/VerifyContact.tsx
@@ -38,18 +38,18 @@ export interface IVerifyContactState extends IAuthPieceState {
 	verifyAttr: any;
 }
 
-export default class VerifyContact extends AuthPiece<
-	IAuthPieceProps,
-	IVerifyContactState
-> {
-	constructor(props: IAuthPieceProps) {
+export default class VerifyContact<
+	P extends IAuthPieceProps,
+	S extends IVerifyContactState
+> extends AuthPiece<P, S> {
+	constructor(props: P) {
 		super(props);
 
 		this._validAuthStates = ['verifyContact'];
 		this.verify = this.verify.bind(this);
 		this.submit = this.submit.bind(this);
 
-		this.state = { verifyAttr: null };
+		this.state = { verifyAttr: null } as S;
 	}
 
 	verify() {


### PR DESCRIPTION
_Description of changes:_ Fixes being able to extend react HOCs while setting props and state on child components.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
