### PR TITLE
fix(@ui-components/master): force TypeScript@~3.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "tslint": "^5.7.0",
     "tslint-config-airbnb": "^5.8.0",
     "typedoc": "^0.11.0",
-    "typescript": "^3.5.3",
+    "typescript": "~3.6.4",
     "uglifyjs-webpack-plugin": "^0.4.6",
     "webpack": "^4.32.0",
     "webpack-bundle-analyzer": "^3.3.2",

--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -243,7 +243,7 @@ export class GraphQLAPIClass {
 			},
 		};
 
-		const endpoint = customGraphqlEndpoint ?? appSyncGraphqlEndpoint;
+		const endpoint = customGraphqlEndpoint || appSyncGraphqlEndpoint;
 
 		if (!endpoint) {
 			const error = new GraphQLError('No graphql endpoint provided.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -21649,10 +21649,10 @@ typescript@^3.3.4000:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
   integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
-typescript@^3.5.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@~3.6.4:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.5.tgz#dae20114a7b4ff4bd642db9c8c699f2953e8bbdb"
+  integrity sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
https://github.com/aws-amplify/amplify-js-samples-staging/pull/42#issuecomment-579427196 was blocked by TypeScript issues.

Investigation found that `^3.5.3` matches `3.7`, which is what has been installed for this branch for sometime.

This is effectively cherry-picking Ivan's 6597db2b0704d7aff5b612557536142b82e1731 that hasn't made it in since 788d7df7b2f1a3c02a6e6909e934de5fdc0b5954.

> https://github.com/aws-amplify/amplify-js/commits/ui-components/master/package.json

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
