### PR TITLE
Fix performance undefined variable in RN

### DIFF
--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -392,7 +392,7 @@ export function monotonicUlidFactory(seed?: number): ULID {
  * See: https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#Example
  */
 export function getNow() {
-	if (performance && typeof performance.now === 'function') {
+	if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
 		return performance.now() | 0; // convert to integer
 	} else {
 		return Date.now();


### PR DESCRIPTION
_Issue #, if available:_
Error in console when running DataStore 2.2.0.
![image](https://user-images.githubusercontent.com/762914/83594556-1d15d600-a592-11ea-83aa-6f09ac00813f.png)


_Description of changes:_
Fixes unhandled promise rejection because of undefined variable ('performance') in React native.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
