### PR TITLE
Suggestion: [WIP] Begin Migration to TS Project References, Stricten TS Configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
 	"name": "aws-amplify-monorepo",
 	"private": true,
 	"version": "0.1.30",
-	"description": "",
 	"scripts": {
 		"setup-dev": "yarn && yarn bootstrap && yarn link-all && yarn build",
 		"bootstrap": "lerna bootstrap",
@@ -14,6 +13,8 @@
 		"build": "lerna run build --stream",
 		"build:esm:watch": "lerna run build:esm:watch --parallel",
 		"build:cjs:watch": "lerna run build:cjs:watch --parallel",
+		"build:with-references": "tsc -b && cd packages/auth && yarn webpack",
+		"watch:with-references": "tsc -w",
 		"clean": "lerna run clean --parallel",
 		"format": "lerna run format",
 		"lint": "lerna run lint",
@@ -31,8 +32,13 @@
 		}
 	},
 	"workspaces": {
-  		"packages": ["packages/*"],
-  		"nohoist": ["**/@types/react-native", "**/@types/react-native/**"]
+		"packages": [
+			"packages/*"
+		],
+		"nohoist": [
+			"**/@types/react-native",
+			"**/@types/react-native/**"
+		]
 	},
 	"repository": {
 		"type": "git",
@@ -75,7 +81,7 @@
 		"tslint": "^5.7.0",
 		"tslint-config-airbnb": "^5.8.0",
 		"typedoc": "^0.16.9",
-		"typescript": "~3.6.4",
+		"typescript": "^3.9.6",
 		"uglifyjs-webpack-plugin": "^0.4.6",
 		"uuid-validate": "^0.0.3",
 		"webpack": "^4.32.0",

--- a/packages/auth/build.js
+++ b/packages/auth/build.js
@@ -1,5 +1,0 @@
-'use strict';
-
-const build = require('../../scripts/build');
-
-build(process.argv[2], process.argv[3]);

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -3,24 +3,20 @@
   "version": "3.3.1",
   "description": "Auth category of aws-amplify",
   "main": "./lib/index.js",
-  "module": "./lib-esm/index.js",
-  "typings": "./lib-esm/index.d.ts",
+  "module": "./esm/index.js",
+  "typings": "./esm/index.d.ts",
   "react-native": {
-    "./lib/index": "./lib-esm/index.js"
+    "./lib/index": "./esm/index.js"
   },
   "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
+    "test": "jest -w 1 --coverage",
     "build-with-test": "npm test && npm run build",
-    "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
-    "build:esm": "node ./build es6",
-    "build:cjs:watch": "node ./build es5 --watch",
-    "build:esm:watch": "node ./build es6 --watch",
-    "build": "npm run clean && npm run build:esm && npm run build:cjs",
-    "clean": "rimraf lib-esm lib dist",
+    "webpack": "webpack && webpack --config ./webpack.config.dev.js",
+    "clean": "rimraf esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts'"
   },

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -85,9 +85,11 @@ const dispatchAuthEvent = (event: string, data: any, message: string) => {
  * Provide authentication steps
  */
 export class AuthClass {
+	// @ts-ignore
 	private _config: AuthOptions;
 	private userPool = null;
 	private user: any = null;
+	// @ts-ignore
 	private _oAuthHandler: OAuth;
 	private _storage;
 	private _storageSync;
@@ -167,10 +169,12 @@ export class AuthClass {
 		if (userPoolId) {
 			const userPoolData: ICognitoUserPoolData = {
 				UserPoolId: userPoolId,
+				// @ts-ignore
 				ClientId: userPoolWebClientId,
 			};
 			userPoolData.Storage = this._storage;
 
+			// @ts-ignore
 			this.userPool = new CognitoUserPool(userPoolData);
 		}
 
@@ -186,6 +190,7 @@ export class AuthClass {
 		// initiailize cognitoauth client if hosted ui options provided
 		// to keep backward compatibility:
 		const cognitoHostedUIConfig = oauth
+			// @ts-ignore
 			? isCognitoHostedOpts(this._config.oauth)
 				? oauth
 				: (<any>oauth).awsCognito
@@ -250,16 +255,22 @@ export class AuthClass {
 			return this.rejectNoUserPool();
 		}
 
+		// @ts-ignore
 		let username: string = null;
+		// @ts-ignore
 		let password: string = null;
 		const attributes: object[] = [];
+		// @ts-ignore
 		let validationData: object[] = null;
 		let clientMetadata;
 
 		if (params && typeof params === 'string') {
 			username = params;
+			// @ts-ignore
 			password = restOfAttrs ? restOfAttrs[0] : null;
+			// @ts-ignore
 			const email: string = restOfAttrs ? restOfAttrs[1] : null;
+			// @ts-ignore
 			const phone_number: string = restOfAttrs ? restOfAttrs[2] : null;
 			if (email) attributes.push({ Name: 'email', Value: email });
 			if (phone_number)
@@ -281,6 +292,7 @@ export class AuthClass {
 					attributes.push(ele);
 				});
 			}
+			// @ts-ignore
 			validationData = params['validationData'] || null;
 		} else {
 			return this.rejectAuthError(AuthErrorTypes.SignUpError);
@@ -297,6 +309,7 @@ export class AuthClass {
 		logger.debug('signUp validation data:', validationData);
 
 		return new Promise((resolve, reject) => {
+			// @ts-ignore
 			this.userPool.signUp(
 				username,
 				password,
@@ -424,7 +437,9 @@ export class AuthClass {
 
 		// for backward compatibility
 		if (typeof usernameOrSignInOpts === 'string') {
+			// @ts-ignore
 			username = usernameOrSignInOpts;
+			// @ts-ignore
 			password = pw;
 		} else if (isUsernamePasswordOpts(usernameOrSignInOpts)) {
 			if (typeof pw !== 'undefined') {
@@ -432,8 +447,11 @@ export class AuthClass {
 					'The password should be defined under the first parameter object!'
 				);
 			}
+			// @ts-ignore
 			username = usernameOrSignInOpts.username;
+			// @ts-ignore
 			password = usernameOrSignInOpts.password;
+			// @ts-ignore
 			validationData = usernameOrSignInOpts.validationData;
 		} else {
 			return this.rejectAuthError(AuthErrorTypes.InvalidUsername);
@@ -443,6 +461,7 @@ export class AuthClass {
 		}
 		const authDetails = new AuthenticationDetails({
 			Username: username,
+			// @ts-ignore
 			Password: password,
 			ValidationData: validationData,
 			ClientMetadata: clientMetadata,
@@ -656,11 +675,14 @@ export class AuthClass {
 				// if it does not exist, then it should be NOMFA
 				const MFAOptions = data.MFAOptions;
 				if (MFAOptions) {
+					// @ts-ignore
 					ret = 'SMS_MFA';
 				} else {
+					// @ts-ignore
 					ret = 'NOMFA';
 				}
 			} else if (mfaList.length === 0) {
+				// @ts-ignore
 				ret = 'NOMFA';
 			} else {
 				logger.debug('invalid case for getPreferredMFA', data);
@@ -700,28 +722,33 @@ export class AuthClass {
 
 		switch (mfaMethod) {
 			case 'TOTP' || 'SOFTWARE_TOKEN_MFA':
+				// @ts-ignore
 				totpMfaSettings = {
 					PreferredMfa: true,
 					Enabled: true,
 				};
 				break;
 			case 'SMS' || 'SMS_MFA':
+				// @ts-ignore
 				smsMfaSettings = {
 					PreferredMfa: true,
 					Enabled: true,
 				};
 				break;
 			case 'NOMFA':
+				// @ts-ignore
 				const mfaList = userData['UserMFASettingList'];
 				const currentMFAType = await this._getMfaTypeFromUserData(userData);
 				if (currentMFAType === 'NOMFA') {
 					return Promise.resolve('No change for mfa type');
 				} else if (currentMFAType === 'SMS_MFA') {
+					// @ts-ignore
 					smsMfaSettings = {
 						PreferredMfa: false,
 						Enabled: false,
 					};
 				} else if (currentMFAType === 'SOFTWARE_TOKEN_MFA') {
+					// @ts-ignore
 					totpMfaSettings = {
 						PreferredMfa: false,
 						Enabled: false,
@@ -735,11 +762,13 @@ export class AuthClass {
 					// to disable SMS or TOTP if exists in that list
 					mfaList.forEach(mfaType => {
 						if (mfaType === 'SMS_MFA') {
+							// @ts-ignore
 							smsMfaSettings = {
 								PreferredMfa: false,
 								Enabled: false,
 							};
 						} else if (mfaType === 'SOFTWARE_TOKEN_MFA') {
+							// @ts-ignore
 							totpMfaSettings = {
 								PreferredMfa: false,
 								Enabled: false,
@@ -1140,6 +1169,7 @@ export class AuthClass {
 						});
 					}
 
+					// @ts-ignore
 					const user = this.userPool.getCurrentUser();
 
 					if (!user) {
@@ -1188,6 +1218,7 @@ export class AuthClass {
 											Value: data.UserAttributes[i].Value,
 										};
 										const userAttribute = new CognitoUserAttribute(attribute);
+										// @ts-ignore
 										attributeList.push(userAttribute);
 									}
 
@@ -1516,8 +1547,10 @@ export class AuthClass {
 		}
 
 		if (this.userPool) {
+			// @ts-ignore
 			const user = this.userPool.getCurrentUser();
 			if (user) {
+				// @ts-ignore
 				await this.cognitoIdentitySignOut(opts, user);
 			} else {
 				logger.debug('no current Cognito user');
@@ -1708,6 +1741,7 @@ export class AuthClass {
 				}
 
 				const info = {
+					// @ts-ignore
 					id: credentials ? credentials.identityId : undefined,
 					username: user.getUsername(),
 					attributes: userAttrs,
@@ -1725,6 +1759,7 @@ export class AuthClass {
 		}
 	}
 
+	// @ts-ignore
 	public async federatedSignIn(
 		options?: FederatedSignInOptions
 	): Promise<ICredentials>;
@@ -1736,6 +1771,7 @@ export class AuthClass {
 	public async federatedSignIn(
 		options?: FederatedSignInOptionsCustom
 	): Promise<ICredentials>;
+	// @ts-ignore
 	public async federatedSignIn(
 		providerOrOptions:
 			| LegacyProvider
@@ -1776,18 +1812,25 @@ export class AuthClass {
 				: (options as FederatedSignInOptionsCustom).customState;
 
 			if (this._config.userPoolId) {
+				// @ts-ignore
 				const client_id = isCognitoHostedOpts(this._config.oauth)
 					? this._config.userPoolWebClientId
+					// @ts-ignore
 					: this._config.oauth.clientID;
 				/*Note: Invenstigate automatically adding trailing slash */
+				// @ts-ignore
 				const redirect_uri = isCognitoHostedOpts(this._config.oauth)
 					? this._config.oauth.redirectSignIn
+					// @ts-ignore
 					: this._config.oauth.redirectUri;
 
 				this._oAuthHandler.oauthSignIn(
+					// @ts-ignore
 					this._config.oauth.responseType,
+					// @ts-ignore
 					this._config.oauth.domain,
 					redirect_uri,
+					// @ts-ignore
 					client_id,
 					provider,
 					customState
@@ -1806,6 +1849,7 @@ export class AuthClass {
 				}
 			} catch (e) {}
 
+			// @ts-ignore
 			const { token, identity_id, expires_at } = response;
 			// Because Credentials.set would update the user info with identity id
 			// So we need to retrieve the user again.
@@ -1866,8 +1910,11 @@ export class AuthClass {
 				this._storage.setItem('amplify-redirected-from-hosted-ui', 'true');
 				try {
 					const {
+						// @ts-ignore
 						accessToken,
+						// @ts-ignore
 						idToken,
+						// @ts-ignore
 						refreshToken,
 						state,
 					} = await this._oAuthHandler.handleAuthResponse(currentUrl);
@@ -1908,6 +1955,7 @@ export class AuthClass {
 					if (window && typeof window.history !== 'undefined') {
 						window.history.replaceState(
 							{},
+							// @ts-ignore
 							null,
 							(this._config.oauth as AwsCognitoOAuthOpts).redirectSignIn
 						);
@@ -1999,6 +2047,7 @@ export class AuthClass {
 	private createCognitoUser(username: string): CognitoUser {
 		const userData: ICognitoUserData = {
 			Username: username,
+			// @ts-ignore
 			Pool: this.userPool,
 		};
 		userData.Storage = this._storage;
@@ -2042,4 +2091,5 @@ export class AuthClass {
 	}
 }
 
+// @ts-ignore
 export const Auth = new AuthClass(null);

--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -183,6 +183,7 @@ export default class OAuth {
 	}
 
 	private async _handleImplicitFlow(currentUrl: string) {
+		// @ts-ignore
 		const { id_token, access_token } = parse(currentUrl)
 			.hash.substr(1) // Remove # from returned code
 			.split('&')
@@ -229,8 +230,10 @@ export default class OAuth {
 				`Starting ${this._config.responseType} flow with ${currentUrl}`
 			);
 			if (this._config.responseType === 'code') {
+				// @ts-ignore
 				return { ...(await this._handleCodeFlow(currentUrl)), state };
 			} else {
+				// @ts-ignore
 				return { ...(await this._handleImplicitFlow(currentUrl)), state };
 			}
 		} catch (e) {
@@ -241,6 +244,7 @@ export default class OAuth {
 
 	private _validateState(urlParams: any): string {
 		if (!urlParams) {
+			// @ts-ignore
 			return;
 		}
 
@@ -324,6 +328,7 @@ export default class OAuth {
 		const state = [];
 		for (let i = 0; i < buffer.byteLength; i += 1) {
 			const index = buffer[i] % CHARSET.length;
+			// @ts-ignore
 			state.push(CHARSET[index]);
 		}
 		return state.join('');

--- a/packages/auth/tsconfig.cjs.json
+++ b/packages/auth/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"module": "CommonJS",
+		"outDir": "cjs",
+		"rootDir": "src",
+		"tsBuildInfoFile": "cjs/.tsbuildinfo"
+	},
+	"exclude": ["__tests__"],
+	"extends": "../../tsconfig.base.json",
+	"include": ["__tests__", "src"]
+}

--- a/packages/auth/tsconfig.esm.json
+++ b/packages/auth/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"module": "ES6",
+		"outDir": "esm",
+		"rootDir": "src",
+		"tsBuildInfoFile": "esm/.tsbuildinfo"
+	},
+	"exclude": ["__tests__"],
+	"extends": "../../tsconfig.base.json",
+	"include": ["__tests__", "src"]
+}

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"files": [],
+	"references": [
+		{
+			"path": "tsconfig.esm.json"
+		},
+		{
+			"path": "tsconfig.cjs.json"
+		}
+	]
+}

--- a/packages/auth/webpack.config.dev.js
+++ b/packages/auth/webpack.config.dev.js
@@ -1,6 +1,6 @@
 var config = require('./webpack.config.js');
 
 var entry = {
-	'aws-amplify-auth': './lib-esm/index.js',
+	'aws-amplify-auth': './esm/index.js',
 };
 module.exports = Object.assign(config, { entry, mode: 'development' });

--- a/packages/auth/webpack.config.js
+++ b/packages/auth/webpack.config.js
@@ -1,8 +1,8 @@
 module.exports = {
 	entry: {
-		'aws-amplify-auth.min': './lib-esm/index.js',
+		'aws-amplify-auth.min': './esm/index.js',
 	},
-	externals: ['react-native', '@aws-amplify/cache', '@aws-amplify/core'],
+	externals: ['react-native', '@aws-amplify/cache', '@aws-amplify/core', 'amazon-cognito-identity-js'],
 	output: {
 		filename: '[name].js',
 		path: __dirname + '/dist',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,36 @@
+{
+	"compilerOptions": {
+		"alwaysStrict": false,
+		"baseUrl": ".",
+		"composite": true,
+		"declaration": true,
+		"declarationMap": true,
+		"downlevelIteration": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"lib": ["DOM", "ES2017", "ES2018.AsyncIterable"],
+		"moduleResolution": "node",
+		"noEmit": false,
+		"noEmitOnError": false,
+		"noImplicitAny": false,
+		"noImplicitThis": false,
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"resolveJsonModule": true,
+		"sourceMap": true,
+		"strict": false,
+		"strictBindCallApply": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"strictPropertyInitialization": true,
+		"target": "ES5",
+		"typeRoots": ["node_modules/@types", "packages/**/node_modules"],
+		"useDefineForClassFields": true
+	},
+	"exclude": [
+		"node_modules",
+		"packages/**/cjs",
+		"packages/**/esm",
+		"packages/**/node_modules"
+	]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,6 +30,7 @@
 	"exclude": [
 		"node_modules",
 		"packages/**/cjs",
+		"packages/**/dist",
 		"packages/**/esm",
 		"packages/**/node_modules"
 	]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"compileOnSave": true,
+	"files": [],
+	"references": [
+		{
+			"path": "packages/auth/tsconfig.json"
+		}
+	]
+}


### PR DESCRIPTION
As of right now, the TS compilation setup is non-standard, and emits builds regardless of TS errors. Useful compiler flags are disabled. Let's phase this out, package by package, starting with the Auth category.

Thanks to TS project references, we have a clear "best practices" solution to managing our packages' incremental compilation and their interdependencies. This solution will enable us to...

- more easily reason about package-specifics (is JSX enabled? Do we need to enable down-level iteration? Etc.)
- reduce friction for new contributors
- cut down on boilerplate from every package's manifest
- eliminate the need for custom build scripts 
- **gradually stricten our use of TypeScript, per-package**

This is a first pass. Once we get this in good shape for Auth (I've temporarily broken the dual TS+Webpack watch for Auth, I've also ts-ignored some 53 type errors), we can begin to do the same for other categories.