### PR TITLE
Add feature to cancel axios requests used by API rest and graphql category

### DIFF
--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -196,7 +196,18 @@ export class GraphQLAPIClass {
 		switch (operationType) {
 			case 'query':
 			case 'mutation':
-				return this._graphql({ query, variables, authMode }, additionalHeaders);
+				const cancellableToken = this._api.getCancellableToken();
+				const initParams = { cancellableToken };
+				const responsePromise = this._graphql(
+					{ query, variables, authMode },
+					additionalHeaders,
+					initParams
+				);
+				this._api.updateRequestToBeCancellable(
+					responsePromise,
+					cancellableToken
+				);
+				return responsePromise;
 			case 'subscription':
 				return this._graphqlSubscribe(
 					{ query, variables, authMode },
@@ -209,7 +220,8 @@ export class GraphQLAPIClass {
 
 	private async _graphql(
 		{ query, variables, authMode }: GraphQLOptions,
-		additionalHeaders = {}
+		additionalHeaders = {},
+		initParams = {}
 	): Promise<GraphQLResult> {
 		if (!this._api) {
 			await this.createInstance();
@@ -241,14 +253,17 @@ export class GraphQLAPIClass {
 			variables,
 		};
 
-		const init = {
-			headers,
-			body,
-			signerServiceInfo: {
-				service: !customGraphqlEndpoint ? 'appsync' : 'execute-api',
-				region: !customGraphqlEndpoint ? region : customEndpointRegion,
+		const init = Object.assign(
+			{
+				headers,
+				body,
+				signerServiceInfo: {
+					service: !customGraphqlEndpoint ? 'appsync' : 'execute-api',
+					region: !customGraphqlEndpoint ? region : customEndpointRegion,
+				},
 			},
-		};
+			initParams
+		);
 
 		const endpoint = customGraphqlEndpoint || appSyncGraphqlEndpoint;
 
@@ -265,6 +280,12 @@ export class GraphQLAPIClass {
 		try {
 			response = await this._api.post(endpoint, init);
 		} catch (err) {
+			// If the exception is because user intentionally
+			// cancelled the request, do not modify the exception
+			// so that clients can identify the exception correctly.
+			if (this._api.isCancel(err)) {
+				throw err;
+			}
 			response = {
 				data: {},
 				errors: [new GraphQLError(err.message)],
@@ -278,6 +299,24 @@ export class GraphQLAPIClass {
 		}
 
 		return response;
+	}
+
+	/**
+	 * Checks to see if an error thrown is from an api request cancellation
+	 * @param {any} error - Any error
+	 * @return {boolean} - A boolean indicating if the error was from an api request cancellation
+	 */
+	isCancel(error) {
+		return this._api.isCancel(error);
+	}
+
+	/**
+	 * Cancels an inflight request. Only applicable for graphql queries and mutations
+	 * @param {any} request - request to cancel
+	 * @return {boolean} - A boolean indicating if the request was cancelled
+	 */
+	cancel(request: Promise<any>, message?: string) {
+		return this._api.cancel(request, message);
 	}
 
 	private _graphqlSubscribe(

--- a/packages/api-rest/__tests__/RestClient-unit-test.ts
+++ b/packages/api-rest/__tests__/RestClient-unit-test.ts
@@ -37,8 +37,32 @@ jest.mock('axios', () => {
 });
 
 import { RestClient } from '../src/RestClient';
+import axios, { CancelTokenStatic } from 'axios';
+
+axios.CancelToken = <CancelTokenStatic>{
+	source: () => ({ token: null, cancel: null }),
+};
+axios.isCancel = (value: any): boolean => {
+	return false;
+};
+
+let isCancelSpy = null;
+let cancelTokenSpy = null;
+let cancelMock = null;
+let tokenMock = null;
 
 describe('RestClient test', () => {
+	beforeEach(() => {
+		cancelMock = jest.fn();
+		tokenMock = jest.fn();
+		isCancelSpy = jest.spyOn(axios, 'isCancel').mockReturnValue(true);
+		cancelTokenSpy = jest
+			.spyOn(axios.CancelToken, 'source')
+			.mockImplementation(() => {
+				return { token: tokenMock, cancel: cancelMock };
+			});
+	});
+
 	describe('ajax', () => {
 		test('fetch with signed request', async () => {
 			const apiOptions = {
@@ -399,6 +423,59 @@ describe('RestClient test', () => {
 			const restClient = new RestClient(apiOptions);
 
 			expect(restClient.endpoint('otherApi')).toBe('endpoint of otherApi');
+		});
+	});
+
+	describe('Cancel Token', () => {
+		const apiOptions = {
+			headers: {},
+			endpoints: [
+				{
+					name: 'myApi',
+					endpoint: 'endpoint of myApi',
+				},
+				{
+					name: 'otherApi',
+					endpoint: 'endpoint of otherApi',
+				},
+			],
+			credentials: {
+				accessKeyId: 'accessKeyId',
+				secretAccessKey: 'secretAccessKey',
+				sessionToken: 'sessionToken',
+			},
+			region: 'myregion',
+		};
+
+		test('request non existent', () => {
+			const restClient = new RestClient(apiOptions);
+			// if the request doesn't exist we can still say it is canceled successfully
+			expect(
+				restClient.cancel(
+					new Promise<any>((req, res) => {})
+				)
+			).toBeTruthy();
+		});
+
+		test('happy case', () => {
+			const restClient = new RestClient(apiOptions);
+
+			const cancellableToken = restClient.getCancellableToken();
+			const request = restClient.ajax('url', 'method', { cancellableToken });
+			restClient.updateRequestToBeCancellable(request, cancellableToken);
+
+			// cancel the request
+			const cancelSuccess = restClient.cancel(request, 'message');
+
+			expect(cancelSuccess).toBeTruthy();
+			expect(cancelTokenSpy).toBeCalledTimes(1);
+			expect(cancelMock).toBeCalledWith('message');
+		});
+
+		test('iscancel called', () => {
+			const restClient = new RestClient(apiOptions);
+			restClient.isCancel({});
+			expect(isCancelSpy).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/api-rest/src/RestAPI.ts
+++ b/packages/api-rest/src/RestAPI.ts
@@ -103,12 +103,17 @@ export class RestAPIClass {
 	 * @param {json} [init] - Request extra params
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
-	async get(apiName, path, init) {
+	get(apiName, path, init): Promise<any> {
 		const endpoint = this._api.endpoint(apiName);
 		if (endpoint.length === 0) {
 			return Promise.reject('API ' + apiName + ' does not exist');
 		}
-		return this._api.get(endpoint + path, init);
+		const cancellableToken = this._api.getCancellableToken();
+		const initParams = Object.assign({}, init);
+		initParams.cancellableToken = cancellableToken;
+		const responsePromise = this._api.get(endpoint + path, initParams);
+		this._api.updateRequestToBeCancellable(responsePromise, cancellableToken);
+		return responsePromise;
 	}
 
 	/**
@@ -118,12 +123,17 @@ export class RestAPIClass {
 	 * @param {json} [init] - Request extra params
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
-	async post(apiName, path, init) {
+	post(apiName, path, init): Promise<any> {
 		const endpoint = this._api.endpoint(apiName);
 		if (endpoint.length === 0) {
 			return Promise.reject('API ' + apiName + ' does not exist');
 		}
-		return this._api.post(endpoint + path, init);
+		const cancellableToken = this._api.getCancellableToken();
+		const initParams = Object.assign({}, init);
+		initParams.cancellableToken = cancellableToken;
+		const responsePromise = this._api.post(endpoint + path, initParams);
+		this._api.updateRequestToBeCancellable(responsePromise, cancellableToken);
+		return responsePromise;
 	}
 
 	/**
@@ -133,12 +143,17 @@ export class RestAPIClass {
 	 * @param {json} [init] - Request extra params
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
-	async put(apiName, path, init) {
+	put(apiName, path, init): Promise<any> {
 		const endpoint = this._api.endpoint(apiName);
 		if (endpoint.length === 0) {
 			return Promise.reject('API ' + apiName + ' does not exist');
 		}
-		return this._api.put(endpoint + path, init);
+		const cancellableToken = this._api.getCancellableToken();
+		const initParams = Object.assign({}, init);
+		initParams.cancellableToken = cancellableToken;
+		const responsePromise = this._api.put(endpoint + path, initParams);
+		this._api.updateRequestToBeCancellable(responsePromise, cancellableToken);
+		return responsePromise;
 	}
 
 	/**
@@ -148,12 +163,17 @@ export class RestAPIClass {
 	 * @param {json} [init] - Request extra params
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
-	async patch(apiName, path, init) {
+	patch(apiName, path, init): Promise<any> {
 		const endpoint = this._api.endpoint(apiName);
 		if (endpoint.length === 0) {
 			return Promise.reject('API ' + apiName + ' does not exist');
 		}
-		return this._api.patch(endpoint + path, init);
+		const cancellableToken = this._api.getCancellableToken();
+		const initParams = Object.assign({}, init);
+		initParams.cancellableToken = cancellableToken;
+		const responsePromise = this._api.patch(endpoint + path, initParams);
+		this._api.updateRequestToBeCancellable(responsePromise, cancellableToken);
+		return responsePromise;
 	}
 
 	/**
@@ -163,12 +183,17 @@ export class RestAPIClass {
 	 * @param {json} [init] - Request extra params
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
-	async del(apiName, path, init) {
+	del(apiName, path, init): Promise<any> {
 		const endpoint = this._api.endpoint(apiName);
 		if (endpoint.length === 0) {
 			return Promise.reject('API ' + apiName + ' does not exist');
 		}
-		return this._api.del(endpoint + path, init);
+		const cancellableToken = this._api.getCancellableToken();
+		const initParams = Object.assign({}, init);
+		initParams.cancellableToken = cancellableToken;
+		const responsePromise = this._api.del(endpoint + path, initParams);
+		this._api.updateRequestToBeCancellable(responsePromise, cancellableToken);
+		return responsePromise;
 	}
 
 	/**
@@ -178,12 +203,35 @@ export class RestAPIClass {
 	 * @param {json} [init] - Request extra params
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
-	async head(apiName, path, init) {
+	head(apiName, path, init): Promise<any> {
 		const endpoint = this._api.endpoint(apiName);
 		if (endpoint.length === 0) {
 			return Promise.reject('API ' + apiName + ' does not exist');
 		}
-		return this._api.head(endpoint + path, init);
+		const cancellableToken = this._api.getCancellableToken();
+		const initParams = Object.assign({}, init);
+		initParams.cancellableToken = cancellableToken;
+		const responsePromise = this._api.head(endpoint + path, initParams);
+		this._api.updateRequestToBeCancellable(responsePromise, cancellableToken);
+		return responsePromise;
+	}
+
+	/**
+	 * Checks to see if an error thrown is from an api request cancellation
+	 * @param {any} error - Any error
+	 * @return {boolean} - A boolean indicating if the error was from an api request cancellation
+	 */
+	isCancel(error) {
+		return this._api.isCancel(error);
+	}
+
+	/**
+	 * Cancels an inflight request
+	 * @param {any} request - request to cancel
+	 * @return {boolean} - A boolean indicating if the request was cancelled
+	 */
+	cancel(request: Promise<any>, message?: string) {
+		return this._api.cancel(request, message);
 	}
 
 	/**

--- a/packages/api-rest/src/RestClient.ts
+++ b/packages/api-rest/src/RestClient.ts
@@ -19,7 +19,7 @@ import {
 } from '@aws-amplify/core';
 
 import { apiOptions } from './types';
-import axios from 'axios';
+import axios, { CancelTokenSource, CancelToken } from 'axios';
 import { parse, format } from 'url';
 
 const logger = new Logger('RestClient');
@@ -42,12 +42,32 @@ export class RestClient {
 	private _region: string = 'us-east-1'; // this will be updated by endpoint function
 	private _service: string = 'execute-api'; // this can be updated by endpoint function
 	private _custom_header = undefined; // this can be updated by endpoint function
+
+	/**
+	 * This weak map provides functionality to let clients cancel
+	 * in-flight axios requests. https://github.com/axios/axios#cancellation
+	 *
+	 * 1. For every axios request, a unique cancel token is generated and added in the request.
+	 * 2. Promise for fulfilling the request is then mapped to that unique cancel token.
+	 * 3. The promise is returned to the client.
+	 * 4. Clients can either wait for the promise to fulfill or call `API.cancel(promise)` to cancel the request.
+	 * 5. If `API.cancel(promise)` is called, then the corresponding cancel token is retrieved from the map below.
+	 * 6. Promise returned to the client will be in rejected state with the error provided during cancel.
+	 * 7. Clients can check if the error is because of cancelling by calling `API.isCancel(error)`.
+	 *
+	 * For more details, see https://github.com/aws-amplify/amplify-js/pull/3769#issuecomment-552660025
+	 */
+	private _cancelTokenMap: WeakMap<any, CancelTokenSource> = null;
+
 	/**
 	 * @param {RestClientOptions} [options] - Instance options
 	 */
 	constructor(options: apiOptions) {
 		this._options = options;
 		logger.debug('API Options', this._options);
+		if (this._cancelTokenMap == null) {
+			this._cancelTokenMap = new WeakMap();
+		}
 	}
 
 	/**
@@ -79,6 +99,7 @@ export class RestClient {
 			data: null,
 			responseType: 'json',
 			timeout: 0,
+			cancelToken: null,
 		};
 
 		let libraryHeaders = {};
@@ -104,6 +125,9 @@ export class RestClient {
 		}
 		if (initParams.timeout) {
 			params.timeout = initParams.timeout;
+		}
+		if (initParams.cancellableToken) {
+			params.cancelToken = initParams.cancellableToken.token;
 		}
 
 		params['signerServiceInfo'] = initParams.signerServiceInfo;
@@ -210,6 +234,48 @@ export class RestClient {
 	 */
 	head(url: string, init) {
 		return this.ajax(url, 'HEAD', init);
+	}
+
+	/**
+	 * Cancel an inflight API request
+	 * @param {Promise<any>} request - The request promise to cancel
+	 * @param {string} [message] - A message to include in the cancelation exception
+	 */
+	cancel(request: Promise<any>, message?: string) {
+		const source = this._cancelTokenMap.get(request);
+		if (source) {
+			source.cancel(message);
+		}
+		return true;
+	}
+
+	/**
+	 * Checks to see if an error thrown is from an api request cancellation
+	 * @param {any} error - Any error
+	 * @return {boolean} - A boolean indicating if the error was from an api request cancellation
+	 */
+	isCancel(error): boolean {
+		return axios.isCancel(error);
+	}
+
+	/**
+	 * Retrieves a new and unique cancel token which can be
+	 * provided in an axios request to be cancelled later.
+	 */
+	getCancellableToken(): CancelTokenSource {
+		return axios.CancelToken.source();
+	}
+
+	/**
+	 * Updates the weakmap with a response promise and its
+	 * cancel token such that the cancel token can be easily
+	 * retrieved (and used for cancelling the request)
+	 */
+	updateRequestToBeCancellable(
+		promise: Promise<any>,
+		cancelTokenSource: CancelTokenSource
+	) {
+		this._cancelTokenMap.set(promise, cancelTokenSource);
 	}
 
 	/**

--- a/packages/api-rest/src/RestClient.ts
+++ b/packages/api-rest/src/RestClient.ts
@@ -19,7 +19,7 @@ import {
 } from '@aws-amplify/core';
 
 import { apiOptions } from './types';
-import axios, { CancelTokenSource, CancelToken } from 'axios';
+import axios, { CancelTokenSource } from 'axios';
 import { parse, format } from 'url';
 
 const logger = new Logger('RestClient');

--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -70,7 +70,7 @@ export class APIClass {
 	 * @param {json} [init] - Request extra params
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
-	async get(apiName, path, init) {
+	get(apiName, path, init): Promise<any> {
 		return this._restApi.get(apiName, path, init);
 	}
 
@@ -81,7 +81,7 @@ export class APIClass {
 	 * @param {json} [init] - Request extra params
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
-	async post(apiName, path, init) {
+	post(apiName, path, init): Promise<any> {
 		return this._restApi.post(apiName, path, init);
 	}
 
@@ -92,7 +92,7 @@ export class APIClass {
 	 * @param {json} [init] - Request extra params
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
-	async put(apiName, path, init) {
+	put(apiName, path, init): Promise<any> {
 		return this._restApi.put(apiName, path, init);
 	}
 
@@ -103,7 +103,7 @@ export class APIClass {
 	 * @param {json} [init] - Request extra params
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
-	async patch(apiName, path, init) {
+	patch(apiName, path, init): Promise<any> {
 		return this._restApi.patch(apiName, path, init);
 	}
 
@@ -114,7 +114,7 @@ export class APIClass {
 	 * @param {json} [init] - Request extra params
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
-	async del(apiName, path, init) {
+	del(apiName, path, init): Promise<any> {
 		return this._restApi.del(apiName, path, init);
 	}
 
@@ -125,8 +125,25 @@ export class APIClass {
 	 * @param {json} [init] - Request extra params
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
-	async head(apiName, path, init) {
+	head(apiName, path, init): Promise<any> {
 		return this._restApi.head(apiName, path, init);
+	}
+
+	/**
+	 * Checks to see if an error thrown is from an api request cancellation
+	 * @param {any} error - Any error
+	 * @return {boolean} - A boolean indicating if the error was from an api request cancellation
+	 */
+	isCancel(error) {
+		return this._restApi.isCancel(error);
+	}
+	/**
+	 * Cancels an inflight request
+	 * @param {any} request - request to cancel
+	 * @return {boolean} - A boolean indicating if the request was cancelled
+	 */
+	cancel(request: Promise<any>, message?: string) {
+		return this._restApi.cancel(request, message);
 	}
 
 	/**


### PR DESCRIPTION
Co-authored-by: kbuechl <karlrbuechler@gmail.com>

_Issue #, if available:_ fixes #989, closes #3769

_Description of changes:_ This is a replacement PR for #3769 since that PR has a lot of merge conflicts which requires a pretty much rewrite since API category has been refactored into api-rest and api-graphql categories.

This PR builds on the same concept as https://github.com/aws-amplify/amplify-js/pull/3769#issuecomment-552660025 but instead of keeping keeping the promises from axios in the weakmap, we are utilizing the promises that library return to the clients. This is because using async/await wraps any promises being returned and renders the whole idea of using promises as key useless.

### **Gist of the implementation:**
We keep a weakmap<promise, canceltoken> for every request made in the RestClient. If the client wants to cancel a request, they can use the `promise` received after making the request and call `API.cancel(promise)`

1. For every axios request, a unique cancel token is generated and added in the request.
2. Promise for fulfilling the request is then mapped to that unique cancel token.
3. The promise is returned to the client.
4. Clients can either wait for the promise to fulfill or call `API.cancel(promise)` to cancel the request.
5. If `API.cancel(promise)` is called, then the corresponding cancel token is retrieved from the map.
6. Promise returned to the client will get rejected state with the error message provided during cancel.
7. Clients can check if the error is because of cancelling by calling `API.isCancel(error)`.

### **Testing**
Other than unit tests, I have manually tested api-rest category by creating a server API that returns success after 5 secs. I then made multiple calls to the API and cancelled half of them randomly after 1 secs of initiation. Validated that the calls cancelled are the ones that were supposed to be cancelled, rest completed successfully.


### **Callouts**
This PR required a slight change in the API category, All the APIs are now marked non-async. They are still returning promises and can be awaited upon (as shown in the unit tests). This is required so that the returned promise doesn't get changed. I don't consider this to be a breaking change in my opinion, want to know what others think.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
