### PR TITLE
Upgrade aws-sdk clients to beta.5 which uses exact dependencies

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -39,10 +39,10 @@
   "dependencies": {
     "@aws-amplify/cache": "^3.1.8",
     "@aws-amplify/core": "^3.2.5",
-    "@aws-sdk/client-firehose": "1.0.0-beta.3",
-    "@aws-sdk/client-kinesis": "1.0.0-beta.3",
-    "@aws-sdk/client-personalize-events": "1.0.0-beta.3",
-    "@aws-sdk/client-pinpoint": "1.0.0-beta.3",
+    "@aws-sdk/client-firehose": "1.0.0-beta.5",
+    "@aws-sdk/client-kinesis": "1.0.0-beta.5",
+    "@aws-sdk/client-personalize-events": "1.0.0-beta.5",
+    "@aws-sdk/client-pinpoint": "1.0.0-beta.5",
     "uuid": "^3.2.1"
   },
   "jest": {

--- a/packages/aws-amplify-react/__tests__/__snapshots__/AmplifyUI-test.tsx.snap
+++ b/packages/aws-amplify-react/__tests__/__snapshots__/AmplifyUI-test.tsx.snap
@@ -205,7 +205,9 @@ exports[`AmplifyUi test render SectionFooter correctly 1`] = `
   className="amplify-section-footer"
   style={Object {}}
 >
-  <Component />
+  <Component
+    theme="theme"
+  />
 </div>
 `;
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,12 +46,12 @@
 	},
 	"dependencies": {
 		"@aws-crypto/sha256-js": "1.0.0-alpha.0",
-		"@aws-sdk/client-cognito-identity": "1.0.0-beta.3",
-		"@aws-sdk/credential-provider-cognito-identity": "1.0.0-beta.3",
-		"@aws-sdk/node-http-handler": "1.0.0-beta.2",
-		"@aws-sdk/types": "1.0.0-beta.2",
+		"@aws-sdk/client-cognito-identity": "1.0.0-beta.5",
+		"@aws-sdk/credential-provider-cognito-identity": "1.0.0-beta.5",
+		"@aws-sdk/node-http-handler": "1.0.0-beta.4",
+		"@aws-sdk/types": "1.0.0-beta.4",
 		"@aws-sdk/util-hex-encoding": "1.0.0-beta.2",
-		"@aws-sdk/util-user-agent-browser": "1.0.0-beta.2",
+		"@aws-sdk/util-user-agent-browser": "1.0.0-beta.4",
 		"url": "^0.11.0",
 		"zen-observable-ts": "0.8.19"
 	},

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
     "@aws-amplify/core": "^3.2.5",
-    "@aws-sdk/client-lex-runtime-service": "1.0.0-beta.3"
+    "@aws-sdk/client-lex-runtime-service": "1.0.0-beta.5"
   },
   "jest": {
     "globals": {

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -36,13 +36,13 @@
   "dependencies": {
     "@aws-amplify/core": "^3.2.5",
     "@aws-amplify/storage": "^3.1.8",
-    "@aws-sdk/client-comprehend": "1.0.0-beta.3",
-    "@aws-sdk/client-polly": "1.0.0-beta.3",
-    "@aws-sdk/client-rekognition": "1.0.0-beta.3",
-    "@aws-sdk/client-textract": "1.0.0-beta.3",
-    "@aws-sdk/client-translate": "1.0.0-beta.3",
-    "@aws-sdk/eventstream-marshaller": "1.0.0-beta.2",
-    "@aws-sdk/util-utf8-node": "1.0.0-beta.2",
+    "@aws-sdk/client-comprehend": "1.0.0-beta.5",
+    "@aws-sdk/client-polly": "1.0.0-beta.5",
+    "@aws-sdk/client-rekognition": "1.0.0-beta.5",
+    "@aws-sdk/client-textract": "1.0.0-beta.5",
+    "@aws-sdk/client-translate": "1.0.0-beta.5",
+    "@aws-sdk/eventstream-marshaller": "1.0.0-beta.4",
+    "@aws-sdk/util-utf8-node": "1.0.0-beta.3",
     "uuid": "^3.2.1"
   },
   "jest": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -36,10 +36,10 @@
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
     "@aws-amplify/core": "^3.2.5",
-    "@aws-sdk/client-s3": "1.0.0-beta.3",
-    "@aws-sdk/s3-request-presigner": "1.0.0-beta.3",
-    "@aws-sdk/util-create-request": "1.0.0-beta.3",
-    "@aws-sdk/util-format-url": "1.0.0-beta.2",
+    "@aws-sdk/client-s3": "1.0.0-beta.5",
+    "@aws-sdk/s3-request-presigner": "1.0.0-beta.5",
+    "@aws-sdk/util-create-request": "1.0.0-beta.5",
+    "@aws-sdk/util-format-url": "1.0.0-beta.4",
     "axios": "0.19.0",
     "events": "^3.1.0",
     "sinon": "^7.5.0"


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Beta.5 version of aws-sdk is released which uses exact dependencies instead of loose versioning for dependent aws-sdk dependencies to ensure that new aws-sdk version releases will not impact amplify customers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
