### PR TITLE
fix(@aws-amplify/storage) Add contentType and Metadata to multipart upload

### DIFF
--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
     "@aws-amplify/core": "^3.2.3",
-    "axios": "^0.19.0"
+    "axios": "0.19.0"
   },
   "jest": {
     "globals": {

--- a/packages/storage/__tests__/providers/AWSS3ProviderManagedUpload-unit-test.ts
+++ b/packages/storage/__tests__/providers/AWSS3ProviderManagedUpload-unit-test.ts
@@ -171,10 +171,7 @@ describe('multi part upload tests', () => {
 		expect(s3ServiceCallSpy).toBeCalledTimes(4);
 
 		// Create multipart upload call
-		expect(s3ServiceCallSpy.mock.calls[0][0].input).toStrictEqual({
-			Bucket: testParams.Bucket,
-			Key: testParams.Key,
-		});
+		expect(s3ServiceCallSpy.mock.calls[0][0].input).toStrictEqual(testParams);
 
 		// Next two upload parts call
 		expect(s3ServiceCallSpy.mock.calls[1][0].input).toStrictEqual({
@@ -295,10 +292,7 @@ describe('multi part upload tests', () => {
 		expect(s3ServiceCallSpy).toBeCalledTimes(5);
 
 		// Create multipart upload call
-		expect(s3ServiceCallSpy.mock.calls[0][0].input).toStrictEqual({
-			Bucket: testParams.Bucket,
-			Key: testParams.Key,
-		});
+		expect(s3ServiceCallSpy.mock.calls[0][0].input).toStrictEqual(testParams);
 
 		// First call succeeds
 		expect(s3ServiceCallSpy.mock.calls[1][0].input).toStrictEqual({

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -40,7 +40,7 @@
     "@aws-sdk/s3-request-presigner": "1.0.0-beta.3",
     "@aws-sdk/util-create-request": "1.0.0-beta.3",
     "@aws-sdk/util-format-url": "1.0.0-beta.2",
-    "axios": "^0.19.0",
+    "axios": "0.19.0",
     "events": "^3.1.0",
     "sinon": "^7.5.0"
   },

--- a/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
+++ b/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
@@ -30,7 +30,7 @@ import {
 import { AxiosHttpHandler, SEND_PROGRESS_EVENT } from './axios-http-handler';
 import * as events from 'events';
 import { parseUrl } from '@aws-sdk/url-parser-node';
-import { httpHandlerOptions } from './httpHandlerOptions.native';
+import { httpHandlerOptions } from './httpHandlerOptions';
 import { streamCollector } from '@aws-sdk/stream-collector-native';
 
 const logger = new Logger('AWSS3ProviderManagedUpload');
@@ -135,10 +135,9 @@ export class AWSS3ProviderManagedUpload {
 	}
 
 	private async createMultiPartUpload() {
-		const createMultiPartUploadCommand = new CreateMultipartUploadCommand({
-			Bucket: this.params.Bucket,
-			Key: this.params.Key,
-		});
+		const createMultiPartUploadCommand = new CreateMultipartUploadCommand(
+			this.params
+		);
 		const s3 = this._createNewS3Client(this.opts);
 		s3.middlewareStack.remove(SET_CONTENT_LENGTH_HEADER);
 		const response = await s3.send(createMultiPartUploadCommand);

--- a/packages/storage/src/providers/axios-http-handler.ts
+++ b/packages/storage/src/providers/axios-http-handler.ts
@@ -56,7 +56,21 @@ export class AxiosHttpHandler implements HttpHandler {
 		axiosRequest.url = url;
 		axiosRequest.method = request.method as Method;
 		axiosRequest.headers = request.headers;
-		axiosRequest.data = request.body;
+		if (request.body) {
+			axiosRequest.data = request.body;
+		} else {
+			// Fix for https://github.com/aws-amplify/amplify-js/issues/5432
+
+			// If the POST request body is empty but content-type header is set, axios is forcibly removing it
+			// See https://github.com/axios/axios/issues/1535 and refusing to fix it https://github.com/axios/axios/issues/755
+			// This change is a workaround to set the data as null (instead of undefined) to prevent axios from
+			// removing the content-type header. Link for the source code
+			// https://github.com/axios/axios/blob/dc4bc49673943e35280e5df831f5c3d0347a9393/lib/adapters/xhr.js#L121-L123
+
+			if (axiosRequest.headers['Content-Type']) {
+				axiosRequest.data = null;
+			}
+		}
 		if (emitter) {
 			axiosRequest.onUploadProgress = function(event) {
 				emitter.emit(SEND_PROGRESS_EVENT, event);

--- a/packages/storage/src/providers/httpHandlerOptions.ts
+++ b/packages/storage/src/providers/httpHandlerOptions.ts
@@ -1,1 +1,3 @@
-export const httpHandlerOptions = {};
+export const httpHandlerOptions = {
+	bufferBody: false,
+};


### PR DESCRIPTION
_Issue #, if available:_ fixes #5432 

_Description of changes:_
* For multipart uploads, any file properties/metadata are supposed to be added in the CreateMultipartRequest as per the S3 documentation
> If you want to provide any metadata describing the object being uploaded, you must provide it in the request to initiate multipart upload. 
* If the POST request body is empty but content-type header is set, axios is forcibly removing it. See https://github.com/axios/axios/issues/1535 and axios refusing to fix it https://github.com/axios/axios/issues/755. This change is a workaround to set the data as null (instead of undefined) to prevent axios from removing the content-type header. Link for the [source code](https://github.com/axios/axios/blob/dc4bc49673943e35280e5df831f5c3d0347a9393/lib/adapters/xhr.js#L121-L123)


* Because of this workaround, forcing the axios version to avoid newer axios versions breaking this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
