### PR TITLE
ci: Add React Native integration testing with Detox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ jobs:
       - save_pods
       - run:
           background: true
-          command: xcrun simctl boot "iPhone 11"
+          command: xcrun simctl boot "iPhone 11" || true
           name: Start iOS simulator (background)
       - run:
           background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,6 +280,9 @@ jobs:
       - run:
           name: Yarn Install
           command: yarn install --non-interactive --no-lockfile
+      - run:
+          name: Install netinfo
+          command: yarn add @react-native-community/netinfo && npx react-native link @react-native-community/netinfo
       # TODO: Metro Bundler doesn't work with linked packages. Consider copying the build output instead
       # - run:
       #     name: 'Link aws-amplify'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,10 +254,10 @@ jobs:
   integ_rn_ios_setup:
     macos:
       xcode: '11.3.1'
-    working_directory: ~/amplify-js-samples-staging
+    working_directory: ~/
     steps:
       - attach_workspace:
-          at: .
+          at: ./amplify-js-samples-staging
       - run: pwd && ls
       - run:
           name: Configure Detox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+version: 2.1
 machine:
   environment:
     PATH: '${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin'
@@ -250,6 +250,37 @@ jobs:
           path: amplify-js-samples-staging/cypress/videos
       - store_artifacts:
           path: amplify-js-samples-staging/cypress/screenshots
+
+  integ_rn_ios_setup:
+    macos:
+      xcode: '11.3.1'
+    working_directory: ~/
+    steps:
+      - attach_workspace:
+          at: /root
+      - run:
+          name: Configure Detox
+          environment:
+            HOMEBREW_NO_AUTO_UPDATE: 1
+          command: |
+            brew tap wix/brew
+            brew install applesimutils
+            yarn global add detox-cli
+      - persist_to_workspace:
+          root: /root
+          paths: amplify-js-samples-staging
+
+  integ_rn_ios_storage:
+    macos:
+      xcode: '11.3.1'
+    working_directory: ~/
+    steps:
+      - attach_workspace:
+          at: /root
+      - run: detox --version
+      - run: pwd
+      - run: ls -alF
+
   deploy:
     <<: *defaults
     working_directory: ~/amplify-js
@@ -280,65 +311,83 @@ workflows:
   build_test_deploy:
     jobs:
       - build
-      - unit_test:
-          requires:
-            - build
       - integ_setup:
-          filters:
-            branches:
-              only:
-                - release
-                - master
-                - 1.0-stable
           requires:
             - build
-      - integ_react_predictions:
-          filters:
-            branches:
-              only:
-                - release
-                - master
-                - 1.0-stable
+      - integ_rn_ios_setup:
           requires:
             - integ_setup
-      - integ_react_auth:
-          filters:
-            branches:
-              only:
-                - release
-                - master
-                - 1.0-stable
+      - integ_rn_ios_storage:
           requires:
-            - integ_setup
-      - integ_angular_auth:
-          filters:
-            branches:
-              only:
-                - release
-                - master
-                - 1.0-stable
-          requires:
-            - integ_setup
-      - integ_vue_auth:
-          filters:
-            branches:
-              only:
-                - release
-                - master
-                - 1.0-stable
-          requires:
-            - integ_setup
-      - deploy:
-          filters:
-            branches:
-              only:
-                - release
-                - master
-                - beta
-                - 1.0-stable
-          requires:
-            - unit_test
-            - integ_react_predictions
-            - integ_react_auth
-            - integ_angular_auth
-            - integ_vue_auth
+            - integ_rn_ios_setup
+      # - unit_test:
+      #     requires:
+      #       - build
+      # - integ_setup:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #           - master
+      #           - 1.0-stable
+      #     requires:
+      #       - build
+      # - integ_react_predictions:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #           - master
+      #           - 1.0-stable
+      #     requires:
+      #       - integ_setup
+      # - integ_react_auth:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #           - master
+      #           - 1.0-stable
+      #     requires:
+      #       - integ_setup
+      # - integ_angular_auth:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #           - master
+      #           - 1.0-stable
+      #     requires:
+      #       - integ_setup
+      # - integ_vue_auth:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #           - master
+      #           - 1.0-stable
+      #     requires:
+      #       - integ_setup
+      # - integ_rn_storage:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #           - master
+      #           - 1.0-stable
+      #     requires:
+      #       - integ_setup
+      # - deploy:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #           - master
+      #           - beta
+      #           - 1.0-stable
+      #     requires:
+      #       - unit_test
+      #       - integ_react_predictions
+      #       - integ_react_auth
+      #       - integ_angular_auth
+      #       - integ_vue_auth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,10 +277,16 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run: pwd && ls -alF
       - run:
           name: Yarn Install
           command: yarn install --non-interactive --no-lockfile
+      - run:
+          name: 'Link aws-amplify'
+          command: |
+            cd ~/amplify-js/packages/aws-amplify
+            yarn link
+            cd ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
+            yarn link aws-amplify
       - restore_pods
       - run:
           name: Install CocoaPods
@@ -307,6 +313,19 @@ jobs:
       - run:
           name: Detox Build
           command: detox build -c ios.sim.debug
+      - run:
+          name: Detox Clean Cache
+          command: detox clean-framework-cache && detox build-framework-cache
+      - run:
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: 'reports/junit'
+            JEST_JUNIT_OUTPUT_NAME: 'detox-test-results.xml'
+          name: Detox Test
+          command: detox test -c ios.sim.debug -u
+      - store_test_results:
+          path: reports/junit
+      - store_artifacts:
+          path: reports/junit
 
   deploy:
     <<: *defaults
@@ -337,11 +356,10 @@ workflows:
   version: 2
   build_test_deploy:
     jobs:
-      # - build
-      # - integ_setup:
-      #     requires:
-      #       - build
-      - integ_setup
+      - build
+      - integ_setup:
+          requires:
+            - build
       - integ_rn_ios_storage:
           requires:
             - integ_setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,7 +286,6 @@ jobs:
           name: 'Link aws-amplify'
           command: |
             cp -rf ~/amplify-js/packages/aws-amplify ./node_modules/
-            mkdir node_modules/@aws-amplify
             cp -rf ~/amplify-js/packages/analytics ./node_modules/@aws-amplify/
             cp -rf ~/amplify-js/packages/api ./node_modules/@aws-amplify/
             cp -rf ~/amplify-js/packages/auth ./node_modules/@aws-amplify/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,70 +410,70 @@ workflows:
           requires:
             - build
       - integ_setup:
-          filters:
-            branches:
-              only:
-                - release
-                - master
-                - 1.0-stable
+          # filters:
+          #   branches:
+          #     only:
+          #       - release
+          #       - master
+          #       - 1.0-stable
           requires:
             - build
-      - integ_react_predictions:
-          filters:
-            branches:
-              only:
-                - release
-                - master
-                - 1.0-stable
-          requires:
-            - integ_setup
-      - integ_react_auth:
-          filters:
-            branches:
-              only:
-                - release
-                - master
-                - 1.0-stable
-          requires:
-            - integ_setup
-      - integ_angular_auth:
-          filters:
-            branches:
-              only:
-                - release
-                - master
-                - 1.0-stable
-          requires:
-            - integ_setup
-      - integ_vue_auth:
-          filters:
-            branches:
-              only:
-                - release
-                - master
-                - 1.0-stable
-          requires:
-            - integ_setup
+      # - integ_react_predictions:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #           - master
+      #           - 1.0-stable
+      #     requires:
+      #       - integ_setup
+      # - integ_react_auth:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #           - master
+      #           - 1.0-stable
+      #     requires:
+      #       - integ_setup
+      # - integ_angular_auth:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #           - master
+      #           - 1.0-stable
+      #     requires:
+      #       - integ_setup
+      # - integ_vue_auth:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #           - master
+      #           - 1.0-stable
+      #     requires:
+      #       - integ_setup
       - integ_rn_ios_storage:
-          filters:
-            branches:
-              only:
-                - release
-                - master
-                - 1.0-stable
+          # filters:
+          #   branches:
+          #     only:
+          #       - release
+          #       - master
+          #       - 1.0-stable
           requires:
             - integ_setup
-      - deploy:
-          filters:
-            branches:
-              only:
-                - release
-                - master
-                - beta
-                - 1.0-stable
-          requires:
-            - unit_test
-            - integ_react_predictions
-            - integ_react_auth
-            - integ_angular_auth
-            - integ_vue_auth
+      # - deploy:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #           - master
+      #           - beta
+      #           - 1.0-stable
+      #     requires:
+      #       - unit_test
+      #       - integ_react_predictions
+      #       - integ_react_auth
+      #       - integ_angular_auth
+      #       - integ_vue_auth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,6 @@ jobs:
 
   integ_rn_ios_setup:
     <<: *defaults_rn
-    working_directory: ~/
     steps:
       - attach_workspace:
           at: ~/
@@ -288,12 +287,11 @@ jobs:
             yarn global add detox-cli
 
   integ_rn_ios_storage:
-    macos:
-      xcode: '11.3.1'
-    working_directory: ~/
+    <<: *defaults_rn
+    working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
     steps:
       - attach_workspace:
-          at: .
+          at: ~/
       - run: detox --version
       - run: pwd
       - run: ls -alF
@@ -334,6 +332,9 @@ workflows:
       - integ_rn_ios_setup:
           requires:
             - integ_setup
+      - integ_rn_ios_storage:
+          requires:
+            - integ_rn_ios_setup
       # - unit_test:
       #     requires:
       #       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,9 +361,6 @@ jobs:
       - run:
           name: Detox Build
           command: detox build -c ios.sim.debug
-      # - run:
-      #     name: Detox Clean Cache
-      #     command: detox clean-framework-cache && detox build-framework-cache
       - run:
           environment:
             JEST_JUNIT_OUTPUT_DIR: 'reports/junit'
@@ -409,70 +406,70 @@ workflows:
           requires:
             - build
       - integ_setup:
-          # filters:
-          #   branches:
-          #     only:
-          #       - release
-          #       - master
-          #       - 1.0-stable
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - 1.0-stable
           requires:
             - build
-      # - integ_react_predictions:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #           - master
-      #           - 1.0-stable
-      #     requires:
-      #       - integ_setup
-      # - integ_react_auth:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #           - master
-      #           - 1.0-stable
-      #     requires:
-      #       - integ_setup
-      # - integ_angular_auth:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #           - master
-      #           - 1.0-stable
-      #     requires:
-      #       - integ_setup
-      # - integ_vue_auth:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #           - master
-      #           - 1.0-stable
-      #     requires:
-      #       - integ_setup
-      - integ_rn_ios_storage:
-          # filters:
-          #   branches:
-          #     only:
-          #       - release
-          #       - master
-          #       - 1.0-stable
+      - integ_react_predictions:
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - 1.0-stable
           requires:
             - integ_setup
-      # - deploy:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #           - master
-      #           - beta
-      #           - 1.0-stable
-      #     requires:
-      #       - unit_test
-      #       - integ_react_predictions
-      #       - integ_react_auth
-      #       - integ_angular_auth
-      #       - integ_vue_auth
+      - integ_react_auth:
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - 1.0-stable
+          requires:
+            - integ_setup
+      - integ_angular_auth:
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - 1.0-stable
+          requires:
+            - integ_setup
+      - integ_vue_auth:
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - 1.0-stable
+          requires:
+            - integ_setup
+      - integ_rn_ios_storage:
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - 1.0-stable
+          requires:
+            - integ_setup
+      - deploy:
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - beta
+                - 1.0-stable
+          requires:
+            - unit_test
+            - integ_react_predictions
+            - integ_react_auth
+            - integ_angular_auth
+            - integ_vue_auth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,22 +281,23 @@ jobs:
           name: Yarn Install
           command: yarn install --non-interactive --no-lockfile
       # Metro Bundler doesn't work with linked packages so we're copying them from amplify-js
+      # TODO: utilize Verdaccio for this instead
       - run:
           name: 'Link aws-amplify'
           command: |
-            cp -r ~/amplify-js/packages/aws-amplify ./node_modules/
+            cp -rf ~/amplify-js/packages/aws-amplify ./node_modules/
             mkdir node_modules/@aws-amplify
-            cp -r ~/amplify-js/packages/analytics ./node_modules/@aws-amplify/
-            cp -r ~/amplify-js/packages/api ./node_modules/@aws-amplify/
-            cp -r ~/amplify-js/packages/auth ./node_modules/@aws-amplify/
-            cp -r ~/amplify-js/packages/cache ./node_modules/@aws-amplify/
-            cp -r ~/amplify-js/packages/core ./node_modules/@aws-amplify/
-            cp -r ~/amplify-js/packages/interactions ./node_modules/@aws-amplify/
-            cp -r ~/amplify-js/packages/predictions ./node_modules/@aws-amplify/
-            cp -r ~/amplify-js/packages/pubsub ./node_modules/@aws-amplify/
-            cp -r ~/amplify-js/packages/storage ./node_modules/@aws-amplify/
-            cp -r ~/amplify-js/packages/amplify-ui ./node_modules/@aws-amplify/ui
-            cp -r ~/amplify-js/packages/xr ./node_modules/@aws-amplify/
+            cp -rf ~/amplify-js/packages/analytics ./node_modules/@aws-amplify/
+            cp -rf ~/amplify-js/packages/api ./node_modules/@aws-amplify/
+            cp -rf ~/amplify-js/packages/auth ./node_modules/@aws-amplify/
+            cp -rf ~/amplify-js/packages/cache ./node_modules/@aws-amplify/
+            cp -rf ~/amplify-js/packages/core ./node_modules/@aws-amplify/
+            cp -rf ~/amplify-js/packages/interactions ./node_modules/@aws-amplify/
+            cp -rf ~/amplify-js/packages/predictions ./node_modules/@aws-amplify/
+            cp -rf ~/amplify-js/packages/pubsub ./node_modules/@aws-amplify/
+            cp -rf ~/amplify-js/packages/storage ./node_modules/@aws-amplify/
+            cp -rf ~/amplify-js/packages/amplify-ui ./node_modules/@aws-amplify/ui
+            cp -rf ~/amplify-js/packages/xr ./node_modules/@aws-amplify/
       - restore_pods
       - run:
           name: Install CocoaPods

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,10 +254,11 @@ jobs:
   integ_rn_ios_setup:
     macos:
       xcode: '11.3.1'
-    working_directory: ~/
+    working_directory: ~/amplify-js-samples-staging
     steps:
       - attach_workspace:
           at: .
+      - run: pwd && ls
       - run:
           name: Configure Detox
           environment:
@@ -267,7 +268,7 @@ jobs:
             brew install applesimutils
             yarn global add detox-cli
       - persist_to_workspace:
-          root: /root
+          root: .
           paths: amplify-js-samples-staging
 
   integ_rn_ios_storage:
@@ -276,7 +277,7 @@ jobs:
     working_directory: ~/
     steps:
       - attach_workspace:
-          at: .
+          at: /root
       - run: detox --version
       - run: pwd
       - run: ls -alF

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,13 @@ jobs:
       - run:
           name: 'Link aws-amplify'
           command: |
-            cp -rf ~/amplify-js/packages/aws-amplify ./node_modules/
+            cp -rf ~/amplify-js/packages/aws-amplify/dist ./node_modules/aws-amplify/dist
+            cp -rf ~/amplify-js/packages/aws-amplify/lib ./node_modules/aws-amplify/lib
+            cp -rf ~/amplify-js/packages/aws-amplify/lib-esm ./node_modules/aws-amplify/lib-esm
+
+            cp -rf ~/amplify-js/packages/amazon-cognito-identity-js/ ./node_modules/
+
+
             cp -rf ~/amplify-js/packages/analytics ./node_modules/@aws-amplify/
             cp -rf ~/amplify-js/packages/api ./node_modules/@aws-amplify/
             cp -rf ~/amplify-js/packages/auth ./node_modules/@aws-amplify/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,13 +280,14 @@ jobs:
       - run:
           name: Yarn Install
           command: yarn install --non-interactive --no-lockfile
-      - run:
-          name: 'Link aws-amplify'
-          command: |
-            cd ~/amplify-js/packages/aws-amplify
-            yarn link
-            cd ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
-            yarn link aws-amplify
+      # TODO: Metro Bundler doesn't work with linked packages. Consider copying the build output instead
+      # - run:
+      #     name: 'Link aws-amplify'
+      #     command: |
+      #       cd ~/amplify-js/packages/aws-amplify
+      #       yarn link
+      #       cd ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
+      #       yarn link aws-amplify
       - restore_pods
       - run:
           name: Install CocoaPods
@@ -360,9 +361,6 @@ workflows:
       - integ_setup:
           requires:
             - build
-      - integ_rn_ios_storage:
-          requires:
-            - integ_setup
       # - unit_test:
       #     requires:
       #       - build
@@ -420,6 +418,9 @@ workflows:
       #           - 1.0-stable
       #     requires:
       #       - integ_setup
+      - integ_rn_ios_storage:
+          requires:
+            - integ_setup
       # - deploy:
       #     filters:
       #       branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,12 +271,31 @@ jobs:
       - store_artifacts:
           path: amplify-js-samples-staging/cypress/screenshots
 
-  integ_rn_ios_setup:
+  integ_rn_ios_storage:
     <<: *defaults_rn
+    working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
     steps:
       - attach_workspace:
           at: ~/
-      - run: pwd && ls
+      - run: pwd && ls -alF
+      - run:
+          name: Yarn Install
+          command: yarn install --non-interactive --no-lockfile
+            - restore_pods
+      - run:
+          name: Install CocoaPods
+          command: |
+            cd ios
+            pod install
+      - save_pods
+      - run:
+          background: true
+          command: xcrun simctl boot "iPhone 11"
+          name: Start iOS simulator (background)
+      - run:
+          background: true
+          command: yarn start
+          name: Start Metro Packager (background)
       - run:
           name: Configure Detox
           environment:
@@ -285,16 +304,9 @@ jobs:
             brew tap wix/brew
             brew install applesimutils
             yarn global add detox-cli
-
-  integ_rn_ios_storage:
-    <<: *defaults_rn
-    working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: detox --version
-      - run: pwd
-      - run: ls -alF
+      - run:
+          name: Detox Build
+          command: detox build -c ios.sim.debug
 
   deploy:
     <<: *defaults
@@ -325,16 +337,14 @@ workflows:
   version: 2
   build_test_deploy:
     jobs:
-      - build
-      - integ_setup:
-          requires:
-            - build
-      - integ_rn_ios_setup:
-          requires:
-            - integ_setup
+      # - build
+      # - integ_setup:
+      #     requires:
+      #       - build
+      - integ_setup
       - integ_rn_ios_storage:
           requires:
-            - integ_rn_ios_setup
+            - integ_setup
       # - unit_test:
       #     requires:
       #       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,9 +273,10 @@ jobs:
 
   integ_rn_ios_setup:
     <<: *defaults_rn
+    working_directory: ~/
     steps:
       - attach_workspace:
-          at: .
+          at: ~/
       - run: pwd && ls
       - run:
           name: Configure Detox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,8 @@ jobs:
       - checkout
       - run: yarn config set workspaces-experimental true
       - run: yarn
-      - run: yarn run bootstrap
-      - run: yarn run build
+      - run: yarn bootstrap
+      - run: yarn build
 
       - save_cache:
           key: amplify-ssh-deps-{{ .Branch }}
@@ -280,17 +280,23 @@ jobs:
       - run:
           name: Yarn Install
           command: yarn install --non-interactive --no-lockfile
+      # Metro Bundler doesn't work with linked packages so we're copying them from amplify-js
       - run:
-          name: Install netinfo
-          command: yarn add @react-native-community/netinfo && npx react-native link @react-native-community/netinfo
-      # TODO: Metro Bundler doesn't work with linked packages. Consider copying the build output instead
-      # - run:
-      #     name: 'Link aws-amplify'
-      #     command: |
-      #       cd ~/amplify-js/packages/aws-amplify
-      #       yarn link
-      #       cd ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
-      #       yarn link aws-amplify
+          name: 'Link aws-amplify'
+          command: |
+            cp -r ~/amplify-js/packages/aws-amplify ./node_modules/
+            mkdir node_modules/@aws-amplify
+            cp -r ~/amplify-js/packages/analytics ./node_modules/@aws-amplify/
+            cp -r ~/amplify-js/packages/api ./node_modules/@aws-amplify/
+            cp -r ~/amplify-js/packages/auth ./node_modules/@aws-amplify/
+            cp -r ~/amplify-js/packages/cache ./node_modules/@aws-amplify/
+            cp -r ~/amplify-js/packages/core ./node_modules/@aws-amplify/
+            cp -r ~/amplify-js/packages/interactions ./node_modules/@aws-amplify/
+            cp -r ~/amplify-js/packages/predictions ./node_modules/@aws-amplify/
+            cp -r ~/amplify-js/packages/pubsub ./node_modules/@aws-amplify/
+            cp -r ~/amplify-js/packages/storage ./node_modules/@aws-amplify/
+            cp -r ~/amplify-js/packages/amplify-ui ./node_modules/@aws-amplify/ui
+            cp -r ~/amplify-js/packages/xr ./node_modules/@aws-amplify/
       - restore_pods
       - run:
           name: Install CocoaPods

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ jobs:
     working_directory: ~/
     steps:
       - attach_workspace:
-          at: ./amplify-js-samples-staging
+          at: .
       - run: pwd && ls
       - run:
           name: Configure Detox
@@ -269,7 +269,7 @@ jobs:
             yarn global add detox-cli
       - persist_to_workspace:
           root: .
-          paths: amplify-js-samples-staging
+          paths: .
 
   integ_rn_ios_storage:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,26 @@ defaults: &defaults
         ## this enables colors in the output
         TERM: xterm
 
+defaults_rn: &defaults_rn
+  macos:
+    xcode: '11.3.1'
+  working_directory: ~/amplify-js-samples-staging
+
+commands:
+  restore_pods:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-storage-app-pods-{{ checksum "ios/Podfile.lock" }}
+            - v1-storage-app-pods-
+
+  save_pods:
+    steps:
+      - save_cache:
+          key: v1-storage-app-pods-{{ checksum "ios/Podfile.lock" }}
+          paths:
+            - ios/Pods
+
 jobs:
   build:
     <<: *defaults
@@ -252,9 +272,7 @@ jobs:
           path: amplify-js-samples-staging/cypress/screenshots
 
   integ_rn_ios_setup:
-    macos:
-      xcode: '11.3.1'
-    working_directory: ~/
+    <<: *defaults_rn
     steps:
       - attach_workspace:
           at: .
@@ -267,9 +285,6 @@ jobs:
             brew tap wix/brew
             brew install applesimutils
             yarn global add detox-cli
-      - persist_to_workspace:
-          root: .
-          paths: .
 
   integ_rn_ios_storage:
     macos:
@@ -318,9 +333,6 @@ workflows:
       - integ_rn_ios_setup:
           requires:
             - integ_setup
-      - integ_rn_ios_storage:
-          requires:
-            - integ_rn_ios_setup
       # - unit_test:
       #     requires:
       #       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,20 +289,53 @@ jobs:
             cp -rf ~/amplify-js/packages/aws-amplify/lib ./node_modules/aws-amplify/lib
             cp -rf ~/amplify-js/packages/aws-amplify/lib-esm ./node_modules/aws-amplify/lib-esm
 
-            cp -rf ~/amplify-js/packages/amazon-cognito-identity-js/ ./node_modules/
+            cp -rf ~/amplify-js/packages/amazon-cognito-identity-js/dist ./node_modules/amazon-cognito-identity-js/dist
+            cp -rf ~/amplify-js/packages/amazon-cognito-identity-js/lib ./node_modules/amazon-cognito-identity-js/lib
+            cp -rf ~/amplify-js/packages/amazon-cognito-identity-js/lib-esm ./node_modules/amazon-cognito-identity-js/lib-esm
 
+            cp -rf ~/amplify-js/packages/analytics/dist ./node_modules/@aws-amplify/analytics/dist
+            cp -rf ~/amplify-js/packages/analytics/lib ./node_modules/@aws-amplify/analytics/lib
+            cp -rf ~/amplify-js/packages/analytics/lib-esm ./node_modules/@aws-amplify/analytics/lib-esm
 
-            cp -rf ~/amplify-js/packages/analytics ./node_modules/@aws-amplify/
-            cp -rf ~/amplify-js/packages/api ./node_modules/@aws-amplify/
-            cp -rf ~/amplify-js/packages/auth ./node_modules/@aws-amplify/
-            cp -rf ~/amplify-js/packages/cache ./node_modules/@aws-amplify/
-            cp -rf ~/amplify-js/packages/core ./node_modules/@aws-amplify/
-            cp -rf ~/amplify-js/packages/interactions ./node_modules/@aws-amplify/
-            cp -rf ~/amplify-js/packages/predictions ./node_modules/@aws-amplify/
-            cp -rf ~/amplify-js/packages/pubsub ./node_modules/@aws-amplify/
-            cp -rf ~/amplify-js/packages/storage ./node_modules/@aws-amplify/
-            cp -rf ~/amplify-js/packages/amplify-ui ./node_modules/@aws-amplify/ui
-            cp -rf ~/amplify-js/packages/xr ./node_modules/@aws-amplify/
+            cp -rf ~/amplify-js/packages/api/dist ./node_modules/@aws-amplify/api/dist
+            cp -rf ~/amplify-js/packages/api/lib ./node_modules/@aws-amplify/api/lib
+            cp -rf ~/amplify-js/packages/api/lib-esm ./node_modules/@aws-amplify/api/lib-esm
+
+            cp -rf ~/amplify-js/packages/auth/dist ./node_modules/@aws-amplify/auth/dist
+            cp -rf ~/amplify-js/packages/auth/lib ./node_modules/@aws-amplify/auth/lib
+            cp -rf ~/amplify-js/packages/auth/lib-esm ./node_modules/@aws-amplify/auth/lib-esm
+
+            cp -rf ~/amplify-js/packages/cache/dist ./node_modules/@aws-amplify/cache/dist
+            cp -rf ~/amplify-js/packages/cache/lib ./node_modules/@aws-amplify/cache/lib
+            cp -rf ~/amplify-js/packages/cache/lib-esm ./node_modules/@aws-amplify/cache/lib-esm
+
+            cp -rf ~/amplify-js/packages/core/dist ./node_modules/@aws-amplify/core/dist
+            cp -rf ~/amplify-js/packages/core/lib ./node_modules/@aws-amplify/core/lib
+            cp -rf ~/amplify-js/packages/core/lib-esm ./node_modules/@aws-amplify/core/lib-esm
+
+            cp -rf ~/amplify-js/packages/interactions/dist ./node_modules/@aws-amplify/interactions/dist
+            cp -rf ~/amplify-js/packages/interactions/lib ./node_modules/@aws-amplify/interactions/lib
+            cp -rf ~/amplify-js/packages/interactions/lib-esm ./node_modules/@aws-amplify/interactions/lib-esm
+
+            cp -rf ~/amplify-js/packages/predictions/dist ./node_modules/@aws-amplify/predictions/dist
+            cp -rf ~/amplify-js/packages/predictions/lib ./node_modules/@aws-amplify/predictions/lib
+            cp -rf ~/amplify-js/packages/predictions/lib-esm ./node_modules/@aws-amplify/predictions/lib-esm
+
+            cp -rf ~/amplify-js/packages/pubsub/dist ./node_modules/@aws-amplify/pubsub/dist
+            cp -rf ~/amplify-js/packages/pubsub/lib ./node_modules/@aws-amplify/pubsub/lib
+            cp -rf ~/amplify-js/packages/pubsub/lib-esm ./node_modules/@aws-amplify/pubsub/lib-esm
+
+            cp -rf ~/amplify-js/packages/storage/dist ./node_modules/@aws-amplify/storage/dist
+            cp -rf ~/amplify-js/packages/storage/lib ./node_modules/@aws-amplify/storage/lib
+            cp -rf ~/amplify-js/packages/storage/lib-esm ./node_modules/@aws-amplify/storage/lib-esm
+
+            cp -rf ~/amplify-js/packages/amplify-ui/dist ./node_modules/@aws-amplify/ui/dist
+            cp -rf ~/amplify-js/packages/amplify-ui/lib ./node_modules/@aws-amplify/ui/lib
+
+            cp -rf ~/amplify-js/packages/xr/dist ./node_modules/@aws-amplify/xr/dist
+            cp -rf ~/amplify-js/packages/xr/lib ./node_modules/@aws-amplify/xr/lib
+            cp -rf ~/amplify-js/packages/xr/lib-esm ./node_modules/@aws-amplify/xr/lib-esm
+
       - restore_pods
       - run:
           name: Install CocoaPods
@@ -373,80 +406,74 @@ workflows:
   build_test_deploy:
     jobs:
       - build
-      - integ_setup:
+      - unit_test:
           requires:
             - build
-      # - unit_test:
-      #     requires:
-      #       - build
-      # - integ_setup:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #           - master
-      #           - 1.0-stable
-      #     requires:
-      #       - build
-      # - integ_react_predictions:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #           - master
-      #           - 1.0-stable
-      #     requires:
-      #       - integ_setup
-      # - integ_react_auth:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #           - master
-      #           - 1.0-stable
-      #     requires:
-      #       - integ_setup
-      # - integ_angular_auth:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #           - master
-      #           - 1.0-stable
-      #     requires:
-      #       - integ_setup
-      # - integ_vue_auth:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #           - master
-      #           - 1.0-stable
-      #     requires:
-      #       - integ_setup
-      # - integ_rn_storage:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #           - master
-      #           - 1.0-stable
-      #     requires:
-      #       - integ_setup
-      - integ_rn_ios_storage:
+      - integ_setup:
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - 1.0-stable
+          requires:
+            - build
+      - integ_react_predictions:
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - 1.0-stable
           requires:
             - integ_setup
-      # - deploy:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #           - master
-      #           - beta
-      #           - 1.0-stable
-      #     requires:
-      #       - unit_test
-      #       - integ_react_predictions
-      #       - integ_react_auth
-      #       - integ_angular_auth
-      #       - integ_vue_auth
+      - integ_react_auth:
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - 1.0-stable
+          requires:
+            - integ_setup
+      - integ_angular_auth:
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - 1.0-stable
+          requires:
+            - integ_setup
+      - integ_vue_auth:
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - 1.0-stable
+          requires:
+            - integ_setup
+      - integ_rn_ios_storage:
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - 1.0-stable
+          requires:
+            - integ_setup
+      - deploy:
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - beta
+                - 1.0-stable
+          requires:
+            - unit_test
+            - integ_react_predictions
+            - integ_react_auth
+            - integ_angular_auth
+            - integ_vue_auth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,9 +323,9 @@ jobs:
       - run:
           name: Detox Build
           command: detox build -c ios.sim.debug
-      - run:
-          name: Detox Clean Cache
-          command: detox clean-framework-cache && detox build-framework-cache
+      # - run:
+      #     name: Detox Clean Cache
+      #     command: detox clean-framework-cache && detox build-framework-cache
       - run:
           environment:
             JEST_JUNIT_OUTPUT_DIR: 'reports/junit'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ jobs:
     working_directory: ~/
     steps:
       - attach_workspace:
-          at: /root
+          at: .
       - run:
           name: Configure Detox
           environment:
@@ -276,7 +276,7 @@ jobs:
     working_directory: ~/
     steps:
       - attach_workspace:
-          at: /root
+          at: .
       - run: detox --version
       - run: pwd
       - run: ls -alF

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,7 @@ jobs:
       - run:
           name: Yarn Install
           command: yarn install --non-interactive --no-lockfile
-            - restore_pods
+      - restore_pods
       - run:
           name: Install CocoaPods
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,6 @@ jobs:
 
             cp -rf ~/amplify-js/packages/amazon-cognito-identity-js/dist ./node_modules/amazon-cognito-identity-js/dist
             cp -rf ~/amplify-js/packages/amazon-cognito-identity-js/lib ./node_modules/amazon-cognito-identity-js/lib
-            cp -rf ~/amplify-js/packages/amazon-cognito-identity-js/lib-esm ./node_modules/amazon-cognito-identity-js/lib-esm
 
             cp -rf ~/amplify-js/packages/analytics/dist ./node_modules/@aws-amplify/analytics/dist
             cp -rf ~/amplify-js/packages/analytics/lib ./node_modules/@aws-amplify/analytics/lib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ jobs:
     working_directory: ~/
     steps:
       - attach_workspace:
-          at: /root
+          at: .
       - run: detox --version
       - run: pwd
       - run: ls -alF


### PR DESCRIPTION
Here's what it looks like when it's running: https://app.circleci.com/jobs/github/aws-amplify/amplify-js/11280

If someone wants to take it for a spin, lmk and we can copy this branch and then temporarily disable the other jobs in the pipeline to have it it only run the detox tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
