### PR TITLE
feat(@ui-components/ui-storybook): show multi-framework code

### DIFF
--- a/packages/amplify-ui-storybook/.storybook/PreviewStory.js
+++ b/packages/amplify-ui-storybook/.storybook/PreviewStory.js
@@ -1,0 +1,37 @@
+import {
+	DocsContext,
+	getSourceProps,
+	Preview,
+	Story,
+} from '@storybook/addon-docs/blocks';
+import React, { useContext } from 'react';
+
+export const PreviewStory = ({ id }) => {
+	const context = useContext(DocsContext);
+	const { code } = getSourceProps({ id }, context);
+	console.log(context.storyStore.fromId(id));
+
+	const frameworkCode = `
+		import { ... } from '@aws-amplify/ui-react';
+
+		export default function App() {
+			return (
+				${code
+					.split('\n')
+					.slice(1, -1)
+					.join('\n')
+					.trimLeft()}
+			)
+		}
+	`
+		.trim()
+		.split('\t')
+		.join('  ');
+
+	console.log({ frameworkCode });
+	return (
+		<Preview mdxSource={frameworkCode}>
+			<Story id={id} />
+		</Preview>
+	);
+};

--- a/packages/amplify-ui-storybook/.storybook/preview.js
+++ b/packages/amplify-ui-storybook/.storybook/preview.js
@@ -2,6 +2,7 @@
 import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
 
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs/blocks';
 import { addDecorator, addParameters } from '@storybook/react';
 import { create } from '@storybook/theming';
 import { extractPropsFromComponentName } from './extractPropsFromComponentName';
@@ -11,6 +12,12 @@ addDecorator(withAmplify);
 
 addParameters({
 	docs: {
+		components: {
+			Meta,
+			Preview,
+			Props,
+			Story,
+		},
 		extractProps: extractPropsFromComponentName,
 	},
 

--- a/packages/amplify-ui-storybook/.storybook/preview.js
+++ b/packages/amplify-ui-storybook/.storybook/preview.js
@@ -7,6 +7,7 @@ import { addDecorator, addParameters } from '@storybook/react';
 import { create } from '@storybook/theming';
 import { extractPropsFromComponentName } from './extractPropsFromComponentName';
 import { withAmplify } from './withAmplify';
+import { PreviewStory } from './PreviewStory';
 
 addDecorator(withAmplify);
 
@@ -15,6 +16,7 @@ addParameters({
 		components: {
 			Meta,
 			Preview,
+			PreviewStory,
 			Props,
 			Story,
 		},

--- a/packages/amplify-ui-storybook/package.json
+++ b/packages/amplify-ui-storybook/package.json
@@ -14,6 +14,7 @@
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "aws-amplify": "^2.2.4",
+    "common-tags": "^1.8.0",
     "react": "^16.12.0",
     "react-app-polyfill": "^1.0.6",
     "react-dom": "^16.12.0",

--- a/packages/amplify-ui-storybook/src/stories/AmplifyAuthenticator.mdx
+++ b/packages/amplify-ui-storybook/src/stories/AmplifyAuthenticator.mdx
@@ -12,7 +12,8 @@ The Authenticator is a drop-in UI component that provides:
 
 ## Live Demo
 
-<Story id="amplifyauthenticator--basic" inline={false} />
+<PreviewStory id="amplifyauthenticator--basic" />
+<Story id="amplifyauthenticator--basic" />
 
 ## Props
 

--- a/packages/amplify-ui-storybook/src/stories/AmplifyAuthenticator.mdx
+++ b/packages/amplify-ui-storybook/src/stories/AmplifyAuthenticator.mdx
@@ -1,5 +1,3 @@
-import { Preview, Props, Story } from '@storybook/addon-docs/blocks';
-
 # AmplifyAuthenticator
 
 The Authenticator is a drop-in UI component that provides:


### PR DESCRIPTION
By default, Storybook's `<Source>` container shows the story code:

```js
() => {
	<AmplifyAuthenticator>
		<h1>You are signed in!</h1>
		<AmplifySignOut />
	</AmplifyAuthenticator>
)
```

Instead, the code should (nearly?) be a copy/pasteable snippet for:

- React
- Angular
- Vue

Example:
> https://ionicframework.com/docs/api/card

For reference, Ionic keeps each framework snippet separate:
> https://github.com/ionic-team/ionic/tree/master/core/src/components/card/usage

Other projects have live playgrounds:
> https://evergreen.segment.com/components/button/

So maybe rather than having per-framework source (that'll happen once Storybook launches multi-framework support in Q2!), this can instead make each story a little more contextual than what's shown above (e.g. adding `import`).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
