### PR TITLE
fix(@aws-amplify/datastore): Make save return a single model instead …

### DIFF
--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -16,7 +16,6 @@ import Observable from 'zen-observable-ts';
 
 let initSchema: typeof initSchemaType;
 let DataStore: typeof DataStoreType;
-let Storage: typeof StorageType;
 
 beforeEach(() => {
 	jest.resetModules();
@@ -192,7 +191,7 @@ describe('DataStore tests', () => {
 
 	describe('Initialization', () => {
 		test('start is called only once', async () => {
-			Storage = require('../src/storage/storage').default;
+			const storage: StorageType = require('../src/storage/storage').default;
 
 			const classes = initSchema(testSchema());
 
@@ -207,11 +206,11 @@ describe('DataStore tests', () => {
 
 			await Promise.all(promises);
 
-			expect(Storage).toHaveBeenCalledTimes(1);
+			expect(storage).toHaveBeenCalledTimes(1);
 		});
 
 		test('It is initialized when observing (no query)', async () => {
-			Storage = require('../src/storage/storage').default;
+			const storage: StorageType = require('../src/storage/storage').default;
 
 			const classes = initSchema(testSchema());
 
@@ -219,7 +218,37 @@ describe('DataStore tests', () => {
 
 			DataStore.observe(Model).subscribe(jest.fn());
 
-			expect(Storage).toHaveBeenCalledTimes(1);
+			expect(storage).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('Basic operations', () => {
+		test('Save returns the saved model', async () => {
+			let model: Model;
+
+			jest.resetModules();
+			jest.doMock('../src/storage/storage', () => {
+				const mock = jest.fn().mockImplementation(() => ({
+					runExclusive: jest.fn(() => [model]),
+				}));
+
+				(<any>mock).getNamespace = () => ({ models: {} });
+
+				return { default: mock };
+			});
+			({ initSchema, DataStore } = require('../src/datastore/datastore'));
+
+			const classes = initSchema(testSchema());
+
+			const { Model } = classes as { Model: PersistentModelConstructor<Model> };
+
+			model = new Model({
+				field1: 'Some value',
+			});
+
+			const result = await DataStore.save(model);
+
+			expect(result).toMatchObject(model);
 		});
 	});
 
@@ -244,6 +273,7 @@ describe('DataStore tests', () => {
 declare class Model {
 	public readonly id: string;
 	public readonly field1: string;
+	public readonly metadata?: Metadata;
 
 	constructor(init: ModelInit<Model>);
 

--- a/packages/datastore/__tests__/indexeddb.test.ts
+++ b/packages/datastore/__tests__/indexeddb.test.ts
@@ -228,7 +228,7 @@ describe('Indexed db storage test', () => {
 	});
 
 	test('query function 1:1', async () => {
-		const [res] = await DataStore.save(blog);
+		const res = await DataStore.save(blog);
 		await DataStore.save(owner);
 		const query = await DataStore.query(Blog, blog.id);
 
@@ -364,8 +364,8 @@ describe('Indexed db storage test', () => {
 	});
 
 	test('delete cascade', async () => {
-		const [a1] = await DataStore.save(new Author({ name: 'author1' }));
-		const [a2] = await DataStore.save(new Author({ name: 'author2' }));
+		const a1 = await DataStore.save(new Author({ name: 'author1' }));
+		const a2 = await DataStore.save(new Author({ name: 'author2' }));
 		const blog = new Blog({
 			name: 'The Blog',
 			owner,
@@ -378,8 +378,8 @@ describe('Indexed db storage test', () => {
 			title: 'Post 2',
 			blog,
 		});
-		const [c1] = await DataStore.save(new Comment({ content: 'c1', post: p1 }));
-		const [c2] = await DataStore.save(new Comment({ content: 'c2', post: p1 }));
+		const c1 = await DataStore.save(new Comment({ content: 'c1', post: p1 }));
+		const c2 = await DataStore.save(new Comment({ content: 'c2', post: p1 }));
 		await DataStore.save(p1);
 		await DataStore.save(p2);
 		await DataStore.save(blog);

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -354,7 +354,7 @@ const createNonModelClass = <T>(typeDefinition: SchemaNonModel) => {
 const save = async <T extends PersistentModel>(
 	model: T,
 	condition?: ProducerModelPredicate<T>
-) => {
+): Promise<T> => {
 	await start();
 	const modelConstructor: PersistentModelConstructor<T> = model
 		? <PersistentModelConstructor<T>>model.constructor
@@ -374,7 +374,7 @@ const save = async <T extends PersistentModel>(
 		condition
 	);
 
-	const savedModel = await storage.runExclusive(async s => {
+	const [savedModel] = await storage.runExclusive(async s => {
 		await s.save(model, producedCondition);
 
 		return s.query(


### PR DESCRIPTION
…of array

_Issue #, if available:_
Fixes #5099

_Description of changes:_
`DataStore.save` was incorrectly returning the very same array that `storage.save` was returning. It should only return the first element of that array, which corresponds to the model being saved.

Note: The array is internally used to notify observers of newly created connected models

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
