### PR TITLE
Fix @aws-amplify/analytics. - Pinpoint header correction

### DIFF
--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -621,6 +621,18 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 			credentials,
 			customUserAgent: getAmplifyUserAgent(),
 		});
+		this.pinpointClient.middlewareStack.addRelativeTo(
+			next => args => {
+				delete args.request.headers['amz-sdk-invocation-id'];
+				delete args.request.headers['amz-sdk-request'];
+				return next(args);
+			},
+			{
+				step: 'finalizeRequest',
+				relation: 'after',
+				toMiddleware: 'retryMiddleware',
+			}
+		);
 
 		if (this._bufferExists() && identityId === credentials.identityId) {
 			// if the identity has remained the same, pass the updated client to the buffer

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -621,6 +621,8 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 			credentials,
 			customUserAgent: getAmplifyUserAgent(),
 		});
+		
+		// TODO: remove this middleware once a long term fix is implemented by aws-sdk-js team.
 		this.pinpointClient.middlewareStack.addRelativeTo(
 			next => args => {
 				delete args.request.headers['amz-sdk-invocation-id'];


### PR DESCRIPTION
_Issue #, if available:_
Pinpoint events not being sent because CORS failure.

Related : 
- https://github.com/aws-amplify/amplify-js/issues/6339

_Description of changes:_

Based on `aws-sdk-js` team's recommendation. A short term fix is implemented. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
