### PR TITLE
(@aws-amplify/ui-components): refactor reset password send/submit button text

### DIFF
--- a/packages/amplify-ui-components/src/common/Translations.ts
+++ b/packages/amplify-ui-components/src/common/Translations.ts
@@ -31,6 +31,7 @@ export enum Translations {
   SELECT_MFA_TYPE_HEADER_TEXT = 'Select MFA Type',
   SELECT_MFA_TYPE_SUBMIT_BUTTON_TEXT = 'Verify',
   SEND_CODE = 'Send Code',
+  SUBMIT = 'Submit',
   SETUP_TOTP_REQUIRED = 'TOTP needs to be configured',
   SIGN_IN_ACTION = 'Sign In',
   SIGN_IN_HEADER_TEXT = 'Sign in to your account',

--- a/packages/amplify-ui-components/src/components.d.ts
+++ b/packages/amplify-ui-components/src/components.d.ts
@@ -306,6 +306,10 @@ export namespace Components {
          */
         "headerText": string;
         /**
+          * The text displayed inside of the send code button for the form
+         */
+        "sendButtonText": string;
+        /**
           * The text displayed inside of the submit button for the form
          */
         "submitButtonText": string;
@@ -1748,6 +1752,10 @@ declare namespace LocalJSX {
           * The header text of the forgot password section
          */
         "headerText"?: string;
+        /**
+          * The text displayed inside of the send code button for the form
+         */
+        "sendButtonText"?: string;
         /**
           * The text displayed inside of the submit button for the form
          */

--- a/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.spec.ts
+++ b/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.spec.ts
@@ -15,8 +15,12 @@ describe('amplify-forgot-password spec:', () => {
       expect(amplifyForgotPassword.headerText).toBe(I18n.get(Translations.RESET_YOUR_PASSWORD));
     });
 
+    it('`sendButtonText` should be set by default', () => {
+      expect(amplifyForgotPassword.sendButtonText).toBe(I18n.get(Translations.SEND_CODE));
+    });
+
     it('`submitButtonText` should be set by default', () => {
-      expect(amplifyForgotPassword.submitButtonText).toBe(I18n.get(Translations.SEND_CODE));
+      expect(amplifyForgotPassword.submitButtonText).toBe(I18n.get(Translations.SUBMIT));
     });
 
     it('should render `usernameAlias` as `username` by default', () => {

--- a/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
@@ -30,8 +30,10 @@ const logger = new Logger('ForgotPassword');
 export class AmplifyForgotPassword {
   /** The header text of the forgot password section */
   @Prop() headerText: string = I18n.get(Translations.RESET_YOUR_PASSWORD);
+  /** The text displayed inside of the send code button for the form */
+  @Prop() sendButtonText: string = I18n.get(Translations.SEND_CODE);
   /** The text displayed inside of the submit button for the form */
-  @Prop() submitButtonText: string = I18n.get(Translations.SEND_CODE);
+  @Prop() submitButtonText: string = I18n.get(Translations.SUBMIT);
   /** The form fields displayed inside of the forgot password form */
   @Prop() formFields: FormFieldTypes | string[] = [];
   /** The function called when making a request to reset password */
@@ -245,6 +247,7 @@ export class AmplifyForgotPassword {
 
   render() {
     const submitFn = this.delivery ? event => this.handleSubmit(event) : event => this.handleSend(event);
+    const submitButtonText = this.delivery ? this.submitButtonText : this.sendButtonText;
     return (
       <amplify-form-section
         headerText={this.headerText}
@@ -260,7 +263,7 @@ export class AmplifyForgotPassword {
           </amplify-button>
         }
         testDataPrefix={'forgot-password'}
-        submitButtonText={I18n.get(Translations.SEND_CODE)}
+        submitButtonText={submitButtonText}
       >
         <amplify-auth-fields formFields={this.newFormFields} />
       </amplify-form-section>

--- a/packages/amplify-ui-components/src/components/amplify-forgot-password/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-forgot-password/readme.md
@@ -12,7 +12,8 @@
 | `handleSend`            | --                   | The function called when making a request to reset password                               | `(event: Event) => void`                            | `event => this.send(event)`                  |
 | `handleSubmit`          | --                   | The function called when submitting a new password                                        | `(event: Event) => void`                            | `event => this.submit(event)`                |
 | `headerText`            | `header-text`        | The header text of the forgot password section                                            | `string`                                            | `I18n.get(Translations.RESET_YOUR_PASSWORD)` |
-| `submitButtonText`      | `submit-button-text` | The text displayed inside of the submit button for the form                               | `string`                                            | `I18n.get(Translations.SEND_CODE)`           |
+| `sendButtonText`        | `send-button-text`   | The text displayed inside of the send code button for the form                            | `string`                                            | `I18n.get(Translations.SEND_CODE)`           |
+| `submitButtonText`      | `submit-button-text` | The text displayed inside of the submit button for the form                               | `string`                                            | `I18n.get(Translations.SUBMIT)`              |
 | `usernameAlias`         | `username-alias`     | Username Alias is used to setup authentication with `username`, `email` or `phone_number` | `"email" \| "phone_number" \| "username"`           | `'username'`                                 |
 
 


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/issues/6253

_Description of changes:_
- Split up send and submit button text for different forms

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
