### PR TITLE
feat(@aws-amplify/auth): add listPoolUsers method

### DIFF
--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -500,11 +500,14 @@ describe('auth unit test', () => {
 
 			await auth.confirmSignUp('username', code);
 
-			expect(
-				await CognitoUser.prototype.confirmRegistration
-			).toBeCalledWith(code, jasmine.any(Boolean), jasmine.any(Function), {
-				foo: 'bar',
-			});
+			expect(await CognitoUser.prototype.confirmRegistration).toBeCalledWith(
+				code,
+				jasmine.any(Boolean),
+				jasmine.any(Function),
+				{
+					foo: 'bar',
+				}
+			);
 			spyon.mockClear();
 		});
 
@@ -517,11 +520,14 @@ describe('auth unit test', () => {
 				clientMetadata: { custom: 'value' },
 			});
 
-			expect(
-				await CognitoUser.prototype.confirmRegistration
-			).toBeCalledWith(code, jasmine.any(Boolean), jasmine.any(Function), {
-				custom: 'value',
-			});
+			expect(await CognitoUser.prototype.confirmRegistration).toBeCalledWith(
+				code,
+				jasmine.any(Boolean),
+				jasmine.any(Function),
+				{
+					custom: 'value',
+				}
+			);
 			spyon.mockClear();
 		});
 
@@ -1645,7 +1651,7 @@ describe('auth unit test', () => {
 
 	describe('currentCrendentials', () => {
 		const spyon = jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
-			return;
+			return Promise.resolve('cred');
 		});
 
 		const auth = new Auth(authOptions);
@@ -1996,11 +2002,14 @@ describe('auth unit test', () => {
 
 			await auth.changePassword(user, oldPassword, newPassword);
 
-			expect(
-				await CognitoUser.prototype.changePassword
-			).toBeCalledWith(oldPassword, newPassword, jasmine.any(Function), {
-				foo: 'bar',
-			});
+			expect(await CognitoUser.prototype.changePassword).toBeCalledWith(
+				oldPassword,
+				newPassword,
+				jasmine.any(Function),
+				{
+					foo: 'bar',
+				}
+			);
 			spyon.mockClear();
 		});
 
@@ -2018,11 +2027,14 @@ describe('auth unit test', () => {
 				custom: 'value',
 			});
 
-			expect(
-				await CognitoUser.prototype.changePassword
-			).toBeCalledWith(oldPassword, newPassword, jasmine.any(Function), {
-				custom: 'value',
-			});
+			expect(await CognitoUser.prototype.changePassword).toBeCalledWith(
+				oldPassword,
+				newPassword,
+				jasmine.any(Function),
+				{
+					custom: 'value',
+				}
+			);
 			spyon.mockClear();
 		});
 	});

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -37,6 +37,7 @@
     "@aws-amplify/cache": "^2.1.6",
     "@aws-amplify/core": "^2.2.5",
     "amazon-cognito-identity-js": "^3.2.5",
+    "aws-sdk": "^2.644.0",
     "crypto-js": "3.1.9-1"
   },
   "jest": {

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -113,6 +113,34 @@ export interface FederatedResponse {
 	expires_at: number;
 }
 
+export interface ListedUser {
+	// The user name of the user you wish to describe.
+	username?: string;
+
+	// A container with information about the user type attributes.
+	attributes?: object;
+
+	// Specifies whether the user is enabled.
+	enabled?: boolean;
+
+	// The user status.
+	status?: string;
+
+	// The creation date of the user.
+	createdDate?: Date;
+
+	// The last modified date of the user.
+	lastModifiedDate?: Date;
+}
+
+/**
+ * interface for users returned from listPoolUsers
+ */
+export interface ListUsersResponse {
+	users: ListedUser[];
+	paginationToken: string;
+}
+
 /**
  * interface for federatedUser
  */
@@ -163,6 +191,13 @@ export interface ConfirmSignUpOptions {
 
 export interface SignOutOpts {
 	global?: boolean;
+}
+
+export interface ListUsersOpts {
+	filter?: string;
+	limit?: number;
+	attributesToGet?: string[];
+	paginationToken?: string;
 }
 
 export interface CurrentUserOpts {


### PR DESCRIPTION
_Issue #, if available:_
#2120
_Description of changes:_
This PR introduces the public method `listPoolUsers` in Auth class. It closes the feature request #2120 by implementing a way of listing users through CognitoIdentityServiceProvider from AWS-SDK. In the first moment I was thinking on implementing this by using amazon-cognito-identity-js lib, however, the client request method only allows endpoints which authorization is not required.

I'm still working with the tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
