### PR TITLE
fix(@aws-amplify/ui-components): federated button styling

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-sign-in-button/amplify-sign-in-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in-button/amplify-sign-in-button.tsx
@@ -4,7 +4,7 @@ import { icons, IconNameType } from '../amplify-icon/icons';
 @Component({
   tag: 'amplify-sign-in-button',
   styleUrl: 'amplify-sign-in-button.scss',
-  shadow: true,
+  scoped: true,
 })
 export class AmplifySignInButton {
   /** (Optional) Override default styling */

--- a/packages/amplify-ui-components/src/components/amplify-sign-in-button/amplify-sign-in-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in-button/amplify-sign-in-button.tsx
@@ -15,11 +15,7 @@ export class AmplifySignInButton {
     return (
       <Host class={`sign-in-button ${this.provider}`}>
         <button>
-          {this.provider in icons && (
-            <span class="icon">
-              <amplify-icon name={this.provider as IconNameType} />
-            </span>
-          )}
+          {this.provider in icons && <amplify-icon name={this.provider as IconNameType} />}
 
           <span class="content">
             <slot />

--- a/packages/amplify-ui-components/src/components/amplify-strike/__snapshots__/amplify-strike.spec.ts.snap
+++ b/packages/amplify-ui-components/src/components/amplify-strike/__snapshots__/amplify-strike.spec.ts.snap
@@ -2,22 +2,18 @@
 
 exports[`amplify-strike stories withOverrideStyle 1`] = `
 <amplify-strike class="strike">
-  <mock:shadow-root>
-    <span class="strike-content">
-      <slot></slot>
-    </span>
-  </mock:shadow-root>
-  Unstyled
+  <!---->
+  <span class="strike-content">
+    Unstyled
+  </span>
 </amplify-strike>
 `;
 
 exports[`amplify-strike stories withText 1`] = `
 <amplify-strike class="strike">
-  <mock:shadow-root>
-    <span class="strike-content">
-      <slot></slot>
-    </span>
-  </mock:shadow-root>
-  or
+  <!---->
+  <span class="strike-content">
+    or
+  </span>
 </amplify-strike>
 `;

--- a/packages/amplify-ui-components/src/components/amplify-strike/amplify-strike.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-strike/amplify-strike.tsx
@@ -3,7 +3,7 @@ import { Component, Host, h, Prop } from '@stencil/core';
 @Component({
   tag: 'amplify-strike',
   styleUrl: 'amplify-strike.scss',
-  shadow: true,
+  scoped: true,
 })
 export class AmplifyStrike {
   /** (Optional) Override default styling */


### PR DESCRIPTION
When testing #4944, I noticed that the federated styles were likely broken by #4872:

> ![Screen Shot 2020-02-18 at 14 26 37](https://user-images.githubusercontent.com/15182/74786298-33a55500-5261-11ea-98a8-10eb3e8b4309.png)

Switching to `scoped: true` fixes it:

> ![Screen Shot 2020-02-18 at 14 19 34](https://user-images.githubusercontent.com/15182/74786320-40c24400-5261-11ea-8b2d-acb33035d9c9.png)


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
