### PR TITLE
Force clear credentials when bypassCache: true

### DIFF
--- a/packages/auth/__tests__/auth-creds-test.ts
+++ b/packages/auth/__tests__/auth-creds-test.ts
@@ -1,0 +1,71 @@
+import { AuthClass as Auth } from '../src/Auth';
+import { Credentials } from '@aws-amplify/core';
+import { AuthOptions } from '../src/types';
+import {
+	CognitoUser,
+	CognitoUserPool,
+	CognitoUserSession,
+	CognitoAccessToken,
+	CognitoIdToken,
+} from 'amazon-cognito-identity-js';
+const authOptions: AuthOptions = {
+	userPoolId: 'us-west-2_0xxxxxxxx',
+	userPoolWebClientId: 'awsUserPoolsWebClientId',
+	region: 'region',
+	identityPoolId: 'awsCognitoIdentityPoolId',
+	mandatorySignIn: false,
+};
+
+describe('credentials syncing tests', () => {
+	it('BypassCache clear credentials', async () => {
+		const auth = new Auth(authOptions);
+
+		jest
+			.spyOn(CognitoUser.prototype, 'authenticateUser')
+			.mockImplementation((authenticationDetails, callback) => {
+				const session = new CognitoUserSession({
+					AccessToken: new CognitoAccessToken({ AccessToken: 'accesstoken' }),
+					IdToken: new CognitoIdToken({ IdToken: 'Idtoken' }),
+				});
+
+				callback.onSuccess(session, false);
+			});
+
+		jest
+			.spyOn(CognitoUserPool.prototype, 'getCurrentUser')
+			.mockImplementation(() => {
+				return new CognitoUser({
+					Pool: new CognitoUserPool({
+						UserPoolId: authOptions.userPoolId,
+						ClientId: authOptions.userPoolWebClientId,
+					}),
+					Username: 'test',
+				});
+			});
+
+		const session = new CognitoUserSession({
+			AccessToken: new CognitoAccessToken({ AccessToken: 'accesstoken' }),
+			IdToken: new CognitoIdToken({ IdToken: 'Idtoken' }),
+		});
+
+		jest
+			.spyOn(CognitoUser.prototype, 'getSession')
+			.mockImplementation(callback => {
+				callback(null, session);
+			});
+
+		const spyCredentials = jest
+			.spyOn(Credentials, 'set')
+			.mockImplementationOnce(c => c);
+
+		const username = 'test';
+		await auth.signIn({ username, password: 'test' });
+
+		const clearCredentialsSpy = jest.spyOn(Credentials, 'clear');
+		await auth.currentAuthenticatedUser({ bypassCache: true });
+
+		expect(clearCredentialsSpy).toHaveBeenCalled();
+
+		jest.clearAllMocks();
+	});
+});

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1150,7 +1150,7 @@ export class AuthClass {
 					}
 
 					// refresh the session if the session expired.
-					user.getSession((err, session) => {
+					user.getSession(async (err, session) => {
 						if (err) {
 							logger.debug('Failed to get the user session', err);
 							rej(err);
@@ -1159,7 +1159,12 @@ export class AuthClass {
 
 						// get user data from Cognito
 						const bypassCache = params ? params.bypassCache : false;
-						// validate the token's scope fisrt before calling this function
+
+						if (bypassCache) {
+							await Credentials.clear();
+						}
+
+						// validate the token's scope first before calling this function
 						const { scope = '' } = session.getAccessToken().decodePayload();
 						if (scope.split(' ').includes(USER_ADMIN_SCOPE)) {
 							user.getUserData(


### PR DESCRIPTION
_Issue #, if available:_
Fixes: #3938
_Description of changes:_
Clearing credentials when `bypassCache: true` for `Auth.currentAuthenticatedUser`, that will lazy allow to lazy load AWS Credentials with using the refreshed token.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
