### PR TITLE
chore: publish:master does --canary release

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"lint": "lerna run lint",
 		"link-all": "yarn unlink-all && lerna exec --no-bail --parallel yarn link",
 		"unlink-all": "lerna exec --no-bail --parallel -- yarn unlink; exit 0",
-		"publish:master": "lerna publish --conventional-commits --force-publish \"*\" --yes --dist-tag=unstable --preid=unstable --exact",
+		"publish:master": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=unstable --preid=unstable --exact",
 		"publish:beta": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=beta --preid=beta --exact",
 		"publish:release": "lerna publish --conventional-commits --yes --message 'chore(release): Publish [ci skip]'",
 		"publish:1.0-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-1.0 --message 'chore(release): Publish [ci skip]'"


### PR DESCRIPTION
This is necessary so `unstable` doesn't start creating versions ahead of future releases to `latest`.

Reverts 9f2800d20b3a89a01903935fda472d2b7e84067b & 6b1ef79f0766cdc8ece49fd5bfa2485742620d78.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
