### PR TITLE
feat(@aws-amplify/datastore): configurable sync pagination limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,10 +313,6 @@ jobs:
             cp -rf ~/amplify-js/packages/core/lib ./node_modules/@aws-amplify/core/lib
             cp -rf ~/amplify-js/packages/core/lib-esm ./node_modules/@aws-amplify/core/lib-esm
 
-            cp -rf ~/amplify-js/packages/datastore/dist ./node_modules/@aws-amplify/datastore/dist
-            cp -rf ~/amplify-js/packages/datastore/lib ./node_modules/@aws-amplify/datastore/lib
-            cp -rf ~/amplify-js/packages/datastore/lib-esm ./node_modules/@aws-amplify/datastore/lib-esm
-
             cp -rf ~/amplify-js/packages/interactions/dist ./node_modules/@aws-amplify/interactions/dist
             cp -rf ~/amplify-js/packages/interactions/lib ./node_modules/@aws-amplify/interactions/lib
             cp -rf ~/amplify-js/packages/interactions/lib-esm ./node_modules/@aws-amplify/interactions/lib-esm

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -645,6 +645,7 @@ let amplifyConfig: Record<string, any> = {};
 let conflictHandler: ConflictHandler;
 let errorHandler: (error: SyncError) => void;
 let maxRecordsToSync: number;
+let paginationLimit: number;
 let fullSyncInterval: number;
 
 function configure(config: DataStoreConfig = {}) {
@@ -653,6 +654,7 @@ function configure(config: DataStoreConfig = {}) {
 		conflictHandler: configConflictHandler,
 		errorHandler: configErrorHandler,
 		maxRecordsToSync: configMaxRecordsToSync,
+		paginationLimit: configPaginationLimit,
 		fullSyncInterval: configFullSyncInterval,
 		...configFromAmplify
 	} = config;
@@ -675,6 +677,11 @@ function configure(config: DataStoreConfig = {}) {
 		(configDataStore && configDataStore.maxRecordsToSync) ||
 		maxRecordsToSync ||
 		config.maxRecordsToSync;
+
+	paginationLimit =
+		(configDataStore && configDataStore.paginationLimit) ||
+		paginationLimit ||
+		config.paginationLimit;
 
 	fullSyncInterval =
 		(configDataStore && configDataStore.fullSyncInterval) ||
@@ -797,6 +804,7 @@ async function start(): Promise<void> {
 			storage,
 			modelInstanceCreator,
 			maxRecordsToSync,
+			paginationLimit,
 			conflictHandler,
 			errorHandler
 		);

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -645,7 +645,7 @@ let amplifyConfig: Record<string, any> = {};
 let conflictHandler: ConflictHandler;
 let errorHandler: (error: SyncError) => void;
 let maxRecordsToSync: number;
-let paginationLimit: number;
+let syncPageSize: number;
 let fullSyncInterval: number;
 
 function configure(config: DataStoreConfig = {}) {
@@ -654,7 +654,7 @@ function configure(config: DataStoreConfig = {}) {
 		conflictHandler: configConflictHandler,
 		errorHandler: configErrorHandler,
 		maxRecordsToSync: configMaxRecordsToSync,
-		paginationLimit: configPaginationLimit,
+		syncPageSize: configSyncPageSize,
 		fullSyncInterval: configFullSyncInterval,
 		...configFromAmplify
 	} = config;
@@ -678,10 +678,10 @@ function configure(config: DataStoreConfig = {}) {
 		maxRecordsToSync ||
 		config.maxRecordsToSync;
 
-	paginationLimit =
-		(configDataStore && configDataStore.paginationLimit) ||
-		paginationLimit ||
-		config.paginationLimit;
+	syncPageSize =
+		(configDataStore && configDataStore.syncPageSize) ||
+		syncPageSize ||
+		config.syncPageSize;
 
 	fullSyncInterval =
 		(configDataStore && configDataStore.fullSyncInterval) ||
@@ -804,7 +804,7 @@ async function start(): Promise<void> {
 			storage,
 			modelInstanceCreator,
 			maxRecordsToSync,
-			paginationLimit,
+			syncPageSize,
 			conflictHandler,
 			errorHandler
 		);

--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -85,6 +85,7 @@ export class SyncEngine {
 		private readonly storage: Storage,
 		private readonly modelInstanceCreator: ModelInstanceCreator,
 		private readonly maxRecordsToSync: number,
+		private readonly paginationLimit: number,
 		conflictHandler: ConflictHandler,
 		errorHandler: ErrorHandler
 	) {
@@ -103,7 +104,8 @@ export class SyncEngine {
 
 		this.syncQueriesProcessor = new SyncProcessor(
 			this.schema,
-			maxRecordsToSync
+			maxRecordsToSync,
+			paginationLimit
 		);
 		this.subscriptionsProcessor = new SubscriptionProcessor(this.schema);
 		this.mutationsProcessor = new MutationProcessor(

--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -85,7 +85,7 @@ export class SyncEngine {
 		private readonly storage: Storage,
 		private readonly modelInstanceCreator: ModelInstanceCreator,
 		private readonly maxRecordsToSync: number,
-		private readonly paginationLimit: number,
+		private readonly syncPageSize: number,
 		conflictHandler: ConflictHandler,
 		errorHandler: ErrorHandler
 	) {
@@ -105,7 +105,7 @@ export class SyncEngine {
 		this.syncQueriesProcessor = new SyncProcessor(
 			this.schema,
 			maxRecordsToSync,
-			paginationLimit
+			syncPageSize
 		);
 		this.subscriptionsProcessor = new SubscriptionProcessor(this.schema);
 		this.mutationsProcessor = new MutationProcessor(

--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -17,7 +17,7 @@ class SyncProcessor {
 	constructor(
 		private readonly schema: InternalSchema,
 		private readonly maxRecordsToSync: number = DEFAULT_MAX_RECORDS_TO_SYNC,
-		private readonly paginationLimit: number = DEFAULT_PAGINATION_LIMIT
+		private readonly syncPageSize: number = DEFAULT_PAGINATION_LIMIT
 	) {
 		this.generateQueries();
 	}
@@ -105,9 +105,9 @@ class SyncProcessor {
 				? this.maxRecordsToSync
 				: DEFAULT_MAX_RECORDS_TO_SYNC;
 
-		const paginationLimit =
-			this.paginationLimit !== undefined
-				? this.paginationLimit
+		const syncPageSize =
+			this.syncPageSize !== undefined
+				? this.syncPageSize
 				: DEFAULT_PAGINATION_LIMIT;
 
 		const parentPromises = new Map<string, Promise<void>>();
@@ -153,7 +153,7 @@ class SyncProcessor {
 
 							const limit = Math.min(
 								maxRecordsToSync - recordsReceived,
-								paginationLimit
+								syncPageSize
 							);
 
 							({ items, nextToken, startedAt } = await this.retrievePage(

--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -16,7 +16,8 @@ class SyncProcessor {
 
 	constructor(
 		private readonly schema: InternalSchema,
-		private readonly maxRecordsToSync: number = DEFAULT_MAX_RECORDS_TO_SYNC
+		private readonly maxRecordsToSync: number = DEFAULT_MAX_RECORDS_TO_SYNC,
+		private readonly paginationLimit: number = DEFAULT_PAGINATION_LIMIT
 	) {
 		this.generateQueries();
 	}
@@ -104,6 +105,11 @@ class SyncProcessor {
 				? this.maxRecordsToSync
 				: DEFAULT_MAX_RECORDS_TO_SYNC;
 
+		const paginationLimit =
+			this.paginationLimit !== undefined
+				? this.paginationLimit
+				: DEFAULT_PAGINATION_LIMIT;
+
 		const parentPromises = new Map<string, Promise<void>>();
 
 		const observable = new Observable<SyncModelPage>(observer => {
@@ -147,7 +153,7 @@ class SyncProcessor {
 
 							const limit = Math.min(
 								maxRecordsToSync - recordsReceived,
-								DEFAULT_PAGINATION_LIMIT
+								paginationLimit
 							);
 
 							({ items, nextToken, startedAt } = await this.retrievePage(

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -383,11 +383,13 @@ export type DataStoreConfig = {
 		conflictHandler?: ConflictHandler; // default : retry until client wins up to x times
 		errorHandler?: (error: SyncError) => void; // default : logger.warn
 		maxRecordsToSync?: number; // merge
+		paginationLimit?: number;
 		fullSyncInterval?: number;
 	};
 	conflictHandler?: ConflictHandler; // default : retry until client wins up to x times
 	errorHandler?: (error: SyncError) => void; // default : logger.warn
 	maxRecordsToSync?: number; // merge
+	paginationLimit?: number;
 	fullSyncInterval?: number;
 };
 

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -383,13 +383,13 @@ export type DataStoreConfig = {
 		conflictHandler?: ConflictHandler; // default : retry until client wins up to x times
 		errorHandler?: (error: SyncError) => void; // default : logger.warn
 		maxRecordsToSync?: number; // merge
-		paginationLimit?: number;
+		syncPageSize?: number;
 		fullSyncInterval?: number;
 	};
 	conflictHandler?: ConflictHandler; // default : retry until client wins up to x times
 	errorHandler?: (error: SyncError) => void; // default : logger.warn
 	maxRecordsToSync?: number; // merge
-	paginationLimit?: number;
+	syncPageSize?: number;
 	fullSyncInterval?: number;
 };
 


### PR DESCRIPTION
Allow user to configure sync pagination limit due to limit reach of 1MB if dynamodb documents are bigger. By reducing pagination limit it's possible to overcome following issue:

```
{
  "data": {
    "syncDocuments": null
  },
  "errors": [
    {
      "path": [
        "syncDocuments"
      ],
      "data": null,
      "errorType": "MappingTemplate",
      "errorInfo": null,
      "locations": [
        {
          "line": 2,
          "column": 5,
          "sourceName": null
        }
      ],
      "message": "Transformation too large"
    }
  ]
}
```

This pull request allow users to add such configuration as following: 
```
DataStore.configure({
    syncPageSize: number
})
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
