### PR TITLE
fix builds that were broken by new terser 4.6.8 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
 		"webpack-cli": "^3.1.0",
 		"winston": "^3.2.1"
 	},
+	"resolutions": {
+		"terser": "4.6.7"
+	},
 	"jest": {
 		"resetMocks": true,
 		"verbose": true


### PR DESCRIPTION
_Issue #, if available:_https://github.com/terser/terser/issues/624

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
