### PR TITLE
Set default Typescript formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
 	"editor.insertSpaces": false,
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"prettier.requireConfig": true,
-	"editor.defaultFormatter": "esbenp.prettier-vscode"
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"[typescript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	}
 }


### PR DESCRIPTION
_Description of changes:_
- Typescript formatter was being used as the default in Typescript files
- Use prettier as the default formatter for Typescript files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
