### PR TITLE
(@aws-amplify/ui-components) Revert User Agent change to Cognito SDK

### DIFF
--- a/packages/amazon-cognito-identity-js/__tests__/UserAgent-test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/UserAgent-test.js
@@ -1,6 +1,6 @@
 import UserAgent, { appendToCognitoUserAgent } from '../src/UserAgent';
 
-const DEFAULT_USER_AGENT = 'amazon-cognito-identity-js';
+const DEFAULT_USER_AGENT = 'aws-amplify/0.1.x js';
 
 describe('UserAgent test', () => {
 	beforeEach(() => {

--- a/packages/amazon-cognito-identity-js/src/UserAgent.js
+++ b/packages/amazon-cognito-identity-js/src/UserAgent.js
@@ -1,8 +1,7 @@
-const DEFAULT_USER_AGENT = 'amazon-cognito-identity-js';
 // constructor
 function UserAgent() {}
 // public
-UserAgent.prototype.userAgent = DEFAULT_USER_AGENT;
+UserAgent.prototype.userAgent = 'aws-amplify/0.1.x js';
 
 export const appendToCognitoUserAgent = content => {
 	if (!content) {

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
@@ -47,7 +47,7 @@ export class AmplifyAuthenticator {
       }
     });
 
-    appendToCognitoUserAgent('amplify-ui');
+    appendToCognitoUserAgent('amplify-authenticator');
     const byHostedUI = localStorage.getItem(SIGNING_IN_WITH_HOSTEDUI_KEY);
     localStorage.removeItem(SIGNING_IN_WITH_HOSTEDUI_KEY);
     if (byHostedUI !== 'true') await this.checkUser();

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -59,7 +59,6 @@ import {
 	CognitoIdToken,
 	CognitoRefreshToken,
 	CognitoAccessToken,
-	appendToCognitoUserAgent,
 } from 'amazon-cognito-identity-js';
 
 import { parse } from 'url';
@@ -72,7 +71,7 @@ const logger = new Logger('AuthClass');
 const USER_ADMIN_SCOPE = 'aws.cognito.signin.user.admin';
 
 const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' &&
-typeof Symbol.for === 'function'
+	typeof Symbol.for === 'function'
 	? Symbol.for('amplify_default')
 	: '@@amplify_default') as Symbol;
 
@@ -232,8 +231,6 @@ export class AuthClass {
 				this._handleAuthResponse(url);
 			});
 		}
-
-		appendToCognitoUserAgent(Platform.userAgent);
 
 		dispatchAuthEvent(
 			'configured',
@@ -1172,7 +1169,7 @@ export class AuthClass {
 						} else {
 							logger.debug(
 								`Unable to get the user data because the ${USER_ADMIN_SCOPE} ` +
-									`is not in the scopes of the access token`
+								`is not in the scopes of the access token`
 							);
 							return res(user);
 						}
@@ -1223,7 +1220,7 @@ export class AuthClass {
 				if (e === 'No userPool') {
 					logger.error(
 						'Cannot get the current user because the user pool is missing. ' +
-							'Please make sure the Auth module is configured with a valid Cognito User Pool ID'
+						'Please make sure the Auth module is configured with a valid Cognito User Pool ID'
 					);
 				}
 				logger.debug('The user is not authenticated by the error', e);
@@ -1772,7 +1769,7 @@ export class AuthClass {
 					logger.warn(`There is already a signed in user: ${loggedInUser} in your app.
 																	You should not call Auth.federatedSignIn method again as it may cause unexpected behavior.`);
 				}
-			} catch (e) {}
+			} catch (e) { }
 
 			const { token, identity_id, expires_at } = response;
 			// Because Credentials.set would update the user info with identity id


### PR DESCRIPTION
_Description of changes:_
- Revert default user agent in Cognito SDK
- Change user agent in `amplify-authenticator` to be component name

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
