### PR TITLE
ci: add retry logic for lerna publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,6 +452,7 @@ releasable_branches: &releasable_branches
       - master
       - ui-components/master
       - 1.0-stable
+      - publish-retry-logic #TODO: remove line before merging
 
 workflows:
   build_test_deploy:
@@ -514,23 +515,23 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
-      - deploy:
-          filters:
-            <<: *releasable_branches
-          requires:
-            - unit_test
-            - integ_react_predictions
-            - integ_react_auth
-            - integ_angular_auth
-            - integ_vue_auth
-            - integ_react_auth_ui
-            - integ_angular_auth_ui
-            - integ_vue_auth_ui
-            - integ_rn_ios_storage
-      - post_release:
-          filters:
-            branches:
-              only:
-                - release
-          requires:
-            - deploy
+      # - deploy:
+      #     filters:
+      #       <<: *releasable_branches
+      #     requires:
+      #       - unit_test
+      #       - integ_react_predictions
+      #       - integ_react_auth
+      #       - integ_angular_auth
+      #       - integ_vue_auth
+      #       - integ_react_auth_ui
+      #       - integ_angular_auth_ui
+      #       - integ_vue_auth_ui
+      #       - integ_rn_ios_storage
+      # - post_release:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #     requires:
+      #       - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,15 +72,7 @@ commands:
             git config --global user.name $NPM_USER
             git status
             git --no-pager diff
-            n=0
-            until [ "$n" -ge 5 ]
-            do
-              ./node_modules/lerna/cli.js publish --no-push --canary minor --dist-tag=unstable --preid=unstable --exact --force-publish --yes && break
-              git reset --hard
-              n=$((n+1))
-              sleep 5
-              echo "Retry $n of 5"
-            done
+            ./.circleci/retry-publish.sh publish:verdaccio
 
   prepare_test_env:
     steps:
@@ -427,15 +419,7 @@ jobs:
               git config --global user.name $GITHUB_USER
               git status
               git --no-pager diff
-              n=0
-              until [ "$n" -ge 5 ]
-              do
-                yarn run publish:$CIRCLE_BRANCH && break
-                git reset --hard
-                n=$((n+1))
-                sleep 5
-                echo "Retry $n of 5"
-              done
+              ./.circleci/retry-publish.sh publish:$CIRCLE_BRANCH
             else
               echo "Skipping deploy."
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ executors:
 
 test_env_vars: &test_env_vars
   environment:
-    NPM_REGISTRY: http://localhost:4873/
+    NPM_REGISTRY: http://0.0.0.0:4873/
     NPM_USER: circleci
     NPM_PASS: circleci
     NPM_EMAIL: circleci@amplify.js
@@ -72,7 +72,15 @@ commands:
             git config --global user.name $NPM_USER
             git status
             git --no-pager diff
-            ./node_modules/lerna/cli.js publish --no-push --canary minor --dist-tag=unstable --preid=unstable --exact --force-publish --yes
+            n=0
+            until [ "$n" -ge 5 ]
+            do
+              ./node_modules/lerna/cli.js publish --no-push --canary minor --dist-tag=unstable --preid=unstable --exact --force-publish --yes && break
+              git reset --hard
+              n=$((n+1))
+              sleep 5
+              echo "Retry $n of 5"
+            done
 
   prepare_test_env:
     steps:
@@ -419,7 +427,15 @@ jobs:
               git config --global user.name $GITHUB_USER
               git status
               git --no-pager diff
-              yarn run publish:$CIRCLE_BRANCH
+              n=0
+              until [ "$n" -ge 5 ]
+              do
+                yarn run publish:$CIRCLE_BRANCH && break
+                git reset --hard
+                n=$((n+1))
+                sleep 5
+                echo "Retry $n of 5"
+              done
             else
               echo "Skipping deploy."
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,7 +452,6 @@ releasable_branches: &releasable_branches
       - master
       - ui-components/master
       - 1.0-stable
-      - publish-retry-logic #TODO: remove line before merging
 
 workflows:
   build_test_deploy:
@@ -515,23 +514,23 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
-      # - deploy:
-      #     filters:
-      #       <<: *releasable_branches
-      #     requires:
-      #       - unit_test
-      #       - integ_react_predictions
-      #       - integ_react_auth
-      #       - integ_angular_auth
-      #       - integ_vue_auth
-      #       - integ_react_auth_ui
-      #       - integ_angular_auth_ui
-      #       - integ_vue_auth_ui
-      #       - integ_rn_ios_storage
-      # - post_release:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #     requires:
-      #       - deploy
+      - deploy:
+          filters:
+            <<: *releasable_branches
+          requires:
+            - unit_test
+            - integ_react_predictions
+            - integ_react_auth
+            - integ_angular_auth
+            - integ_vue_auth
+            - integ_react_auth_ui
+            - integ_angular_auth_ui
+            - integ_vue_auth_ui
+            - integ_rn_ios_storage
+      - post_release:
+          filters:
+            branches:
+              only:
+                - release
+          requires:
+            - deploy

--- a/.circleci/retry-publish.sh
+++ b/.circleci/retry-publish.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+n=0
+until [ "$n" -ge 5 ]
+do
+	yarn $1 && break
+	git reset --hard
+	n=$((n+1))
+	sleep 5
+	echo "Retry $n of 5"
+done

--- a/.circleci/retry-publish.sh
+++ b/.circleci/retry-publish.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 
+# initialize counter
 n=0
+# loop until n >= 5
 until [ "$n" -ge 5 ]
 do
+	# $1 is the argument passed in, e.g. publish:verdaccio
+	# if the publish command succeeds, `break` exits the loop
 	yarn $1 && break
+	# if the command fails
+	# reset git HEAD (remove the package.json changes made by lerna)
 	git reset --hard
+	# increment counter
 	n=$((n+1))
+	# wait 5 seconds
 	sleep 5
 	echo "Retry $n of 5"
 done

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 		"publish:master": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=unstable --preid=unstable --exact",
 		"publish:beta": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=beta --preid=beta --exact",
 		"publish:release": "lerna publish --conventional-commits --yes --message 'chore(release): Publish [ci skip]'",
-		"publish:1.0-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-1.0 --message 'chore(release): Publish [ci skip]'"
+		"publish:1.0-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-1.0 --message 'chore(release): Publish [ci skip]'",
+		"publish:verdaccio": "lerna publish --no-push --canary minor --dist-tag=unstable --preid=unstable --exact --force-publish --yes"
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
Add bash retry logic for `lerna publish` - when publishing to verdaccio as well as to npm


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
