### PR TITLE
fix(@aws-amplify/ui-components): Listen to auth channel for managing Hosted UI auth state

### DIFF
--- a/packages/amplify-ui-components/src/common/constants.ts
+++ b/packages/amplify-ui-components/src/common/constants.ts
@@ -32,6 +32,7 @@ export const SUCCESS = 'SUCCESS';
 export const FAILURE = 'FAILURE';
 
 // Hub Events and Channels
+export const AUTH_CHANNEL = 'auth';
 export const UI_AUTH_CHANNEL = 'UI Auth';
 export const TOAST_AUTH_ERROR_EVENT = 'ToastAuthError';
 export const AUTH_STATE_CHANGE_EVENT = 'AuthStateChange';

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
@@ -1,6 +1,7 @@
 import { Component, State, Prop, h, Host } from '@stencil/core';
 import { AuthState, CognitoUserInterface, FederatedConfig, UsernameAliasStrings } from '../../common/types/auth-types';
 import {
+  AUTH_CHANNEL,
   NO_AUTH_MODULE_FOUND,
   SIGNING_IN_WITH_HOSTEDUI_KEY,
   AUTHENTICATOR_AUTHSTATE,
@@ -30,6 +31,19 @@ export class AmplifyAuthenticator {
   @State() toastMessage: string = '';
 
   async componentWillLoad() {
+    Hub.listen(AUTH_CHANNEL, ({ payload: { event, data } }) => {
+      switch (event) {
+        case 'cognitoHostedUI':
+          return this.onAuthStateChange(AuthState.SignedIn, data);
+
+        case 'cognitoHostedUI_failure':
+        case 'parsingUrl_failure':
+        case 'signOut':
+        case 'customGreetingSignOut':
+          return this.onAuthStateChange(AuthState.SignIn, null);
+      }
+    });
+
     Hub.listen(UI_AUTH_CHANNEL, data => {
       const { payload } = data;
       switch (payload.event) {


### PR DESCRIPTION
_Issue #, if available:_ #5232

_Description of changes:_

I've been able to reproduce Ivan's hosted UI bug.  Found several ancillary issues to be resolved: https://github.com/aws-amplify/amplify-js/issues/5232#issuecomment-606345994

This PR brings over logic from `aws-amplify-react` that was missing in `amplify-authenticator`:

https://github.com/aws-amplify/amplify-js/blob/38e55b090e10b71251439344365f6aa9344d049a/packages/aws-amplify-react/src/Auth/Authenticator.tsx#L70-L79

> ![hosted-ui](https://user-images.githubusercontent.com/15182/78073372-a3752800-7355-11ea-8938-575122f9308a.gif)

It's worth noting that the `Auth` category still returns lots of errors (which isn't specific to the components, but is in `master`):

> ![Screen Shot 2020-03-31 at 1 27 18 PM](https://user-images.githubusercontent.com/15182/78073942-a4f32000-7356-11ea-861a-dc21cdc52e2f.png)

It's worth noting that there have been consistent issues with hosted UI & redirecting:
> https://github.com/aws-amplify/amplify-js/issues/3841#issuecomment-543338595

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
