### PR TITLE
Bump react output target version

### DIFF
--- a/packages/amplify-ui-components/package.json
+++ b/packages/amplify-ui-components/package.json
@@ -40,7 +40,7 @@
     "@stencil/angular-output-target": "^0.0.2",
     "@stencil/core": "^1.10.2",
     "@stencil/eslint-plugin": "0.2.1",
-    "@stencil/react-output-target": "^0.0.2",
+    "@stencil/react-output-target": "^0.0.6",
     "@stencil/sass": "^1.1.1",
     "@storybook/addon-a11y": "^5.2.5",
     "@storybook/addon-actions": "^5.2.5",


### PR DESCRIPTION
_Issue #, if available:_
fixes: https://github.com/aws-amplify/amplify-js/issues/5552

_Description of changes:_
- Fix deprecated method warning in React components

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
