### PR TITLE
fix(@aws-amplify/ui-components): Default federated, since aws-exports#oauth gets merged with it

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-federated-buttons/amplify-federated-buttons.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-federated-buttons/amplify-federated-buttons.tsx
@@ -13,7 +13,7 @@ export class AmplifyFederatedButtons {
   /** The current authentication state. */
   @Prop() authState: AuthState = AuthState.SignIn;
   /** Federated credentials & configuration. */
-  @Prop() federated: FederatedConfig;
+  @Prop() federated: FederatedConfig = {};
   /** Passed from the Authenticator component in order to change Authentication state
    * e.g. SignIn -> 'Create Account' link -> SignUp
    */


### PR DESCRIPTION
`federated` gets merged with `oauth`, but when `undefined` it throws run-time errors unless a user manually adds `<amplify-authenticator federated={...} />`.

https://github.com/aws-amplify/amplify-js/blob/778a39a11b623ed28585fb222b618ec0e4189f95/packages/amplify-ui-components/src/components/amplify-federated-buttons/amplify-federated-buttons.tsx#L27-L35

---


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
