### PR TITLE
ci: use macos executor for deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,7 @@ executors:
       - image: verdaccio/verdaccio
     resource_class: large
 
-  android-executor:
-    macos:
-      xcode: 11.4.1
-
-  ios-executor:
+  mac-executor:
     macos:
       xcode: 11.4.1
 
@@ -544,50 +540,51 @@ jobs:
           spec: custom-authenticator
 
   integ_rn_ios_storage:
-    executor: ios-executor
+    executor: mac-executor
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
     steps:
       - integ_test_rn_ios
 
   integ_rn_ios_push_notifications:
-    executor: ios-executor
+    executor: mac-executor
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react-native/push-notifications/PushNotificationApp
     steps:
       - integ_test_rn_ios
 
   integ_rn_android_storage:
-    executor: android-executor
+    executor: mac-executor
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
     steps:
       - integ_test_rn_android
 
   deploy:
-    executor: build-executor
+    executor: mac-executor
     working_directory: ~/amplify-js
     steps:
       - attach_workspace:
-          at: /root
+          at: ~/
       - restore_cache:
           keys:
             - amplify-ssh-deps-{{ .Branch }}
             - amplify-ssh-deps
-      - run:
-          name: 'Publish to Amplify Package'
-          command: |
-            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-              echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-              npm whoami
-              git config --global user.email $GITHUB_EMAIL
-              git config --global user.name $GITHUB_USER
-              git status
-              git --no-pager diff
-              yarn publish:$CIRCLE_BRANCH
-            else
-              echo "Skipping deploy."
-            fi
+      # - run:
+      #     name: 'Publish to Amplify Package'
+      #     command: |
+      #       if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+      #         echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      #         npm whoami
+      #         git config --global user.email $GITHUB_EMAIL
+      #         git config --global user.name $GITHUB_USER
+      #         git status
+      #         git --no-pager diff
+      #         yarn publish:$CIRCLE_BRANCH
+      #       else
+      #         echo "Skipping deploy."
+      #       fi
+      - run: ls -alF
 
   post_release:
     executor: build-executor
@@ -617,120 +614,121 @@ releasable_branches: &releasable_branches
       - main
       - ui-components/master
       - 1.0-stable
+      - ci_deploy_macos #TODO: remove line before merging
 
 workflows:
   build_test_deploy:
     jobs:
       - build
-      - integ_setup:
-          filters:
-            <<: *releasable_branches
-      - integ_setup_ui:
-          filters:
-            <<: *releasable_branches
-      - unit_test:
-          requires:
-            - build
-      - integ_react_auth:
-          requires:
-            - integ_setup
-            - build
-          filters:
-            <<: *releasable_branches
-      - integ_angular_auth:
-          requires:
-            - integ_setup
-            - build
-          filters:
-            <<: *releasable_branches
-      - integ_vue_auth:
-          requires:
-            - integ_setup
-            - build
-          filters:
-            <<: *releasable_branches
-      - integ_react_predictions:
-          requires:
-            - integ_setup
-            - build
-          filters:
-            <<: *releasable_branches
-      - integ_react_datastore:
-          requires:
-            - integ_setup
-            - build
-          filters:
-            <<: *releasable_branches
-      - integ_react_storage:
-          requires:
-            - integ_setup
-            - build
-          filters:
-            <<: *releasable_branches
-      - integ_react_storage_ui:
-          requires:
-            - integ_setup
-            - build
-          filters:
-            <<: *releasable_branches
-      - integ_rn_ios_storage:
-          requires:
-            - integ_setup
-            - build
-          filters:
-            <<: *releasable_branches
-      - integ_rn_ios_push_notifications:
-          requires:
-            - integ_setup
-            - build
-          filters:
-            <<: *releasable_branches
-      - integ_rn_android_storage:
-          requires:
-            - integ_setup
-            - build
-          filters:
-            <<: *releasable_branches
-      - integ_react_auth_ui:
-          requires:
-            - integ_setup_ui
-            - build
-          filters:
-            <<: *releasable_branches
-      - integ_angular_auth_ui:
-          requires:
-            - integ_setup_ui
-            - build
-          filters:
-            <<: *releasable_branches
-      - integ_vue_auth_ui:
-          requires:
-            - integ_setup_ui
-            - build
-          filters:
-            <<: *releasable_branches
+      # - integ_setup:
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_setup_ui:
+      #     filters:
+      #       <<: *releasable_branches
+      # - unit_test:
+      #     requires:
+      #       - build
+      # - integ_react_auth:
+      #     requires:
+      #       - integ_setup
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_angular_auth:
+      #     requires:
+      #       - integ_setup
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_vue_auth:
+      #     requires:
+      #       - integ_setup
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_react_predictions:
+      #     requires:
+      #       - integ_setup
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_react_datastore:
+      #     requires:
+      #       - integ_setup
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_react_storage:
+      #     requires:
+      #       - integ_setup
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_react_storage_ui:
+      #     requires:
+      #       - integ_setup
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_rn_ios_storage:
+      #     requires:
+      #       - integ_setup
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_rn_ios_push_notifications:
+      #     requires:
+      #       - integ_setup
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_rn_android_storage:
+      #     requires:
+      #       - integ_setup
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_react_auth_ui:
+      #     requires:
+      #       - integ_setup_ui
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_angular_auth_ui:
+      #     requires:
+      #       - integ_setup_ui
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_vue_auth_ui:
+      #     requires:
+      #       - integ_setup_ui
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
       - deploy:
           filters:
             <<: *releasable_branches
-          requires:
-            - unit_test
-            - integ_react_predictions
-            - integ_react_datastore
-            - integ_react_storage
-            - integ_react_storage_ui
-            - integ_react_auth
-            - integ_angular_auth
-            - integ_vue_auth
-            - integ_react_auth_ui
-            - integ_angular_auth_ui
-            - integ_vue_auth_ui
-            - integ_rn_ios_storage
-            - integ_rn_ios_push_notifications
-            - integ_rn_android_storage
-      - post_release:
-          filters:
-            branches:
-              only:
-                - release
-          requires:
-            - deploy
+          #     requires:
+          #       - unit_test
+          #       - integ_react_predictions
+          #       - integ_react_datastore
+          #       - integ_react_storage
+          #       - integ_react_storage_ui
+          #       - integ_react_auth
+          #       - integ_angular_auth
+          #       - integ_vue_auth
+          #       - integ_react_auth_ui
+          #       - integ_angular_auth_ui
+          #       - integ_vue_auth_ui
+          #       - integ_rn_ios_storage
+          #       - integ_rn_ios_push_notifications
+          #       - integ_rn_android_storage
+          # - post_release:
+          #     filters:
+          #       branches:
+          #         only:
+          #           - release
+          # requires:
+          #   - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -708,6 +708,8 @@ workflows:
       #     filters:
       #       <<: *releasable_branches
       - deploy:
+          requires:
+            - build
           filters:
             <<: *releasable_branches
           #     requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       - image: verdaccio/verdaccio
     resource_class: large
 
-  mac-executor:
+  macos-executor:
     macos:
       xcode: 11.4.1
 
@@ -535,47 +535,46 @@ jobs:
           spec: custom-authenticator
 
   integ_rn_ios_storage:
-    executor: mac-executor
+    executor: macos-executor
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
     steps:
       - integ_test_rn_ios
 
   integ_rn_ios_push_notifications:
-    executor: mac-executor
+    executor: macos-executor
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react-native/push-notifications/PushNotificationApp
     steps:
       - integ_test_rn_ios
 
   integ_rn_android_storage:
-    executor: mac-executor
+    executor: macos-executor
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
     steps:
       - integ_test_rn_android
 
   deploy:
-    executor: mac-executor
+    executor: macos-executor
     working_directory: ~/amplify-js
     steps:
       - attach_workspace:
           at: ~/
-      # - run:
-      #     name: 'Publish to Amplify Package'
-      #     command: |
-      #       if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-      #         echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-      #         npm whoami
-      #         git config --global user.email $GITHUB_EMAIL
-      #         git config --global user.name $GITHUB_USER
-      #         git status
-      #         git --no-pager diff
-      #         yarn publish:$CIRCLE_BRANCH
-      #       else
-      #         echo "Skipping deploy."
-      #       fi
-      - run: ls -alF
+      - run:
+          name: 'Publish to Amplify Package'
+          command: |
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+              echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+              npm whoami
+              git config --global user.email $GITHUB_EMAIL
+              git config --global user.name $GITHUB_USER
+              git status
+              git --no-pager diff
+              yarn publish:$CIRCLE_BRANCH
+            else
+              echo "Skipping deploy."
+            fi
 
   post_release:
     executor: build-executor
@@ -601,122 +600,120 @@ releasable_branches: &releasable_branches
       - main
       - ui-components/master
       - 1.0-stable
-      - ci_deploy_macos #TODO: remove line before merging
 
 workflows:
   build_test_deploy:
     jobs:
       - build
-      # - integ_setup:
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_setup_ui:
-      #     filters:
-      #       <<: *releasable_branches
-      # - unit_test:
-      #     requires:
-      #       - build
-      # - integ_react_auth:
-      #     requires:
-      #       - integ_setup
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_angular_auth:
-      #     requires:
-      #       - integ_setup
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_vue_auth:
-      #     requires:
-      #       - integ_setup
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_react_predictions:
-      #     requires:
-      #       - integ_setup
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_react_datastore:
-      #     requires:
-      #       - integ_setup
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_react_storage:
-      #     requires:
-      #       - integ_setup
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_react_storage_ui:
-      #     requires:
-      #       - integ_setup
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_rn_ios_storage:
-      #     requires:
-      #       - integ_setup
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_rn_ios_push_notifications:
-      #     requires:
-      #       - integ_setup
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_rn_android_storage:
-      #     requires:
-      #       - integ_setup
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_react_auth_ui:
-      #     requires:
-      #       - integ_setup_ui
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_angular_auth_ui:
-      #     requires:
-      #       - integ_setup_ui
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_vue_auth_ui:
-      #     requires:
-      #       - integ_setup_ui
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
+      - integ_setup:
+          filters:
+            <<: *releasable_branches
+      - integ_setup_ui:
+          filters:
+            <<: *releasable_branches
+      - unit_test:
+          requires:
+            - build
+      - integ_react_auth:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_angular_auth:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_vue_auth:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_react_predictions:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_react_datastore:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_react_storage:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_react_storage_ui:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_rn_ios_storage:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_rn_ios_push_notifications:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_rn_android_storage:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_react_auth_ui:
+          requires:
+            - integ_setup_ui
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_angular_auth_ui:
+          requires:
+            - integ_setup_ui
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_vue_auth_ui:
+          requires:
+            - integ_setup_ui
+            - build
+          filters:
+            <<: *releasable_branches
       - deploy:
           filters:
             <<: *releasable_branches
           requires:
-            - build
-          #       - unit_test
-          #       - integ_react_predictions
-          #       - integ_react_datastore
-          #       - integ_react_storage
-          #       - integ_react_storage_ui
-          #       - integ_react_auth
-          #       - integ_angular_auth
-          #       - integ_vue_auth
-          #       - integ_react_auth_ui
-          #       - integ_angular_auth_ui
-          #       - integ_vue_auth_ui
-          #       - integ_rn_ios_storage
-          #       - integ_rn_ios_push_notifications
-          #       - integ_rn_android_storage
-          # - post_release:
-          #     filters:
-          #       branches:
-          #         only:
-          #           - release
-          # requires:
-          #   - deploy
+            - unit_test
+            - integ_react_predictions
+            - integ_react_datastore
+            - integ_react_storage
+            - integ_react_storage_ui
+            - integ_react_auth
+            - integ_angular_auth
+            - integ_vue_auth
+            - integ_react_auth_ui
+            - integ_angular_auth_ui
+            - integ_vue_auth_ui
+            - integ_rn_ios_storage
+            - integ_rn_ios_push_notifications
+            - integ_rn_android_storage
+      - post_release:
+          filters:
+            branches:
+              only:
+                - release
+          requires:
+            - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,11 +319,6 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn run bootstrap
       - run: yarn run build
-
-      - save_cache:
-          key: amplify-ssh-deps-{{ .Branch }}
-          paths:
-            - ~/.ssh
       - persist_to_workspace:
           root: /root
           paths:
@@ -566,10 +561,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - restore_cache:
-          keys:
-            - amplify-ssh-deps-{{ .Branch }}
-            - amplify-ssh-deps
       # - run:
       #     name: 'Publish to Amplify Package'
       #     command: |
@@ -591,10 +582,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /root
-      - restore_cache:
-          keys:
-            - amplify-ssh-deps-{{ .Branch }}
-            - amplify-ssh-deps
       - run:
           name: 'Post-release steps'
           command: |
@@ -708,11 +695,10 @@ workflows:
       #     filters:
       #       <<: *releasable_branches
       - deploy:
-          requires:
-            - build
           filters:
             <<: *releasable_branches
-          #     requires:
+          requires:
+            - build
           #       - unit_test
           #       - integ_react_predictions
           #       - integ_react_datastore


### PR DESCRIPTION
Another attempt at resolving the infamous zlib error in the deploy job.

Since the `lerna publish` command in the deploy job has many side effects, e.g. incrementing versions in package.json, creating a commit and pushing up tags to GitHub, it's difficult to retry the command (like we do in the publish to Verdaccio steps), as before we can re-run the command, we would need to undo these side effects, which in turn can have cascading repercussions. 

Since we have never encountered these zlib errors when running the publish command locally in macOS, I think it's a decent bet that it might be exclusive to Linux environments.

Therefore, I'm changing the executor for the deploy job to use a macos environment. 

Also, removing some unneeded caching steps.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
