### PR TITLE
fix (@aws-amplify/storage) - track property

### DIFF
--- a/packages/storage/__tests__/providers/AWSS3Provider-unit-test.ts
+++ b/packages/storage/__tests__/providers/AWSS3Provider-unit-test.ts
@@ -206,7 +206,6 @@ describe('StorageProvider test', () => {
 					event: 'getSignedUrl',
 					data: {
 						attrs: { method: 'get', result: 'success' },
-						metrics: null,
 					},
 					message: 'Signed URL: url',
 				},
@@ -505,7 +504,6 @@ describe('StorageProvider test', () => {
 							method: 'put',
 							result: 'success',
 						},
-						metrics: null,
 					},
 					message: 'Upload success for key',
 				},
@@ -627,7 +625,6 @@ describe('StorageProvider test', () => {
 					event: 'delete',
 					data: {
 						attrs: { method: 'remove', result: 'success' },
-						metrics: null,
 					},
 					message: 'Deleted key successfully',
 				},
@@ -781,7 +778,6 @@ describe('StorageProvider test', () => {
 					event: 'list',
 					data: {
 						attrs: { method: 'list', result: 'success' },
-						metrics: null,
 					},
 					message: '1 items returned from list operation',
 				},

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -46,7 +46,7 @@ const dispatchStorageEvent = (
 	message: string
 ) => {
 	if (track) {
-		let data = { attrs };
+		const data = { attrs };
 		if (metrics) {
 			data['metrics'] = metrics;
 		}

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -46,11 +46,15 @@ const dispatchStorageEvent = (
 	message: string
 ) => {
 	if (track) {
+		let data = { attrs };
+		if (metrics) {
+			data['metrics'] = metrics;
+		}
 		Hub.dispatch(
 			'storage',
 			{
 				event,
-				data: { attrs, metrics },
+				data,
 				message,
 			},
 			'Storage',


### PR DESCRIPTION
_Issue #, if available:_
The storage category provides a way to track events in pinpoint provided the track event is set to `true`. This was not working.

Initially, the tracking wasn't working since there was a [pinpoint issue around CORS](https://github.com/aws-amplify/amplify-js/pull/6392). 

Once that was resolved the storage track `putEvents` where failing with an error
<img width="1181" alt="Screen Shot 2020-07-27 at 11 24 15 AM" src="https://user-images.githubusercontent.com/35131273/88572311-2eacb480-cffc-11ea-8890-07c433efa1d1.png">

This was happening due to `null` value was being sent in place of metrics by default. This was blocking storage UI component's `track` functionality too

_Description of changes:_

This PR address the issue and append metrics to `Analytics.record` call only if present.

After the PR events are being sent (screenshot of network tab):
![image](https://user-images.githubusercontent.com/35131273/88572518-8519f300-cffc-11ea-9136-f297a67c6283.png)




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
