### PR TITLE
Update any and 'SUCCESS' response types of resendConfirmationCode and forgotPassword

### DIFF
--- a/packages/amazon-cognito-identity-js/index.d.ts
+++ b/packages/amazon-cognito-identity-js/index.d.ts
@@ -8,6 +8,14 @@ declare module 'amazon-cognito-identity-js' {
 		DeliveryMedium: string;
 		Destination: string;
 	}
+    
+    export interface ForgotPasswordResponse {
+        CodeDeliveryDetails?: CodeDeliveryDetails;
+    }
+
+    export interface ResendConfirmationCodeResponse {
+        CodeDeliveryDetails?: CodeDeliveryDetails;
+    }
 
 	export type ClientMetadata = { [key: string]: string } | undefined;
 
@@ -100,7 +108,7 @@ declare module 'amazon-cognito-identity-js' {
 			clientMetaData?: ClientMetadata
 		): void;
 		public resendConfirmationCode(
-			callback: NodeCallback<Error, 'SUCCESS'>,
+			callback: NodeCallback<Error, ResendConfirmationCodeResponse>,
 			clientMetaData?: ClientMetadata
 		): void;
 		public changePassword(
@@ -110,7 +118,7 @@ declare module 'amazon-cognito-identity-js' {
 		): void;
 		public forgotPassword(
 			callbacks: {
-				onSuccess: (data: any) => void;
+				onSuccess: (data: ForgotPasswordResponse) => void;
 				onFailure: (err: Error) => void;
 				inputVerificationCode?: (data: any) => void;
 			},

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -58,6 +58,7 @@ import {
 	CognitoIdToken,
 	CognitoRefreshToken,
 	CognitoAccessToken,
+	ResendConfirmationCodeResponse,
 } from 'amazon-cognito-identity-js';
 
 import { parse } from 'url';
@@ -383,7 +384,7 @@ export class AuthClass {
 	public resendSignUp(
 		username: string,
 		clientMetadata: ClientMetaData = this._config.clientMetadata
-	): Promise<string> {
+	): Promise<ResendConfirmationCodeResponse> {
 		if (!this.userPool) {
 			return this.rejectNoUserPool();
 		}
@@ -1600,8 +1601,8 @@ export class AuthClass {
 		return new Promise((resolve, reject) => {
 			user.forgotPassword(
 				{
-					onSuccess: () => {
-						resolve();
+					onSuccess: data => {
+						resolve(data);
 						return;
 					},
 					onFailure: err => {


### PR DESCRIPTION
- change any type at onSuccess argument as CodeDeliveryDetails instead
- change 'SUCCESS' type at resolve argument of resendConfirmationCode's callback as CodeDeliveryDetails instead

Description of changes:
Changed some types and make it more strict

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.