### PR TITLE
fix(@aws-amplify/datastore): Fix disconnection handler

### DIFF
--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -652,7 +652,8 @@ export class SyncEngine {
 				},
 				error: err => {
 					reject(err);
-					this.disconnectionHandler(datastoreConnectivity);
+					const handleDisconnect = this.disconnectionHandler(datastoreConnectivity);
+					handleDisconnect(err);
 				},
 			});
 		});

--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -357,11 +357,13 @@ class SubscriptionProcessor {
 															errors: [],
 														},
 													} = subscriptionError;
-													logger.warn(message);
+													logger.warn('subscriptionError', message);
 
 													if (typeof subscriptionReadyCallback === 'function') {
 														subscriptionReadyCallback();
 													}
+
+													observer.error(message);
 												},
 											})
 									);


### PR DESCRIPTION
_Issue #, if available:_
#6162

_Description of changes:_
This PR will ensure disconnectionHandler is called when a subscription fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
