### PR TITLE
Bump jest types version in UI components

### DIFF
--- a/packages/amplify-ui-components/package.json
+++ b/packages/amplify-ui-components/package.json
@@ -46,7 +46,7 @@
     "@storybook/addon-console": "^1.2.1",
     "@storybook/addon-knobs": "^5.2.5",
     "@storybook/html": "^5.2.5",
-    "@types/jest": "24.0.21",
+    "@types/jest": "24.9.1",
     "@types/node": "^12.6.3",
     "@types/puppeteer": "1.19.1",
     "@types/webpack": "^4.4.35",


### PR DESCRIPTION
_Description of changes:_
- Jest types was out of date for stencil's jest tests.. bumping version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
