### PR TITLE
Explicitly set `responseType` to `blob` rather than using `new Blob`

### DIFF
--- a/packages/storage/src/providers/axios-http-handler.ts
+++ b/packages/storage/src/providers/axios-http-handler.ts
@@ -63,20 +63,13 @@ export class AxiosHttpHandler implements HttpHandler {
 				logger.debug(event);
 			};
 		}
+
+		if (this.httpOptions.bufferBody) {
+			axiosRequest.responseType = 'blob';
+		}
+
 		const raceOfPromises = [
 			axios(axiosRequest).then(response => {
-				// Return the response with buffered body
-				if (this.httpOptions.bufferBody) {
-					return {
-						response: new HttpResponse({
-							headers: response.headers,
-							statusCode: response.status,
-							body: new Blob([response.data]),
-						}),
-					};
-				}
-				// Return the response with streaming body
-
 				return {
 					response: new HttpResponse({
 						headers: response.headers,


### PR DESCRIPTION
`publish:master` was blocked by a failing integration test:

> https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/4324/workflows/69414fdd-8207-4249-a112-2c782191e1ba/jobs/12230

The regression was intermittent, but ultimately was due to iOS not getting a correct `blob` when created via `new Blob([response.data])`.

By using Axios' built-in `responseType: "blob"`, this bypasses the `Blob` bug specific to iOS, returning `null` for `result`:

> ![Screen Shot 2020-03-31 at 6 44 06 PM](https://user-images.githubusercontent.com/15182/78179317-db43a480-7415-11ea-8526-1f6e801e9ca9.png)


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
