### PR TITLE
Export UsernameAttributes enum

### DIFF
--- a/packages/aws-amplify-react/src/Auth/index.tsx
+++ b/packages/aws-amplify-react/src/Auth/index.tsx
@@ -34,6 +34,7 @@ export { default as TOTPSetup } from './TOTPSetup';
 export { default as Loading } from './Loading';
 
 export * from './Provider';
+export * from './common/types';
 
 export function withAuthenticator(
 	Comp,


### PR DESCRIPTION
This change makes it possible to specify the usernameAttribute prop in TypeScript without using `any`.

Fixes #5196 

_Description of changes:_

Here I've exposed the UsernameAttributes enum as a named export by exposing everything in the `common/types.ts` file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
