### PR TITLE
UI Component - Fix keydown press.

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-email-field/__snapshots__/amplify-email-field.spec.ts.snap
+++ b/packages/amplify-ui-components/src/components/amplify-email-field/__snapshots__/amplify-email-field.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`amplify-email-field spec: Render logic -> should render \`placeholder\`
 exports[`amplify-email-field spec: Render logic -> should render default values by default 1`] = `
 <amplify-email-field>
   <mock:shadow-root>
-    <amplify-form-field fieldid="email" label="Email Address *" placeholder="amplify@example.com" type="email"></amplify-form-field>
+    <amplify-form-field fieldid="email" label="Email Address *" placeholder="Enter your email address" type="email"></amplify-form-field>
   </mock:shadow-root>
 </amplify-email-field>
 `;

--- a/packages/amplify-ui-components/src/components/amplify-input/amplify-input.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-input/amplify-input.tsx
@@ -32,7 +32,7 @@ export class AmplifyInput {
           id={this.fieldId}
           aria-describedby={this.fieldId && this.description ? `${this.fieldId}-description` : null}
           type={this.type}
-          onChange={event => this.handleInputChange(event)}
+          onInput={event => this.handleInputChange(event)}
           placeholder={this.placeholder}
           name={this.name}
           class="input"


### PR DESCRIPTION
_Issue #, if available:_
fix https://github.com/aws-amplify/amplify-js/issues/5512

_Description of changes:_

Refactoring back to `onInput` because of the following.

> change events fire when the user commits a value change to a form control. This may be done, for example, by clicking outside of the control or by using the Tab key to switch to a different control.

https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onchange

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
