### PR TITLE
Remove AuthClass from requiredModules

### DIFF
--- a/packages/aws-amplify-vue/src/plugins/AmplifyPlugin.js
+++ b/packages/aws-amplify-vue/src/plugins/AmplifyPlugin.js
@@ -15,7 +15,7 @@
   This plugin is a mechanism for avoiding the importation of Amplify into Amplify-Vue,
   while also making Amplify available to the entire host application.
 */
-const requiredModules = ['Auth', 'AuthClass', 'I18n', 'Logger'];
+const requiredModules = ['Auth', 'I18n', 'Logger'];
 
 const AmplifyPlugin = {
 	install(Vue, AmplifyModules) {


### PR DESCRIPTION
When troubleshooting why `aws-amplify-vue@unstable` works but `aws-amplify-vue@preview` **does not**, I discovered that `AuthClass` is not exported available as `AmplifyModules`.

`AuthClass` is currently required for the plugin to work, despite not having any explicit dependencies on it:

https://github.com/aws-amplify/amplify-js/blob/0c336ef5895401be365b2b22db4aecdbf7f81b8a/packages/aws-amplify-vue/src/plugins/AmplifyPlugin.js#L18-L33

Vue captures the underlying `AmplifyPlugin installation method...` error and only outputs the following error:

```console
* [Vue warn]: Error in mounted hook (Promise/async): "TypeError: this.$Amplify is undefined"
    
    found in
    
    ---> <Authenticator>
           <App> at src/App.vue
             <Root>
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
