### PR TITLE
fix(@aws-amplify/datastore): Fix potential NPE

### DIFF
--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -392,7 +392,11 @@ export function monotonicUlidFactory(seed?: number): ULID {
  * See: https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#Example
  */
 export function getNow() {
-	if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+	if (
+		typeof performance !== 'undefined' &&
+		performance &&
+		typeof performance.now === 'function'
+	) {
 		return performance.now() | 0; // convert to integer
 	} else {
 		return Date.now();


### PR DESCRIPTION
Consumers could define a global variable "performance" with a null value. This PR addresses that (unlikely but possible) case

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
