### PR TITLE
fix(@aws-amplify/ui-component) - formField phone_number compose

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
@@ -65,7 +65,7 @@ export class AmplifyForgotPassword {
             {
               type: 'email',
               required: true,
-              handleInputChange: this.handleFormFieldInput('email'),
+              handleInputChange: this.handleFormFieldInputChange('email'),
               inputProps: {
                 'data-test': 'forgot-password-email-input',
               },
@@ -77,7 +77,7 @@ export class AmplifyForgotPassword {
             {
               type: 'phone_number',
               required: true,
-              handleInputChange: this.handleFormFieldInput('phone_number'),
+              handleInputChange: this.handleFormFieldInputChange('phone_number'),
               inputProps: {
                 'data-test': 'forgot-password-phone-number-input',
               },
@@ -90,7 +90,7 @@ export class AmplifyForgotPassword {
             {
               type: 'username',
               required: true,
-              handleInputChange: this.handleFormFieldInput('username'),
+              handleInputChange: this.handleFormFieldInputChange('username'),
               inputProps: {
                 'data-test': 'forgot-password-username-input',
               },
@@ -107,7 +107,7 @@ export class AmplifyForgotPassword {
     }
   }
 
-  private handleFormFieldInput(fieldType) {
+  private handleFormFieldInputChange(fieldType) {
     switch (fieldType) {
       case 'username':
       case 'email':
@@ -128,10 +128,7 @@ export class AmplifyForgotPassword {
       : (event, cb) => {
           cb(event);
         };
-    const callback =
-      field.type === 'phone_number'
-        ? event => (this.forgotPasswordAttrs.userInput = event.target.value)
-        : this.handleFormFieldInput(field.type);
+    const callback = this.handleFormFieldInputChange(field.type);
     fnToCall(event, callback.bind(this));
   }
 
@@ -177,7 +174,7 @@ export class AmplifyForgotPassword {
         {
           type: 'code',
           required: true,
-          handleInputChange: this.handleFormFieldInput('code'),
+          handleInputChange: this.handleFormFieldInputChange('code'),
           inputProps: {
             'data-test': 'forgot-password-code-input',
           },
@@ -185,7 +182,7 @@ export class AmplifyForgotPassword {
         {
           type: 'password',
           required: true,
-          handleInputChange: this.handleFormFieldInput('password'),
+          handleInputChange: this.handleFormFieldInputChange('password'),
           label: 'New password',
           placeholder: 'Enter your new password',
         },

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
@@ -80,7 +80,7 @@ export class AmplifySignIn {
     password: '',
   };
 
-  private handleFormFieldInput(fieldType) {
+  private handleFormFieldInputChange(fieldType) {
     switch (fieldType) {
       case 'username':
       case 'email':
@@ -98,10 +98,7 @@ export class AmplifySignIn {
       : (event, cb) => {
           cb(event);
         };
-    const callback =
-      field.type === 'phone_number'
-        ? event => (this.signInAttributes.userInput = event.target.value)
-        : this.handleFormFieldInput(field.type);
+    const callback = this.handleFormFieldInputChange(field.type);
     fnToCall(event, callback.bind(this));
   }
 
@@ -200,7 +197,7 @@ export class AmplifySignIn {
           formFieldInputs.push({
             type: 'email',
             required: true,
-            handleInputChange: this.handleFormFieldInput('email'),
+            handleInputChange: this.handleFormFieldInputChange('email'),
             inputProps: {
               'data-test': 'sign-in-email-input',
             },
@@ -210,7 +207,7 @@ export class AmplifySignIn {
           formFieldInputs.push({
             type: 'phone_number',
             required: true,
-            handleInputChange: this.handleFormFieldInput('phone_number'),
+            handleInputChange: this.handleFormFieldInputChange('phone_number'),
             inputProps: {
               'data-test': 'sign-in-phone-number-input',
             },
@@ -221,7 +218,7 @@ export class AmplifySignIn {
           formFieldInputs.push({
             type: 'username',
             required: true,
-            handleInputChange: this.handleFormFieldInput('username'),
+            handleInputChange: this.handleFormFieldInputChange('username'),
             inputProps: {
               'data-test': 'sign-in-username-input',
             },
@@ -244,7 +241,7 @@ export class AmplifySignIn {
           </div>
         ),
         required: true,
-        handleInputChange: this.handleFormFieldInput('password'),
+        handleInputChange: this.handleFormFieldInputChange('password'),
         inputProps: {
           'data-test': 'sign-in-password-input',
         },

--- a/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
@@ -97,10 +97,7 @@ export class AmplifySignUp {
       : (event, cb) => {
           cb(event);
         };
-    const callback =
-      field.type === 'phone_number'
-        ? event => (this.signUpAttributes.attributes.phone_number = event.target.value)
-        : this.handleFormFieldInputChange(field.type);
+    const callback = this.handleFormFieldInputChange(field.type);
     fnToCall(event, callback.bind(this));
   }
 


### PR DESCRIPTION
_Issue #, if available:_
Fixes https://github.com/aws-amplify/amplify-js/issues/5298

_Description of changes:_

The phone number formField's value was assigned directly to the user attribute without `composePhoneNumberInput` method being invoked causing the bug. This PR enforces the follow and handle the phone_field follow as intended.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
