### PR TITLE
feat(@aws-amplify/pubsub) add mokcing support for websocket subscription

### DIFF
--- a/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
@@ -217,6 +217,10 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 		});
 	}
 
+	protected get isSSLEnabled() {
+		return !this.options
+			.aws_appsync_dangerously_connect_to_http_endpoint_for_testing;
+	}
 	private async _startSubscriptionWithAWSAppSyncRealTime({
 		options,
 		observer,
@@ -567,8 +571,10 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 				try {
 					this.socketStatus = SOCKET_STATUS.CONNECTING;
 					// Creating websocket url with required query strings
+					const protocol = this.isSSLEnabled ? 'wss://' : 'ws://';
 					const discoverableEndpoint = appSyncGraphqlEndpoint
-						.replace('https://', 'wss://')
+						.replace('https://', protocol)
+						.replace('http://', protocol)
 						.replace('appsync-api', 'appsync-realtime-api')
 						.replace('gogi-beta', 'grt-beta');
 


### PR DESCRIPTION
Updated the AWSAppSyncRealTime provider to connect to Amplify CLI mock websocket server when local mocking

_Issue #, if available:_
https://github.com/aws-amplify/amplify-cli/issues/3008
_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
