### PR TITLE
chore(@aws-amplify/ui-components): output dist/docs.json

### DIFF
--- a/packages/amplify-ui-components/stencil.config.ts
+++ b/packages/amplify-ui-components/stencil.config.ts
@@ -45,6 +45,7 @@ export const config: Config = {
       proxiesFile: '../amplify-ui-react/src/components.ts',
     }),
     { type: 'dist' },
+    { type: 'docs-json', file: 'dist/docs.json' },
     { type: 'docs-readme' },
     {
       type: 'www',


### PR DESCRIPTION
Stencil doesn't output `custom-elements.json`, which is used by other tools to reflect on what custom tags, properties, events, & styles a library provides.

This PR simply uses Stencil's existing `docs-json` plugin to output our components as JSON so that other tools can leverage them more effectively:

- Our own documentation
- Our own Storybook (#4973)

This format isn't the same schema as `custom-elements.json`, but we map `docs.json` to `custom-elements.json` in a future PR, once we identify the need.

Based on my research, `docs.json` is more descriptive than `custom-elements.json` and **closely matches what Stencil's `docs` plugin outputs, but as JSON.**

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
