### PR TITLE
Pin UglifyJS version

### DIFF
--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -64,7 +64,7 @@
     "rxjs": "^6.2.1",
     "source-map-explorer": "^1.3.3",
     "to-string-loader": "^1.1.5",
-    "uglify-js": "^3.4.7",
+    "uglify-js": "3.9.4",
     "zone": "^0.3.4",
     "zone.js": "^0.8.26"
   },


### PR DESCRIPTION
_Issue #, if available:_
Unit tests failing on `ERROR: invalid option --screw-ie8` in `aws-amplify-angular` because of their latest version update to `3.10.0`

_Description of changes:_
- Pin version to `3.9.4`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
