### PR TITLE
Import and use Pubsub directly in GraphQL subscriptions instead of us…

### DIFF
--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -288,8 +288,8 @@ export class GraphQLAPIClass {
 		const authenticationType =
 			defaultAuthenticationType || aws_appsync_authenticationType || 'AWS_IAM';
 
-		if (Amplify.PubSub && typeof Amplify.PubSub.subscribe === 'function') {
-			return Amplify.PubSub.subscribe('', {
+		if (PubSub && typeof PubSub.subscribe === 'function') {
+			return PubSub.subscribe('', {
 				provider: INTERNAL_AWS_APPSYNC_REALTIME_PUBSUB_PROVIDER,
 				appSyncGraphqlEndpoint,
 				authenticationType,


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ After modularization updates, Amplify.\<Catgeory\> is not available unless explicitly imported. This PR updates API category to explicitly rely on Pubsub module instead of using it through globalish Static Amplify object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
