### PR TITLE
Make redirectUrl after oAuth/Federated Sign-in configurable

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -70,7 +70,7 @@ const logger = new Logger('AuthClass');
 const USER_ADMIN_SCOPE = 'aws.cognito.signin.user.admin';
 
 const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' &&
-typeof Symbol.for === 'function'
+	typeof Symbol.for === 'function'
 	? Symbol.for('amplify_default')
 	: '@@amplify_default') as Symbol;
 
@@ -1164,7 +1164,7 @@ export class AuthClass {
 						} else {
 							logger.debug(
 								`Unable to get the user data because the ${USER_ADMIN_SCOPE} ` +
-									`is not in the scopes of the access token`
+								`is not in the scopes of the access token`
 							);
 							return res(user);
 						}
@@ -1215,7 +1215,7 @@ export class AuthClass {
 				if (e === 'No userPool') {
 					logger.error(
 						'Cannot get the current user because the user pool is missing. ' +
-							'Please make sure the Auth module is configured with a valid Cognito User Pool ID'
+						'Please make sure the Auth module is configured with a valid Cognito User Pool ID'
 					);
 				}
 				logger.debug('The user is not authenticated by the error', e);
@@ -1764,7 +1764,7 @@ export class AuthClass {
 					logger.warn(`There is already a signed in user: ${loggedInUser} in your app.
 																	You should not call Auth.federatedSignIn method again as it may cause unexpected behavior.`);
 				}
-			} catch (e) {}
+			} catch (e) { }
 
 			const { token, identity_id, expires_at } = response;
 			// Because Credentials.set would update the user info with identity id
@@ -1878,12 +1878,19 @@ export class AuthClass {
 				currentUser.setSignInUserSession(session);
 				//#endregion
 
-				if (window && typeof window.history !== 'undefined') {
+				if (
+					window && typeof window.history !== 'undefined' &&
+					(this._config.oauth as AwsCognitoOAuthOpts).disableRedirectAfterSignIn !== true
+				) {
+					const replaceStateUrl = (this._config.oauth as AwsCognitoOAuthOpts).redirectAfterSignIn ?
+						(this._config.oauth as AwsCognitoOAuthOpts).redirectAfterSignIn :
+						(this._config.oauth as AwsCognitoOAuthOpts).redirectSignIn;
 					window.history.replaceState(
 						{},
 						null,
-						(this._config.oauth as AwsCognitoOAuthOpts).redirectSignIn
+						replaceStateUrl
 					);
+
 				}
 
 				return credentials;

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -127,6 +127,8 @@ export interface AwsCognitoOAuthOpts {
 	scope: Array<string>;
 	redirectSignIn: string;
 	redirectSignOut: string;
+	disableRedirectAfterSignIn?: boolean;
+	redirectAfterSignIn?: string;
 	responseType: string;
 	options?: object;
 	urlOpener?: (url: string, redirectUrl: string) => Promise<any>;
@@ -207,8 +209,8 @@ export type SignInOpts = UsernamePasswordOpts;
 
 export type ClientMetaData =
 	| {
-			[key: string]: string;
-	  }
+		[key: string]: string;
+	}
 	| undefined;
 
 export function isUsernamePasswordOpts(obj: any): obj is UsernamePasswordOpts {


### PR DESCRIPTION
_Issue #, if available:_

#3391 , #5061 

_Description of changes:_


Added 2 new AwsCognitoOAuthOpts optional parameters:
- disableRedirectAfterSignIn
- redirectAfterSignIn

By setting `disableRedirectAfterSignIn` to true, [replaceState()](https://github.com/pulsedotso/amplify-js/blob/feature/make-redirect-on-sign-in-more-flexible/packages/auth/src/Auth.ts#L1883) method won't be called.

By setting the `redirectAfterSignIn` URL, replaceState() will redirect the user to the custom redirectAfterSignIn URL.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
