### PR TITLE
feat(@aws-amplify/api): pass additionalHeaders to graphql function

### DIFF
--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -347,9 +347,13 @@ export default class APIClass {
 	 * Executes a GraphQL operation
 	 *
 	 * @param {GraphQLOptions} GraphQL Options
+	 * @param {object} additionalHeaders headers to merge in after any `graphql_headers` set in the config
 	 * @returns {Promise<GraphQLResult> | Observable<object>}
 	 */
-	graphql({ query: paramQuery, variables = {}, authMode }: GraphQLOptions) {
+	graphql(
+		{ query: paramQuery, variables = {}, authMode }: GraphQLOptions,
+		addtionalHeaders?: { [key: string]: string }
+	) {
 		const query =
 			typeof paramQuery === 'string'
 				? parse(paramQuery)
@@ -365,7 +369,7 @@ export default class APIClass {
 		switch (operationType) {
 			case 'query':
 			case 'mutation':
-				return this._graphql({ query, variables, authMode });
+				return this._graphql({ query, variables, authMode }, addtionalHeaders);
 			case 'subscription':
 				return this._graphqlSubscribe({
 					query,
@@ -399,8 +403,8 @@ export default class APIClass {
 				(customEndpointRegion
 					? await this._headerBasedAuth(authMode)
 					: { Authorization: null })),
-			...additionalHeaders,
 			...(await graphql_headers({ query, variables })),
+			...additionalHeaders,
 			...(!customGraphqlEndpoint && {
 				[USER_AGENT_HEADER]: Constants.userAgent,
 			}),


### PR DESCRIPTION
Additional headers are merged **after** merging in headers set at config time.
Additional headers will overwrite any existing values and merge the rest.

_Issue #, if available:_ https://github.com/aws-amplify/amplify-js/issues/4981

_Description of changes:_ Existing private `_graphql` function allowed passing a param called `additionalHeaders` but was never used. The public `graphql` function now accepts an optional `additionalHeaders` param and is passed to private `_graphql` method. `_graphql` method was modified to merge in `additionalHeaders` **after** merging in previously set headers. This is how I would expect the parameter to function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
