### PR TITLE
add React Native testIDs to auth

### DIFF
--- a/packages/aws-amplify-react-native/src/AmplifyTestIDs.js
+++ b/packages/aws-amplify-react-native/src/AmplifyTestIDs.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// Using CJS so these can be used with Detox tests.
+module.exports = {
+	AUTH: {
+		BACK_TO_SIGN_IN_BUTTON: 'aws-amplify__auth--back-to-sign-in-button',
+		CHANGE_PASSWORD_TEXT: 'aws-amplify__auth--change-password-text',
+		CONFIRM_A_CODE_BUTTON: 'aws-amplify__auth--confirm-a-code-button',
+		CONFIRM_BUTTON: 'aws-amplify__auth--confirm-button',
+		CONFIRM_SIGN_IN_TEXT: 'aws-amplify__auth--confirm-sign-in-text',
+		CONFIRM_SIGN_UP_TEXT: 'aws-amplify__auth--confirm-sign-up-text',
+		CONFIRMATION_CODE_INPUT: 'aws-amplify__auth--confirmation-code-input',
+		EMAIL_INPUT: 'aws-amplify__auth--email-input',
+		ERROR_ROW_TEXT: 'aws-amplify__auth--error-row-text',
+		FORGOT_PASSWORD_BUTTON: 'aws-amplify__auth--forgot-password-button',
+		FORGOT_PASSWORD_TEXT: 'aws-amplify__auth--forgot-password-text',
+		GREETING_SIGNED_IN_TEXT: 'aws-amplify__auth--greeting-signed-in-text',
+		GREETING_SIGNED_OUT_TEXT: 'aws-amplify__auth--greeting-signed-out-text',
+		LOADING_TEXT: 'aws-amplify__auth--loading-text',
+		PASSWORD_INPUT: 'aws-amplify__auth--password-input',
+		PHONE_INPUT: 'aws-amplify__auth--phone-input',
+		RESEND_CODE_BUTTON: 'aws-amplify__auth--resend-code-button',
+		SEND_BUTTON: 'aws-amplify__auth--send-button',
+		SIGN_IN_BUTTON: 'aws-amplify__auth--sign-in-button',
+		SIGN_IN_TO_YOUR_ACCOUNT_TEXT:
+			'aws-amplify__auth--sign-in-to-your-account-text',
+		SIGN_OUT_BUTTON: 'aws-amplify__auth--sign-out-button',
+		SIGN_UP_BUTTON: 'aws-amplify__auth--sign-up-button',
+		SIGN_UP_TEXT: 'aws-amplify__auth--sign-up-text',
+		SKIP_BUTTON: 'aws-amplify__auth--skip-button',
+		SUBMIT_BUTTON: 'aws-amplify__auth--submit-button',
+		USERNAME_INPUT: 'aws-amplify__auth--username-input',
+		VERIFY_CONTACT_PICKER: 'aws-amplify__auth--verify-contact-picker',
+		VERIFY_CONTACT_TEXT: 'aws-amplify__auth--verify-contact-text',
+		VERIFY_BUTTON: 'aws-amplify__auth--verify-button',
+	},
+};

--- a/packages/aws-amplify-react-native/src/AmplifyUI.js
+++ b/packages/aws-amplify-react-native/src/AmplifyUI.js
@@ -31,6 +31,7 @@ import AmplifyTheme, {
 } from './AmplifyTheme';
 import { Icon } from 'react-native-elements';
 import countryDialCodes from './CountryDialCodes';
+import TEST_ID from './AmplifyTestIDs';
 
 export const FormField = props => {
 	const theme = props.theme || AmplifyTheme;
@@ -113,10 +114,18 @@ export const SectionFooter = props => {
 	const theme = props.theme || AmplifyTheme;
 	return (
 		<View style={theme.sectionFooter}>
-			<LinkCell theme={theme} onPress={() => onStateChange('confirmSignUp')}>
+			<LinkCell
+				theme={theme}
+				onPress={() => onStateChange('confirmSignUp')}
+				testID={TEST_ID.AUTH.CONFIRM_A_CODE_BUTTON}
+			>
 				{I18n.get('Confirm a Code')}
 			</LinkCell>
-			<LinkCell theme={theme} onPress={() => onStateChange('signIn')}>
+			<LinkCell
+				theme={theme}
+				onPress={() => onStateChange('signIn')}
+				testID={TEST_ID.AUTH.SIGN_IN_BUTTON}
+			>
 				{I18n.get('Sign In')}
 			</LinkCell>
 		</View>
@@ -130,6 +139,7 @@ export const LinkCell = props => {
 			<TouchableHighlight
 				onPress={props.onPress}
 				underlayColor={linkUnderlayColor}
+				testID={props.testID}
 			>
 				<Text style={theme.sectionFooterLink}>{props.children}</Text>
 			</TouchableHighlight>
@@ -141,7 +151,9 @@ export const Header = props => {
 	const theme = props.theme || AmplifyTheme;
 	return (
 		<View style={theme.sectionHeader}>
-			<Text style={theme.sectionHeaderText}>{props.children}</Text>
+			<Text style={theme.sectionHeaderText} testID={props.testID}>
+				{props.children}
+			</Text>
 		</View>
 	);
 };
@@ -152,7 +164,9 @@ export const ErrorRow = props => {
 	return (
 		<View style={theme.errorRow}>
 			<Icon name="warning" color={errorIconColor} />
-			<Text style={theme.errorRowText}>{props.children}</Text>
+			<Text style={theme.errorRowText} testID={TEST_ID.AUTH.ERROR_ROW_TEXT}>
+				{props.children}
+			</Text>
 		</View>
 	);
 };

--- a/packages/aws-amplify-react-native/src/Auth/AuthPiece.js
+++ b/packages/aws-amplify-react-native/src/Auth/AuthPiece.js
@@ -18,6 +18,7 @@ import { Auth, Logger, JS, I18n } from 'aws-amplify';
 import AmplifyTheme from '../AmplifyTheme';
 import AmplifyMessageMap from '../AmplifyMessageMap';
 import { FormField, PhoneField } from '../AmplifyUI';
+import TEST_ID from '../AmplifyTestIDs';
 
 const logger = new Logger('AuthPiece');
 
@@ -62,6 +63,7 @@ export default class AuthPiece extends React.Component {
 					label={I18n.get('Email')}
 					placeholder={I18n.get('Enter your email')}
 					required={true}
+					testID={TEST_ID.AUTH.EMAIL_INPUT}
 					value={value}
 				/>
 			);
@@ -75,6 +77,7 @@ export default class AuthPiece extends React.Component {
 					placeholder={I18n.get('Enter your phone number')}
 					keyboardType="phone-pad"
 					required={true}
+					testID={TEST_ID.AUTH.PHONE_INPUT}
 					value={value}
 				/>
 			);
@@ -86,6 +89,7 @@ export default class AuthPiece extends React.Component {
 					label={I18n.get(this.getUsernameLabel())}
 					placeholder={I18n.get('Enter your username')}
 					required={true}
+					testID={TEST_ID.AUTH.USERNAME_INPUT}
 					value={value}
 				/>
 			);

--- a/packages/aws-amplify-react-native/src/Auth/ConfirmSignIn.js
+++ b/packages/aws-amplify-react-native/src/Auth/ConfirmSignIn.js
@@ -23,6 +23,7 @@ import {
 	Wrapper,
 } from '../AmplifyUI';
 import AuthPiece from './AuthPiece';
+import TEST_ID from '../AmplifyTestIDs';
 
 const logger = new Logger('ConfirmSignIn');
 
@@ -53,7 +54,9 @@ export default class ConfirmSignIn extends AuthPiece {
 		return (
 			<Wrapper>
 				<View style={theme.section}>
-					<Header theme={theme}>{I18n.get('Confirm Sign In')}</Header>
+					<Header theme={theme} testID={TEST_ID.AUTH.CONFIRM_SIGN_IN_TEXT}>
+						{I18n.get('Confirm Sign In')}
+					</Header>
 					<View style={theme.sectionBody}>
 						<FormField
 							theme={theme}
@@ -61,16 +64,22 @@ export default class ConfirmSignIn extends AuthPiece {
 							label={I18n.get('Confirmation Code')}
 							placeholder={I18n.get('Enter your confirmation code')}
 							required={true}
+							testID={TEST_ID.AUTH.CONFIRMATION_CODE_INPUT}
 						/>
 						<AmplifyButton
 							theme={theme}
 							text={I18n.get('Confirm')}
 							onPress={this.confirm}
 							disabled={!this.state.code}
+							testID={TEST_ID.AUTH.CONFIRM_BUTTON}
 						/>
 					</View>
 					<View style={theme.sectionFooter}>
-						<LinkCell theme={theme} onPress={() => this.changeState('signIn')}>
+						<LinkCell
+							theme={theme}
+							onPress={() => this.changeState('signIn')}
+							testID={TEST_ID.AUTH.BACK_TO_SIGN_IN_BUTTON}
+						>
 							{I18n.get('Back to Sign In')}
 						</LinkCell>
 					</View>

--- a/packages/aws-amplify-react-native/src/Auth/ConfirmSignUp.js
+++ b/packages/aws-amplify-react-native/src/Auth/ConfirmSignUp.js
@@ -23,6 +23,7 @@ import {
 	Wrapper,
 } from '../AmplifyUI';
 import AuthPiece from './AuthPiece';
+import TEST_ID from '../AmplifyTestIDs';
 
 const logger = new Logger('ConfirmSignUp');
 
@@ -73,7 +74,9 @@ export default class ConfirmSignUp extends AuthPiece {
 		return (
 			<Wrapper>
 				<View style={theme.section}>
-					<Header theme={theme}>{I18n.get('Confirm Sign Up')}</Header>
+					<Header theme={theme} testID={TEST_ID.AUTH.CONFIRM_SIGN_UP_TEXT}>
+						{I18n.get('Confirm Sign Up')}
+					</Header>
 					<View style={theme.sectionBody}>
 						{this.renderUsernameField(theme, username)}
 						<FormField
@@ -82,12 +85,14 @@ export default class ConfirmSignUp extends AuthPiece {
 							label={I18n.get('Confirmation Code')}
 							placeholder={I18n.get('Enter your confirmation code')}
 							required={true}
+							testID={TEST_ID.AUTH.CONFIRMATION_CODE_INPUT}
 						/>
 						<AmplifyButton
 							theme={theme}
 							text={I18n.get('Confirm')}
 							onPress={this.confirm}
 							disabled={!username || !this.state.code}
+							testID={TEST_ID.AUTH.CONFIRM_BUTTON}
 						/>
 					</View>
 					<View style={theme.sectionFooter}>
@@ -95,10 +100,15 @@ export default class ConfirmSignUp extends AuthPiece {
 							theme={theme}
 							onPress={this.resend}
 							disabled={!this.state.username}
+							testID={TEST_ID.AUTH.RESEND_CODE_BUTTON}
 						>
 							{I18n.get('Resend code')}
 						</LinkCell>
-						<LinkCell theme={theme} onPress={() => this.changeState('signIn')}>
+						<LinkCell
+							theme={theme}
+							onPress={() => this.changeState('signIn')}
+							testID={TEST_ID.AUTH.BACK_TO_SIGN_IN_BUTTON}
+						>
 							{I18n.get('Back to Sign In')}
 						</LinkCell>
 					</View>

--- a/packages/aws-amplify-react-native/src/Auth/ForgotPassword.js
+++ b/packages/aws-amplify-react-native/src/Auth/ForgotPassword.js
@@ -23,6 +23,7 @@ import {
 	Wrapper,
 } from '../AmplifyUI';
 import AuthPiece from './AuthPiece';
+import TEST_ID from '../AmplifyTestIDs';
 
 const logger = new Logger('ForgotPassword');
 
@@ -71,6 +72,7 @@ export default class ForgotPassword extends AuthPiece {
 					theme={theme}
 					onPress={this.send}
 					disabled={!this.getUsernameFromInput()}
+					testID={TEST_ID.AUTH.SEND_BUTTON}
 				/>
 			</View>
 		);
@@ -85,6 +87,7 @@ export default class ForgotPassword extends AuthPiece {
 					label={I18n.get('Confirmation Code')}
 					placeholder={I18n.get('Enter your confirmation code')}
 					required={true}
+					testID={TEST_ID.AUTH.CONFIRMATION_CODE_INPUT}
 				/>
 				<FormField
 					theme={theme}
@@ -93,12 +96,14 @@ export default class ForgotPassword extends AuthPiece {
 					placeholder={I18n.get('Enter your new password')}
 					secureTextEntry={true}
 					required={true}
+					testID={TEST_ID.AUTH.PASSWORD_INPUT}
 				/>
 				<AmplifyButton
 					text={I18n.get('Submit')}
 					theme={theme}
 					onPress={this.submit}
 					disabled={!(this.state.code && this.state.password)}
+					testID={TEST_ID.AUTH.SUBMIT_BUTTON}
 				/>
 			</View>
 		);
@@ -108,13 +113,19 @@ export default class ForgotPassword extends AuthPiece {
 		return (
 			<Wrapper>
 				<View style={theme.section}>
-					<Header theme={theme}>{I18n.get('Forgot Password')}</Header>
+					<Header theme={theme} testID={TEST_ID.AUTH.FORGOT_PASSWORD_TEXT}>
+						{I18n.get('Forgot Password')}
+					</Header>
 					<View style={theme.sectionBody}>
 						{!this.state.delivery && this.forgotBody(theme)}
 						{this.state.delivery && this.submitBody(theme)}
 					</View>
 					<View style={theme.sectionFooter}>
-						<LinkCell theme={theme} onPress={() => this.changeState('signIn')}>
+						<LinkCell
+							theme={theme}
+							onPress={() => this.changeState('signIn')}
+							testID={TEST_ID.AUTH.BACK_TO_SIGN_IN_BUTTON}
+						>
 							{I18n.get('Back to Sign In')}
 						</LinkCell>
 					</View>

--- a/packages/aws-amplify-react-native/src/Auth/Greetings.js
+++ b/packages/aws-amplify-react-native/src/Auth/Greetings.js
@@ -17,6 +17,7 @@ import { Auth, I18n, Logger } from 'aws-amplify';
 import { AmplifyButton } from '../AmplifyUI';
 import AmplifyTheme from '../AmplifyTheme';
 import AuthPiece from './AuthPiece';
+import TEST_ID from '../AmplifyTestIDs';
 
 const logger = new Logger('Greetings');
 
@@ -67,16 +68,27 @@ export default class Greetings extends AuthPiece {
 
 		const content = signedIn ? (
 			<View style={theme.navBar}>
-				<Text style={theme.greetingMessage}>{message}</Text>
+				<Text
+					style={theme.greetingMessage}
+					testID={TEST_ID.AUTH.GREETING_SIGNED_IN_TEXT}
+				>
+					{message}
+				</Text>
 				<AmplifyButton
 					theme={theme}
 					text={I18n.get('Sign Out')}
 					onPress={this.signOut}
 					style={theme.navButton}
+					testID={TEST_ID.AUTH.SIGN_OUT_BUTTON}
 				/>
 			</View>
 		) : (
-			<Text style={theme.greetingMessage}>{message}</Text>
+			<Text
+				style={theme.greetingMessage}
+				testID={TEST_ID.AUTH.GREETING_SIGNED_OUT_TEXT}
+			>
+				{message}
+			</Text>
 		);
 
 		return content;

--- a/packages/aws-amplify-react-native/src/Auth/Loading.js
+++ b/packages/aws-amplify-react-native/src/Auth/Loading.js
@@ -16,6 +16,7 @@ import { View, Text } from 'react-native';
 import { I18n } from 'aws-amplify';
 import AuthPiece from './AuthPiece';
 import { Header } from '../AmplifyUI';
+import TEST_ID from '../AmplifyTestIDs';
 
 export default class Loading extends AuthPiece {
 	constructor(props) {
@@ -27,7 +28,9 @@ export default class Loading extends AuthPiece {
 	showComponent(theme) {
 		return (
 			<View style={theme.section}>
-				<Header theme={theme}>{I18n.get('Loading...')}</Header>
+				<Header theme={theme} testID={TEST_ID.AUTH.LOADING_TEXT}>
+					{I18n.get('Loading...')}
+				</Header>
 			</View>
 		);
 	}

--- a/packages/aws-amplify-react-native/src/Auth/RequireNewPassword.js
+++ b/packages/aws-amplify-react-native/src/Auth/RequireNewPassword.js
@@ -23,6 +23,7 @@ import {
 	Wrapper,
 } from '../AmplifyUI';
 import AuthPiece from './AuthPiece';
+import TEST_ID from '../AmplifyTestIDs';
 
 const logger = new Logger('RequireNewPassword');
 
@@ -79,7 +80,9 @@ export default class RequireNewPassword extends AuthPiece {
 		return (
 			<Wrapper>
 				<ScrollView style={theme.section}>
-					<Header theme={theme}>{I18n.get('Change Password')}</Header>
+					<Header theme={theme} testID={TEST_ID.AUTH.CHANGE_PASSWORD_TEXT}>
+						{I18n.get('Change Password')}
+					</Header>
 					<View style={theme.sectionBody}>
 						<FormField
 							theme={theme}
@@ -107,7 +110,11 @@ export default class RequireNewPassword extends AuthPiece {
 						/>
 					</View>
 					<View style={theme.sectionFooter}>
-						<LinkCell theme={theme} onPress={() => this.changeState('signIn')}>
+						<LinkCell
+							theme={theme}
+							onPress={() => this.changeState('signIn')}
+							testID={TEST_ID.AUTH.BACK_TO_SIGN_IN_BUTTON}
+						>
 							{I18n.get('Back to Sign In')}
 						</LinkCell>
 					</View>

--- a/packages/aws-amplify-react-native/src/Auth/SignIn.js
+++ b/packages/aws-amplify-react-native/src/Auth/SignIn.js
@@ -23,6 +23,7 @@ import {
 	ErrorRow,
 	Wrapper,
 } from '../AmplifyUI';
+import TEST_ID from '../AmplifyTestIDs';
 
 const logger = new Logger('SignIn');
 
@@ -65,7 +66,12 @@ export default class SignIn extends AuthPiece {
 		return (
 			<Wrapper>
 				<View style={theme.section}>
-					<Header theme={theme}>{I18n.get('Sign in to your account')}</Header>
+					<Header
+						theme={theme}
+						testID={TEST_ID.AUTH.SIGN_IN_TO_YOUR_ACCOUNT_TEXT}
+					>
+						{I18n.get('Sign in to your account')}
+					</Header>
 					<View style={theme.sectionBody}>
 						{this.renderUsernameField(theme)}
 						<FormField
@@ -75,22 +81,29 @@ export default class SignIn extends AuthPiece {
 							placeholder={I18n.get('Enter your password')}
 							secureTextEntry={true}
 							required={true}
+							testID={TEST_ID.AUTH.PASSWORD_INPUT}
 						/>
 						<AmplifyButton
 							text={I18n.get('Sign In').toUpperCase()}
 							theme={theme}
 							onPress={this.signIn}
 							disabled={!this.getUsernameFromInput() && this.state.password}
+							testID={TEST_ID.AUTH.SIGN_IN_BUTTON}
 						/>
 					</View>
 					<View style={theme.sectionFooter}>
 						<LinkCell
 							theme={theme}
 							onPress={() => this.changeState('forgotPassword')}
+							testID={TEST_ID.AUTH.FORGOT_PASSWORD_BUTTON}
 						>
 							{I18n.get('Forgot Password')}
 						</LinkCell>
-						<LinkCell theme={theme} onPress={() => this.changeState('signUp')}>
+						<LinkCell
+							theme={theme}
+							onPress={() => this.changeState('signUp')}
+							testID={TEST_ID.AUTH.SIGN_UP_BUTTON}
+						>
 							{I18n.get('Sign Up')}
 						</LinkCell>
 					</View>

--- a/packages/aws-amplify-react-native/src/Auth/SignUp.js
+++ b/packages/aws-amplify-react-native/src/Auth/SignUp.js
@@ -29,6 +29,7 @@ import signUpWithUsernameFields, {
 	signUpWithEmailFields,
 	signUpWithPhoneNumberFields,
 } from './common/default-sign-up-fields';
+import TEST_ID from '../AmplifyTestIDs';
 
 const logger = new Logger('SignUp');
 export default class SignUp extends AuthPiece {
@@ -220,7 +221,9 @@ export default class SignUp extends AuthPiece {
 		return (
 			<Wrapper>
 				<ScrollView style={theme.section}>
-					<Header theme={theme}>{I18n.get(this.header)}</Header>
+					<Header theme={theme} testID={TEST_ID.AUTH.SIGN_UP_TEXT}>
+						{I18n.get(this.header)}
+					</Header>
 					<View style={theme.sectionBody}>
 						{this.signUpFields.map(field => {
 							return field.key !== 'phone_number' ? (
@@ -237,6 +240,7 @@ export default class SignUp extends AuthPiece {
 									label={I18n.get(field.label)}
 									placeholder={I18n.get(field.placeholder)}
 									required={field.required}
+									testID={field.testID}
 								/>
 							) : (
 								<PhoneField
@@ -248,6 +252,7 @@ export default class SignUp extends AuthPiece {
 									keyboardType="phone-pad"
 									required={field.required}
 									defaultDialCode={this.getDefaultDialCode()}
+									testID={field.testID}
 								/>
 							);
 						})}
@@ -256,16 +261,22 @@ export default class SignUp extends AuthPiece {
 							theme={theme}
 							onPress={this.signUp}
 							disabled={!this.isValid}
+							testID={TEST_ID.AUTH.SIGN_UP_BUTTON}
 						/>
 					</View>
 					<View style={theme.sectionFooter}>
 						<LinkCell
 							theme={theme}
 							onPress={() => this.changeState('confirmSignUp')}
+							testID={TEST_ID.AUTH.CONFIRM_A_CODE_BUTTON}
 						>
 							{I18n.get('Confirm a Code')}
 						</LinkCell>
-						<LinkCell theme={theme} onPress={() => this.changeState('signIn')}>
+						<LinkCell
+							theme={theme}
+							onPress={() => this.changeState('signIn')}
+							testID={TEST_ID.AUTH.SIGN_IN_BUTTON}
+						>
 							{I18n.get('Sign In')}
 						</LinkCell>
 					</View>

--- a/packages/aws-amplify-react-native/src/Auth/VerifyContact.js
+++ b/packages/aws-amplify-react-native/src/Auth/VerifyContact.js
@@ -23,6 +23,7 @@ import {
 	Wrapper,
 } from '../AmplifyUI';
 import AuthPiece from './AuthPiece';
+import TEST_ID from '../AmplifyTestIDs';
 
 const logger = new Logger('VerifyContact');
 
@@ -105,6 +106,7 @@ export default class VerifyContact extends AuthPiece {
 				<Picker
 					selectedValue={this.state.pickAttr}
 					onValueChange={(value, index) => this.setState({ pickAttr: value })}
+					testID={TEST_ID.AUTH.VERIFY_CONTACT_PICKER}
 				>
 					<Picker.Item label={I18n.get('Email')} value="email" />
 					<Picker.Item label={I18n.get('Phone Number')} value="phone_number" />
@@ -115,6 +117,7 @@ export default class VerifyContact extends AuthPiece {
 				<Picker
 					selectedValue={this.state.pickAttr}
 					onValueChange={(value, index) => this.setState({ pickAttr: value })}
+					testID={TEST_ID.AUTH.VERIFY_CONTACT_PICKER}
 				>
 					<Picker.Item label={I18n.get('Email')} value="email" />
 				</Picker>
@@ -124,6 +127,7 @@ export default class VerifyContact extends AuthPiece {
 				<Picker
 					selectedValue={this.state.pickAttr}
 					onValueChange={(value, index) => this.setState({ pickAttr: value })}
+					testID={TEST_ID.AUTH.VERIFY_CONTACT_PICKER}
 				>
 					<Picker.Item label={I18n.get('Phone Number')} value="phone_number" />
 				</Picker>
@@ -149,6 +153,7 @@ export default class VerifyContact extends AuthPiece {
 					text={I18n.get('Verify')}
 					onPress={this.verify}
 					disabled={!this.state.pickAttr}
+					testID={TEST_ID.AUTH.VERIFY_BUTTON}
 				/>
 			</View>
 		);
@@ -163,12 +168,14 @@ export default class VerifyContact extends AuthPiece {
 					label={I18n.get('Confirmation Code')}
 					placeholder={I18n.get('Enter your confirmation code')}
 					required={true}
+					testID={TEST_ID.AUTH.CONFIRMATION_CODE_INPUT}
 				/>
 				<AmplifyButton
 					theme={theme}
 					text={I18n.get('Submit')}
 					onPress={this.submit}
 					disabled={!this.state.code}
+					testID={TEST_ID.AUTH.SUBMIT_BUTTON}
 				/>
 			</View>
 		);
@@ -178,13 +185,16 @@ export default class VerifyContact extends AuthPiece {
 		return (
 			<Wrapper>
 				<View style={theme.section}>
-					<Header theme={theme}>{I18n.get('Verify Contact')}</Header>
+					<Header theme={theme} testID={TEST_ID.AUTH.VERIFY_CONTACT_TEXT}>
+						{I18n.get('Verify Contact')}
+					</Header>
 					{!this.state.verifyAttr && this.verifyBody(theme)}
 					{this.state.verifyAttr && this.submitBody(theme)}
 					<View style={theme.sectionFooter}>
 						<LinkCell
 							theme={theme}
 							onPress={() => this.changeState('signedIn')}
+							testID={TEST_ID.AUTH.SKIP_BUTTON}
 						>
 							{I18n.get('Skip')}
 						</LinkCell>

--- a/packages/aws-amplify-react-native/src/Auth/common/default-sign-up-fields.js
+++ b/packages/aws-amplify-react-native/src/Auth/common/default-sign-up-fields.js
@@ -1,3 +1,5 @@
+import TEST_ID from '../../AmplifyTestIDs';
+
 export default [
 	{
 		label: 'Username',
@@ -5,6 +7,7 @@ export default [
 		required: true,
 		placeholder: 'Username',
 		displayOrder: 1,
+		testID: TEST_ID.AUTH.USERNAME_INPUT,
 	},
 	{
 		label: 'Password',
@@ -13,6 +16,7 @@ export default [
 		placeholder: 'Password',
 		type: 'password',
 		displayOrder: 2,
+		testID: TEST_ID.AUTH.PASSWORD_INPUT,
 	},
 	{
 		label: 'Email',
@@ -21,6 +25,7 @@ export default [
 		placeholder: 'Email',
 		type: 'email',
 		displayOrder: 3,
+		testID: TEST_ID.AUTH.EMAIL_INPUT,
 	},
 	{
 		label: 'Phone Number',
@@ -28,6 +33,7 @@ export default [
 		placeholder: 'Phone Number',
 		required: true,
 		displayOrder: 4,
+		testID: TEST_ID.AUTH.PHONE_INPUT,
 	},
 ];
 
@@ -39,6 +45,7 @@ export const signUpWithEmailFields = [
 		placeholder: 'Email',
 		type: 'email',
 		displayOrder: 1,
+		testID: TEST_ID.AUTH.EMAIL_INPUT,
 	},
 	{
 		label: 'Password',
@@ -47,6 +54,7 @@ export const signUpWithEmailFields = [
 		placeholder: 'Password',
 		type: 'password',
 		displayOrder: 2,
+		testID: TEST_ID.AUTH.PASSWORD_INPUT,
 	},
 	{
 		label: 'Phone Number',
@@ -54,6 +62,7 @@ export const signUpWithEmailFields = [
 		placeholder: 'Phone Number',
 		required: true,
 		displayOrder: 3,
+		testID: TEST_ID.AUTH.PHONE_INPUT,
 	},
 ];
 
@@ -64,6 +73,7 @@ export const signUpWithPhoneNumberFields = [
 		placeholder: 'Phone Number',
 		required: true,
 		displayOrder: 1,
+		testID: TEST_ID.AUTH.PHONE_INPUT,
 	},
 	{
 		label: 'Password',
@@ -72,6 +82,7 @@ export const signUpWithPhoneNumberFields = [
 		placeholder: 'Password',
 		type: 'password',
 		displayOrder: 2,
+		testID: TEST_ID.AUTH.PASSWORD_INPUT,
 	},
 	{
 		label: 'Email',
@@ -80,5 +91,6 @@ export const signUpWithPhoneNumberFields = [
 		placeholder: 'Email',
 		type: 'email',
 		displayOrder: 3,
+		testID: TEST_ID.AUTH.EMAIL_INPUT,
 	},
 ];


### PR DESCRIPTION
_Description of changes:_
There are currently no `testID` props on the components from `withAuthenticator` in React Native, which makes end-to-end testing difficult.

This adds the `testID` prop to various components in order to allow the auth workflows to be tested.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
