### PR TITLE
Improvement on .graphql return type

### DIFF
--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -350,7 +350,7 @@ export default class APIClass {
 	 * @param {object} additionalHeaders headers to merge in after any `graphql_headers` set in the config
 	 * @returns {Promise<GraphQLResult> | Observable<object>}
 	 */
-	graphql(
+	graphql<T>(
 		{ query: paramQuery, variables = {}, authMode }: GraphQLOptions,
 		additionalHeaders?: { [key: string]: string }
 	) {
@@ -381,10 +381,10 @@ export default class APIClass {
 		throw new Error(`invalid operation type: ${operationType}`);
 	}
 
-	private async _graphql(
+	private async _graphql<T>(
 		{ query, variables, authMode }: GraphQLOptions,
 		additionalHeaders = {}
-	): Promise<GraphQLResult> {
+	): Promise<GraphQLResult<T>> {
 		if (!this._api) {
 			await this.createInstance();
 		}
@@ -454,11 +454,11 @@ export default class APIClass {
 		return response;
 	}
 
-	private _graphqlSubscribe({
+	private _graphqlSubscribe<T>({
 		query,
 		variables,
 		authMode: defaultAuthenticationType,
-	}: GraphQLOptions): Observable<any> {
+	}: GraphQLOptions): Observable<T> & { [key: string]: any] } {
 		const {
 			aws_appsync_region: region,
 			aws_appsync_graphqlEndpoint: appSyncGraphqlEndpoint,


### PR DESCRIPTION
Fixes #4257 

Noticed that GraphQLResult already supports <T> type.

1. Declared `API.graphql` as `API.graphql<T>`.
2. Changed `API.graphql` result `Observable<any>` to `Observable<T>`
2. Union-ed `API.graphql` result `Observable<any>` with `{ [key: string]: any }`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
