### PR TITLE
[RN] Migrate zen-observable to zen-observable-ts and fix zen-push import

### DIFF
--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -42,7 +42,7 @@
     "@aws-amplify/api-rest": "^1.0.0",
     "graphql": "14.0.0",
     "uuid": "^3.2.1",
-    "zen-observable": "^0.8.6"
+    "zen-observable-ts": "0.8.19"
   },
   "peerDependencies": {
     "@aws-amplify/pubsub": "^2.1.1"

--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -15,7 +15,7 @@ import { GraphQLError } from 'graphql/error/GraphQLError';
 import { OperationDefinitionNode } from 'graphql/language';
 import { print } from 'graphql/language/printer';
 import { parse } from 'graphql/language/parser';
-import * as Observable from 'zen-observable';
+import Observable from 'zen-observable-ts';
 import Amplify, {
 	ConsoleLogger as Logger,
 	Credentials,

--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -17,7 +17,7 @@ import {
 	GraphQLResult,
 } from '@aws-amplify/api-graphql';
 import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
-import * as Observable from 'zen-observable';
+import Observable from 'zen-observable-ts';
 
 const logger = new Logger('API');
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
 		"@aws-sdk/util-hex-encoding": "^1.0.0-alpha.2",
 		"@aws-sdk/util-user-agent-browser": "^1.0.0-alpha.8",
 		"url": "^0.11.0",
-		"zen-observable": "^0.8.6"
+		"zen-observable-ts": "0.8.19"
 	},
 	"peerDependencies": {
 		"@react-native-community/netinfo": "^5.5.0"

--- a/packages/core/src/Util/Reachability.native.ts
+++ b/packages/core/src/Util/Reachability.native.ts
@@ -1,5 +1,5 @@
 import { default as NetInfo } from '@react-native-community/netinfo';
-import * as Observable from 'zen-observable';
+import Observable from 'zen-observable-ts';
 import { ConsoleLogger as Logger } from '../Logger';
 
 const logger = new Logger('Reachability', 'DEBUG');

--- a/packages/core/src/Util/Reachability.ts
+++ b/packages/core/src/Util/Reachability.ts
@@ -1,4 +1,4 @@
-import * as Observable from 'zen-observable';
+import Observable from 'zen-observable-ts';
 
 type NetworkStatus = {
 	online: boolean;

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -1,5 +1,5 @@
 import 'fake-indexeddb/auto';
-import * as uuidValidate from 'uuid-validate';
+import uuidValidate from 'uuid-validate';
 import {
 	initSchema as initSchemaType,
 	DataStore as DataStoreType,

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -60,7 +60,8 @@
             "esnext.asynciterable",
             "es2017.object"
           ],
-          "allowJs": true
+          "allowJs": true,
+          "esModuleInterop": true
         }
       }
     },

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -5,6 +5,9 @@
   "main": "./lib/index.js",
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
+  "react-native": {
+    "./lib/index": "./lib-esm/index.js"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -1,7 +1,7 @@
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import { Draft, immerable, produce, setAutoFreeze } from 'immer';
 import { v1 as uuid1, v4 as uuid4 } from 'uuid';
-import Observable from 'zen-observable-ts';
+import Observable, { ZenObservable } from 'zen-observable-ts';
 import {
 	isPredicatesAll,
 	ModelPredicateCreator,

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -1,6 +1,6 @@
 import { Mutex } from '@aws-amplify/core';
-import Observable from 'zen-observable-ts';
-import * as PushStream from 'zen-push';
+import Observable, { ZenObservable } from 'zen-observable-ts';
+import PushStream from 'zen-push';
 import { ModelInstanceCreator } from '../datastore/datastore';
 import { ModelPredicateCreator } from '../predicates';
 import {

--- a/packages/datastore/src/sync/datastoreConnectivity.ts
+++ b/packages/datastore/src/sync/datastoreConnectivity.ts
@@ -1,4 +1,4 @@
-import * as Observable from 'zen-observable';
+import Observable, { ZenObservable } from 'zen-observable-ts';
 import { ConsoleLogger as Logger, Reachability } from '@aws-amplify/core';
 
 const logger = new Logger('DataStore');

--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -1,6 +1,6 @@
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import { CONTROL_MSG as PUBSUB_CONTROL_MSG } from '@aws-amplify/pubsub';
-import Observable from 'zen-observable-ts';
+import Observable, { ZenObservable } from 'zen-observable-ts';
 import { ModelInstanceCreator } from '../datastore/datastore';
 import { ModelPredicateCreator } from '../predicates';
 import { ExclusiveStorage as Storage } from '../storage/storage';

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -4,7 +4,7 @@ import {
 	jitteredExponentialRetry,
 	NonRetryableError,
 } from '@aws-amplify/core';
-import Observable from 'zen-observable-ts';
+import Observable, { ZenObservable } from 'zen-observable-ts';
 import { MutationEvent } from '../';
 import { ModelInstanceCreator } from '../../datastore/datastore';
 import { ExclusiveStorage as Storage } from '../../storage/storage';

--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -3,7 +3,7 @@ import Auth from '@aws-amplify/auth';
 import Cache from '@aws-amplify/cache';
 import { ConsoleLogger as Logger, Hub } from '@aws-amplify/core';
 import '@aws-amplify/pubsub';
-import Observable from 'zen-observable-ts';
+import Observable, { ZenObservable } from 'zen-observable-ts';
 import {
 	InternalSchema,
 	PersistentModel,

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -45,7 +45,7 @@
     "graphql": "14.0.0",
     "paho-mqtt": "^1.1.0",
     "uuid": "^3.2.1",
-    "zen-observable": "^0.8.6"
+    "zen-observable-ts": "0.8.19"
   },
   "jest": {
     "globals": {

--- a/packages/pubsub/src/Providers/AWSAppSyncProvider.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncProvider.ts
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 import { Client } from 'paho-mqtt';
-import * as Observable from 'zen-observable';
+import Observable from 'zen-observable-ts';
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 
 import { MqttOverWSProvider } from './MqttOverWSProvider';
@@ -96,9 +96,9 @@ export class AWSAppSyncProvider extends MqttOverWSProvider {
 				const { mqttConnections = [], newSubscriptions } = options;
 
 				// creates a map of {"topic": "alias"}
-				const newAliases = Object.entries(newSubscriptions).map(
-					([alias, v]: [string, { topic: string }]) => [v.topic, alias]
-				);
+				const newAliases = Object.entries(
+					newSubscriptions
+				).map(([alias, v]: [string, { topic: string }]) => [v.topic, alias]);
 
 				// Merge new aliases with old ones
 				this._topicAlias = new Map([

--- a/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import * as Observable from 'zen-observable';
+import Observable, { ZenObservable } from 'zen-observable-ts';
 import { GraphQLError } from 'graphql';
 import * as url from 'url';
 import { v4 as uuid } from 'uuid';

--- a/packages/pubsub/src/Providers/MqttOverWSProvider.ts
+++ b/packages/pubsub/src/Providers/MqttOverWSProvider.ts
@@ -12,7 +12,7 @@
  */
 import * as Paho from 'paho-mqtt';
 import { v4 as uuid } from 'uuid';
-import * as Observable from 'zen-observable';
+import Observable from 'zen-observable-ts';
 
 import { AbstractPubSubProvider } from './PubSubProvider';
 import { ProvidertOptions, SubscriptionObserver } from '../types';

--- a/packages/pubsub/src/Providers/PubSubProvider.ts
+++ b/packages/pubsub/src/Providers/PubSubProvider.ts
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import * as Observable from 'zen-observable';
+import Observable from 'zen-observable-ts';
 import { PubSubProvider, ProvidertOptions } from '../types';
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 

--- a/packages/pubsub/src/PubSub.ts
+++ b/packages/pubsub/src/PubSub.ts
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 // import '../Common/Polyfills';
-import * as Observable from 'zen-observable';
+import Observable from 'zen-observable-ts';
 
 import {
 	Amplify,

--- a/packages/pubsub/src/types/Provider.ts
+++ b/packages/pubsub/src/types/Provider.ts
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import * as Observable from 'zen-observable';
+import Observable from 'zen-observable-ts';
 import { ProvidertOptions } from './PubSub';
 
 export interface PubSubProvider {


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
* Migrate zen-observable to zen-observable-ts. zen-observable was causing issues with RN and ES modules. zen-observable-ts seems better suited for this. It was already used in Datastore package, this change makes it consistent everywhere else.
* zen-push was being imported as wild card which is not compatible with RN and ES modules
* Force ES modules to be used in datastore category for RN

Tested Datastore subscriptions in Web and react native.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
