### PR TITLE
Backport graphql api parameter to API.graphql

### DIFF
--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -154,9 +154,10 @@ export class APIClass {
 	 * @returns {Promise<GraphQLResult> | Observable<object>}
 	 */
 	graphql(
-		options: GraphQLOptions
+		options: GraphQLOptions,
+		additionalHeaders?: { [key: string]: string }
 	): Promise<GraphQLResult> | Observable<object> {
-		return this._graphqlApi.graphql(options);
+		return this._graphqlApi.graphql(options, additionalHeaders);
 	}
 }
 


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/pull/5001

_Description of changes:_
- Backport `additionalHeaders` from `API.graphql`
- https://github.com/aws-amplify/amplify-js/pull/5001#issuecomment-623147532

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
