### PR TITLE
Link questions to Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Usage Question
     url: https://github.com/aws-amplify/amplify-js/discussions
     about: Ask a question about AWS Amplify usage
-  - name: Feature Request
-    url: https://github.com/aws-amplify/amplify-js/discussions
-    about: Suggest an idea for this project

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Usage Question
+    url: https://github.com/aws-amplify/amplify-js/discussions
+    about: Ask a question about AWS Amplify usage
+  - name: Feature Request
+    url: https://github.com/aws-amplify/amplify-js/discussions
+    about: Suggest an idea for this project

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,6 +3,8 @@
 Temporarily removed/hidden from GitHub's New Issue Chooser while we pilot Discussions:
 > https://github.com/aws-amplify/amplify-js/pull/5361
 
+-->
+
 ---
 name: Feature request
 about: Suggest an idea for this project
@@ -22,5 +24,3 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context, an idea of the implementation or screenshots about the feature request here.
-
--->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,8 @@
+<!--
+
+Temporarily removed/hidden from GitHub's New Issue Chooser while we pilot Discussions:
+> https://github.com/aws-amplify/amplify-js/pull/5361
+
 ---
 name: Feature request
 about: Suggest an idea for this project
@@ -17,3 +22,5 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context, an idea of the implementation or screenshots about the feature request here.
+
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,3 @@
-<!--
-
-Temporarily removed/hidden from GitHub's New Issue Chooser while we pilot Discussions:
-> https://github.com/aws-amplify/amplify-js/pull/5361
-
--->
-
 ---
 name: Feature request
 about: Suggest an idea for this project

--- a/.github/ISSUE_TEMPLATE/usage-question.md
+++ b/.github/ISSUE_TEMPLATE/usage-question.md
@@ -3,6 +3,8 @@
 Temporarily removed/hidden from GitHub's New Issue Chooser while we pilot Discussions:
 > https://github.com/aws-amplify/amplify-js/pull/5361
 
+-->
+
 ---
 name: Usage Question
 about: Ask a question about AWS Amplify usage
@@ -18,4 +20,3 @@ E.g. Cognito, AWS AppSync, etc.
 ** Provide additional details e.g. code snippets **
 E.g. Sample code, versions of Amplify you are using
 
--->

--- a/.github/ISSUE_TEMPLATE/usage-question.md
+++ b/.github/ISSUE_TEMPLATE/usage-question.md
@@ -1,3 +1,8 @@
+<!--
+
+Temporarily removed/hidden from GitHub's New Issue Chooser while we pilot Discussions:
+> https://github.com/aws-amplify/amplify-js/pull/5361
+
 ---
 name: Usage Question
 about: Ask a question about AWS Amplify usage
@@ -12,3 +17,5 @@ E.g. Auth, Predictions, Storage, etc.
 E.g. Cognito, AWS AppSync, etc.
 ** Provide additional details e.g. code snippets **
 E.g. Sample code, versions of Amplify you are using
+
+-->


### PR DESCRIPTION
Currently, https://github.com/aws-amplify/amplify-js/issues/new/choose looks like:
> ![Screen Shot 2020-04-10 at 11 17 53 AM](https://user-images.githubusercontent.com/15182/79013818-627fcf00-7b1e-11ea-84be-a43116498f5e.png)

With this PR, users will instead get links to https://github.com/aws-amplify/amplify-js/discussions like:
> ![Screen Shot 2020-04-10 at 11 20 28 AM](https://user-images.githubusercontent.com/15182/79013847-73304500-7b1e-11ea-829b-34100f13b5b0.png)
> – https://github.com/zeit/next.js/issues/new/choose


Already issues can be converted to Discussions:
> ![Screen Shot 2020-04-10 at 11 55 07 AM](https://user-images.githubusercontent.com/15182/79015709-31090280-7b22-11ea-95a5-b7f64969b2d0.png)

**However**, I'm interested to see how customers leverage it as they go through the issue chooser (or the Discussions tab directly).  We can consider converting questions at a later date.



Reference for `config.yml`:
> https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
