### PR TITLE
fix(core): move react-native dependency from dev

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,6 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "devDependencies": {
-    "@react-native-community/netinfo": "4.7.0",
     "find": "^0.2.7",
     "prepend-file": "^1.3.1",
     "react-native": "0.59.0"
@@ -45,7 +44,8 @@
   "dependencies": {
     "aws-sdk": "2.518.0",
     "url": "^0.11.0",
-    "zen-observable": "^0.8.6"
+    "zen-observable": "^0.8.6",
+    "@react-native-community/netinfo": "4.7.0"
   },
   "jest": {
     "globals": {


### PR DESCRIPTION
@react-native-community/netinfo is required to build core. Needs to be in main dependencies, not dev.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
