### PR TITLE
fix(@aws-amplify/ui-components): formFields hint handle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ executors:
     docker:
       - image: cypress/base:12.16.1
     resource_class: large
+    working_directory: ~/amplify-js
 
   js-test-executor:
     docker:
@@ -71,7 +72,23 @@ commands:
             git config --global user.name $NPM_USER
             git status
             git --no-pager diff
-            ./node_modules/lerna/cli.js publish --no-push --canary --yes --dist-tag=unstable --preid=unstable --exact --force-publish
+            ./node_modules/lerna/cli.js publish --no-push --canary minor --dist-tag=unstable --preid=unstable --exact --force-publish --yes
+
+  prepare_test_env:
+    steps:
+      - attach_workspace:
+          at: /root
+      - restore_cache:
+          key: amplify-js-{{ .Branch }}-{{ checksum "~/amplify-js-samples-staging/yarn.lock" }}
+      - publish_to_verdaccio
+
+  prepare_ui_test_env:
+    steps:
+      - attach_workspace:
+          at: /root
+      - restore_cache:
+          key: amplify-js-ui
+      - publish_to_verdaccio
 
   integ_test_js:
     parameters:
@@ -82,11 +99,6 @@ commands:
       spec:
         type: string
     steps:
-      - attach_workspace:
-          at: /root
-      - restore_cache:
-          key: amplify-js-{{ .Branch }}-{{ checksum "~/amplify-js-samples-staging/yarn.lock" }}
-      - publish_to_verdaccio
       - run:
           name: 'Install << parameters.test_name >> sample'
           command: |
@@ -117,19 +129,14 @@ commands:
       sample_name:
         type: string
       spec:
-        # optional
-        # the script will use sample_name by default
+        # optional - the script will use sample_name by default
         type: string
         default: ''
     steps:
-      - attach_workspace:
-          at: /root
-      - restore_cache:
-          key: amplify-js-ui
-      - publish_to_verdaccio
       - run:
           name: 'Install << parameters.test_name >> sample'
           command: |
+            cd << parameters.framework >>/<< parameters.category >>/<< parameters.sample_name >>
             echo "Current NPM registry: " $(yarn config get registry)
             yarn
       - run:
@@ -205,7 +212,6 @@ commands:
 jobs:
   build:
     executor: build-executor
-    working_directory: ~/amplify-js
     steps:
       - checkout
       - run: yarn config set workspaces-experimental true
@@ -224,7 +230,6 @@ jobs:
 
   unit_test:
     executor: build-executor
-    working_directory: ~/amplify-js
     steps:
       - attach_workspace:
           at: /root
@@ -274,6 +279,7 @@ jobs:
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react/auth/with-authenticator
     steps:
+      - prepare_test_env
       - integ_test_js:
           test_name: 'React Authenticator'
           framework: react
@@ -284,6 +290,7 @@ jobs:
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/angular/auth/amplify-authenticator
     steps:
+      - prepare_test_env
       - integ_test_js:
           test_name: 'Angular Authenticator'
           framework: angular
@@ -294,6 +301,7 @@ jobs:
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/vue/auth/amplify-authenticator
     steps:
+      - prepare_test_env
       - integ_test_js:
           test_name: 'Vue Authenticator'
           framework: vue
@@ -304,6 +312,7 @@ jobs:
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react/predictions/multi-user-translation
     steps:
+      - prepare_test_env
       - integ_test_js:
           test_name: 'React Predictions'
           framework: react
@@ -334,35 +343,68 @@ jobs:
   integ_react_auth_ui:
     executor: js-test-executor
     <<: *test_env_vars
-    working_directory: ~/amplify-js-samples-staging-ui/samples/react/auth/amplify-authenticator
+    working_directory: ~/amplify-js-samples-staging-ui/samples
     steps:
+      - prepare_ui_test_env
       - integ_test_ui:
           test_name: 'React Authenticator'
           framework: react
           category: auth
           sample_name: amplify-authenticator
+      - integ_test_ui:
+          test_name: 'React Typescript Authenticator'
+          framework: react
+          category: auth
+          sample_name: typescript-amplify-authenticator
+          spec: amplify-authenticator
+      - integ_test_ui:
+          test_name: 'React Custom Authenticator'
+          framework: react
+          category: auth
+          sample_name: amplify-authenticator
+          spec: custom-authenticator
+      - integ_test_ui:
+          test_name: 'React Custom Authenticator'
+          framework: react
+          category: auth
+          sample_name: with-authenticator
+          spec: amplify-authenticator
 
   integ_angular_auth_ui:
     executor: js-test-executor
     <<: *test_env_vars
-    working_directory: ~/amplify-js-samples-staging-ui/samples/angular/auth/amplify-authenticator
+    working_directory: ~/amplify-js-samples-staging-ui/samples
     steps:
+      - prepare_ui_test_env
       - integ_test_ui:
           test_name: 'Angular Authenticator'
           framework: angular
           category: auth
           sample_name: amplify-authenticator
+      - integ_test_ui:
+          test_name: 'Angular Custom Authenticator'
+          framework: angular
+          category: auth
+          sample_name: amplify-authenticator
+          spec: custom-authenticator
 
   integ_vue_auth_ui:
     executor: js-test-executor
     <<: *test_env_vars
-    working_directory: ~/amplify-js-samples-staging-ui/samples/vue/auth/amplify-authenticator
+    working_directory: ~/amplify-js-samples-staging-ui/samples
     steps:
+      - prepare_ui_test_env
       - integ_test_ui:
           test_name: 'Vue Authenticator'
           framework: vue
           category: auth
           sample_name: amplify-authenticator
+      - integ_test_ui:
+          test_name: 'Vue Custom Authenticator'
+          framework: vue
+          category: auth
+          sample_name: amplify-authenticator
+          spec: custom-authenticator
 
   integ_rn_ios_storage:
     executor: ios-executor
@@ -398,7 +440,6 @@ jobs:
 
   post_release:
     executor: build-executor
-    working_directory: ~/amplify-js
     steps:
       - attach_workspace:
           at: /root

--- a/packages/amplify-ui-components/src/common/helpers.ts
+++ b/packages/amplify-ui-components/src/common/helpers.ts
@@ -59,16 +59,11 @@ export const onAuthUIStateChange = (authStateHandler: AuthStateHandler) => {
         }
         break;
     }
-  }
+  };
   Hub.listen(UI_AUTH_CHANNEL, authUIStateHandler);
   return () => Hub.remove(UI_AUTH_CHANNEL, authUIStateHandler);
-}
+};
 
-export const handleAuthFormFieldHint = (field) => {
-  if(field["hint"] === null || typeof field["hint"] === "string"){
-    return false;
-  }
-  else{
-    return true;
-  }
-}
+export const isHintValid = field => {
+  return !(field['hint'] === null || typeof field['hint'] === 'string');
+};

--- a/packages/amplify-ui-components/src/common/helpers.ts
+++ b/packages/amplify-ui-components/src/common/helpers.ts
@@ -63,3 +63,12 @@ export const onAuthUIStateChange = (authStateHandler: AuthStateHandler) => {
   Hub.listen(UI_AUTH_CHANNEL, authUIStateHandler);
   return () => Hub.remove(UI_AUTH_CHANNEL, authUIStateHandler);
 }
+
+export const handleAuthFormFieldHint = (field) => {
+  if(field["hint"] === null || typeof field["hint"] === "string"){
+    return false;
+  }
+  else{
+    return true;
+  }
+}

--- a/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
@@ -81,6 +81,16 @@ export class AmplifyConfirmSignUp {
     } else {
       this.formFields.forEach(field => {
         const newField = { ...field };
+        if (newField.type === "code") {
+          newField["hint"] = (
+            <div>
+              {I18n.get(Translations.CONFIRM_SIGN_UP_LOST_CODE)}{' '}
+              <amplify-button variant="anchor" onClick={() => this.resendConfirmCode()}>
+                {I18n.get(Translations.CONFIRM_SIGN_UP_RESEND_CODE)}
+              </amplify-button>
+            </div>
+          );
+        }
         newField['handleInputChange'] = event => this.handleFormFieldInputWithCallback(event, field);
         this.newFormFields.push(newField);
       });

--- a/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
@@ -6,7 +6,7 @@ import { Translations } from '../../common/Translations';
 import { AuthState, CognitoUserInterface, AuthStateHandler, UsernameAliasStrings } from '../../common/types/auth-types';
 
 import { Auth } from '@aws-amplify/auth';
-import { dispatchToastHubEvent, dispatchAuthStateChangeEvent, checkUsernameAlias } from '../../common/helpers';
+import { dispatchToastHubEvent, dispatchAuthStateChangeEvent, checkUsernameAlias, handleAuthFormFieldHint } from '../../common/helpers';
 
 @Component({
   tag: 'amplify-confirm-sign-up',
@@ -82,14 +82,14 @@ export class AmplifyConfirmSignUp {
       this.formFields.forEach(field => {
         const newField = { ...field };
         if (newField.type === "code") {
-          newField["hint"] = (
+          newField["hint"] = handleAuthFormFieldHint(newField) ? (
             <div>
               {I18n.get(Translations.CONFIRM_SIGN_UP_LOST_CODE)}{' '}
               <amplify-button variant="anchor" onClick={() => this.resendConfirmCode()}>
                 {I18n.get(Translations.CONFIRM_SIGN_UP_RESEND_CODE)}
               </amplify-button>
             </div>
-          );
+          ) : newField["hint"];
         }
         newField['handleInputChange'] = event => this.handleFormFieldInputWithCallback(event, field);
         this.newFormFields.push(newField);

--- a/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
@@ -6,7 +6,12 @@ import { Translations } from '../../common/Translations';
 import { AuthState, CognitoUserInterface, AuthStateHandler, UsernameAliasStrings } from '../../common/types/auth-types';
 
 import { Auth } from '@aws-amplify/auth';
-import { dispatchToastHubEvent, dispatchAuthStateChangeEvent, checkUsernameAlias, handleAuthFormFieldHint } from '../../common/helpers';
+import {
+  dispatchToastHubEvent,
+  dispatchAuthStateChangeEvent,
+  checkUsernameAlias,
+  isHintValid,
+} from '../../common/helpers';
 
 @Component({
   tag: 'amplify-confirm-sign-up',
@@ -95,15 +100,17 @@ export class AmplifyConfirmSignUp {
       const newFields = [];
       this.formFields.forEach(field => {
         const newField = { ...field };
-        if (newField.type === "code") {
-          newField["hint"] = handleAuthFormFieldHint(newField) ? (
+        if (newField.type === 'code') {
+          newField['hint'] = isHintValid(newField) ? (
             <div>
               {I18n.get(Translations.CONFIRM_SIGN_UP_LOST_CODE)}{' '}
               <amplify-button variant="anchor" onClick={() => this.resendConfirmCode()}>
                 {I18n.get(Translations.CONFIRM_SIGN_UP_RESEND_CODE)}
               </amplify-button>
             </div>
-          ) : newField["hint"];
+          ) : (
+            newField['hint']
+          );
         }
         newField['handleInputChange'] = event => this.handleFormFieldInputWithCallback(event, field);
         newFields.push(newField);

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
@@ -25,6 +25,7 @@ import {
   dispatchAuthStateChangeEvent,
   composePhoneNumberInput,
   checkUsernameAlias,
+  handleAuthFormFieldHint,
 } from '../../common/helpers';
 import { SignInAttributes } from './amplify-sign-in-interface';
 
@@ -256,10 +257,7 @@ export class AmplifySignIn {
         const newField = { ...field };
         // TODO: handle hint better
         if(newField.type === "password") {
-          if(newField["hint"] === null || typeof newField["hint"] === "string"){
-          }
-          else {
-          newField["hint"] = (
+          newField["hint"] = handleAuthFormFieldHint(newField) ? (
             <div>
               {I18n.get(Translations.FORGOT_PASSWORD_TEXT)}{' '}
               <amplify-button
@@ -270,9 +268,8 @@ export class AmplifySignIn {
                 {I18n.get(Translations.RESET_PASSWORD_TEXT)}
               </amplify-button>
             </div>
-          );
+          ) : newField["hint"];
           }
-        }
         newField['handleInputChange'] = event => this.handleFormFieldInputWithCallback(event, field);
         this.newFormFields.push(newField);
       });

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
@@ -25,7 +25,7 @@ import {
   dispatchAuthStateChangeEvent,
   composePhoneNumberInput,
   checkUsernameAlias,
-  handleAuthFormFieldHint,
+  isHintValid,
 } from '../../common/helpers';
 import { SignInAttributes } from './amplify-sign-in-interface';
 
@@ -260,8 +260,8 @@ export class AmplifySignIn {
       this.formFields.forEach(field => {
         const newField = { ...field };
         // TODO: handle hint better
-        if(newField.type === "password") {
-          newField["hint"] = handleAuthFormFieldHint(newField) ? (
+        if (newField.type === 'password') {
+          newField['hint'] = isHintValid(newField) ? (
             <div>
               {I18n.get(Translations.FORGOT_PASSWORD_TEXT)}{' '}
               <amplify-button
@@ -272,8 +272,10 @@ export class AmplifySignIn {
                 {I18n.get(Translations.RESET_PASSWORD_TEXT)}
               </amplify-button>
             </div>
-          ) : newField["hint"];
-          }
+          ) : (
+            newField['hint']
+          );
+        }
         newField['handleInputChange'] = event => this.handleFormFieldInputWithCallback(event, field);
         newFields.push(newField);
       });

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
@@ -254,6 +254,25 @@ export class AmplifySignIn {
     } else {
       this.formFields.forEach(field => {
         const newField = { ...field };
+        // TODO: handle hint better
+        if(newField.type === "password") {
+          if(newField["hint"] === null || typeof newField["hint"] === "string"){
+          }
+          else {
+          newField["hint"] = (
+            <div>
+              {I18n.get(Translations.FORGOT_PASSWORD_TEXT)}{' '}
+              <amplify-button
+                variant="anchor"
+                onClick={() => this.handleAuthStateChange(AuthState.ForgotPassword)}
+                data-test="sign-in-forgot-password-link"
+              >
+                {I18n.get(Translations.RESET_PASSWORD_TEXT)}
+              </amplify-button>
+            </div>
+          );
+          }
+        }
         newField['handleInputChange'] = event => this.handleFormFieldInputWithCallback(event, field);
         this.newFormFields.push(newField);
       });


### PR DESCRIPTION
_Issue #, if available:_ #5298

_Description of changes:_
Handle provide hint with default value under certain conditions.

This PR handles hint for password and code and  in the following ways,
- `hint: null` is passed to `formFields`
![image](https://user-images.githubusercontent.com/35131273/81341956-4876d500-9067-11ea-813f-a473f8bb0f83.png)

- string is to `hint` in `formFields`
![image](https://user-images.githubusercontent.com/35131273/81341916-385ef580-9067-11ea-9198-ee5b12c97365.png)

- if nothing is passed in or a function component, it would resolve to fallback
![image](https://user-images.githubusercontent.com/35131273/81342119-870c8f80-9067-11ea-9606-e2b382806678.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
