### PR TITLE
Use the correct dial code for Poland

### DIFF
--- a/packages/amplify-ui-components/src/common/country-dial-codes.ts
+++ b/packages/amplify-ui-components/src/common/country-dial-codes.ts
@@ -17,7 +17,7 @@ const countryDialCodes = [
   { label: '+45', value: '+45'},
   { label: '+46', value: '+46'},
   { label: '+47', value: '+47'},
-  { label: '+48', value: '+47'},
+  { label: '+48', value: '+48'},
   { label: '+49', value: '+49'},
   { label: '+51', value: '+51'},
   { label: '+52', value: '+52'},


### PR DESCRIPTION
Picking the country dial code for Poland during sign-up (`+48`) results in the wrong phone number being registered (with `+47` prefix instead of `+48`).

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
