### PR TITLE
ci: use ci:test script for all integ tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,14 @@ commands:
         type: string
       framework:
         type: string
-      spec:
+      category:
         type: string
+      sample_name:
+        type: string
+      spec:
+        # optional - the script will use sample_name by default
+        type: string
+        default: ''
     steps:
       - run:
           name: 'Install << parameters.test_name >> sample'
@@ -116,7 +122,7 @@ commands:
           name: 'Run cypress tests for << parameters.test_name >> Sample'
           command: |
             cd ~/amplify-js-samples-staging
-            yarn cypress:<< parameters.framework >> --spec "cypress/integration/<< parameters.spec >>"
+            yarn ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>
       - store_artifacts:
           path: ~/amplify-js-samples-staging/cypress/videos
       - store_artifacts:
@@ -370,7 +376,9 @@ jobs:
       - integ_test_js:
           test_name: 'React Authenticator'
           framework: react
-          spec: auth/authenticator.spec.js
+          category: auth
+          sample_name: with-authenticator
+          spec: authenticator.spec.js
 
   integ_angular_auth:
     executor: js-test-executor
@@ -381,7 +389,9 @@ jobs:
       - integ_test_js:
           test_name: 'Angular Authenticator'
           framework: angular
-          spec: auth/authenticator.spec.js
+          category: auth
+          sample_name: with-authenticator
+          spec: authenticator.spec.js
 
   integ_vue_auth:
     executor: js-test-executor
@@ -392,7 +402,9 @@ jobs:
       - integ_test_js:
           test_name: 'Vue Authenticator'
           framework: vue
-          spec: auth/authenticator.spec.js
+          category: auth
+          sample_name: with-authenticator
+          spec: authenticator.spec.js
 
   integ_react_predictions:
     executor: js-test-executor
@@ -403,7 +415,9 @@ jobs:
       - integ_test_js:
           test_name: 'React Predictions'
           framework: react
-          spec: predictions/multiuser-translation.spec.js
+          category: predictions
+          sample_name: multi-user-translation
+          spec: multiuser-translation.spec.js
 
   integ_react_datastore:
     executor: js-test-executor
@@ -414,7 +428,8 @@ jobs:
       - integ_test_js:
           test_name: 'React DataStore'
           framework: react
-          spec: datastore/many-to-many.spec.js
+          category: datastore
+          sample_name: many-to-many
 
   integ_react_storage:
     executor: js-test-executor
@@ -425,6 +440,8 @@ jobs:
       - integ_test_js:
           test_name: 'React Storage'
           framework: react
+          category: storage
+          sample_name: storageApp
           spec: storage/storage.spec.js
 
   integ_setup_ui:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,6 +606,7 @@ releasable_branches: &releasable_branches
       - main
       - ui-components/master
       - 1.0-stable
+      - cypress_ci_test #TODO: delete line before merging
 
 workflows:
   build_test_deploy:
@@ -692,27 +693,27 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
-      - deploy:
-          filters:
-            <<: *releasable_branches
-          requires:
-            - unit_test
-            - integ_react_predictions
-            - integ_react_datastore
-            - integ_react_storage
-            - integ_react_auth
-            - integ_angular_auth
-            - integ_vue_auth
-            - integ_react_auth_ui
-            - integ_angular_auth_ui
-            - integ_vue_auth_ui
-            - integ_rn_ios_storage
-            - integ_rn_ios_push_notifications
-            - integ_rn_android_storage
-      - post_release:
-          filters:
-            branches:
-              only:
-                - release
-          requires:
-            - deploy
+      # - deploy:
+      #     filters:
+      #       <<: *releasable_branches
+      #     requires:
+      #       - unit_test
+      #       - integ_react_predictions
+      #       - integ_react_datastore
+      #       - integ_react_storage
+      #       - integ_react_auth
+      #       - integ_angular_auth
+      #       - integ_vue_auth
+      #       - integ_react_auth_ui
+      #       - integ_angular_auth_ui
+      #       - integ_vue_auth_ui
+      #       - integ_rn_ios_storage
+      #       - integ_rn_ios_push_notifications
+      #       - integ_rn_android_storage
+      # - post_release:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #     requires:
+      #       - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,7 +602,6 @@ releasable_branches: &releasable_branches
       - main
       - ui-components/master
       - 1.0-stable
-      - cypress_ci_test #TODO: delete line before merging
 
 workflows:
   build_test_deploy:
@@ -689,27 +688,27 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
-      # - deploy:
-      #     filters:
-      #       <<: *releasable_branches
-      #     requires:
-      #       - unit_test
-      #       - integ_react_predictions
-      #       - integ_react_datastore
-      #       - integ_react_storage
-      #       - integ_react_auth
-      #       - integ_angular_auth
-      #       - integ_vue_auth
-      #       - integ_react_auth_ui
-      #       - integ_angular_auth_ui
-      #       - integ_vue_auth_ui
-      #       - integ_rn_ios_storage
-      #       - integ_rn_ios_push_notifications
-      #       - integ_rn_android_storage
-      # - post_release:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #     requires:
-      #       - deploy
+      - deploy:
+          filters:
+            <<: *releasable_branches
+          requires:
+            - unit_test
+            - integ_react_predictions
+            - integ_react_datastore
+            - integ_react_storage
+            - integ_react_auth
+            - integ_angular_auth
+            - integ_vue_auth
+            - integ_react_auth_ui
+            - integ_angular_auth_ui
+            - integ_vue_auth_ui
+            - integ_rn_ios_storage
+            - integ_rn_ios_push_notifications
+            - integ_rn_android_storage
+      - post_release:
+          filters:
+            branches:
+              only:
+                - release
+          requires:
+            - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,10 +115,6 @@ commands:
             echo "Current NPM registry: " $(yarn config get registry)
             yarn
       - run:
-          name: 'Start << parameters.test_name >> Sample server in background'
-          command: yarn start
-          background: true
-      - run:
           name: 'Run cypress tests for << parameters.test_name >> Sample'
           command: |
             cd ~/amplify-js-samples-staging
@@ -378,7 +374,7 @@ jobs:
           framework: react
           category: auth
           sample_name: with-authenticator
-          spec: authenticator.spec.js
+          spec: authenticator
 
   integ_angular_auth:
     executor: js-test-executor
@@ -391,7 +387,7 @@ jobs:
           framework: angular
           category: auth
           sample_name: with-authenticator
-          spec: authenticator.spec.js
+          spec: authenticator
 
   integ_vue_auth:
     executor: js-test-executor
@@ -404,7 +400,7 @@ jobs:
           framework: vue
           category: auth
           sample_name: with-authenticator
-          spec: authenticator.spec.js
+          spec: authenticator
 
   integ_react_predictions:
     executor: js-test-executor
@@ -417,7 +413,7 @@ jobs:
           framework: react
           category: predictions
           sample_name: multi-user-translation
-          spec: multiuser-translation.spec.js
+          spec: multiuser-translation
 
   integ_react_datastore:
     executor: js-test-executor
@@ -442,7 +438,7 @@ jobs:
           framework: react
           category: storage
           sample_name: storageApp
-          spec: storage/storage.spec.js
+          spec: storage
 
   integ_setup_ui:
     executor: build-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ jobs:
           test_name: 'Angular Authenticator'
           framework: angular
           category: auth
-          sample_name: with-authenticator
+          sample_name: amplify-authenticator
           spec: authenticator
 
   integ_vue_auth:
@@ -399,7 +399,7 @@ jobs:
           test_name: 'Vue Authenticator'
           framework: vue
           category: auth
-          sample_name: with-authenticator
+          sample_name: amplify-authenticator
           spec: authenticator
 
   integ_react_predictions:


### PR DESCRIPTION
Test run with all integ tests here: https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/5398/workflows/d4d634ae-ebf8-49ac-b9a0-6ef62e56f726

Utilizing the `ci:test` script for more reliable integ testing in CCI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
