### PR TITLE
Allow in PubSub to add async custom headers

### DIFF
--- a/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
@@ -241,7 +241,6 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 
 		const dataString = JSON.stringify(data);
 		const headerObj = {
-			...graphql_headers(),
 			...(await this._awsRealTimeHeaderBasedAuth({
 				apiKey,
 				appSyncGraphqlEndpoint,
@@ -250,6 +249,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 				canonicalUri: '',
 				region,
 			})),
+			...(await graphql_headers()),
 			[USER_AGENT_HEADER]: Constants.userAgent,
 		};
 


### PR DESCRIPTION
Allow in PubSub the same capabilities as API for custom headers:
* Async header
* Override headers (Authorization)

Check issue #4928 for explanations.

_Issue #4928:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
