### PR TITLE
Remove headers from the request that axios deems unsafe to set

### DIFF
--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -35,7 +35,7 @@ import * as events from 'events';
 const logger = new Logger('AWSS3Provider');
 
 const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' &&
-	typeof Symbol.for === 'function'
+typeof Symbol.for === 'function'
 	? Symbol.for('amplify_default')
 	: '@@amplify_default') as Symbol;
 
@@ -61,7 +61,6 @@ const dispatchStorageEvent = (
 };
 
 const localTestingStorageEndpoint = 'http://localhost:20005';
-
 /**
  * Provide storage methods to use AWS S3
  */
@@ -295,7 +294,7 @@ export class AWSS3Provider implements StorageProvider {
 					} else {
 						logger.warn(
 							'progressCallback should be a function, not a ' +
-							typeof progressCallback
+								typeof progressCallback
 						);
 					}
 				}

--- a/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
+++ b/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
@@ -37,7 +37,7 @@ const logger = new Logger('AWSS3ProviderManagedUpload');
 
 const localTestingStorageEndpoint = 'http://localhost:20005';
 
-const SET_CONTENT_LENGTH_HEADER = 'SET_CONTENT_LENGTH';
+const SET_CONTENT_LENGTH_HEADER = 'contentLengthMiddleware';
 export declare interface Part {
 	bodyPart: any;
 	partNumber: number;
@@ -139,7 +139,6 @@ export class AWSS3ProviderManagedUpload {
 			this.params
 		);
 		const s3 = this._createNewS3Client(this.opts);
-		s3.middlewareStack.remove(SET_CONTENT_LENGTH_HEADER);
 		const response = await s3.send(createMultiPartUploadCommand);
 		logger.debug(response.UploadId);
 		return response.UploadId;
@@ -162,7 +161,6 @@ export class AWSS3ProviderManagedUpload {
 			};
 			const uploadPartCommand = new UploadPartCommand(uploadPartCommandInput);
 			const s3 = this._createNewS3Client(this.opts, part.emitter);
-			s3.middlewareStack.remove(SET_CONTENT_LENGTH_HEADER);
 			promises.push(s3.send(uploadPartCommand));
 		}
 		try {
@@ -195,7 +193,6 @@ export class AWSS3ProviderManagedUpload {
 		};
 		const completeUploadCommand = new CompleteMultipartUploadCommand(input);
 		const s3 = this._createNewS3Client(this.opts);
-		s3.middlewareStack.remove(SET_CONTENT_LENGTH_HEADER);
 		try {
 			const data = await s3.send(completeUploadCommand);
 			return data.Key;
@@ -239,7 +236,6 @@ export class AWSS3ProviderManagedUpload {
 		};
 
 		const s3 = this._createNewS3Client(this.opts);
-		s3.middlewareStack.remove(SET_CONTENT_LENGTH_HEADER);
 		await s3.send(new AbortMultipartUploadCommand(input));
 
 		// verify that all parts are removed.
@@ -357,6 +353,7 @@ export class AWSS3ProviderManagedUpload {
 			customUserAgent: getAmplifyUserAgent(),
 			urlParser: parseUrl,
 		});
+		client.middlewareStack.remove(SET_CONTENT_LENGTH_HEADER);
 		return client;
 	}
 }

--- a/packages/storage/src/providers/axios-http-handler.ts
+++ b/packages/storage/src/providers/axios-http-handler.ts
@@ -56,6 +56,18 @@ export class AxiosHttpHandler implements HttpHandler {
 		axiosRequest.url = url;
 		axiosRequest.method = request.method as Method;
 		axiosRequest.headers = request.headers;
+
+		// The host header is automatically added by the browser and adding it explicitly in the
+		// axios request throws an error https://github.com/aws-amplify/amplify-js/issues/5376
+		// This is because the host header is a forbidden header for the http client to set
+		// see https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name and
+		// https://fetch.spec.whatwg.org/#forbidden-header-name
+		// The reason we are removing this header here instead of in the aws-sdk's client
+		// middleware is that the host header is required to be in the request signature and if
+		// we remove it from the middlewares, then the request fails because the header is added
+		// by the browser but is absent from the signature.
+		delete axiosRequest.headers['host'];
+
 		if (request.body) {
 			axiosRequest.data = request.body;
 		} else {


### PR DESCRIPTION
_Issue #, if available:_ fixes #5376 

_Description of changes:_

There are two headers that are creating warnings in customer apps `host` and `Content-Length` Both of these headers are forbidden for http clients to set for security reasons, see https://fetch.spec.whatwg.org/#forbidden-header-name and https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name

Both of these headers are set by the browsers automatically based on the request. Host is determined from the url and content length from the body. aws-sdk-js-v3 adds both of these headers in the request (which fetch doesn't seem to create warnings even though it doesn't set it) while axios creates the noise mentioned in the issue #5376 

There are two ways we can remove these headers from being set in axios request, one from the aws-sdk middleware which is responsible for setting the headers and other directly in the axios request. The difference is that removing the middleware header in aws-sdk client causes the sigv4 signature generated without that header and later aws services complain that the header present in the request(added automatically by the browser) is not signed.

However content-length header does not generate such warnings from aws services and hence we are removing it from middlewares and hence from the signature to avoid any conflict between content-length value generated by the browser and by the aws-sdk and resulting in signature mismatch exception.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
