### PR TITLE
Export necessary providers and types from the package root

### DIFF
--- a/packages/predictions/src/index.ts
+++ b/packages/predictions/src/index.ts
@@ -19,7 +19,7 @@ import {
 	AmazonAIInterpretPredictionsProvider,
 } from './Providers';
 
-import { InterpretTextCategories } from './types';
+export * from './types';
 
 export {
 	Predictions,
@@ -27,7 +27,6 @@ export {
 	AmazonAIConvertPredictionsProvider,
 	AmazonAIPredictionsProvider,
 	AmazonAIInterpretPredictionsProvider,
-	InterpretTextCategories,
 };
 
 /**

--- a/packages/pubsub/src/index.ts
+++ b/packages/pubsub/src/index.ts
@@ -12,7 +12,8 @@
  */
 import { PubSub } from './PubSub';
 
-export * from './Providers/AWSIotProvider';
+export * from './Providers';
+
 export { PubSub };
 
 /**


### PR DESCRIPTION
Export necessary providers and types from the package root to avoid importing from generated paths

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
