### PR TITLE
@feat(@aws-amplify/ui-components): Error/audio handling and css improvements

### DIFF
--- a/packages/amplify-ui-components/Readme.md
+++ b/packages/amplify-ui-components/Readme.md
@@ -351,6 +351,7 @@ Theming for the UI components can be achieved by using [CSS Variables](https://d
 | `--amplify-light-grey`         | #c4c4c4              |
 | `--amplify-white`              | #ffffff              |
 | `--amplify-red`                | #dd3f5b              |
+| `--amplify-blue`               | #099ac8              |
 
 ## Amplify Authenticator `usernameAlias`
 

--- a/packages/amplify-ui-components/src/common/Translations.ts
+++ b/packages/amplify-ui-components/src/common/Translations.ts
@@ -112,6 +112,7 @@ export enum AuthStrings {
 export enum InteractionsStrings {
   CHATBOT_TITLE = 'ChatBot Lex',
   TEXT_INPUT_PLACEHOLDER = 'Write a message',
+  VOICE_INPUT_PLACEHOLDER = 'Click mic to speak',
   CHAT_DISABLED_ERROR = 'Error: Either voice or text must be enabled for the chatbot',
   NO_BOT_NAME_ERROR = 'Error: Bot Name must be provided to ChatBot',
 }

--- a/packages/amplify-ui-components/src/common/Translations.ts
+++ b/packages/amplify-ui-components/src/common/Translations.ts
@@ -114,7 +114,7 @@ export enum InteractionsStrings {
   TEXT_INPUT_PLACEHOLDER = 'Write a message',
   VOICE_INPUT_PLACEHOLDER = 'Click mic to speak',
   CHAT_DISABLED_ERROR = 'Error: Either voice or text must be enabled for the chatbot',
-  NO_BOT_NAME_ERROR = 'Error: Bot Name must be provided to ChatBot',
+  NO_BOT_NAME_ERROR = 'Error: Bot name must be provided to ChatBot',
 }
 
 type Translations = AuthErrorStrings | AuthStrings | InteractionsStrings;

--- a/packages/amplify-ui-components/src/common/audio-control/recorder.ts
+++ b/packages/amplify-ui-components/src/common/audio-control/recorder.ts
@@ -157,7 +157,6 @@ export class AudioRecorder {
           this.playbackSource.start(0);
         };
         const errorCallback = err => {
-          console.error('test');
           return rej(err);
         };
 

--- a/packages/amplify-ui-components/src/components/amplify-chatbot/__snapshots__/amplify-chatbot.spec.tsx.snap
+++ b/packages/amplify-ui-components/src/components/amplify-chatbot/__snapshots__/amplify-chatbot.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`amplify-chatbot renders chatbot 1`] = `
         <amplify-input description="text" disabled="" placeholder="Write a message" value=""></amplify-input>
         <amplify-button class="icon-button" data-test="chatbot-send-button" disabled="" icon="send" variant="icon"></amplify-button>
       </div>
-      <amplify-toast message="Bot undefined does not exist"></amplify-toast>
+      <amplify-toast message="Error: Bot name must be provided to ChatBot"></amplify-toast>
     </div>
   </mock:shadow-root>
 </amplify-chatbot>

--- a/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.scss
+++ b/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.scss
@@ -6,8 +6,10 @@
   --header-size: var(--amplify-text-lg);
   --bot-background-color: rgb(230, 230, 230);
   --bot-text-color: black;
+  --bot-dot-color: var(--bot-text-color);
   --user-background-color: #099ac8;
   --user-text-color: var(--amplify-white);
+  --user-dot-color: var(--user-text-color);
 }
 .amplify-chatbot {
   display: inline-flex;

--- a/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.scss
+++ b/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.scss
@@ -7,7 +7,7 @@
   --bot-background-color: rgb(230, 230, 230);
   --bot-text-color: black;
   --bot-dot-color: var(--bot-text-color);
-  --user-background-color: #099ac8;
+  --user-background-color: var(--amplify-blue);
   --user-text-color: var(--amplify-white);
   --user-dot-color: var(--user-text-color);
 }

--- a/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.tsx
@@ -305,13 +305,17 @@ export class AmplifyChatbot {
 
   private footerJSX(): JSXBase.IntrinsicElements[] {
     if (this.chatState === ChatState.Listening) return this.listeningFooterJSX();
+
+    const inputPlaceholder = this.textEnabled
+      ? Translations.TEXT_INPUT_PLACEHOLDER
+      : Translations.VOICE_INPUT_PLACEHOLDER;
     const textInput = (
       <amplify-input
-        placeholder={I18n.get(Translations.TEXT_INPUT_PLACEHOLDER)}
+        placeholder={I18n.get(inputPlaceholder)}
         description="text"
         handleInputChange={evt => this.handleTextChange(evt)}
         value={this.text}
-        disabled={this.chatState === ChatState.Error}
+        disabled={this.chatState === ChatState.Error || !this.textEnabled}
       />
     );
     const micButton = this.voiceEnabled && (

--- a/packages/amplify-ui-components/src/components/amplify-chatbot/animation.scss
+++ b/packages/amplify-ui-components/src/components/amplify-chatbot/animation.scss
@@ -1,53 +1,48 @@
 /**
  * Loading animation adapted from: https://github.com/nzbin/three-dots.
  */
+
+// set dot color for bot
+.bot .dot {
+  background-color: var(--bot-dot-color);
+}
+
+// set dot color for user
+.user .dot {
+  background-color: var(--user-dot-color);
+}
+
 .dot-flashing {
-  position: relative;
-  margin-left: 1rem;
-  margin-right: 1rem;
-  margin-top: 0.3rem;
-  margin-bottom: 0.3rem;
-  width: 0.625rem;
-  height: 0.625rem;
-  border-radius: 10rem;
-  background-color: rgba(0, 0, 0, 0.65);
-  -webkit-animation: dot-flashing 1s infinite linear alternate;
-  animation: dot-flashing 1s infinite linear alternate;
-  -webkit-animation-delay: 0.5s;
-  animation-delay: 0.5s;
-
-  &::before,
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    background-color: rgba(0, 0, 0, 0.65);
-  }
-
-  &::before {
-    left: -1rem;
+  width: 2.625rem;
+  .dot {
+    display: inline-block;
     width: 0.625rem;
     height: 0.625rem;
     border-radius: 10rem;
+    opacity: 0.65;
+  }
+  .left {
     animation: dot-flashing 1s infinite alternate;
     animation-delay: 0s;
   }
-
-  &::after {
-    left: 1rem;
-    width: 0.625rem;
-    height: 0.625rem;
-    border-radius: 10rem;
+  .middle {
+    margin-left: 0.375rem;
+    margin-right: 0.375rem;
+    animation: dot-flashing 1s infinite linear alternate;
+    animation-delay: 0.5s;
+  }
+  .right {
     animation: dot-flashing 1s infinite alternate;
     animation-delay: 1s;
   }
 }
+
 @keyframes dot-flashing {
   0% {
-    background-color: rgba(0, 0, 0, 0.65);
+    opacity: 0.65;
   }
   50%,
   100% {
-    background-color: rgba(0, 0, 0, 0.1);
+    opacity: 0.1;
   }
 }

--- a/packages/amplify-ui-components/src/global/theme.ts
+++ b/packages/amplify-ui-components/src/global/theme.ts
@@ -54,8 +54,8 @@ if (browserOrNode().isBrowser) {
       --amplify-light-grey: #c4c4c4;
       --amplify-white: #ffffff;
       --amplify-smoke-white: #f5f5f5;
-
       --amplify-red: #dd3f5b;
+      --amplify-blue: #099ac8;
     }
   `),
   );


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_  This PR makes improvements to chatbot that is on `ui-preview` right now.

Improvements:
- Errors are now divided into recoverable and unrecoverable errors and are handled accordingly. 
- Users no longer need to wait for bot to finish speaking. They can interrupt the audio by pressing mic or send button.
- Loading dots are now customizable. 
- Use different input placeholder when only voice is enabled.

Fix:
- Disable text sending through `enter` keystroke when only voice is enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
