### PR TITLE
Make all the strings in amplify-forgot-password translatable

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-forgot-password/__snapshots__/amplify-forgot-password.spec.ts.snap
+++ b/packages/amplify-ui-components/src/components/amplify-forgot-password/__snapshots__/amplify-forgot-password.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`amplify-forgot-password spec: Render logic -> should render 1`] = `
 <amplify-forgot-password>
   <mock:shadow-root>
-    <amplify-form-section headertext="Reset your password" testdataprefix="forgot-password">
+    <amplify-form-section headertext="Reset your password" submitbuttontext="Send Code" testdataprefix="forgot-password">
       <amplify-auth-fields></amplify-auth-fields>
     </amplify-form-section>
   </mock:shadow-root>

--- a/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
@@ -196,8 +196,8 @@ export class AmplifyForgotPassword {
           type: 'password',
           required: true,
           handleInputChange: this.handleFormFieldInputChange('password'),
-          label: 'New password',
-          placeholder: 'Enter your new password',
+          label: I18n.get(Translations.NEW_PASSWORD_LABEL),
+          placeholder: I18n.get(Translations.NEW_PASSWORD_PLACEHOLDER),
         },
       ];
       this.delivery = data.CodeDeliveryDetails;
@@ -246,6 +246,7 @@ export class AmplifyForgotPassword {
           </amplify-button>
         }
         testDataPrefix={'forgot-password'}
+        submitButtonText={I18n.get(Translations.SEND_CODE)}
       >
         <amplify-auth-fields formFields={this.newFormFields} />
       </amplify-form-section>


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Our project uses Finnish translations with the app and noticed that in the amplify-forgot-password some of the texts were not utilizing the Translations enum. I simply updated the code to utilize these instead of static strings. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
