### PR TITLE
stay signedin after confirm signup

### DIFF
--- a/packages/amplify-ui-components/src/common/types/auth-types.ts
+++ b/packages/amplify-ui-components/src/common/types/auth-types.ts
@@ -71,6 +71,7 @@ export interface CognitoUserInterface {
     email?: string;
     phone_number?: string;
   };
+  [attributes: string]: any;
 }
 
 export type AuthStateHandler = (nextAuthState: AuthState, data?: object) => void;

--- a/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
@@ -50,6 +50,7 @@ export class AmplifyConfirmSignUp {
   @State() code: string;
   @State() loading: boolean = false;
   @State() userInput: string = this.user ? this.user.username : null;
+  private _signUpAttrs = this.user && this.user.signUpAttrs ? this.user.signUpAttrs : null;
 
   componentWillLoad() {
     checkUsernameAlias(this.usernameAlias);
@@ -57,8 +58,8 @@ export class AmplifyConfirmSignUp {
       {
         type: `${this.usernameAlias}`,
         required: true,
-        value: this.user ? this.user.username : null,
-        disabled: this.user && this.user.username ? true : false,
+        value: this.userInput,
+        disabled: this.userInput ? true : false,
       },
       {
         type: 'code',
@@ -111,7 +112,9 @@ export class AmplifyConfirmSignUp {
     this.loading = true;
 
     try {
-      const user = await Auth.confirmSignUp(this.userInput, this.code);
+      const confirmSignUpResult = await Auth.confirmSignUp(this.userInput, this.code);
+      const user =
+        confirmSignUpResult && this._signUpAttrs && (await Auth.signIn(this.userInput, this._signUpAttrs.password));
       this.handleAuthStateChange(AuthState.SignedIn, user);
     } catch (error) {
       dispatchToastHubEvent(error);
@@ -129,10 +132,7 @@ export class AmplifyConfirmSignUp {
         secondaryFooterContent={
           <div>
             <span>
-              <amplify-button
-                variant="anchor"
-                onClick={() => this.handleAuthStateChange(AuthState.SignIn)}
-              >
+              <amplify-button variant="anchor" onClick={() => this.handleAuthStateChange(AuthState.SignIn)}>
                 {I18n.get(Translations.BACK_TO_SIGN_IN)}
               </amplify-button>
             </span>

--- a/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
@@ -136,9 +136,8 @@ export class AmplifySignUp {
           phone_number: composePhoneNumberInput(this.phoneNumber),
         },
       };
-
       const data = await Auth.signUp(signUpAttrs);
-      this.handleAuthStateChange(AuthState.ConfirmSignUp, data.user);
+      this.handleAuthStateChange(AuthState.ConfirmSignUp, { ...data.user, signUpAttrs });
     } catch (error) {
       dispatchToastHubEvent(error);
     }


### PR DESCRIPTION
_Issue #, if available:_ Fixes #5201 

_Description of changes:_ 

- This PR ensures the user to be `signedIn` after performing `confirmSignUp`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
