### PR TITLE
feat(@aws-amplify/datastore): Make DataStore available in aws-amplify…

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -38,6 +38,7 @@
     "@aws-amplify/auth": "^2.1.7",
     "@aws-amplify/cache": "^2.1.7",
     "@aws-amplify/core": "^2.2.6",
+    "@aws-amplify/datastore": "^1.1.0",
     "@aws-amplify/interactions": "^2.1.7",
     "@aws-amplify/predictions": "^2.1.7",
     "@aws-amplify/pubsub": "^2.1.8",

--- a/packages/aws-amplify/src/index.ts
+++ b/packages/aws-amplify/src/index.ts
@@ -28,6 +28,7 @@ import Interactions, { InteractionsClass } from '@aws-amplify/interactions';
 import * as UI from '@aws-amplify/ui';
 import XR, { XRClass } from '@aws-amplify/xr';
 import Predictions from '@aws-amplify/predictions';
+import { DataStore } from '@aws-amplify/datastore';
 
 import Amplify, {
 	ConsoleLogger as Logger,
@@ -54,6 +55,7 @@ Amplify.Interactions = Interactions;
 Amplify.UI = UI;
 Amplify.XR = XR;
 Amplify.Predictions = Predictions;
+Amplify.DataStore = DataStore;
 
 export {
 	Auth,

--- a/packages/core/src/Amplify.ts
+++ b/packages/core/src/Amplify.ts
@@ -20,6 +20,7 @@ export default class Amplify {
 	static UI = null;
 	static XR = null;
 	static Predictions = null;
+	static DataStore = null;
 
 	static Logger = LoggerClass;
 	static ServiceWorker = null;


### PR DESCRIPTION
… package

_Issue #, if available:_
N/A

_Description of changes:_
Make DataStore available in the `Amplify` object when using the `aws-amplify` package

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
