### PR TITLE
fix(analytics): fix Firehose data encoding

### DIFF
--- a/packages/analytics/src/Providers/AWSKinesisFirehoseProvider.ts
+++ b/packages/analytics/src/Providers/AWSKinesisFirehoseProvider.ts
@@ -47,21 +47,15 @@ export class AWSKinesisFirehoseProvider extends AWSKinesisProvider {
 		const records = {};
 
 		group.map(params => {
-			// spit by streamName
+			// split by streamName
 			const evt = params.event;
-			const { streamName } = evt;
+			const { streamName, data } = evt;
 			if (records[streamName] === undefined) {
 				records[streamName] = [];
 			}
 
-			const PartitionKey =
-				evt.partitionKey || `partition-${credentials.identityId}`;
-
-			Object.assign(evt.data, { PartitionKey });
-
-			const data =
-				typeof evt.data === 'string' ? evt.data : JSON.stringify(evt.data);
-			const Data = Buffer.from(data);
+			const bufferData = typeof data === 'string' ? data : JSON.stringify(data);
+			const Data = Buffer.from(bufferData);
 			const record = { Data };
 			records[streamName].push(record);
 		});

--- a/packages/analytics/src/Providers/AWSKinesisFirehoseProvider.ts
+++ b/packages/analytics/src/Providers/AWSKinesisFirehoseProvider.ts
@@ -58,7 +58,10 @@ export class AWSKinesisFirehoseProvider extends AWSKinesisProvider {
 				evt.partitionKey || `partition-${credentials.identityId}`;
 
 			Object.assign(evt.data, { PartitionKey });
-			const Data = Buffer.from(JSON.stringify(evt.data));
+
+			const data =
+				typeof evt.data === 'string' ? evt.data : JSON.stringify(evt.data);
+			const Data = Buffer.from(data);
 			const record = { Data };
 			records[streamName].push(record);
 		});

--- a/packages/analytics/src/Providers/AWSKinesisFirehoseProvider.ts
+++ b/packages/analytics/src/Providers/AWSKinesisFirehoseProvider.ts
@@ -58,7 +58,7 @@ export class AWSKinesisFirehoseProvider extends AWSKinesisProvider {
 				evt.partitionKey || `partition-${credentials.identityId}`;
 
 			Object.assign(evt.data, { PartitionKey });
-			const Data = JSON.stringify(evt.data);
+			const Data = Buffer.from(JSON.stringify(evt.data));
 			const record = { Data };
 			records[streamName].push(record);
 		});

--- a/packages/analytics/src/Providers/AWSKinesisFirehoseProvider.ts
+++ b/packages/analytics/src/Providers/AWSKinesisFirehoseProvider.ts
@@ -54,7 +54,9 @@ export class AWSKinesisFirehoseProvider extends AWSKinesisProvider {
 				records[streamName] = [];
 			}
 
-			const bufferData = typeof data === 'string' ? data : JSON.stringify(data);
+			const bufferData =
+				data && typeof data !== 'string' ? JSON.stringify(data) : data;
+
 			const Data = Buffer.from(bufferData);
 			const record = { Data };
 			records[streamName].push(record);


### PR DESCRIPTION
https://github.com/aws-amplify/amplify-js/issues/5337

Fixes encoding issue when recording to Kinesis Firehose. 
Remove references to `PartitionKey` in `AWSKinesisFirehoseProvider.ts:_sendEvents` as that param is only used by Kinesis, not Firehose.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
