### PR TITLE
fix(@aws-amplify-react-native):  Add missing testID attributes in RequireNewPassword component.

### DIFF
--- a/packages/aws-amplify-react-native/src/AmplifyTestIDs.js
+++ b/packages/aws-amplify-react-native/src/AmplifyTestIDs.js
@@ -15,6 +15,7 @@
 module.exports = {
 	AUTH: {
 		BACK_TO_SIGN_IN_BUTTON: 'aws-amplify__auth--back-to-sign-in-button',
+		CHANGE_PASSWORD_BUTTON: 'aws-amplify__auth--change-password-button',
 		CHANGE_PASSWORD_TEXT: 'aws-amplify__auth--change-password-text',
 		CONFIRM_A_CODE_BUTTON: 'aws-amplify__auth--confirm-a-code-button',
 		CONFIRM_BUTTON: 'aws-amplify__auth--confirm-button',

--- a/packages/aws-amplify-react-native/src/Auth/RequireNewPassword.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/RequireNewPassword.tsx
@@ -104,6 +104,7 @@ export default class RequireNewPassword extends AuthPiece<
 							placeholder={I18n.get('Enter your password')}
 							secureTextEntry={true}
 							required={true}
+							testID={TEST_ID.AUTH.PASSWORD_INPUT}
 						/>
 						{requiredAttributes.map(attribute => {
 							logger.debug('attributes', attribute);
@@ -120,6 +121,7 @@ export default class RequireNewPassword extends AuthPiece<
 										Object.keys(requiredAttributes).length
 								)
 							}
+							testID={TEST_ID.AUTH.CHANGE_PASSWORD_BUTTON}
 						/>
 					</View>
 					<View style={theme.sectionFooter}>


### PR DESCRIPTION
I noticed while writing Detox tests on a project that there are missing testIDs in the RequireNewPassword component. This pull request adds the missing attributes so the UI can be controlled in tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
