### PR TITLE
fix(ui): amplify-input component input change

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-input/amplify-input.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-input/amplify-input.tsx
@@ -32,7 +32,8 @@ export class AmplifyInput {
           id={this.fieldId}
           aria-describedby={this.fieldId && this.description ? `${this.fieldId}-description` : null}
           type={this.type}
-          onInput={event => this.handleInputChange(event)}
+          onChange={this.handleInputChange}
+          onInput={this.handleInputChange}
           placeholder={this.placeholder}
           name={this.name}
           class="input"

--- a/packages/aws-amplify-react/__tests__/__snapshots__/AmplifyUI-test.tsx.snap
+++ b/packages/aws-amplify-react/__tests__/__snapshots__/AmplifyUI-test.tsx.snap
@@ -205,7 +205,9 @@ exports[`AmplifyUi test render SectionFooter correctly 1`] = `
   className="amplify-section-footer"
   style={Object {}}
 >
-  <Component />
+  <Component
+    theme="theme"
+  />
 </div>
 `;
 


### PR DESCRIPTION
Per @sammartinez's suggestion, adding both event handlers. 

The problem with just keeping `onInput` seems to be that `shadowType` (https://github.com/aws-amplify/amplify-js-samples-staging/blob/ui-components/master/cypress/test-utils/amplify-authenticator-tasks.js#L92) doesn't trigger that event. 

The integ tests passed for me when ran locally after this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
