### PR TITLE
Revert "fix(aws-amplify-angular): decorateSignUp matches Auth.signUp"

### DIFF
--- a/packages/aws-amplify-angular/src/__mocks__/mock_module.ts
+++ b/packages/aws-amplify-angular/src/__mocks__/mock_module.ts
@@ -5,7 +5,7 @@ const authModule = {
 				resolve(1);
 			});
 		},
-		signUp: (...args: any[])=> {
+		signUp: () => {
 			return new Promise((resolve, reject) => {
 				resolve({ username: 'fakename' });
 			});

--- a/packages/aws-amplify-angular/src/__tests__/providers/auth.decorator.spec.ts
+++ b/packages/aws-amplify-angular/src/__tests__/providers/auth.decorator.spec.ts
@@ -1,11 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { authDecorator } from '../../providers/auth.decorator';
-import { authModule } from '../../__mocks__/mock_module';
-import { AuthState } from '../../providers';
-import { BehaviorSubject } from 'rxjs';
 
 describe('AuthDecorator', () => {
-
 	beforeEach(() => {
 		TestBed.configureTestingModule({
 			providers: [authDecorator],
@@ -14,44 +10,6 @@ describe('AuthDecorator', () => {
 
 	it('should be created', () => {
 		expect(authDecorator).toBeTruthy();
-	});
-
-	describe('set correct authState', () => {
-
-		const undecoratedAuth = Object.assign({}, authModule.Auth);
-		let authState: BehaviorSubject<AuthState>;
-
-		beforeEach(() => {
-			authState = new BehaviorSubject<AuthState>({ state: '', user: undefined });
-			authModule.Auth = undecoratedAuth;
-		});
-
-		it('should set correct authState on signIn where confirm required and using legacy signup args', async () => {
-			const username = 'fakeusername';
-			spyOn(authModule.Auth, 'signUp').and.callFake((username: string, password: string) => {
-				return Promise.resolve({
-					username,
-					challengeName: 'SMS_MFA'
-				});
-			});
-			authDecorator(authState, authModule.Auth);
-			await authModule.Auth.signUp(username, 'fakepassword');
-			expect(authState.getValue()).toStrictEqual({ state: 'confirmSignUp', user: { username }});
-		});
-
-		it('should set correct authState on signIn where confirm required and using signUpParams', async () => {
-			const username = 'fakeusername';
-			spyOn(authModule.Auth, 'signUp').and.callFake((signUpParams: { username: string }) => {
-				return Promise.resolve({
-					username: signUpParams.username,
-					challengeName: 'SMS_MFA'
-				});
-			});
-			authDecorator(authState, authModule.Auth);
-			await authModule.Auth.signUp({ username });
-			expect(authState.getValue()).toStrictEqual({ state: 'confirmSignUp', user: { username }});
-		});
-
 	});
 
 	afterAll(() => {

--- a/packages/aws-amplify-angular/src/providers/auth.decorator.ts
+++ b/packages/aws-amplify-angular/src/providers/auth.decorator.ts
@@ -94,25 +94,11 @@ function decorateSignOut(authState: Subject<AuthState>, Auth) {
 function decorateSignUp(authState: Subject<AuthState>, Auth) {
 	const _signUp = Auth.signUp;
 	Auth.signUp = (
-		params: string | { username: string },
-		...restOfAttrs: string[]
+		username: string,
+		password: string,
+		email: string,
+		phone_number: string
 	): Promise<any> => {
-
-		let username: string = null;
-		let password: string = null;
-		let email: string = null;
-		let phone_number: string = null;
-
-		if (params && typeof params === 'string') {
-			username = params;
-			password = restOfAttrs ? restOfAttrs[0] : null;
-			email = restOfAttrs ? restOfAttrs[1] : null;
-			phone_number = restOfAttrs ? restOfAttrs[2] : null;
-		} else if (params && typeof params === 'object') {
-			username = params['username'];
-			password = params['password'];
-		}
-
 		return _signUp
 			.call(Auth, username, password, email, phone_number)
 			.then(data => {


### PR DESCRIPTION
Reverts aws-amplify/amplify-js#5443

This introduced a regression found in integration tests where `email` was not being correctly passed to `Auth.signUp`:
> https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/4976/workflows/7c22204f-aecb-4a40-a548-7c139a25facb/jobs/15189

Choosing to revert to unblock our release pipeline before re-applying work.