### PR TITLE
Add optionality to init type for api get op

### DIFF
--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -87,7 +87,7 @@ export class APIClass {
 	 * @param {json} [init] - Request extra params
 	 * @return {Promise} - A promise that resolves to an object with response status and JSON data, if successful.
 	 */
-	get(apiName, path, init): Promise<any> {
+	get(apiName, path, init?: any): Promise<any> {
 		return this._restApi.get(apiName, path, init);
 	}
 


### PR DESCRIPTION
_Issue #, if available:_ #1313

_Description of changes:_ add optionality to `init` param for `get` operation in API category.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
