### PR TITLE
feat (@aws-amplify/datastore): can be specified id in ModelInit.

### DIFF
--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -234,8 +234,9 @@ const createModelClass = <T extends PersistentModel>(
 			} = modelInstanceMetadata;
 
 			const id =
-				// instancesIds is set by modelInstanceCreator, it is accessible only internally
-				_id !== null && _id !== undefined
+				init.id !== null && init.id !== undefined
+					? init.id
+					: _id !== null && _id !== undefined
 					? _id
 					: modelDefinition.syncable
 					? uuid4()

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -151,7 +151,7 @@ export type PersistentModelConstructor<T extends PersistentModel> = {
 	copyOf(src: T, mutator: (draft: MutableModel<T>) => T | void): T;
 };
 export type PersistentModel = Readonly<{ id: string } & Record<string, any>>;
-export type ModelInit<T> = Omit<T, 'id'>;
+export type ModelInit<T> = Omit<T, 'id'> & { id?: string };
 export type MutableModel<T> = Omit<
 	{
 		-readonly [P in keyof T]: T[P];


### PR DESCRIPTION
* `DynamoDB` can specify unique constraints only by primary keys.
* `GraphQL Transform` can create a primary key with a composite key, but DataStore can join only by `id` currently.

Therefore, I want to set an arbitrary values for the primary key and apply a unique constraint.
However, in DataStore, `id` is automatically generated by `uuid` in the model generation process.
For these reasons, I changed it to be able to specify ID in `ModelInit`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
