### PR TITLE
Fix : vague error message when sync-retry failed

### DIFF
--- a/packages/core/src/Util/Retry.ts
+++ b/packages/core/src/Util/Retry.ts
@@ -36,10 +36,12 @@ export async function retry(
 	try {
 		return await functionToRetry(...args);
 	} catch (err) {
-		logger.debug(`error on ${functionToRetry.name}: ${err} `);
+		logger.debug(`error on ${functionToRetry.name}: ${JSON.stringify(err)} `);
 
 		if (isNonRetryableError(err)) {
-			logger.debug(`${functionToRetry.name} non retryable error ${err}`);
+			logger.debug(
+				`${functionToRetry.name} non retryable error ${JSON.stringify(err)}`
+			);
 			throw err;
 		}
 


### PR DESCRIPTION
_Issue #, if available:_ #5638

_Description of changes:_

Changing the logging message to convert the error into a string using JSON.stringify, the logger was printing [object object] for retry error messages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
