### PR TITLE
swap out soon-to-be-deprecated AsyncStorage

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -64,6 +64,7 @@
   "jsnext:main": "es/index.js",
   "types": "./index.d.ts",
   "dependencies": {
+    "@react-native-community/async-storage": "^1.12.0",
     "buffer": "4.9.1",
     "crypto-js": "^3.3.0",
     "isomorphic-unfetch": "^3.0.0",

--- a/packages/amazon-cognito-identity-js/src/StorageHelper-rn.js
+++ b/packages/amazon-cognito-identity-js/src/StorageHelper-rn.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
 const MEMORY_KEY_PREFIX = '@MemoryStorage:';
 let dataMemory = {};

--- a/packages/cache/__mocks__/AsyncStorage.js
+++ b/packages/cache/__mocks__/AsyncStorage.js
@@ -1,4 +1,6 @@
-const AsyncStorage = jest.genMockFromModule('react-native');
+const AsyncStorage = jest.genMockFromModule(
+	'@react-native-community/async-storage'
+);
 
 var store = {};
 var curSize = 0;

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -35,7 +35,8 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/core": "^3.5.2"
+    "@aws-amplify/core": "^3.5.2",
+    "@react-native-community/async-storage": "^1.12.0"
   },
   "jest": {
     "globals": {

--- a/packages/cache/src/AsyncStorageCache.ts
+++ b/packages/cache/src/AsyncStorageCache.ts
@@ -13,7 +13,7 @@
 
 import { StorageCache } from './StorageCache';
 import { defaultConfig, getCurrTime } from './Utils';
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 import { ICache } from './types';
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
 		"@aws-sdk/types": "1.0.0-gamma.6",
 		"@aws-sdk/util-hex-encoding": "1.0.0-gamma.6",
 		"@aws-sdk/util-user-agent-browser": "1.0.0-gamma.7",
+		"@react-native-community/async-storage": "^1.12.0",
 		"universal-cookie": "^4.0.3",
 		"url": "^0.11.0",
 		"zen-observable-ts": "0.8.19"

--- a/packages/core/src/RNComponents/reactnative.ts
+++ b/packages/core/src/RNComponents/reactnative.ts
@@ -11,4 +11,5 @@
  * and limitations under the License.
  */
 
-export { Linking, AppState, AsyncStorage } from 'react-native';
+export { default as AsyncStorage } from '@react-native-community/async-storage';
+export { Linking, AppState } from 'react-native';

--- a/packages/core/src/StorageHelper/reactnative.ts
+++ b/packages/core/src/StorageHelper/reactnative.ts
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
 const MEMORY_KEY_PREFIX = '@MemoryStorage:';
 let dataMemory = {};

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -45,6 +45,7 @@
 		"@aws-amplify/api": "^3.2.2",
 		"@aws-amplify/core": "^3.5.2",
 		"@aws-amplify/pubsub": "^3.2.0",
+		"@react-native-community/async-storage": "^1.12.0",
 		"idb": "5.0.2",
 		"immer": "6.0.1",
 		"ulid": "2.3.0",

--- a/packages/datastore/src/storage/adapter/InMemoryStore.native.ts
+++ b/packages/datastore/src/storage/adapter/InMemoryStore.native.ts
@@ -1,4 +1,4 @@
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
 // See: https://reactnative.dev/docs/asyncstorage
 export function createInMemoryStore() {

--- a/packages/pushnotification/package.json
+++ b/packages/pushnotification/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@aws-amplify/core": "^3.5.2",
+    "@react-native-community/async-storage": "^1.12.0",
     "@react-native-community/push-notification-ios": "1.0.3"
   },
   "peerdependencies": {

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -14,10 +14,10 @@
 import {
 	NativeModules,
 	DeviceEventEmitter,
-	AsyncStorage,
 	Platform,
 	AppState,
 } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
 import { Amplify, ConsoleLogger as Logger, JS } from '@aws-amplify/core';
 


### PR DESCRIPTION
_Issue #, if available:_ #6703

_Description of changes:_

It seems that `react-native`'s `AsyncStorage` is being deprecated. The migration includes swapping usage with `react-native-community`'s [async-storage](https://github.com/react-native-community/async-storage).

This draft PR (untested) does just this (swaps modules). Doesn't need other alterations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
