### PR TITLE
fix(cache): export correct module for RN

### DIFF
--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -6,7 +6,7 @@
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
   "react-native": {
-    "./index": "./lib/reactnative.js"
+    "./lib/index.js": "./lib/reactnative.js"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
_Issue #, if available:_
Fixes: https://github.com/aws-amplify/amplify-js/issues/4711

_Description of changes:_
Revert change from https://github.com/aws-amplify/amplify-js/commit/e61d9066bdaed8f0fdf4902d55386987a2691832 to import RN-specific cache module

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
