### PR TITLE
Fix AWSS3Provider url expire parameter

### DIFF
--- a/packages/storage/__tests__/providers/AWSS3Provider-unit-test.ts
+++ b/packages/storage/__tests__/providers/AWSS3Provider-unit-test.ts
@@ -15,6 +15,7 @@ import { Hub, Credentials } from '@aws-amplify/core';
 import * as formatURL from '@aws-sdk/util-format-url';
 import { S3Client, ListObjectsCommand } from '@aws-sdk/client-s3';
 import { S3RequestPresigner } from '@aws-sdk/s3-request-presigner';
+import { RequestPresigningArguments } from '@aws-sdk/types';
 
 /**
  * NOTE - These test cases use Hub.dispatch but they should
@@ -349,7 +350,7 @@ describe('StorageProvider test', () => {
 			// was created in the source vs in the test.
 			const diff =
 				new Date(Date.now() + 1200 * 1000).getMilliseconds() -
-				(spyon.mock.calls[0][1] as Date).getMilliseconds();
+				(spyon.mock.calls[0][1] as RequestPresigningArguments).expiresIn * 1000;
 			expect(diff).toBeLessThan(100);
 		});
 
@@ -376,7 +377,7 @@ describe('StorageProvider test', () => {
 			// was created in the source vs in the test. 900 secs is default
 			const diff =
 				new Date(Date.now() + 900 * 1000).getMilliseconds() -
-				(spyon.mock.calls[0][1] as Date).getMilliseconds();
+				(spyon.mock.calls[0][1] as RequestPresigningArguments).expiresIn * 1000;
 			expect(diff).toBeLessThan(100);
 		});
 

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -35,7 +35,7 @@ import * as events from 'events';
 const logger = new Logger('AWSS3Provider');
 
 const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' &&
-typeof Symbol.for === 'function'
+	typeof Symbol.for === 'function'
 	? Symbol.for('amplify_default')
 	: '@@amplify_default') as Symbol;
 
@@ -182,13 +182,12 @@ export class AWSS3Provider implements StorageProvider {
 		}
 
 		params.Expires = expires || 900; // Default is 15 mins as defined in V2 AWS SDK
-		params.Expires = new Date(Date.now() + params.Expires * 1000); // expires is in secs
 
 		try {
 			const signer = new S3RequestPresigner({ ...s3.config });
 			const request = await createRequest(s3, new GetObjectCommand(params));
 			const url = formatUrl(
-				(await signer.presign(request, params.Expires)) as any
+				(await signer.presign(request, { expiresIn: params.Expires })) as any
 			);
 			dispatchStorageEvent(
 				track,
@@ -301,7 +300,7 @@ export class AWSS3Provider implements StorageProvider {
 					} else {
 						logger.warn(
 							'progressCallback should be a function, not a ' +
-								typeof progressCallback
+							typeof progressCallback
 						);
 					}
 				}


### PR DESCRIPTION
Issue #: #5677

Description of changes:
Removed line converting params.Expires in AWSS3Provider get method to a Date object and modified the second argument in the presign method of the S3RequestPresigner object to the correct argument supported from the library.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
