### PR TITLE
chore(@aws-amplify/ui-components): Pin @aws-amplify/ui-components to ^0.1.0

### DIFF
--- a/packages/amplify-ui-angular/package.json
+++ b/packages/amplify-ui-angular/package.json
@@ -31,7 +31,7 @@
 		"dist/"
 	],
 	"dependencies": {
-		"@aws-amplify/ui-components": "*"
+		"@aws-amplify/ui-components": "^0.1.0"
 	},
 	"devDependencies": {
 		"@angular/compiler-cli": "^7.2.1",

--- a/packages/amplify-ui-react/package.json
+++ b/packages/amplify-ui-react/package.json
@@ -30,7 +30,7 @@
 		"typescript": "^3.3.4000"
 	},
 	"dependencies": {
-		"@aws-amplify/ui-components": "*"
+		"@aws-amplify/ui-components": "^0.1.0"
 	},
 	"peerDependencies": {
 		"react": "^16.7.0",

--- a/packages/amplify-ui-vue/package.json
+++ b/packages/amplify-ui-vue/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/aws-amplify/amplify-js.git"
 	},
 	"dependencies": {
-		"@aws-amplify/ui-components": "*"
+		"@aws-amplify/ui-components": "^0.1.0"
 	},
 	"scripts": {
 		"build": "npm run clean && npm run compile",


### PR DESCRIPTION
- [x] Confirmed that `yarn install` hoists `@aws-amplify/ui-components` to the workspace root, rather than `amplify-ui-{framework}/node_modules/...`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
