### PR TITLE
fix(@aws-amplify/api-graphql) Respect additionalHeaders in GraphQLAPI subscription requests

### DIFF
--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -198,7 +198,10 @@ export class GraphQLAPIClass {
 			case 'mutation':
 				return this._graphql({ query, variables, authMode }, additionalHeaders);
 			case 'subscription':
-				return this._graphqlSubscribe({ query, variables, authMode });
+				return this._graphqlSubscribe(
+					{ query, variables, authMode },
+					additionalHeaders
+				);
 		}
 
 		throw new Error(`invalid operation type: ${operationType}`);
@@ -277,11 +280,10 @@ export class GraphQLAPIClass {
 		return response;
 	}
 
-	private _graphqlSubscribe({
-		query,
-		variables,
-		authMode: defaultAuthenticationType,
-	}: GraphQLOptions): Observable<any> {
+	private _graphqlSubscribe(
+		{ query, variables, authMode: defaultAuthenticationType }: GraphQLOptions,
+		additionalHeaders = {}
+	): Observable<any> {
 		const {
 			aws_appsync_region: region,
 			aws_appsync_graphqlEndpoint: appSyncGraphqlEndpoint,
@@ -302,6 +304,7 @@ export class GraphQLAPIClass {
 				region,
 				variables,
 				graphql_headers,
+				additionalHeaders,
 			});
 		} else {
 			logger.debug('No pubsub module applied for subscription');

--- a/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
@@ -234,6 +234,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 			apiKey,
 			region,
 			graphql_headers = () => ({}),
+			additionalHeaders = {},
 		} = options;
 
 		const subscriptionState: SUBSCRIPTION_STATUS = SUBSCRIPTION_STATUS.PENDING;
@@ -263,6 +264,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 				region,
 			})),
 			...(await graphql_headers()),
+			...additionalHeaders,
 			[USER_AGENT_HEADER]: Constants.userAgent,
 		};
 


### PR DESCRIPTION
_Issue #5576_

_Description of changes:_

An `additionalHeaders` object can be supplied to `GraphQLAPI.graphql({query, variables}, additionalHeaders)`, but prior to this PR the option is only respected for query and mutation requests.

In the case of AppSync, these headers are passed to the resolver as input in `context.request.headers`, allowing for queries, mutations, and now subscriptions to be authorized (or execute any custom logic) based on these headers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
