### PR TITLE
fix(amazon-cognito-identity-js): `undefined` params in sendMFASelectionAnswer callbacks

### DIFF
--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -1979,14 +1979,14 @@ export default class CognitoUser {
 			this.Session = data.Session;
 			if (answerChallenge === 'SMS_MFA') {
 				return callback.mfaRequired(
-					data.challengeName,
-					data.challengeParameters
+					data.ChallengeName,
+					data.ChallengeParameters
 				);
 			}
 			if (answerChallenge === 'SOFTWARE_TOKEN_MFA') {
 				return callback.totpRequired(
-					data.challengeName,
-					data.challengeParameters
+					data.ChallengeName,
+					data.ChallengeParameters
 				);
 			}
 			return undefined;


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

This fixes a bug with `sendMFASelectionAnswer` returning `undefined` parameters in its callbacks: 

```
cognitoUser.sendMFASelectionAnswer(mfaType, {
  mfaRequired: function(challengeName, challengeParameters) {
    console.log(challengeName, challengeParameters); // both undefined
  },
  totpRequired: function(challengeName, challengeParameters) {
    console.log(challengeName, challengeParameters); // both undefined too
  },
})
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
