### PR TITLE
ci: zlib fix using npm-packlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
 		"winston": "^3.2.1"
 	},
 	"resolutions": {
-		"terser": "4.6.7"
+		"terser": "4.6.7",
+		"npm-packlist": "1.1.12"
 	},
 	"jest": {
 		"resetMocks": true,


### PR DESCRIPTION
I've been noticing that sometimes even with the retry logic, CCI jobs will error out with the zlib error (after 5 retries).
Going to try this suggested fix: https://github.com/lerna/lerna/issues/2278#issuecomment-652538695


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
