### PR TITLE
feat(aws-amplify-react-native): Add S3ImagePicker

### DIFF
--- a/packages/aws-amplify-react-native/package.json
+++ b/packages/aws-amplify-react-native/package.json
@@ -37,7 +37,8 @@
 		"graphql": "^14.0.0",
 		"react-native-fs": "^2.12.1",
 		"react-native-sound": "^0.10.9",
-		"react-native-voice": "^0.2.6"
+		"react-native-voice": "^0.2.6",
+		"expo-image-picker": "^8.3.0"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/aws-amplify-react-native/src/AmplifyTheme.ts
+++ b/packages/aws-amplify-react-native/src/AmplifyTheme.ts
@@ -158,4 +158,11 @@ export default StyleSheet.create({
 		textAlign: 'center',
 		padding: 20,
 	},
+	imagePicker: {
+		height: 120,
+		width: 120,
+		borderRadius: 120 / 2,
+		borderColor: buttonColor,
+		borderWidth: 2,
+	},
 });

--- a/packages/aws-amplify-react-native/src/Storage/S3ImagePicker.tsx
+++ b/packages/aws-amplify-react-native/src/Storage/S3ImagePicker.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import {
+	Image,
+	TouchableOpacity,
+	Alert,
+	ActivityIndicator,
+} from 'react-native';
+
+import { I18n, Storage, Logger } from 'aws-amplify';
+import {
+	launchCameraAsync,
+	launchImageLibraryAsync,
+	MediaTypeOptions,
+	ImagePickerResult,
+} from 'expo-image-picker';
+import { Buffer } from 'buffer';
+
+import AmplifyTheme, { AmplifyThemeType } from '../AmplifyTheme';
+import { AccessLevel } from './common/types';
+
+const logger = new Logger('Storage.S3ImagePicker');
+
+interface IS3ImagePickerProps {
+	path?: string;
+	level?: AccessLevel;
+	track?: boolean;
+	identityId?: string;
+	fileToKey?: (data: object) => string | string;
+	alertTitle?: string;
+	takePhotoButtonText?: string;
+	choosePhotoButtonText?: string;
+	cancelButtonText?: string;
+	allowsEditing?: boolean;
+	theme?: AmplifyThemeType;
+}
+
+export const S3ImagePicker = ({
+	path = '',
+	level = AccessLevel.Public,
+	track,
+	fileToKey,
+	alertTitle = 'Add profile photo',
+	takePhotoButtonText = 'Take Photo',
+	choosePhotoButtonText = 'Choose From Library',
+	cancelButtonText = 'Cancel',
+	allowsEditing = true,
+	theme = AmplifyTheme,
+}: IS3ImagePickerProps) => {
+	const [source, setSource] = useState<string>();
+	const [loading, setLoading] = useState<boolean>(false);
+
+	const handlePick = async (result: ImagePickerResult) => {
+		if (result.cancelled || !result.base64) {
+			logger.debug('image picker canceled');
+			return;
+		}
+
+		setLoading(true);
+
+		const key =
+			path +
+			calcKey(
+				{ uri: result.uri, height: result.height, width: result.width },
+				fileToKey
+			);
+
+		logger.debug(`uploading ${key}...`);
+
+		try {
+			await Storage.put(key, new Buffer(result.base64, 'base64'), {
+				contentType: 'image/*',
+				level,
+				track,
+			});
+		} catch (error) {
+			logger.error(error);
+			return;
+		}
+
+		setLoading(false);
+		setSource(result.uri);
+	};
+
+	return (
+		<TouchableOpacity
+			onPress={showImagePicker}
+			style={{ alignItems: 'center', justifyContent: 'center' }}
+		>
+			{loading && (
+				<ActivityIndicator
+					style={{ position: 'absolute', width: '100%', height: '100%' }}
+				/>
+			)}
+			<Image style={theme.imagePicker} source={{ uri: source }} />
+		</TouchableOpacity>
+	);
+
+	function showImagePicker() {
+		Alert.alert(I18n.get(alertTitle), undefined, [
+			{
+				text: I18n.get(takePhotoButtonText),
+				onPress: async () => {
+					logger.debug('Opening camera...');
+
+					const result = await launchCameraAsync({
+						mediaTypes: MediaTypeOptions.Images,
+						allowsEditing,
+						aspect: [1, 1],
+						quality: 1,
+						base64: true,
+					});
+
+					handlePick(result);
+				},
+			},
+			{
+				text: I18n.get(choosePhotoButtonText),
+				onPress: async () => {
+					logger.debug('Opening library...');
+
+					const result = await launchImageLibraryAsync({
+						mediaTypes: MediaTypeOptions.Images,
+						allowsEditing,
+						aspect: [1, 1],
+						quality: 1,
+						base64: true,
+					});
+
+					handlePick(result);
+				},
+			},
+			{
+				text: I18n.get(cancelButtonText),
+				style: 'cancel',
+			},
+		]);
+	}
+};
+
+const calcKey = (
+	{ uri, height, width }: { uri: string; height: number; width: number },
+	fileToKey?: (data: object) => string | string
+) => {
+	let key = uri.replace(/^.*[\\\/]/, '');
+
+	if (fileToKey) {
+		if (typeof fileToKey === 'string') {
+			key = fileToKey;
+		} else if (typeof fileToKey === 'function') {
+			key = fileToKey({ uri, height, width });
+		} else {
+			key = encodeURI(JSON.stringify(fileToKey));
+		}
+		if (!key) {
+			key = 'empty_key';
+		}
+	}
+
+	return key.replace(/\s/g, '_');
+};

--- a/packages/aws-amplify-react-native/src/Storage/S3ImagePicker.tsx
+++ b/packages/aws-amplify-react-native/src/Storage/S3ImagePicker.tsx
@@ -93,8 +93,11 @@ export const S3ImagePicker = ({
 			style={{ alignItems: 'center', justifyContent: 'center' }}
 		>
 			<ImageBackground
-				style={theme.imagePicker}
-				imageStyle={theme.image}
+				style={{
+					width: theme.imagePicker.width,
+					height: theme.imagePicker.height,
+				}}
+				imageStyle={theme.imagePicker}
 				source={{ uri: source }}
 			>
 				<View

--- a/packages/aws-amplify-react-native/src/Storage/S3ImagePicker.tsx
+++ b/packages/aws-amplify-react-native/src/Storage/S3ImagePicker.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import {
-	Image,
 	TouchableOpacity,
 	Alert,
 	ActivityIndicator,
+	View,
+	ImageBackground,
 } from 'react-native';
 
 import { I18n, Storage, Logger } from 'aws-amplify';
@@ -14,8 +15,13 @@ import {
 	ImagePickerResult,
 } from 'expo-image-picker';
 import { Buffer } from 'buffer';
+import Icon from 'react-native-vector-icons/FontAwesome';
 
-import AmplifyTheme, { AmplifyThemeType } from '../AmplifyTheme';
+import AmplifyTheme, {
+	AmplifyThemeType,
+	placeholderColor,
+} from '../AmplifyTheme';
+
 import { AccessLevel } from './common/types';
 
 const logger = new Logger('Storage.S3ImagePicker');
@@ -86,12 +92,25 @@ export const S3ImagePicker = ({
 			onPress={showImagePicker}
 			style={{ alignItems: 'center', justifyContent: 'center' }}
 		>
-			{loading && (
-				<ActivityIndicator
-					style={{ position: 'absolute', width: '100%', height: '100%' }}
-				/>
-			)}
-			<Image style={theme.imagePicker} source={{ uri: source }} />
+			<ImageBackground
+				style={theme.imagePicker}
+				imageStyle={theme.image}
+				source={{ uri: source }}
+			>
+				<View
+					style={{
+						justifyContent: 'center',
+						alignItems: 'center',
+						height: '100%',
+						width: '100%',
+					}}
+				>
+					{loading && !source && <ActivityIndicator />}
+					{!loading && !source && (
+						<Icon name="camera" size={30} color={placeholderColor} />
+					)}
+				</View>
+			</ImageBackground>
 		</TouchableOpacity>
 	);
 

--- a/packages/aws-amplify-react-native/src/Storage/common/types.ts
+++ b/packages/aws-amplify-react-native/src/Storage/common/types.ts
@@ -1,0 +1,5 @@
+export enum AccessLevel {
+	Public = 'public',
+	Private = 'private',
+	Protected = 'protected',
+}

--- a/packages/aws-amplify-react-native/src/Storage/index.ts
+++ b/packages/aws-amplify-react-native/src/Storage/index.ts
@@ -13,3 +13,4 @@
 
 export { default as S3Image } from './S3Image';
 export { default as S3Album } from './S3Album';
+export { S3ImagePicker } from './S3ImagePicker';


### PR DESCRIPTION
_Issue #, if available:_ N/A

_Description of changes:_ This PR adds an S3ImagePicker, a convenient way to choose and upload images to S3, to `aws-amplify-react-native`.

Features:
- Take a picture using the device's camera
- Choose a photo from the image library
- Upload the chosen picture to S3

Requirements:
- Add [`expo-image-picker`](https://docs.expo.io/versions/latest/sdk/imagepicker/) as a dependency (version: `^8.3.0`)

Example:
- Note: Make sure to request camera/image library permissions before the user interacts with the `S3ImagePicker` (e.g., using the `requestCameraPermissionsAsync` and `requestCameraRollPermissionsAsync` methods).
```jsx
import Amplify from 'aws-amplify';
import { S3ImagePicker, AccessLevel } from 'aws-amplify-react-native';

import awsexports from './aws-exports';

Amplify.configure(awsexports);

const theme = StyleSheet.create({
    imagePicker: {
        // Custom `S3ImagePicker` style
    },
});

const App = () => { 
    return (
        <S3ImagePicker
	    path='/images'
	    level={AccessLevel.Public}
            theme={theme}
            allowsEditing
            track
	/>
   );
}

export default App;
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
