### PR TITLE
fix(@aws-amplify/auth): CodeDeliveryDetails return type for Auth.resendSignUp

### DIFF
--- a/packages/amazon-cognito-identity-js/index.d.ts
+++ b/packages/amazon-cognito-identity-js/index.d.ts
@@ -98,7 +98,7 @@ declare module 'amazon-cognito-identity-js' {
 			callback: IAuthenticationCallback
 		): void;
 		public resendConfirmationCode(
-			callback: NodeCallback<Error, 'SUCCESS'>,
+			callback: NodeCallback<Error, any>,
 			clientMetaData?: ClientMetadata
 		): void;
 		public changePassword(

--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -133,7 +133,13 @@ jest.mock('amazon-cognito-identity-js/lib/CognitoUser', () => {
 	};
 
 	CognitoUser.prototype.resendConfirmationCode = callback => {
-		callback(null, 'result');
+		callback(null, {
+			CodeDeliveryDetails: {
+				AttributeName: 'email',
+				DeliveryMedium: 'EMAIL',
+				Destination: 'amplify@*****.com',
+			},
+		});
 	};
 
 	CognitoUser.prototype.changePassword = (
@@ -500,11 +506,14 @@ describe('auth unit test', () => {
 
 			await auth.confirmSignUp('username', code);
 
-			expect(
-				await CognitoUser.prototype.confirmRegistration
-			).toBeCalledWith(code, jasmine.any(Boolean), jasmine.any(Function), {
-				foo: 'bar',
-			});
+			expect(await CognitoUser.prototype.confirmRegistration).toBeCalledWith(
+				code,
+				jasmine.any(Boolean),
+				jasmine.any(Function),
+				{
+					foo: 'bar',
+				}
+			);
 			spyon.mockClear();
 		});
 
@@ -517,11 +526,14 @@ describe('auth unit test', () => {
 				clientMetadata: { custom: 'value' },
 			});
 
-			expect(
-				await CognitoUser.prototype.confirmRegistration
-			).toBeCalledWith(code, jasmine.any(Boolean), jasmine.any(Function), {
-				custom: 'value',
-			});
+			expect(await CognitoUser.prototype.confirmRegistration).toBeCalledWith(
+				code,
+				jasmine.any(Boolean),
+				jasmine.any(Function),
+				{
+					custom: 'value',
+				}
+			);
 			spyon.mockClear();
 		});
 
@@ -594,7 +606,13 @@ describe('auth unit test', () => {
 			const auth = new Auth(authOptions);
 
 			expect.assertions(1);
-			expect(await auth.resendSignUp('username')).toBe('result');
+			expect(await auth.resendSignUp('username')).toMatchObject({
+				CodeDeliveryDetails: {
+					AttributeName: 'email',
+					DeliveryMedium: 'EMAIL',
+					Destination: 'amplify@*****.com',
+				},
+			});
 
 			spyon.mockClear();
 		});
@@ -1996,11 +2014,14 @@ describe('auth unit test', () => {
 
 			await auth.changePassword(user, oldPassword, newPassword);
 
-			expect(
-				await CognitoUser.prototype.changePassword
-			).toBeCalledWith(oldPassword, newPassword, jasmine.any(Function), {
-				foo: 'bar',
-			});
+			expect(await CognitoUser.prototype.changePassword).toBeCalledWith(
+				oldPassword,
+				newPassword,
+				jasmine.any(Function),
+				{
+					foo: 'bar',
+				}
+			);
 			spyon.mockClear();
 		});
 
@@ -2018,11 +2039,14 @@ describe('auth unit test', () => {
 				custom: 'value',
 			});
 
-			expect(
-				await CognitoUser.prototype.changePassword
-			).toBeCalledWith(oldPassword, newPassword, jasmine.any(Function), {
-				custom: 'value',
-			});
+			expect(await CognitoUser.prototype.changePassword).toBeCalledWith(
+				oldPassword,
+				newPassword,
+				jasmine.any(Function),
+				{
+					custom: 'value',
+				}
+			);
 			spyon.mockClear();
 		});
 	});

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -388,12 +388,12 @@ export default class AuthClass {
 	 * Resend the verification code
 	 * @param {String} username - The username to be confirmed
 	 * @param {ClientMetadata} clientMetadata - Metadata to be passed to Cognito Lambda triggers
-	 * @return - A promise resolves data if success
+	 * @return - A promise resolves code delivery details if successful
 	 */
 	public resendSignUp(
 		username: string,
 		clientMetadata: ClientMetaData = this._config.clientMetadata
-	): Promise<string> {
+	): Promise<any> {
 		if (!this.userPool) {
 			return this.rejectNoUserPool();
 		}

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -60,6 +60,7 @@ import {
 	CognitoIdToken,
 	CognitoRefreshToken,
 	CognitoAccessToken,
+	CodeDeliveryDetails,
 } from 'amazon-cognito-identity-js';
 
 import { parse } from 'url';
@@ -388,12 +389,12 @@ export default class AuthClass {
 	 * Resend the verification code
 	 * @param {String} username - The username to be confirmed
 	 * @param {ClientMetadata} clientMetadata - Metadata to be passed to Cognito Lambda triggers
-	 * @return - A promise resolves code delivery details if successful
+	 * @return - A promise resolves the CodeDeliveryDetails if successful
 	 */
 	public resendSignUp(
 		username: string,
 		clientMetadata: ClientMetaData = this._config.clientMetadata
-	): Promise<any> {
+	): Promise<CodeDeliveryDetails> {
 		if (!this.userPool) {
 			return this.rejectNoUserPool();
 		}


### PR DESCRIPTION
_Issue #, if available:_

Fixes #5029 & adds to #5112 to replace `any` with `CodeDeliveryDetails`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
