### PR TITLE
Configure all new components or categories when imported

### DIFF
--- a/packages/analytics/__tests__/Analytics-unit-test.ts
+++ b/packages/analytics/__tests__/Analytics-unit-test.ts
@@ -85,16 +85,6 @@ describe('Analytics test', () => {
 			await analytics.startSession();
 			expect(record_spyon).toBeCalled();
 		});
-		test('analytics not configured', async () => {
-			const analytics = new Analytics();
-
-			try {
-				await analytics.startSession();
-			} catch (e) {
-				expect(e.message).toBe('Analytics has not been configured');
-			}
-			expect.assertions(1);
-		});
 	});
 
 	describe('stopSession test', () => {
@@ -106,16 +96,6 @@ describe('Analytics test', () => {
 
 			await analytics.stopSession();
 			expect(record_spyon).toBeCalled();
-		});
-		test('analytics not configured', async () => {
-			const analytics = new Analytics();
-
-			try {
-				await analytics.stopSession();
-			} catch (e) {
-				expect(e.message).toBe('Analytics has not been configured');
-			}
-			expect.assertions(1);
 		});
 	});
 
@@ -133,16 +113,6 @@ describe('Analytics test', () => {
 			});
 			expect(record_spyon).toBeCalled();
 		});
-		test('analytics not configured', async () => {
-			const analytics = new Analytics();
-
-			try {
-				await analytics.record({});
-			} catch (e) {
-				expect(e.message).toBe('Analytics has not been configured');
-			}
-			expect.assertions(1);
-		});
 	});
 
 	describe('updateEndpoint test', () => {
@@ -156,16 +126,6 @@ describe('Analytics test', () => {
 				UserId: 'id',
 			});
 			expect(record_spyon).toBeCalled();
-		});
-		test('analytics not configured', async () => {
-			const analytics = new Analytics();
-
-			try {
-				await analytics.updateEndpoint({});
-			} catch (e) {
-				expect(e.message).toBe('Analytics has not been configured');
-			}
-			expect.assertions(1);
 		});
 	});
 
@@ -198,8 +158,9 @@ describe('Analytics test', () => {
 		test('happy case', () => {
 			const analytics = new Analytics();
 
+			// this provider is added by default in the configure method
+			// of analytics when initialized. No need to add it again here.
 			const provider = new AWSAnalyticsProvider();
-			analytics.addPluggable(provider);
 
 			analytics.removePluggable(provider.getProviderName());
 

--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -129,7 +129,6 @@ export class AnalyticsClass {
 			`The Analytics category has been configured successfully`
 		);
 		logger.debug('current configuration', this._config);
-
 		return this._config;
 	}
 
@@ -234,12 +233,6 @@ export class AnalyticsClass {
 		provider?,
 		metrics?: EventMetrics
 	) {
-		if (!this.isAnalyticsConfigured()) {
-			const errMsg = 'Analytics has not been configured';
-			logger.debug(errMsg);
-			return Promise.reject(new Error(errMsg));
-		}
-
 		let params = null;
 		// this is just for compatibility, going to be deprecated
 		if (typeof event === 'string') {
@@ -264,12 +257,6 @@ export class AnalyticsClass {
 	}
 
 	private _sendEvent(params) {
-		if (!this.isAnalyticsConfigured()) {
-			const errMsg = 'Analytics has not been configured';
-			logger.debug(errMsg);
-			return Promise.reject(new Error(errMsg));
-		}
-
 		if (this._disabled) {
 			logger.debug('Analytics has been disabled');
 			return Promise.resolve();
@@ -306,10 +293,6 @@ export class AnalyticsClass {
 		} else {
 			tracker.configure(opts);
 		}
-	}
-
-	private isAnalyticsConfigured() {
-		return this._config && Object.entries(this._config).length > 0;
 	}
 }
 

--- a/packages/api-rest/__tests__/RestAPI-test.ts
+++ b/packages/api-rest/__tests__/RestAPI-test.ts
@@ -482,22 +482,6 @@ describe('Rest API test', () => {
 			await api.get('apiName', 'path', 'init');
 			expect(spyon4).toBeCalled();
 		});
-
-		test('no restclient instance', async () => {
-			const api = new API(config);
-			const spyon = jest
-				.spyOn(API.prototype, 'createInstance')
-				.mockImplementationOnce(() => {
-					return Promise.reject('err');
-				});
-
-			expect.assertions(1);
-			try {
-				await api.get('apiName', 'path', 'init');
-			} catch (e) {
-				expect(e).toBe('err');
-			}
-		});
 	});
 
 	describe('post test', () => {
@@ -588,22 +572,6 @@ describe('Rest API test', () => {
 			await api.post('apiName', 'path', 'init');
 			expect(spyon4).toBeCalled();
 		});
-
-		test('no restclient instance', async () => {
-			const api = new API(config);
-			const spyon = jest
-				.spyOn(API.prototype, 'createInstance')
-				.mockImplementationOnce(() => {
-					return Promise.reject('err');
-				});
-
-			expect.assertions(1);
-			try {
-				await api.post('apiName', 'path', 'init');
-			} catch (e) {
-				expect(e).toBe('err');
-			}
-		});
 	});
 
 	describe('put test', () => {
@@ -685,22 +653,6 @@ describe('Rest API test', () => {
 			expect.assertions(1);
 			await api.put('apiName', 'path', 'init');
 			expect(spyon4).toBeCalled();
-		});
-
-		test('no restclient instance', async () => {
-			const api = new API(config);
-			const spyon = jest
-				.spyOn(API.prototype, 'createInstance')
-				.mockImplementationOnce(() => {
-					return Promise.reject('err');
-				});
-
-			expect.assertions(1);
-			try {
-				await api.put('apiName', 'path', 'init');
-			} catch (e) {
-				expect(e).toBe('err');
-			}
 		});
 	});
 
@@ -784,22 +736,6 @@ describe('Rest API test', () => {
 			await api.patch('apiName', 'path', 'init');
 			expect(spyon4).toBeCalled();
 		});
-
-		test('no restclient instance', async () => {
-			const api = new API(config);
-			const spyon = jest
-				.spyOn(API.prototype, 'createInstance')
-				.mockImplementationOnce(() => {
-					return Promise.reject('err');
-				});
-
-			expect.assertions(1);
-			try {
-				await api.patch('apiName', 'path', 'init');
-			} catch (e) {
-				expect(e).toBe('err');
-			}
-		});
 	});
 
 	describe('del test', () => {
@@ -881,22 +817,6 @@ describe('Rest API test', () => {
 			expect.assertions(1);
 			await api.del('apiName', 'path', 'init');
 			expect(spyon4).toBeCalled();
-		});
-
-		test('no restclient instance', async () => {
-			const api = new API(config);
-			const spyon = jest
-				.spyOn(API.prototype, 'createInstance')
-				.mockImplementationOnce(() => {
-					return Promise.reject('err');
-				});
-
-			expect.assertions(1);
-			try {
-				await api.del('apiName', 'path', 'init');
-			} catch (e) {
-				expect(e).toBe('err');
-			}
 		});
 	});
 
@@ -980,22 +900,6 @@ describe('Rest API test', () => {
 			await api.head('apiName', 'path', 'init');
 			expect(spyon4).toBeCalled();
 		});
-
-		test('no restclient instance', async () => {
-			const api = new API(config);
-			const spyon = jest
-				.spyOn(API.prototype, 'createInstance')
-				.mockImplementationOnce(() => {
-					return Promise.reject('err');
-				});
-
-			expect.assertions(1);
-			try {
-				await api.head('apiName', 'path', 'init');
-			} catch (e) {
-				expect(e).toBe('err');
-			}
-		});
 	});
 
 	describe('endpoint test', () => {
@@ -1010,22 +914,6 @@ describe('Rest API test', () => {
 			await api.endpoint('apiName');
 
 			expect(spyon).toBeCalledWith('apiName');
-		});
-
-		test('no restclient instance', async () => {
-			const api = new API(config);
-			const spyon = jest
-				.spyOn(API.prototype, 'createInstance')
-				.mockImplementationOnce(() => {
-					return Promise.reject('err');
-				});
-
-			expect.assertions(1);
-			try {
-				await api.endpoint('apiName');
-			} catch (e) {
-				expect(e).toBe('err');
-			}
 		});
 	});
 });

--- a/packages/api-rest/src/RestAPI.ts
+++ b/packages/api-rest/src/RestAPI.ts
@@ -92,12 +92,8 @@ export class RestAPIClass {
 	 */
 	createInstance() {
 		logger.debug('create Rest API instance');
-		if (this._options) {
-			this._api = new RestClient(this._options);
-			return true;
-		} else {
-			return Promise.reject('API not configured');
-		}
+		this._api = new RestClient(this._options);
+		return true;
 	}
 
 	/**
@@ -108,14 +104,6 @@ export class RestAPIClass {
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
 	async get(apiName, path, init) {
-		if (!this._api) {
-			try {
-				await this.createInstance();
-			} catch (error) {
-				return Promise.reject(error);
-			}
-		}
-
 		const endpoint = this._api.endpoint(apiName);
 		if (endpoint.length === 0) {
 			return Promise.reject('API ' + apiName + ' does not exist');
@@ -131,14 +119,6 @@ export class RestAPIClass {
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
 	async post(apiName, path, init) {
-		if (!this._api) {
-			try {
-				await this.createInstance();
-			} catch (error) {
-				return Promise.reject(error);
-			}
-		}
-
 		const endpoint = this._api.endpoint(apiName);
 		if (endpoint.length === 0) {
 			return Promise.reject('API ' + apiName + ' does not exist');
@@ -154,14 +134,6 @@ export class RestAPIClass {
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
 	async put(apiName, path, init) {
-		if (!this._api) {
-			try {
-				await this.createInstance();
-			} catch (error) {
-				return Promise.reject(error);
-			}
-		}
-
 		const endpoint = this._api.endpoint(apiName);
 		if (endpoint.length === 0) {
 			return Promise.reject('API ' + apiName + ' does not exist');
@@ -177,14 +149,6 @@ export class RestAPIClass {
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
 	async patch(apiName, path, init) {
-		if (!this._api) {
-			try {
-				await this.createInstance();
-			} catch (error) {
-				return Promise.reject(error);
-			}
-		}
-
 		const endpoint = this._api.endpoint(apiName);
 		if (endpoint.length === 0) {
 			return Promise.reject('API ' + apiName + ' does not exist');
@@ -200,14 +164,6 @@ export class RestAPIClass {
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
 	async del(apiName, path, init) {
-		if (!this._api) {
-			try {
-				await this.createInstance();
-			} catch (error) {
-				return Promise.reject(error);
-			}
-		}
-
 		const endpoint = this._api.endpoint(apiName);
 		if (endpoint.length === 0) {
 			return Promise.reject('API ' + apiName + ' does not exist');
@@ -223,14 +179,6 @@ export class RestAPIClass {
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
 	async head(apiName, path, init) {
-		if (!this._api) {
-			try {
-				await this.createInstance();
-			} catch (error) {
-				return Promise.reject(error);
-			}
-		}
-
 		const endpoint = this._api.endpoint(apiName);
 		if (endpoint.length === 0) {
 			return Promise.reject('API ' + apiName + ' does not exist');
@@ -244,13 +192,6 @@ export class RestAPIClass {
 	 * @return {string} - The endpoint of the api
 	 */
 	async endpoint(apiName) {
-		if (!this._api) {
-			try {
-				await this.createInstance();
-			} catch (error) {
-				return Promise.reject(error);
-			}
-		}
 		return this._api.endpoint(apiName);
 	}
 }

--- a/packages/api-rest/src/RestClient.ts
+++ b/packages/api-rest/src/RestClient.ts
@@ -46,7 +46,6 @@ export class RestClient {
 	 * @param {RestClientOptions} [options] - Instance options
 	 */
 	constructor(options: apiOptions) {
-		const { endpoints } = options;
 		this._options = options;
 		logger.debug('API Options', this._options);
 	}

--- a/packages/api/__tests__/API-test.ts
+++ b/packages/api/__tests__/API-test.ts
@@ -6,10 +6,10 @@ describe('API test', () => {
 	test('configure', () => {
 		jest
 			.spyOn(RestAPIClass.prototype, 'configure')
-			.mockReturnValueOnce({ restapi: 'configured' });
+			.mockReturnValue({ restapi: 'configured' });
 		jest
 			.spyOn(GraphQLAPIClass.prototype, 'configure')
-			.mockReturnValueOnce({ graphqlapi: 'configured' });
+			.mockReturnValue({ graphqlapi: 'configured' });
 		const api = new API(null);
 		expect(api.configure(null)).toStrictEqual({
 			graphqlapi: 'configured',

--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -1453,7 +1453,7 @@ describe('auth unit test', () => {
 		test('happy case with source federation', async () => {
 			const spyon = jest
 				.spyOn(StorageHelper.prototype, 'getStorage')
-				.mockImplementationOnce(() => {
+				.mockImplementation(() => {
 					return {
 						setItem() {},
 						getItem() {
@@ -1538,7 +1538,7 @@ describe('auth unit test', () => {
 		test('with federated info', async () => {
 			const spyon = jest
 				.spyOn(StorageHelper.prototype, 'getStorage')
-				.mockImplementationOnce(() => {
+				.mockImplementation(() => {
 					return {
 						setItem() {},
 						getItem() {
@@ -1569,7 +1569,7 @@ describe('auth unit test', () => {
 		test('with cognito session', async () => {
 			const spyon = jest
 				.spyOn(StorageHelper.prototype, 'getStorage')
-				.mockImplementationOnce(() => {
+				.mockImplementation(() => {
 					return {
 						setItem() {},
 						getItem() {
@@ -1603,7 +1603,7 @@ describe('auth unit test', () => {
 		test('with guest', async () => {
 			const spyon = jest
 				.spyOn(StorageHelper.prototype, 'getStorage')
-				.mockImplementationOnce(() => {
+				.mockImplementation(() => {
 					return {
 						setItem() {},
 						getItem() {
@@ -1637,7 +1637,7 @@ describe('auth unit test', () => {
 		test('json parse error', async () => {
 			const spyon = jest
 				.spyOn(StorageHelper.prototype, 'getStorage')
-				.mockImplementationOnce(() => {
+				.mockImplementation(() => {
 					return {
 						setItem() {},
 						getItem() {
@@ -1858,7 +1858,7 @@ describe('auth unit test', () => {
 		beforeAll(() => {
 			jest
 				.spyOn(StorageHelper.prototype, 'getStorage')
-				.mockImplementationOnce(() => {
+				.mockImplementation(() => {
 					return {
 						setItem() {},
 						getItem() {},

--- a/packages/core/__tests__/Amplify-test.ts
+++ b/packages/core/__tests__/Amplify-test.ts
@@ -1,6 +1,17 @@
 import Amplify from '../src';
 
 describe('Amplify config test', () => {
+	test('empty config', () => {
+		const mockComp = {
+			configure: jest.fn(),
+		};
+
+		Amplify.register(mockComp);
+		const res = Amplify.configure(null);
+
+		expect(mockComp.configure).toBeCalledWith({});
+	});
+
 	test('happy case', () => {
 		const mockComp = {
 			configure: jest.fn(),
@@ -10,20 +21,8 @@ describe('Amplify config test', () => {
 		const res = Amplify.configure({
 			attr: 'attr',
 		});
-
 		expect(mockComp.configure).toBeCalled();
 		expect(res).toEqual({ attr: 'attr' });
-	});
-
-	test('empty config', () => {
-		const mockComp = {
-			configure: jest.fn(),
-		};
-
-		Amplify.register(mockComp);
-		const res = Amplify.configure(null);
-
-		expect(mockComp.configure).not.toBeCalled();
 	});
 });
 
@@ -35,6 +34,7 @@ describe('addPluggable test', () => {
 
 		const mockComp = {
 			addPluggable: jest.fn(),
+			configure: jest.fn(),
 		};
 
 		Amplify.register(mockComp);

--- a/packages/core/__tests__/Credentials-test.ts
+++ b/packages/core/__tests__/Credentials-test.ts
@@ -8,6 +8,9 @@ const authClass = {
 	currentUserCredentials() {
 		return Promise.resolve('cred');
 	},
+	configure(config: any) {
+		return config;
+	},
 };
 
 const cacheClass = {
@@ -16,6 +19,9 @@ const cacheClass = {
 	},
 	getItem() {
 		return null;
+	},
+	configure(config: any) {
+		return config;
 	},
 };
 

--- a/packages/core/src/Amplify.ts
+++ b/packages/core/src/Amplify.ts
@@ -33,6 +33,14 @@ export class Amplify {
 		} else {
 			logger.debug('no getModuleName method for component', comp);
 		}
+
+		// Finally configure this new component(category) loaded
+		// With the new modularization changes in Amplify V3, all the Amplify
+		// component are not loaded/registered right away but when they are
+		// imported (and hence instantiated) in the client's app. This ensures
+		// that all new components imported get correctly configured with the
+		// configuration that Amplify.configure() was called with.
+		comp.configure(this._config);
 	}
 
 	static configure(config) {


### PR DESCRIPTION
_Issue #, if available:_ #5671, 

_Description of changes:_ 

## What
This change is to call configure() and apply current _"Amplify"_ configuration to all the new categories imported or initialized (especially when imported in a UI component). For instance the following App code will work with the change which right now throws exception "Auth module is not configured"
```
...
import { withAuthenticator } from "@aws-amplify/ui-react";
import awsconfig from './aws-exports';

import Amplify from '@aws-amplify/core';
Amplify.configure(awsconfig);

function App() {
  return (
    <div className="App">
      <header className="App-header">
            ...
      </header>
    </div>
  );
}

export default withAuthenticator(App);

```

## Why
After the modularization updates, when an `Amplify.configure()` is called, not all the modules/categories are imported/initialized and hence `Amplify.configure()` misses these categories that are later imported in the App and initialized. 

For instance if users are using UI-components which import Auth (or other categories) and users don't import Auth category directly in the file where `Amplify.configure()` is called, it results in Auth category to not be configured with the aws_exports.

## Assumptions and side effects
This operation `comp.configure(this._config);` is safe with the assumption that all categories' configure() method is idempotent and non-destructive

This also means that categories will always start out configured with default values and hence a lot of redundant code and tests are removed that expect configure is not yet called on a new category imported/initialized.

## Tested
I've tested this PR with the above code and the existing apps with various types of import styles such as

* No root level imports and using Auth UI components
```
import Amplify from '@aws-amplify/core';
import Storage from '@aws-amplify/storage`;
import { withAuthenticator } from "@aws-amplify/ui-react";

Amplify.configure(aws_exports);

// Works now after this change (before Auth was not configured but storage was)
```

* No root level imports and importing category in a different file
```
// App.js
import Amplify from '@aws-amplify/core';
Amplify.configure(aws_exports);

// upload.js
import Storage from '@aws-amplify/storage`;
Storage.put();

// Works now after this change (before this change Storage was not configured)
```

* No root level imports and not using any Auth UI components
```
import Amplify from '@aws-amplify/core';
import Storage from '@aws-amplify/storage`;

Amplify.configure(aws_exports);

// Results in Auth module not present, same as V2 as Auth is needed for guest access still
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
