### PR TITLE
Specific ts-jest tsconfig.json, since ts-jest defaults to <root>/tsconfig.json

### DIFF
--- a/packages/amplify-ui-react/jest.config.js
+++ b/packages/amplify-ui-react/jest.config.js
@@ -1,4 +1,12 @@
 module.exports = {
+	globals: {
+		'ts-jest': {
+			tsConfig: {
+				esModuleInterop: true,
+				jsx: 'react',
+			},
+		},
+	},
 	preset: 'ts-jest',
 	testEnvironment: 'node',
 };


### PR DESCRIPTION
@jordanranz raised an issue with `yarn test` in the project root returning errors:

```console
@aws-amplify/ui-react: FAIL __tests__/withAuthenticator-test.tsx
@aws-amplify/ui-react:   ● Test suite failed to run
@aws-amplify/ui-react:     TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
@aws-amplify/ui-react:     __tests__/withAuthenticator-test.tsx:1:8 - error TS1259: Module '"/Users/jranz/amplify/amplify-js/node_modules/@types/react/index"' can only be default-imported using the 'esModuleInterop' flag
@aws-amplify/ui-react:     1 import React from 'react';
@aws-amplify/ui-react:              ~~~~~
@aws-amplify/ui-react:       ../../node_modules/@types/react/index.d.ts:63:1
@aws-amplify/ui-react:         63 export = React;
@aws-amplify/ui-react:            ~~~~~~~~~~~~~~~
@aws-amplify/ui-react:         This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
@aws-amplify/ui-react:     __tests__/withAuthenticator-test.tsx:3:35 - error TS6142: Module '../src/withAuthenticator' was resolved to '/Users/jranz/amplify/amplify-js/packages/amplify-ui-react/src/withAuthenticator.tsx', but '--jsx' is not set.
@aws-amplify/ui-react:     3 import { withAuthenticator } from '../src/withAuthenticator';
@aws-amplify/ui-react:                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~
@aws-amplify/ui-react:     __tests__/withAuthenticator-test.tsx:5:19 - error TS17004: Cannot use JSX unless the '--jsx' flag is provided.
@aws-amplify/ui-react:     5 const App = () => <h1>My App</h1>;
@aws-amplify/ui-react:                         ~~~~
@aws-amplify/ui-react:     __tests__/withAuthenticator-test.tsx:11:31 - error TS17004: Cannot use JSX unless the '--jsx' flag is provided.
@aws-amplify/ui-react:     11   expect(renderToStaticMarkup(<Wrapped />)).toMatchInlineSnapshot(
@aws-amplify/ui-react:                                      ~~~~~~~~~~~
@aws-amplify/ui-react: Test Suites: 1 failed, 1 total
@aws-amplify/ui-react: Tests:       0 total
@aws-amplify/ui-react: Snapshots:   0 total
@aws-amplify/ui-react: Time:        2.483s
@aws-amplify/ui-react: Ran all test suites.
@aws-amplify/ui-react: error Command failed with exit code 1.
@aws-amplify/ui-react: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I'm unsure how this _wasn't_ a problem with yesterday's release, but I could reproduce locally.


**`ts-jest` didn't have a `tsconfig.json` to reference, causing the failiure**.  Part of the miss is our `./scripts/build.js` inlines tsconfig settings, so there aren't any on the filesystem for our tools to depend on:
> https://stackoverflow.com/a/55081587

This PR adds it inline:
> https://kulshekhar.github.io/ts-jest/user/config/

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
