### PR TITLE
fix(@aws-amplify/ui-components): Fix Vue production

### DIFF
--- a/packages/amplify-ui-vue/package.json
+++ b/packages/amplify-ui-vue/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aws-amplify/ui-vue",
-	"sideEffects": false,
+	"sideEffects": true,
 	"version": "0.0.1",
 	"description": "Vue specific wrapper for @aws-amplify/ui-components",
 	"publishConfig": {


### PR DESCRIPTION
`vue build` was ignoring `import "@aws-amplify/ui-vue"` from production due to `sideEffects: false`.

**Note that removing this line entirely has the same result as `sideEffects: true`, but explicitness is beneficial when things are "magical" like tree-shaking**.


~~**tldr; Drop `@aws-amplify/ui-vue` in favor of manual setup from https://stenciljs.com/docs/vue.**~~

~~`@aws-amplify/ui-vue` was largely a wrapper around https://stenciljs.com/docs/vue, but it turns out that Vue's `build` command **marks the package for dead code removal**.~~

~~Instead, I've updated the README to match.  This mean the `ui-vue` package has been removed.~~

~~_I'm currently looking into adding `sideEffects: true`..._~~



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
