### PR TITLE
fix(auth) - prevent urlListener from firing auth flow twice with the same URL 

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -225,12 +225,20 @@ export default class AuthClass {
 			});
 
 			// **NOTE** - Remove this in a future major release as it is a breaking change
-			const d = [];
+			// Prevents _handleAuthResponse from being called multiple times in Expo
+			// See https://github.com/aws-amplify/amplify-js/issues/4388
+			const usedResponseUrls = {};
 			urlListener(({ url }) => {
-				if (!d.includes(url)) {
-					d.push(url);
-					this._handleAuthResponse(url);
+				console.log('urlListener', url, usedResponseUrls);
+				if (usedResponseUrls[url]) {
+					return;
 				}
+
+				usedResponseUrls[url] = true;
+
+				console.log('urlListener responseUrls', usedResponseUrls);
+
+				this._handleAuthResponse(url);
 			});
 		}
 

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -72,7 +72,7 @@ const logger = new Logger('AuthClass');
 const USER_ADMIN_SCOPE = 'aws.cognito.signin.user.admin';
 
 const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' &&
-typeof Symbol.for === 'function'
+	typeof Symbol.for === 'function'
 	? Symbol.for('amplify_default')
 	: '@@amplify_default') as Symbol;
 
@@ -225,8 +225,12 @@ export default class AuthClass {
 			});
 
 			// **NOTE** - Remove this in a future major release as it is a breaking change
+			var d = [];
 			urlListener(({ url }) => {
-				this._handleAuthResponse(url);
+				if (!d.includes(url)) {
+					d.push(url);
+					this._handleAuthResponse(url);
+				}
 			});
 		}
 
@@ -1162,7 +1166,7 @@ export default class AuthClass {
 						} else {
 							logger.debug(
 								`Unable to get the user data because the ${USER_ADMIN_SCOPE} ` +
-									`is not in the scopes of the access token`
+								`is not in the scopes of the access token`
 							);
 							return res(user);
 						}
@@ -1213,7 +1217,7 @@ export default class AuthClass {
 				if (e === 'No userPool') {
 					logger.error(
 						'Cannot get the current user because the user pool is missing. ' +
-							'Please make sure the Auth module is configured with a valid Cognito User Pool ID'
+						'Please make sure the Auth module is configured with a valid Cognito User Pool ID'
 					);
 				}
 				logger.debug('The user is not authenticated by the error', e);
@@ -1762,7 +1766,7 @@ export default class AuthClass {
 					logger.warn(`There is already a signed in user: ${loggedInUser} in your app.
 																	You should not call Auth.federatedSignIn method again as it may cause unexpected behavior.`);
 				}
-			} catch (e) {}
+			} catch (e) { }
 
 			const { token, identity_id, expires_at } = response;
 			// Because Credentials.set would update the user info with identity id

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -229,15 +229,11 @@ export default class AuthClass {
 			// See https://github.com/aws-amplify/amplify-js/issues/4388
 			const usedResponseUrls = {};
 			urlListener(({ url }) => {
-				console.log('urlListener', url, usedResponseUrls);
 				if (usedResponseUrls[url]) {
 					return;
 				}
 
 				usedResponseUrls[url] = true;
-
-				console.log('urlListener responseUrls', usedResponseUrls);
-
 				this._handleAuthResponse(url);
 			});
 		}

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -72,7 +72,7 @@ const logger = new Logger('AuthClass');
 const USER_ADMIN_SCOPE = 'aws.cognito.signin.user.admin';
 
 const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' &&
-	typeof Symbol.for === 'function'
+typeof Symbol.for === 'function'
 	? Symbol.for('amplify_default')
 	: '@@amplify_default') as Symbol;
 
@@ -1166,7 +1166,7 @@ export default class AuthClass {
 						} else {
 							logger.debug(
 								`Unable to get the user data because the ${USER_ADMIN_SCOPE} ` +
-								`is not in the scopes of the access token`
+									`is not in the scopes of the access token`
 							);
 							return res(user);
 						}
@@ -1217,7 +1217,7 @@ export default class AuthClass {
 				if (e === 'No userPool') {
 					logger.error(
 						'Cannot get the current user because the user pool is missing. ' +
-						'Please make sure the Auth module is configured with a valid Cognito User Pool ID'
+							'Please make sure the Auth module is configured with a valid Cognito User Pool ID'
 					);
 				}
 				logger.debug('The user is not authenticated by the error', e);
@@ -1766,7 +1766,7 @@ export default class AuthClass {
 					logger.warn(`There is already a signed in user: ${loggedInUser} in your app.
 																	You should not call Auth.federatedSignIn method again as it may cause unexpected behavior.`);
 				}
-			} catch (e) { }
+			} catch (e) {}
 
 			const { token, identity_id, expires_at } = response;
 			// Because Credentials.set would update the user info with identity id
@@ -1837,7 +1837,7 @@ export default class AuthClass {
 					logger.debug('AWS credentials', credentials);
 				}
 
-				/* 
+				/*
                 Prior to the request we do sign the custom state along with the state we set. This check will verify
                 if there is a dash indicated when setting custom state from the request. If a dash is contained
                 then there is custom state present on the state string.

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -225,7 +225,7 @@ export default class AuthClass {
 			});
 
 			// **NOTE** - Remove this in a future major release as it is a breaking change
-			var d = [];
+			const d = [];
 			urlListener(({ url }) => {
 				if (!d.includes(url)) {
 					d.push(url);


### PR DESCRIPTION
_Issue #, if available:_
#4388
_Description of changes:_
Added a solution provided by @mithunkalan that prevents the auth flow from being executed twice by the same url. This was an issue impacting both react-native and react-native with expo that caused an "invalid_grant" error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
