### PR TITLE
fix(@aws-amplify/ui-react): Exclude files via .npmignore rather than files

### DIFF
--- a/packages/amplify-ui-react/package.json
+++ b/packages/amplify-ui-react/package.json
@@ -12,7 +12,7 @@
 	},
 	"scripts": {
 		"test": "jest",
-    "build-with-test": "npm test && npm run build",
+		"build-with-test": "npm test && npm run build",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",
 		"build:cjs:watch": "node ./build es5 --watch",
@@ -24,9 +24,6 @@
 	"main": "./lib/index.js",
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
-	"files": [
-		"dist/"
-	],
 	"devDependencies": {
 		"@types/react": "^16.0.41",
 		"@types/react-dom": "^16.0.11",


### PR DESCRIPTION
`@aws-amplify/ui-react` whitelisted `files` instead of ignoring:

![Screen Shot 2020-04-08 at 2 16 30 PM](https://user-images.githubusercontent.com/15182/78834540-94205b00-79a3-11ea-8846-246258ffd468.png)

`aws-amplify-react` uses `.npmignore`:

![Screen Shot 2020-04-08 at 2 16 34 PM](https://user-images.githubusercontent.com/15182/78834546-95518800-79a3-11ea-9727-ac8a9e95015c.png)



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
