### PR TITLE
Disable autocomplete on all Input components

### DIFF
--- a/packages/aws-amplify-react/__tests__/Amplify-UI/__snapshots__/Amplify-UI-Components-React-test.tsx.snap
+++ b/packages/aws-amplify-react/__tests__/Amplify-UI/__snapshots__/Amplify-UI-Components-React-test.tsx.snap
@@ -22,6 +22,7 @@ exports[`AmplifyUi test render FormRow correctly 1`] = `
 
 exports[`AmplifyUi test render Input correctly 1`] = `
 <input
+  autoComplete="off"
   className="Input__input___3e_bf"
   style={Object {}}
 />

--- a/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ConfirmSignIn-test.tsx.snap
+++ b/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ConfirmSignIn-test.tsx.snap
@@ -1235,7 +1235,6 @@ exports[`ConfirmSignIn render test render correctly with Props confirmSignIn 1`]
            *
         </Component>
         <Component
-          autoComplete="off"
           autoFocus={true}
           data-test="confirm-sign-in-code-input"
           key="code"

--- a/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ConfirmSignUp-test.tsx.snap
+++ b/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ConfirmSignUp-test.tsx.snap
@@ -1973,7 +1973,6 @@ exports[`ConfirmSignIn normal case render correctly with Props confirmSignUp 1`]
          *
       </Component>
       <Component
-        autoComplete="off"
         autoFocus={true}
         data-test="confirm-sign-up-confirmation-code-input"
         key="code"

--- a/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ForgotPassword-test.tsx.snap
+++ b/packages/aws-amplify-react/__tests__/Auth/__snapshots__/ForgotPassword-test.tsx.snap
@@ -3950,7 +3950,6 @@ exports[`forgotPassword normal case render correctly with state delivery set 1`]
            *
         </Component>
         <Component
-          autoComplete="off"
           key="code"
           name="code"
           onChange={[Function]}
@@ -4691,7 +4690,6 @@ exports[`forgotPassword normal case render correctly with state delivery set 1`]
            *
         </Component>
         <Component
-          autoComplete="off"
           key="password"
           name="password"
           onChange={[Function]}

--- a/packages/aws-amplify-react/__tests__/Auth/__snapshots__/VerifyContact-test.tsx.snap
+++ b/packages/aws-amplify-react/__tests__/Auth/__snapshots__/VerifyContact-test.tsx.snap
@@ -35,7 +35,6 @@ exports[`VerifyContent test render test render submitView if verifyAttr is set 1
   >
     <div>
       <Component
-        autoComplete="off"
         key="code"
         name="code"
         onChange={[Function]}

--- a/packages/aws-amplify-react/src/Amplify-UI/Amplify-UI-Components-React.tsx
+++ b/packages/aws-amplify-react/src/Amplify-UI/Amplify-UI-Components-React.tsx
@@ -186,8 +186,15 @@ export const InputRow = props => {
 export const Input = props => {
 	const theme = props.theme || AmplifyTheme;
 	const style = propStyle(props, theme.input);
-	const p = objectLessAttributes(props, 'theme');
-	return <input {...p} className={AmplifyUI.input} style={style} />;
+	const p = objectLessAttributes(props, ['autoComplete', 'theme']);
+	return (
+		<input
+			{...p}
+			className={AmplifyUI.input}
+			style={style}
+			autoComplete="off"
+		/>
+	);
 };
 
 export const SelectInput = props => {

--- a/packages/aws-amplify-react/src/Auth/ConfirmSignIn.tsx
+++ b/packages/aws-amplify-react/src/Auth/ConfirmSignIn.tsx
@@ -125,7 +125,6 @@ export class ConfirmSignIn extends AuthPiece<
 								theme={theme}
 								key="code"
 								name="code"
-								autoComplete="off"
 								onChange={this.handleInputChange}
 								data-test={auth.confirmSignIn.codeInput}
 							/>

--- a/packages/aws-amplify-react/src/Auth/ConfirmSignUp.tsx
+++ b/packages/aws-amplify-react/src/Auth/ConfirmSignUp.tsx
@@ -15,7 +15,7 @@ import * as React from 'react';
 import { I18n, ConsoleLogger as Logger } from '@aws-amplify/core';
 import { Auth } from '@aws-amplify/auth';
 
-import { AuthPiece, IAuthPieceProps, IAuthPieceState  } from './AuthPiece';
+import { AuthPiece, IAuthPieceProps, IAuthPieceState } from './AuthPiece';
 import {
 	FormSection,
 	SectionHeader,
@@ -35,10 +35,7 @@ import { auth } from '../Amplify-UI/data-test-attributes';
 
 const logger = new Logger('ConfirmSignUp');
 
-export class ConfirmSignUp extends AuthPiece<
-	IAuthPieceProps,
-	IAuthPieceState
-> {
+export class ConfirmSignUp extends AuthPiece<IAuthPieceProps, IAuthPieceState> {
 	constructor(props: IAuthPieceProps) {
 		super(props);
 
@@ -116,7 +113,6 @@ export class ConfirmSignUp extends AuthPiece<
 							theme={theme}
 							key="code"
 							name="code"
-							autoComplete="off"
 							onChange={this.handleInputChange}
 							data-test={auth.confirmSignUp.confirmationCodeInput}
 						/>

--- a/packages/aws-amplify-react/src/Auth/ForgotPassword.tsx
+++ b/packages/aws-amplify-react/src/Auth/ForgotPassword.tsx
@@ -106,7 +106,6 @@ export class ForgotPassword extends AuthPiece<
 						theme={theme}
 						key="code"
 						name="code"
-						autoComplete="off"
 						onChange={this.handleInputChange}
 					/>
 				</FormField>
@@ -118,7 +117,6 @@ export class ForgotPassword extends AuthPiece<
 						type="password"
 						key="password"
 						name="password"
-						autoComplete="off"
 						onChange={this.handleInputChange}
 					/>
 				</FormField>

--- a/packages/aws-amplify-react/src/Auth/VerifyContact.tsx
+++ b/packages/aws-amplify-react/src/Auth/VerifyContact.tsx
@@ -41,7 +41,7 @@ export interface IVerifyContactState extends IAuthPieceState {
 export class VerifyContact extends AuthPiece<
 	IAuthPieceProps,
 	IVerifyContactState
-	> {
+> {
 	constructor(props: IAuthPieceProps) {
 		super(props);
 
@@ -138,7 +138,6 @@ export class VerifyContact extends AuthPiece<
 					theme={theme}
 					key="code"
 					name="code"
-					autoComplete="off"
 					onChange={this.handleInputChange}
 				/>
 			</div>
@@ -173,14 +172,14 @@ export class VerifyContact extends AuthPiece<
 								{I18n.get('Submit')}
 							</Button>
 						) : (
-								<Button
-									theme={theme}
-									onClick={this.verify}
-									data-test={auth.verifyContact.verifyButton}
-								>
-									{I18n.get('Verify')}
-								</Button>
-							)}
+							<Button
+								theme={theme}
+								onClick={this.verify}
+								data-test={auth.verifyContact.verifyButton}
+							>
+								{I18n.get('Verify')}
+							</Button>
+						)}
 					</SectionFooterPrimaryContent>
 					<SectionFooterSecondaryContent theme={theme}>
 						<Link


### PR DESCRIPTION
Fixes #5048

_Description of changes:_
When an app using react components is shared between multiple customers or a machine is left unlocked, username/email/phone autocomplete may be persisted in the browser and accessed by other users. 

By making the `<Input>` component to automatically set autocomplete=OFF to all scenarios, we can include not only passwords but also all the other fields.

If you disagree we can also make this configurable (but perhaps the default should still be OFF).

Thoughts?

Thanks for your help.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
