### PR TITLE
fix(@aws-amplify/core): Revert environment checks

### DIFF
--- a/packages/core/__tests__/JS-node-runtime-test.ts
+++ b/packages/core/__tests__/JS-node-runtime-test.ts
@@ -6,7 +6,7 @@
  * Since this is allowed per test file and not per test or describe, we have
  * two tests, one for node and other for browser
  */
-import * as core from '../dist/aws-amplify-core.js';
+import * as core from '../lib';
 
 describe('JS build test', () => {
 	test('when its node ', () => {

--- a/packages/core/src/JS.ts
+++ b/packages/core/src/JS.ts
@@ -165,26 +165,17 @@ export default class JS {
 		return result;
 	}
 
-	/**
-	 * Webpack adds node shim to the bundle overriding the `process` variable
-	 * causing issues detecting nodejs environment. Creating a new function will
-	 * help to avoid incorrect environment detection as new function will have
-	 * it's `this` binded to global scope. Credit: https://stackoverflow.com/a/31090240
-	 */
 	static browserOrNode() {
-		// function to check if the global scope is "window"
-		const isBrowser = new Function(
-			'try {return this===window;}catch(e){ return false;}'
-		);
-
-		// function to test if global scope is binded to "global"
-		const isNode = new Function(
-			'try {return this===global;}catch(e){return false;}'
-		);
+		const isBrowser =
+			typeof window !== 'undefined' && typeof window.document !== 'undefined';
+		const isNode =
+			typeof process !== 'undefined' &&
+			process.versions != null &&
+			process.versions.node != null;
 
 		return {
-			isBrowser: isBrowser(),
-			isNode: isNode(),
+			isBrowser,
+			isNode,
 		};
 	}
 


### PR DESCRIPTION
This fix reverts our environment checks to a previous version that worked fine, but failed under certain curcustances now fixed (see #4678)

The solution using `new Function('return this')()` caused problems when using CSP

_Issue #, if available:_
Fixes: #4723 

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
