### PR TITLE
SectionFooterContent should inherit theme prop

### DIFF
--- a/packages/aws-amplify-react/src/AmplifyUI.tsx
+++ b/packages/aws-amplify-react/src/AmplifyUI.tsx
@@ -102,7 +102,7 @@ export const SectionFooter = props => {
 	const p = objectLessAttributes(props, 'theme');
 	return beforeAfter(
 		<div {...p} className="amplify-section-footer" style={style}>
-			<SectionFooterContent>{props.children}</SectionFooterContent>
+			<SectionFooterContent theme={theme}>{props.children}</SectionFooterContent>
 		</div>
 	);
 };


### PR DESCRIPTION
_Issue_ https://github.com/aws-amplify/amplify-js/issues/5355

_Description of changes:_

Add theme property on `SectionFooterContent`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
