### PR TITLE
fix (aws-amplify-react-native) : analytics warning/error when using auth module

### DIFF
--- a/packages/aws-amplify-react-native/src/Auth/Authenticator.js
+++ b/packages/aws-amplify-react-native/src/Auth/Authenticator.js
@@ -101,13 +101,15 @@ export default class Authenticator extends React.Component {
 			this.props.onStateChange(state, data);
 		}
 
-		switch (state) {
-			case 'signedIn':
-				Analytics.record('_userauth.sign_in');
-				break;
-			case 'signedUp':
-				Analytics.record('_userauth.sign_up');
-				break;
+		if (Analytics._config && Object.entries(Analytics._config).length > 0) {
+			switch (state) {
+				case 'signedIn':
+					Analytics.record('_userauth.sign_in');
+					break;
+				case 'signedUp':
+					Analytics.record('_userauth.sign_up');
+					break;
+			}
 		}
 	}
 


### PR DESCRIPTION
_Issue #, if available:_ fixes #4824 

_Description of changes:_

Checking if the analytics module is configured before making the call for record similar to [this implementation](https://github.com/aws-amplify/amplify-js/blob/b4b40aa62644ea3688068e4e64f4573c568677a0/packages/analytics/src/Analytics.ts#L311)

This will be revisited with rewrite of auth modules in react native. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
