### PR TITLE
fix(@aws-amplify/api) Export graphql types from @aws-amplify/api/types folder as well

### DIFF
--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -1,0 +1,10 @@
+/**
+ * This exports from the types directory is a temporary workaround, since Amplify CLI  currently
+ * generates code that relies on this import path https://github.com/aws-amplify/amplify-cli/issues/3863
+ * This will be removed in future release when CLI and customers moves to recommeneded import styles.
+ */
+export {
+	graphqlOperation,
+	GraphQLResult,
+	GRAPHQL_AUTH_MODE,
+} from '@aws-amplify/api-graphql';

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 /**
  * This exports from the types directory is a temporary workaround, since Amplify CLI  currently
  * generates code that relies on this import path https://github.com/aws-amplify/amplify-cli/issues/3863


### PR DESCRIPTION
_Issue #, if available:_https://github.com/aws-amplify/amplify-cli/issues/3863

_Description of changes:_Re-Export graphql types from @aws-amplify/api/types folder to maintain backwards compatibility with consumers still using @aws-amplify/api/lib/types style imports.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
