### PR TITLE
initialized local phone number to empty string to prevent null refere…

### DIFF
--- a/packages/aws-amplify-angular/src/components/authenticator/sign-up-component/sign-up.component.core.ts
+++ b/packages/aws-amplify-angular/src/components/authenticator/sign-up-component/sign-up.component.core.ts
@@ -110,7 +110,7 @@ export class SignUpComponentCore implements OnInit {
 	_signUpConfig: any;
 	_usernameAttributes: string = 'username';
 	user: any = {};
-	local_phone_number: string;
+	local_phone_number: string = '';
 	country_code: string = '1';
 	header: string = 'Create a new account';
 	defaultSignUpFields: SignUpField[] = defaultSignUpFieldAssets;


### PR DESCRIPTION
initialized local phone number to empty string to prevent null reference when the submit of the sign up is called and the sign up class tries to validate the value with a string.regex.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
