### PR TITLE
Fix issue for AppSyncRealTimeProvider with Buffer on react-native

### DIFF
--- a/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
@@ -14,7 +14,7 @@ import * as Observable from 'zen-observable';
 import { GraphQLError } from 'graphql';
 import * as url from 'url';
 import { v4 as uuid } from 'uuid';
-
+import { Buffer } from 'buffer';
 import { ProvidertOptions } from '../types';
 import {
 	Logger,


### PR DESCRIPTION
_Issue #, if available:_
Fixes: #4910 
_Description of changes:_
Adding Buffer import to fix issue with React-Native

Tested on a react-native App using react-native cli and a regular web App
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
