### PR TITLE
ci: return correct exit code after retrying

### DIFF
--- a/.circleci/retry-yarn-script.sh
+++ b/.circleci/retry-yarn-script.sh
@@ -21,8 +21,8 @@ done
 
 # initialize counter
 n=0
-# loop until n >= first param
-until [ "$n" -ge $N ]
+# loop until n > first param
+until [ "$n" -gt $N ]
 do
 	# $1 is the argument passed in, e.g. publish:verdaccio
 	# if the publish command succeeds, `break` exits the loop
@@ -34,17 +34,18 @@ do
   	echo "Resetting git HEAD"
 		git reset --hard
 	fi
-	
-	# increment counter
-	n=$((n+1))
-	# wait 5 seconds
-	sleep 5
-	echo "Retry $n of $N"
 
 	if [ "$n" -eq $N ]; 
 	then
 		echo "Returning error"
 		exit 1
 	fi
+
+	# increment counter
+	n=$((n+1))
+	
+	# wait 5 seconds
+	sleep 5
+	echo "Retry $n of $N"
 done
 

--- a/.circleci/retry-yarn-script.sh
+++ b/.circleci/retry-yarn-script.sh
@@ -40,4 +40,11 @@ do
 	# wait 5 seconds
 	sleep 5
 	echo "Retry $n of $N"
+
+	if [ "$n" -eq $N ]; 
+	then
+		echo "Returning error"
+		exit 1
+	fi
 done
+


### PR DESCRIPTION
`exit 1` after retrying test instead of allowing job to succeed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
