### PR TITLE
fix(@aws-amplify/auth): add totpRequired callback to completeNewPassword

### DIFF
--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -1161,6 +1161,7 @@ describe('auth unit test', () => {
 					onFailure: jasmine.any(Function),
 					mfaRequired: jasmine.any(Function),
 					mfaSetup: jasmine.any(Function),
+					totpRequired: jasmine.any(Function),
 				},
 				{ foo: 'bar' }
 			);
@@ -1190,6 +1191,7 @@ describe('auth unit test', () => {
 					onFailure: jasmine.any(Function),
 					mfaRequired: jasmine.any(Function),
 					mfaSetup: jasmine.any(Function),
+					totpRequired: jasmine.any(Function),
 				},
 				{ custom: 'value' }
 			);

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -970,6 +970,12 @@ export class AuthClass {
 						user['challengeParam'] = challengeParam;
 						resolve(user);
 					},
+					totpRequired: (challengeName, challengeParam) => {
+						logger.debug('signIn mfa setup', challengeName);
+						user['challengeName'] = challengeName;
+						user['challengeParam'] = challengeParam;
+						resolve(user);
+					},
 				},
 				clientMetadata
 			);


### PR DESCRIPTION
_Issue #, if available:_
#4321
#6106

_Description of changes:_
Add missing `totpRequired` to `callback` for `completeNewPassword`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
