### PR TITLE
fix(@aws-amplify/datastore): Improve query and observe typings

### DIFF
--- a/packages/datastore/__tests__/subscription.test.ts
+++ b/packages/datastore/__tests__/subscription.test.ts
@@ -3,10 +3,11 @@ import {
 	USER_CREDENTIALS,
 } from '../src/sync/processors/subscription';
 import { TransformerMutationType } from '../src/sync/utils';
+import { SchemaModel } from '../src/types';
 
 describe('sync engine subscription module', () => {
 	test('owner authorization', () => {
-		const model = {
+		const model: SchemaModel = {
 			syncable: true,
 			name: 'Post',
 			pluralName: 'Posts',
@@ -75,6 +76,7 @@ describe('sync engine subscription module', () => {
 		};
 
 		expect(
+			// @ts-ignore
 			SubscriptionProcessor.prototype.getAuthorizationInfo(
 				model,
 				TransformerMutationType.CREATE,
@@ -84,7 +86,7 @@ describe('sync engine subscription module', () => {
 		).toEqual(authInfo);
 	});
 	test('group authorization', () => {
-		const model = {
+		const model: SchemaModel = {
 			syncable: true,
 			name: 'Post',
 			pluralName: 'Posts',
@@ -152,6 +154,7 @@ describe('sync engine subscription module', () => {
 		};
 
 		expect(
+			// @ts-ignore
 			SubscriptionProcessor.prototype.getAuthorizationInfo(
 				model,
 				TransformerMutationType.CREATE,
@@ -161,7 +164,7 @@ describe('sync engine subscription module', () => {
 		).toEqual(authInfo);
 	});
 	test('public iam authorization for unauth user', () => {
-		const model = {
+		const model: SchemaModel = {
 			syncable: true,
 			name: 'Post',
 			pluralName: 'Posts',
@@ -210,6 +213,7 @@ describe('sync engine subscription module', () => {
 		};
 
 		expect(
+			// @ts-ignore
 			SubscriptionProcessor.prototype.getAuthorizationInfo(
 				model,
 				TransformerMutationType.CREATE,
@@ -218,7 +222,7 @@ describe('sync engine subscription module', () => {
 		).toEqual(authInfo);
 	});
 	test('private iam authorization for unauth user', () => {
-		const model = {
+		const model: SchemaModel = {
 			syncable: true,
 			name: 'Post',
 			pluralName: 'Posts',
@@ -267,6 +271,7 @@ describe('sync engine subscription module', () => {
 		};
 
 		expect(
+			// @ts-ignore
 			SubscriptionProcessor.prototype.getAuthorizationInfo(
 				model,
 				TransformerMutationType.CREATE,
@@ -275,7 +280,7 @@ describe('sync engine subscription module', () => {
 		).toEqual(null);
 	});
 	test('private iam authorization for auth user', () => {
-		const model = {
+		const model: SchemaModel = {
 			syncable: true,
 			name: 'Post',
 			pluralName: 'Posts',
@@ -324,6 +329,7 @@ describe('sync engine subscription module', () => {
 		};
 
 		expect(
+			// @ts-ignore
 			SubscriptionProcessor.prototype.getAuthorizationInfo(
 				model,
 				TransformerMutationType.CREATE,
@@ -332,7 +338,7 @@ describe('sync engine subscription module', () => {
 		).toEqual(authInfo);
 	});
 	test('public apiKey authorization without credentials', () => {
-		const model = {
+		const model: SchemaModel = {
 			syncable: true,
 			name: 'Post',
 			pluralName: 'Posts',
@@ -381,6 +387,7 @@ describe('sync engine subscription module', () => {
 		};
 
 		expect(
+			// @ts-ignore
 			SubscriptionProcessor.prototype.getAuthorizationInfo(
 				model,
 				TransformerMutationType.CREATE,

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -13,7 +13,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
+    "test": "npm run lint && jest -w 1 --coverage",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",
@@ -22,7 +22,7 @@
     "build": "npm run clean && npm run build:esm && npm run build:cjs",
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
-    "lint": "tslint 'src/**/*.ts'"
+    "lint": "tslint '{__tests__,src}/**/*.ts'"
   },
   "repository": {
     "type": "git",
@@ -51,7 +51,7 @@
   "jest": {
     "globals": {
       "ts-jest": {
-        "diagnostics": false,
+        "diagnostics": true,
         "tsConfig": {
           "lib": [
             "es5",

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -508,7 +508,7 @@ const observe: {
 			? modelOrConstructor
 			: undefined;
 
-	if (modelConstructor === undefined) {
+	if (modelOrConstructor && modelConstructor === undefined) {
 		const model = <T>modelOrConstructor;
 		const modelConstructor =
 			model && (<Object>Object.getPrototypeOf(model)).constructor;

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -488,26 +488,25 @@ const remove: {
 		return deleted;
 	}
 };
-
 const observe: {
-	(): Observable<SubscriptionMessage<any>>;
-	<T extends PersistentModel>(obj: T): Observable<SubscriptionMessage<T>>;
+	(): Observable<SubscriptionMessage<PersistentModel>>;
+
+	<T extends PersistentModel>(model: T): Observable<SubscriptionMessage<T>>;
+
 	<T extends PersistentModel>(
 		modelConstructor: PersistentModelConstructor<T>,
-		id: string
+		criteria?: string | ProducerModelPredicate<T>
 	): Observable<SubscriptionMessage<T>>;
-	<T extends PersistentModel>(
-		modelConstructor: PersistentModelConstructor<T>
-	): Observable<SubscriptionMessage<T>>;
-	<T extends PersistentModel>(
-		modelConstructor: PersistentModelConstructor<T>,
-		criteria: ProducerModelPredicate<T>
-	): Observable<SubscriptionMessage<T>>;
-} = <T extends PersistentModel>(
-	modelConstructor?: PersistentModelConstructor<T>,
+} = <T extends PersistentModel = PersistentModel>(
+	modelOrConstructor?: PersistentModelConstructor<T>,
 	idOrCriteria?: string | ProducerModelPredicate<T>
-) => {
+): Observable<SubscriptionMessage<T>> => {
 	let predicate: ModelPredicate<T>;
+
+	const modelConstructor: PersistentModelConstructor<T> =
+		modelOrConstructor && isValidModelConstructor(modelOrConstructor)
+			? modelOrConstructor
+			: undefined;
 
 	if (idOrCriteria !== undefined && modelConstructor === undefined) {
 		const msg = 'Cannot provide criteria without a modelConstructor';
@@ -530,13 +529,13 @@ const observe: {
 	} else {
 		predicate =
 			modelConstructor &&
-			ModelPredicateCreator.createFromExisting(
+			ModelPredicateCreator.createFromExisting<T>(
 				getModelDefinition(modelConstructor),
 				idOrCriteria
 			);
 	}
 
-	return new Observable<SubscriptionMessage<any>>(observer => {
+	return new Observable<SubscriptionMessage<T>>(observer => {
 		let handle: ZenObservable.Subscription;
 
 		(async () => {
@@ -570,7 +569,7 @@ const query: {
 	modelConstructor: PersistentModelConstructor<T>,
 	idOrCriteria?: string | ProducerModelPredicate<T> | typeof PredicateAll,
 	pagination?: PaginationInput
-) => {
+): Promise<T | T[] | undefined> => {
 	await start();
 	if (!isValidModelConstructor(modelConstructor)) {
 		const msg = 'Constructor is not for a valid model';

--- a/packages/datastore/src/storage/adapter/indexeddb.ts
+++ b/packages/datastore/src/storage/adapter/indexeddb.ts
@@ -343,7 +343,7 @@ class IndexedDBAdapter implements Adapter {
 	}
 
 	private async enginePagination<T>(
-		storeName,
+		storeName: string,
 		pagination?: PaginationInput
 	): Promise<T[]> {
 		let result: T[];
@@ -366,7 +366,7 @@ class IndexedDBAdapter implements Adapter {
 			const hasLimit = typeof limit === 'number' && limit > 0;
 			let moreRecords = true;
 			let itemsLeft = limit;
-			while (moreRecords && cursor.value) {
+			while (moreRecords && cursor && cursor.value) {
 				pageResults.push(cursor.value);
 
 				cursor = await cursor.continue();

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -169,7 +169,7 @@ export type NonModelTypeConstructor<T> = {
 };
 export type PersistentModelConstructor<T extends PersistentModel> = {
 	new (init: ModelInit<T>): T;
-	copyOf(src: T, mutator: (draft: MutableModel<T>) => T | void): T;
+	copyOf(src: T, mutator: (draft: MutableModel<T>) => void): T;
 };
 export type TypeConstructorMap = Record<
 	string,


### PR DESCRIPTION
_Issue #, if available:_
Fixes #5422 

_Description of changes:_
- Improve `query` and `observe` typings. (Types verified with an angular 9 app)
- Validate tests with tslint (`npm run test` will fail when there are compilation errors in test files)

This also includes a small fix to handle an indexeddb cursor when store is empty

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
