### PR TITLE
set node types version for amplify-ui-angular

### DIFF
--- a/packages/amplify-ui-angular/package.json
+++ b/packages/amplify-ui-angular/package.json
@@ -36,6 +36,7 @@
 	"devDependencies": {
 		"@angular/compiler-cli": "^7.2.1",
 		"@angular/core": "^7.2.1",
+		"@types/node": "^12.12.36",
 		"rollup": "^1.1.2",
 		"rollup-plugin-node-resolve": "^4.0.0",
 		"rxjs": "^6.2.0",


### PR DESCRIPTION
_Description of changes:_
Builds are failing because the latest major version (13.13.0) of `@types/node` released earlier today is being added.
(See error message below)

Even though we are including `"@types/node": "^12.6.3"` in `amplify-ui-components`, it looks like our dependency of `rollup` in `amplify-ui-angular` has a [dependency](https://github.com/rollup/rollup/blob/v1.32.1/package.json#L68) of `"@types/node": "*"`, so the latest version is being used.

It seems that we would want to lock the major version at 12, so this PR is just explicitly setting `@types/node` as a dependency for `amplify-ui-angular`.

```
@aws-amplify/ui-angular: node_modules/@types/node/globals.d.ts(1075,15): error TS2430: Interface 'Require' incorrectly extends interface 'RequireFunction'.
@aws-amplify/ui-angular:   Types of property 'cache' are incompatible.
@aws-amplify/ui-angular:     Type 'Dict<NodeModule>' is not assignable to type '{ [id: string]: NodeModule; }'.
@aws-amplify/ui-angular:       Index signatures are incompatible.
@aws-amplify/ui-angular:         Type 'NodeModule | undefined' is not assignable to type 'NodeModule'.
@aws-amplify/ui-angular:           Type 'undefined' is not assignable to type 'NodeModule'.
@aws-amplify/ui-angular: npm ERR! code ELIFECYCLE
@aws-amplify/ui-angular: npm ERR! errno 1
@aws-amplify/ui-angular: npm ERR! @aws-amplify/ui-angular@0.2.2 build.es2015: `ngc -p tsconfig.json && rollup --config ./scripts/rollup.config.js`
@aws-amplify/ui-angular: npm ERR! Exit status 1
@aws-amplify/ui-angular: npm ERR! 
@aws-amplify/ui-angular: npm ERR! Failed at the @aws-amplify/ui-angular@0.2.2 build.es2015 script.
@aws-amplify/ui-angular: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
@aws-amplify/ui-angular: npm ERR! A complete log of this run can be found in:
@aws-amplify/ui-angular: npm ERR!     /root/.npm/_logs/2020-04-17T22_19_37_866Z-debug.log
@aws-amplify/ui-angular: npm ERR! code ELIFECYCLE
@aws-amplify/ui-angular: npm ERR! errno 1
@aws-amplify/ui-angular: npm ERR! @aws-amplify/ui-angular@0.2.2 build.ng: `npm run build.es2015 && npm run build.es5`
@aws-amplify/ui-angular: npm ERR! Exit status 1
@aws-amplify/ui-angular: npm ERR! 
@aws-amplify/ui-angular: npm ERR! Failed at the @aws-amplify/ui-angular@0.2.2 build.ng script.
@aws-amplify/ui-angular: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
@aws-amplify/ui-angular: npm ERR! A complete log of this run can be found in:
@aws-amplify/ui-angular: npm ERR!     /root/.npm/_logs/2020-04-17T22_19_37_875Z-debug.log
@aws-amplify/ui-angular: error Command failed with exit code 1.
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
