### PR TITLE
fix(aws-amplify-react): BREAKING - Remove "import '@aws-amplify/ui/dist/style.css'"

### DIFF
--- a/packages/aws-amplify-react/src/Amplify-UI/Amplify-UI-Components-React.tsx
+++ b/packages/aws-amplify-react/src/Amplify-UI/Amplify-UI-Components-React.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { objectLessAttributes } from '@aws-amplify/core';
 
-import '@aws-amplify/ui/dist/style.css';
 import * as AmplifyUI from '@aws-amplify/ui';
 
 import AmplifyTheme from './Amplify-UI-Theme';


### PR DESCRIPTION
**This will require a MAJOR version bump, ideally with `modularization`**.

_Issue #, if available:_ Fixes #3348, fixes #3854, fixes #2230, fixes #3053. Related to #1613, but there's more work to be done to support categories in Next.js.

Importing non-JS files is invalid JavaScript, as it relies on a bundler (e.g. webpack) & breaks SSR for Next.js.

It works with CRA because CRA *builds all dependencies*, just-in-case.

Docs PR: https://github.com/aws-amplify/docs/pull/1258

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
