### PR TITLE
bugfix #5860: using custom state forces congnito UI for custom provider

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -25,6 +25,7 @@ import {
 	isCognitoHostedOpts,
 	isFederatedSignInOptions,
 	isFederatedSignInOptionsCustom,
+	hasCustomState,
 	FederatedSignInOptionsCustom,
 	LegacyProvider,
 	FederatedSignInOptions,
@@ -1787,6 +1788,7 @@ export class AuthClass {
 		if (
 			isFederatedSignInOptions(providerOrOptions) ||
 			isFederatedSignInOptionsCustom(providerOrOptions) ||
+			hasCustomState(providerOrOptions) ||
 			typeof providerOrOptions === 'undefined'
 		) {
 			const options = providerOrOptions || {

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -91,8 +91,11 @@ export function isFederatedSignInOptionsCustom(
 	return obj && !!keys.find(k => obj.hasOwnProperty(k));
 }
 
-export function hasCustomState(obj: any): obj is FederatedSignInOptions {
-	const keys: (keyof FederatedSignInOptions)[] = ['customState'];
+export function hasCustomState(obj: any): boolean {
+	const keys: (
+		| keyof FederatedSignInOptions
+		| keyof FederatedSignInOptionsCustom
+	)[] = ['customState'];
 	return obj && !!keys.find(k => obj.hasOwnProperty(k));
 }
 

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -92,10 +92,10 @@ export function isFederatedSignInOptionsCustom(
 }
 
 export function hasCustomState(obj: any): boolean {
-	const keys: (
-		| keyof FederatedSignInOptions
-		| keyof FederatedSignInOptionsCustom
-	)[] = ['customState'];
+	const keys: (keyof (
+		| FederatedSignInOptions
+		| FederatedSignInOptionsCustom
+	))[] = ['customState'];
 	return obj && !!keys.find(k => obj.hasOwnProperty(k));
 }
 

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -80,17 +80,19 @@ export type FederatedSignInOptionsCustom = {
 export function isFederatedSignInOptions(
 	obj: any
 ): obj is FederatedSignInOptions {
-	const keys: (keyof FederatedSignInOptions)[] = ['provider', 'customState'];
+	const keys: (keyof FederatedSignInOptions)[] = ['provider'];
 	return obj && !!keys.find(k => obj.hasOwnProperty(k));
 }
 
 export function isFederatedSignInOptionsCustom(
 	obj: any
 ): obj is FederatedSignInOptionsCustom {
-	const keys: (keyof FederatedSignInOptionsCustom)[] = [
-		'customProvider',
-		'customState',
-	];
+	const keys: (keyof FederatedSignInOptionsCustom)[] = ['customProvider'];
+	return obj && !!keys.find(k => obj.hasOwnProperty(k));
+}
+
+export function hasCustomState(obj: any): obj is FederatedSignInOptions {
+	const keys: (keyof FederatedSignInOptions)[] = ['customState'];
 	return obj && !!keys.find(k => obj.hasOwnProperty(k));
 }
 


### PR DESCRIPTION
_Issue #, if available:_ #5860 

_Description of changes:_ 

- use provider/customProvider keys to determine the type of Provider instead of also relying on customState
- add check for customState key if no provider is passed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
