### PR TITLE
fix(@aws-amplify/ui-components): Styling fixes

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-auth-fields/__snapshots__/amplify-auth-fields.spec.ts.snap
+++ b/packages/amplify-ui-components/src/components/amplify-auth-fields/__snapshots__/amplify-auth-fields.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`amplify-auth-fields spec: Render logic -> should render with a \`username\` and \`password\` field 1`] = `
 <amplify-auth-fields formfields="username,password">
   <mock:shadow-root>
-    <div></div>
+    <div class="auth-fields"></div>
   </mock:shadow-root>
 </amplify-auth-fields>
 `;
@@ -11,7 +11,7 @@ exports[`amplify-auth-fields spec: Render logic -> should render with a \`userna
 exports[`amplify-auth-fields spec: Render logic -> should render with no default values and a empty string 1`] = `
 <amplify-auth-fields>
   <mock:shadow-root>
-    <div></div>
+    <div class="auth-fields"></div>
   </mock:shadow-root>
 </amplify-auth-fields>
 `;

--- a/packages/amplify-ui-components/src/components/amplify-auth-fields/amplify-auth-fields.scss
+++ b/packages/amplify-ui-components/src/components/amplify-auth-fields/amplify-auth-fields.scss
@@ -1,0 +1,3 @@
+.auth-fields {
+  margin-bottom: 2rem;
+}

--- a/packages/amplify-ui-components/src/components/amplify-auth-fields/amplify-auth-fields.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-auth-fields/amplify-auth-fields.tsx
@@ -4,6 +4,7 @@ import componentFieldMapping from './component-field-mapping';
 
 @Component({
   tag: 'amplify-auth-fields',
+  styleUrl: 'amplify-auth-fields.scss',
   shadow: true,
 })
 export class AmplifyAuthFields {
@@ -44,6 +45,6 @@ export class AmplifyAuthFields {
   }
 
   render() {
-    return <div>{this.constructFormFieldOptions(this.formFields)}</div>;
+    return <div class="auth-fields">{this.constructFormFieldOptions(this.formFields)}</div>;
   }
 }

--- a/packages/amplify-ui-components/src/components/amplify-button/amplify-button.scss
+++ b/packages/amplify-ui-components/src/components/amplify-button/amplify-button.scss
@@ -60,6 +60,7 @@
 
 .anchor {
   color: var(--link-color);
+  background-color: inherit;
   padding: 0;
   border: none;
   font: inherit;

--- a/packages/amplify-ui-components/src/components/amplify-input/amplify-input.scss
+++ b/packages/amplify-ui-components/src/components/amplify-input/amplify-input.scss
@@ -20,7 +20,7 @@
   border: 1px solid var(--border-color);
   border-radius: 3px;
   box-sizing: border-box;
-  margin-bottom: 10px;
+  margin: 0;
 
   &:focus {
     outline: none;

--- a/packages/amplify-ui-components/src/components/amplify-select/amplify-select.scss
+++ b/packages/amplify-ui-components/src/components/amplify-select/amplify-select.scss
@@ -22,6 +22,7 @@
   flex-basis: auto;
   width: fit-content;
   height: 51px;
+  margin: 0;
 
   background-image: var(--background-image);
   background-position: calc(100% - 20px) calc(1em + 8px), calc(100% - 15px) calc(1em + 8px), calc(100% - 2.5em) 0.5em;


### PR DESCRIPTION
_Description of changes:_
- Fix grey background on hints in Safari:
![Screen Shot 2020-05-08 at 9 56 32 AM](https://user-images.githubusercontent.com/3868826/81429528-c348fa00-9112-11ea-8db1-95c1bf097b51.png)

- Fix janky phone field in Safari
![Screen Shot 2020-05-08 at 9 56 44 AM](https://user-images.githubusercontent.com/3868826/81429599-dfe53200-9112-11ea-914c-c090d094ce3a.png)

- Add margin to auth fields and remove from individual input

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
