### PR TITLE
fix(@aws-amplify/auth): Cache retrieved session tokens before dispatching signIn event (on OAuth)

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1850,6 +1850,10 @@ export class AuthClass {
 				const currentUser = this.createCognitoUser(
 					session.getIdToken().decodePayload()['cognito:username']
 				);
+
+				// This calls cacheTokens() in Cognito SDK
+				currentUser.setSignInUserSession(session);
+
 				dispatchAuthEvent(
 					'signIn',
 					currentUser,
@@ -1873,9 +1877,6 @@ export class AuthClass {
 						`State for user ${currentUser.getUsername()}`
 					);
 				}
-
-				// This calls cacheTokens() in Cognito SDK
-				currentUser.setSignInUserSession(session);
 				//#endregion
 
 				if (window && typeof window.history !== 'undefined') {


### PR DESCRIPTION
_Issue #, if available:_ #5925

_Description of changes:_

On OAuth signIn, changed to call `currentUser.setSignInUserSession(session)` before dispatching `signIn` event.
Adjusting to normal signIn case (where the method is called before the event) to take the consistency.

The more detailed context is on [issue](https://github.com/aws-amplify/amplify-js/issues/5925).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
