### PR TITLE
fix(auth): workaround for expo fed sign in

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -106,6 +106,7 @@ export default class AuthClass {
 	constructor(config: AuthOptions) {
 		this.configure(config);
 		this.currentUserCredentials = this.currentUserCredentials.bind(this);
+		this._handleAuthResponseCalled = false;
 
 		if (AWS.config) {
 			AWS.config.update({ customUserAgent: Constants.userAgent });

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -97,6 +97,7 @@ export default class AuthClass {
 	private _oAuthHandler: OAuth;
 	private _storage;
 	private _storageSync;
+	private _handleAuthResponseCalled: boolean = false;
 
 	/**
 	 * Initialize Auth with AWS configurations
@@ -1717,6 +1718,8 @@ export default class AuthClass {
 			}
 		}
 
+		this._handleAuthResponseCalled = false;
+
 		if (
 			isFederatedSignInOptions(providerOrOptions) ||
 			isFederatedSignInOptionsCustom(providerOrOptions) ||
@@ -1790,6 +1793,13 @@ export default class AuthClass {
 		if (!this._config.userPoolId) {
 			throw new Error(`OAuth responses require a User Pool defined in config`);
 		}
+
+		// this fixes the Expo federatedSignIn issue where this method gets called multiple times
+		if (this._handleAuthResponseCalled) {
+			return;
+		}
+
+		this._handleAuthResponseCalled = true;
 
 		dispatchAuthEvent(
 			'parsingCallbackUrl',


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/issues/4388
https://github.com/aws-amplify/amplify-js/issues/4003
https://github.com/aws-amplify/amplify-js/issues/3550

_Description of changes:_
Prevent Expo from calling `Auth._handleAuthResponse` multiple times when redirected from Hosted UI which causes apps to error out.

Added flag that ensures `Auth._handleAuthResponse` is called only once per `Auth.federatedSignIn` invocation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
