### PR TITLE
ci: add retry for integ tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ commands:
             JEST_JUNIT_OUTPUT_DIR: 'reports/junit'
             JEST_JUNIT_OUTPUT_NAME: 'detox-test-results.xml'
           name: Detox Test
-          command: command: ~/amplify-js/.circleci/retry-yarn-script.sh 'detox test -c ios.sim.debug -u' 3
+          command: ~/amplify-js/.circleci/retry-yarn-script.sh 'detox test -c ios.sim.debug -u' 3
       - store_test_results:
           path: reports/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ commands:
             JEST_JUNIT_OUTPUT_DIR: 'reports/junit'
             JEST_JUNIT_OUTPUT_NAME: 'detox-test-results.xml'
           name: Detox Test
-          command: detox test -c ios.sim.debug -u
+          command: command: ~/amplify-js/.circleci/retry-yarn-script.sh 'detox test -c ios.sim.debug -u' 3
       - store_test_results:
           path: reports/junit
       - store_artifacts:
@@ -306,7 +306,7 @@ commands:
             JEST_JUNIT_OUTPUT_DIR: 'reports/junit'
             JEST_JUNIT_OUTPUT_NAME: 'detox-test-results.xml'
           name: Detox Test
-          command: detox test -c android.emu.debug -u
+          command: ~/amplify-js/.circleci/retry-yarn-script.sh 'detox test -c android.emu.debug -u' 3
       - store_test_results:
           path: reports/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -604,7 +604,6 @@ releasable_branches: &releasable_branches
       - main
       - ui-components/master
       - 1.0-stable
-      - retry_integ_tests # TODO: remove this before merging
 
 workflows:
   build_test_deploy:
@@ -691,27 +690,27 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
-      # - deploy:
-      #     filters:
-      #       <<: *releasable_branches
-      #     requires:
-      #       - unit_test
-      #       - integ_react_predictions
-      #       - integ_react_datastore
-      #       - integ_react_storage
-      #       - integ_react_auth
-      #       - integ_angular_auth
-      #       - integ_vue_auth
-      #       - integ_react_auth_ui
-      #       - integ_angular_auth_ui
-      #       - integ_vue_auth_ui
-      #       - integ_rn_ios_storage
-      #       - integ_rn_ios_push_notifications
-      #       - integ_rn_android_storage
-      # - post_release:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #     requires:
-      #       - deploy
+      - deploy:
+          filters:
+            <<: *releasable_branches
+          requires:
+            - unit_test
+            - integ_react_predictions
+            - integ_react_datastore
+            - integ_react_storage
+            - integ_react_auth
+            - integ_angular_auth
+            - integ_vue_auth
+            - integ_react_auth_ui
+            - integ_angular_auth_ui
+            - integ_vue_auth_ui
+            - integ_rn_ios_storage
+            - integ_rn_ios_push_notifications
+            - integ_rn_android_storage
+      - post_release:
+          filters:
+            branches:
+              only:
+                - release
+          requires:
+            - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,12 @@ test_env_vars: &test_env_vars
     NPM_PASS: circleci
     NPM_EMAIL: circleci@amplify.js
 
+# flags:
+# -s = script name
+# -n = how many times to retry
+# -r (optional) = run git reset in between retries
+retry_on_error: &retry_on_error '~/amplify-js/.circleci/retry-yarn-script.sh'
+
 commands:
   restore_pods:
     steps:
@@ -76,7 +82,7 @@ commands:
             git config --global user.name $NPM_USER
             git status
             git --no-pager diff
-            ~/amplify-js/.circleci/retry-yarn-script.sh publish:verdaccio 5 git_reset
+            *retry_on_error -s publish:verdaccio -n 5 -r true
 
   prepare_test_env:
     steps:
@@ -118,7 +124,7 @@ commands:
           name: 'Run cypress tests for << parameters.test_name >> Sample'
           command: |
             cd ~/amplify-js-samples-staging
-            ~/amplify-js/.circleci/retry-yarn-script.sh 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' 3
+            *retry_on_error -s 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' -n 3
       - store_artifacts:
           path: ~/amplify-js-samples-staging/cypress/videos
       - store_artifacts:
@@ -149,7 +155,7 @@ commands:
           name: 'Run << parameters.test_name >> UI tests'
           command: |
             cd ~/amplify-js-samples-staging-ui
-            ~/amplify-js/.circleci/retry-yarn-script.sh 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' 3
+            *retry_on_error -s 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' -n 3
       - store_artifacts:
           path: ~/amplify-js-samples-staging-ui/cypress/videos
       - store_artifacts:
@@ -209,7 +215,8 @@ commands:
             JEST_JUNIT_OUTPUT_DIR: 'reports/junit'
             JEST_JUNIT_OUTPUT_NAME: 'detox-test-results.xml'
           name: Detox Test
-          command: ~/amplify-js/.circleci/retry-yarn-script.sh 'detox test -c ios.sim.debug -u' 3
+          command: |
+            *retry_on_error -s 'detox test -c ios.sim.debug -u' -n 3
       - store_test_results:
           path: reports/junit
       - store_artifacts:
@@ -306,7 +313,8 @@ commands:
             JEST_JUNIT_OUTPUT_DIR: 'reports/junit'
             JEST_JUNIT_OUTPUT_NAME: 'detox-test-results.xml'
           name: Detox Test
-          command: ~/amplify-js/.circleci/retry-yarn-script.sh 'detox test -c android.emu.debug -u' 3
+          command: |
+            *retry_on_error -s 'detox test -c android.emu.debug -u' 3
       - store_test_results:
           path: reports/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,6 +602,7 @@ releasable_branches: &releasable_branches
       - main
       - ui-components/master
       - 1.0-stable
+      - retry_integ_tests # TODO: remove this before merging
 
 workflows:
   build_test_deploy:
@@ -688,27 +689,27 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
-      - deploy:
-          filters:
-            <<: *releasable_branches
-          requires:
-            - unit_test
-            - integ_react_predictions
-            - integ_react_datastore
-            - integ_react_storage
-            - integ_react_auth
-            - integ_angular_auth
-            - integ_vue_auth
-            - integ_react_auth_ui
-            - integ_angular_auth_ui
-            - integ_vue_auth_ui
-            - integ_rn_ios_storage
-            - integ_rn_ios_push_notifications
-            - integ_rn_android_storage
-      - post_release:
-          filters:
-            branches:
-              only:
-                - release
-          requires:
-            - deploy
+      # - deploy:
+      #     filters:
+      #       <<: *releasable_branches
+      #     requires:
+      #       - unit_test
+      #       - integ_react_predictions
+      #       - integ_react_datastore
+      #       - integ_react_storage
+      #       - integ_react_auth
+      #       - integ_angular_auth
+      #       - integ_vue_auth
+      #       - integ_react_auth_ui
+      #       - integ_angular_auth_ui
+      #       - integ_vue_auth_ui
+      #       - integ_rn_ios_storage
+      #       - integ_rn_ios_push_notifications
+      #       - integ_rn_android_storage
+      # - post_release:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #     requires:
+      #       - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ commands:
             git config --global user.name $NPM_USER
             git status
             git --no-pager diff
-            ./.circleci/retry-publish.sh publish:verdaccio
+            ./.circleci/retry-yarn-script.sh publish:verdaccio 5 git_reset
 
   prepare_test_env:
     steps:
@@ -118,7 +118,7 @@ commands:
           name: 'Run cypress tests for << parameters.test_name >> Sample'
           command: |
             cd ~/amplify-js-samples-staging
-            yarn ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>
+            ./.circleci/retry-yarn-script.sh 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' 3
       - store_artifacts:
           path: ~/amplify-js-samples-staging/cypress/videos
       - store_artifacts:
@@ -149,7 +149,7 @@ commands:
           name: 'Run << parameters.test_name >> UI tests'
           command: |
             cd ~/amplify-js-samples-staging-ui
-            yarn ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>
+            ./.circleci/retry-yarn-script.sh 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' 3
       - store_artifacts:
           path: ~/amplify-js-samples-staging-ui/cypress/videos
       - store_artifacts:
@@ -569,7 +569,7 @@ jobs:
               git config --global user.name $GITHUB_USER
               git status
               git --no-pager diff
-              ./.circleci/retry-publish.sh publish:$CIRCLE_BRANCH
+              yarn publish:$CIRCLE_BRANCH
             else
               echo "Skipping deploy."
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ commands:
             git config --global user.name $NPM_USER
             git status
             git --no-pager diff
-            ./.circleci/retry-yarn-script.sh publish:verdaccio 5 git_reset
+            ~/amplify-js/.circleci/retry-yarn-script.sh publish:verdaccio 5 git_reset
 
   prepare_test_env:
     steps:
@@ -118,7 +118,7 @@ commands:
           name: 'Run cypress tests for << parameters.test_name >> Sample'
           command: |
             cd ~/amplify-js-samples-staging
-            ./.circleci/retry-yarn-script.sh 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' 3
+            ~/amplify-js/.circleci/retry-yarn-script.sh 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' 3
       - store_artifacts:
           path: ~/amplify-js-samples-staging/cypress/videos
       - store_artifacts:
@@ -149,7 +149,7 @@ commands:
           name: 'Run << parameters.test_name >> UI tests'
           command: |
             cd ~/amplify-js-samples-staging-ui
-            ./.circleci/retry-yarn-script.sh 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' 3
+            ~/amplify-js/.circleci/retry-yarn-script.sh 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' 3
       - store_artifacts:
           path: ~/amplify-js-samples-staging-ui/cypress/videos
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,12 +32,6 @@ test_env_vars: &test_env_vars
     NPM_PASS: circleci
     NPM_EMAIL: circleci@amplify.js
 
-# flags:
-# -s = script name
-# -n = how many times to retry
-# -r (optional) = run git reset in between retries
-retry_on_error: &retry_on_error '~/amplify-js/.circleci/retry-yarn-script.sh'
-
 commands:
   restore_pods:
     steps:
@@ -82,7 +76,7 @@ commands:
             git config --global user.name $NPM_USER
             git status
             git --no-pager diff
-            *retry_on_error -s publish:verdaccio -n 5 -r true
+            ~/amplify-js/.circleci/retry-yarn-script.sh -s publish:verdaccio -n 5 -r true
 
   prepare_test_env:
     steps:
@@ -124,7 +118,7 @@ commands:
           name: 'Run cypress tests for << parameters.test_name >> Sample'
           command: |
             cd ~/amplify-js-samples-staging
-            *retry_on_error -s 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' -n 3
+            ~/amplify-js/.circleci/retry-yarn-script.sh -s 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' -n 3
       - store_artifacts:
           path: ~/amplify-js-samples-staging/cypress/videos
       - store_artifacts:
@@ -155,7 +149,7 @@ commands:
           name: 'Run << parameters.test_name >> UI tests'
           command: |
             cd ~/amplify-js-samples-staging-ui
-            *retry_on_error -s 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' -n 3
+            ~/amplify-js/.circleci/retry-yarn-script.sh -s 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >>' -n 3
       - store_artifacts:
           path: ~/amplify-js-samples-staging-ui/cypress/videos
       - store_artifacts:
@@ -216,7 +210,7 @@ commands:
             JEST_JUNIT_OUTPUT_NAME: 'detox-test-results.xml'
           name: Detox Test
           command: |
-            *retry_on_error -s 'detox test -c ios.sim.debug -u' -n 3
+            ~/amplify-js/.circleci/retry-yarn-script.sh -s 'detox test -c ios.sim.debug -u' -n 3
       - store_test_results:
           path: reports/junit
       - store_artifacts:
@@ -314,7 +308,7 @@ commands:
             JEST_JUNIT_OUTPUT_NAME: 'detox-test-results.xml'
           name: Detox Test
           command: |
-            *retry_on_error -s 'detox test -c android.emu.debug -u' 3
+            ~/amplify-js/.circleci/retry-yarn-script.sh -s 'detox test -c android.emu.debug -u' 3
       - store_test_results:
           path: reports/junit
       - store_artifacts:

--- a/.circleci/retry-yarn-script.sh
+++ b/.circleci/retry-yarn-script.sh
@@ -1,18 +1,29 @@
 #!/bin/bash
 
 # usage example: 
-# ./retry-command.sh 3 publish:verdaccio
+# ./retry-command.sh -s publish:verdaccio -n 3
+# ./retry-command.sh -s publish:verdaccio -n 3 -r true
+
+while getopts s:n:r: option
+do
+	case "${option}"
+	in
+		s) SCRIPT=${OPTARG};;
+		n) N=${OPTARG};;
+		r) GIT_RESET=${OPTARG};;
+	esac
+done
 
 # initialize counter
 n=0
 # loop until n >= first param
-until [ "$n" -ge $2 ]
+until [ "$n" -ge $N ]
 do
 	# $1 is the argument passed in, e.g. publish:verdaccio
 	# if the publish command succeeds, `break` exits the loop
-	yarn $1 && break
+	yarn $SCRIPT && break
 	
-	if [[ $3 = 'git_reset' ]]
+	if [[ $GIT_RESET ]]
 	then
 	# reset git HEAD (remove the package.json changes made by lerna)
   	echo "Resetting git HEAD"
@@ -23,5 +34,5 @@ do
 	n=$((n+1))
 	# wait 5 seconds
 	sleep 5
-	echo "Retry $n of $2"
+	echo "Retry $n of $N"
 done

--- a/.circleci/retry-yarn-script.sh
+++ b/.circleci/retry-yarn-script.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
 
+# usage example: 
+# ./retry-command.sh 3 publish:verdaccio
+
 # initialize counter
 n=0
-# loop until n >= 5
-until [ "$n" -ge 5 ]
+# loop until n >= first param
+until [ "$n" -ge $2 ]
 do
 	# $1 is the argument passed in, e.g. publish:verdaccio
 	# if the publish command succeeds, `break` exits the loop
 	yarn $1 && break
-	# if the command fails
+	
+	if [[ $3 = 'git_reset' ]]
+	then
 	# reset git HEAD (remove the package.json changes made by lerna)
-	git reset --hard
+  	echo "Resetting git HEAD"
+		git reset --hard
+	fi
+	
 	# increment counter
 	n=$((n+1))
 	# wait 5 seconds
 	sleep 5
-	echo "Retry $n of 5"
+	echo "Retry $n of $2"
 done

--- a/.circleci/retry-yarn-script.sh
+++ b/.circleci/retry-yarn-script.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# flags:
+# -s = script name
+# -n = how many times to retry
+# -r (optional) = run git reset in between retries
+
 # usage example: 
 # ./retry-command.sh -s publish:verdaccio -n 3
 # ./retry-command.sh -s publish:verdaccio -n 3 -r true

--- a/.circleci/retry-yarn-script.sh
+++ b/.circleci/retry-yarn-script.sh
@@ -6,7 +6,7 @@
 # -r (optional) = run git reset in between retries
 
 # usage example: 
-# ./retry-command.sh -s publish:verdaccio -n 3
+# ./retry-command.sh -s lint -n 5
 # ./retry-command.sh -s publish:verdaccio -n 3 -r true
 
 while getopts s:n:r: option


### PR DESCRIPTION
Retry failed integration test suites 3 times before failing the job in circleci

Tested the pipeline on this branch with integ tests enabled here: https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/5419/workflows/63060753-8fa6-435a-b6d8-3c7642fe555a
++ previous 3 runs on the same branch


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
