### PR TITLE
fix(@aws-amplify/storage) Update expires param to be a number

### DIFF
--- a/packages/storage/__tests__/providers/AWSS3Provider-unit-test.ts
+++ b/packages/storage/__tests__/providers/AWSS3Provider-unit-test.ts
@@ -345,12 +345,7 @@ describe('StorageProvider test', () => {
 				options.bucket + '.s3.' + options.region + '.amazonaws.com'
 			);
 
-			// For test to be deterministic, let's assume a 100 ms difference between when the date
-			// was created in the source vs in the test.
-			const diff =
-				new Date(Date.now() + 1200 * 1000).getMilliseconds() -
-				(spyon.mock.calls[0][1] as Date).getMilliseconds();
-			expect(diff).toBeLessThan(100);
+			expect(spyon.mock.calls[0][1].expiresIn).toBe(1200);
 		});
 
 		test('get object with default expires option', async () => {
@@ -372,12 +367,7 @@ describe('StorageProvider test', () => {
 				options.bucket + '.s3.' + options.region + '.amazonaws.com'
 			);
 
-			// For test to be deterministic, let's assume a 100 ms difference between when the date
-			// was created in the source vs in the test. 900 secs is default
-			const diff =
-				new Date(Date.now() + 900 * 1000).getMilliseconds() -
-				(spyon.mock.calls[0][1] as Date).getMilliseconds();
-			expect(diff).toBeLessThan(100);
+			expect(spyon.mock.calls[0][1].expiresIn).toBe(900);
 		});
 
 		test('get object with identityId option', async () => {

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -182,13 +182,12 @@ export class AWSS3Provider implements StorageProvider {
 		}
 
 		params.Expires = expires || 900; // Default is 15 mins as defined in V2 AWS SDK
-		params.Expires = new Date(Date.now() + params.Expires * 1000); // expires is in secs
 
 		try {
 			const signer = new S3RequestPresigner({ ...s3.config });
 			const request = await createRequest(s3, new GetObjectCommand(params));
 			const url = formatUrl(
-				(await signer.presign(request, params.Expires)) as any
+				(await signer.presign(request, { expiresIn: params.Expires })) as any
 			);
 			dispatchStorageEvent(
 				track,


### PR DESCRIPTION
_Issue #, if available:_ fixes #5677 

_Description of changes:_ Since beta versions of aws-sdk, the expire option is a number and not a Date object. Updating S3 provider to reflect that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
