### PR TITLE
Fix - PubSub realtime provider not reset when configuration endpoint changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
 		"typedoc": "^0.11.0",
 		"typescript": "~3.6.4",
 		"uglifyjs-webpack-plugin": "^0.4.6",
+		"uuid-validate": "^0.0.3",
 		"webpack": "^4.32.0",
 		"webpack-bundle-analyzer": "^3.3.2",
 		"webpack-cli": "^3.1.0",

--- a/packages/datastore/.npmignore
+++ b/packages/datastore/.npmignore
@@ -1,0 +1,15 @@
+__mocks__/**
+__tests__/**
+coverage/**
+docs/**
+node_modules/**
+.vscode/**
+.DS_Store
+*.log
+prepend-license.js
+prettier.config.json
+tsconfig.json
+tsfmt.json
+tslint.json
+typeDoc.js
+webpack.config.js

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -1,0 +1,186 @@
+import 'fake-indexeddb/auto';
+import * as uuidValidate from 'uuid-validate';
+import { initSchema as initSchemaType } from '../src/datastore/datastore';
+import {
+	ModelInit,
+	MutableModel,
+	PersistentModelConstructor,
+	Schema,
+} from '../src/types';
+
+let initSchema: typeof initSchemaType;
+
+beforeEach(() => {
+	jest.resetModules();
+
+	({ initSchema } = require('../src/datastore/datastore'));
+});
+
+describe('DataStore tests', () => {
+	describe('initSchema tests', () => {
+		test('Class is created', () => {
+			const classes = initSchema(testSchema());
+
+			expect(classes).toHaveProperty('Model');
+
+			const { Model } = classes;
+
+			let property: keyof PersistentModelConstructor<any> = 'copyOf';
+			expect(Model).toHaveProperty(property);
+
+			expect(typeof Model.copyOf).toBe('function');
+		});
+
+		test('Class can be instantiated', () => {
+			const { Model } = initSchema(testSchema()) as {
+				Model: PersistentModelConstructor<Model>;
+			};
+
+			const model = new Model({
+				field1: 'something',
+			});
+
+			expect(model).toBeInstanceOf(Model);
+
+			expect(model.id).toBeDefined();
+
+			// syncable models use uuid v4
+			expect(uuidValidate(model.id, 4)).toBe(true);
+		});
+
+		test('Non-syncable models get a uuid v1', () => {
+			const { LocalModel } = initSchema(testSchema()) as {
+				LocalModel: PersistentModelConstructor<Model>;
+			};
+
+			const model = new LocalModel({
+				field1: 'something',
+			});
+
+			expect(model).toBeInstanceOf(LocalModel);
+
+			expect(model.id).toBeDefined();
+
+			// local models use something like a uuid v1, see https://github.com/kelektiv/node-uuid/issues/75#issuecomment-483756623
+			expect(
+				uuidValidate(model.id.replace(/^(.{4})-(.{4})-(.{8})/, '$3-$2-$1'), 1)
+			).toBe(true);
+		});
+	});
+
+	describe('Immutability', () => {
+		test('Field cannot be changed', () => {
+			const { Model } = initSchema(testSchema()) as {
+				Model: PersistentModelConstructor<Model>;
+			};
+
+			const model = new Model({
+				field1: 'something',
+			});
+
+			expect(() => {
+				(<any>model).field1 = 'edit';
+			}).toThrowError("Cannot assign to read only property 'field1' of object");
+		});
+
+		test('Model can be copied+edited by creating an edited copy', () => {
+			const { Model } = initSchema(testSchema()) as {
+				Model: PersistentModelConstructor<Model>;
+			};
+
+			const model1 = new Model({
+				field1: 'something',
+			});
+
+			const model2 = Model.copyOf(model1, draft => {
+				draft.field1 = 'edited';
+			});
+
+			expect(model1).not.toBe(model2);
+
+			// ID should be kept the same
+			expect(model1.id).toBe(model2.id);
+
+			expect(model1.field1).toBe('something');
+			expect(model2.field1).toBe('edited');
+		});
+
+		test('Id cannot be changed inside copyOf', () => {
+			const { Model } = initSchema(testSchema()) as {
+				Model: PersistentModelConstructor<Model>;
+			};
+
+			const model1 = new Model({
+				field1: 'something',
+			});
+
+			const model2 = Model.copyOf(model1, draft => {
+				(<any>draft).id = 'a-new-id';
+			});
+
+			// ID should be kept the same
+			expect(model1.id).toBe(model2.id);
+		});
+	});
+});
+
+//#region Test helpers
+
+declare class Model {
+	public readonly id: string;
+	public readonly field1: string;
+
+	constructor(init: ModelInit<Model>);
+
+	static copyOf(
+		src: Model,
+		mutator: (draft: MutableModel<Model>) => void | Model
+	): Model;
+}
+
+function testSchema(): Schema {
+	return {
+		enums: {},
+		models: {
+			Model: {
+				name: 'Model',
+				syncable: true,
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+					},
+					field1: {
+						name: 'field1',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+					},
+				},
+			},
+			LocalModel: {
+				name: 'LocalModel',
+				syncable: false,
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+					},
+					field1: {
+						name: 'field1',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+					},
+				},
+			},
+		},
+		version: 1,
+	};
+}
+
+//#endregion

--- a/packages/datastore/__tests__/indexeddb.test.ts
+++ b/packages/datastore/__tests__/indexeddb.test.ts
@@ -1,0 +1,372 @@
+import * as idb from 'idb';
+import 'fake-indexeddb/auto';
+import { DataStore } from '../src/index';
+import {
+	Post,
+	Author,
+	BlogOwner,
+	Blog,
+	Comment,
+	PostAuthorJoin,
+} from './model';
+import { USER } from '../src/util';
+let db: idb.IDBPDatabase;
+
+describe('Indexed db storage test', () => {
+	let blog, blog2, blog3, owner, owner2;
+	beforeAll(async () => {
+		await DataStore.query(Post);
+	});
+	beforeEach(async () => {
+		owner = new BlogOwner({ name: 'aaaa' });
+		owner2 = new BlogOwner({ name: 'owner' });
+		blog = new Blog({
+			name: 'Avatar: Last Airbender',
+			owner,
+		});
+		blog2 = new Blog({
+			name: 'blog2',
+			owner: owner2,
+		});
+		blog3 = new Blog({
+			name: 'Avatar 101',
+			owner: new BlogOwner({ name: 'owner 3' }),
+		});
+	});
+	test('setup function', async () => {
+		const namespaceResolver = jest.fn();
+		db = await idb.openDB('amplify-datastore', 1);
+
+		const createdObjStores = db.objectStoreNames;
+		const expectedStores = [
+			`${USER}_Author`,
+			`${USER}_Blog`,
+			`${USER}_BlogOwner`,
+			`${USER}_Comment`,
+			`${USER}_Post`,
+			`${USER}_PostAuthorJoin`,
+		];
+
+		expectedStores.map(item => {
+			expect(createdObjStores).toContain(item);
+		});
+		expect(createdObjStores).not.toContain(`${USER}_blah`);
+
+		// TODO: better way to get this
+		const commentStore = (<any>db)._rawDatabase.rawObjectStores.get(
+			`${USER}_Comment`
+		);
+		const postAuthorStore = (<any>db)._rawDatabase.rawObjectStores.get(
+			`${USER}_PostAuthorJoin`
+		);
+
+		expect(commentStore.rawIndexes.has('commentPostId')).toBe(true); // checks 1:M
+		expect(postAuthorStore.rawIndexes.has('postId')).toBe(true); // checks M:M
+		expect(postAuthorStore.rawIndexes.has('authorId')).toBe(true); // checks M:M
+	});
+
+	test('save function 1:1 insert', async () => {
+		await DataStore.save(blog);
+		await DataStore.save(owner);
+
+		const get1 = await db
+			.transaction(`${USER}_Blog`, 'readonly')
+			.objectStore(`${USER}_Blog`)
+			.get(blog.id);
+
+		expect([...Object.keys(blog).sort(), 'blogOwnerId']).toEqual(
+			expect.arrayContaining(Object.keys(get1).sort())
+		);
+
+		expect(get1['blogOwnerId']).toBe(owner.id);
+
+		const get2 = await db
+			.transaction(`${USER}_BlogOwner`, 'readonly')
+			.objectStore(`${USER}_BlogOwner`)
+			.get(owner.id);
+
+		expect([...Object.keys(owner)].sort()).toEqual(
+			expect.arrayContaining(Object.keys(get2).sort())
+		);
+
+		await DataStore.save(blog2);
+		const get3 = await db
+			.transaction(`${USER}_Blog`, 'readonly')
+			.objectStore(`${USER}_Blog`)
+			.get(blog2.id);
+
+		expect([...Object.keys(blog2).sort(), 'blogOwnerId']).toEqual(
+			expect.arrayContaining(Object.keys(get3).sort())
+		);
+	});
+
+	test('save function 1:M insert', async () => {
+		// test 1:M
+		const p = new Post({
+			title: 'Avatar',
+			blog,
+		});
+		const c1 = new Comment({ content: 'comment 1', post: p });
+		await DataStore.save(c1);
+		const getComment = await db
+			.transaction(`${USER}_Comment`, 'readonly')
+			.objectStore(`${USER}_Comment`)
+			.get(c1.id);
+
+		expect([...Object.keys(c1), 'commentPostId'].sort()).toEqual(
+			expect.arrayContaining(Object.keys(getComment).sort())
+		);
+
+		const checkIndex = await db
+			.transaction(`${USER}_Comment`, 'readonly')
+			.objectStore(`${USER}_Comment`)
+			.index('commentPostId')
+			.get(p.id);
+
+		expect(checkIndex['commentPostId']).toEqual(p.id);
+	});
+
+	test('save function M:M insert', async () => {
+		const post = new Post({
+			title: 'Avatar',
+			blog,
+		});
+
+		await DataStore.save(post);
+		const getPost = await db
+			.transaction(`${USER}_Post`, 'readonly')
+			.objectStore(`${USER}_Post`)
+			.get(post.id);
+
+		expect(getPost.author).toBeUndefined();
+
+		const a1 = new Author({ name: 'author1' });
+		const a2 = new Author({ name: 'author2' });
+
+		await DataStore.save(a1);
+		await DataStore.save(a2);
+
+		const getA1 = await db
+			.transaction(`${USER}_Author`, 'readonly')
+			.objectStore(`${USER}_Author`)
+			.get(a1.id);
+		expect(getA1.name).toEqual('author1');
+
+		const getA2 = await db
+			.transaction(`${USER}_Author`, 'readonly')
+			.objectStore(`${USER}_Author`)
+			.get(a2.id);
+		expect(getA2.name).toEqual('author2');
+
+		await DataStore.save(new PostAuthorJoin({ post, author: a1 }));
+
+		await DataStore.save(new PostAuthorJoin({ post, author: a2 }));
+
+		const p2 = new Post({ title: 'q', blog });
+		await DataStore.save(new PostAuthorJoin({ post: p2, author: a2 }));
+
+		const getAuthors = await db
+			.transaction(`${USER}_PostAuthorJoin`)
+			.objectStore(`${USER}_PostAuthorJoin`)
+			.index('postId')
+			.getAll(post.id);
+
+		expect(getAuthors).toHaveLength(2);
+	});
+
+	test('save update', async () => {
+		await DataStore.save(blog);
+		await DataStore.save(owner);
+
+		const get1 = await db
+			.transaction(`${USER}_Blog`, 'readonly')
+			.objectStore(`${USER}_Blog`)
+			.get(blog.id);
+
+		expect(get1['blogOwnerId']).toBe(owner.id);
+		const updated = Blog.copyOf(blog, draft => {
+			draft.name = 'Avatar: The Last Airbender';
+		});
+
+		await DataStore.save(updated);
+		const get2 = await db
+			.transaction(`${USER}_Blog`, 'readonly')
+			.objectStore(`${USER}_Blog`)
+			.get(blog.id);
+
+		expect(get2.name).toEqual(updated.name);
+	});
+
+	test('query function 1:1', async () => {
+		const [res] = await DataStore.save(blog);
+		await DataStore.save(owner);
+		const query = await DataStore.query(Blog, blog.id);
+
+		expect(query).toEqual(res);
+
+		await DataStore.save(blog3);
+		const query1 = await DataStore.query(Blog);
+		query1.forEach(item => {
+			if (item.owner) {
+				expect(item.owner).toHaveProperty('name');
+			}
+		});
+	});
+
+	test('query M:1 eager load', async () => {
+		const p = new Post({
+			title: 'Avatar',
+			blog,
+		});
+		const c1 = new Comment({ content: 'comment 1', post: p });
+		const c2 = new Comment({ content: 'comment 2', post: p });
+
+		await DataStore.save(p);
+		await DataStore.save(c1);
+		await DataStore.save(c2);
+
+		const q1 = await DataStore.query(Comment, c1.id);
+
+		expect(q1.post.id).toEqual(p.id);
+	});
+
+	test('delete 1:1 function', async () => {
+		await DataStore.save(blog);
+		await DataStore.save(owner);
+
+		await DataStore.delete(Blog, blog.id);
+		await DataStore.delete(BlogOwner, owner.id);
+
+		expect(await DataStore.query(BlogOwner, owner.id)).toBeUndefined();
+		expect(await DataStore.query(Blog, blog.id)).toBeUndefined();
+
+		await DataStore.save(owner);
+		await DataStore.save(owner2);
+
+		await DataStore.save(
+			Blog.copyOf(blog, draft => {
+				draft;
+			})
+		);
+		await DataStore.save(blog2);
+		await DataStore.save(blog3);
+
+		await DataStore.delete(Blog, c => c.name('beginsWith', 'Avatar'));
+
+		expect(await DataStore.query(Blog, blog.id)).toBeUndefined();
+		expect(await DataStore.query(Blog, blog2.id)).toBeDefined();
+		expect(await DataStore.query(Blog, blog3.id)).toBeUndefined();
+	});
+
+	test('delete M:1 function', async () => {
+		const post = new Post({
+			title: 'Avatar',
+			blog,
+		});
+		const c1 = new Comment({ content: 'c1', post });
+		const c2 = new Comment({ content: 'c2', post });
+
+		await DataStore.save(post);
+
+		await DataStore.save(c1);
+		await DataStore.save(c2);
+
+		await DataStore.delete(Comment, c1.id);
+
+		expect(await DataStore.query(Comment, c1.id)).toBeUndefined;
+		expect((await DataStore.query(Comment, c2.id)).id).toEqual(c2.id);
+	});
+
+	test('delete 1:M function', async () => {
+		const post = new Post({
+			title: 'Avatar 1',
+			blog,
+		});
+		const post2 = new Post({
+			title: 'Avatar 2',
+			blog,
+		});
+
+		await DataStore.save(post);
+		await DataStore.save(post2);
+
+		const c1 = new Comment({ content: 'c1', post });
+		const c2 = new Comment({ content: 'c2', post });
+		const c3 = new Comment({ content: 'c3', post: post2 });
+
+		await DataStore.save(c1);
+		await DataStore.save(c2);
+		await DataStore.save(c3);
+
+		await DataStore.delete(Post, post.id);
+		expect(await DataStore.query(Comment, c1.id)).toBeUndefined();
+		expect(await DataStore.query(Comment, c2.id)).toBeUndefined();
+		expect((await DataStore.query(Comment, c3.id)).id).toEqual(c3.id);
+		expect(await DataStore.query(Post, post.id)).toBeUndefined();
+	});
+
+	test('delete M:M function', async () => {
+		const a1 = new Author({ name: 'author1' });
+		const a2 = new Author({ name: 'author2' });
+		const a3 = new Author({ name: 'author3' });
+		const blog = new Blog({ name: 'B1', owner: new BlogOwner({ name: 'O1' }) });
+
+		const post = new Post({
+			title: 'Avatar',
+			blog,
+		});
+		const post2 = new Post({
+			title: 'Avatar 2',
+			blog,
+		});
+		await DataStore.save(post);
+		await DataStore.save(post2);
+
+		await DataStore.delete(Post, post.id);
+		const res = await db
+			.transaction('user_PostAuthorJoin', 'readwrite')
+			.objectStore('user_PostAuthorJoin')
+			.index('postId')
+			.getAll(post.id);
+		expect(res).toHaveLength(0);
+		await DataStore.delete(Post, c => c);
+		await DataStore.delete(Author, c => c);
+	});
+
+	test('delete cascade', async () => {
+		const [a1] = await DataStore.save(new Author({ name: 'author1' }));
+		const [a2] = await DataStore.save(new Author({ name: 'author2' }));
+		const blog = new Blog({
+			name: 'The Blog',
+			owner,
+		});
+		const p1 = new Post({
+			title: 'Post 1',
+			blog,
+		});
+		const p2 = new Post({
+			title: 'Post 2',
+			blog,
+		});
+		const [c1] = await DataStore.save(new Comment({ content: 'c1', post: p1 }));
+		const [c2] = await DataStore.save(new Comment({ content: 'c2', post: p1 }));
+		await DataStore.save(p1);
+		await DataStore.save(p2);
+		await DataStore.save(blog);
+		await DataStore.delete(BlogOwner, owner.id);
+		expect(await DataStore.query(Blog, blog.id)).toBeUndefined();
+		expect(await DataStore.query(BlogOwner, owner.id)).toBeUndefined();
+		expect(await DataStore.query(Post, p1.id)).toBeUndefined();
+		expect(await DataStore.query(Post, p2.id)).toBeUndefined();
+		expect(await DataStore.query(Comment, c1.id)).toBeUndefined();
+		expect(await DataStore.query(Comment, c2.id)).toBeUndefined();
+		expect(await DataStore.query(Author, a1.id)).toEqual(a1);
+		expect(await DataStore.query(Author, a2.id)).toEqual(a2);
+		const refResult = await db
+			.transaction(`${USER}_PostAuthorJoin`, 'readonly')
+			.objectStore(`${USER}_PostAuthorJoin`)
+			.index('postId')
+			.getAll(p1.id);
+		expect(refResult).toHaveLength(0);
+	});
+});

--- a/packages/datastore/__tests__/model.ts
+++ b/packages/datastore/__tests__/model.ts
@@ -1,0 +1,98 @@
+import {
+	ModelInit,
+	MutableModel,
+	PersistentModelConstructor,
+} from '@aws-amplify/datastore';
+
+import { initSchema } from '../src/index';
+import { newSchema } from './schema';
+
+declare class BlogModel {
+	readonly id: string;
+	readonly name: string;
+	readonly posts?: PostModel[];
+	readonly owner: BlogOwnerModel;
+	constructor(init: ModelInit<BlogModel>);
+	static copyOf(
+		source: BlogModel,
+		mutator: (draft: MutableModel<BlogModel>) => MutableModel<BlogModel> | void
+	): BlogModel;
+}
+
+declare class PostModel {
+	readonly id: string;
+	readonly title: string;
+	readonly blog?: BlogModel;
+	readonly comments?: CommentModel[];
+	readonly authors?: PostAuthorJoinModel[];
+	constructor(init: ModelInit<PostModel>);
+	static copyOf(
+		source: PostModel,
+		mutator: (draft: MutableModel<PostModel>) => MutableModel<PostModel> | void
+	): PostModel;
+}
+
+declare class CommentModel {
+	readonly id: string;
+	readonly content?: string;
+	readonly post?: PostModel;
+	constructor(init: ModelInit<CommentModel>);
+	static copyOf(
+		source: CommentModel,
+		mutator: (
+			draft: MutableModel<CommentModel>
+		) => MutableModel<CommentModel> | void
+	): CommentModel;
+}
+
+declare class PostAuthorJoinModel {
+	readonly id: string;
+	readonly author?: AuthorModel;
+	readonly post?: PostModel;
+	constructor(init: ModelInit<PostAuthorJoinModel>);
+	static copyOf(
+		source: PostAuthorJoinModel,
+		mutator: (
+			draft: MutableModel<PostAuthorJoinModel>
+		) => MutableModel<PostAuthorJoinModel> | void
+	): PostAuthorJoinModel;
+}
+
+declare class AuthorModel {
+	readonly id: string;
+	readonly name: string;
+	readonly posts?: PostAuthorJoinModel[];
+	constructor(init: ModelInit<AuthorModel>);
+	static copyOf(
+		source: AuthorModel,
+		mutator: (
+			draft: MutableModel<AuthorModel>
+		) => MutableModel<AuthorModel> | void
+	): AuthorModel;
+}
+
+declare class BlogOwnerModel {
+	readonly name: string;
+	readonly id: string;
+	readonly blog?: BlogModel;
+	constructor(init: ModelInit<BlogOwnerModel>);
+	static copyOf(
+		source: BlogOwnerModel,
+		mutator: (
+			draft: MutableModel<BlogOwnerModel>
+		) => MutableModel<BlogOwnerModel> | void
+	): BlogOwnerModel;
+}
+
+const { Author, Post, Comment, Blog, BlogOwner, PostAuthorJoin } = initSchema(
+	newSchema
+) as {
+	Author: PersistentModelConstructor<AuthorModel>;
+	Post: PersistentModelConstructor<PostModel>;
+	Comment: PersistentModelConstructor<CommentModel>;
+	Blog: PersistentModelConstructor<BlogModel>;
+	BlogOwner: PersistentModelConstructor<BlogOwnerModel>;
+	PostAuthorJoin: PersistentModelConstructor<PostAuthorJoinModel>;
+};
+
+export { Author, Post, Comment, Blog, BlogOwner, PostAuthorJoin };

--- a/packages/datastore/__tests__/schema.ts
+++ b/packages/datastore/__tests__/schema.ts
@@ -1,0 +1,307 @@
+import { Schema } from '../src/types';
+
+export const newSchema: Schema = {
+	models: {
+		Blog: {
+			syncable: true,
+			name: 'Blog',
+			pluralName: 'Blogs',
+			attributes: [
+				{
+					type: 'model',
+					properties: {},
+				},
+			],
+			fields: {
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				name: {
+					name: 'name',
+					isArray: false,
+					type: 'String',
+					isRequired: true,
+					attributes: [],
+				},
+				posts: {
+					name: 'posts',
+					isArray: true,
+					type: {
+						model: 'Post',
+					},
+					isRequired: false,
+					attributes: [],
+					association: {
+						connectionType: 'HAS_MANY',
+						associatedWith: 'blog',
+					},
+				},
+				owner: {
+					name: 'owner',
+					isArray: false,
+					type: {
+						model: 'BlogOwner',
+					},
+					isRequired: true,
+					attributes: [],
+					association: {
+						connectionType: 'BELONGS_TO',
+						targetName: 'blogOwnerId',
+					},
+				},
+			},
+		},
+		Post: {
+			syncable: true,
+			name: 'Post',
+			pluralName: 'Posts',
+			attributes: [
+				{
+					type: 'model',
+					properties: {},
+				},
+			],
+			fields: {
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				title: {
+					name: 'title',
+					isArray: false,
+					type: 'String',
+					isRequired: true,
+					attributes: [],
+				},
+				blog: {
+					name: 'blog',
+					isArray: false,
+					type: {
+						model: 'Blog',
+					},
+					isRequired: false,
+					attributes: [],
+					association: {
+						connectionType: 'BELONGS_TO',
+						targetName: 'postBlogId',
+					},
+				},
+				comments: {
+					name: 'comments',
+					isArray: true,
+					type: {
+						model: 'Comment',
+					},
+					isRequired: false,
+					attributes: [],
+					association: {
+						connectionType: 'HAS_MANY',
+						associatedWith: 'post',
+					},
+				},
+				authors: {
+					name: 'authors',
+					isArray: true,
+					type: {
+						model: 'PostAuthorJoin',
+					},
+					isRequired: false,
+					attributes: [],
+					association: {
+						connectionType: 'HAS_MANY',
+						associatedWith: 'post',
+					},
+				},
+			},
+		},
+		Comment: {
+			syncable: true,
+			name: 'Comment',
+			pluralName: 'Comments',
+			attributes: [
+				{
+					type: 'model',
+					properties: {},
+				},
+			],
+			fields: {
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				content: {
+					name: 'content',
+					isArray: false,
+					type: 'String',
+					isRequired: false,
+					attributes: [],
+				},
+				post: {
+					name: 'post',
+					isArray: false,
+					type: {
+						model: 'Post',
+					},
+					isRequired: false,
+					attributes: [],
+					association: {
+						connectionType: 'BELONGS_TO',
+						targetName: 'commentPostId',
+					},
+				},
+			},
+		},
+		PostAuthorJoin: {
+			syncable: true,
+			name: 'PostAuthorJoin',
+			pluralName: 'PostAuthorJoins',
+			attributes: [
+				{
+					type: 'model',
+					properties: {},
+				},
+				{
+					type: 'key',
+					properties: {
+						name: 'byAuthor',
+						fields: ['authorId'],
+					},
+				},
+				{
+					type: 'key',
+					properties: {
+						name: 'byPost',
+						fields: ['postId'],
+					},
+				},
+			],
+			fields: {
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				author: {
+					name: 'author',
+					isArray: false,
+					type: {
+						model: 'Author',
+					},
+					isRequired: false,
+					attributes: [],
+					association: {
+						connectionType: 'BELONGS_TO',
+						targetName: 'authorId',
+					},
+				},
+				post: {
+					name: 'post',
+					isArray: false,
+					type: {
+						model: 'Post',
+					},
+					isRequired: false,
+					attributes: [],
+					association: {
+						connectionType: 'BELONGS_TO',
+						targetName: 'postId',
+					},
+				},
+			},
+		},
+		Author: {
+			syncable: true,
+			name: 'Author',
+			pluralName: 'Authors',
+			attributes: [
+				{
+					type: 'model',
+					properties: {},
+				},
+			],
+			fields: {
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				name: {
+					name: 'name',
+					isArray: false,
+					type: 'String',
+					isRequired: true,
+					attributes: [],
+				},
+				posts: {
+					name: 'posts',
+					isArray: true,
+					type: {
+						model: 'PostAuthorJoin',
+					},
+					isRequired: false,
+					attributes: [],
+					association: {
+						connectionType: 'HAS_MANY',
+						associatedWith: 'author',
+					},
+				},
+			},
+		},
+		BlogOwner: {
+			syncable: true,
+			name: 'BlogOwner',
+			pluralName: 'BlogOwners',
+			attributes: [
+				{
+					type: 'model',
+					properties: {},
+				},
+			],
+			fields: {
+				name: {
+					name: 'name',
+					isArray: false,
+					type: 'String',
+					isRequired: true,
+					attributes: [],
+				},
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				blog: {
+					name: 'blog',
+					isArray: false,
+					type: {
+						model: 'Blog',
+					},
+					isRequired: false,
+					attributes: [],
+					association: {
+						connectionType: 'HAS_ONE',
+						associatedWith: 'owner',
+					},
+				},
+			},
+		},
+	},
+	enums: {},
+	version: 'a66372d29356c40e7cd29e41527cead7',
+};

--- a/packages/datastore/build.js
+++ b/packages/datastore/build.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const build = require('../../scripts/build');
+
+build(process.argv[2], process.argv[3]);

--- a/packages/datastore/index.js
+++ b/packages/datastore/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+	module.exports = require('./dist/aws-amplify-datastore.min.js');
+} else {
+	module.exports = require('./dist/aws-amplify-datastore.js');
+}

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -1,0 +1,91 @@
+{
+  "name": "@aws-amplify/datastore",
+  "version": "1.0.0",
+  "description": "AppSyncLocal support for aws-amplify",
+  "main": "./index.js",
+  "module": "./lib-esm/index.js",
+  "typings": "./lib-esm/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
+    "build-with-test": "npm test && npm run build",
+    "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
+    "build:esm": "node ./build es6",
+    "build:cjs:watch": "node ./build es5 --watch",
+    "build:esm:watch": "node ./build es6 --watch",
+    "build": "npm run clean && npm run build:esm && npm run build:cjs",
+    "clean": "rimraf lib-esm lib dist",
+    "format": "echo \"Not implemented\"",
+    "lint": "tslint 'src/**/*.ts'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws-amplify/amplify-js.git"
+  },
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/aws/aws-amplify/issues"
+  },
+  "homepage": "https://aws-amplify.github.io/",
+  "devDependencies": {
+    "@types/uuid": "3.4.5"
+  },
+  "dependencies": {
+    "@aws-amplify/api": "^2.1.0",
+    "@aws-amplify/core": "^2.1.0",
+    "@aws-amplify/pubsub": "^2.1.0",
+    "idb": "4.0.4",
+    "immer": "3.1.3",
+    "uuid": "3.3.2",
+    "zen-observable-ts": "0.8.19",
+    "zen-push": "0.2.1"
+  },
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "diagnostics": false,
+        "tsConfig": {
+          "lib": [
+            "es5",
+            "es2015",
+            "dom",
+            "esnext.asynciterable",
+            "es2017.object"
+          ],
+          "allowJs": true
+        }
+      }
+    },
+    "transform": {
+      "^.+\\.(js|jsx|ts|tsx)$": "ts-jest"
+    },
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+    "testPathIgnorePatterns" : [
+      "__tests__/model.ts",
+      "__tests__/schema.ts"
+    ],
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "json",
+      "jsx"
+    ],
+    "testEnvironment": "jsdom",
+    "testURL": "http://localhost/",
+    "coverageThreshold": {
+      "global": {
+        "branches": 0,
+        "functions": 0,
+        "lines": 0,
+        "statements": 0
+      }
+    },
+    "coveragePathIgnorePatterns": [
+      "/node_modules/"
+    ]
+  }
+}

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -1,0 +1,789 @@
+import { ConsoleLogger as Logger } from '@aws-amplify/core';
+import { Draft, immerable, produce, setAutoFreeze } from 'immer';
+import { v1 as uuid1, v4 as uuid4 } from 'uuid';
+import Observable from 'zen-observable-ts';
+import { isPredicatesAll, ModelPredicateCreator } from '../predicates';
+import Storage from '../storage/storage';
+import { SyncEngine } from '../sync';
+import {
+	ConflictHandler,
+	DataStoreConfig,
+	GraphQLScalarType,
+	InternalSchema,
+	isGraphQLScalarType,
+	ModelFieldType,
+	ModelInit,
+	ModelInstanceMetadata,
+	ModelPredicate,
+	MutableModel,
+	NamespaceResolver,
+	PaginationInput,
+	PersistentModel,
+	PersistentModelConstructor,
+	ProducerModelPredicate,
+	Schema,
+	SchemaModel,
+	SchemaNamespace,
+	SubscriptionMessage,
+	SyncConflict,
+	SyncError,
+} from '../types';
+import {
+	DATASTORE,
+	establishRelation,
+	exhaustiveCheck,
+	isModelConstructor,
+	NAMESPACES,
+	STORAGE,
+	SYNC,
+	USER,
+} from '../util';
+
+setAutoFreeze(true);
+
+const logger = new Logger('DataStore');
+
+declare class Setting {
+	constructor(init: ModelInit<Setting>);
+	static copyOf(
+		src: Setting,
+		mutator: (draft: MutableModel<Setting>) => void | Setting
+	): Setting;
+	public readonly id: string;
+	public readonly key: string;
+	public readonly value: string;
+}
+
+const SETTING_SCHEMA_VERSION = 'schemaVersion';
+
+let storage: Storage;
+let schema: InternalSchema;
+const classNamespaceMap = new WeakMap<
+	PersistentModelConstructor<any>,
+	string
+>();
+
+const getModelDefinition = (
+	modelConstructor: PersistentModelConstructor<any>
+) => {
+	const namespace = classNamespaceMap.get(modelConstructor);
+
+	return schema.namespaces[namespace].models[modelConstructor.name];
+};
+
+const isValidModelConstructor = <T extends PersistentModel>(
+	obj: any
+): obj is PersistentModelConstructor<T> => {
+	return isModelConstructor(obj) && classNamespaceMap.has(obj);
+};
+
+const namespaceResolver: NamespaceResolver = modelConstructor =>
+	classNamespaceMap.get(modelConstructor);
+
+let dataStoreClasses: {
+	[modelName: string]: PersistentModelConstructor<any>;
+};
+
+let userClasses: {
+	[modelName: string]: PersistentModelConstructor<any>;
+};
+
+let syncClasses: {
+	[modelName: string]: PersistentModelConstructor<any>;
+};
+
+let storageClasses: {
+	[modelName: string]: PersistentModelConstructor<any>;
+};
+
+const initSchema = (userSchema: Schema) => {
+	if (schema !== undefined) {
+		throw new Error('The schema has already been initialized');
+	}
+
+	logger.log('validating schema', { schema: userSchema });
+
+	const internalUserNamespace: SchemaNamespace = {
+		name: USER,
+		...userSchema,
+	};
+
+	logger.log('DataStore', 'Init models');
+	userClasses = createModelClassses(internalUserNamespace);
+	logger.log('DataStore', 'Models initialized');
+
+	const dataStoreNamespace = getNamespace();
+	const storageNamespace = Storage.getNamespace();
+	const syncNamespace = SyncEngine.getNamespace();
+
+	dataStoreClasses = createModelClassses(dataStoreNamespace);
+	storageClasses = createModelClassses(storageNamespace);
+	syncClasses = createModelClassses(syncNamespace);
+
+	schema = {
+		namespaces: {
+			[dataStoreNamespace.name]: dataStoreNamespace,
+			[internalUserNamespace.name]: internalUserNamespace,
+			[storageNamespace.name]: storageNamespace,
+			[syncNamespace.name]: syncNamespace,
+		},
+		version: userSchema.version,
+	};
+
+	Object.keys(schema.namespaces).forEach(namespace => {
+		schema.namespaces[namespace].relationships = establishRelation(
+			schema.namespaces[namespace]
+		);
+
+		const modelAssociations = new Map<string, string[]>();
+
+		Object.values(schema.namespaces[namespace].models).forEach(model => {
+			const wea: string[] = [];
+
+			Object.values(model.fields)
+				.filter(
+					field =>
+						field.association &&
+						field.association.connectionType === 'BELONGS_TO'
+				)
+				.forEach(field => wea.push((<ModelFieldType>field.type).model));
+
+			modelAssociations.set(model.name, wea);
+		});
+
+		const result = new Map<string, string[]>();
+
+		let count = 1000;
+		while (true && count > 0) {
+			if (modelAssociations.size === 0) {
+				break;
+			}
+			count--;
+			if (count === 0) {
+				throw new Error(
+					'Models are not topologically sortable. Please verify your schema.'
+				);
+			}
+
+			for (const modelName of Array.from(modelAssociations.keys())) {
+				const parents = modelAssociations.get(modelName);
+
+				if (parents.every(x => result.has(x))) {
+					result.set(modelName, parents);
+				}
+			}
+
+			Array.from(result.keys()).forEach(x => modelAssociations.delete(x));
+		}
+
+		schema.namespaces[namespace].modelTopologicalOrdering = result;
+	});
+
+	return userClasses;
+};
+
+const createModelClassses: (
+	namespace: SchemaNamespace
+) => {
+	[modelName: string]: PersistentModelConstructor<any>;
+} = namespace => {
+	const classes: {
+		[modelName: string]: PersistentModelConstructor<any>;
+	} = {};
+
+	Object.entries(namespace.models).forEach(([modelName, modelDefinition]) => {
+		const clazz = createModelClass(modelDefinition);
+		classes[modelName] = clazz;
+
+		classNamespaceMap.set(clazz, namespace.name);
+	});
+
+	return classes;
+};
+
+export declare type ModelInstanceCreator = typeof modelInstanceCreator;
+
+const instancesMetadata = new WeakSet<
+	ModelInit<PersistentModel & Partial<ModelInstanceMetadata>>
+>();
+function modelInstanceCreator<T extends PersistentModel = PersistentModel>(
+	modelConstructor: PersistentModelConstructor<T>,
+	init: ModelInit<T> & Partial<ModelInstanceMetadata>
+): T {
+	instancesMetadata.add(init);
+
+	return <T>new modelConstructor(init);
+}
+
+const createModelClass = <T extends PersistentModel>(
+	modelDefinition: SchemaModel
+) => {
+	const clazz = <PersistentModelConstructor<T>>(<unknown>class Model {
+		constructor(init: ModelInit<T>) {
+			const modelInstanceMetadata: ModelInstanceMetadata = instancesMetadata.has(
+				init
+			)
+				? <ModelInstanceMetadata>(<unknown>init)
+				: <ModelInstanceMetadata>{};
+			const {
+				id: _id,
+				_version,
+				_lastChangedAt,
+				_deleted,
+			} = modelInstanceMetadata;
+
+			const id =
+				// instancesIds is set by modelInstanceCreator, it is accessible only internally
+				_id !== null && _id !== undefined
+					? _id
+					: modelDefinition.syncable
+					? uuid4()
+					: // Transform UUID v1 into a lexicographically sortable string
+					  uuid1().replace(/^(.{8})-(.{4})-(.{4})/, '$3-$2-$1');
+
+			const instance = produce(
+				this,
+				(draft: Draft<T & ModelInstanceMetadata>) => {
+					Object.entries(init).forEach(([k, v]) => {
+						const fieldDefinition = modelDefinition.fields[k];
+
+						if (fieldDefinition !== undefined) {
+							const { type, isRequired, name } = fieldDefinition;
+
+							if (isRequired && (v === null || v === undefined)) {
+								throw new Error(`Field ${name} is required`);
+							}
+
+							if (isGraphQLScalarType(type)) {
+								const jsType = GraphQLScalarType.getJSType(type);
+
+								if (typeof v !== jsType && v !== null) {
+									throw new Error(
+										`Field ${name} should be of type ${jsType}, ${typeof v} received. ${v}`
+									);
+								}
+							}
+						}
+
+						(<any>draft)[k] = v;
+					});
+
+					draft.id = id;
+
+					if (modelDefinition.syncable) {
+						draft._version = _version;
+						draft._lastChangedAt = _lastChangedAt;
+						draft._deleted = _deleted;
+					}
+				}
+			);
+
+			return instance;
+		}
+
+		static copyOf(source: T, fn: (draft: MutableModel<T>) => T) {
+			if (
+				!isValidModelConstructor(
+					Object.getPrototypeOf(source || {}).constructor
+				)
+			) {
+				const msg = 'The source object is not a valid model';
+				logger.error(msg, { source });
+
+				throw new Error(msg);
+			}
+
+			return produce(source, draft => {
+				fn(draft);
+				draft.id = source.id;
+			});
+		}
+	});
+
+	clazz[immerable] = true;
+
+	Object.defineProperty(clazz, 'name', { value: modelDefinition.name });
+
+	return clazz;
+};
+
+const save = async <T extends PersistentModel>(
+	model: T,
+	condition?: ProducerModelPredicate<T>
+) => {
+	await start();
+	const modelConstructor: PersistentModelConstructor<T> = model
+		? <PersistentModelConstructor<T>>model.constructor
+		: undefined;
+
+	if (!isValidModelConstructor(modelConstructor)) {
+		const msg = 'Object is not an instance of a valid model';
+		logger.error(msg, { model });
+
+		throw new Error(msg);
+	}
+
+	const modelDefinition = getModelDefinition(modelConstructor);
+
+	const producedCondition = ModelPredicateCreator.createFromExisting(
+		modelDefinition,
+		condition
+	);
+
+	const savedModel = await storage.runExclusive(async s => {
+		await s.save(model, producedCondition);
+
+		return s.query(
+			modelConstructor,
+			ModelPredicateCreator.createForId(modelDefinition, model.id)
+		);
+	});
+
+	return savedModel;
+};
+
+const remove: {
+	<T extends PersistentModel>(
+		model: T,
+		condition?: ProducerModelPredicate<T>
+	): Promise<T>;
+	<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		id: string
+	): Promise<T>;
+	<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		condition: ProducerModelPredicate<T>
+	): Promise<T[]>;
+} = async <T extends PersistentModel>(
+	modelOrConstructor: T | PersistentModelConstructor<T>,
+	idOrCriteria?: string | ProducerModelPredicate<T>
+) => {
+	await start();
+	let condition: ModelPredicate<T>;
+
+	if (!modelOrConstructor) {
+		const msg = 'Model or Model Constructor required';
+		logger.error(msg, { modelOrConstructor });
+
+		throw new Error(msg);
+	}
+
+	if (isValidModelConstructor(modelOrConstructor)) {
+		const modelConstructor = modelOrConstructor;
+
+		if (!idOrCriteria) {
+			const msg =
+				'Id to delete or criteria required. Do you want to delete all? Pass Predicates.ALL';
+			logger.error(msg, { idOrCriteria });
+
+			throw new Error(msg);
+		}
+
+		if (typeof idOrCriteria === 'string') {
+			condition = ModelPredicateCreator.createForId<T>(
+				getModelDefinition(modelConstructor),
+				idOrCriteria
+			);
+		} else {
+			condition = ModelPredicateCreator.createFromExisting(
+				getModelDefinition(modelConstructor),
+				idOrCriteria
+			);
+
+			if (!condition || !ModelPredicateCreator.isValidPredicate(condition)) {
+				const msg =
+					'Criteria required. Do you want to delete all? Pass Predicates.ALL';
+				logger.error(msg, { condition });
+
+				throw new Error(msg);
+			}
+		}
+
+		const [deleted] = await storage.delete(modelConstructor, condition);
+
+		return deleted;
+	} else {
+		const model = modelOrConstructor;
+		const modelConstructor = Object.getPrototypeOf(model || {})
+			.constructor as PersistentModelConstructor<T>;
+
+		if (!isValidModelConstructor(modelConstructor)) {
+			const msg = 'Object is not an instance of a valid model';
+			logger.error(msg, { model });
+
+			throw new Error(msg);
+		}
+
+		const modelDefinition = getModelDefinition(modelConstructor);
+
+		const idPredicate = ModelPredicateCreator.createForId<T>(
+			modelDefinition,
+			model.id
+		);
+
+		if (idOrCriteria) {
+			if (typeof idOrCriteria !== 'function') {
+				const msg = 'Invalid criteria';
+				logger.error(msg, { idOrCriteria });
+
+				throw new Error(msg);
+			}
+
+			condition = idOrCriteria(idPredicate);
+		} else {
+			condition = idPredicate;
+		}
+
+		const [[deleted]] = await storage.delete(model, condition);
+
+		return deleted;
+	}
+};
+
+const observe: {
+	(): Observable<SubscriptionMessage<any>>;
+	<T extends PersistentModel>(obj: T): Observable<SubscriptionMessage<T>>;
+	<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		id: string
+	): Observable<SubscriptionMessage<T>>;
+	<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>
+	): Observable<SubscriptionMessage<T>>;
+	<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		criteria: ProducerModelPredicate<T>
+	): Observable<SubscriptionMessage<T>>;
+} = <T extends PersistentModel>(
+	modelConstructor?: PersistentModelConstructor<T>,
+	idOrCriteria?: string | ProducerModelPredicate<T>
+) => {
+	start();
+	let predicate: ModelPredicate<T>;
+
+	if (idOrCriteria !== undefined && modelConstructor === undefined) {
+		const msg = 'Cannot provide criteria without a modelConstructor';
+		logger.error(msg, idOrCriteria);
+		throw new Error(msg);
+	}
+
+	if (modelConstructor && !isValidModelConstructor(modelConstructor)) {
+		const msg = 'Constructor is not for a valid model';
+		logger.error(msg, { modelConstructor });
+
+		throw new Error(msg);
+	}
+
+	if (typeof idOrCriteria === 'string') {
+		predicate = ModelPredicateCreator.createForId<T>(
+			getModelDefinition(modelConstructor),
+			idOrCriteria
+		);
+	} else {
+		predicate =
+			modelConstructor &&
+			ModelPredicateCreator.createFromExisting(
+				getModelDefinition(modelConstructor),
+				idOrCriteria
+			);
+	}
+
+	return storage
+		.observe(modelConstructor, predicate)
+		.filter(({ model }) => namespaceResolver(model) === USER);
+};
+
+const query: {
+	<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		id: string
+	): Promise<T | undefined>;
+	<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		criteria?: ProducerModelPredicate<T>,
+		pagination?: PaginationInput
+	): Promise<T[]>;
+} = async <T extends PersistentModel>(
+	modelConstructor: PersistentModelConstructor<T>,
+	idOrCriteria?: string | ProducerModelPredicate<T>,
+	pagination?: PaginationInput
+) => {
+	await start();
+	if (!isValidModelConstructor(modelConstructor)) {
+		const msg = 'Constructor is not for a valid model';
+		logger.error(msg, { modelConstructor });
+
+		throw new Error(msg);
+	}
+
+	if (typeof idOrCriteria === 'string') {
+		if (pagination !== undefined) {
+			logger.warn('Pagination is ignored when querying by id');
+		}
+
+		const predicate = ModelPredicateCreator.createForId<T>(
+			getModelDefinition(modelConstructor),
+			idOrCriteria
+		);
+		const [result] = await storage.query(modelConstructor, predicate);
+
+		if (result) {
+			return result;
+		}
+
+		return undefined;
+	}
+
+	// Predicates.ALL means "all records", so no predicate (undefined)
+	const predicate = !isPredicatesAll(idOrCriteria)
+		? ModelPredicateCreator.createFromExisting(
+				getModelDefinition(modelConstructor),
+				idOrCriteria
+		  )
+		: undefined;
+
+	const { limit, page } = pagination || {};
+
+	if (page !== undefined && limit === undefined) {
+		throw new Error('Limit is required when requesting a page');
+	}
+
+	if (page !== undefined) {
+		if (typeof page !== 'number') {
+			throw new Error('Page should be a number');
+		}
+
+		if (page < 0) {
+			throw new Error("Page can't be negative");
+		}
+	}
+
+	if (limit !== undefined) {
+		if (typeof limit !== 'number') {
+			throw new Error('Limit should be a number');
+		}
+
+		if (limit < 0) {
+			throw new Error("Limit can't be negative");
+		}
+	}
+
+	return storage.query(modelConstructor, predicate, pagination);
+};
+
+let sync: SyncEngine;
+let amplifyConfig: Record<string, any> = {};
+let conflictHandler: ConflictHandler;
+let errorHandler: (error: SyncError) => void;
+let maxRecordsToSync: number;
+let fullSyncInterval: number;
+
+function configure(config: DataStoreConfig = {}) {
+	const {
+		DataStore: configDataStore,
+		conflictHandler: configConflictHandler,
+		errorHandler: configErrorHandler,
+		maxRecordsToSync: configMaxRecordsToSync,
+		fullSyncInterval: configFullSyncInterval,
+		...configFromAmplify
+	} = config;
+
+	amplifyConfig = { ...configFromAmplify, ...amplifyConfig };
+
+	conflictHandler =
+		(configDataStore && configDataStore.conflictHandler) ||
+		conflictHandler ||
+		config.conflictHandler ||
+		defaultConflictHandler;
+
+	errorHandler =
+		(configDataStore && configDataStore.errorHandler) ||
+		errorHandler ||
+		config.errorHandler ||
+		defaultErrorHandler;
+
+	maxRecordsToSync =
+		(configDataStore && configDataStore.maxRecordsToSync) ||
+		maxRecordsToSync ||
+		config.maxRecordsToSync;
+
+	fullSyncInterval =
+		(configDataStore && configDataStore.fullSyncInterval) ||
+		configFullSyncInterval ||
+		config.fullSyncInterval ||
+		24 * 60; // 1 day
+}
+
+function defaultConflictHandler(conflictData: SyncConflict): PersistentModel {
+	const { localModel, modelConstructor, remoteModel } = conflictData;
+	const { _version } = remoteModel;
+	return modelInstanceCreator(modelConstructor, { ...localModel, _version });
+}
+
+function defaultErrorHandler(error: SyncError) {
+	logger.warn(error);
+}
+
+function getModelConstructorByModelName(
+	namespaceName: NAMESPACES,
+	modelName: string
+) {
+	switch (namespaceName) {
+		case DATASTORE:
+			return dataStoreClasses[modelName];
+		case USER:
+			return userClasses[modelName];
+		case SYNC:
+			return syncClasses[modelName];
+		case STORAGE:
+			return storageClasses[modelName];
+		default:
+			exhaustiveCheck(namespaceName);
+			break;
+	}
+}
+
+async function checkSchemaVersion(
+	storage: Storage,
+	version: string
+): Promise<void> {
+	const Setting = dataStoreClasses.Setting as PersistentModelConstructor<
+		Setting
+	>;
+
+	const modelDefinition = schema.namespaces[DATASTORE].models.Setting;
+
+	await storage.runExclusive(async s => {
+		const [schemaVersionSetting] = await s.query(
+			Setting,
+			ModelPredicateCreator.createFromExisting(modelDefinition, c =>
+				c.key('eq', SETTING_SCHEMA_VERSION)
+			)
+		);
+
+		if (schemaVersionSetting !== undefined) {
+			const storedValue = JSON.parse(schemaVersionSetting.value);
+
+			if (storedValue !== version) {
+				await s.clear(false);
+			}
+		}
+
+		await s.save(
+			modelInstanceCreator(Setting, {
+				key: SETTING_SCHEMA_VERSION,
+				value: JSON.stringify(version),
+			})
+		);
+	});
+}
+
+let syncSubscription: ZenObservable.Subscription;
+
+async function start(): Promise<void> {
+	if (storage !== undefined) {
+		return;
+	}
+
+	storage = new Storage(
+		schema,
+		namespaceResolver,
+		getModelConstructorByModelName,
+		modelInstanceCreator
+	);
+
+	await checkSchemaVersion(storage, schema.version);
+
+	if (sync !== undefined) {
+		return;
+	}
+
+	const { aws_appsync_graphqlEndpoint } = amplifyConfig;
+
+	if (aws_appsync_graphqlEndpoint) {
+		sync = new SyncEngine(
+			schema,
+			namespaceResolver,
+			syncClasses,
+			userClasses,
+			storage,
+			modelInstanceCreator,
+			maxRecordsToSync,
+			conflictHandler,
+			errorHandler
+		);
+
+		const fullSyncIntervalInMilliseconds = fullSyncInterval * 1000 * 60; // fullSyncInterval from param is in minutes
+		syncSubscription = sync
+			.start({ fullSyncInterval: fullSyncIntervalInMilliseconds })
+			.subscribe({
+				error: err => {
+					logger.warn('Sync error', err);
+				},
+			});
+	}
+}
+
+async function clear() {
+	if (storage === undefined) {
+		return;
+	}
+
+	if (syncSubscription && !syncSubscription.closed) {
+		syncSubscription.unsubscribe();
+	}
+
+	await storage.clear();
+
+	storage = undefined;
+	sync = undefined;
+}
+
+function getNamespace(): SchemaNamespace {
+	const namespace: SchemaNamespace = {
+		name: DATASTORE,
+		relationships: {},
+		enums: {},
+		models: {
+			Setting: {
+				name: 'Setting',
+				pluralName: 'Settings',
+				syncable: false,
+				fields: {
+					id: {
+						name: 'id',
+						type: 'ID',
+						isRequired: true,
+						isArray: false,
+					},
+					key: {
+						name: 'key',
+						type: 'String',
+						isRequired: true,
+						isArray: false,
+					},
+					value: {
+						name: 'value',
+						type: 'String',
+						isRequired: true,
+						isArray: false,
+					},
+				},
+			},
+		},
+	};
+
+	return namespace;
+}
+
+const dataStore = {
+	query,
+	save,
+	delete: remove,
+	observe,
+	configure,
+	clear,
+};
+
+export { initSchema, dataStore };

--- a/packages/datastore/src/index.ts
+++ b/packages/datastore/src/index.ts
@@ -1,0 +1,14 @@
+import Amplify from '@aws-amplify/core';
+import { dataStore as DataStore, initSchema } from './datastore/datastore';
+import { Predicates } from './predicates';
+
+export * from './types';
+export { DataStore, initSchema, Predicates };
+
+const datastore = { configure: DataStore.configure, getModuleName };
+
+function getModuleName() {
+	return 'DataStore';
+}
+
+Amplify.register(datastore);

--- a/packages/datastore/src/predicates/index.ts
+++ b/packages/datastore/src/predicates/index.ts
@@ -1,0 +1,164 @@
+import {
+	AllOperators,
+	ModelPredicate,
+	PersistentModel,
+	PredicateExpression,
+	PredicateGroups,
+	PredicatesGroup,
+	ProducerModelPredicate,
+	SchemaModel,
+} from '../types';
+import { exhaustiveCheck } from '../util';
+
+const predicatesAllSet = new WeakSet<ProducerModelPredicate<any>>();
+
+export function isPredicatesAll(predicate: ProducerModelPredicate<any>) {
+	return predicatesAllSet.has(predicate);
+}
+
+export class Predicates {
+	public static get ALL() {
+		const predicate = <ProducerModelPredicate<any>>(c => c);
+
+		predicatesAllSet.add(predicate);
+
+		return predicate;
+	}
+}
+
+export class ModelPredicateCreator {
+	private static predicateGroupsMap = new WeakMap<
+		ModelPredicate<any>,
+		PredicatesGroup<any>
+	>();
+
+	private static createPredicateBuilder<T extends PersistentModel>(
+		modelDefinition: SchemaModel
+	) {
+		const { name: modelName } = modelDefinition;
+		const fieldNames = new Set<keyof T>(Object.keys(modelDefinition.fields));
+
+		let handler: ProxyHandler<ModelPredicate<T>>;
+		const predicate = new Proxy(
+			{} as ModelPredicate<T>,
+			(handler = {
+				get(
+					_target,
+					propertyKey,
+					receiver: ModelPredicate<T>
+				): PredicateExpression<T, any> {
+					const groupType = propertyKey as keyof PredicateGroups<T>;
+
+					switch (groupType) {
+						case 'and':
+						case 'or':
+						case 'not':
+							const result: PredicateExpression<T, any> = (
+								newPredicate: (criteria: ModelPredicate<T>) => ModelPredicate<T>
+							) => {
+								const group: PredicatesGroup<T> = {
+									type: groupType,
+									predicates: [],
+								};
+
+								// Create a new recorder
+								const tmpPredicateRecorder = new Proxy(
+									{} as ModelPredicate<T>,
+									handler
+								);
+
+								// Set the recorder group
+								ModelPredicateCreator.predicateGroupsMap.set(
+									tmpPredicateRecorder,
+									group
+								);
+
+								// Apply the predicates to the recorder (this is the step that records the changes)
+								newPredicate(tmpPredicateRecorder);
+
+								// Push the group to the top-level recorder
+								ModelPredicateCreator.predicateGroupsMap
+									.get(receiver)
+									.predicates.push(group);
+
+								return receiver;
+							};
+
+							return result;
+						default:
+							exhaustiveCheck(groupType, false);
+					}
+
+					const field = propertyKey as keyof T;
+
+					if (!fieldNames.has(field)) {
+						throw new Error(
+							`Invalid field for model. field: ${field}, model: ${modelName}`
+						);
+					}
+
+					const result: PredicateExpression<T, any> = (
+						operator: keyof AllOperators,
+						operand: any
+					) => {
+						ModelPredicateCreator.predicateGroupsMap
+							.get(receiver)
+							.predicates.push({ field, operator, operand });
+
+						return receiver;
+					};
+
+					return result;
+				},
+			})
+		);
+
+		const group: PredicatesGroup<T> = {
+			type: 'and',
+			predicates: [],
+		};
+		ModelPredicateCreator.predicateGroupsMap.set(predicate, group);
+
+		return predicate;
+	}
+
+	static isValidPredicate<T extends PersistentModel>(
+		predicate: any
+	): predicate is ModelPredicate<T> {
+		return ModelPredicateCreator.predicateGroupsMap.has(predicate);
+	}
+
+	static getPredicates<T extends PersistentModel>(
+		predicate: ModelPredicate<T>,
+		throwOnInvalid: boolean = true
+	) {
+		if (throwOnInvalid && !ModelPredicateCreator.isValidPredicate(predicate)) {
+			throw new Error('The predicate is not valid');
+		}
+
+		return ModelPredicateCreator.predicateGroupsMap.get(predicate);
+	}
+
+	static createFromExisting<T extends PersistentModel>(
+		modelDefinition: SchemaModel,
+		existing: ProducerModelPredicate<T>
+	) {
+		if (!existing || !modelDefinition) {
+			return undefined;
+		}
+
+		return existing(
+			ModelPredicateCreator.createPredicateBuilder(modelDefinition)
+		);
+	}
+
+	static createForId<T extends PersistentModel>(
+		modelDefinition: SchemaModel,
+		id: string
+	) {
+		return ModelPredicateCreator.createPredicateBuilder<T>(modelDefinition).id(
+			'eq',
+			<any>id
+		);
+	}
+}

--- a/packages/datastore/src/storage/adapter/index.ts
+++ b/packages/datastore/src/storage/adapter/index.ts
@@ -1,0 +1,30 @@
+import {
+	ModelPredicate,
+	OpType,
+	PaginationInput,
+	PersistentModel,
+	PersistentModelConstructor,
+	QueryOne,
+	SystemComponent,
+} from '../../types';
+
+export interface Adapter extends SystemComponent {
+	clear(): Promise<void>;
+	save<T extends PersistentModel>(
+		model: T,
+		condition?: ModelPredicate<T>
+	): Promise<[T, OpType.INSERT | OpType.UPDATE][]>;
+	delete: <T extends PersistentModel>(
+		modelOrModelConstructor: T | PersistentModelConstructor<T>,
+		condition?: ModelPredicate<T>
+	) => Promise<[T[], T[]]>;
+	query<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		predicate?: ModelPredicate<T>,
+		pagination?: PaginationInput
+	): Promise<T[]>;
+	queryOne<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		firstOrLast: QueryOne
+	): Promise<T | undefined>;
+}

--- a/packages/datastore/src/storage/adapter/indexeddb.ts
+++ b/packages/datastore/src/storage/adapter/indexeddb.ts
@@ -1,0 +1,639 @@
+import { ConsoleLogger as Logger } from '@aws-amplify/core';
+import * as idb from 'idb';
+import { Adapter } from '.';
+import { ModelInstanceCreator } from '../../datastore/datastore';
+import { ModelPredicateCreator } from '../../predicates';
+import {
+	InternalSchema,
+	isPredicateObj,
+	ModelPredicate,
+	NamespaceResolver,
+	OpType,
+	PersistentModel,
+	PersistentModelConstructor,
+	PredicateObject,
+	QueryOne,
+	RelationType,
+	PaginationInput,
+} from '../../types';
+import {
+	exhaustiveCheck,
+	getIndex,
+	isModelConstructor,
+	traverseModel,
+	validatePredicate,
+	isPrivateMode,
+} from '../../util';
+
+const logger = new Logger('DataStore');
+
+const DB_NAME = 'amplify-datastore';
+
+class IndexedDBAdapter implements Adapter {
+	private schema: InternalSchema;
+	private namespaceResolver: NamespaceResolver;
+	private modelInstanceCreator: ModelInstanceCreator;
+	private getModelConstructorByModelName: (
+		namsespaceName: string,
+		modelName: string
+	) => PersistentModelConstructor<any>;
+	private db: idb.IDBPDatabase;
+	private initPromise: Promise<void>;
+	private resolve: (value?: any) => void;
+	private reject: (value?: any) => void;
+
+	private async checkPrivate() {
+		const isPrivate = await isPrivateMode().then(isPrivate => {
+			return isPrivate;
+		});
+		if (isPrivate) {
+			logger.error("IndexedDB not supported in this browser's private mode");
+			return Promise.reject(
+				"IndexedDB not supported in this browser's private mode"
+			);
+		} else {
+			return Promise.resolve();
+		}
+	}
+
+	private getStorenameForModel(
+		modelConstructor: PersistentModelConstructor<any>
+	) {
+		const namespace = this.namespaceResolver(modelConstructor);
+		const { name: modelName } = modelConstructor;
+
+		return this.getStorename(namespace, modelName);
+	}
+
+	private getStorename(namespace: string, modelName: string) {
+		const storeName = `${namespace}_${modelName}`;
+
+		return storeName;
+	}
+
+	async setUp(
+		theSchema: InternalSchema,
+		namespaceResolver: NamespaceResolver,
+		modelInstanceCreator: ModelInstanceCreator,
+		getModelConstructorByModelName: (
+			namsespaceName: string,
+			modelName: string
+		) => PersistentModelConstructor<any>
+	) {
+		await this.checkPrivate();
+		if (!this.initPromise) {
+			this.initPromise = new Promise((res, rej) => {
+				this.resolve = res;
+				this.reject = rej;
+			});
+		} else {
+			await this.initPromise;
+		}
+
+		this.schema = theSchema;
+		this.namespaceResolver = namespaceResolver;
+		this.modelInstanceCreator = modelInstanceCreator;
+		this.getModelConstructorByModelName = getModelConstructorByModelName;
+
+		try {
+			if (!this.db) {
+				this.db = await idb.openDB(DB_NAME, 1, {
+					upgrade: (db, _oldVersion, _newVersion, _txn) => {
+						const keyPath: string = <string>(<keyof PersistentModel>'id');
+						Object.keys(theSchema.namespaces).forEach(namespaceName => {
+							const namespace = theSchema.namespaces[namespaceName];
+
+							Object.keys(namespace.models).forEach(modelName => {
+								const indexes = this.schema.namespaces[namespaceName]
+									.relationships[modelName].indexes;
+								const storeName = this.getStorename(namespaceName, modelName);
+								const store = db.createObjectStore(storeName, { keyPath });
+								indexes.forEach(index => store.createIndex(index, index));
+							});
+						});
+					},
+				});
+
+				this.resolve();
+			}
+		} catch (error) {
+			this.reject(error);
+		}
+	}
+
+	async save<T extends PersistentModel>(
+		model: T,
+		condition?: ModelPredicate<T>
+	): Promise<[T, OpType.INSERT | OpType.UPDATE][]> {
+		await this.checkPrivate();
+		const modelConstructor = Object.getPrototypeOf(model)
+			.constructor as PersistentModelConstructor<T>;
+		const storeName = this.getStorenameForModel(modelConstructor);
+		const connectedModels = traverseModel(
+			modelConstructor.name,
+			model,
+			this.schema.namespaces[this.namespaceResolver(modelConstructor)],
+			this.modelInstanceCreator,
+			this.getModelConstructorByModelName
+		);
+		const namespaceName = this.namespaceResolver(modelConstructor);
+
+		const set = new Set<string>();
+		const connectionStoreNames = Object.values(connectedModels).map(
+			({ modelName, item, instance }) => {
+				const storeName = this.getStorename(namespaceName, modelName);
+				set.add(storeName);
+				return { storeName, item, instance };
+			}
+		);
+		const tx = this.db.transaction(
+			[storeName, ...Array.from(set.values())],
+			'readwrite'
+		);
+		const store = tx.objectStore(storeName);
+
+		const fromDB = await store.get(model.id);
+
+		if (condition) {
+			const predicates = ModelPredicateCreator.getPredicates(condition);
+			const { predicates: predicateObjs, type } = predicates;
+
+			const isValid = validatePredicate(fromDB, type, predicateObjs);
+
+			if (!isValid) {
+				const msg = 'Conditional update failed';
+				logger.error(msg, { model: fromDB, condition: predicateObjs });
+
+				throw new Error(msg);
+			}
+		}
+
+		const result: [T, OpType.INSERT | OpType.UPDATE][] = [];
+
+		for await (const resItem of connectionStoreNames) {
+			const { storeName, item, instance } = resItem;
+			const store = tx.objectStore(storeName);
+
+			const { id } = item;
+
+			const opType: OpType =
+				(await store.get(id)) === undefined ? OpType.INSERT : OpType.UPDATE;
+
+			// It is me
+			if (id === model.id) {
+				await store.put(item);
+
+				result.push([instance, opType]);
+			} else {
+				if (opType === OpType.INSERT) {
+					await store.put(item);
+
+					result.push([instance, opType]);
+				}
+			}
+		}
+
+		await tx.done;
+
+		return result;
+	}
+
+	private async load<T>(
+		namespaceName: string,
+		srcModelName: string,
+		records: T[]
+	): Promise<T[]> {
+		const namespace = this.schema.namespaces[namespaceName];
+		const relations = namespace.relationships[srcModelName].relationTypes;
+		const connectionStoreNames = relations.map(({ modelName }) => {
+			return this.getStorename(namespaceName, modelName);
+		});
+		const modelConstructor = this.getModelConstructorByModelName(
+			namespaceName,
+			srcModelName
+		);
+
+		if (connectionStoreNames.length === 0) {
+			return records.map(record =>
+				this.modelInstanceCreator(modelConstructor, record)
+			);
+		}
+
+		const tx = this.db.transaction([...connectionStoreNames], 'readonly');
+
+		for await (const relation of relations) {
+			const { fieldName, modelName, targetName } = relation;
+			const storeName = this.getStorename(namespaceName, modelName);
+			const store = tx.objectStore(storeName);
+			const modelConstructor = this.getModelConstructorByModelName(
+				namespaceName,
+				modelName
+			);
+
+			switch (relation.relationType) {
+				case 'HAS_ONE':
+					for await (const recordItem of records) {
+						if (recordItem[fieldName]) {
+							const connectionRecord = await store.get(recordItem[fieldName]);
+
+							recordItem[fieldName] =
+								connectionRecord &&
+								this.modelInstanceCreator(modelConstructor, connectionRecord);
+						}
+					}
+
+					break;
+				case 'BELONGS_TO':
+					for await (const recordItem of records) {
+						if (recordItem[targetName]) {
+							const connectionRecord = await store.get(recordItem[targetName]);
+
+							recordItem[fieldName] =
+								connectionRecord &&
+								this.modelInstanceCreator(modelConstructor, connectionRecord);
+							delete recordItem[targetName];
+						}
+					}
+
+					break;
+				case 'HAS_MANY':
+					// TODO: Lazy loading
+					break;
+				default:
+					exhaustiveCheck(relation.relationType);
+					break;
+			}
+		}
+
+		return records.map(record =>
+			this.modelInstanceCreator(modelConstructor, record)
+		);
+	}
+
+	async query<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		predicate?: ModelPredicate<T>,
+		pagination?: PaginationInput
+	): Promise<T[]> {
+		await this.checkPrivate();
+		const storeName = this.getStorenameForModel(modelConstructor);
+		const namespaceName = this.namespaceResolver(modelConstructor);
+
+		if (predicate) {
+			const predicates = ModelPredicateCreator.getPredicates(predicate);
+			if (predicates) {
+				const { predicates: predicateObjs, type } = predicates;
+				const idPredicate =
+					predicateObjs.length === 1 &&
+					(predicateObjs.find(
+						p => isPredicateObj(p) && p.field === 'id' && p.operator === 'eq'
+					) as PredicateObject<T>);
+
+				if (idPredicate) {
+					const { operand: id } = idPredicate;
+
+					const record = <any>await this.db.get(storeName, id);
+
+					if (record) {
+						const [x] = await this.load(namespaceName, modelConstructor.name, [
+							record,
+						]);
+
+						return [x];
+					}
+					return [];
+				}
+
+				// TODO: Use indices if possible
+				const all = <T[]>await this.db.getAll(storeName);
+
+				const filtered = predicateObjs
+					? all.filter(m => validatePredicate(m, type, predicateObjs))
+					: all;
+
+				return await this.load(
+					namespaceName,
+					modelConstructor.name,
+					this.inMemoryPagination(filtered, pagination)
+				);
+			}
+		}
+
+		return await this.load(
+			namespaceName,
+			modelConstructor.name,
+			await this.enginePagination(storeName, pagination)
+		);
+	}
+
+	private inMemoryPagination<T>(
+		records: T[],
+		pagination?: PaginationInput
+	): T[] {
+		if (pagination) {
+			const { page = 0, limit = 0 } = pagination;
+			const start = Math.max(0, page * limit) || 0;
+
+			const end = limit > 0 ? start + limit : records.length;
+
+			return records.slice(start, end);
+		}
+
+		return records;
+	}
+
+	private async enginePagination<T>(
+		storeName,
+		pagination?: PaginationInput
+	): Promise<T[]> {
+		let result: T[];
+
+		if (pagination) {
+			const { page = 0, limit = 0 } = pagination;
+			const initialRecord = Math.max(0, page * limit) || 0;
+
+			let cursor = await this.db
+				.transaction(storeName)
+				.objectStore(storeName)
+				.openCursor();
+
+			if (initialRecord > 0) {
+				await cursor.advance(initialRecord);
+			}
+
+			const pageResults: T[] = [];
+
+			const hasLimit = typeof limit === 'number' && limit > 0;
+			let moreRecords = true;
+			let itemsLeft = limit;
+			while (moreRecords && cursor.value) {
+				pageResults.push(cursor.value);
+
+				cursor = await cursor.continue();
+
+				if (hasLimit) {
+					itemsLeft--;
+					moreRecords = itemsLeft > 0 && cursor !== null;
+				} else {
+					moreRecords = cursor !== null;
+				}
+			}
+
+			result = pageResults;
+		} else {
+			result = <T[]>await this.db.getAll(storeName);
+		}
+
+		return result;
+	}
+
+	async queryOne<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		firstOrLast: QueryOne = QueryOne.FIRST
+	): Promise<T | undefined> {
+		await this.checkPrivate();
+		const storeName = this.getStorenameForModel(modelConstructor);
+
+		const cursor = await this.db
+			.transaction([storeName], 'readonly')
+			.objectStore(storeName)
+			.openCursor(undefined, firstOrLast === QueryOne.FIRST ? 'next' : 'prev');
+
+		const result = cursor ? <T>cursor.value : undefined;
+
+		return result && this.modelInstanceCreator(modelConstructor, result);
+	}
+
+	async delete<T extends PersistentModel>(
+		modelOrModelConstructor: T | PersistentModelConstructor<T>,
+		condition?: ModelPredicate<T>
+	): Promise<[T[], T[]]> {
+		await this.checkPrivate();
+		const deleteQueue: { storeName: string; items: T[] }[] = [];
+
+		if (isModelConstructor(modelOrModelConstructor)) {
+			const modelConstructor = modelOrModelConstructor;
+			const nameSpace = this.namespaceResolver(modelConstructor);
+
+			const storeName = this.getStorenameForModel(modelConstructor);
+
+			const models = await this.query(modelConstructor, condition);
+			const relations = this.schema.namespaces[nameSpace].relationships[
+				modelConstructor.name
+			].relationTypes;
+
+			if (condition !== undefined) {
+				await this.deleteTraverse(
+					relations,
+					models,
+					modelConstructor.name,
+					nameSpace,
+					deleteQueue
+				);
+
+				await this.deleteItem(deleteQueue);
+
+				const deletedModels = deleteQueue.reduce(
+					(acc, { items }) => acc.concat(items),
+					<T[]>[]
+				);
+
+				return [models, deletedModels];
+			} else {
+				await this.deleteTraverse(
+					relations,
+					models,
+					modelConstructor.name,
+					nameSpace,
+					deleteQueue
+				);
+
+				// Delete all
+				await this.db
+					.transaction([storeName], 'readwrite')
+					.objectStore(storeName)
+					.clear();
+
+				const deletedModels = deleteQueue.reduce(
+					(acc, { items }) => acc.concat(items),
+					<T[]>[]
+				);
+
+				return [models, deletedModels];
+			}
+		} else {
+			const model = modelOrModelConstructor;
+
+			const modelConstructor = Object.getPrototypeOf(model)
+				.constructor as PersistentModelConstructor<T>;
+			const nameSpace = this.namespaceResolver(modelConstructor);
+
+			const storeName = this.getStorenameForModel(modelConstructor);
+
+			if (condition) {
+				const tx = this.db.transaction([storeName], 'readwrite');
+				const store = tx.objectStore(storeName);
+
+				const fromDB = await store.get(model.id);
+
+				const predicates = ModelPredicateCreator.getPredicates(condition);
+				const { predicates: predicateObjs, type } = predicates;
+
+				const isValid = validatePredicate(fromDB, type, predicateObjs);
+
+				if (!isValid) {
+					const msg = 'Conditional update failed';
+					logger.error(msg, { model: fromDB, condition: predicateObjs });
+
+					throw new Error(msg);
+				}
+				await tx.done;
+
+				const relations = this.schema.namespaces[nameSpace].relationships[
+					modelConstructor.name
+				].relationTypes;
+				await this.deleteTraverse(
+					relations,
+					[model],
+					modelConstructor.name,
+					nameSpace,
+					deleteQueue
+				);
+			} else {
+				const relations = this.schema.namespaces[nameSpace].relationships[
+					modelConstructor.name
+				].relationTypes;
+
+				await this.deleteTraverse(
+					relations,
+					[model],
+					modelConstructor.name,
+					nameSpace,
+					deleteQueue
+				);
+			}
+
+			await this.deleteItem(deleteQueue);
+
+			const deletedModels = deleteQueue.reduce(
+				(acc, { items }) => acc.concat(items),
+				<T[]>[]
+			);
+
+			return [[model], deletedModels];
+		}
+	}
+
+	private async deleteItem<T extends PersistentModel>(
+		deleteQueue?: { storeName: string; items: T[] | IDBValidKey[] }[]
+	) {
+		const connectionStoreNames = deleteQueue.map(({ storeName }) => {
+			return storeName;
+		});
+
+		const tx = this.db.transaction([...connectionStoreNames], 'readwrite');
+		for await (const deleteItem of deleteQueue) {
+			const { storeName, items } = deleteItem;
+			const store = tx.objectStore(storeName);
+
+			for await (const item of items) {
+				if (item) {
+					if (typeof item === 'object') {
+						await store.delete(item['id']);
+					}
+					await store.delete(item.toString());
+				}
+			}
+		}
+	}
+
+	private async deleteTraverse<T extends PersistentModel>(
+		relations: RelationType[],
+		models: T[],
+		srcModel: string,
+		nameSpace: string,
+		deleteQueue: { storeName: string; items: T[] }[]
+	): Promise<void> {
+		for await (const rel of relations) {
+			const { relationType, fieldName, modelName } = rel;
+			const storeName = this.getStorename(nameSpace, modelName);
+			switch (relationType) {
+				case 'HAS_ONE':
+					for await (const model of models) {
+						const index = getIndex(
+							this.schema.namespaces[nameSpace].relationships[modelName]
+								.relationTypes,
+							srcModel
+						);
+						const recordToDelete = <T>await this.db
+							.transaction(storeName, 'readwrite')
+							.objectStore(storeName)
+							.index(index)
+							.get(model.id);
+
+						await this.deleteTraverse(
+							this.schema.namespaces[nameSpace].relationships[modelName]
+								.relationTypes,
+							recordToDelete ? [recordToDelete] : [],
+							modelName,
+							nameSpace,
+							deleteQueue
+						);
+					}
+					break;
+				case 'HAS_MANY':
+					const index = getIndex(
+						this.schema.namespaces[nameSpace].relationships[modelName]
+							.relationTypes,
+						srcModel
+					);
+					for await (const model of models) {
+						const childrenArray = await this.db
+							.transaction(storeName, 'readwrite')
+							.objectStore(storeName)
+							.index(index)
+							.getAll(model['id']);
+
+						await this.deleteTraverse(
+							this.schema.namespaces[nameSpace].relationships[modelName]
+								.relationTypes,
+							childrenArray,
+							modelName,
+							nameSpace,
+							deleteQueue
+						);
+					}
+					break;
+				case 'BELONGS_TO':
+					// Intentionally blank
+					break;
+				default:
+					exhaustiveCheck(relationType);
+					break;
+			}
+		}
+
+		deleteQueue.push({
+			storeName: this.getStorename(nameSpace, srcModel),
+			items: models.map(record =>
+				this.modelInstanceCreator(
+					this.getModelConstructorByModelName(nameSpace, srcModel),
+					record
+				)
+			),
+		});
+	}
+
+	async clear(): Promise<void> {
+		await this.checkPrivate();
+
+		this.db.close();
+
+		await idb.deleteDB(DB_NAME);
+
+		this.db = undefined;
+		this.initPromise = undefined;
+	}
+}
+
+export default new IndexedDBAdapter();

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -1,0 +1,348 @@
+import { Mutex } from '@aws-amplify/core';
+import Observable from 'zen-observable-ts';
+import * as PushStream from 'zen-push';
+import { ModelInstanceCreator } from '../datastore/datastore';
+import { ModelPredicateCreator } from '../predicates';
+import {
+	InternalSchema,
+	ModelPredicate,
+	NamespaceResolver,
+	OpType,
+	PaginationInput,
+	PersistentModel,
+	PersistentModelConstructor,
+	PredicateGroups,
+	PredicateObject,
+	PredicatesGroup,
+	QueryOne,
+	SchemaNamespace,
+	SubscriptionMessage,
+} from '../types';
+import { isModelConstructor, STORAGE, validatePredicate } from '../util';
+import { Adapter } from './adapter';
+
+const getDefaultAdapter: () => Adapter = () => {
+	if (window.indexedDB) {
+		return require('./adapter/indexeddb').default;
+	}
+	if (process && process.env) {
+		throw new Error('Node is not supported');
+	}
+};
+
+export type StorageSubscriptionMessage = SubscriptionMessage<any> & {
+	mutator?: Symbol;
+};
+
+export type StorageFacade = Omit<Adapter, 'setUp'>;
+
+class Storage implements StorageFacade {
+	private initialized: Promise<void>;
+	private readonly pushStream: {
+		observable: Observable<StorageSubscriptionMessage>;
+	} & Required<ZenObservable.Observer<StorageSubscriptionMessage>>;
+
+	constructor(
+		private readonly schema: InternalSchema,
+		private readonly namespaceResolver: NamespaceResolver,
+		private readonly getModelConstructorByModelName: (
+			namsespaceName: string,
+			modelName: string
+		) => PersistentModelConstructor<any>,
+		private readonly modelInstanceCreator: ModelInstanceCreator,
+		private readonly adapter?: Adapter
+	) {
+		this.adapter = adapter || getDefaultAdapter();
+		this.pushStream = new PushStream();
+	}
+
+	static getNamespace() {
+		const namespace: SchemaNamespace = {
+			name: STORAGE,
+			relationships: {},
+			enums: {},
+			models: {},
+		};
+
+		return namespace;
+	}
+
+	private async init() {
+		if (this.initialized !== undefined) {
+			return;
+		}
+		let resolve: (value?: void | PromiseLike<void>) => void;
+		let reject: (value?: void | PromiseLike<void>) => void;
+
+		this.initialized = new Promise<void>((res, rej) => {
+			resolve = res;
+			reject = rej;
+		});
+
+		this.adapter
+			.setUp(
+				this.schema,
+				this.namespaceResolver,
+				this.modelInstanceCreator,
+				this.getModelConstructorByModelName
+			)
+			.then(resolve, reject);
+
+		await this.initialized;
+	}
+
+	async save<T extends PersistentModel>(
+		model: T,
+		condition?: ModelPredicate<T>,
+		mutator?: Symbol
+	): Promise<[T, OpType.INSERT | OpType.UPDATE][]> {
+		await this.init();
+
+		const result = await this.adapter.save(model, condition);
+
+		result.forEach(r => {
+			const [element, opType] = r;
+
+			const modelConstructor = (Object.getPrototypeOf(element) as Object)
+				.constructor as PersistentModelConstructor<T>;
+
+			this.pushStream.next({
+				model: modelConstructor,
+				opType,
+				element,
+				mutator,
+				condition: ModelPredicateCreator.getPredicates(condition, false),
+			});
+		});
+
+		return result;
+	}
+
+	delete<T extends PersistentModel>(
+		model: T,
+		condition?: ModelPredicate<T>,
+		mutator?: Symbol
+	): Promise<[T[], T[]]>;
+	delete<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		condition?: ModelPredicate<T>,
+		mutator?: Symbol
+	): Promise<[T[], T[]]>;
+	async delete<T extends PersistentModel>(
+		modelOrModelConstructor: T | PersistentModelConstructor<T>,
+		condition?: ModelPredicate<T>,
+		mutator?: Symbol
+	): Promise<[T[], T[]]> {
+		await this.init();
+
+		let deleted: T[];
+		let models: T[];
+
+		[models, deleted] = await this.adapter.delete(
+			modelOrModelConstructor,
+			condition
+		);
+
+		const modelIds = new Set(models.map(({ id }) => id));
+
+		if (
+			!isModelConstructor(modelOrModelConstructor) &&
+			!Array.isArray(deleted)
+		) {
+			deleted = [deleted];
+		}
+
+		deleted.forEach(model => {
+			const modelConstructor = (Object.getPrototypeOf(model) as Object)
+				.constructor as PersistentModelConstructor<T>;
+
+			let theCondition: PredicatesGroup<any>;
+
+			if (!isModelConstructor(modelOrModelConstructor)) {
+				theCondition = modelIds.has(model.id)
+					? ModelPredicateCreator.getPredicates(condition, false)
+					: undefined;
+			}
+
+			this.pushStream.next({
+				model: modelConstructor,
+				opType: OpType.DELETE,
+				element: model,
+				mutator,
+				condition: theCondition,
+			});
+		});
+
+		return [models, deleted];
+	}
+
+	async query<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		predicate?: ModelPredicate<T>,
+		pagination?: PaginationInput
+	): Promise<T[]> {
+		await this.init();
+
+		return await this.adapter.query(modelConstructor, predicate, pagination);
+	}
+
+	async queryOne<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		firstOrLast: QueryOne = QueryOne.FIRST
+	): Promise<T> {
+		await this.init();
+
+		const record = await this.adapter.queryOne(modelConstructor, firstOrLast);
+		return record;
+	}
+
+	observe<T extends PersistentModel>(
+		modelConstructor?: PersistentModelConstructor<T>,
+		predicate?: ModelPredicate<T>,
+		skipOwn?: Symbol
+	): Observable<SubscriptionMessage<T>> {
+		const listenToAll = !modelConstructor;
+		const hasPredicate = !!predicate;
+
+		let result = this.pushStream.observable
+			.filter(({ mutator }) => {
+				return !skipOwn || mutator !== skipOwn;
+			})
+			.map(({ mutator: _mutator, ...message }) => message);
+
+		if (!listenToAll) {
+			let predicates: (PredicateObject<T> | PredicatesGroup<T>)[],
+				type: keyof PredicateGroups<T>;
+
+			if (hasPredicate) {
+				({ predicates, type } = ModelPredicateCreator.getPredicates(predicate));
+			}
+
+			result = result.filter(({ model, element }) => {
+				if (modelConstructor !== model) {
+					return false;
+				}
+
+				if (hasPredicate) {
+					return validatePredicate(element, type, predicates);
+				}
+
+				return true;
+			});
+		}
+
+		return result;
+	}
+
+	async clear(completeObservable = true) {
+		this.initialized = undefined;
+
+		await this.adapter.clear();
+
+		if (completeObservable) {
+			this.pushStream.complete();
+		}
+	}
+}
+
+class ExclusiveStorage implements StorageFacade {
+	private storage: Storage;
+	private readonly mutex = new Mutex();
+	constructor(
+		schema: InternalSchema,
+		namespaceResolver: NamespaceResolver,
+		getModelConstructorByModelName: (
+			namsespaceName: string,
+			modelName: string
+		) => PersistentModelConstructor<any>,
+		modelInstanceCreator: ModelInstanceCreator,
+		adapter?: Adapter
+	) {
+		this.storage = new Storage(
+			schema,
+			namespaceResolver,
+			getModelConstructorByModelName,
+			modelInstanceCreator,
+			adapter
+		);
+	}
+
+	runExclusive<T>(fn: (storage: Storage) => Promise<T>) {
+		return <Promise<T>>this.mutex.runExclusive(fn.bind(this, this.storage));
+	}
+
+	async save<T extends PersistentModel>(
+		model: T,
+		condition?: ModelPredicate<T>,
+		mutator?: Symbol
+	): Promise<[T, OpType.INSERT | OpType.UPDATE][]> {
+		return this.runExclusive<[T, OpType.INSERT | OpType.UPDATE][]>(storage =>
+			storage.save<T>(model, condition, mutator)
+		);
+	}
+
+	async delete<T extends PersistentModel>(
+		model: T,
+		condition?: ModelPredicate<T>,
+		mutator?: Symbol
+	): Promise<[T[], T[]]>;
+	async delete<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		condition?: ModelPredicate<T>,
+		mutator?: Symbol
+	): Promise<[T[], T[]]>;
+	async delete<T extends PersistentModel>(
+		modelOrModelConstructor: T | PersistentModelConstructor<T>,
+		condition?: ModelPredicate<T>,
+		mutator?: Symbol
+	): Promise<[T[], T[]]> {
+		return this.runExclusive<[T[], T[]]>(storage => {
+			if (isModelConstructor(modelOrModelConstructor)) {
+				const modelConstructor = modelOrModelConstructor;
+
+				return storage.delete(modelConstructor, condition, mutator);
+			} else {
+				const model = modelOrModelConstructor;
+
+				return storage.delete(model, condition, mutator);
+			}
+		});
+	}
+
+	async query<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		predicate?: ModelPredicate<T>,
+		pagination?: PaginationInput
+	): Promise<T[]> {
+		return this.runExclusive<T[]>(storage =>
+			storage.query<T>(modelConstructor, predicate, pagination)
+		);
+	}
+
+	async queryOne<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		firstOrLast: QueryOne = QueryOne.FIRST
+	): Promise<T> {
+		return this.runExclusive<T>(storage =>
+			storage.queryOne<T>(modelConstructor, firstOrLast)
+		);
+	}
+
+	static getNamespace() {
+		return Storage.getNamespace();
+	}
+
+	observe<T extends PersistentModel>(
+		modelConstructor?: PersistentModelConstructor<T>,
+		predicate?: ModelPredicate<T>,
+		skipOwn?: Symbol
+	): Observable<SubscriptionMessage<T>> {
+		return this.storage.observe(modelConstructor, predicate, skipOwn);
+	}
+
+	async clear() {
+		await this.storage.clear();
+	}
+}
+
+export default ExclusiveStorage;

--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -1,0 +1,596 @@
+import { ConsoleLogger as Logger, Reachability } from '@aws-amplify/core';
+import Observable from 'zen-observable-ts';
+import { ModelInstanceCreator } from '../datastore/datastore';
+import { ModelPredicateCreator } from '../predicates';
+import Storage from '../storage/storage';
+import {
+	ConflictHandler,
+	ErrorHandler,
+	InternalSchema,
+	ModelInit,
+	MutableModel,
+	NamespaceResolver,
+	PersistentModel,
+	PersistentModelConstructor,
+	SchemaModel,
+	SchemaNamespace,
+} from '../types';
+import { SYNC } from '../util';
+import { ModelMerger } from './merger';
+import { MutationEventOutbox } from './outbox';
+import { MutationProcessor } from './processors/mutation';
+import { CONTROL_MSG, SubscriptionProcessor } from './processors/subscription';
+import { SyncModelPage, SyncProcessor } from './processors/sync';
+import {
+	createMutationInstanceFromModelOperation,
+	predicateToGraphQLCondition,
+	TransformerMutationType,
+} from './utils';
+
+const logger = new Logger('DataStore');
+
+const ownSymbol = Symbol('sync');
+
+type StartParams = {
+	fullSyncInterval: number;
+};
+
+export declare class MutationEvent {
+	constructor(init: ModelInit<MutationEvent>);
+	static copyOf(
+		src: MutationEvent,
+		mutator: (draft: MutableModel<MutationEvent>) => void | MutationEvent
+	): MutationEvent;
+	public readonly id: string;
+	public readonly model: string;
+	public readonly operation: TransformerMutationType;
+	public readonly data: string;
+	public readonly modelId: string;
+	public readonly condition: string;
+}
+
+declare class ModelMetadata {
+	constructor(init: ModelInit<ModelMetadata>);
+	static copyOf(
+		src: ModelMetadata,
+		mutator: (draft: MutableModel<ModelMetadata>) => void | ModelMetadata
+	): ModelMetadata;
+	public readonly id: string;
+	public readonly namespace: string;
+	public readonly model: string;
+	public readonly fullSyncInterval: number;
+	public readonly lastSync?: number;
+	public readonly lastFullSync?: number;
+}
+
+export class SyncEngine {
+	private started: boolean = false;
+	private online = false;
+	private processingMutations = false;
+	private fullSyncTimeoutId: number;
+
+	private readonly syncQueriesProcessor: SyncProcessor;
+	private readonly subscriptionsProcessor: SubscriptionProcessor;
+	private readonly mutationsProcessor: MutationProcessor;
+	private readonly modelMerger: ModelMerger;
+	private readonly outbox: MutationEventOutbox;
+
+	constructor(
+		private readonly schema: InternalSchema,
+		private readonly namespaceResolver: NamespaceResolver,
+		private readonly modelClasses: Record<
+			string,
+			PersistentModelConstructor<any>
+		>,
+		private readonly userModelClasses: Record<
+			string,
+			PersistentModelConstructor<any>
+		>,
+		private readonly storage: Storage,
+		private readonly modelInstanceCreator: ModelInstanceCreator,
+		private readonly maxRecordsToSync: number,
+		conflictHandler: ConflictHandler,
+		errorHandler: ErrorHandler
+	) {
+		const MutationEvent = this.modelClasses['MutationEvent'];
+
+		this.outbox = new MutationEventOutbox(
+			this.schema,
+			this.namespaceResolver,
+			MutationEvent,
+			ownSymbol
+		);
+
+		this.modelMerger = new ModelMerger(this.outbox, ownSymbol);
+
+		this.syncQueriesProcessor = new SyncProcessor(
+			this.schema,
+			maxRecordsToSync
+		);
+		this.subscriptionsProcessor = new SubscriptionProcessor(this.schema);
+		this.mutationsProcessor = new MutationProcessor(
+			this.schema,
+			this.storage,
+			this.userModelClasses,
+			this.outbox,
+			this.modelInstanceCreator,
+			MutationEvent,
+			conflictHandler,
+			errorHandler
+		);
+	}
+
+	start(params: StartParams) {
+		return new Observable<void>(observer => {
+			logger.log('starting sync engine...');
+			this.started = true;
+
+			let subscriptions: ZenObservable.Subscription[] = [];
+			(async () => {
+				try {
+					await this.setupModels(params);
+				} catch (err) {
+					logger.error(
+						"Sync engine stopped. IndexedDB not supported in this browser's private mode"
+					);
+					return;
+				}
+
+				new Reachability().networkMonitor().subscribe(async ({ online }) => {
+					this.online = online;
+					if (online) {
+						const [
+							ctlSubsObservable,
+							dataSubsObservable,
+						] = this.subscriptionsProcessor.start();
+						try {
+							subscriptions.push(
+								await this.waitForSubscriptionsReady(ctlSubsObservable)
+							);
+						} catch (err) {
+							observer.error(err);
+							return;
+						}
+
+						logger.log('Realtime ready');
+						const currentTimeStamp = new Date().getTime();
+
+						const modelLastSync: Map<
+							SchemaModel,
+							[string, number]
+						> = await this.getModelsMetadataWithNextFullSync(currentTimeStamp);
+						const paginatingModels = new Set(modelLastSync.keys());
+
+						const syncQueriesObservable = this.syncQueriesProcessor.start(
+							modelLastSync
+						);
+
+						if (this.isFullSync(modelLastSync)) {
+							clearTimeout(this.fullSyncTimeoutId);
+							this.fullSyncTimeoutId = undefined;
+						}
+
+						try {
+							const syncQuerySubscription = await this.waitForSyncQueries(
+								syncQueriesObservable,
+								paginatingModels
+							);
+
+							if (syncQuerySubscription) {
+								subscriptions.push(syncQuerySubscription);
+							}
+						} catch (err) {
+							observer.error(err);
+							return;
+						}
+
+						// process mutations
+						subscriptions.push(
+							this.mutationsProcessor
+								.start()
+								.subscribe(
+									([_transformerMutationType, modelDefinition, item]) => {
+										const modelConstructor = this.userModelClasses[
+											modelDefinition.name
+										];
+
+										const model = this.modelInstanceCreator(
+											modelConstructor,
+											item
+										);
+
+										this.modelMerger.merge(this.storage, model);
+									}
+								)
+						);
+
+						// TODO: extract to funciton
+						subscriptions.push(
+							dataSubsObservable.subscribe(
+								([_transformerMutationType, modelDefinition, item]) => {
+									const modelConstructor = this.userModelClasses[
+										modelDefinition.name
+									];
+
+									const model = this.modelInstanceCreator(
+										modelConstructor,
+										item
+									);
+
+									this.modelMerger.merge(this.storage, model);
+								}
+							)
+						);
+					} else {
+						subscriptions.forEach(sub => sub.unsubscribe());
+						subscriptions = [];
+					}
+				});
+
+				this.storage
+					.observe(null, null, ownSymbol)
+					.filter(({ model }) => {
+						const modelDefinition = this.getModelDefinition(model);
+
+						return modelDefinition.syncable === true;
+					})
+					.subscribe({
+						next: async ({ opType, model, element, condition }) => {
+							const namespace = this.schema.namespaces[
+								this.namespaceResolver(model)
+							];
+							const MutationEventConstructor = this.modelClasses[
+								'MutationEvent'
+							];
+							const graphQLCondition = predicateToGraphQLCondition(condition);
+							const mutationEvent = createMutationInstanceFromModelOperation(
+								namespace.relationships,
+								this.getModelDefinition(model),
+								opType,
+								model,
+								element,
+								graphQLCondition,
+								MutationEventConstructor,
+								this.modelInstanceCreator
+							);
+
+							await this.outbox.enqueue(this.storage, mutationEvent);
+
+							if (this.online) {
+								this.mutationsProcessor.resume();
+							}
+						},
+					});
+			})();
+			return () => {
+				subscriptions.forEach(sub => sub.unsubscribe());
+			};
+		});
+	}
+
+	private async getModelsMetadataWithNextFullSync(
+		currentTimeStamp: number
+	): Promise<Map<SchemaModel, [string, number]>> {
+		const modelLastSync: Map<SchemaModel, [string, number]> = new Map(
+			(await this.getModelsMetadata()).map(
+				({ namespace, model, lastSync, lastFullSync, fullSyncInterval }) => {
+					const nextFullSync = lastFullSync + fullSyncInterval;
+					const syncFrom =
+						!lastFullSync || nextFullSync < currentTimeStamp
+							? 0 // perform full sync if expired
+							: lastSync; // perform delta sync
+
+					return [
+						this.schema.namespaces[namespace].models[model],
+						[namespace, syncFrom],
+					];
+				}
+			)
+		);
+
+		return modelLastSync;
+	}
+
+	private isFullSync(modelsMap: Map<SchemaModel, [string, number]>) {
+		for (const [, syncFrom] of Array.from(modelsMap.values())) {
+			if (syncFrom === 0) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private async waitForSyncQueries(
+		observable: Observable<SyncModelPage>,
+		paginatingModels: Set<SchemaModel>
+	): Promise<ZenObservable.Subscription> {
+		return new Promise((resolve, reject) => {
+			if (!this.online) {
+				resolve();
+			}
+			const currentTimeStamp = new Date().getTime();
+			const subscription = observable.subscribe({
+				error: err => {
+					reject(err);
+				},
+				next: async ({
+					namespace,
+					modelDefinition,
+					items,
+					done,
+					startedAt,
+					isFullSync,
+				}) => {
+					const promises = items.map(async item => {
+						const modelConstructor = this.userModelClasses[
+							modelDefinition.name
+						];
+
+						const model = this.modelInstanceCreator(modelConstructor, item);
+
+						return this.modelMerger.merge(this.storage, model);
+					});
+
+					await Promise.all(promises);
+
+					if (done) {
+						paginatingModels.delete(modelDefinition);
+
+						// update last sync for type
+						let modelMetadata = await this.getModelMetadata(
+							namespace,
+							modelDefinition.name
+						);
+
+						modelMetadata = this.modelClasses.ModelMetadata.copyOf(
+							modelMetadata,
+							draft => {
+								draft.lastSync = startedAt;
+								draft.lastFullSync = isFullSync
+									? currentTimeStamp
+									: modelMetadata.lastFullSync;
+							}
+						);
+
+						const { fullSyncInterval } = modelMetadata;
+
+						await this.storage.save(modelMetadata, undefined, ownSymbol);
+
+						// resolve promise if all done
+						if (paginatingModels.size === 0) {
+							resolve(subscription);
+						}
+
+						if (isFullSync && !this.fullSyncTimeoutId) {
+							// register next full sync when no full sync is already scheduled
+
+							this.fullSyncTimeoutId = <number>(
+								(<unknown>setTimeout(async () => {
+									const currentTimeStamp = new Date().getTime();
+
+									const modelLastSync = await this.getModelsMetadataWithNextFullSync(
+										currentTimeStamp
+									);
+
+									const paginatingModels = new Set(modelLastSync.keys());
+
+									const syncQueriesObservable = this.syncQueriesProcessor.start(
+										modelLastSync
+									);
+
+									this.fullSyncTimeoutId = undefined;
+									this.waitForSyncQueries(
+										syncQueriesObservable,
+										paginatingModels
+									);
+								}, fullSyncInterval))
+							);
+						}
+					}
+				},
+			});
+		});
+	}
+
+	private async waitForSubscriptionsReady(
+		ctlSubsObservable: Observable<CONTROL_MSG>
+	): Promise<ZenObservable.Subscription> {
+		return new Promise((resolve, reject) => {
+			const subscription = ctlSubsObservable.subscribe({
+				next: msg => {
+					if (msg === CONTROL_MSG.CONNECTED) {
+						resolve(subscription);
+					}
+				},
+				error: err => {
+					reject(`subscription failed ${err}`);
+				},
+			});
+		});
+	}
+
+	private async setupModels(params: StartParams) {
+		const { fullSyncInterval } = params;
+		const ModelMetadata = this.modelClasses
+			.ModelMetadata as PersistentModelConstructor<ModelMetadata>;
+
+		const models: [string, string][] = [];
+
+		Object.values(this.schema.namespaces).forEach(namespace => {
+			Object.values(namespace.models)
+				.filter(({ syncable }) => syncable)
+				.forEach(model => {
+					models.push([namespace.name, model.name]);
+				});
+		});
+
+		const promises = models.map(async ([namespace, model]) => {
+			const modelMetadata = await this.getModelMetadata(namespace, model);
+
+			if (modelMetadata === undefined) {
+				await this.storage.save(
+					this.modelInstanceCreator(ModelMetadata, {
+						model,
+						namespace,
+						lastSync: null,
+						fullSyncInterval,
+						lastFullSync: null,
+					}),
+					undefined,
+					ownSymbol
+				);
+			} else {
+				await this.storage.save(
+					this.modelClasses.ModelMetadata.copyOf(modelMetadata, draft => {
+						draft.fullSyncInterval = fullSyncInterval;
+					})
+				);
+			}
+		});
+
+		await Promise.all(promises);
+	}
+
+	private async getModelsMetadata(): Promise<ModelMetadata[]> {
+		const ModelMetadata = this.modelClasses
+			.ModelMetadata as PersistentModelConstructor<ModelMetadata>;
+
+		const modelsMetadata = await this.storage.query(ModelMetadata);
+
+		return modelsMetadata;
+	}
+
+	private async getModelMetadata(
+		namespace: string,
+		model: string
+	): Promise<ModelMetadata> {
+		const ModelMetadata = this.modelClasses
+			.ModelMetadata as PersistentModelConstructor<ModelMetadata>;
+
+		const predicate = ModelPredicateCreator.createFromExisting<ModelMetadata>(
+			this.schema.namespaces[SYNC].models[ModelMetadata.name],
+			c => c.namespace('eq', namespace).model('eq', model)
+		);
+
+		const [modelMetadata] = await this.storage.query(ModelMetadata, predicate);
+
+		return modelMetadata;
+	}
+
+	private getModelDefinition(
+		modelConstructor: PersistentModelConstructor<any>
+	): SchemaModel {
+		const namespaceName = this.namespaceResolver(modelConstructor);
+
+		const modelDefinition = this.schema.namespaces[namespaceName].models[
+			modelConstructor.name
+		];
+
+		return modelDefinition;
+	}
+
+	static getNamespace() {
+		const namespace: SchemaNamespace = {
+			name: SYNC,
+			relationships: {},
+			enums: {
+				OperationType: {
+					name: 'OperationType',
+					values: ['CREATE', 'UPDATE', 'DELETE'],
+				},
+			},
+			models: {
+				MutationEvent: {
+					name: 'MutationEvent',
+					pluralName: 'MutationEvents',
+					syncable: false,
+					fields: {
+						id: {
+							name: 'id',
+							type: 'ID',
+							isRequired: true,
+							isArray: false,
+						},
+						model: {
+							name: 'model',
+							type: 'String',
+							isRequired: true,
+							isArray: false,
+						},
+						data: {
+							name: 'data',
+							type: 'String',
+							isRequired: true,
+							isArray: false,
+						},
+						modelId: {
+							name: 'modelId',
+							type: 'String',
+							isRequired: true,
+							isArray: false,
+						},
+						operation: {
+							name: 'operation',
+							type: {
+								enum: 'Operationtype',
+							},
+							isArray: false,
+							isRequired: true,
+						},
+						condition: {
+							name: 'condition',
+							type: 'String',
+							isArray: false,
+							isRequired: true,
+						},
+					},
+				},
+				ModelMetadata: {
+					name: 'ModelMetadata',
+					pluralName: 'ModelsMetadata',
+					syncable: false,
+					fields: {
+						id: {
+							name: 'id',
+							type: 'ID',
+							isRequired: true,
+							isArray: false,
+						},
+						namespace: {
+							name: 'namespace',
+							type: 'String',
+							isRequired: true,
+							isArray: false,
+						},
+						model: {
+							name: 'model',
+							type: 'String',
+							isRequired: true,
+							isArray: false,
+						},
+						lastSync: {
+							name: 'lastSync',
+							type: 'Int',
+							isRequired: false,
+							isArray: false,
+						},
+						lastFullSync: {
+							name: 'lastFullSync',
+							type: 'Int',
+							isRequired: false,
+							isArray: false,
+						},
+						fullSyncInterval: {
+							name: 'fullSyncInterval',
+							type: 'Int',
+							isRequired: true,
+							isArray: false,
+						},
+					},
+				},
+			},
+		};
+		return namespace;
+	}
+}

--- a/packages/datastore/src/sync/merger.ts
+++ b/packages/datastore/src/sync/merger.ts
@@ -1,0 +1,33 @@
+import Storage from '../storage/storage';
+import { ModelInstanceMetadata } from '../types';
+import { MutationEventOutbox } from './outbox';
+
+class ModelMerger {
+	constructor(
+		private readonly outbox: MutationEventOutbox,
+		private readonly ownSymbol: Symbol
+	) {}
+
+	public async merge<T extends ModelInstanceMetadata>(
+		exclusiveStorage: Storage,
+		model: T
+	): Promise<void> {
+		exclusiveStorage.runExclusive(async storage => {
+			const mutationsForModel = await this.outbox.getForModel(storage, model);
+
+			const isDelete = model._deleted;
+
+			if (mutationsForModel.length === 0) {
+				if (isDelete) {
+					await storage.delete(model, undefined, this.ownSymbol);
+				} else {
+					await storage.save(model, undefined, this.ownSymbol);
+				}
+			}
+		});
+
+		return;
+	}
+}
+
+export { ModelMerger };

--- a/packages/datastore/src/sync/outbox.ts
+++ b/packages/datastore/src/sync/outbox.ts
@@ -1,0 +1,122 @@
+import { MutationEvent } from '.';
+import { ModelPredicateCreator } from '../predicates';
+import Storage, { StorageFacade } from '../storage/storage';
+import {
+	InternalSchema,
+	NamespaceResolver,
+	PersistentModel,
+	PersistentModelConstructor,
+	QueryOne,
+} from '../types';
+import { SYNC } from '../util';
+import { TransformerMutationType } from './utils';
+
+// TODO: Persist deleted ids
+
+class MutationEventOutbox {
+	private inProgressMutationEventId: string;
+
+	constructor(
+		private readonly schema: InternalSchema,
+		private readonly namespaceResolver: NamespaceResolver,
+		private readonly MutationEvent: PersistentModelConstructor<MutationEvent>,
+		private readonly ownSymbol: Symbol
+	) {}
+
+	public async enqueue(
+		storage: Storage,
+		mutationEvent: MutationEvent
+	): Promise<void> {
+		const mutationEventModelDefinition = this.schema.namespaces[SYNC].models[
+			'MutationEvent'
+		];
+
+		const predicate = ModelPredicateCreator.createFromExisting<MutationEvent>(
+			mutationEventModelDefinition,
+			c =>
+				c
+					.modelId('eq', mutationEvent.modelId)
+					.id('ne', this.inProgressMutationEventId)
+		);
+
+		const [first] = await storage.query(this.MutationEvent, predicate);
+
+		if (first === undefined) {
+			await storage.save(mutationEvent, undefined, this.ownSymbol);
+			return;
+		}
+
+		const { operation: incomingMutationType } = mutationEvent;
+
+		if (first.operation === TransformerMutationType.CREATE) {
+			if (incomingMutationType === TransformerMutationType.DELETE) {
+				// delete all for model
+				await storage.delete(this.MutationEvent, predicate);
+			} else {
+				// first gets updated with incoming's data, condition intentionally skiped
+				await storage.save(
+					this.MutationEvent.copyOf(first, draft => {
+						draft.data = mutationEvent.data;
+					}),
+					undefined,
+					this.ownSymbol
+				);
+			}
+		} else {
+			const { condition: incomingConditionJSON } = mutationEvent;
+			const incomingCondition = JSON.parse(incomingConditionJSON);
+
+			// If no condition
+			if (Object.keys(incomingCondition).length === 0) {
+				// delete all for model
+				await storage.delete(this.MutationEvent, predicate);
+			}
+
+			// Enqueue new one
+			await storage.save(mutationEvent, undefined, this.ownSymbol);
+		}
+	}
+
+	public async dequeue(storage: StorageFacade): Promise<MutationEvent> {
+		const head = await this.peek(storage);
+
+		await storage.delete(head);
+
+		this.inProgressMutationEventId = undefined;
+
+		return head;
+	}
+
+	/**
+	 * Doing a peek() implies that the mutation goes "inProgress"
+	 *
+	 * @param storage
+	 */
+	public async peek(storage: StorageFacade): Promise<MutationEvent> {
+		const head = await storage.queryOne(this.MutationEvent, QueryOne.FIRST);
+
+		this.inProgressMutationEventId = head ? head.id : undefined;
+
+		return head;
+	}
+
+	public async getForModel<T extends PersistentModel>(
+		storage: StorageFacade,
+		model: T
+	): Promise<MutationEvent[]> {
+		const mutationEventModelDefinition = this.schema.namespaces[SYNC].models
+			.MutationEvent;
+
+		const mutationEvents = await storage.query(
+			this.MutationEvent,
+			ModelPredicateCreator.createFromExisting(
+				mutationEventModelDefinition,
+				c => c.modelId('eq', model.id)
+			)
+		);
+
+		return mutationEvents;
+	}
+}
+
+export { MutationEventOutbox };

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -1,0 +1,407 @@
+import API, { GraphQLResult } from '@aws-amplify/api';
+import {
+	ConsoleLogger as Logger,
+	jitteredExponentialRetry,
+	NonRetryableError,
+} from '@aws-amplify/core';
+import Observable from 'zen-observable-ts';
+import { MutationEvent } from '../';
+import { ModelInstanceCreator } from '../../datastore/datastore';
+import Storage from '../../storage/storage';
+import {
+	ConflictHandler,
+	DISCARD,
+	ErrorHandler,
+	GraphQLCondition,
+	InternalSchema,
+	isModelFieldType,
+	ModelInstanceMetadata,
+	OpType,
+	PersistentModel,
+	PersistentModelConstructor,
+	SchemaModel,
+	isTargetNameAssociation,
+} from '../../types';
+import { exhaustiveCheck, USER } from '../../util';
+import { MutationEventOutbox } from '../outbox';
+import {
+	buildGraphQLOperation,
+	createMutationInstanceFromModelOperation,
+	TransformerMutationType,
+} from '../utils';
+
+const MAX_ATTEMPTS = 10;
+
+const logger = new Logger('DataStore');
+
+class MutationProcessor {
+	private observer: ZenObservable.Observer<
+		[TransformerMutationType, SchemaModel, PersistentModel]
+	>;
+	private readonly typeQuery = new WeakMap<
+		SchemaModel,
+		[TransformerMutationType, string, string][]
+	>();
+	private processing: boolean = false;
+
+	constructor(
+		private readonly schema: InternalSchema,
+		private readonly storage: Storage,
+		private readonly userClasses: {
+			[modelName: string]: PersistentModelConstructor<PersistentModel>;
+		},
+		private readonly outbox: MutationEventOutbox,
+		private readonly modelInstanceCreator: ModelInstanceCreator,
+		private readonly MutationEvent: PersistentModelConstructor<MutationEvent>,
+		private readonly conflictHandler?: ConflictHandler,
+		private readonly errorHandler?: ErrorHandler
+	) {
+		this.generateQueries();
+	}
+
+	private generateQueries() {
+		Object.values(this.schema.namespaces).forEach(namespace => {
+			Object.values(namespace.models)
+				.filter(({ syncable }) => syncable)
+				.forEach(model => {
+					const [createMutation] = buildGraphQLOperation(model, 'CREATE');
+					const [updateMutation] = buildGraphQLOperation(model, 'UPDATE');
+					const [deleteMutation] = buildGraphQLOperation(model, 'DELETE');
+
+					this.typeQuery.set(model, [
+						createMutation,
+						updateMutation,
+						deleteMutation,
+					]);
+				});
+		});
+	}
+
+	private isReady() {
+		return this.observer !== undefined;
+	}
+
+	public start(): Observable<
+		[TransformerMutationType, SchemaModel, PersistentModel]
+	> {
+		const observable = new Observable<
+			[TransformerMutationType, SchemaModel, PersistentModel]
+		>(observer => {
+			this.observer = observer;
+
+			this.resume();
+
+			return () => {
+				this.pause();
+			};
+		});
+
+		return observable;
+	}
+
+	public async resume(): Promise<void> {
+		if (this.processing || !this.isReady()) {
+			return;
+		}
+
+		this.processing = true;
+		let head: MutationEvent;
+
+		// start to drain outbox
+		while (this.processing && (head = await this.outbox.peek(this.storage))) {
+			const { model, operation, data, condition } = head;
+			const modelConstructor = this.userClasses[model];
+			let result: GraphQLResult<Record<string, PersistentModel>>;
+			let opName: string;
+			let modelDefinition: SchemaModel;
+			try {
+				[result, opName, modelDefinition] = await this.jitteredRetry(
+					model,
+					operation,
+					data,
+					condition,
+					modelConstructor,
+					this.MutationEvent,
+					head
+				);
+			} catch (error) {
+				if (error.message === 'Offline' || error.message === 'RetryMutation') {
+					continue;
+				}
+			}
+
+			if (result === undefined) {
+				logger.debug('done retrying');
+				await this.outbox.dequeue(this.storage);
+				continue;
+			}
+
+			const record = result.data[opName];
+			await this.outbox.dequeue(this.storage);
+
+			this.observer.next([operation, modelDefinition, record]);
+		}
+
+		// pauses itself
+		this.pause();
+	}
+
+	private async jitteredRetry(
+		model: string,
+		operation: TransformerMutationType,
+		data: string,
+		condition: string,
+		modelConstructor: PersistentModelConstructor<PersistentModel>,
+		MutationEvent: PersistentModelConstructor<MutationEvent>,
+		mutationEvent: MutationEvent
+	): Promise<
+		[GraphQLResult<Record<string, PersistentModel>>, string, SchemaModel]
+	> {
+		return await jitteredExponentialRetry(
+			async (
+				model: string,
+				operation: TransformerMutationType,
+				data: string,
+				condition: string,
+				modelConstructor: PersistentModelConstructor<PersistentModel>,
+				MutationEvent: PersistentModelConstructor<MutationEvent>,
+				mutationEvent: MutationEvent
+			) => {
+				const [
+					query,
+					variables,
+					graphQLCondition,
+					opName,
+					modelDefinition,
+				] = this.createQueryVariables(model, operation, data, condition);
+				const tryWith = { query, variables };
+				let attempt = 0;
+
+				const opType = this.opTypeFromTransformerOperation(operation);
+
+				do {
+					try {
+						const result = <GraphQLResult<Record<string, PersistentModel>>>(
+							await API.graphql(tryWith)
+						);
+						return [result, opName, modelDefinition];
+					} catch (err) {
+						if (err.errors && err.errors.length > 0) {
+							const [error] = err.errors;
+							if (error.message === 'Network Error') {
+								if (!this.processing) {
+									throw new NonRetryableError('Offline');
+								}
+								// TODO: Check errors on different env (react-native or other browsers)
+								throw new Error('Network Error');
+							}
+
+							// TODO: add on ConflictConditionalCheck error query last from server
+							if (error.errorType === 'ConflictUnhandled') {
+								attempt++;
+								let retryWith: PersistentModel | typeof DISCARD;
+
+								if (attempt > MAX_ATTEMPTS) {
+									retryWith = DISCARD;
+								} else {
+									try {
+										retryWith = await this.conflictHandler({
+											modelConstructor,
+											localModel: this.modelInstanceCreator(
+												modelConstructor,
+												variables.input
+											),
+											remoteModel: this.modelInstanceCreator(
+												modelConstructor,
+												error.data
+											),
+											operation: opType,
+											attempts: attempt,
+										});
+									} catch (err) {
+										logger.warn('conflict trycatch', err);
+										continue;
+									}
+								}
+
+								if (retryWith === DISCARD) {
+									// Query latest from server and notify merger
+
+									const [[, opName, query]] = buildGraphQLOperation(
+										modelDefinition,
+										'GET'
+									);
+
+									const serverData = <
+										GraphQLResult<Record<string, PersistentModel>>
+									>await API.graphql({
+										query,
+										variables: { id: variables.input.id },
+									});
+
+									return [serverData, opName, modelDefinition];
+								}
+
+								const namespace = this.schema.namespaces[USER];
+
+								// convert retry with to tryWith
+								const updatedMutation = createMutationInstanceFromModelOperation(
+									namespace.relationships,
+									modelDefinition,
+									opType,
+									modelConstructor,
+									retryWith,
+									graphQLCondition,
+									MutationEvent,
+									this.modelInstanceCreator,
+									mutationEvent.id
+								);
+
+								await this.storage.save(updatedMutation);
+
+								throw new NonRetryableError('RetryMutation');
+							} else {
+								try {
+									this.errorHandler({
+										localModel: this.modelInstanceCreator(
+											modelConstructor,
+											variables.input
+										),
+										message: error.message,
+										operation,
+										errorType: error.errorType,
+										errorInfo: error.errorInfo,
+										remoteModel: error.data
+											? this.modelInstanceCreator(modelConstructor, error.data)
+											: null,
+									});
+								} catch (err) {
+									logger.warn({ _err: err });
+								} finally {
+									// Return empty tuple, dequeues the mutation
+									return error.data
+										? [
+												{ data: { [opName]: error.data } },
+												opName,
+												modelDefinition,
+										  ]
+										: [];
+								}
+							}
+						}
+					}
+				} while (tryWith);
+			},
+			[
+				model,
+				operation,
+				data,
+				condition,
+				modelConstructor,
+				MutationEvent,
+				mutationEvent,
+			]
+		);
+	}
+
+	private createQueryVariables(
+		model: string,
+		operation: TransformerMutationType,
+		data: string,
+		condition: string
+	): [string, Record<string, any>, GraphQLCondition, string, SchemaModel] {
+		const modelDefinition = this.schema.namespaces[USER].models[model];
+
+		const queriesTuples = this.typeQuery.get(modelDefinition);
+
+		const [, opName, query] = queriesTuples.find(
+			([transformerMutationType]) => transformerMutationType === operation
+		);
+
+		const { _version, ...parsedData } = <ModelInstanceMetadata>JSON.parse(data);
+
+		const filteredData =
+			operation === TransformerMutationType.DELETE
+				? <ModelInstanceMetadata>{ id: parsedData.id }
+				: Object.values(modelDefinition.fields)
+						.filter(({ type, association }) => {
+							// connections
+							if (isModelFieldType(type)) {
+								// BELONGS_TO
+								if (
+									isTargetNameAssociation(association) &&
+									association.connectionType === 'BELONGS_TO'
+								) {
+									return true;
+								}
+
+								// All other connections
+								return false;
+							}
+
+							// scalars
+							return true;
+						})
+						.map(({ name, type, association }) => {
+							let fieldName = name;
+							let val = parsedData[name];
+
+							if (
+								isModelFieldType(type) &&
+								isTargetNameAssociation(association)
+							) {
+								fieldName = association.targetName;
+								val = parsedData[fieldName];
+							}
+
+							return [fieldName, val];
+						})
+						.reduce((acc, [k, v]) => {
+							acc[k] = v;
+							return acc;
+						}, <typeof parsedData>{});
+
+		const input: ModelInstanceMetadata = {
+			...filteredData,
+			_version,
+		};
+
+		const graphQLCondition = <GraphQLCondition>JSON.parse(condition);
+
+		const variables = {
+			input,
+			...(operation === TransformerMutationType.CREATE
+				? {}
+				: {
+						condition:
+							Object.keys(graphQLCondition).length > 0
+								? graphQLCondition
+								: null,
+				  }),
+		};
+		return [query, variables, graphQLCondition, opName, modelDefinition];
+	}
+
+	private opTypeFromTransformerOperation(
+		operation: TransformerMutationType
+	): OpType {
+		switch (operation) {
+			case TransformerMutationType.CREATE:
+				return OpType.INSERT;
+			case TransformerMutationType.DELETE:
+				return OpType.DELETE;
+			case TransformerMutationType.UPDATE:
+				return OpType.UPDATE;
+			case TransformerMutationType.GET: // Intentionally blank
+				break;
+			default:
+				exhaustiveCheck(operation);
+		}
+	}
+
+	public pause() {
+		this.processing = false;
+	}
+}
+
+export { MutationProcessor };

--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -1,0 +1,177 @@
+import API, { GraphQLResult } from '@aws-amplify/api';
+import { ConsoleLogger as Logger, Hub } from '@aws-amplify/core';
+import Observable from 'zen-observable-ts';
+import { InternalSchema, PersistentModel, SchemaModel } from '../../types';
+import { buildGraphQLOperation, TransformerMutationType } from '../utils';
+
+const logger = new Logger('DataStore');
+
+export enum CONTROL_MSG {
+	CONNECTED = 'CONNECTED',
+}
+
+class SubscriptionProcessor {
+	private readonly typeQuery = new WeakMap<
+		SchemaModel,
+		[TransformerMutationType, string, string][]
+	>();
+	private buffer: [
+		TransformerMutationType,
+		SchemaModel,
+		PersistentModel
+	][] = [];
+	private dataObserver: ZenObservable.Observer<any>;
+
+	constructor(private readonly schema: InternalSchema) {
+		this.generateQueries();
+	}
+
+	private generateQueries() {
+		Object.values(this.schema.namespaces).forEach(namespace => {
+			Object.values(namespace.models)
+				.filter(({ syncable }) => syncable)
+				.forEach(model => {
+					const queries = buildGraphQLOperation(model, 'SUBSCRIBE');
+
+					this.typeQuery.set(model, queries);
+				});
+		});
+	}
+
+	private hubQueryCompletionListener(
+		completed: Function,
+		variables: any,
+		capsule: {
+			payload: {
+				data?: any;
+			};
+		}
+	) {
+		if (variables === capsule.payload.data.variables) {
+			completed();
+		}
+	}
+
+	start(): [
+		Observable<CONTROL_MSG>,
+		Observable<[TransformerMutationType, SchemaModel, PersistentModel]>
+	] {
+		const ctlObservable = new Observable<CONTROL_MSG>(observer => {
+			const promises: Promise<void>[] = [];
+			const subscriptions: ZenObservable.Subscription[] = [];
+
+			Object.values(this.schema.namespaces).forEach(namespace => {
+				Object.values(namespace.models)
+					.filter(({ syncable }) => syncable)
+					.forEach(async modelDefinition => {
+						const queries = this.typeQuery.get(modelDefinition);
+
+						queries.forEach(([transformerMutationType, opName, query]) => {
+							const marker = {};
+
+							const queryObservable = <
+								Observable<{
+									value: GraphQLResult<Record<string, PersistentModel>>;
+								}>
+							>(<unknown>API.graphql({ query, variables: marker }));
+
+							subscriptions.push(
+								queryObservable
+									.map(({ value }) => value)
+									.subscribe({
+										next: ({ data, errors }) => {
+											if (Array.isArray(errors) && errors.length > 0) {
+												const messages = (<
+													{
+														message: string;
+													}[]
+												>errors).map(({ message }) => message);
+
+												logger.warn(
+													`Skipping incoming subscription. Messages: ${messages.join(
+														'\n'
+													)}`
+												);
+
+												this.drainBuffer();
+												return;
+											}
+
+											const { [opName]: record } = data;
+
+											this.pushToBuffer(
+												transformerMutationType,
+												modelDefinition,
+												record
+											);
+
+											this.drainBuffer();
+										},
+										error: subscriptionError => {
+											const {
+												error: { errors: [{ message = '' } = {}] } = {
+													errors: [],
+												},
+											} = subscriptionError;
+											observer.error(message);
+										},
+									})
+							);
+
+							promises.push(
+								(async () => {
+									let boundFunction: any;
+
+									await new Promise(res => {
+										boundFunction = this.hubQueryCompletionListener.bind(
+											this,
+											res,
+											marker
+										);
+										Hub.listen('api', boundFunction);
+									});
+									Hub.remove('api', boundFunction);
+								})()
+							);
+						});
+					});
+			});
+
+			Promise.all(promises).then(() => observer.next(CONTROL_MSG.CONNECTED));
+
+			return () => {
+				subscriptions.forEach(subscription => subscription.unsubscribe());
+			};
+		});
+
+		const dataObservable = new Observable<
+			[TransformerMutationType, SchemaModel, PersistentModel]
+		>(observer => {
+			this.dataObserver = observer;
+			this.drainBuffer();
+
+			return () => {
+				this.dataObserver = null;
+			};
+		});
+
+		return [ctlObservable, dataObservable];
+	}
+
+	private pushToBuffer(
+		transformerMutationType: TransformerMutationType,
+		modelDefinition: SchemaModel,
+		data: PersistentModel
+	) {
+		this.buffer.push([transformerMutationType, modelDefinition, data]);
+	}
+
+	private drainBuffer() {
+		if (this.dataObserver) {
+			this.buffer.forEach(data => this.dataObserver.next(data));
+			this.buffer = [];
+		}
+	}
+}
+
+export { SubscriptionProcessor };

--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -1,0 +1,202 @@
+import API, { GraphQLResult } from '@aws-amplify/api';
+import Observable from 'zen-observable-ts';
+import {
+	InternalSchema,
+	ModelInstanceMetadata,
+	SchemaModel,
+} from '../../types';
+import { buildGraphQLOperation } from '../utils';
+import { jitteredExponentialRetry } from '@aws-amplify/core';
+
+const DEFAULT_PAGINATION_LIMIT = 100;
+const DEFAULT_MAX_RECORDS_TO_SYNC = 10000;
+
+class SyncProcessor {
+	private readonly typeQuery = new WeakMap<SchemaModel, [string, string]>();
+
+	constructor(
+		private readonly schema: InternalSchema,
+		private readonly maxRecordsToSync: number = DEFAULT_MAX_RECORDS_TO_SYNC
+	) {
+		this.generateQueries();
+	}
+
+	private generateQueries() {
+		Object.values(this.schema.namespaces).forEach(namespace => {
+			Object.values(namespace.models)
+				.filter(({ syncable }) => syncable)
+				.forEach(model => {
+					const [
+						[_transformerMutationType, ...opNameQuery],
+					] = buildGraphQLOperation(model, 'LIST');
+
+					this.typeQuery.set(model, opNameQuery);
+				});
+		});
+	}
+
+	private async retrievePage<
+		T extends ModelInstanceMetadata = ModelInstanceMetadata
+	>(
+		modelDefinition: SchemaModel,
+		lastSync: number,
+		nextToken: string,
+		limit: number = null
+	): Promise<{ nextToken: string; startedAt: number; items: T[] }> {
+		const [opName, query] = this.typeQuery.get(modelDefinition);
+
+		const variables = {
+			limit,
+			nextToken,
+			lastSync,
+		};
+
+		// TODO: Use retryStartegy from core
+		const { data } = <
+			GraphQLResult<{
+				[opName: string]: {
+					items: T[];
+					nextToken: string;
+					startedAt: number;
+				};
+			}>
+		>await this.jitteredRetry<T>(query, variables);
+
+		const { [opName]: opResult } = data;
+
+		const { items, nextToken: newNextToken, startedAt } = opResult;
+
+		return { nextToken: newNextToken, startedAt, items };
+	}
+
+	private async jitteredRetry<T>(
+		query: string,
+		variables: { limit: number; lastSync: number; nextToken: string }
+	): Promise<
+		GraphQLResult<{
+			[opName: string]: {
+				items: T[];
+				nextToken: string;
+				startedAt: number;
+			};
+		}>
+	> {
+		return await jitteredExponentialRetry(
+			async (query, variables) => {
+				return await API.graphql({
+					query,
+					variables,
+				});
+			},
+			[query, variables]
+		);
+	}
+
+	start(
+		typesLastSync: Map<SchemaModel, [string, number]>
+	): Observable<SyncModelPage> {
+		let processing = true;
+
+		const maxRecordsToSync =
+			this.maxRecordsToSync !== undefined
+				? this.maxRecordsToSync
+				: DEFAULT_MAX_RECORDS_TO_SYNC;
+
+		const parentPromises = new Map<string, Promise<void>>();
+
+		const observable = new Observable<SyncModelPage>(observer => {
+			const sortedTypesLastSyncs = Object.values(this.schema.namespaces).reduce(
+				(map, namespace) => {
+					for (const modelName of Array.from(
+						namespace.modelTopologicalOrdering.keys()
+					)) {
+						const typeLastSync = typesLastSync.get(namespace.models[modelName]);
+						map.set(namespace.models[modelName], typeLastSync);
+					}
+					return map;
+				},
+				new Map<SchemaModel, [string, number]>()
+			);
+
+			const allModelsReady = Array.from(sortedTypesLastSyncs.entries())
+				.filter(([{ syncable }]) => syncable)
+				.map(async ([modelDefinition, [namespace, lastSync]]) => {
+					let done = false;
+					let nextToken: string = null;
+					let startedAt: number = null;
+					let items: ModelInstanceMetadata[] = null;
+
+					let recordsReceived = 0;
+
+					const parents = this.schema.namespaces[
+						namespace
+					].modelTopologicalOrdering.get(modelDefinition.name);
+					const promises = parents.map(parent =>
+						parentPromises.get(`${namespace}_${parent}`)
+					);
+
+					const promise = new Promise<void>(async res => {
+						await Promise.all(promises);
+
+						do {
+							if (!processing) {
+								return;
+							}
+
+							const limit = Math.min(
+								maxRecordsToSync - recordsReceived,
+								DEFAULT_PAGINATION_LIMIT
+							);
+
+							({ items, nextToken, startedAt } = await this.retrievePage(
+								modelDefinition,
+								lastSync,
+								nextToken,
+								limit
+							));
+
+							recordsReceived += items.length;
+
+							done = nextToken === null || recordsReceived >= maxRecordsToSync;
+
+							observer.next({
+								namespace,
+								modelDefinition,
+								items,
+								done,
+								startedAt,
+								isFullSync: !lastSync,
+							});
+						} while (!done);
+
+						res();
+					});
+
+					parentPromises.set(`${namespace}_${modelDefinition.name}`, promise);
+
+					await promise;
+				});
+
+			Promise.all(allModelsReady).then(() => {
+				observer.complete();
+			});
+
+			return () => {
+				processing = false;
+			};
+		});
+
+		return observable;
+	}
+}
+
+export type SyncModelPage = {
+	namespace: string;
+	modelDefinition: SchemaModel;
+	items: ModelInstanceMetadata[];
+	startedAt: number;
+	done: boolean;
+	isFullSync: boolean;
+};
+
+export { SyncProcessor };

--- a/packages/datastore/src/sync/utils.ts
+++ b/packages/datastore/src/sync/utils.ts
@@ -1,0 +1,265 @@
+import { MutationEvent } from '.';
+import { ModelInstanceCreator } from '../datastore/datastore';
+import {
+	GraphQLCondition,
+	isAssociatedWith,
+	isEnumFieldType,
+	isGraphQLScalarType,
+	isPredicateObj,
+	isTargetNameAssociation,
+	ModelFields,
+	ModelInstanceMetadata,
+	OpType,
+	PersistentModel,
+	PersistentModelConstructor,
+	PredicatesGroup,
+	RelationshipType,
+	SchemaModel,
+} from '../types';
+import { exhaustiveCheck } from '../util';
+
+enum GraphQLOperationType {
+	SUBSCRIBE = 'subscription',
+	LIST = 'query',
+	CREATE = 'mutation',
+	UPDATE = 'mutation',
+	DELETE = 'mutation',
+	GET = 'query',
+}
+
+export enum TransformerMutationType {
+	CREATE = 'Create',
+	UPDATE = 'Update',
+	DELETE = 'Delete',
+	GET = 'Get',
+}
+
+const dummyMetadata: Omit<ModelInstanceMetadata, 'id'> = {
+	_version: undefined,
+	_lastChangedAt: undefined,
+	_deleted: undefined,
+};
+
+const metadataFields = <(keyof ModelInstanceMetadata)[]>(
+	Object.keys(dummyMetadata)
+);
+export function getMetadataFields(): ReadonlyArray<string> {
+	return metadataFields;
+}
+
+// TODO: Ask for parent/children ids
+function generateSelectionSet(modelDefinition: SchemaModel): string {
+	const scalarFields = getScalarFields(modelDefinition);
+
+	const scalarAndMetadataFields = Object.values(scalarFields)
+		.map(({ name }) => name)
+		.concat(getMetadataFields())
+		.concat(getConnectionFields(modelDefinition));
+
+	const result = scalarAndMetadataFields.join('\n');
+
+	return result;
+}
+
+function getScalarFields(modelDefinition: SchemaModel): ModelFields {
+	const { fields } = modelDefinition;
+
+	const result = Object.values(fields)
+		.filter(field => {
+			if (isGraphQLScalarType(field.type) || isEnumFieldType(field.type)) {
+				return true;
+			}
+
+			return false;
+		})
+		.reduce((acc, field) => {
+			acc[field.name] = field;
+
+			return acc;
+		}, {} as ModelFields);
+
+	return result;
+}
+
+function getConnectionFields(modelDefinition: SchemaModel): string[] {
+	const result = [];
+
+	Object.values(modelDefinition.fields)
+		.filter(({ association }) => association && Object.keys(association).length)
+		.forEach(({ name, association }) => {
+			const { connectionType } = association;
+
+			switch (connectionType) {
+				case 'HAS_ONE':
+				case 'HAS_MANY':
+					// Intentionally blank
+					break;
+				case 'BELONGS_TO':
+					if (isTargetNameAssociation(association)) {
+						result.push(`${name} { id _deleted }`);
+					}
+					break;
+				default:
+					exhaustiveCheck(connectionType);
+			}
+		});
+
+	return result;
+}
+
+export function buildGraphQLOperation(
+	modelDefinition: SchemaModel,
+	graphQLOpType: keyof typeof GraphQLOperationType
+): [TransformerMutationType, string, string][] {
+	let selectionSet = generateSelectionSet(modelDefinition);
+
+	const { name: typeName, pluralName: pluralTypeName } = modelDefinition;
+
+	let operation: string;
+	let documentArgs: string = ' ';
+	let operationArgs: string = ' ';
+	let subscriptions: [TransformerMutationType, string][] = [];
+	let transformerMutationType: TransformerMutationType;
+
+	switch (graphQLOpType) {
+		case 'SUBSCRIBE':
+			subscriptions = [
+				TransformerMutationType.CREATE,
+				TransformerMutationType.UPDATE,
+				TransformerMutationType.DELETE,
+			].map(op => {
+				const opName = `on${op}${typeName}`;
+				return [op, opName];
+			});
+			break;
+		case 'LIST':
+			operation = `sync${pluralTypeName}`;
+			documentArgs = `($limit: Int, $nextToken: String, $lastSync: AWSTimestamp)`;
+			operationArgs =
+				'(limit: $limit, nextToken: $nextToken, lastSync: $lastSync)';
+			selectionSet = `items {
+							${selectionSet}
+						}
+						nextToken
+						startedAt`;
+			break;
+		case 'CREATE':
+			operation = `create${typeName}`;
+			documentArgs = `($input: Create${typeName}Input!)`;
+			operationArgs = '(input: $input)';
+			transformerMutationType = TransformerMutationType.CREATE;
+			break;
+		case 'UPDATE':
+			operation = `update${typeName}`;
+			documentArgs = `($input: Update${typeName}Input!, $condition: Model${typeName}ConditionInput)`;
+			operationArgs = '(input: $input, condition: $condition)';
+			transformerMutationType = TransformerMutationType.UPDATE;
+			break;
+		case 'DELETE':
+			operation = `delete${typeName}`;
+			documentArgs = `($input: Delete${typeName}Input!, $condition: Model${typeName}ConditionInput)`;
+			operationArgs = '(input: $input, condition: $condition)';
+			transformerMutationType = TransformerMutationType.DELETE;
+			break;
+		case 'GET':
+			operation = `get${typeName}`;
+			documentArgs = `($id: ID!)`;
+			operationArgs = '(id: $id)';
+			transformerMutationType = TransformerMutationType.GET;
+			break;
+
+		default:
+			exhaustiveCheck(graphQLOpType);
+	}
+
+	if (subscriptions.length > 0) {
+		return subscriptions.map(([opType, opName]) => [
+			opType,
+			opName,
+			`${GraphQLOperationType[graphQLOpType]} operation${documentArgs}{
+			${opName}${operationArgs}{
+				${selectionSet}
+			}
+		}`,
+		]);
+	}
+
+	return [
+		[
+			transformerMutationType,
+			operation,
+			`${GraphQLOperationType[graphQLOpType]} operation${documentArgs}{
+		${operation}${operationArgs}{
+			${selectionSet}
+		}
+	}`,
+		],
+	];
+}
+
+export function createMutationInstanceFromModelOperation<
+	T extends PersistentModel
+>(
+	relationships: RelationshipType,
+	modelDefinition: SchemaModel,
+	opType: OpType,
+	model: PersistentModelConstructor<T>,
+	element: T,
+	condition: GraphQLCondition,
+	MutationEventConstructor: PersistentModelConstructor<MutationEvent>,
+	modelInstanceCreator: ModelInstanceCreator,
+	id?: string
+): MutationEvent {
+	let operation: TransformerMutationType;
+
+	switch (opType) {
+		case OpType.INSERT:
+			operation = TransformerMutationType.CREATE;
+			break;
+		case OpType.UPDATE:
+			operation = TransformerMutationType.UPDATE;
+			break;
+		case OpType.DELETE:
+			operation = TransformerMutationType.DELETE;
+			break;
+		default:
+			exhaustiveCheck(opType);
+	}
+
+	const mutationEvent = modelInstanceCreator(MutationEventConstructor, {
+		...(id ? { id } : {}),
+		data: JSON.stringify(element),
+		modelId: element.id,
+		model: model.name,
+		operation,
+		condition: JSON.stringify(condition),
+	});
+
+	return mutationEvent;
+}
+
+export function predicateToGraphQLCondition(
+	predicate: PredicatesGroup<any>
+): GraphQLCondition {
+	const result = {};
+
+	if (!predicate || !Array.isArray(predicate.predicates)) {
+		return result;
+	}
+
+	predicate.predicates.forEach(p => {
+		if (isPredicateObj(p)) {
+			const { field, operator, operand } = p;
+
+			if (field === 'id') {
+				return;
+			}
+
+			result[field] = { [operator]: operand };
+		} else {
+			result[p.type] = predicateToGraphQLCondition(p);
+		}
+	});
+
+	return result;
+}

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -1,0 +1,386 @@
+import { ModelInstanceCreator } from './datastore/datastore';
+import { exhaustiveCheck } from './util';
+
+//#region Schema types
+export type Schema = UserSchema & {
+	version: string;
+};
+export type UserSchema = {
+	models: SchemaModels;
+	relationships?: RelationshipType;
+	enums: SchemaEnums;
+	modelTopologicalOrdering?: Map<string, string[]>;
+};
+export type InternalSchema = {
+	namespaces: SchemaNamespaces;
+	version: string;
+};
+export type SchemaNamespaces = Record<string, SchemaNamespace>;
+export type SchemaNamespace = UserSchema & {
+	name: string;
+};
+export type SchemaModels = Record<string, SchemaModel>;
+export type SchemaModel = {
+	name: string;
+	pluralName: string;
+	attributes?: ModelAttributes;
+	fields: ModelFields;
+	syncable?: boolean;
+};
+type SchemaEnums = Record<string, SchemaEnum>;
+type SchemaEnum = {
+	name: string;
+	values: string[];
+};
+
+export type ModelAssociation = AssociatedWith | TargetNameAssociation;
+type AssociatedWith = {
+	connectionType: 'HAS_MANY' | 'HAS_ONE';
+	associatedWith: string;
+};
+export function isAssociatedWith(obj: any): obj is AssociatedWith {
+	return obj && obj.associatedWith;
+}
+
+type TargetNameAssociation = {
+	connectionType: 'BELONGS_TO';
+	targetName: string;
+};
+export function isTargetNameAssociation(
+	obj: any
+): obj is TargetNameAssociation {
+	return obj && obj.targetName;
+}
+
+type ModelAttributes = ModelAttribute[];
+type ModelAttribute = { type: string; properties?: Record<string, any> };
+
+export type ModelFields = Record<string, ModelField>;
+export enum GraphQLScalarType {
+	ID,
+	String,
+	Int,
+	Float,
+	Boolean,
+	AWSDate,
+	AWSTime,
+	AWSDateTime,
+	AWSTimestamp,
+	AWSEmail,
+	AWSJSON,
+	AWSURL,
+	AWSPhone,
+	AWSIPAddress,
+}
+
+export namespace GraphQLScalarType {
+	export function getJSType(
+		scalar: keyof Omit<typeof GraphQLScalarType, 'getJSType'>
+	): 'string' | 'number' | 'boolean' {
+		switch (scalar) {
+			case 'Boolean':
+				return 'boolean';
+			case 'ID':
+			case 'String':
+			case 'AWSDate':
+			case 'AWSTime':
+			case 'AWSDateTime':
+			case 'AWSEmail':
+			case 'AWSJSON':
+			case 'AWSURL':
+			case 'AWSPhone':
+			case 'AWSIPAddress':
+				return 'string';
+			case 'Int':
+			case 'Float':
+			case 'AWSTimestamp':
+				return 'number';
+			default:
+				exhaustiveCheck(scalar);
+		}
+	}
+}
+
+export function isGraphQLScalarType(
+	obj: any
+): obj is keyof Omit<typeof GraphQLScalarType, 'getJSType'> {
+	return obj && GraphQLScalarType[obj] !== undefined;
+}
+
+export type ModelFieldType = { model: string };
+export function isModelFieldType(obj: any): obj is ModelFieldType {
+	const modelField: keyof ModelFieldType = 'model';
+	if (obj && obj[modelField]) return true;
+
+	return false;
+}
+
+type EnumFieldType = { enum: string };
+export function isEnumFieldType(obj: any): obj is EnumFieldType {
+	const modelField: keyof EnumFieldType = 'enum';
+	if (obj && obj[modelField]) return true;
+
+	return false;
+}
+
+type ModelField = {
+	name: string;
+	type:
+		| keyof Omit<typeof GraphQLScalarType, 'getJSType'>
+		| ModelFieldType
+		| EnumFieldType;
+	isArray: boolean;
+	isRequired?: boolean;
+	association?: ModelAssociation;
+	attributes?: ModelAttributes[];
+};
+//#endregion
+
+//#region Model definition
+export type PersistentModelConstructor<T extends PersistentModel> = {
+	new (init: ModelInit<T>): T;
+	copyOf(src: T, mutator: (draft: MutableModel<T>) => T | void): T;
+};
+export type PersistentModel = Readonly<{ id: string } & Record<string, any>>;
+export type ModelInit<T> = Omit<T, 'id'>;
+export type MutableModel<T> = Omit<
+	{
+		-readonly [P in keyof T]: T[P];
+	},
+	'id'
+>;
+
+export type ModelInstanceMetadata = {
+	id: string;
+	_version: number;
+	_lastChangedAt: number;
+	_deleted: boolean;
+};
+
+//#endregion
+
+//#region Subscription messages
+export enum OpType {
+	INSERT = 'INSERT',
+	UPDATE = 'UPDATE',
+	DELETE = 'DELETE',
+}
+
+export type SubscriptionMessage<T extends PersistentModel> = {
+	opType: OpType;
+	element: T;
+	model: PersistentModelConstructor<T>;
+	condition: PredicatesGroup<T> | null;
+};
+//#endregion
+
+//#region Predicates
+export type PredicateExpression<M extends PersistentModel, FT> = TypeName<
+	FT
+> extends keyof MapTypeToOperands<FT>
+	? (
+			operator: keyof MapTypeToOperands<FT>[TypeName<FT>],
+			operand: MapTypeToOperands<FT>[TypeName<FT>][keyof MapTypeToOperands<
+				FT
+			>[TypeName<FT>]]
+	  ) => ModelPredicate<M>
+	: never;
+
+type EqualityOperators<T> = {
+	ne: T;
+	eq: T;
+};
+type ScalarNumberOperators<T> = EqualityOperators<T> & {
+	le: T;
+	lt: T;
+	ge: T;
+	gt: T;
+};
+type NumberOperators<T> = ScalarNumberOperators<T> & {
+	between: [T, T];
+};
+type StringOperators<T> = ScalarNumberOperators<T> & {
+	beginsWith: T;
+	contains: T;
+	notContains: T;
+};
+type BooleanOperators<T> = EqualityOperators<T>;
+type ArrayOperators<T> = {
+	contains: T;
+	notContains: T;
+};
+export type AllOperators = NumberOperators<any> &
+	StringOperators<any> &
+	ArrayOperators<any>;
+
+type MapTypeToOperands<T> = {
+	number: NumberOperators<NonNullable<T>>;
+	string: StringOperators<NonNullable<T>>;
+	boolean: BooleanOperators<NonNullable<T>>;
+	'number[]': ArrayOperators<number>;
+	'string[]': ArrayOperators<string>;
+	'boolean[]': ArrayOperators<boolean>;
+};
+
+type TypeName<T> = T extends string
+	? 'string'
+	: T extends number
+	? 'number'
+	: T extends boolean
+	? 'boolean'
+	: T extends string[]
+	? 'string[]'
+	: T extends number[]
+	? 'number[]'
+	: T extends boolean[]
+	? 'boolean[]'
+	: never;
+
+export type PredicateGroups<T extends PersistentModel> = {
+	and: (
+		predicate: (predicate: ModelPredicate<T>) => ModelPredicate<T>
+	) => ModelPredicate<T>;
+	or: (
+		predicate: (predicate: ModelPredicate<T>) => ModelPredicate<T>
+	) => ModelPredicate<T>;
+	not: (
+		predicate: (predicate: ModelPredicate<T>) => ModelPredicate<T>
+	) => ModelPredicate<T>;
+};
+
+export type ModelPredicate<M extends PersistentModel> = {
+	[K in keyof M]-?: PredicateExpression<M, NonNullable<M[K]>>;
+} &
+	PredicateGroups<M>;
+
+export type ProducerModelPredicate<M extends PersistentModel> = (
+	condition: ModelPredicate<M>
+) => ModelPredicate<M>;
+
+export type PredicatesGroup<T extends PersistentModel> = {
+	type: keyof PredicateGroups<T>;
+	predicates: (PredicateObject<T> | PredicatesGroup<T>)[];
+};
+
+export function isPredicateObj<T extends PersistentModel>(
+	obj: any
+): obj is PredicateObject<T> {
+	return obj && (<PredicateObject<T>>obj).field !== undefined;
+}
+
+export function isPredicateGroup<T extends PersistentModel>(
+	obj: any
+): obj is PredicatesGroup<T> {
+	return obj && (<PredicatesGroup<T>>obj).type !== undefined;
+}
+
+export type PredicateObject<T extends PersistentModel> = {
+	field: keyof T;
+	operator: keyof AllOperators;
+	operand: any;
+};
+
+export enum QueryOne {
+	FIRST,
+	LAST,
+}
+
+export type GraphQLCondition = Partial<
+	| {
+			[field: string]: {
+				[operator: string]: string | number | [number, number];
+			};
+	  }
+	| {
+			and: [GraphQLCondition];
+			or: [GraphQLCondition];
+			not: GraphQLCondition;
+	  }
+>;
+
+//#endregion
+
+//#region Pagination
+
+export type PaginationInput = {
+	limit?: number;
+	page?: number;
+};
+
+//#endregion
+
+//#region System Components
+
+export type SystemComponent = {
+	setUp(
+		schema: InternalSchema,
+		namespaceResolver: NamespaceResolver,
+		modelInstanceCreator: ModelInstanceCreator,
+		getModelConstructorByModelName: (
+			namsespaceName: string,
+			modelName: string
+		) => PersistentModelConstructor<any>
+	): Promise<void>;
+};
+
+export type NamespaceResolver = (
+	modelConstructor: PersistentModelConstructor<any>
+) => string;
+
+//#endregion
+
+//#region Relationship types
+export type RelationType = {
+	fieldName: string;
+	modelName: string;
+	relationType: 'HAS_ONE' | 'HAS_MANY' | 'BELONGS_TO';
+	targetName?: string;
+};
+
+export type RelationshipType = {
+	[modelName: string]: { indexes: string[]; relationTypes: RelationType[] };
+};
+
+//#endregion
+
+//#region DataStore config types
+export type DataStoreConfig = {
+	DataStore?: {
+		conflictHandler?: ConflictHandler; // default : retry until client wins up to x times
+		errorHandler?: (error: SyncError) => void; // default : logger.warn
+		maxRecordsToSync?: number; // merge
+		fullSyncInterval?: number;
+	};
+	conflictHandler?: ConflictHandler; // default : retry until client wins up to x times
+	errorHandler?: (error: SyncError) => void; // default : logger.warn
+	maxRecordsToSync?: number; // merge
+	fullSyncInterval?: number;
+};
+
+export type SyncConflict = {
+	modelConstructor: PersistentModelConstructor<any>;
+	localModel: PersistentModel;
+	remoteModel: PersistentModel;
+	operation: OpType;
+	attempts: number;
+};
+
+export type SyncError = {
+	message: string;
+	errorType: string;
+	errorInfo: string;
+	localModel: PersistentModel;
+	remoteModel: PersistentModel;
+	operation: string;
+};
+
+export const DISCARD = Symbol('DISCARD');
+
+export type ConflictHandler = (
+	conflict: SyncConflict
+) =>
+	| Promise<PersistentModel | typeof DISCARD>
+	| PersistentModel
+	| typeof DISCARD;
+export type ErrorHandler = (error: SyncError) => void;
+//#endregion

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -1,0 +1,338 @@
+import { ModelInstanceCreator } from './datastore/datastore';
+import {
+	AllOperators,
+	isPredicateGroup,
+	isPredicateObj,
+	ModelInstanceMetadata,
+	PersistentModel,
+	PersistentModelConstructor,
+	PredicateGroups,
+	PredicateObject,
+	PredicatesGroup,
+	RelationshipType,
+	RelationType,
+	SchemaNamespace,
+} from './types';
+
+import { v4 as uuid } from 'uuid';
+
+export const exhaustiveCheck = (obj: never, throwOnError: boolean = true) => {
+	if (throwOnError) {
+		throw new Error(`Invalid ${obj}`);
+	}
+};
+
+export const validatePredicate = <T extends PersistentModel>(
+	model: T,
+	groupType: keyof PredicateGroups<T>,
+	predicatesOrGroups: (PredicateObject<T> | PredicatesGroup<T>)[]
+) => {
+	let filterType: keyof Pick<any[], 'every' | 'some'>;
+	let isNegation = false;
+
+	switch (groupType) {
+		case 'not':
+			filterType = 'every';
+			isNegation = true;
+			break;
+		case 'and':
+			filterType = 'every';
+			break;
+		case 'or':
+			filterType = 'some';
+			break;
+		default:
+			exhaustiveCheck(groupType);
+	}
+
+	if (predicatesOrGroups.length === 0) {
+		return true;
+	}
+
+	const result: boolean = predicatesOrGroups[filterType](predicateOrGroup => {
+		if (isPredicateObj(predicateOrGroup)) {
+			const { field, operator, operand } = predicateOrGroup;
+			const value = model[field];
+
+			return validatePredicateField(value, operator, operand);
+		}
+
+		if (isPredicateGroup(predicateOrGroup)) {
+			const { type, predicates } = predicateOrGroup;
+			return validatePredicate(model, type, predicates);
+		}
+
+		throw new Error('Not a predicate or group');
+	});
+
+	return isNegation ? !result : result;
+};
+
+const validatePredicateField = <T>(
+	value: T,
+	operator: keyof AllOperators,
+	operand: T | [T, T]
+) => {
+	switch (operator) {
+		case 'ne':
+			return value !== operand;
+		case 'eq':
+			return value === operand;
+		case 'le':
+			return value <= operand;
+		case 'lt':
+			return value < operand;
+		case 'ge':
+			return value >= operand;
+		case 'gt':
+			return value > operand;
+		case 'between':
+			const [min, max] = <[T, T]>operand;
+			return value >= min && value <= max;
+		case 'beginsWith':
+			return (<string>(<unknown>value)).startsWith(<string>(<unknown>operand));
+		case 'contains':
+			return (
+				(<string>(<unknown>value)).indexOf(<string>(<unknown>operand)) > -1
+			);
+		case 'notContains':
+			return (
+				(<string>(<unknown>value)).indexOf(<string>(<unknown>operand)) === -1
+			);
+		default:
+			exhaustiveCheck(operator, false);
+			return false;
+	}
+};
+
+export const isModelConstructor = <T extends PersistentModel>(
+	obj: any
+): obj is PersistentModelConstructor<T> => {
+	return (
+		obj && typeof (<PersistentModelConstructor<T>>obj).copyOf === 'function'
+	);
+};
+
+export const establishRelation = (
+	namespace: SchemaNamespace
+): RelationshipType => {
+	const relationship: RelationshipType = {};
+
+	Object.keys(namespace.models).forEach((mKey: string) => {
+		relationship[mKey] = { indexes: [], relationTypes: [] };
+
+		const model = namespace.models[mKey];
+		Object.keys(model.fields).forEach((attr: string) => {
+			const fieldAttribute = model.fields[attr];
+			if (
+				typeof fieldAttribute.type === 'object' &&
+				'model' in fieldAttribute.type
+			) {
+				const connectionType = fieldAttribute.association.connectionType;
+				relationship[mKey].relationTypes.push({
+					fieldName: fieldAttribute.name,
+					modelName: fieldAttribute.type.model,
+					relationType: connectionType,
+					targetName: fieldAttribute.association['targetName'],
+				});
+				if (connectionType === 'BELONGS_TO') {
+					relationship[mKey].indexes.push(
+						fieldAttribute.association['targetName']
+					);
+				}
+			}
+		});
+	});
+
+	return relationship;
+};
+
+const topologicallySortedModels = new WeakMap<SchemaNamespace, string[]>();
+
+export const traverseModel = <T extends PersistentModel>(
+	srcModelName: string,
+	instance: T,
+	namespace: SchemaNamespace,
+	modelInstanceCreator: ModelInstanceCreator,
+	getModelConstructorByModelName: (
+		namsespaceName: string,
+		modelName: string
+	) => PersistentModelConstructor<any>
+) => {
+	const relationships = namespace.relationships;
+	const modelConstructor = getModelConstructorByModelName(
+		namespace.name,
+		srcModelName
+	);
+
+	const relation = relationships[srcModelName];
+	const result: {
+		modelName: string;
+		item: T;
+		instance: T;
+	}[] = [];
+
+	const newInstance = modelConstructor.copyOf(instance, draftInstance => {
+		relation.relationTypes.forEach((rItem: RelationType) => {
+			const modelConstructor = getModelConstructorByModelName(
+				namespace.name,
+				rItem.modelName
+			);
+
+			switch (rItem.relationType) {
+				case 'HAS_ONE':
+					if (instance[rItem.fieldName]) {
+						let modelInstance: T;
+						try {
+							modelInstance = modelInstanceCreator(
+								modelConstructor,
+								instance[rItem.fieldName]
+							);
+						} catch (error) {
+							// Do nothing
+						}
+
+						result.push({
+							modelName: rItem.modelName,
+							item: instance[rItem.fieldName],
+							instance: modelInstance,
+						});
+
+						(<any>draftInstance)[rItem.fieldName] = (<PersistentModel>(
+							draftInstance[rItem.fieldName]
+						)).id;
+					}
+
+					break;
+				case 'BELONGS_TO':
+					if (instance[rItem.fieldName]) {
+						let modelInstance: T;
+						try {
+							modelInstance = modelInstanceCreator(
+								modelConstructor,
+								instance[rItem.fieldName]
+							);
+						} catch (error) {
+							// Do nothing
+						}
+
+						const isDeleted = (<ModelInstanceMetadata>(
+							draftInstance[rItem.fieldName]
+						))._deleted;
+
+						if (!isDeleted) {
+							result.push({
+								modelName: rItem.modelName,
+								item: instance[rItem.fieldName],
+								instance: modelInstance,
+							});
+						}
+					}
+
+					(<any>draftInstance)[rItem.targetName] = draftInstance[
+						rItem.fieldName
+					]
+						? (<PersistentModel>draftInstance[rItem.fieldName]).id
+						: null;
+
+					delete draftInstance[rItem.fieldName];
+
+					break;
+				case 'HAS_MANY':
+					// Intentionally blank
+					break;
+				default:
+					exhaustiveCheck(rItem.relationType);
+					break;
+			}
+		});
+	});
+
+	result.unshift({
+		modelName: srcModelName,
+		item: newInstance,
+		instance: newInstance,
+	});
+
+	if (!topologicallySortedModels.has(namespace)) {
+		topologicallySortedModels.set(
+			namespace,
+			Array.from(namespace.modelTopologicalOrdering.keys())
+		);
+	}
+
+	const sortedModels = topologicallySortedModels.get(namespace);
+
+	result.sort((a, b) => {
+		return (
+			sortedModels.indexOf(a.modelName) - sortedModels.indexOf(b.modelName)
+		);
+	});
+
+	return result;
+};
+
+export const getIndex = (rel: RelationType[], src: string): string => {
+	let index = '';
+	rel.some((relItem: RelationType) => {
+		if (relItem.modelName === src) {
+			index = relItem.targetName;
+		}
+	});
+	return index;
+};
+
+export enum NAMESPACES {
+	DATASTORE = 'datastore',
+	USER = 'user',
+	SYNC = 'sync',
+	STORAGE = 'storage',
+}
+
+const DATASTORE = NAMESPACES.DATASTORE;
+const USER = NAMESPACES.USER;
+const SYNC = NAMESPACES.SYNC;
+const STORAGE = NAMESPACES.STORAGE;
+
+export { USER, SYNC, STORAGE, DATASTORE };
+
+let privateModeCheckResult;
+
+export const isPrivateMode = () => {
+	return new Promise(resolve => {
+		const dbname = uuid();
+		let db;
+
+		const isPrivate = () => {
+			privateModeCheckResult = false;
+
+			resolve(true);
+		};
+
+		const isNotPrivate = async () => {
+			if (db && db.result && typeof db.result.close === 'function') {
+				await db.result.close();
+			}
+
+			await indexedDB.deleteDatabase(dbname);
+
+			privateModeCheckResult = true;
+
+			return resolve(false);
+		};
+
+		if (privateModeCheckResult === true) {
+			return isNotPrivate();
+		}
+
+		if (privateModeCheckResult === false) {
+			return isPrivate();
+		}
+
+		if (indexedDB === null) return isPrivate();
+
+		db = indexedDB.open(dbname);
+		db.onerror = isPrivate;
+		db.onsuccess = isNotPrivate;
+	});
+};

--- a/packages/datastore/tslint.json
+++ b/packages/datastore/tslint.json
@@ -1,0 +1,45 @@
+{
+	"defaultSeverity": "error",
+	"plugins": ["prettier"],
+	"extends": [],
+	"jsRules": {},
+	"rules": {
+		"prefer-const": true,
+		"max-line-length": [true, 120],
+		"no-empty-interface": true,
+		"no-var-keyword": true,
+		"object-literal-shorthand": true,
+		"no-eval": true,
+		"space-before-function-paren": [
+			true,
+			{
+				"anonymous": "never",
+				"named": "never"
+			}
+		],
+		"no-parameter-reassignment": true,
+		"align": [true, "parameters"],
+		"no-duplicate-imports": true,
+		"one-variable-per-declaration": [false, "ignore-for-loop"],
+		"triple-equals": [true, "allow-null-check"],
+		"comment-format": [true, "check-space"],
+		"indent": [false],
+		"whitespace": [
+			false,
+			"check-branch",
+			"check-decl",
+			"check-operator",
+			"check-preblock"
+		],
+		"eofline": true,
+		"variable-name": [
+			true,
+			"check-format",
+			"allow-pascal-case",
+			"allow-snake-case",
+			"allow-leading-underscore"
+		],
+		"semicolon": [true, "always", "ignore-interfaces"]
+	},
+	"rulesDirectory": []
+}

--- a/packages/datastore/webpack.config.dev.js
+++ b/packages/datastore/webpack.config.dev.js
@@ -1,0 +1,6 @@
+var config = require('./webpack.config.js');
+
+var entry = {
+	'aws-amplify-datastore': './lib-esm/index.js',
+};
+module.exports = Object.assign(config, { entry, mode: 'development' });

--- a/packages/datastore/webpack.config.js
+++ b/packages/datastore/webpack.config.js
@@ -1,0 +1,40 @@
+module.exports = {
+	entry: {
+		'aws-amplify-datastore.min': './lib-esm/index.js',
+	},
+	externals: ['@aws-amplify/pubsub'],
+	output: {
+		filename: '[name].js',
+		path: __dirname + '/dist',
+		library: 'aws_amplify_datastore',
+		libraryTarget: 'umd',
+		umdNamedDefine: true,
+		devtoolModuleFilenameTemplate: require('../aws-amplify/webpack-utils')
+			.devtoolModuleFilenameTemplate,
+	},
+	// Enable sourcemaps for debugging webpack's output.
+	devtool: 'source-map',
+	resolve: {
+		extensions: ['.mjs', '.js', '.json'],
+	},
+	mode: 'production',
+	module: {
+		rules: [
+			// All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
+			//{ enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' },
+			{
+				test: /\.js?$/,
+				exclude: /node_modules/,
+				use: [
+					'babel-loader',
+					{
+						loader: 'babel-loader',
+						options: {
+							presets: ['@babel/preset-env'],
+						},
+					},
+				],
+			},
+		],
+	},
+};


### PR DESCRIPTION
When PubSub is initialized, it does a lazy initial instantiation but on subsequent updates of the configuration such as a client changing which AppsyncAPI endpoint they are using, the realtime provider does not update. Subsequent subscriptions will be added to the initial provider, not the new provider.