### PR TITLE
fix(@aws-amplify/ui-react): Fix user not being set on initial render

### DIFF
--- a/packages/amplify-ui-react/src/withAuthenticator.tsx
+++ b/packages/amplify-ui-react/src/withAuthenticator.tsx
@@ -19,22 +19,28 @@ export function withAuthenticator(
 
 		React.useEffect(() => {
 			appendToCognitoUserAgent('withAuthenticator');
-			async () => {
-				try {
-					const user = await Auth.currentAuthenticatedUser();
-					if (user) setSignedIn(true);
-				} catch (err) {
-					logger.debug(err);
-				}
-			};
-			return onAuthUIStateChange(authState => {
+			checkUser();
+		}, []);
+
+		async function checkUser() {
+			await setUser();
+			onAuthUIStateChange(authState => {
 				if (authState === AuthState.SignedIn) {
 					setSignedIn(true);
 				} else if (authState === AuthState.SignedOut) {
 					setSignedIn(false);
 				}
 			});
-		}, []);
+		}
+
+		async function setUser() {
+			try {
+				const user = await Auth.currentAuthenticatedUser();
+				if (user) setSignedIn(true);
+			} catch (err) {
+				logger.debug(err);
+			}
+		};
 
 		if (!signedIn) {
 			return (


### PR DESCRIPTION
This fixes an issue with an async call in `useEffect`.

In this update, the code ensures that the `setUser` function is complete before returning.