### PR TITLE
fix(@aws-amplify/core): automatically set clock offset based on CognitoIdentityCredentials systemClockOffset

### DIFF
--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -5,6 +5,7 @@ import JS from './JS';
 import { FacebookOAuth, GoogleOAuth } from './OAuthHelper';
 import { ICredentials } from './types';
 import Amplify from './Amplify';
+import { DateUtils } from './Util';
 
 const logger = new Logger('Credentials');
 
@@ -201,6 +202,7 @@ export class Credentials {
 			},
 			{
 				region,
+				correctClockSkew: true,
 			}
 		);
 
@@ -228,6 +230,7 @@ export class Credentials {
 						},
 						{
 							region,
+							correctClockSkew: true,
 						}
 					);
 					return this._loadCredentials(newCredentials, 'guest', false, null);
@@ -284,6 +287,7 @@ export class Credentials {
 			},
 			{
 				region,
+				correctClockSkew: true,
 			}
 		);
 
@@ -308,6 +312,7 @@ export class Credentials {
 			},
 			{
 				region,
+				correctClockSkew: true,
 			}
 		);
 
@@ -331,6 +336,15 @@ export class Credentials {
 				}
 
 				logger.debug('Load credentials successfully', credentials);
+				if (
+					credentials['cognito'] &&
+					credentials['cognito']['config'] &&
+					credentials['cognito']['config']['systemClockOffset']
+				) {
+					DateUtils.setClockOffset(
+						credentials['cognito']['config']['systemClockOffset']
+					);
+				}
 				that._credentials = credentials;
 				that._credentials.authenticated = authenticated;
 				that._credentials_source = source;
@@ -413,6 +427,7 @@ export class Credentials {
 				},
 				{
 					region,
+					correctClockSkew: true,
 				}
 			);
 			credentials.clearCachedId();

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -319,6 +319,19 @@ export class Credentials {
 		return this._loadCredentials(credentials, 'userPool', true, null);
 	}
 
+	private _setClockOffset(credentials) {
+		if (
+			credentials &&
+			credentials['cognito'] &&
+			credentials['cognito']['config'] &&
+			credentials['cognito']['config']['systemClockOffset']
+		) {
+			DateUtils.setClockOffset(
+				credentials['cognito']['config']['systemClockOffset']
+			);
+		}
+	}
+
 	private _loadCredentials(
 		credentials,
 		source,
@@ -336,15 +349,7 @@ export class Credentials {
 				}
 
 				logger.debug('Load credentials successfully', credentials);
-				if (
-					credentials['cognito'] &&
-					credentials['cognito']['config'] &&
-					credentials['cognito']['config']['systemClockOffset']
-				) {
-					DateUtils.setClockOffset(
-						credentials['cognito']['config']['systemClockOffset']
-					);
-				}
+				that._setClockOffset(credentials);
 				that._credentials = credentials;
 				that._credentials.authenticated = authenticated;
 				that._credentials_source = source;


### PR DESCRIPTION
_Issue #, if available:_
fix #4312, #2014, #3719 based on #4844

_Description of changes:_
Turn on correctClockSkew option provided by AWS.CognitoIdentityCredentials in Amplify Credentials class
Use DateUtils to setClockOffset using systemClockOffset calculated by AWS.CognitoIdentityCredentials 
in aws-sdk 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
