### PR TITLE
fix(@aws-amplify/analytics) send the analytics data to kinesis and firehose correctly encoded

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -43,7 +43,7 @@
     "@aws-sdk/client-kinesis": "1.0.0-beta.5",
     "@aws-sdk/client-personalize-events": "1.0.0-beta.5",
     "@aws-sdk/client-pinpoint": "1.0.0-beta.5",
-    "@aws-sdk/util-utf8-browser": "0.1.0-preview.1",
+    "@aws-sdk/util-utf8-browser": "1.0.0-beta.2",
     "uuid": "^3.2.1"
   },
   "jest": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -43,6 +43,7 @@
     "@aws-sdk/client-kinesis": "1.0.0-beta.5",
     "@aws-sdk/client-personalize-events": "1.0.0-beta.5",
     "@aws-sdk/client-pinpoint": "1.0.0-beta.5",
+    "@aws-sdk/util-utf8-browser": "0.1.0-preview.1",
     "uuid": "^3.2.1"
   },
   "jest": {

--- a/packages/analytics/src/Providers/AWSKinesisFirehoseProvider.ts
+++ b/packages/analytics/src/Providers/AWSKinesisFirehoseProvider.ts
@@ -17,6 +17,7 @@ import {
 	PutRecordBatchCommand,
 	FirehoseClient,
 } from '@aws-sdk/client-firehose';
+import { fromUtf8 } from '@aws-sdk/util-utf8-browser';
 
 const logger = new Logger('AWSKineisFirehoseProvider');
 
@@ -56,8 +57,7 @@ export class AWSKinesisFirehoseProvider extends AWSKinesisProvider {
 
 			const bufferData =
 				data && typeof data !== 'string' ? JSON.stringify(data) : data;
-
-			const Data = Buffer.from(bufferData);
+			const Data = fromUtf8(bufferData);
 			const record = { Data };
 			records[streamName].push(record);
 		});

--- a/packages/analytics/src/Providers/AWSKinesisProvider.ts
+++ b/packages/analytics/src/Providers/AWSKinesisProvider.ts
@@ -18,6 +18,7 @@ import {
 } from '@aws-amplify/core';
 import { KinesisClient, PutRecordsCommand } from '@aws-sdk/client-kinesis';
 import { AnalyticsProvider } from '../types';
+import { fromUtf8 } from '@aws-sdk/util-utf8-browser';
 
 const logger = new Logger('AWSKinesisProvider');
 
@@ -174,7 +175,11 @@ export class AWSKinesisProvider implements AnalyticsProvider {
 				records[streamName] = [];
 			}
 
-			const Data = JSON.stringify(evt.data);
+			const bufferData =
+				evt.data && typeof evt.data !== 'string'
+					? JSON.stringify(evt.data)
+					: evt.data;
+			const Data = fromUtf8(bufferData);
 			const PartitionKey =
 				evt.partitionKey || 'partition-' + credentials.identityId;
 			const record = { Data, PartitionKey };


### PR DESCRIPTION
3_Issue #, if available:_ fixes #5544

_Description of changes:_

aws-sdk requires the record format to be a UInt8Array instead of string. This PR converts the string(or a JSON object) to an UInt8Array that is then base64encoded by the aws-sdk before sending to Kinesis or Firehose.

Tested in React and ReactNative

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
