### PR TITLE
chore(@aws-amplify/ui-components): Remove unused variables

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-country-dial-code/amplify-country-dial-code.stories.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-country-dial-code/amplify-country-dial-code.stories.tsx
@@ -1,5 +1,4 @@
 import { storiesOf } from '@storybook/html';
-import { knobs } from '../../common/testing';
 
 const coutnryDialCodeStories = storiesOf('amplify-country-dial-code', module);
 

--- a/packages/amplify-ui-components/src/components/amplify-label/amplify-label.spec.ts
+++ b/packages/amplify-ui-components/src/components/amplify-label/amplify-label.spec.ts
@@ -2,13 +2,6 @@ import { newSpecPage } from '@stencil/core/testing';
 import { AmplifyLabel } from './amplify-label';
 
 describe('amplify-label spec:', () => {
-  describe('Component logic ->', () => {
-    let label;
-
-    beforeEach(() => {
-      label = new AmplifyLabel();
-    });
-  });
   describe('Render logic ->', () => {
     it('should render a label by default', async () => {
       const page = await newSpecPage({

--- a/packages/amplify-ui-components/src/components/amplify-link/amplify-link.spec.ts
+++ b/packages/amplify-ui-components/src/components/amplify-link/amplify-link.spec.ts
@@ -2,13 +2,6 @@ import { newSpecPage } from '@stencil/core/testing';
 import { AmplifyLink } from './amplify-link';
 
 describe('amplify-link spec:', () => {
-  describe('Component logic ->', () => {
-    let link;
-
-    beforeEach(() => {
-      link = new AmplifyLink();
-    });
-  });
   describe('Render logic ->', () => {
     it('should render a link by default', async () => {
       const page = await newSpecPage({

--- a/packages/amplify-ui-components/src/components/amplify-verify-contact/amplify-verify-contact.stories.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-verify-contact/amplify-verify-contact.stories.tsx
@@ -1,7 +1,5 @@
 import { h } from '@stencil/core';
 
-import { knobs } from '../../common/testing';
-
 export default {
   title: 'amplify-verify-contact',
 };


### PR DESCRIPTION
When running Storybook (#4973), there were unused variables.

This PR removes them.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
