### PR TITLE
feat(@aws-amplify/datastore): Support non-@model types in DataStore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
             yarn run test --scope @aws-amplify/analytics
             yarn run test --scope @aws-amplify/cache
             yarn run test --scope @aws-amplify/core
+            yarn run test --scope @aws-amplify/datastore
             yarn run test --scope @aws-amplify/interactions
             yarn run test --scope @aws-amplify/pubsub
             yarn run test --scope @aws-amplify/predictions
@@ -311,6 +312,10 @@ jobs:
             cp -rf ~/amplify-js/packages/core/dist ./node_modules/@aws-amplify/core/dist
             cp -rf ~/amplify-js/packages/core/lib ./node_modules/@aws-amplify/core/lib
             cp -rf ~/amplify-js/packages/core/lib-esm ./node_modules/@aws-amplify/core/lib-esm
+
+            cp -rf ~/amplify-js/packages/datastore/dist ./node_modules/@aws-amplify/datastore/dist
+            cp -rf ~/amplify-js/packages/datastore/lib ./node_modules/@aws-amplify/datastore/lib
+            cp -rf ~/amplify-js/packages/datastore/lib-esm ./node_modules/@aws-amplify/datastore/lib-esm
 
             cp -rf ~/amplify-js/packages/interactions/dist ./node_modules/@aws-amplify/interactions/dist
             cp -rf ~/amplify-js/packages/interactions/lib ./node_modules/@aws-amplify/interactions/lib

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -9,6 +9,7 @@ import {
 	MutableModel,
 	PersistentModelConstructor,
 	Schema,
+	NonModelTypeConstructor,
 } from '../src/types';
 import StorageType from '../src/storage/storage';
 import Observable from 'zen-observable-ts';
@@ -36,12 +37,12 @@ beforeEach(() => {
 
 describe('DataStore tests', () => {
 	describe('initSchema tests', () => {
-		test('Class is created', () => {
+		test('Model class is created', () => {
 			const classes = initSchema(testSchema());
 
 			expect(classes).toHaveProperty('Model');
 
-			const { Model } = classes;
+			const { Model } = classes as { Model: PersistentModelConstructor<Model> };
 
 			let property: keyof PersistentModelConstructor<any> = 'copyOf';
 			expect(Model).toHaveProperty(property);
@@ -49,7 +50,7 @@ describe('DataStore tests', () => {
 			expect(typeof Model.copyOf).toBe('function');
 		});
 
-		test('Class can be instantiated', () => {
+		test('Model class can be instantiated', () => {
 			const { Model } = initSchema(testSchema()) as {
 				Model: PersistentModelConstructor<Model>;
 			};
@@ -91,6 +92,32 @@ describe('DataStore tests', () => {
 			expect(() => {
 				initSchema(testSchema());
 			}).toThrow('The schema has already been initialized');
+		});
+
+		test('Non @model class is created', () => {
+			const classes = initSchema(testSchema());
+
+			expect(classes).toHaveProperty('Metadata');
+
+			const { Metadata } = classes;
+
+			let property: keyof PersistentModelConstructor<any> = 'copyOf';
+			expect(Metadata).not.toHaveProperty(property);
+		});
+
+		test('Non @model class can be instantiated', () => {
+			const { Metadata } = initSchema(testSchema()) as {
+				Metadata: NonModelTypeConstructor<Metadata>;
+			};
+
+			const metadata = new Metadata({
+				author: 'some author',
+				tags: [],
+			});
+
+			expect(metadata).toBeInstanceOf(Metadata);
+
+			expect(metadata).not.toHaveProperty('id');
 		});
 	});
 
@@ -147,6 +174,20 @@ describe('DataStore tests', () => {
 			// ID should be kept the same
 			expect(model1.id).toBe(model2.id);
 		});
+
+		test('Non @model - Field cannot be changed', () => {
+			const { Metadata } = initSchema(testSchema()) as {
+				Metadata: NonModelTypeConstructor<Metadata>;
+			};
+
+			const nonModel = new Metadata({
+				author: 'something',
+			});
+
+			expect(() => {
+				(<any>nonModel).author = 'edit';
+			}).toThrowError("Cannot assign to read only property 'author' of object");
+		});
 	});
 
 	describe('Initialization', () => {
@@ -155,7 +196,7 @@ describe('DataStore tests', () => {
 
 			const classes = initSchema(testSchema());
 
-			const { Model } = classes;
+			const { Model } = classes as { Model: PersistentModelConstructor<Model> };
 
 			const promises = [
 				DataStore.query(Model),
@@ -168,18 +209,33 @@ describe('DataStore tests', () => {
 
 			expect(Storage).toHaveBeenCalledTimes(1);
 		});
+
+		test('It is initialized when observing (no query)', async () => {
+			Storage = require('../src/storage/storage').default;
+
+			const classes = initSchema(testSchema());
+
+			const { Model } = classes as { Model: PersistentModelConstructor<Model> };
+
+			DataStore.observe(Model).subscribe(jest.fn());
+
+			expect(Storage).toHaveBeenCalledTimes(1);
+		});
 	});
 
-	test('It is initialized when observing (no query)', async () => {
-		Storage = require('../src/storage/storage').default;
+	test("non-@models can't be saved", async () => {
+		const { Metadata } = initSchema(testSchema()) as {
+			Metadata: NonModelTypeConstructor<Metadata>;
+		};
 
-		const classes = initSchema(testSchema());
+		const metadata = new Metadata({
+			author: 'some author',
+			tags: [],
+		});
 
-		const { Model } = classes;
-
-		DataStore.observe(Model).subscribe(jest.fn());
-
-		expect(Storage).toHaveBeenCalledTimes(1);
+		await expect(DataStore.save(<any>metadata)).rejects.toThrow(
+			'Object is not an instance of a valid model'
+		);
 	});
 });
 
@@ -195,6 +251,12 @@ declare class Model {
 		src: Model,
 		mutator: (draft: MutableModel<Model>) => void | Model
 	): Model;
+}
+
+export declare class Metadata {
+	readonly author: string;
+	readonly tags?: string[];
+	constructor(init: Metadata);
 }
 
 function testSchema(): Schema {
@@ -218,6 +280,15 @@ function testSchema(): Schema {
 						type: 'String',
 						isRequired: true,
 					},
+					metadata: {
+						name: 'metadata',
+						isArray: false,
+						type: {
+							type: 'Metadata',
+						},
+						isRequired: false,
+						attributes: [],
+					},
 				},
 			},
 			LocalModel: {
@@ -236,6 +307,27 @@ function testSchema(): Schema {
 						isArray: false,
 						type: 'String',
 						isRequired: true,
+					},
+				},
+			},
+		},
+		types: {
+			Metadata: {
+				name: 'Metadata',
+				fields: {
+					author: {
+						name: 'author',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					tags: {
+						name: 'tags',
+						isArray: true,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
 					},
 				},
 			},

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -284,7 +284,7 @@ function testSchema(): Schema {
 						name: 'metadata',
 						isArray: false,
 						type: {
-							type: 'Metadata',
+							nonModel: 'Metadata',
 						},
 						isRequired: false,
 						attributes: [],

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -311,7 +311,7 @@ function testSchema(): Schema {
 				},
 			},
 		},
-		types: {
+		nonModels: {
 			Metadata: {
 				name: 'Metadata',
 				fields: {

--- a/packages/datastore/__tests__/graphql.ts
+++ b/packages/datastore/__tests__/graphql.ts
@@ -129,16 +129,6 @@ describe('DataStore GraphQL generation', () => {
 			`,
 		],
 		[
-			TransformerMutationType.GET,
-			/* GraphQL */ `
-				subscription operation {
-					onGetPost {
-						${postSelectionSet}
-					}
-				}
-			`,
-		],
-		[
 			TransformerMutationType.UPDATE,
 			/* GraphQL */ `
 				subscription operation {

--- a/packages/datastore/__tests__/graphql.ts
+++ b/packages/datastore/__tests__/graphql.ts
@@ -1,0 +1,181 @@
+import { parse, print } from 'graphql';
+import { SchemaNamespace } from '../src';
+import {
+	buildGraphQLOperation,
+	buildSubscriptionGraphQLOperation,
+	TransformerMutationType,
+} from '../src/sync/utils';
+import { newSchema } from './schema';
+
+const postSelectionSet = `
+id
+title
+metadata {
+	rating
+	tags
+	nested {
+		aField
+	}
+}
+_version
+_lastChangedAt
+_deleted
+reference {
+	id
+	_deleted
+}
+blog {
+	id
+	_deleted
+}
+`;
+
+describe('DataStore GraphQL generation', () => {
+	test.each([
+		[
+			'LIST',
+			/* GraphQL */ `
+				query operation(
+					$limit: Int
+					$nextToken: String
+					$lastSync: AWSTimestamp
+				) {
+					syncPosts(limit: $limit, nextToken: $nextToken, lastSync: $lastSync) {
+						items {
+							${postSelectionSet}
+						}
+						nextToken
+						startedAt
+					}
+				}
+			`,
+		],
+		[
+			'CREATE',
+			/* GraphQL */ `
+				mutation operation($input: CreatePostInput!) {
+					createPost(input: $input) {
+						${postSelectionSet}
+					}
+				}
+			`,
+		],
+		[
+			'UPDATE',
+			/* GraphQL */ `
+				mutation operation(
+					$input: UpdatePostInput!
+					$condition: ModelPostConditionInput
+				) {
+					updatePost(input: $input, condition: $condition) {
+						${postSelectionSet}
+					}
+				}
+			`,
+		],
+		,
+		[
+			'DELETE',
+			/* GraphQL */ `
+				mutation operation(
+					$input: DeletePostInput!
+					$condition: ModelPostConditionInput
+				) {
+					deletePost(input: $input, condition: $condition) {
+						${postSelectionSet}
+					}
+				}
+			`,
+		],
+		,
+		[
+			'GET',
+			/* GraphQL */ `
+				query operation($id: ID!) {
+					getPost(id: $id) {
+						${postSelectionSet}
+					}
+				}
+			`,
+		],
+	])(
+		'%s - has full selection set including types, and inputs',
+		(graphQLOpType, expectedGraphQL) => {
+			const namespace = <SchemaNamespace>(<unknown>newSchema);
+
+			const {
+				models: { Post: postModelDefinition },
+			} = namespace;
+
+			const [[, , query]] = buildGraphQLOperation(
+				namespace,
+				postModelDefinition,
+				<any>graphQLOpType
+			);
+
+			expect(print(parse(query))).toStrictEqual(print(parse(expectedGraphQL)));
+		}
+	);
+
+	test.each([
+		[
+			TransformerMutationType.CREATE,
+			/* GraphQL */ `
+				subscription operation {
+					onCreatePost {
+						${postSelectionSet}
+					}
+				}
+			`,
+		],
+		[
+			TransformerMutationType.GET,
+			/* GraphQL */ `
+				subscription operation {
+					onGetPost {
+						${postSelectionSet}
+					}
+				}
+			`,
+		],
+		[
+			TransformerMutationType.UPDATE,
+			/* GraphQL */ `
+				subscription operation {
+					onUpdatePost {
+						${postSelectionSet}
+					}
+				}
+			`,
+		],
+		[
+			TransformerMutationType.DELETE,
+			/* GraphQL */ `
+				subscription operation {
+					onDeletePost {
+						${postSelectionSet}
+					}
+				}
+			`,
+		],
+	])(
+		'Subscription (%s)  - has full selection set including types, and inputs',
+		(transformerMutationType, expectedGraphQL) => {
+			const namespace = <SchemaNamespace>(<unknown>newSchema);
+
+			const {
+				models: { Post: postModelDefinition },
+			} = namespace;
+
+			const [, , query] = buildSubscriptionGraphQLOperation(
+				namespace,
+				postModelDefinition,
+				<any>transformerMutationType,
+				false,
+				''
+			);
+
+			expect(print(parse(query))).toStrictEqual(print(parse(expectedGraphQL)));
+		}
+	);
+});

--- a/packages/datastore/__tests__/indexeddb.test.ts
+++ b/packages/datastore/__tests__/indexeddb.test.ts
@@ -34,7 +34,6 @@ describe('Indexed db storage test', () => {
 		});
 	});
 	test('setup function', async () => {
-		const namespaceResolver = jest.fn();
 		db = await idb.openDB('amplify-datastore', 1);
 
 		const createdObjStores = db.objectStoreNames;
@@ -368,5 +367,20 @@ describe('Indexed db storage test', () => {
 			.index('postId')
 			.getAll(p1.id);
 		expect(refResult).toHaveLength(0);
+	});
+
+	test('delete non existent', async () => {
+		const author = new Author({ name: 'author1' });
+
+		const deleted = await DataStore.delete(author);
+
+		expect(deleted).toStrictEqual(author);
+
+		const fromDB = await db
+			.transaction(`${USER}_Author`, 'readonly')
+			.objectStore(`${USER}_Author`)
+			.get(author.id);
+
+		expect(fromDB).toBeUndefined();
 	});
 });

--- a/packages/datastore/__tests__/model.ts
+++ b/packages/datastore/__tests__/model.ts
@@ -4,7 +4,7 @@ import {
 	PersistentModelConstructor,
 } from '@aws-amplify/datastore';
 
-import { initSchema } from '../src/index';
+import { initSchema, NonModelTypeConstructor } from '../src/index';
 import { newSchema } from './schema';
 
 declare class BlogModel {
@@ -26,11 +26,24 @@ declare class PostModel {
 	readonly reference?: PostModel;
 	readonly comments?: CommentModel[];
 	readonly authors?: PostAuthorJoinModel[];
+	readonly metadata?: PostMetadataType;
 	constructor(init: ModelInit<PostModel>);
 	static copyOf(
 		source: PostModel,
 		mutator: (draft: MutableModel<PostModel>) => MutableModel<PostModel> | void
 	): PostModel;
+}
+
+declare class PostMetadataType {
+	readonly rating: number;
+	readonly tags?: string[];
+	readonly nested?: NestedType;
+	constructor(init: ModelInit<PostMetadataType>);
+}
+
+declare class NestedType {
+	readonly aField: string;
+	constructor(init: ModelInit<NestedType>);
 }
 
 declare class CommentModel {
@@ -85,15 +98,33 @@ declare class BlogOwnerModel {
 	): BlogOwnerModel;
 }
 
-const { Author, Post, Comment, Blog, BlogOwner, PostAuthorJoin } = initSchema(
-	newSchema
-) as {
+const {
+	Author,
+	Post,
+	Comment,
+	Blog,
+	BlogOwner,
+	PostAuthorJoin,
+	PostMetadata,
+	Nested,
+} = initSchema(newSchema) as {
 	Author: PersistentModelConstructor<AuthorModel>;
 	Post: PersistentModelConstructor<PostModel>;
 	Comment: PersistentModelConstructor<CommentModel>;
 	Blog: PersistentModelConstructor<BlogModel>;
 	BlogOwner: PersistentModelConstructor<BlogOwnerModel>;
 	PostAuthorJoin: PersistentModelConstructor<PostAuthorJoinModel>;
+	PostMetadata: NonModelTypeConstructor<PostMetadataType>;
+	Nested: NonModelTypeConstructor<NestedType>;
 };
-
-export { Author, Post, Comment, Blog, BlogOwner, PostAuthorJoin };
+``;
+export {
+	Author,
+	Post,
+	Comment,
+	Blog,
+	BlogOwner,
+	PostAuthorJoin,
+	PostMetadata,
+	Nested,
+};

--- a/packages/datastore/__tests__/schema.ts
+++ b/packages/datastore/__tests__/schema.ts
@@ -132,6 +132,15 @@ export const newSchema: Schema = {
 						associatedWith: 'post',
 					},
 				},
+				metadata: {
+					name: 'metadata',
+					isArray: false,
+					type: {
+						type: 'PostMetadata',
+					},
+					isRequired: false,
+					attributes: [],
+				},
 			},
 		},
 		Comment: {
@@ -316,5 +325,47 @@ export const newSchema: Schema = {
 		},
 	},
 	enums: {},
+	types: {
+		PostMetadata: {
+			name: 'PostMetadata',
+			fields: {
+				author: {
+					name: 'rating',
+					isArray: false,
+					type: 'Int',
+					isRequired: true,
+					attributes: [],
+				},
+				tags: {
+					name: 'tags',
+					isArray: true,
+					type: 'String',
+					isRequired: false,
+					attributes: [],
+				},
+				nested: {
+					name: 'nested',
+					isArray: false,
+					type: {
+						type: 'Nested',
+					},
+					isRequired: true,
+					attributes: [],
+				},
+			},
+		},
+		Nested: {
+			name: 'Nested',
+			fields: {
+				aField: {
+					name: 'aField',
+					isArray: false,
+					type: 'String',
+					isRequired: true,
+					attributes: [],
+				},
+			},
+		},
+	},
 	version: 'a66372d29356c40e7cd29e41527cead7',
 };

--- a/packages/datastore/__tests__/schema.ts
+++ b/packages/datastore/__tests__/schema.ts
@@ -325,7 +325,7 @@ export const newSchema: Schema = {
 		},
 	},
 	enums: {},
-	types: {
+	nonModels: {
 		PostMetadata: {
 			name: 'PostMetadata',
 			fields: {

--- a/packages/datastore/__tests__/schema.ts
+++ b/packages/datastore/__tests__/schema.ts
@@ -136,7 +136,7 @@ export const newSchema: Schema = {
 					name: 'metadata',
 					isArray: false,
 					type: {
-						type: 'PostMetadata',
+						nonModel: 'PostMetadata',
 					},
 					isRequired: false,
 					attributes: [],
@@ -347,7 +347,7 @@ export const newSchema: Schema = {
 					name: 'nested',
 					isArray: false,
 					type: {
-						type: 'Nested',
+						nonModel: 'Nested',
 					},
 					isRequired: true,
 					attributes: [],

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -39,7 +39,7 @@
     "@aws-amplify/core": "^2.2.5",
     "@aws-amplify/pubsub": "^2.1.7",
     "idb": "4.0.4",
-    "immer": "3.1.3",
+    "immer": "6.0.1",
     "uuid": "3.3.2",
     "zen-observable-ts": "0.8.19",
     "zen-push": "0.2.1"

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -108,16 +108,16 @@ const initSchema = (userSchema: Schema) => {
 	};
 
 	logger.log('DataStore', 'Init models');
-	userClasses = createModelAndTypeClassses(internalUserNamespace);
+	userClasses = createTypeClasses(internalUserNamespace);
 	logger.log('DataStore', 'Models initialized');
 
 	const dataStoreNamespace = getNamespace();
 	const storageNamespace = Storage.getNamespace();
 	const syncNamespace = SyncEngine.getNamespace();
 
-	dataStoreClasses = createModelAndTypeClassses(dataStoreNamespace);
-	storageClasses = createModelAndTypeClassses(storageNamespace);
-	syncClasses = createModelAndTypeClassses(syncNamespace);
+	dataStoreClasses = createTypeClasses(dataStoreNamespace);
+	storageClasses = createTypeClasses(storageNamespace);
+	syncClasses = createTypeClasses(syncNamespace);
 
 	schema = {
 		namespaces: {
@@ -182,7 +182,7 @@ const initSchema = (userSchema: Schema) => {
 	return userClasses;
 };
 
-const createModelAndTypeClassses: (
+const createTypeClasses: (
 	namespace: SchemaNamespace
 ) => TypeConstructorMap = namespace => {
 	const classes: TypeConstructorMap = {};

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -219,7 +219,7 @@ function modelInstanceCreator<T extends PersistentModel = PersistentModel>(
 	return <T>new modelConstructor(init);
 }
 
-const _cosa = <T>(
+const initializeInstance = <T>(
 	init: ModelInit<T>,
 	modelDefinition: SchemaModel | SchemaType,
 	draft: Draft<T & ModelInstanceMetadata>
@@ -271,7 +271,7 @@ const createModelClass = <T extends PersistentModel>(
 			const instance = produce(
 				this,
 				(draft: Draft<T & ModelInstanceMetadata>) => {
-					_cosa(init, modelDefinition, draft);
+					initializeInstance(init, modelDefinition, draft);
 
 					const modelInstanceMetadata: ModelInstanceMetadata = instancesMetadata.has(
 						init
@@ -339,7 +339,7 @@ const createTypeClass = <T extends PersistentModel>(
 			const instance = produce(
 				this,
 				(draft: Draft<T & ModelInstanceMetadata>) => {
-					_cosa(init, typeDefinition, draft);
+					initializeInstance(init, typeDefinition, draft);
 				}
 			);
 

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -196,7 +196,7 @@ const createTypeClasses: (
 
 	Object.entries(namespace.nonModels || {}).forEach(
 		([typeName, typeDefinition]) => {
-			const clazz = createTypeClass(typeDefinition);
+			const clazz = createNonModelClass(typeDefinition);
 			classes[typeName] = clazz;
 		}
 	);
@@ -330,7 +330,7 @@ const createModelClass = <T extends PersistentModel>(
 	return clazz;
 };
 
-const createTypeClass = <T>(typeDefinition: SchemaNonModel) => {
+const createNonModelClass = <T>(typeDefinition: SchemaNonModel) => {
 	const clazz = <NonModelTypeConstructor<T>>(<unknown>class Model {
 		constructor(init: ModelInit<T>) {
 			const instance = produce(

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -317,17 +317,6 @@ const createModelClass = <T extends PersistentModel>(
 				throw new Error(msg);
 			}
 
-			const namespaceName = namespaceResolver(modelConstructor);
-			const namespace = schema.namespaces[namespaceName];
-			const nonModelTypes = namespace.types || {};
-
-			const nonModelTypeFields: ModelFields = {};
-			Object.entries(modelDefinition.fields).forEach(([fieldName, field]) => {
-				if (field.type in nonModelTypes) {
-					nonModelTypeFields[fieldName] = field;
-				}
-			});
-
 			return produce(source, draft => {
 				fn(<MutableModel<T>>draft);
 				draft.id = source.id;

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -330,9 +330,7 @@ const createModelClass = <T extends PersistentModel>(
 	return clazz;
 };
 
-const createTypeClass = <T extends PersistentModel>(
-	typeDefinition: SchemaNonModel
-) => {
+const createTypeClass = <T>(typeDefinition: SchemaNonModel) => {
 	const clazz = <NonModelTypeConstructor<T>>(<unknown>class Model {
 		constructor(init: ModelInit<T>) {
 			const instance = produce(

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -194,7 +194,7 @@ const createModelAndTypeClassses: (
 		modelNamespaceMap.set(clazz, namespace.name);
 	});
 
-	Object.entries(namespace.types || {}).forEach(
+	Object.entries(namespace.nonModels || {}).forEach(
 		([typeName, typeDefinition]) => {
 			const clazz = createTypeClass(typeDefinition);
 			classes[typeName] = clazz;
@@ -837,7 +837,7 @@ function getNamespace(): SchemaNamespace {
 		name: DATASTORE,
 		relationships: {},
 		enums: {},
-		types: {},
+		nonModels: {},
 		models: {
 			Setting: {
 				name: 'Setting',

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -839,7 +839,7 @@ async function clear() {
 
 	await storage.clear();
 
-	initialized = undefined; //Should re-initialize when start() is called.
+	initialized = undefined; // Should re-initialize when start() is called.
 	storage = undefined;
 	sync = undefined;
 }

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -15,7 +15,6 @@ import {
 	GraphQLScalarType,
 	InternalSchema,
 	isGraphQLScalarType,
-	ModelFields,
 	ModelFieldType,
 	ModelInit,
 	ModelInstanceMetadata,
@@ -31,7 +30,7 @@ import {
 	Schema,
 	SchemaModel,
 	SchemaNamespace,
-	SchemaType,
+	SchemaNonModel,
 	SubscriptionMessage,
 	SyncConflict,
 	SyncError,
@@ -221,7 +220,7 @@ function modelInstanceCreator<T extends PersistentModel = PersistentModel>(
 
 const initializeInstance = <T>(
 	init: ModelInit<T>,
-	modelDefinition: SchemaModel | SchemaType,
+	modelDefinition: SchemaModel | SchemaNonModel,
 	draft: Draft<T & ModelInstanceMetadata>
 ) => {
 	Object.entries(init).forEach(([k, v]) => {
@@ -332,7 +331,7 @@ const createModelClass = <T extends PersistentModel>(
 };
 
 const createTypeClass = <T extends PersistentModel>(
-	typeDefinition: SchemaType
+	typeDefinition: SchemaNonModel
 ) => {
 	const clazz = <NonModelTypeConstructor<T>>(<unknown>class Model {
 		constructor(init: ModelInit<T>) {

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -18,7 +18,6 @@ import {
 	ModelFieldType,
 	ModelInit,
 	ModelInstanceMetadata,
-	ModelOrTypeConstructorMap,
 	ModelPredicate,
 	MutableModel,
 	NamespaceResolver,
@@ -34,6 +33,7 @@ import {
 	SubscriptionMessage,
 	SyncConflict,
 	SyncError,
+	TypeConstructorMap,
 } from '../types';
 import {
 	DATASTORE,
@@ -87,13 +87,13 @@ const isValidModelConstructor = <T extends PersistentModel>(
 const namespaceResolver: NamespaceResolver = modelConstructor =>
 	modelNamespaceMap.get(modelConstructor);
 
-let dataStoreClasses: ModelOrTypeConstructorMap;
+let dataStoreClasses: TypeConstructorMap;
 
-let userClasses: ModelOrTypeConstructorMap;
+let userClasses: TypeConstructorMap;
 
-let syncClasses: ModelOrTypeConstructorMap;
+let syncClasses: TypeConstructorMap;
 
-let storageClasses: ModelOrTypeConstructorMap;
+let storageClasses: TypeConstructorMap;
 
 const initSchema = (userSchema: Schema) => {
 	if (schema !== undefined) {
@@ -184,8 +184,8 @@ const initSchema = (userSchema: Schema) => {
 
 const createModelAndTypeClassses: (
 	namespace: SchemaNamespace
-) => ModelOrTypeConstructorMap = namespace => {
-	const classes: ModelOrTypeConstructorMap = {};
+) => TypeConstructorMap = namespace => {
+	const classes: TypeConstructorMap = {};
 
 	Object.entries(namespace.models).forEach(([modelName, modelDefinition]) => {
 		const clazz = createModelClass(modelDefinition);

--- a/packages/datastore/src/storage/adapter/indexeddb.ts
+++ b/packages/datastore/src/storage/adapter/indexeddb.ts
@@ -476,6 +476,13 @@ class IndexedDBAdapter implements Adapter {
 
 				const fromDB = await store.get(model.id);
 
+				if (fromDB === undefined) {
+					const msg = 'Model instance not found in storage';
+					logger.warn(msg, { model });
+
+					return [[model], []];
+				}
+
 				const predicates = ModelPredicateCreator.getPredicates(condition);
 				const { predicates: predicateObjs, type } = predicates;
 

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -54,7 +54,7 @@ class Storage implements StorageFacade {
 			relationships: {},
 			enums: {},
 			models: {},
-			types: {},
+			nonModels: {},
 		};
 
 		return namespace;

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -54,6 +54,7 @@ class Storage implements StorageFacade {
 			relationships: {},
 			enums: {},
 			models: {},
+			types: {},
 		};
 
 		return namespace;

--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -1,4 +1,5 @@
-import { ConsoleLogger as Logger, Reachability } from '@aws-amplify/core';
+import { ConsoleLogger as Logger } from '@aws-amplify/core';
+import { CONTROL_MSG as PUBSUB_CONTROL_MSG } from '@aws-amplify/pubsub';
 import Observable from 'zen-observable-ts';
 import { ModelInstanceCreator } from '../datastore/datastore';
 import { ModelPredicateCreator } from '../predicates';
@@ -8,14 +9,15 @@ import {
 	ErrorHandler,
 	InternalSchema,
 	ModelInit,
-	ModelOrTypeConstructorMap,
 	MutableModel,
 	NamespaceResolver,
 	PersistentModelConstructor,
 	SchemaModel,
 	SchemaNamespace,
+	TypeConstructorMap,
 } from '../types';
 import { SYNC } from '../util';
+import DataStoreConnectivity from './datastoreConnectivity';
 import { ModelMerger } from './merger';
 import { MutationEventOutbox } from './outbox';
 import { MutationProcessor } from './processors/mutation';
@@ -26,8 +28,6 @@ import {
 	predicateToGraphQLCondition,
 	TransformerMutationType,
 } from './utils';
-import DataStoreConnectivity from './datastoreConnectivity';
-import { CONTROL_MSG as PUBSUB_CONTROL_MSG } from '@aws-amplify/pubsub';
 
 const logger = new Logger('DataStore');
 
@@ -80,8 +80,8 @@ export class SyncEngine {
 	constructor(
 		private readonly schema: InternalSchema,
 		private readonly namespaceResolver: NamespaceResolver,
-		private readonly modelClasses: ModelOrTypeConstructorMap,
-		private readonly userModelClasses: ModelOrTypeConstructorMap,
+		private readonly modelClasses: TypeConstructorMap,
+		private readonly userModelClasses: TypeConstructorMap,
 		private readonly storage: Storage,
 		private readonly modelInstanceCreator: ModelInstanceCreator,
 		private readonly maxRecordsToSync: number,

--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -531,7 +531,7 @@ export class SyncEngine {
 					values: ['CREATE', 'UPDATE', 'DELETE'],
 				},
 			},
-			types: {},
+			nonModels: {},
 			models: {
 				MutationEvent: {
 					name: 'MutationEvent',

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -17,11 +17,11 @@ import {
 	isModelFieldType,
 	isTargetNameAssociation,
 	ModelInstanceMetadata,
-	ModelOrTypeConstructorMap,
 	OpType,
 	PersistentModel,
 	PersistentModelConstructor,
 	SchemaModel,
+	TypeConstructorMap,
 } from '../../types';
 import { exhaustiveCheck, USER } from '../../util';
 import { MutationEventOutbox } from '../outbox';
@@ -48,7 +48,7 @@ class MutationProcessor {
 	constructor(
 		private readonly schema: InternalSchema,
 		private readonly storage: Storage,
-		private readonly userClasses: ModelOrTypeConstructorMap,
+		private readonly userClasses: TypeConstructorMap,
 		private readonly outbox: MutationEventOutbox,
 		private readonly modelInstanceCreator: ModelInstanceCreator,
 		private readonly MutationEvent: PersistentModelConstructor<MutationEvent>,

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -15,12 +15,13 @@ import {
 	GraphQLCondition,
 	InternalSchema,
 	isModelFieldType,
+	isTargetNameAssociation,
 	ModelInstanceMetadata,
+	ModelOrTypeConstructorMap,
 	OpType,
 	PersistentModel,
 	PersistentModelConstructor,
 	SchemaModel,
-	isTargetNameAssociation,
 } from '../../types';
 import { exhaustiveCheck, USER } from '../../util';
 import { MutationEventOutbox } from '../outbox';
@@ -47,9 +48,7 @@ class MutationProcessor {
 	constructor(
 		private readonly schema: InternalSchema,
 		private readonly storage: Storage,
-		private readonly userClasses: {
-			[modelName: string]: PersistentModelConstructor<PersistentModel>;
-		},
+		private readonly userClasses: ModelOrTypeConstructorMap,
 		private readonly outbox: MutationEventOutbox,
 		private readonly modelInstanceCreator: ModelInstanceCreator,
 		private readonly MutationEvent: PersistentModelConstructor<MutationEvent>,
@@ -64,9 +63,21 @@ class MutationProcessor {
 			Object.values(namespace.models)
 				.filter(({ syncable }) => syncable)
 				.forEach(model => {
-					const [createMutation] = buildGraphQLOperation(model, 'CREATE');
-					const [updateMutation] = buildGraphQLOperation(model, 'UPDATE');
-					const [deleteMutation] = buildGraphQLOperation(model, 'DELETE');
+					const [createMutation] = buildGraphQLOperation(
+						namespace,
+						model,
+						'CREATE'
+					);
+					const [updateMutation] = buildGraphQLOperation(
+						namespace,
+						model,
+						'UPDATE'
+					);
+					const [deleteMutation] = buildGraphQLOperation(
+						namespace,
+						model,
+						'DELETE'
+					);
 
 					this.typeQuery.set(model, [
 						createMutation,
@@ -106,16 +117,20 @@ class MutationProcessor {
 
 		this.processing = true;
 		let head: MutationEvent;
+		const namespaceName = USER;
 
 		// start to drain outbox
 		while (this.processing && (head = await this.outbox.peek(this.storage))) {
 			const { model, operation, data, condition } = head;
-			const modelConstructor = this.userClasses[model];
+			const modelConstructor = this.userClasses[
+				model
+			] as PersistentModelConstructor<MutationEvent>;
 			let result: GraphQLResult<Record<string, PersistentModel>>;
 			let opName: string;
 			let modelDefinition: SchemaModel;
 			try {
 				[result, opName, modelDefinition] = await this.jitteredRetry(
+					namespaceName,
 					model,
 					operation,
 					data,
@@ -147,6 +162,7 @@ class MutationProcessor {
 	}
 
 	private async jitteredRetry(
+		namespaceName: string,
 		model: string,
 		operation: TransformerMutationType,
 		data: string,
@@ -173,7 +189,13 @@ class MutationProcessor {
 					graphQLCondition,
 					opName,
 					modelDefinition,
-				] = this.createQueryVariables(model, operation, data, condition);
+				] = this.createQueryVariables(
+					namespaceName,
+					model,
+					operation,
+					data,
+					condition
+				);
 				const tryWith = { query, variables };
 				let attempt = 0;
 
@@ -228,6 +250,7 @@ class MutationProcessor {
 									// Query latest from server and notify merger
 
 									const [[, opName, query]] = buildGraphQLOperation(
+										this.schema.namespaces[namespaceName],
 										modelDefinition,
 										'GET'
 									);
@@ -242,7 +265,7 @@ class MutationProcessor {
 									return [serverData, opName, modelDefinition];
 								}
 
-								const namespace = this.schema.namespaces[USER];
+								const namespace = this.schema.namespaces[namespaceName];
 
 								// convert retry with to tryWith
 								const updatedMutation = createMutationInstanceFromModelOperation(
@@ -305,12 +328,13 @@ class MutationProcessor {
 	}
 
 	private createQueryVariables(
+		namespaceName: string,
 		model: string,
 		operation: TransformerMutationType,
 		data: string,
 		condition: string
 	): [string, Record<string, any>, GraphQLCondition, string, SchemaModel] {
-		const modelDefinition = this.schema.namespaces[USER].models[model];
+		const modelDefinition = this.schema.namespaces[namespaceName].models[model];
 
 		const queriesTuples = this.typeQuery.get(modelDefinition);
 
@@ -322,7 +346,7 @@ class MutationProcessor {
 
 		const filteredData =
 			operation === TransformerMutationType.DELETE
-				? <ModelInstanceMetadata>{ id: parsedData.id }
+				? <ModelInstanceMetadata>{ id: parsedData.id } // For DELETE mutations, only ID is sent
 				: Object.values(modelDefinition.fields)
 						.filter(({ type, association }) => {
 							// connections
@@ -339,7 +363,7 @@ class MutationProcessor {
 								return false;
 							}
 
-							// scalars
+							// scalars and non-model types
 							return true;
 						})
 						.map(({ name, type, association }) => {
@@ -361,6 +385,7 @@ class MutationProcessor {
 							return acc;
 						}, <typeof parsedData>{});
 
+		// Build mutation variables input object
 		const input: ModelInstanceMetadata = {
 			...filteredData,
 			_version,

--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -1,13 +1,15 @@
-import '@aws-amplify/pubsub';
-
-import Observable from 'zen-observable-ts';
-
 import API, { GraphQLResult, GRAPHQL_AUTH_MODE } from '@aws-amplify/api';
 import Auth from '@aws-amplify/auth';
 import Cache from '@aws-amplify/cache';
 import { ConsoleLogger as Logger, Hub } from '@aws-amplify/core';
-
-import { InternalSchema, PersistentModel, SchemaModel } from '../../types';
+import '@aws-amplify/pubsub';
+import Observable from 'zen-observable-ts';
+import {
+	InternalSchema,
+	PersistentModel,
+	SchemaModel,
+	SchemaNamespace,
+} from '../../types';
 import {
 	buildSubscriptionGraphQLOperation,
 	getAuthorizationRules,
@@ -41,6 +43,7 @@ class SubscriptionProcessor {
 	constructor(private readonly schema: InternalSchema) {}
 
 	private buildSubscription(
+		namespace: SchemaNamespace,
 		model: SchemaModel,
 		transformerMutationType: TransformerMutationType,
 		userCredentials: USER_CREDENTIALS,
@@ -65,6 +68,7 @@ class SubscriptionProcessor {
 			) || {};
 
 		const [opType, opName, query] = buildSubscriptionGraphQLOperation(
+			namespace,
 			model,
 			transformerMutationType,
 			isOwner,
@@ -278,6 +282,7 @@ class SubscriptionProcessor {
 								TransformerMutationType.DELETE,
 							].map(op =>
 								this.buildSubscription(
+									namespace,
 									modelDefinition,
 									op,
 									userCredentials,

--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -26,9 +26,11 @@ class SyncProcessor {
 			Object.values(namespace.models)
 				.filter(({ syncable }) => syncable)
 				.forEach(model => {
-					const [
-						[_transformerMutationType, ...opNameQuery],
-					] = buildGraphQLOperation(model, 'LIST');
+					const [[, ...opNameQuery]] = buildGraphQLOperation(
+						namespace,
+						model,
+						'LIST'
+					);
 
 					this.typeQuery.set(model, opNameQuery);
 				});

--- a/packages/datastore/src/sync/utils.ts
+++ b/packages/datastore/src/sync/utils.ts
@@ -5,7 +5,9 @@ import {
 	isEnumFieldType,
 	isGraphQLScalarType,
 	isPredicateObj,
+	isSchemaModel,
 	isTargetNameAssociation,
+	isTypeFieldType,
 	ModelFields,
 	ModelInstanceMetadata,
 	OpType,
@@ -14,6 +16,8 @@ import {
 	PredicatesGroup,
 	RelationshipType,
 	SchemaModel,
+	SchemaNamespace,
+	SchemaType,
 } from '../types';
 import { exhaustiveCheck } from '../util';
 import { MutationEvent } from './';
@@ -46,21 +50,31 @@ export function getMetadataFields(): ReadonlyArray<string> {
 	return metadataFields;
 }
 
-// TODO: Ask for parent/children ids
-function generateSelectionSet(modelDefinition: SchemaModel): string {
+function generateSelectionSet(
+	namespace: SchemaNamespace,
+	modelDefinition: SchemaModel | SchemaType
+): string {
 	const scalarFields = getScalarFields(modelDefinition);
+	const nonModelFields = getNonModelFields(namespace, modelDefinition);
 
-	const scalarAndMetadataFields = Object.values(scalarFields)
+	let scalarAndMetadataFields = Object.values(scalarFields)
 		.map(({ name }) => name)
-		.concat(getMetadataFields())
-		.concat(getConnectionFields(modelDefinition));
+		.concat(nonModelFields);
+
+	if (isSchemaModel(modelDefinition)) {
+		scalarAndMetadataFields = scalarAndMetadataFields
+			.concat(getMetadataFields())
+			.concat(getConnectionFields(modelDefinition));
+	}
 
 	const result = scalarAndMetadataFields.join('\n');
 
 	return result;
 }
 
-function getScalarFields(modelDefinition: SchemaModel): ModelFields {
+function getScalarFields(
+	modelDefinition: SchemaModel | SchemaType
+): ModelFields {
 	const { fields } = modelDefinition;
 
 	const result = Object.values(fields)
@@ -102,6 +116,39 @@ function getConnectionFields(modelDefinition: SchemaModel): string[] {
 					exhaustiveCheck(connectionType);
 			}
 		});
+
+	return result;
+}
+
+function getNonModelFields(
+	namespace: SchemaNamespace,
+	modelDefinition: SchemaModel | SchemaType
+): string[] {
+	const result = [];
+
+	Object.values(modelDefinition.fields).forEach(({ name, type }) => {
+		if (isTypeFieldType(type)) {
+			const typeDefinition = namespace.types![type.type];
+			const scalarFields = Object.values(getScalarFields(typeDefinition)).map(
+				({ name }) => name
+			);
+
+			const nested = [];
+			Object.values(typeDefinition.fields).forEach(field => {
+				const { type, name } = field;
+
+				if (isTypeFieldType(type)) {
+					const typeDefinition = namespace.types![type.type];
+
+					nested.push(
+						`${name} { ${generateSelectionSet(namespace, typeDefinition)} }`
+					);
+				}
+			});
+
+			result.push(`${name} { ${scalarFields.join(' ')} ${nested.join(' ')} }`);
+		}
+	});
 
 	return result;
 }
@@ -158,12 +205,13 @@ export function getAuthorizationRules(
 }
 
 export function buildSubscriptionGraphQLOperation(
+	namespace: SchemaNamespace,
 	modelDefinition: SchemaModel,
 	transformerMutationType: TransformerMutationType,
 	isOwnerAuthorization: boolean,
 	ownerField: string
 ): [TransformerMutationType, string, string] {
-	const selectionSet = generateSelectionSet(modelDefinition);
+	const selectionSet = generateSelectionSet(namespace, modelDefinition);
 
 	const { name: typeName, pluralName: pluralTypeName } = modelDefinition;
 
@@ -188,10 +236,11 @@ export function buildSubscriptionGraphQLOperation(
 }
 
 export function buildGraphQLOperation(
+	namespace: SchemaNamespace,
 	modelDefinition: SchemaModel,
 	graphQLOpType: keyof typeof GraphQLOperationType
 ): [TransformerMutationType, string, string][] {
-	let selectionSet = generateSelectionSet(modelDefinition);
+	let selectionSet = generateSelectionSet(namespace, modelDefinition);
 
 	const { name: typeName, pluralName: pluralTypeName } = modelDefinition;
 

--- a/packages/datastore/src/sync/utils.ts
+++ b/packages/datastore/src/sync/utils.ts
@@ -7,7 +7,7 @@ import {
 	isPredicateObj,
 	isSchemaModel,
 	isTargetNameAssociation,
-	isTypeFieldType,
+	isNonModelFieldType,
 	ModelFields,
 	ModelInstanceMetadata,
 	OpType,
@@ -127,8 +127,8 @@ function getNonModelFields(
 	const result = [];
 
 	Object.values(modelDefinition.fields).forEach(({ name, type }) => {
-		if (isTypeFieldType(type)) {
-			const typeDefinition = namespace.nonModels![type.type];
+		if (isNonModelFieldType(type)) {
+			const typeDefinition = namespace.nonModels![type.nonModel];
 			const scalarFields = Object.values(getScalarFields(typeDefinition)).map(
 				({ name }) => name
 			);
@@ -137,8 +137,8 @@ function getNonModelFields(
 			Object.values(typeDefinition.fields).forEach(field => {
 				const { type, name } = field;
 
-				if (isTypeFieldType(type)) {
-					const typeDefinition = namespace.nonModels![type.type];
+				if (isNonModelFieldType(type)) {
+					const typeDefinition = namespace.nonModels![type.nonModel];
 
 					nested.push(
 						`${name} { ${generateSelectionSet(namespace, typeDefinition)} }`

--- a/packages/datastore/src/sync/utils.ts
+++ b/packages/datastore/src/sync/utils.ts
@@ -17,7 +17,7 @@ import {
 	RelationshipType,
 	SchemaModel,
 	SchemaNamespace,
-	SchemaType,
+	SchemaNonModel,
 } from '../types';
 import { exhaustiveCheck } from '../util';
 import { MutationEvent } from './';
@@ -52,7 +52,7 @@ export function getMetadataFields(): ReadonlyArray<string> {
 
 function generateSelectionSet(
 	namespace: SchemaNamespace,
-	modelDefinition: SchemaModel | SchemaType
+	modelDefinition: SchemaModel | SchemaNonModel
 ): string {
 	const scalarFields = getScalarFields(modelDefinition);
 	const nonModelFields = getNonModelFields(namespace, modelDefinition);
@@ -73,7 +73,7 @@ function generateSelectionSet(
 }
 
 function getScalarFields(
-	modelDefinition: SchemaModel | SchemaType
+	modelDefinition: SchemaModel | SchemaNonModel
 ): ModelFields {
 	const { fields } = modelDefinition;
 
@@ -122,7 +122,7 @@ function getConnectionFields(modelDefinition: SchemaModel): string[] {
 
 function getNonModelFields(
 	namespace: SchemaNamespace,
-	modelDefinition: SchemaModel | SchemaType
+	modelDefinition: SchemaModel | SchemaNonModel
 ): string[] {
 	const result = [];
 

--- a/packages/datastore/src/sync/utils.ts
+++ b/packages/datastore/src/sync/utils.ts
@@ -128,7 +128,7 @@ function getNonModelFields(
 
 	Object.values(modelDefinition.fields).forEach(({ name, type }) => {
 		if (isTypeFieldType(type)) {
-			const typeDefinition = namespace.types![type.type];
+			const typeDefinition = namespace.nonModels![type.type];
 			const scalarFields = Object.values(getScalarFields(typeDefinition)).map(
 				({ name }) => name
 			);
@@ -138,7 +138,7 @@ function getNonModelFields(
 				const { type, name } = field;
 
 				if (isTypeFieldType(type)) {
-					const typeDefinition = namespace.types![type.type];
+					const typeDefinition = namespace.nonModels![type.type];
 
 					nested.push(
 						`${name} { ${generateSelectionSet(namespace, typeDefinition)} }`

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -7,7 +7,7 @@ export type Schema = UserSchema & {
 };
 export type UserSchema = {
 	models: SchemaModels;
-	types?: SchemaTypes;
+	types?: SchemaNonModels;
 	relationships?: RelationshipType;
 	enums: SchemaEnums;
 	modelTopologicalOrdering?: Map<string, string[]>;
@@ -31,8 +31,8 @@ export type SchemaModel = {
 export function isSchemaModel(obj: any): obj is SchemaModel {
 	return obj && (<SchemaModel>obj).pluralName !== undefined;
 }
-export type SchemaTypes = Record<string, SchemaType>;
-export type SchemaType = {
+export type SchemaNonModels = Record<string, SchemaNonModel>;
+export type SchemaNonModel = {
 	name: string;
 	fields: ModelFields;
 };

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -7,7 +7,7 @@ export type Schema = UserSchema & {
 };
 export type UserSchema = {
 	models: SchemaModels;
-	types?: SchemaNonModels;
+	nonModels: SchemaNonModels;
 	relationships?: RelationshipType;
 	enums: SchemaEnums;
 	modelTopologicalOrdering?: Map<string, string[]>;

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -7,7 +7,7 @@ export type Schema = UserSchema & {
 };
 export type UserSchema = {
 	models: SchemaModels;
-	nonModels: SchemaNonModels;
+	nonModels?: SchemaNonModels;
 	relationships?: RelationshipType;
 	enums: SchemaEnums;
 	modelTopologicalOrdering?: Map<string, string[]>;

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -7,6 +7,7 @@ export type Schema = UserSchema & {
 };
 export type UserSchema = {
 	models: SchemaModels;
+	types?: SchemaTypes;
 	relationships?: RelationshipType;
 	enums: SchemaEnums;
 	modelTopologicalOrdering?: Map<string, string[]>;
@@ -26,6 +27,14 @@ export type SchemaModel = {
 	attributes?: ModelAttributes;
 	fields: ModelFields;
 	syncable?: boolean;
+};
+export function isSchemaModel(obj: any): obj is SchemaModel {
+	return obj && (<SchemaModel>obj).pluralName !== undefined;
+}
+export type SchemaTypes = Record<string, SchemaType>;
+export type SchemaType = {
+	name: string;
+	fields: ModelFields;
 };
 type SchemaEnums = Record<string, SchemaEnum>;
 type SchemaEnum = {
@@ -124,6 +133,14 @@ export function isModelFieldType(obj: any): obj is ModelFieldType {
 	return false;
 }
 
+export type TypeFieldType = { type: string };
+export function isTypeFieldType(obj: any): obj is TypeFieldType {
+	const typeField: keyof TypeFieldType = 'type';
+	if (obj && obj[typeField]) return true;
+
+	return false;
+}
+
 type EnumFieldType = { enum: string };
 export function isEnumFieldType(obj: any): obj is EnumFieldType {
 	const modelField: keyof EnumFieldType = 'enum';
@@ -137,6 +154,7 @@ type ModelField = {
 	type:
 		| keyof Omit<typeof GraphQLScalarType, 'getJSType'>
 		| ModelFieldType
+		| TypeFieldType
 		| EnumFieldType;
 	isArray: boolean;
 	isRequired?: boolean;
@@ -146,18 +164,25 @@ type ModelField = {
 //#endregion
 
 //#region Model definition
+export type NonModelTypeConstructor<T> = {
+	new (init: T): T;
+};
 export type PersistentModelConstructor<T extends PersistentModel> = {
 	new (init: ModelInit<T>): T;
 	copyOf(src: T, mutator: (draft: MutableModel<T>) => T | void): T;
 };
+export type ModelOrTypeConstructorMap = Record<
+	string,
+	PersistentModelConstructor<any> | NonModelTypeConstructor<any>
+>;
 export type PersistentModel = Readonly<{ id: string } & Record<string, any>>;
 export type ModelInit<T> = Omit<T, 'id'>;
-export type MutableModel<T> = Omit<
-	{
-		-readonly [P in keyof T]: T[P];
-	},
-	'id'
->;
+type DeepWritable<T> = {
+	-readonly [P in keyof T]: T[P] extends TypeName<T[P]>
+		? T[P]
+		: DeepWritable<T[P]>;
+};
+export type MutableModel<T> = Omit<DeepWritable<T>, 'id'>;
 
 export type ModelInstanceMetadata = {
 	id: string;

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -171,7 +171,7 @@ export type PersistentModelConstructor<T extends PersistentModel> = {
 	new (init: ModelInit<T>): T;
 	copyOf(src: T, mutator: (draft: MutableModel<T>) => T | void): T;
 };
-export type ModelOrTypeConstructorMap = Record<
+export type TypeConstructorMap = Record<
 	string,
 	PersistentModelConstructor<any> | NonModelTypeConstructor<any>
 >;

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -133,9 +133,9 @@ export function isModelFieldType(obj: any): obj is ModelFieldType {
 	return false;
 }
 
-export type TypeFieldType = { type: string };
-export function isTypeFieldType(obj: any): obj is TypeFieldType {
-	const typeField: keyof TypeFieldType = 'type';
+export type NonModelFieldType = { nonModel: string };
+export function isNonModelFieldType(obj: any): obj is NonModelFieldType {
+	const typeField: keyof NonModelFieldType = 'nonModel';
 	if (obj && obj[typeField]) return true;
 
 	return false;
@@ -154,7 +154,7 @@ type ModelField = {
 	type:
 		| keyof Omit<typeof GraphQLScalarType, 'getJSType'>
 		| ModelFieldType
-		| TypeFieldType
+		| NonModelFieldType
 		| EnumFieldType;
 	isArray: boolean;
 	isRequired?: boolean;

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -30,6 +30,10 @@ export const validatePredicate = <T extends PersistentModel>(
 	let filterType: keyof Pick<any[], 'every' | 'some'>;
 	let isNegation = false;
 
+	if (predicatesOrGroups.length === 0) {
+		return true;
+	}
+
 	switch (groupType) {
 		case 'not':
 			filterType = 'every';
@@ -43,10 +47,6 @@ export const validatePredicate = <T extends PersistentModel>(
 			break;
 		default:
 			exhaustiveCheck(groupType);
-	}
-
-	if (predicatesOrGroups.length === 0) {
-		return true;
 	}
 
 	const result: boolean = predicatesOrGroups[filterType](predicateOrGroup => {


### PR DESCRIPTION
_Issue #, if available:_
See aws-amplify/amplify-cli#2988

_Description of changes:_
This change allows the usage of types with no `@model` directive.

Field values of a non-\@<!-- -->model type will be stored alongside the @<!-- -->model instance

e.g. with the following schema, the JSON shown is stored

```graphql
type Note @model {
  id: ID!
  content: String!
  metadata: Metadata
}

type Metadata {
  author: String!
  tags: [String]
  nested: Nested
}

type Nested {
  x: Int
}
```

```json
{
  "__typename": "Note",
  "_lastChangedAt": 1584144474971,
  "_version": 1,
  "content": "Content 1584144474557",
  "createdAt": "2020-03-14T00:07:54.911Z",
  "id": "b41f57cc-4375-4bc5-83e2-1da694381f7f",
  "metadata": {
    "author": "Manolo",
    "tags": [
      "amazon",
      "aws",
      "mobile"
    ],
    "nested": {
      "x": 12345
    }
  },
  "updatedAt": "2020-03-14T00:07:54.911Z"
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
