### PR TITLE
master -> main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -580,13 +580,13 @@ jobs:
             git add ./packages/core/src/Platform/version.ts
             git commit -m "chore(release): update version.ts [ci skip]"
             git push origin release
-            git push origin release:master
+            git push origin release:main
 
 releasable_branches: &releasable_branches
   branches:
     only:
       - release
-      - master
+      - main
       - ui-components/master
       - 1.0-stable
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,17 +5,17 @@ Thank you for your interest in contributing to our project! <3 Whether it's a bu
 - [Our History and Ethos](#our-history-and-ethos)
 - [Our Design](#our-design)
 - [Development Process](#development-process)
-  * [Setting up for local development](#setting-up-for-local-development)
-  * [Architecture of the codebase](#architecture-of-the-codebase)
-  * [Steps towards contributions](#steps-towards-contributions)
+  - [Setting up for local development](#setting-up-for-local-development)
+  - [Architecture of the codebase](#architecture-of-the-codebase)
+  - [Steps towards contributions](#steps-towards-contributions)
 - [Pull Requests](#pull-requests)
 - [Debugging](#debugging)
 - [Release](#release)
-  * [Finding contributions to work on](#finding-contributions-to-work-on)
-  * [Related Repositories](#related-repositories)
-  * [Code of Conduct](#code-of-conduct)
-  * [Security issue notifications](#security-issue-notifications)
-  * [Licensing](#licensing)
+  - [Finding contributions to work on](#finding-contributions-to-work-on)
+  - [Related Repositories](#related-repositories)
+  - [Code of Conduct](#code-of-conduct)
+  - [Security issue notifications](#security-issue-notifications)
+  - [Licensing](#licensing)
 
 # Our History and Ethos
 
@@ -47,7 +47,7 @@ Our work is done directly on Github and PR's are sent to the github repo by core
 
 This section should get you running with **Amplify JS** and get you familiar with the basics of the codebase. You will need the latest version of [nodejs](https://nodejs.org/en/) on your system and developing locally also requires `yarn` workspaces. You can install it [here](https://classic.yarnpkg.com/en/docs/install#mac-stable).
 
-Start by, [Forking](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the master branch of [amplify-js](https://github.com/aws-amplify/amplify-js).
+Start by, [Forking](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the main branch of [amplify-js](https://github.com/aws-amplify/amplify-js).
 
 ```
 $ git clone git@github.com:[username]/amplify-js.git
@@ -58,40 +58,39 @@ $ yarn bootstrap
 $ yarn build
 ```
 
-> Note: Make sure to always [sync your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork) with master branch of amplify-js
+> Note: Make sure to always [sync your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork) with main branch of amplify-js
 
-## Architecture of the codebase 
+## Architecture of the codebase
 
 Amplify JS is a monorepo built with `Yarn` and `Lerna`. All the categories of Amplify live within the `packages` directory in the root. Each category inside packages has its own `src/` and `package.json`.
 
 #### Packages inside Amplify JS
 
-- [core](https://github.com/aws-amplify/amplify-js/tree/master/packages/core) 
-- [cache](https://github.com/aws-amplify/amplify-js/tree/master/packages/cache)
-- [auth](https://github.com/aws-amplify/amplify-js/tree/master/packages/auth)
-- [api](https://github.com/aws-amplify/amplify-js/tree/master/packages/api)
-- [analytics](https://github.com/aws-amplify/amplify-js/tree/master/packages/analytics)
-- [storage](https://github.com/aws-amplify/amplify-js/tree/master/packages/storage)
-- [interactions](https://github.com/aws-amplify/amplify-js/tree/master/packages/interactions)
-- [predictions](https://github.com/aws-amplify/amplify-js/tree/master/packages/predictions)
-- [pubsub](https://github.com/aws-amplify/amplify-js/tree/master/packages/pubsub)
-- [datastore](https://github.com/aws-amplify/amplify-js/tree/master/packages/datastore)
-- [pushnotification](https://github.com/aws-amplify/amplify-js/tree/master/packages/pushnotification)
-- [xr](https://github.com/aws-amplify/amplify-js/tree/master/packages/xr)
-- [amplify-ui](https://github.com/aws-amplify/amplify-js/tree/master/packages/amplify-ui)
-- [aws-amplify-react](https://github.com/aws-amplify/amplify-js/tree/master/packages/aws-amplify-react)
-- [aws-amplify-react-native](https://github.com/aws-amplify/amplify-js/tree/master/packages/aws-amplify-react-native)
-- [aws-amplify-angular](https://github.com/aws-amplify/amplify-js/tree/master/packages/aws-amplify-angular)
-- [aws-amplify-vue](https://github.com/aws-amplify/amplify-js/tree/master/packages/aws-amplify-vue)
-- [amplify-ui-components](https://github.com/aws-amplify/amplify-js/tree/master/packages/amplify-ui-components)
-- [amplify-ui-react](https://github.com/aws-amplify/amplify-js/tree/master/packages/amplify-ui-react)
-- [amplify-ui-angular](https://github.com/aws-amplify/amplify-js/tree/master/packages/amplify-ui-angular)
-- [amplify-ui-vue](https://github.com/aws-amplify/amplify-js/tree/master/packages/amplify-ui-vue)
-- [amplify-ui-storybook](https://github.com/aws-amplify/amplify-js/tree/master/packages/amplify-ui-storybook)
-
-
+- [core](https://github.com/aws-amplify/amplify-js/tree/main/packages/core)
+- [cache](https://github.com/aws-amplify/amplify-js/tree/main/packages/cache)
+- [auth](https://github.com/aws-amplify/amplify-js/tree/main/packages/auth)
+- [api](https://github.com/aws-amplify/amplify-js/tree/main/packages/api)
+- [analytics](https://github.com/aws-amplify/amplify-js/tree/main/packages/analytics)
+- [storage](https://github.com/aws-amplify/amplify-js/tree/main/packages/storage)
+- [interactions](https://github.com/aws-amplify/amplify-js/tree/main/packages/interactions)
+- [predictions](https://github.com/aws-amplify/amplify-js/tree/main/packages/predictions)
+- [pubsub](https://github.com/aws-amplify/amplify-js/tree/main/packages/pubsub)
+- [datastore](https://github.com/aws-amplify/amplify-js/tree/main/packages/datastore)
+- [pushnotification](https://github.com/aws-amplify/amplify-js/tree/main/packages/pushnotification)
+- [xr](https://github.com/aws-amplify/amplify-js/tree/main/packages/xr)
+- [amplify-ui](https://github.com/aws-amplify/amplify-js/tree/main/packages/amplify-ui)
+- [aws-amplify-react](https://github.com/aws-amplify/amplify-js/tree/main/packages/aws-amplify-react)
+- [aws-amplify-react-native](https://github.com/aws-amplify/amplify-js/tree/main/packages/aws-amplify-react-native)
+- [aws-amplify-angular](https://github.com/aws-amplify/amplify-js/tree/main/packages/aws-amplify-angular)
+- [aws-amplify-vue](https://github.com/aws-amplify/amplify-js/tree/main/packages/aws-amplify-vue)
+- [amplify-ui-components](https://github.com/aws-amplify/amplify-js/tree/main/packages/amplify-ui-components)
+- [amplify-ui-react](https://github.com/aws-amplify/amplify-js/tree/main/packages/amplify-ui-react)
+- [amplify-ui-angular](https://github.com/aws-amplify/amplify-js/tree/main/packages/amplify-ui-angular)
+- [amplify-ui-vue](https://github.com/aws-amplify/amplify-js/tree/main/packages/amplify-ui-vue)
+- [amplify-ui-storybook](https://github.com/aws-amplify/amplify-js/tree/main/packages/amplify-ui-storybook)
 
 ## Steps towards contributions
+
 - To make changes with respect to a specific category, go into `packages/[category]`.
 - Make changes to required file.
 - Write unit tests
@@ -185,7 +184,7 @@ _[Skip step 1 to 3 if you have already done this]_
    - use slashes to seperate parts of branch names
    - Hyphenate well defined branch name
 5. Once your work is committed and you're ready to share, run test `yarn test`.
-**Note:**  Manually test your changes in a sample app with different edge cases and also test across different browsers and platform
+   **Note:** Manually test your changes in a sample app with different edge cases and also test across different browsers and platform
 6. Then, Push your branch `git push origin -u`
 7. This previous step will give you a URL to view a GitHub page in your browser. Copy-paste this, and complete the workflow in the UI. It will invite you to "create a PR" from your newly published branch. Fill out the PR template to submit a PR.
 8. Finally, the Amplify JS team will review your PR. Add reviewers based on the core member who is tracking the issue with you or code owners.
@@ -198,8 +197,9 @@ Sometimes the issue can be solved by doing a clean and fresh build. To do this, 
 # Release
 
 To give a bird's eye view of the release cycle,
+
 - We follow semantic versioning for our releases
-- Every merge into the `master` ends up as `unstable` package in the npm
+- Every merge into the `main` ends up as `unstable` package in the npm
 - The core team will cut a release out to `stable` from `unstable` bi-weekly
 
 ## Finding contributions to work on
@@ -235,6 +235,6 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/aws-amplify/amplify-ios/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/aws-amplify/amplify-js/blob/main/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
     <img src="https://img.shields.io/discord/308323056592486420?logo=discord"" alt="Discord Chat" />  
   </a>
   <a href="https://codecov.io/gh/aws-amplify/amplify-js">
-    <img src="https://codecov.io/gh/aws-amplify/amplify-js/branch/master/graph/badge.svg" />
+    <img src="https://codecov.io/gh/aws-amplify/amplify-js/branch/main/graph/badge.svg" />
   </a>
   <a href="https://lgtm.com/projects/g/aws-amplify/amplify-js/context:javascript"><img alt="Language grade: JavaScript" src="https://img.shields.io/lgtm/grade/javascript/g/aws-amplify/amplify-js.svg?logo=lgtm&logoWidth=18"/>
   </a>
   <a href="https://circleci.com/gh/aws-amplify/amplify-js">
-    <img src="https://img.shields.io/circleci/project/github/aws-amplify/amplify-js/master.svg" alt="build:started">
+    <img src="https://img.shields.io/circleci/project/github/aws-amplify/amplify-js/main.svg" alt="build:started">
   </a>
 </p>
 
@@ -73,7 +73,7 @@ If you can't migrate to [aws-sdk-js-v3](https://github.com/aws/aws-sdk-js-v3) or
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [Examples](#examples)
-- [Contributing](https://github.com/aws/aws-amplify/blob/master/CONTRIBUTING.md)
+- [Contributing](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md)
 
 ## Installation
 

--- a/docs/.gitlab-ci.yml
+++ b/docs/.gitlab-ci.yml
@@ -12,4 +12,4 @@ pages:
     paths:
     - public
   only:
-  - master
+  - main

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,7 +20,7 @@ description: >- # this means to ignore newlines until "baseurl:"
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com 
 github:
-  repository_url: https://github.com/aws-amplify/amplify-js/edit/master/docs/
+  repository_url: https://github.com/aws-amplify/amplify-js/edit/main/docs/
 
 show_downloads: "true"
 include: 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -289,7 +289,7 @@
         
         <div id="footer">
            <span class="credits left">Project maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></span>
-           <span class="credits right"><a href="https://github.com/aws/aws-amplify/blob/master/CONTRIBUTING.md">Contributing Guidelines</a></span>
+           <span class="credits right"><a href="https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md">Contributing Guidelines</a></span>
         </div>
       </section>
     </div>

--- a/docs/_layouts/home.md
+++ b/docs/_layouts/home.md
@@ -13,10 +13,10 @@ layout: default
       <img src="https://img.shields.io/npm/dm/aws-amplify.svg" alt="npm downloads" height="18">
     </a>
     <a href="https://travis-ci.org/aws/aws-amplify">
-      <img src="https://travis-ci.org/aws/aws-amplify.svg?branch=master" alt="build:started">
+      <img src="https://travis-ci.org/aws/aws-amplify.svg?branch=main" alt="build:started">
     </a>
     <a href="https://codecov.io/gh/aws/aws-amplify">
-      <img src="https://codecov.io/gh/aws/aws-amplify/branch/master/graph/badge.svg" />
+      <img src="https://codecov.io/gh/aws/aws-amplify/branch/main/graph/badge.svg" />
     </a>
   </p>
   
@@ -67,4 +67,4 @@ layout: default
   
   ## Contributing
   
-  See [Contributing Guidelines](https://github.com/aws/aws-amplify/blob/master/CONTRIBUTING.md)
+  See [Contributing Guidelines](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md)

--- a/docs/amplify-theme/_includes/docs-header.html
+++ b/docs/amplify-theme/_includes/docs-header.html
@@ -143,7 +143,7 @@
 
 	const feedback_url = "https://github.com/aws-amplify/amplify-js/issues/new/choose";
 	const tweet_url = "https://twitter.com/intent/tweet?text=Get%20started%20with%20AWS%20Amplify%20at%20https://aws-amplify.github.io/amplify-js/media/quick_start";
-	const edit_url = "https://github.com/aws-amplify/amplify-js/blob/master/docs/media/";
+	const edit_url = "https://github.com/aws-amplify/amplify-js/blob/main/docs/media/";
 
 	document.getElementById("feedback-link").href = feedback_url;
 	document.getElementById("tweet-link").href = tweet_url;

--- a/docs/api/globals.html
+++ b/docs/api/globals.html
@@ -3431,12 +3431,12 @@ img { max-width: 100%; }
 				<img src="https://badges.gitter.im/aws/aws-amplify.png" alt="Gitter Chat" />
 			</a>
 			<a href="https://codecov.io/gh/aws-amplify/amplify-js">
-				<img src="https://codecov.io/gh/aws-amplify/amplify-js/branch/master/graph/badge.svg" />
+				<img src="https://codecov.io/gh/aws-amplify/amplify-js/branch/main/graph/badge.svg" />
 			</a>
 			<a href="https://lgtm.com/projects/g/aws-amplify/amplify-js/context:javascript"><img alt="Language grade: JavaScript" src="https://img.shields.io/lgtm/grade/javascript/g/aws-amplify/amplify-js.svg?logo=lgtm&logoWidth=18"/>
 			</a>
 			<a href="https://circleci.com/gh/aws-amplify/amplify-js">
-				<img src="https://img.shields.io/circleci/project/github/aws-amplify/amplify-js/master.svg" alt="build:started">
+				<img src="https://img.shields.io/circleci/project/github/aws-amplify/amplify-js/main.svg" alt="build:started">
 			</a>
 		</p>
 		<a href="#aws-amplify-is-a-javascript-library-for-frontend-and-mobile-developers-building-cloud-enabled-applications" id="aws-amplify-is-a-javascript-library-for-frontend-and-mobile-developers-building-cloud-enabled-applications" style="color: inherit; text-decoration: none;">
@@ -3470,7 +3470,7 @@ img { max-width: 100%; }
 			<li><a href="#installation">Installation</a></li>
 			<li><a href="#configuration">Configuration</a></li>
 			<li><a href="#examples">Examples</a></li>
-			<li><a href="https://github.com/aws/aws-amplify/blob/master/CONTRIBUTING.md">Contributing</a></li>
+			<li><a href="https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md">Contributing</a></li>
 		</ul>
 		<a href="#installation" id="installation" style="color: inherit; text-decoration: none;">
 			<h2>Installation</h2>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -3431,12 +3431,12 @@ img { max-width: 100%; }
 				<img src="https://badges.gitter.im/aws/aws-amplify.png" alt="Gitter Chat" />
 			</a>
 			<a href="https://codecov.io/gh/aws-amplify/amplify-js">
-				<img src="https://codecov.io/gh/aws-amplify/amplify-js/branch/master/graph/badge.svg" />
+				<img src="https://codecov.io/gh/aws-amplify/amplify-js/branch/main/graph/badge.svg" />
 			</a>
 			<a href="https://lgtm.com/projects/g/aws-amplify/amplify-js/context:javascript"><img alt="Language grade: JavaScript" src="https://img.shields.io/lgtm/grade/javascript/g/aws-amplify/amplify-js.svg?logo=lgtm&logoWidth=18"/>
 			</a>
 			<a href="https://circleci.com/gh/aws-amplify/amplify-js">
-				<img src="https://img.shields.io/circleci/project/github/aws-amplify/amplify-js/master.svg" alt="build:started">
+				<img src="https://img.shields.io/circleci/project/github/aws-amplify/amplify-js/main.svg" alt="build:started">
 			</a>
 		</p>
 		<a href="#aws-amplify-is-a-javascript-library-for-frontend-and-mobile-developers-building-cloud-enabled-applications" id="aws-amplify-is-a-javascript-library-for-frontend-and-mobile-developers-building-cloud-enabled-applications" style="color: inherit; text-decoration: none;">
@@ -3470,7 +3470,7 @@ img { max-width: 100%; }
 			<li><a href="#installation">Installation</a></li>
 			<li><a href="#configuration">Configuration</a></li>
 			<li><a href="#examples">Examples</a></li>
-			<li><a href="https://github.com/aws/aws-amplify/blob/master/CONTRIBUTING.md">Contributing</a></li>
+			<li><a href="https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md">Contributing</a></li>
 		</ul>
 		<a href="#installation" id="installation" style="color: inherit; text-decoration: none;">
 			<h2>Installation</h2>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"lint": "lerna run lint",
 		"link-all": "yarn unlink-all && lerna exec --no-bail --parallel yarn link",
 		"unlink-all": "lerna exec --no-bail --parallel -- yarn unlink; exit 0",
-		"publish:master": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=unstable --preid=unstable --exact",
+		"publish:main": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=unstable --preid=unstable --exact",
 		"publish:beta": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=beta --preid=beta --exact",
 		"publish:release": "lerna publish --conventional-commits --yes --message 'chore(release): Publish [ci skip]'",
 		"publish:1.0-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-1.0 --message 'chore(release): Publish [ci skip]'",

--- a/packages/amazon-cognito-identity-js/RNAWSCognito.podspec
+++ b/packages/amazon-cognito-identity-js/RNAWSCognito.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.platforms = { :ios => "8.0" }
   s.license = { :file => 'LICENSE.txt' }
-  s.homepage = "https://github.com/aws/aws-amplify/tree/master/packages/amazon-cognito-identity-js"
+  s.homepage = "https://github.com/aws-amplify/amplify-js/tree/main/packages/amazon-cognito-identity-js"
   s.author = "Amazon"
 
   s.summary = "Amazon Cognito Identity SDK for JavaScript"

--- a/packages/aws-amplify-react-native/README.md
+++ b/packages/aws-amplify-react-native/README.md
@@ -2,4 +2,4 @@
 
 AWS Amplify is a JavaScript library for frontend and mobile developers building cloud-enabled applications. The library is a declarative interface across different categories of operations in order to make common tasks easier to add into your application. The default implementation works with Amazon Web Services (AWS) resources but is designed to be open and pluggable for usage with other cloud services that wish to provide an implementation or custom backends.
 
-`aws-amplify-react-native` is one of the AWS Amplify library packages, specially built for React Native App development. Documentation is available [here](https://github.com/aws/aws-amplify/blob/master/README.md)
+`aws-amplify-react-native` is one of the AWS Amplify library packages, specially built for React Native App development. Documentation is available [here](https://github.com/aws-amplify/amplify-js/blob/main/README.md)

--- a/packages/aws-amplify-react/README.md
+++ b/packages/aws-amplify-react/README.md
@@ -2,4 +2,4 @@
 
 AWS Amplify is a JavaScript library for frontend and mobile developers building cloud-enabled applications. The library is a declarative interface across different categories of operations in order to make common tasks easier to add into your application. The default implementation works with Amazon Web Services (AWS) resources but is designed to be open and pluggable for usage with other cloud services that wish to provide an implementation or custom backends.
 
-`aws-amplify-react` is one of the AWS Amplify library packages, provide building blocks for React App development. Documentation is available [here](https://github.com/aws/aws-amplify/blob/master/README.md)
+`aws-amplify-react` is one of the AWS Amplify library packages, provide building blocks for React App development. Documentation is available [here](https://github.com/aws-amplify/amplify-js/blob/main/README.md)


### PR DESCRIPTION
_Description of changes:_
- Update CircleCI to use `main` branch instead of `master`
- Update links throughout repo
- Various Prettier `.md` updates

_TODO after this gets merged:_
- Set `main` as default branch in GitHub and update branch protection rules
- Update destination branch for all PRs
- Update links in [docs](https://github.com/aws-amplify/docs) repo

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
