### PR TITLE
Revert formSubmit, add isBrowser check

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-button/amplify-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-button/amplify-button.tsx
@@ -1,6 +1,7 @@
 import { Element, Component, Prop, h } from '@stencil/core';
 import { ButtonTypes, ButtonVariant } from '../../common/types/ui-types';
 import { hasShadowDom } from '../../common/helpers';
+import { browserOrNode } from '@aws-amplify/core';
 
 @Component({
   tag: 'amplify-button',
@@ -32,9 +33,15 @@ export class AmplifyButton {
         const formSection = this.el.closest('amplify-form-section');
         form = formSection && formSection.shadowRoot.querySelector('form');
       }
-      if (form) {
+      if (form && browserOrNode().isBrowser) {
         ev.preventDefault();
-        form.requestSubmit();
+
+        const fakeButton = document.createElement('button');
+        fakeButton.type = this.type;
+        fakeButton.style.display = 'none';
+        form.appendChild(fakeButton);
+        fakeButton.click();
+        fakeButton.remove();
       }
     }
   };

--- a/packages/amplify-ui-components/src/components/amplify-button/amplify-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-button/amplify-button.tsx
@@ -1,7 +1,6 @@
 import { Element, Component, Prop, h } from '@stencil/core';
 import { ButtonTypes, ButtonVariant } from '../../common/types/ui-types';
 import { hasShadowDom } from '../../common/helpers';
-import { browserOrNode } from '@aws-amplify/core';
 
 @Component({
   tag: 'amplify-button',
@@ -33,7 +32,7 @@ export class AmplifyButton {
         const formSection = this.el.closest('amplify-form-section');
         form = formSection && formSection.shadowRoot.querySelector('form');
       }
-      if (form && browserOrNode().isBrowser) {
+      if (form) {
         ev.preventDefault();
 
         const fakeButton = document.createElement('button');


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/issues/5325

_Description of changes:_
- Revert back to simulate form submit with button
- Add browser check for server side rendering

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
