### PR TITLE
Adds I18n capability to the Sign In errors

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
@@ -176,6 +176,7 @@ export class AmplifySignIn {
         this.checkContact(user);
       }
     } catch (error) {
+      error.message = I18n.get(error.message);
       dispatchToastHubEvent(error);
       if (error.code === 'UserNotConfirmedException') {
         logger.debug('the user is not confirmed');


### PR DESCRIPTION
Issue #[867](https://github.com/aws-amplify/amplify-js/issues/867)

Adds I18n support for the Sign In errors being displayed in the Toast bar.

