### PR TITLE
fix(aws-amplify-react): Fix Federated icons when using React Bootstrap

### DIFF
--- a/packages/amplify-ui/src/Button.css
+++ b/packages/amplify-ui/src/Button.css
@@ -127,4 +127,5 @@
   overflow: hidden;
   text-overflow: ellipsis;
   text-align: center;
+  line-height: initial;
 }

--- a/packages/amplify-ui/src/Button.css
+++ b/packages/amplify-ui/src/Button.css
@@ -114,7 +114,8 @@
 
 .signInButtonIcon {
   position: absolute;
-  left: 0; 
+  left: 0;
+  box-sizing: content-box;
 }
 
 .signInButtonContent {


### PR DESCRIPTION
_Issue #, if available:_ #5064

**Demo**: https://codesandbox.io/s/amplify-jsissues5064-zj1z1

@michaelcuneo discovered that, when using React Bootstrap, federated buttons looked like this:

> ![with-bootstrap](https://user-images.githubusercontent.com/15182/76378808-a8712980-630b-11ea-8527-c327c7218c80.png)

This is due to CSS resets present when including:

```js
import 'bootstrap/dist/css/bootstrap.min.css';
```

Without `bootstrap`, styles appear correctly:
> <img width="488" alt="without-bootstrap" src="https://user-images.githubusercontent.com/15182/76378864-d0f92380-630b-11ea-82e3-1ff3956bb58e.png">

This bug required addressing 2 things:

- [x] e6b7dd99dec1af6de450018168370094b4c8650f Setting `box-sizing` back to `content-box` (or `initial`).

	> <img width="333" alt="Screen Shot 2020-03-10 at 7 55 21 PM" src="https://user-images.githubusercontent.com/15182/76378960-0dc51a80-630c-11ea-95d7-b8803ee6afb2.png">

- [x] 2393ede31e40a90b9c8356d9bbf88a95a7862d61 Explicitly setting `line-height`.

	> <img width="311" alt="Screen Shot 2020-03-10 at 8 00 23 PM" src="https://user-images.githubusercontent.com/15182/76378972-14539200-630c-11ea-89bc-b01ec11da4b9.png">

With these changes, things render as expected:

> <img width="438" alt="Screen Shot 2020-03-10 at 8 00 51 PM" src="https://user-images.githubusercontent.com/15182/76378988-1b7aa000-630c-11ea-812c-69138723ac4a.png">

I haven't validated this with a local build, only via Codesandbox, so additional validation is needed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


