### PR TITLE
fix(@aws-amplify/ui-components): Update scss and reset chat state upon finish 

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.scss
+++ b/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.scss
@@ -65,6 +65,7 @@
   align-items: center;
   border-top: 0.062rem solid rgba(0, 0, 0, 0.05);
   padding-right: 0.625rem;
+  min-height: 3.125rem;
   amplify-input {
     --border: none;
     --margin: 0;

--- a/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.scss
+++ b/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.scss
@@ -8,13 +8,6 @@
   --bot-text-color: black;
   --user-background-color: #099ac8;
   --user-text-color: var(--amplify-white);
-
-  width: 100%;
-  height: var(--height);
-  @include md {
-    width: var(--width);
-  }
-  max-width: var(--width);
 }
 .amplify-chatbot {
   display: inline-flex;
@@ -26,7 +19,11 @@
   font-family: var(--amplify-font-family);
   margin-bottom: 1rem;
   width: 100%;
-  height: 100%;
+  height: var(--height);
+  @include md {
+    width: var(--width);
+  }
+  max-width: var(--width);
 }
 .header {
   padding: 1.25rem 0.375rem 1.25rem 0.375rem;

--- a/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.tsx
@@ -117,6 +117,8 @@ export class AmplifyChatbot {
       });
       if (this.clearOnComplete) {
         this.reset();
+      } else {
+        this.chatState = ChatState.Initial;
       }
     };
 
@@ -256,7 +258,7 @@ export class AmplifyChatbot {
       messageList.push(
         <div class="bubble bot">
           <div class="dot-flashing" />
-        </div>
+        </div>,
       );
     }
     return messageList;

--- a/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.tsx
@@ -258,7 +258,7 @@ export class AmplifyChatbot {
       messageList.push(
         <div class="bubble bot">
           <div class="dot-flashing" />
-        </div>,
+        </div>
       );
     }
     return messageList;


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ This moves width/height control to container level, add min-width to chatbot footer, and resets chat state upon session finish. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
