### PR TITLE
Remove isomorphic-ws & ws from SSR DataStore usage

### DIFF
--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -47,10 +47,8 @@
 		"@aws-amplify/pubsub": "^3.1.0",
 		"idb": "5.0.2",
 		"immer": "6.0.1",
-		"isomorphic-ws": "^4.0.1",
 		"ulid": "2.3.0",
 		"uuid": "3.3.2",
-		"ws": "^7.2.3",
 		"zen-observable-ts": "0.8.19",
 		"zen-push": "0.2.1"
 	},

--- a/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
@@ -28,7 +28,6 @@ import {
 } from '@aws-amplify/core';
 import Cache from '@aws-amplify/cache';
 import Auth from '@aws-amplify/auth';
-import WebSocket from 'isomorphic-ws';
 import { AbstractPubSubProvider } from './PubSubProvider';
 import { CONTROL_MSG } from '../index';
 


### PR DESCRIPTION
_Issue #, if available:_ #6718 

#6146 added `isomorphic-ws` for `WebSocket` support in Node.js, but for those installing `@aws-amplify/*` packages separately (vs. `aws-amplify` in our integration tests & samples), this dependency wasn't added.

Removing instead, since this was more of a polyfill and subscriptions won't be used for SSR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
