### PR TITLE
React native has deprecated AsyncStorage and it will be moved to it's…

### DIFF
--- a/packages/amazon-cognito-identity-js/src/StorageHelper-rn.js
+++ b/packages/amazon-cognito-identity-js/src/StorageHelper-rn.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
 const MEMORY_KEY_PREFIX = '@MemoryStorage:';
 let dataMemory = {};


### PR DESCRIPTION
… own package very soon. Amazon does not update this library anymore so we have to fix it ourselves or be stuck on an older react-native version forever.
