### PR TITLE
fix(cache): export correct module for RN

### DIFF
--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -6,7 +6,7 @@
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
   "react-native": {
-    "./index": "./lib/reactnative.js"
+    "./lib/index": "./lib/reactnative.js"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Issue #, if available:
Fixes: #4711

Description of changes:
Revert change from e61d906 to import RN-specific cache module

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.