### PR TITLE
chore: complete the provider interface and impl dummy

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@aws-amplify/cache": "^3.1.24",
     "@aws-amplify/core": "^3.4.7",
+    "@aws-sdk/client-cognito-identity-provider": "^1.0.0-alpha.1",
     "amazon-cognito-identity-js": "^4.3.5",
     "crypto-js": "^3.3.0"
   },

--- a/packages/auth/src/ProviderDefault/index.ts
+++ b/packages/auth/src/ProviderDefault/index.ts
@@ -1,0 +1,137 @@
+import {
+	AuthProvider,
+	AuthOptions,
+	SignUp,
+	ConfirmSignUp,
+	DeleteAccount,
+	ResendSignUpCode,
+	AuthSignUpResult,
+	ChangePassword,
+	AuthStateFlow,
+	UpdateUserAttribute,
+	UpdatePreferredMfa,
+	VerifyUserAttribute,
+	ConfirmVerifyUserAttribute,
+	SignIn,
+	AuthSignInResult,
+	SignInWithSocialToken,
+	SignInWithSocialUI,
+	ConfirmSignIn,
+	AuthConfirmSignInResult,
+	SetupTotp,
+	VerifyTotpToken,
+	ResetPassword,
+	ConfirmResetPassword,
+	GetUser,
+	AuthUser,
+	RegisterDevice,
+	UnregisterDevice,
+} from '../types';
+
+export class AuthProviderDefault implements AuthProvider {
+	getModuleName = (): 'Auth' => 'Auth';
+	getProviderName = () => 'AmazonCognito';
+
+	configure(config: AuthOptions) {
+		alert('configure Call');
+	}
+
+	signUp: SignUp = async params => {
+		alert('signUp Call');
+		return undefined as AuthSignUpResult;
+	};
+
+	confirmSignUp: ConfirmSignUp = async params => {
+		alert('confirmSignUp Call');
+		return undefined as AuthSignUpResult;
+	};
+
+	deleteAccount: DeleteAccount = async () => {
+		alert('deleteAccount Call');
+	};
+
+	resendSignUpCode: ResendSignUpCode = async params => {
+		alert('resendSignUpCode Call');
+		return undefined as AuthSignUpResult;
+	};
+
+	changePassword: ChangePassword = async params => {
+		alert('changePassword Call');
+		return undefined as AuthStateFlow;
+	};
+
+	updateUserAttribute: UpdateUserAttribute = async params => {
+		alert('updateUserAttribute call');
+		return undefined as AuthStateFlow;
+	};
+
+	updatePreferredMFA: UpdatePreferredMfa = async params => {
+		alert('updatePreferredMFA Call');
+		return undefined as AuthStateFlow;
+	};
+
+	verifyUserAttribute: VerifyUserAttribute = async params => {
+		alert('verifyUserAttribute Call');
+		return undefined as AuthStateFlow;
+	};
+
+	confirmVerifyUserAttribute: ConfirmVerifyUserAttribute = async params => {
+		alert('confirmVerifyUserAttribute Call');
+		return undefined as AuthStateFlow;
+	};
+
+	signIn: SignIn = async params => {
+		alert('SignIn Call');
+		return undefined as AuthSignInResult;
+	};
+
+	signInWithSocialToken: SignInWithSocialToken = async params => {
+		alert('signInWithSocialToken Call');
+		return undefined as AuthSignInResult;
+	};
+
+	signInWithSocialUI: SignInWithSocialUI = async params => {
+		alert('signInWithSocialUI Call');
+		return undefined as AuthSignInResult;
+	};
+
+	confirmSignIn: ConfirmSignIn = async params => {
+		alert('confirmSignIn Call');
+		return undefined as AuthConfirmSignInResult;
+	};
+
+	setupTotp: SetupTotp = async params => {
+		alert('setupTotp Call');
+		return undefined as AuthStateFlow;
+	};
+
+	verifyTotpToken: VerifyTotpToken = async params => {
+		alert('verifyTotpToken Call');
+		return undefined as AuthStateFlow;
+	};
+
+	resetPassword: ResetPassword = async params => {
+		alert('resetPassword Call');
+		return undefined as AuthStateFlow;
+	};
+
+	confirmResetPassword: ConfirmResetPassword = async params => {
+		alert('confirmResetPassword Call');
+		return undefined as AuthStateFlow;
+	};
+
+	getUser: GetUser = async () => {
+		alert('getUser Call');
+		return undefined as AuthUser;
+	};
+
+	registerDevice: RegisterDevice = async params => {
+		alert('registerDevice Call');
+		return undefined as AuthUser;
+	};
+
+	unregisterDevice: UnregisterDevice = async params => {
+		alert('unregisterDevice Call');
+		return undefined as AuthUser;
+	};
+}

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -17,17 +17,6 @@ import {
 	CognitoUserAttribute,
 } from 'amazon-cognito-identity-js';
 
-/**
- * Parameters for user sign up
- */
-export interface SignUpParams {
-	username: string;
-	password: string;
-	attributes?: object;
-	validationData?: CognitoUserAttribute[];
-	clientMetadata?: { [key: string]: string };
-}
-
 export interface AuthCache {
 	setItem();
 	getItem();

--- a/packages/auth/src/types/Provider/change-password.ts
+++ b/packages/auth/src/types/Provider/change-password.ts
@@ -1,0 +1,11 @@
+import { AuthStateFlow, AuthUser } from './common';
+
+export interface ChangePasswordParams {
+	user: AuthUser;
+	oldPassword: string;
+	newPassword: string;
+}
+
+export type ChangePassword = (
+	params: ChangePasswordParams
+) => Promise<AuthStateFlow>;

--- a/packages/auth/src/types/Provider/common.ts
+++ b/packages/auth/src/types/Provider/common.ts
@@ -1,0 +1,50 @@
+export interface AuthUserAttribute {
+	Name: string;
+	Value: string;
+}
+
+export enum DeliveryMedium {
+	EMAIL = 'EMAIL',
+	SMS = 'SMS',
+	UNKNOWN = 'UNKNOWN',
+}
+
+export interface AuthCodeDeliveryDetails {
+	destination: string;
+	deliveryMedium: DeliveryMedium;
+	attributeName: string | ((value: string) => string);
+}
+
+export interface AuthSignUpOptions {
+	userAttributes: AuthUserAttribute[];
+	pluginOptions?: any;
+}
+
+export interface AuthSignUpResult {
+	isSignUpComplete: boolean;
+	nextStep?: AuthNextSignUpStep;
+}
+
+export enum AuthSignUpStep {
+	CONFIRM_SIGN_UP = 'CONFIRM_SIGN_UP',
+	DONE = 'DONE',
+}
+
+export interface AuthNextSignUpStep {
+	signUpStep: AuthSignUpStep;
+	additionalInfo: Record<string, string>;
+	codeDeliveryDetails: AuthCodeDeliveryDetails;
+}
+
+export interface AuthStateFlow {}
+
+export interface AuthUser {}
+
+// TODO: get correct enum values
+export enum MfaOption {
+	EMAIL = 'TOTP',
+	SMS = 'SMS',
+	NOMFA = 'NOMFA',
+}
+
+export interface AuthSignInResult {}

--- a/packages/auth/src/types/Provider/confirm-new-password.ts
+++ b/packages/auth/src/types/Provider/confirm-new-password.ts
@@ -1,0 +1,11 @@
+import { AuthStateFlow } from './common';
+
+export interface ConfirmNewPasswordParams {
+	state: AuthStateFlow;
+	password: string;
+	providerOptions: Record<string, any>;
+}
+
+export type ConfirmNewPassword = (
+	params: ConfirmNewPasswordParams
+) => Promise<AuthStateFlow>;

--- a/packages/auth/src/types/Provider/confirm-reset-password.ts
+++ b/packages/auth/src/types/Provider/confirm-reset-password.ts
@@ -1,0 +1,11 @@
+import { AuthStateFlow } from './common';
+
+export interface ConfirmResetPasswordParams {
+	username: string;
+	code: string;
+	providerOptions: Record<string, any>;
+}
+
+export type ConfirmResetPassword = (
+	params: ConfirmResetPasswordParams
+) => Promise<AuthStateFlow>;

--- a/packages/auth/src/types/Provider/confirm-sign-in.ts
+++ b/packages/auth/src/types/Provider/confirm-sign-in.ts
@@ -1,0 +1,12 @@
+export interface AuthConfirmSignInOptions {}
+
+export interface ConfirmSignInParams {
+	challengeResponse: string;
+	options: AuthConfirmSignInOptions;
+}
+
+export interface AuthConfirmSignInResult {}
+
+export type ConfirmSignIn = (
+	params: ConfirmSignInParams
+) => Promise<AuthConfirmSignInResult>;

--- a/packages/auth/src/types/Provider/confirm-sign-up.ts
+++ b/packages/auth/src/types/Provider/confirm-sign-up.ts
@@ -1,0 +1,11 @@
+import { AuthSignUpOptions, AuthSignUpResult } from './common';
+
+export interface ConfirmSignUpParams {
+	username: string;
+	code: string;
+	options?: AuthSignUpOptions;
+}
+
+export type ConfirmSignUp = (
+	params: ConfirmSignUpParams
+) => Promise<AuthSignUpResult>;

--- a/packages/auth/src/types/Provider/confirm-verify-user-attribute.ts
+++ b/packages/auth/src/types/Provider/confirm-verify-user-attribute.ts
@@ -1,0 +1,11 @@
+import { AuthStateFlow, AuthUser } from './common';
+
+export interface ConfirmVerifyUserAttributeParams {
+	user: AuthUser;
+	attribute: string;
+	code: string;
+}
+
+export type ConfirmVerifyUserAttribute = (
+	params: ConfirmVerifyUserAttributeParams
+) => Promise<AuthStateFlow>;

--- a/packages/auth/src/types/Provider/delete-account.ts
+++ b/packages/auth/src/types/Provider/delete-account.ts
@@ -1,0 +1,1 @@
+export type DeleteAccount = () => Promise<void>;

--- a/packages/auth/src/types/Provider/get-user.ts
+++ b/packages/auth/src/types/Provider/get-user.ts
@@ -1,0 +1,3 @@
+import { AuthUser } from './common';
+
+export type GetUser = () => Promise<AuthUser>;

--- a/packages/auth/src/types/Provider/index.ts
+++ b/packages/auth/src/types/Provider/index.ts
@@ -1,0 +1,71 @@
+import { AuthOptions } from '../Auth';
+import { ConfirmSignUp } from './confirm-sign-up';
+import { DeleteAccount } from './delete-account';
+import { ResendSignUpCode } from './resend-sign-up-code';
+import { SignUp } from './sign-up';
+import { ChangePassword } from './change-password';
+import { UpdateUserAttribute } from './update-user-attribute';
+import { UpdatePreferredMfa } from './update-preferred-mfa';
+import { VerifyUserAttribute } from './verify-user-attribute';
+import { ConfirmVerifyUserAttribute } from './confirm-verify-user-attribute';
+import { SignIn } from './sign-in';
+import { SignInWithSocialToken } from './sign-in-with-social-token';
+import { SignInWithSocialUI } from './sign-in-with-social-ui';
+import { ConfirmSignIn } from './confirm-sign-in';
+import { SetupTotp } from './setup-totp';
+import { VerifyTotpToken } from './verify-totp-token';
+import { ResetPassword } from './reset-password';
+import { ConfirmResetPassword } from './confirm-reset-password';
+import { GetUser } from './get-user';
+import { RegisterDevice } from './register-device';
+import { UnregisterDevice } from './unregister-device';
+
+export interface AuthProvider {
+	getModuleName(): 'Auth';
+	getProviderName(): string;
+
+	configure(config: AuthOptions): void;
+	//
+	signUp: SignUp;
+	resendSignUpCode: ResendSignUpCode;
+	confirmSignUp: ConfirmSignUp;
+	deleteAccount: DeleteAccount;
+	changePassword: ChangePassword;
+	updateUserAttribute: UpdateUserAttribute;
+	updatePreferredMFA: UpdatePreferredMfa;
+	verifyUserAttribute: VerifyUserAttribute;
+	confirmVerifyUserAttribute: ConfirmVerifyUserAttribute;
+	signIn: SignIn;
+	signInWithSocialToken: SignInWithSocialToken;
+	signInWithSocialUI: SignInWithSocialUI;
+	confirmSignIn: ConfirmSignIn;
+	setupTotp: SetupTotp;
+	verifyTotpToken: VerifyTotpToken;
+	resetPassword: ResetPassword;
+	confirmResetPassword: ConfirmResetPassword;
+	getUser: GetUser;
+	registerDevice: RegisterDevice;
+	unregisterDevice: UnregisterDevice;
+}
+
+export * from './common';
+export * from './confirm-sign-up';
+export * from './delete-account';
+export * from './resend-sign-up-code';
+export * from './sign-up';
+export * from './change-password';
+export * from './update-user-attribute';
+export * from './update-preferred-mfa';
+export * from './verify-user-attribute';
+export * from './confirm-verify-user-attribute';
+export * from './sign-in';
+export * from './sign-in-with-social-token';
+export * from './sign-in-with-social-ui';
+export * from './confirm-sign-in';
+export * from './setup-totp';
+export * from './verify-totp-token';
+export * from './reset-password';
+export * from './confirm-reset-password';
+export * from './get-user';
+export * from './register-device';
+export * from './unregister-device';

--- a/packages/auth/src/types/Provider/register-device.ts
+++ b/packages/auth/src/types/Provider/register-device.ts
@@ -1,0 +1,10 @@
+import { AuthUser, AuthStateFlow } from './common';
+
+export interface RegisterDeviceParams {
+	user: AuthUser;
+	providerOptions: Record<string, any>;
+}
+
+export type RegisterDevice = (
+	params: RegisterDeviceParams
+) => Promise<AuthStateFlow>;

--- a/packages/auth/src/types/Provider/resend-sign-up-code.ts
+++ b/packages/auth/src/types/Provider/resend-sign-up-code.ts
@@ -1,0 +1,14 @@
+import { AuthSignUpResult } from './common';
+
+// TODO: this type is missing from "Amplify Auth Category Interface"
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface AuthResendSignUpCodeOptions {}
+
+export interface ResendSignUpCodeParams {
+	username: string;
+	options?: AuthResendSignUpCodeOptions;
+}
+
+export type ResendSignUpCode = (
+	params: ResendSignUpCodeParams
+) => Promise<AuthSignUpResult>;

--- a/packages/auth/src/types/Provider/reset-password.ts
+++ b/packages/auth/src/types/Provider/reset-password.ts
@@ -1,0 +1,10 @@
+import { AuthStateFlow } from './common';
+
+export interface ResetPasswordParams {
+	username: string;
+	providerOptions: Record<string, any>;
+}
+
+export type ResetPassword = (
+	params: ResetPasswordParams
+) => Promise<AuthStateFlow>;

--- a/packages/auth/src/types/Provider/setup-totp.ts
+++ b/packages/auth/src/types/Provider/setup-totp.ts
@@ -1,0 +1,8 @@
+import { AuthStateFlow } from './common';
+
+export interface SetupTotpParams {
+	authStateFlow: AuthStateFlow;
+	providerOptions: Record<string, any>;
+}
+
+export type SetupTotp = (params: SetupTotpParams) => Promise<AuthStateFlow>;

--- a/packages/auth/src/types/Provider/sign-in-with-social-token.ts
+++ b/packages/auth/src/types/Provider/sign-in-with-social-token.ts
@@ -1,0 +1,15 @@
+import { AuthSignInResult } from './common';
+
+interface AuthUITokenProvider {}
+
+interface AuthSignInWithSocialTokenOptions {}
+
+export interface SignInWithSocialTokenParams {
+	socialProvider: AuthUITokenProvider;
+	token: string;
+	options?: AuthSignInWithSocialTokenOptions;
+}
+
+export type SignInWithSocialToken = (
+	params: SignInWithSocialTokenParams
+) => Promise<AuthSignInResult>;

--- a/packages/auth/src/types/Provider/sign-in-with-social-ui.ts
+++ b/packages/auth/src/types/Provider/sign-in-with-social-ui.ts
@@ -1,0 +1,14 @@
+import { AuthSignInResult } from './common';
+
+export enum AuthUISocialProvider {}
+
+export interface AuthSignInWithUIOptions {}
+
+export interface SignInWithSocialUIParams {
+	socialProvider: AuthUISocialProvider;
+	options: AuthSignInWithUIOptions;
+}
+
+export type SignInWithSocialUI = (
+	params?: SignInWithSocialUIParams
+) => Promise<AuthSignInResult>;

--- a/packages/auth/src/types/Provider/sign-in.ts
+++ b/packages/auth/src/types/Provider/sign-in.ts
@@ -1,0 +1,11 @@
+import { AuthSignInResult } from './common';
+
+interface AuthSignInOptions {}
+
+export interface SignInParams {
+	username?: string;
+	password?: string;
+	options?: AuthSignInOptions;
+}
+
+export type SignIn = (params: SignInParams) => Promise<AuthSignInResult>;

--- a/packages/auth/src/types/Provider/sign-up.ts
+++ b/packages/auth/src/types/Provider/sign-up.ts
@@ -1,0 +1,18 @@
+import { AuthSignUpOptions, AuthSignUpResult } from './common';
+
+// // PREVIOUS:
+// export interface SignUpParams {
+// 	username: string;
+// 	password: string;
+// 	attributes?: object;
+// 	validationData?: CognitoUserAttribute[];
+// 	clientMetadata?: { [key: string]: string };
+// }
+
+export interface SignUpParams {
+	username: string;
+	password?: string;
+	options?: AuthSignUpOptions;
+}
+
+export type SignUp = (params: SignUpParams) => Promise<AuthSignUpResult>;

--- a/packages/auth/src/types/Provider/unregister-device.ts
+++ b/packages/auth/src/types/Provider/unregister-device.ts
@@ -1,0 +1,10 @@
+import { AuthStateFlow, AuthUser } from './common';
+
+export interface UnregisterDeviceParams {
+	user: AuthUser;
+	providerOptions: Record<string, any>;
+}
+
+export type UnregisterDevice = (
+	params: UnregisterDeviceParams
+) => Promise<AuthStateFlow>;

--- a/packages/auth/src/types/Provider/update-preferred-mfa.ts
+++ b/packages/auth/src/types/Provider/update-preferred-mfa.ts
@@ -1,0 +1,10 @@
+import { MfaOption, AuthUser, AuthStateFlow } from './common';
+
+export interface UpdatePreferredMfaParams {
+	user: AuthUser;
+	mfaOption: MfaOption;
+}
+
+export type UpdatePreferredMfa = (
+	params: UpdatePreferredMfaParams
+) => Promise<AuthStateFlow>;

--- a/packages/auth/src/types/Provider/update-user-attribute.ts
+++ b/packages/auth/src/types/Provider/update-user-attribute.ts
@@ -1,0 +1,10 @@
+import { AuthStateFlow, AuthUser } from './common';
+
+export interface UpdateUserAttributeParams {
+	user: AuthUser;
+	attributes: Record<string, any>;
+}
+
+export type UpdateUserAttribute = (
+	params: UpdateUserAttributeParams
+) => Promise<AuthStateFlow>;

--- a/packages/auth/src/types/Provider/verify-totp-token.ts
+++ b/packages/auth/src/types/Provider/verify-totp-token.ts
@@ -1,0 +1,10 @@
+import { AuthStateFlow } from './common';
+
+export interface VerifyTotpTokenParams {
+	authStateFlow: AuthStateFlow;
+	providerOptions: Record<string, any>;
+}
+
+export type VerifyTotpToken = (
+	params: VerifyTotpTokenParams
+) => Promise<AuthStateFlow>;

--- a/packages/auth/src/types/Provider/verify-user-attribute.ts
+++ b/packages/auth/src/types/Provider/verify-user-attribute.ts
@@ -1,0 +1,10 @@
+import { AuthUser, AuthStateFlow } from './common';
+
+export interface VerifyUserAttributeParams {
+	user: AuthUser;
+	attribute: string;
+}
+
+export type VerifyUserAttribute = (
+	params: VerifyUserAttributeParams
+) => Promise<AuthStateFlow>;

--- a/packages/auth/src/types/index.ts
+++ b/packages/auth/src/types/index.ts
@@ -12,3 +12,4 @@
  */
 
 export * from './Auth';
+export * from './Provider';


### PR DESCRIPTION
- complete auth provider type defs (empty interfaces to-be-pieced-in after conversation with @elorzafe)
- implement dummy default auth provider
- begin modifying auth-package-root-level `Auth.ts` to support custom provider