### PR TITLE
React native datastore feature

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -63,7 +63,7 @@
   "types": "./index.d.ts",
   "dependencies": {
     "buffer": "4.9.1",
-    "crypto-js": "^3.1.9-1",
+    "crypto-js": "3.1.9-1",
     "js-cookie": "^2.1.4"
   },
   "devDependencies": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -37,7 +37,7 @@
     "@aws-amplify/cache": "^2.1.5",
     "@aws-amplify/core": "^2.2.4",
     "amazon-cognito-identity-js": "^3.2.4",
-    "crypto-js": "^3.1.9-1"
+    "crypto-js": "3.1.9-1"
   },
   "jest": {
     "globals": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,9 @@
   "homepage": "https://aws-amplify.github.io/",
   "devDependencies": {
     "find": "^0.2.7",
-    "prepend-file": "^1.3.1"
+    "prepend-file": "^1.3.1",
+    "@react-native-community/netinfo": "4.7.0",
+    "react-native": "0.59.0"
   },
   "dependencies": {
     "aws-sdk": "2.518.0",

--- a/packages/core/src/Util/Reachability.native.ts
+++ b/packages/core/src/Util/Reachability.native.ts
@@ -1,0 +1,52 @@
+import {
+	default as NetInfo,
+	NetInfoState,
+} from '@react-native-community/netinfo';
+import * as Observable from 'zen-observable';
+import { ConsoleLogger as Logger } from '../Logger';
+
+const logger = new Logger('Reachability', 'DEBUG');
+
+type NetworkStatus = {
+	online: boolean;
+};
+
+export default class ReachabilityNavigator implements Reachability {
+	networkMonitor(): Observable<NetworkStatus> {
+		return new Observable(observer => {
+			logger.log('subscribing to reachability');
+
+			let online = false;
+
+			NetInfo.fetch().then(({ isInternetReachable }) => {
+				online = isInternetReachable;
+
+				logger.log('Notifying initial reachability state', online);
+
+				observer.next({ online });
+			});
+
+			const id = setInterval(async () => {
+				const { isInternetReachable } = await NetInfo.fetch();
+
+				if (online !== isInternetReachable) {
+					online = isInternetReachable;
+
+					logger.log('Notifying reachability change', online);
+
+					observer.next({ online });
+				}
+			}, 2000);
+
+			return () => {
+				logger.warn('unsubscribing reachability');
+
+				clearInterval(id);
+			};
+		});
+	}
+}
+
+interface Reachability {
+	networkMonitor(): Observable<NetworkStatus>;
+}

--- a/packages/datastore/src/storage/adapter/AsyncStorageDatabase.ts
+++ b/packages/datastore/src/storage/adapter/AsyncStorageDatabase.ts
@@ -1,0 +1,97 @@
+import { AsyncStorage } from 'react-native';
+import { PersistentModel, QueryOne } from '../../types';
+
+const DB_NAME = '@AmplifyDatastore';
+const COLLECTION = 'Collection';
+const DATA = 'Data';
+
+// write a function for getCollectionForStore.
+// handle errors.
+// write batch save/ transactional save.
+class AsyncStorageDatabase {
+	async save<T extends PersistentModel>(item: T, storeName: string) {
+		const itemKey = this.getKeyForItem(storeName, item.id);
+		await AsyncStorage.setItem(itemKey, JSON.stringify(item));
+		const storeKey = this.getKeyForStore(storeName);
+		const collectionForStoreAsString = await AsyncStorage.getItem(storeKey);
+		const collectionForStore = JSON.parse(collectionForStoreAsString);
+		const collection = collectionForStore || [];
+		collection.push(itemKey);
+		await AsyncStorage.setItem(storeKey, JSON.stringify(collection));
+	}
+
+	async get<T extends PersistentModel>(
+		id: string,
+		storeName: string
+	): Promise<T> {
+		const itemKey = this.getKeyForItem(storeName, id);
+		const recordAsString = await AsyncStorage.getItem(itemKey);
+		const record = JSON.parse(recordAsString);
+		return record;
+	}
+
+	async getOne(firstOrLast: QueryOne, storeName: string) {
+		const storeKey = this.getKeyForStore(storeName);
+		const collectionForStoreAsString = await AsyncStorage.getItem(storeKey);
+		const collectionForStore = JSON.parse(collectionForStoreAsString);
+		const collection = collectionForStore || [];
+		const itemKey =
+			firstOrLast === QueryOne.FIRST
+				? collection[0]
+				: collection[collection.length - 1];
+		const result = itemKey
+			? JSON.parse(await AsyncStorage.getItem(itemKey))
+			: undefined;
+		return result;
+	}
+
+	/**
+	 * This function gets all the records stored in async storage for a particular storeName
+	 * It uses getAllKeys to first retrieve the keys and then filters based on the prefix
+	 * It then loads all the records for that filtered set of keys using multiGet()
+	 */
+	async getAll<T extends PersistentModel>(storeName: string): Promise<T[]> {
+		const allKeys = await AsyncStorage.getAllKeys();
+		const prefixForStoreItems = this.getKeyPrefixForStoreItems(storeName);
+		const keysForStore = allKeys.filter(key =>
+			key.startsWith(prefixForStoreItems)
+		);
+		const storeRecordStrings = await AsyncStorage.multiGet(keysForStore);
+		const records = storeRecordStrings.map(([key, value]) => JSON.parse(value));
+		return records;
+	}
+
+	async delete(id: string, storeName: string) {
+		const itemKey = this.getKeyForItem(storeName, id);
+		const storeKey = this.getKeyForStore(storeName);
+		const collectionForStoreAsString = await AsyncStorage.getItem(storeKey);
+		const collectionForStore = JSON.parse(collectionForStoreAsString);
+		const collection = collectionForStore || [];
+		collection.splice(collection.indexOf(itemKey), 1);
+		await AsyncStorage.setItem(storeKey, JSON.stringify(collection));
+		await AsyncStorage.removeItem(itemKey);
+	}
+	/**
+	 * Clear the AsyncStorage of all DataStore entries
+	 */
+	async clear() {
+		const allKeys = await AsyncStorage.getAllKeys();
+		const allDataStoreKeys = allKeys.filter(key => key.startsWith(DB_NAME));
+		await AsyncStorage.multiRemove(allDataStoreKeys);
+	}
+
+	// Can ID not be a string?
+	private getKeyForItem(storeName: string, id: string): string {
+		return `${DB_NAME}::${storeName}::${DATA}::${id}`;
+	}
+
+	private getKeyForStore(storeName: string): string {
+		return `${DB_NAME}::${storeName}::${COLLECTION}`;
+	}
+
+	private getKeyPrefixForStoreItems(storeName: string): string {
+		return `${DB_NAME}::${storeName}::${DATA}`;
+	}
+}
+
+export default new AsyncStorageDatabase();

--- a/packages/datastore/src/storage/adapter/asyncstorage.ts
+++ b/packages/datastore/src/storage/adapter/asyncstorage.ts
@@ -1,0 +1,524 @@
+import { ConsoleLogger as Logger } from '@aws-amplify/core';
+import { AsyncStorage } from 'react-native';
+import AsyncStorageDatabase from './AsyncStorageDatabase';
+import { Adapter } from '.';
+import { ModelInstanceCreator } from '../../datastore/datastore';
+import { ModelPredicateCreator } from '../../predicates';
+import {
+	InternalSchema,
+	isPredicateObj,
+	ModelPredicate,
+	NamespaceResolver,
+	OpType,
+	PersistentModel,
+	PersistentModelConstructor,
+	PredicateObject,
+	QueryOne,
+	RelationType,
+	PaginationInput,
+} from '../../types';
+import {
+	exhaustiveCheck,
+	getIndex,
+	isModelConstructor,
+	traverseModel,
+	validatePredicate,
+} from '../../util';
+
+const logger = new Logger('DataStore');
+
+class AsyncStorageAdapter implements Adapter {
+	private schema: InternalSchema;
+	private namespaceResolver: NamespaceResolver;
+	private modelInstanceCreator: ModelInstanceCreator;
+	private getModelConstructorByModelName: (
+		namsespaceName: string,
+		modelName: string
+	) => PersistentModelConstructor<any>;
+	private db: any;
+	private initPromise: Promise<void>;
+	private resolve: (value?: any) => void;
+	private reject: (value?: any) => void;
+
+	private getStorenameForModel(
+		modelConstructor: PersistentModelConstructor<any>
+	) {
+		const namespace = this.namespaceResolver(modelConstructor);
+		const { name: modelName } = modelConstructor;
+
+		return this.getStorename(namespace, modelName);
+	}
+
+	private getStorename(namespace: string, modelName: string) {
+		const storeName = `${namespace}_${modelName}`;
+
+		return storeName;
+	}
+
+	async setUp(
+		theSchema: InternalSchema,
+		namespaceResolver: NamespaceResolver,
+		modelInstanceCreator: ModelInstanceCreator,
+		getModelConstructorByModelName: (
+			namsespaceName: string,
+			modelName: string
+		) => PersistentModelConstructor<any>
+	) {
+		if (!this.initPromise) {
+			this.initPromise = new Promise((res, rej) => {
+				this.resolve = res;
+				this.reject = rej;
+			});
+		} else {
+			await this.initPromise;
+		}
+		this.schema = theSchema;
+		this.namespaceResolver = namespaceResolver;
+		this.modelInstanceCreator = modelInstanceCreator;
+		this.getModelConstructorByModelName = getModelConstructorByModelName;
+		try {
+			if (!this.db) {
+				this.db = AsyncStorageDatabase;
+				this.resolve();
+			}
+		} catch (error) {
+			this.reject(error);
+		}
+	}
+
+	async save<T extends PersistentModel>(
+		model: T,
+		condition?: ModelPredicate<T>
+	): Promise<[T, OpType.INSERT | OpType.UPDATE][]> {
+		const modelConstructor = Object.getPrototypeOf(model)
+			.constructor as PersistentModelConstructor<T>;
+		const storeName = this.getStorenameForModel(modelConstructor);
+		const connectedModels = traverseModel(
+			modelConstructor.name,
+			model,
+			this.schema.namespaces[this.namespaceResolver(modelConstructor)],
+			this.modelInstanceCreator,
+			this.getModelConstructorByModelName
+		);
+		const namespaceName = this.namespaceResolver(modelConstructor);
+		const set = new Set<string>();
+		const connectionStoreNames = Object.values(connectedModels).map(
+			({ modelName, item, instance }) => {
+				const storeName = this.getStorename(namespaceName, modelName);
+				set.add(storeName);
+				return { storeName, item, instance };
+			}
+		);
+		const fromDB = await AsyncStorageDatabase.get(model.id, storeName);
+
+		if (condition) {
+			const predicates = ModelPredicateCreator.getPredicates(condition);
+			const { predicates: predicateObjs, type } = predicates;
+
+			const isValid = validatePredicate(fromDB, type, predicateObjs);
+
+			if (!isValid) {
+				const msg = 'Conditional update failed';
+				logger.error(msg, { model: fromDB, condition: predicateObjs });
+
+				throw new Error(msg);
+			}
+		}
+
+		const result: [T, OpType.INSERT | OpType.UPDATE][] = [];
+
+		for await (const resItem of connectionStoreNames) {
+			const { storeName, item, instance } = resItem;
+
+			const { id } = item;
+
+			const opType: OpType = (await AsyncStorageDatabase.get(id, storeName))
+				? OpType.UPDATE
+				: OpType.INSERT;
+
+			if (id === model.id) {
+				await AsyncStorageDatabase.save(item, storeName);
+
+				result.push([instance, opType]);
+			} else {
+				if (opType === OpType.INSERT) {
+					await AsyncStorageDatabase.save(item, storeName);
+
+					result.push([instance, opType]);
+				}
+			}
+			const savedItem = await AsyncStorageDatabase.get(id, storeName);
+		}
+
+		return result;
+	}
+
+	private async load<T>(
+		namespaceName: string,
+		srcModelName: string,
+		records: T[]
+	): Promise<T[]> {
+		const namespace = this.schema.namespaces[namespaceName];
+		const relations = namespace.relationships[srcModelName].relationTypes;
+		const connectionStoreNames = relations.map(({ modelName }) => {
+			return this.getStorename(namespaceName, modelName);
+		});
+		const modelConstructor = this.getModelConstructorByModelName(
+			namespaceName,
+			srcModelName
+		);
+
+		if (connectionStoreNames.length === 0) {
+			return records.map(record =>
+				this.modelInstanceCreator(modelConstructor, record)
+			);
+		}
+
+		for await (const relation of relations) {
+			const { fieldName, modelName, targetName, relationType } = relation;
+			const storeName = this.getStorename(namespaceName, modelName);
+			const modelConstructor = this.getModelConstructorByModelName(
+				namespaceName,
+				modelName
+			);
+
+			switch (relationType) {
+				case 'HAS_ONE':
+					for await (const recordItem of records) {
+						if (recordItem[fieldName]) {
+							const connectionRecord = await AsyncStorageDatabase.get(
+								recordItem[fieldName],
+								storeName
+							);
+
+							recordItem[fieldName] =
+								connectionRecord &&
+								this.modelInstanceCreator(modelConstructor, connectionRecord);
+						}
+					}
+
+					break;
+				case 'BELONGS_TO':
+					for await (const recordItem of records) {
+						if (recordItem[targetName]) {
+							const connectionRecord = await AsyncStorageDatabase.get(
+								recordItem[targetName],
+								storeName
+							);
+
+							recordItem[fieldName] =
+								connectionRecord &&
+								this.modelInstanceCreator(modelConstructor, connectionRecord);
+							delete recordItem[targetName];
+						}
+					}
+
+					break;
+				case 'HAS_MANY':
+					// TODO: Lazy loading
+					break;
+				default:
+					exhaustiveCheck(relationType);
+					break;
+			}
+		}
+
+		return records.map(record =>
+			this.modelInstanceCreator(modelConstructor, record)
+		);
+	}
+
+	async query<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		predicate?: ModelPredicate<T>,
+		pagination?: PaginationInput
+	): Promise<T[]> {
+		const storeName = this.getStorenameForModel(modelConstructor);
+		const namespaceName = this.namespaceResolver(modelConstructor);
+
+		if (predicate) {
+			const predicates = ModelPredicateCreator.getPredicates(predicate);
+			if (predicates) {
+				const { predicates: predicateObjs, type } = predicates;
+				const idPredicate =
+					predicateObjs.length === 1 &&
+					(predicateObjs.find(
+						p => isPredicateObj(p) && p.field === 'id' && p.operator === 'eq'
+					) as PredicateObject<T>);
+
+				if (idPredicate) {
+					const { operand: id } = idPredicate;
+
+					const record = <any>await AsyncStorageDatabase.get(id, storeName);
+
+					if (record) {
+						const [x] = await this.load(namespaceName, modelConstructor.name, [
+							record,
+						]);
+						return [x];
+					}
+					return [];
+				}
+
+				const all = <T[]>await AsyncStorageDatabase.getAll(storeName);
+
+				const filtered = predicateObjs
+					? all.filter(m => validatePredicate(m, type, predicateObjs))
+					: all;
+
+				return await this.load(
+					namespaceName,
+					modelConstructor.name,
+					this.inMemoryPagination(filtered, pagination)
+				);
+			}
+		}
+		const all = <T[]>await AsyncStorageDatabase.getAll(storeName);
+
+		return await this.load(
+			namespaceName,
+			modelConstructor.name,
+			this.inMemoryPagination(all, pagination)
+		);
+	}
+
+	private inMemoryPagination<T>(
+		records: T[],
+		pagination?: PaginationInput
+	): T[] {
+		if (pagination) {
+			const { page = 0, limit = 0 } = pagination;
+			const start = Math.max(0, page * limit) || 0;
+
+			const end = limit > 0 ? start + limit : records.length;
+
+			return records.slice(start, end);
+		}
+
+		return records;
+	}
+
+	async queryOne<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		firstOrLast: QueryOne = QueryOne.FIRST
+	): Promise<T | undefined> {
+		const storeName = this.getStorenameForModel(modelConstructor);
+		const result = <T>await AsyncStorageDatabase.getOne(firstOrLast, storeName);
+		return result && this.modelInstanceCreator(modelConstructor, result);
+	}
+
+	async delete<T extends PersistentModel>(
+		modelOrModelConstructor: T | PersistentModelConstructor<T>,
+		condition?: ModelPredicate<T>
+	): Promise<[T[], T[]]> {
+		const deleteQueue: { storeName: string; items: T[] }[] = [];
+
+		if (isModelConstructor(modelOrModelConstructor)) {
+			const modelConstructor = modelOrModelConstructor;
+			const nameSpace = this.namespaceResolver(modelConstructor);
+
+			const storeName = this.getStorenameForModel(modelConstructor);
+			// models to be deleted.
+			const models = await this.query(modelConstructor, condition);
+			// TODO: refactor this to use a function like getRelations()
+			const relations = this.schema.namespaces[nameSpace].relationships[
+				modelConstructor.name
+			].relationTypes;
+
+			if (condition !== undefined) {
+				await this.deleteTraverse(
+					relations,
+					models,
+					modelConstructor.name,
+					nameSpace,
+					deleteQueue
+				);
+
+				await this.deleteItem(deleteQueue);
+
+				const deletedModels = deleteQueue.reduce(
+					(acc, { items }) => acc.concat(items),
+					<T[]>[]
+				);
+				return [models, deletedModels];
+			} else {
+				await this.deleteTraverse(
+					relations,
+					models,
+					modelConstructor.name,
+					nameSpace,
+					deleteQueue
+				);
+
+				await this.deleteItem(deleteQueue);
+
+				const deletedModels = deleteQueue.reduce(
+					(acc, { items }) => acc.concat(items),
+					<T[]>[]
+				);
+
+				return [models, deletedModels];
+			}
+		} else {
+			const model = modelOrModelConstructor;
+
+			const modelConstructor = Object.getPrototypeOf(model)
+				.constructor as PersistentModelConstructor<T>;
+			const nameSpace = this.namespaceResolver(modelConstructor);
+
+			const storeName = this.getStorenameForModel(modelConstructor);
+			if (condition) {
+				const fromDB = await AsyncStorageDatabase.get(model.id, storeName);
+				const predicates = ModelPredicateCreator.getPredicates(condition);
+				const { predicates: predicateObjs, type } = predicates;
+
+				const isValid = validatePredicate(fromDB, type, predicateObjs);
+				if (!isValid) {
+					const msg = 'Conditional update failed';
+					logger.error(msg, { model: fromDB, condition: predicateObjs });
+
+					throw new Error(msg);
+				}
+
+				const relations = this.schema.namespaces[nameSpace].relationships[
+					modelConstructor.name
+				].relationTypes;
+				await this.deleteTraverse(
+					relations,
+					[model],
+					modelConstructor.name,
+					nameSpace,
+					deleteQueue
+				);
+			} else {
+				const relations = this.schema.namespaces[nameSpace].relationships[
+					modelConstructor.name
+				].relationTypes;
+
+				await this.deleteTraverse(
+					relations,
+					[model],
+					modelConstructor.name,
+					nameSpace,
+					deleteQueue
+				);
+			}
+
+			await this.deleteItem(deleteQueue);
+
+			const deletedModels = deleteQueue.reduce(
+				(acc, { items }) => acc.concat(items),
+				<T[]>[]
+			);
+
+			return [[model], deletedModels];
+		}
+	}
+
+	private async deleteItem<T extends PersistentModel>(
+		deleteQueue?: { storeName: string; items: T[] | IDBValidKey[] }[]
+	) {
+		const connectionStoreNames = deleteQueue.map(({ storeName }) => {
+			return storeName;
+		});
+
+		for await (const deleteItem of deleteQueue) {
+			const { storeName, items } = deleteItem;
+
+			for await (const item of items) {
+				if (item) {
+					if (typeof item === 'object') {
+						const id = item['id'];
+						await AsyncStorageDatabase.delete(id, storeName);
+					}
+				}
+			}
+		}
+	}
+	/**
+	 * Populates the delete Queue with all the items to delete
+	 * @param relations
+	 * @param models
+	 * @param srcModel
+	 * @param nameSpace
+	 * @param deleteQueue
+	 */
+	private async deleteTraverse<T extends PersistentModel>(
+		relations: RelationType[],
+		models: T[],
+		srcModel: string,
+		nameSpace: string,
+		deleteQueue: { storeName: string; items: T[] }[]
+	): Promise<void> {
+		for await (const rel of relations) {
+			const { relationType, modelName } = rel;
+			const storeName = this.getStorename(nameSpace, modelName);
+			const index = getIndex(
+				this.schema.namespaces[nameSpace].relationships[modelName]
+					.relationTypes,
+				srcModel
+			);
+			switch (relationType) {
+				case 'HAS_ONE':
+					for await (const model of models) {
+						const allRecords = await AsyncStorageDatabase.getAll(storeName);
+						const recordToDelete = allRecords.filter(
+							childItem => childItem[index] === model.id
+						);
+
+						await this.deleteTraverse(
+							this.schema.namespaces[nameSpace].relationships[modelName]
+								.relationTypes,
+							recordToDelete,
+							modelName,
+							nameSpace,
+							deleteQueue
+						);
+					}
+					break;
+				case 'HAS_MANY':
+					for await (const model of models) {
+						const allRecords = await AsyncStorageDatabase.getAll(storeName);
+						const childrenArray = allRecords.filter(
+							childItem => childItem[index] === model.id
+						);
+
+						await this.deleteTraverse(
+							this.schema.namespaces[nameSpace].relationships[modelName]
+								.relationTypes,
+							childrenArray,
+							modelName,
+							nameSpace,
+							deleteQueue
+						);
+					}
+					break;
+				case 'BELONGS_TO':
+					// Intentionally blank
+					break;
+				default:
+					exhaustiveCheck(relationType);
+					break;
+			}
+		}
+
+		deleteQueue.push({
+			storeName: this.getStorename(nameSpace, srcModel),
+			items: models.map(record =>
+				this.modelInstanceCreator(
+					this.getModelConstructorByModelName(nameSpace, srcModel),
+					record
+				)
+			),
+		});
+	}
+
+	async clear(): Promise<void> {
+		await AsyncStorageDatabase.clear();
+
+		this.db = undefined;
+		this.initPromise = undefined;
+	}
+}
+
+export default new AsyncStorageAdapter();

--- a/packages/datastore/src/storage/adapter/getDefaultAdapter/index.native.ts
+++ b/packages/datastore/src/storage/adapter/getDefaultAdapter/index.native.ts
@@ -1,0 +1,8 @@
+import { Adapter } from '..';
+import AsyncStorageAdapter from '../asyncstorage';
+
+const getDefaultAdapter: () => Adapter = () => {
+	return AsyncStorageAdapter;
+};
+
+export default getDefaultAdapter;

--- a/packages/datastore/src/storage/adapter/getDefaultAdapter/index.ts
+++ b/packages/datastore/src/storage/adapter/getDefaultAdapter/index.ts
@@ -1,0 +1,12 @@
+import { Adapter } from '..';
+
+const getDefaultAdapter: () => Adapter = () => {
+	if (window.indexedDB) {
+		return require('../indexeddb').default;
+	}
+	if (process && process.env) {
+		throw new Error('Node is not supported');
+	}
+};
+
+export default getDefaultAdapter;

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -20,15 +20,7 @@ import {
 } from '../types';
 import { isModelConstructor, STORAGE, validatePredicate } from '../util';
 import { Adapter } from './adapter';
-
-const getDefaultAdapter: () => Adapter = () => {
-	if (window.indexedDB) {
-		return require('./adapter/indexeddb').default;
-	}
-	if (process && process.env) {
-		throw new Error('Node is not supported');
-	}
-};
+import getDefaultAdapter from './adapter/getDefaultAdapter';
 
 export type StorageSubscriptionMessage = SubscriptionMessage<any> & {
 	mutator?: Symbol;
@@ -52,7 +44,7 @@ class Storage implements StorageFacade {
 		private readonly modelInstanceCreator: ModelInstanceCreator,
 		private readonly adapter?: Adapter
 	) {
-		this.adapter = adapter || getDefaultAdapter();
+		this.adapter = getDefaultAdapter();
 		this.pushStream = new PushStream();
 	}
 

--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -130,9 +130,7 @@ export class SyncEngine {
 				try {
 					await this.setupModels(params);
 				} catch (err) {
-					logger.error(
-						"Sync engine stopped. IndexedDB not supported in this browser's private mode"
-					);
+					logger.error('Sync engine error on start', err);
 					return;
 				}
 


### PR DESCRIPTION
 #### This PR adds the code to implement and enable the DataStore feature for React Native apps.
_Issue #, if available:_
Addresses feature request #4527  

_Description of changes:_

- Wrote a React Native specific storage adapter that uses AsyncStorage under the hood
- Created a database-like abstraction for AsyncStorage to make it easier to plug into the adapter
- To implement the notion of separate stores in AsyncStorage, we keep track of a collection of keys prefixed by storeName
- Logic to get default adapter now lives in platform specific files
- Wrote a React Native specific implementation for Reachability using @react-native-community/netinfo 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
