### PR TITLE
Expose background color css api for global theme and authenticator

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.scss
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.scss
@@ -1,0 +1,3 @@
+:host {
+  --background-color: var(--amplify-background-color);
+}

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
@@ -17,6 +17,7 @@ const logger = new Logger('Authenticator');
 
 @Component({
   tag: 'amplify-authenticator',
+  styleUrl: 'amplify-authenticator.scss',
   shadow: true,
 })
 export class AmplifyAuthenticator {

--- a/packages/amplify-ui-components/src/components/amplify-section/amplify-section.scss
+++ b/packages/amplify-ui-components/src/components/amplify-section/amplify-section.scss
@@ -1,8 +1,6 @@
 :host {
-  --background-color: var(--amplify-white);
   --font-family: var(--amplify-font-family);
 }
-
 
 .section {
   position: relative;

--- a/packages/amplify-ui-components/src/global/theme.ts
+++ b/packages/amplify-ui-components/src/global/theme.ts
@@ -46,6 +46,8 @@ if (browserOrNode().isBrowser) {
       --amplify-tertiary-tint: #7da1ff;
       --amplify-tertiary-shade: #537BE5;
 
+      --amplify-background-color: var(--amplify-white);
+
       /* Neutral */
       --amplify-grey: #828282;
       --amplify-light-grey: #c4c4c4;

--- a/packages/amplify-ui-vue/package.json
+++ b/packages/amplify-ui-vue/package.json
@@ -23,6 +23,7 @@
 		"build": "npm run clean && npm run compile",
 		"clean": "rm -rf dist",
 		"compile": "npm run tsc",
-		"tsc": "tsc -p ."
+		"tsc": "tsc -p .",
+		"watch": "tsc -w -p ."
 	}
 }

--- a/packages/amplify-ui-vue/package.json
+++ b/packages/amplify-ui-vue/package.json
@@ -23,7 +23,6 @@
 		"build": "npm run clean && npm run compile",
 		"clean": "rm -rf dist",
 		"compile": "npm run tsc",
-		"tsc": "tsc -p .",
-		"watch": "tsc -w -p ."
+		"tsc": "tsc -p ."
 	}
 }


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/issues/5799

_Description of changes:_
- Expose `--background-color` on `amplify-authenticator` which will cascade down to children in it's shadow dom
- Expose `--amplify-background-color` global theme background variable and use it for the default Authenticator background color

![Kapture 2020-05-28 at 12 55 24](https://user-images.githubusercontent.com/3868826/83187784-8ce41680-a0e3-11ea-9162-c18581ac1f54.gif)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
