### PR TITLE
Fix incorrect type definition

### DIFF
--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -14,7 +14,7 @@
 import {
 	ICookieStorageData,
 	ICognitoStorage,
-	CognitoUserAttribute,
+	ICognitoUserAttributeData,
 } from 'amazon-cognito-identity-js';
 
 /**
@@ -24,7 +24,7 @@ export interface SignUpParams {
 	username: string;
 	password: string;
 	attributes?: object;
-	validationData?: CognitoUserAttribute[];
+	validationData?: ICognitoUserAttributeData[];
 	clientMetadata?: { [key: string]: string };
 }
 


### PR DESCRIPTION

> EDIT: Closing this PR in favour of #6900

~~_Description of changes:_~~

~~`Auth.signUp` had invalid types for `validationData`. It should be an array of `Name`/`Value` pairs, [as per the documentation](https://docs.amplify.aws/lib/auth/advanced/q/platform/js#pre-authentication-and-pre-sign-up-lambda-triggers). This PR fixes that~~

~~This is how it should be used:~~
```js
Auth.signUp({
  username: "username",
  password: "password"
  validationData: [
    // correct usage
    { Name: "my name", Value: "my value" },
  ],
});
```

~~However the type definitions suggest that you should be passing it a list of classes which is wrong:~~

```js
Auth.signUp({
  username: "username",
  password: "password"
  validationData: [
    // this is wrong
    new CognitoUserAttribute({ Name: "my name", Value: "my value" }),
  ],
});
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. ✅ yes
