### PR TITLE
fix(@aws-amplify/auth): Use optional chaining since obj can be undefined

### DIFF
--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -211,5 +211,5 @@ export type ClientMetaData =
 	| undefined;
 
 export function isUsernamePasswordOpts(obj: any): obj is UsernamePasswordOpts {
-	return !!(obj as UsernamePasswordOpts).username;
+	return !!(obj as UsernamePasswordOpts)?.username;
 }


### PR DESCRIPTION
_Issue #, if available:_
- https://github.com/aws-amplify/amplify-js/issues/1775
- https://github.com/aws-amplify/amplify-js/issues/4109

_Description of changes:_
This was a really simple change, using TS optional chaining to avoid `Cannot read property 'X' of undefined` errors.
Although the issues are closed, I was able to reproduce the behavior on the latest release (2.2.6).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
