### PR TITLE
fix(@aws-amplify/datastore): Fix query and delete types

### DIFF
--- a/packages/datastore/src/predicates/index.ts
+++ b/packages/datastore/src/predicates/index.ts
@@ -12,17 +12,20 @@ import { exhaustiveCheck } from '../util';
 
 const predicatesAllSet = new WeakSet<ProducerModelPredicate<any>>();
 
-export function isPredicatesAll(predicate: ProducerModelPredicate<any>) {
+export function isPredicatesAll(predicate: any) {
 	return predicatesAllSet.has(predicate);
 }
 
+// This symbol is not used at runtime, only its type (unique symbol)
+export const PredicateAll = Symbol('A predicate that matches all records');
+
 export class Predicates {
-	public static get ALL() {
+	public static get ALL(): typeof PredicateAll {
 		const predicate = <ProducerModelPredicate<any>>(c => c);
 
 		predicatesAllSet.add(predicate);
 
-		return predicate;
+		return <typeof PredicateAll>(<unknown>predicate);
 	}
 }
 


### PR DESCRIPTION
_Issue #, if available:_
Fixes #4827

_Description of changes:_
This change is a backwards compatible way to keep using `Predicates.ALL` without changing the behavior at all, only the types of the public API

- Introduce a new symbol (not exported from entry-point)
- Changed `query` and `delete` signatures to accept the symbol
- Change `Predicates.ALL` return type to the symbol

Tested with
```typescript
console.log('No criteria', await DataStore.query(Note));
console.log('Predicates.ALL', await DataStore.query(Note, Predicates.ALL));
console.log('c => c', await DataStore.query(Note, c => c));
console.log(`c => c.content('beginsWith', 'XXX')`, await DataStore.query(Note, c => c.content('beginsWith', 'XXX')));
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
