### PR TITLE
Use *-legacy naming for legacy samples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,40 +363,40 @@ jobs:
   integ_react_auth:
     executor: js-test-executor
     <<: *test_env_vars
-    working_directory: ~/amplify-js-samples-staging/samples/react/auth/with-authenticator
+    working_directory: ~/amplify-js-samples-staging/samples/react/auth/with-authenticator-legacy
     steps:
       - prepare_test_env
       - integ_test_js:
           test_name: 'React Authenticator'
           framework: react
           category: auth
-          sample_name: with-authenticator
+          sample_name: with-authenticator-legacy
           spec: authenticator
 
   integ_angular_auth:
     executor: js-test-executor
     <<: *test_env_vars
-    working_directory: ~/amplify-js-samples-staging/samples/angular/auth/amplify-authenticator
+    working_directory: ~/amplify-js-samples-staging/samples/angular/auth/amplify-authenticator-legacy
     steps:
       - prepare_test_env
       - integ_test_js:
           test_name: 'Angular Authenticator'
           framework: angular
           category: auth
-          sample_name: amplify-authenticator
+          sample_name: amplify-authenticator-legacy
           spec: authenticator
 
   integ_vue_auth:
     executor: js-test-executor
     <<: *test_env_vars
-    working_directory: ~/amplify-js-samples-staging/samples/vue/auth/amplify-authenticator
+    working_directory: ~/amplify-js-samples-staging/samples/vue/auth/amplify-authenticator-legacy
     steps:
       - prepare_test_env
       - integ_test_js:
           test_name: 'Vue Authenticator'
           framework: vue
           category: auth
-          sample_name: amplify-authenticator
+          sample_name: amplify-authenticator-legacy
           spec: authenticator
 
   integ_react_predictions:


### PR DESCRIPTION
_Description of changes:_
- Sample name now is *-legacy for legacy UI samples

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
