### PR TITLE
Allow passing custom user attributes during sign up

### DIFF
--- a/packages/aws-amplify-react/__tests__/Auth/SignUp-test.tsx
+++ b/packages/aws-amplify-react/__tests__/Auth/SignUp-test.tsx
@@ -870,3 +870,301 @@ describe('signUp with signUpConfig', () => {
 		expect(spyon).toBeCalled();
 	});
 });
+
+describe('signUp with customAttributes', () => {
+	let wrapper;
+	beforeEach(() => {
+		wrapper = shallow(<SignUp />);
+	});
+
+	test('signUp should pass custom attributes, if provided', async () => {
+		const wrapper = shallow(<SignUp />);
+		wrapper.setProps({
+			authState: 'signUp',
+			theme: AmplifyTheme,
+			signUpConfig: {
+				customAttributes: [
+					{
+						name: 'custom_name',
+						value: 'custom_value',
+					},
+				],
+			},
+		});
+
+		const spyon = jest
+			.spyOn(Auth, 'signUp')
+			.mockImplementationOnce((user, password) => {
+				return new Promise((res, rej) => {
+					res(mockResult);
+				});
+			});
+
+		const event_username = {
+			target: {
+				name: 'username',
+				value: 'user1',
+			},
+		};
+		const event_password = {
+			target: {
+				name: 'password',
+				value: 'abc',
+			},
+		};
+
+		const event_email = {
+			target: {
+				name: 'email',
+				value: 'email@amazon.com',
+			},
+		};
+
+		const phone_number = '+12345678901';
+
+		wrapper
+			.find(Input)
+			.at(0)
+			.simulate('change', event_username);
+		wrapper
+			.find(Input)
+			.at(1)
+			.simulate('change', event_password);
+		wrapper
+			.find(Input)
+			.at(2)
+			.simulate('change', event_email);
+		wrapper
+			.find(PhoneField)
+			.at(0)
+			.simulate('changeText', phone_number);
+		await wrapper.find(Button).simulate('click');
+
+		expect(spyon).toBeCalledWith({
+			attributes: {
+				custom_name: 'custom_value',
+				email: 'email@amazon.com',
+				phone_number: '+12345678901',
+			},
+			password: 'abc',
+			username: 'user1',
+		});
+
+		spyon.mockClear();
+	});
+
+	test('signUp should not complete if custom attribute name is empty', async () => {
+		const wrapper = shallow(<SignUp />);
+		wrapper.setProps({
+			authState: 'signUp',
+			theme: AmplifyTheme,
+			signUpConfig: {
+				customAttributes: [
+					{
+						name: '',
+						value: 'custom_value',
+					},
+				],
+			},
+		});
+
+		const spyon = jest
+			.spyOn(Auth, 'signUp')
+			.mockImplementationOnce((user, password) => {
+				return new Promise((res, rej) => {
+					res(mockResult);
+				});
+			});
+
+		const event_username = {
+			target: {
+				name: 'username',
+				value: 'user1',
+			},
+		};
+		const event_password = {
+			target: {
+				name: 'password',
+				value: 'abc',
+			},
+		};
+
+		const event_email = {
+			target: {
+				name: 'email',
+				value: 'email@amazon.com',
+			},
+		};
+
+		const phone_number = '+12345678901';
+
+		wrapper
+			.find(Input)
+			.at(0)
+			.simulate('change', event_username);
+		wrapper
+			.find(Input)
+			.at(1)
+			.simulate('change', event_password);
+		wrapper
+			.find(Input)
+			.at(2)
+			.simulate('change', event_email);
+		wrapper
+			.find(PhoneField)
+			.at(0)
+			.simulate('changeText', phone_number);
+
+		try {
+			await wrapper.find(Button).simulate('click');
+		} catch (err) {
+			expect(err).toEqual(
+				new Error('Custom attribute is expected to have non-empty name')
+			);
+		}
+	});
+
+	test('signUp should not complete if custom attribute value is empty', async () => {
+		const wrapper = shallow(<SignUp />);
+		wrapper.setProps({
+			authState: 'signUp',
+			theme: AmplifyTheme,
+			signUpConfig: {
+				customAttributes: [
+					{
+						name: 'custom_name',
+						value: '',
+					},
+				],
+			},
+		});
+
+		const spyon = jest
+			.spyOn(Auth, 'signUp')
+			.mockImplementationOnce((user, password) => {
+				return new Promise((res, rej) => {
+					res(mockResult);
+				});
+			});
+
+		const event_username = {
+			target: {
+				name: 'username',
+				value: 'user1',
+			},
+		};
+		const event_password = {
+			target: {
+				name: 'password',
+				value: 'abc',
+			},
+		};
+
+		const event_email = {
+			target: {
+				name: 'email',
+				value: 'email@amazon.com',
+			},
+		};
+
+		const phone_number = '+12345678901';
+
+		wrapper
+			.find(Input)
+			.at(0)
+			.simulate('change', event_username);
+		wrapper
+			.find(Input)
+			.at(1)
+			.simulate('change', event_password);
+		wrapper
+			.find(Input)
+			.at(2)
+			.simulate('change', event_email);
+		wrapper
+			.find(PhoneField)
+			.at(0)
+			.simulate('changeText', phone_number);
+
+		try {
+			await wrapper.find(Button).simulate('click');
+		} catch (err) {
+			expect(err).toEqual(
+				new Error('Custom attribute is expected to have non-empty value')
+			);
+		}
+	});
+
+	test('signUp should not complete if custom attribute clashes with the standard one', async () => {
+		const wrapper = shallow(<SignUp />);
+		wrapper.setProps({
+			authState: 'signUp',
+			theme: AmplifyTheme,
+			signUpConfig: {
+				customAttributes: [
+					{
+						name: 'email',
+						value: 'email1@amazon.com',
+					},
+				],
+			},
+		});
+
+		const spyon = jest
+			.spyOn(Auth, 'signUp')
+			.mockImplementationOnce((user, password) => {
+				return new Promise((res, rej) => {
+					res(mockResult);
+				});
+			});
+
+		const event_username = {
+			target: {
+				name: 'username',
+				value: 'user1',
+			},
+		};
+		const event_password = {
+			target: {
+				name: 'password',
+				value: 'abc',
+			},
+		};
+
+		const event_email = {
+			target: {
+				name: 'email',
+				value: 'email@amazon.com',
+			},
+		};
+
+		const phone_number = '+12345678901';
+
+		wrapper
+			.find(Input)
+			.at(0)
+			.simulate('change', event_username);
+		wrapper
+			.find(Input)
+			.at(1)
+			.simulate('change', event_password);
+		wrapper
+			.find(Input)
+			.at(2)
+			.simulate('change', event_email);
+		wrapper
+			.find(PhoneField)
+			.at(0)
+			.simulate('changeText', phone_number);
+
+		try {
+			await wrapper.find(Button).simulate('click');
+		} catch (err) {
+			expect(err).toEqual(
+				new Error(
+					"Attribute with name 'email' is already present in the SignUp info"
+				)
+			);
+		}
+	});
+});

--- a/packages/aws-amplify-react/src/Auth/SignUp.tsx
+++ b/packages/aws-amplify-react/src/Auth/SignUp.tsx
@@ -50,6 +50,12 @@ export interface ISignUpConfig {
 	hideAllDefaults?: boolean;
 	hiddenDefaults?: string[];
 	signUpFields?: ISignUpField[];
+	customAttributes?: ICustomAttribute[];
+}
+
+export interface ICustomAttribute {
+	name: string;
+	value: string;
 }
 
 export interface ISignUpProps extends IAuthPieceProps {
@@ -60,6 +66,7 @@ export default class SignUp extends AuthPiece<ISignUpProps, IAuthPieceState> {
 	public defaultSignUpFields: ISignUpField[];
 	public header: string;
 	public signUpFields: ISignUpField[];
+	public customAttributes: ICustomAttribute[];
 
 	constructor(props: ISignUpProps) {
 		super(props);
@@ -264,6 +271,22 @@ export default class SignUp extends AuthPiece<ISignUpProps, IAuthPieceState> {
 				`Couldn't find the label: ${this.getUsernameLabel()}, in sign up fields according to usernameAttributes!`
 			);
 		}
+
+		this.customAttributes.forEach(attr => {
+			if (!attr.name) {
+				throw new Error(`Custom attribute is expected to have non-empty name`);
+			}
+			if (!attr.value) {
+				throw new Error(`Custom attribute is expected to have non-empty value`);
+			}
+			if (attr.name in signup_info.attributes) {
+				throw new Error(
+					`Attribute with name '${attr.name}' is already present in the SignUp info`
+				);
+			}
+			signup_info.attributes[attr.name] = attr.value;
+		});
+
 		Auth.signUp(signup_info)
 			.then(data => {
 				this.setState({ requestPending: false });
@@ -285,6 +308,10 @@ export default class SignUp extends AuthPiece<ISignUpProps, IAuthPieceState> {
 			this.signUpFields = this.props.signUpConfig.signUpFields;
 		}
 		this.sortFields();
+		this.customAttributes =
+			this.props.signUpConfig && this.props.signUpConfig.customAttributes
+				? this.props.signUpConfig.customAttributes
+				: [];
 		return (
 			<FormSection theme={theme} data-test={auth.signUp.section}>
 				<SectionHeader theme={theme} data-test={auth.signUp.headerSection}>


### PR DESCRIPTION
_Description of changes:_

I want to be able to pass custom user attributes (set programmatically, not visible to user) to Auth.signUp function.
As an example, I would like to pass user locale as a value of an attribute, so later I could use it in the lambda to localize email messages in a language of the user.

```
    const signUpConfig = {
        customeAttributes: [
            {
                name: "user_locale",
                value: "ru"
            }
        ]
    };

    return (
        <Authenticator signUpConfig={signUpConfig} />
    );
```

If there is a better way to achieve this, please let me know.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
