### PR TITLE
Add headerText to TOTPSetup component

### DIFF
--- a/packages/amplify-ui-components/src/components.d.ts
+++ b/packages/amplify-ui-components/src/components.d.ts
@@ -769,6 +769,10 @@ export namespace Components {
          */
         "handleAuthStateChange": AuthStateHandler;
         /**
+          * Used for header text in totp setup component
+         */
+        "headerText": string;
+        /**
           * Used in order to configure TOTP for a user
          */
         "user": CognitoUserInterface;
@@ -1904,6 +1908,10 @@ declare namespace LocalJSX {
           * Auth state change handler for this component
          */
         "handleAuthStateChange"?: AuthStateHandler;
+        /**
+          * Used for header text in totp setup component
+         */
+        "headerText"?: string;
         /**
           * Used in order to configure TOTP for a user
          */

--- a/packages/amplify-ui-components/src/components/amplify-totp-setup/amplify-totp-setup.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-totp-setup/amplify-totp-setup.tsx
@@ -25,6 +25,8 @@ export class AmplifyTOTPSetup {
   @Prop() user: CognitoUserInterface;
   /** Auth state change handler for this component */
   @Prop() handleAuthStateChange: AuthStateHandler = dispatchAuthStateChangeEvent;
+  /** Used for header text in totp setup component */
+  @Prop() headerText: string = I18n.get(Translations.TOTP_HEADER_TEXT);
 
   @State() code: string | null = null;
   @State() setupMessage: string | null = null;
@@ -136,7 +138,7 @@ export class AmplifyTOTPSetup {
   render() {
     return (
       <amplify-form-section
-        headerText={I18n.get(Translations.TOTP_HEADER_TEXT)}
+        headerText={this.headerText}
         submitButtonText={I18n.get(Translations.TOTP_SUBMIT_BUTTON_TEXT)}
         handleSubmit={event => this.verifyTotpToken(event)}
         loading={this.loading}

--- a/packages/amplify-ui-components/src/components/amplify-totp-setup/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-totp-setup/readme.md
@@ -5,10 +5,11 @@
 
 ## Properties
 
-| Property                | Attribute | Description                                  | Type                                                | Default                        |
-| ----------------------- | --------- | -------------------------------------------- | --------------------------------------------------- | ------------------------------ |
-| `handleAuthStateChange` | --        | Auth state change handler for this component | `(nextAuthState: AuthState, data?: object) => void` | `dispatchAuthStateChangeEvent` |
-| `user`                  | --        | Used in order to configure TOTP for a user   | `CognitoUserInterface`                              | `undefined`                    |
+| Property                | Attribute     | Description                                  | Type                                                | Default                                   |
+| ----------------------- | ------------- | -------------------------------------------- | --------------------------------------------------- | ----------------------------------------- |
+| `handleAuthStateChange` | --            | Auth state change handler for this component | `(nextAuthState: AuthState, data?: object) => void` | `dispatchAuthStateChangeEvent`            |
+| `headerText`            | `header-text` | Used for header text in totp setup component | `string`                                            | `I18n.get(Translations.TOTP_HEADER_TEXT)` |
+| `user`                  | --            | Used in order to configure TOTP for a user   | `CognitoUserInterface`                              | `undefined`                               |
 
 
 ## Dependencies


### PR DESCRIPTION
_Description of changes:_
- Add `headerText` to `AmplifyTOTPSetup` component to match customization docs
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
