### PR TITLE
Enable publish to npm tag stable-2.0 from branch 2.0-stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,6 +413,7 @@ workflows:
                 - release
                 - master
                 - 1.0-stable
+                - 2.0-stable
           requires:
             - build
       - integ_react_predictions:
@@ -422,6 +423,7 @@ workflows:
                 - release
                 - master
                 - 1.0-stable
+                - 2.0-stable
           requires:
             - integ_setup
       - integ_react_auth:
@@ -431,6 +433,7 @@ workflows:
                 - release
                 - master
                 - 1.0-stable
+                - 2.0-stable
           requires:
             - integ_setup
       - integ_angular_auth:
@@ -440,6 +443,7 @@ workflows:
                 - release
                 - master
                 - 1.0-stable
+                - 2.0-stable
           requires:
             - integ_setup
       - integ_vue_auth:
@@ -449,6 +453,7 @@ workflows:
                 - release
                 - master
                 - 1.0-stable
+                - 2.0-stable
           requires:
             - integ_setup
       - integ_rn_ios_storage:
@@ -458,6 +463,7 @@ workflows:
                 - release
                 - master
                 - 1.0-stable
+                - 2.0-stable
           requires:
             - integ_setup
       - deploy:
@@ -468,6 +474,7 @@ workflows:
                 - master
                 - beta
                 - 1.0-stable
+                - 2.0-stable
           requires:
             - unit_test
             - integ_react_predictions

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 		"publish:master": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=unstable --preid=unstable --exact",
 		"publish:beta": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=beta --preid=beta --exact",
 		"publish:release": "lerna publish --conventional-commits --yes --message 'chore(release): Publish [ci skip]'",
-		"publish:1.0-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-1.0 --message 'chore(release): Publish [ci skip]'"
+		"publish:1.0-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-1.0 --message 'chore(release): Publish [ci skip]'",
+		"publish:2.0-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-2.0 --message 'chore(release): Publish [ci skip]'"
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Merging this will trigger a release in CircleCI which will create a new NPM tag 2.0-stable

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
