### PR TITLE
fix(@aws-amplify/datastore): Save parent model with flattened ids for…

### DIFF
--- a/packages/datastore/src/storage/adapter/asyncstorage.ts
+++ b/packages/datastore/src/storage/adapter/asyncstorage.ts
@@ -543,6 +543,8 @@ class AsyncStorageAdapter implements Adapter {
 		const batch: ModelInstanceMetadata[] = [];
 
 		for (const item of items) {
+			const { id } = item;
+
 			const connectedModels = traverseModel(
 				modelConstructor.name,
 				this.modelInstanceCreator(modelConstructor, item),
@@ -551,11 +553,11 @@ class AsyncStorageAdapter implements Adapter {
 				this.getModelConstructorByModelName
 			);
 
-			Object.values(connectedModels)
-				.map(({ item }) => item)
-				.forEach(item => {
-					batch.push(item);
-				});
+			const { instance } = connectedModels.find(
+				({ instance }) => instance.id === id
+			);
+
+			batch.push(instance);
 		}
 
 		return await this.db.batchSave(storeName, batch);

--- a/packages/datastore/src/storage/adapter/indexeddb.ts
+++ b/packages/datastore/src/storage/adapter/indexeddb.ts
@@ -26,6 +26,7 @@ import {
 	validatePredicate,
 } from '../../util';
 import { Adapter } from './index';
+import { tsIndexSignature } from '@babel/types';
 
 const logger = new Logger('DataStore');
 
@@ -770,13 +771,15 @@ class IndexedDBAdapter implements Adapter {
 			const key = await index.getKey(id);
 
 			if (!_deleted) {
-				for (const { item } of Object.values(connectedModels)) {
-					result.push([
-						<T>(<unknown>item),
-						key ? OpType.UPDATE : OpType.INSERT,
-					]);
-					await store.put(item, key);
-				}
+				const { instance } = connectedModels.find(
+					({ instance }) => instance.id === id
+				);
+
+				result.push([
+					<T>(<unknown>instance),
+					key ? OpType.UPDATE : OpType.INSERT,
+				]);
+				await store.put(instance, key);
 			} else {
 				result.push([<T>(<unknown>item), OpType.DELETE]);
 


### PR DESCRIPTION
Save parent model with flattened ids for relations when batch saving results from GraphQL

**Before:**
```json
{
	"id":"xxx-xxx-xxx",
	"attrib1": "Some value",
	"connection": {
		"id": "yyy-yyy-yyy",
		"attrib2": "Another value"
	}
}
```

**After:**
```json
{
	"id":"xxx-xxx-xxx",
	"attrib1": "Some value",
	"parentChildId": "yyy-yyy-yyy"
}
```

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
