### PR TITLE
ci: restore ssh cache step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,6 +319,10 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn run bootstrap
       - run: yarn run build
+      - save_cache:
+          key: amplify-ssh-deps-{{ .Branch }}
+          paths:
+            - ~/.ssh
       - persist_to_workspace:
           root: /root
           paths:
@@ -581,6 +585,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /root
+      - restore_cache:
+          keys:
+            - amplify-ssh-deps-{{ .Branch }}
+            - amplify-ssh-deps
       - run:
           name: 'Post-release steps'
           command: |


### PR DESCRIPTION
This fixes the issue we encountered yesterday during the release. Namely, when doing a `git pull` in the post_release, we see an interactive prompt:

```
The authenticity of host 'github.com (140.82.112.4)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? 
```

Caching the .ssh directory in the build job and restoring in post_release prevents this interactive prompt from appearing since the host gets saved in known_hosts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
