### PR TITLE
chore: pin @types/babel__traverse to allow ui-angular to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 		"winston": "^3.2.1"
 	},
 	"resolutions": {
+		"@types/babel__traverse": "7.0.8",
 		"terser": "4.6.7",
 		"npm-packlist": "1.1.12"
 	},


### PR DESCRIPTION
Upstream dependency @types/babel__traverse was updated to require TypeScript@3.4.0. Since ui-angular is still on 3.2, the build script for that package is failing.

This change forces packages to resolve @types/babel__traverse: 7.0.8, which supports TS@3.2

More of a band-aid fix to unblock us. We should look into upgrading ui-angular to more recent versions of TS, Angular, and Angular Compiler


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
