### PR TITLE
feat(@aws-amplify/datastore): add query sorting

### DIFF
--- a/packages/aws-amplify/webpack-utils.js
+++ b/packages/aws-amplify/webpack-utils.js
@@ -38,6 +38,7 @@ const packageFolderMap = {
 	'aws-amplify-vue': 'aws-amplify-vue',
 	cache: '@aws-amplify/cache',
 	core: '@aws-amplify/core',
+	datastore: '@aws-amplify/datastore',
 	interactions: '@aws-amplify/interactions',
 	pubsub: '@aws-amplify/pubsub',
 	pushnotification: '@aws-amplify/pushnotification',

--- a/packages/datastore/__tests__/AsyncStorage.ts
+++ b/packages/datastore/__tests__/AsyncStorage.ts
@@ -17,6 +17,7 @@ import {
 	Person as PersonType,
 } from './model';
 import { newSchema } from './schema';
+import { SortDirection } from '../src/types';
 
 let AsyncStorageAdapter: typeof AsyncStorageAdapterType;
 
@@ -312,7 +313,7 @@ describe('AsyncStorage tests', () => {
 		const sortedPersons = await DataStore.query(Person, null, {
 			page: 0,
 			limit: 20,
-			sort: s => s.firstName('DESCENDING'),
+			sort: s => s.firstName(SortDirection.DESCENDING),
 		});
 
 		expect(sortedPersons[0].firstName).toEqual('Meow Meow');
@@ -351,9 +352,9 @@ describe('AsyncStorage tests', () => {
 				limit: 20,
 				sort: s =>
 					s
-						.firstName('ASCENDING')
-						.lastName('ASCENDING')
-						.username('ASCENDING'),
+						.firstName(SortDirection.ASCENDING)
+						.lastName(SortDirection.ASCENDING)
+						.username(SortDirection.ASCENDING),
 			}
 		);
 

--- a/packages/datastore/__tests__/AsyncStorage.ts
+++ b/packages/datastore/__tests__/AsyncStorage.ts
@@ -14,6 +14,7 @@ import {
 	Post as PostType,
 	PostAuthorJoin as PostAuthorJoinType,
 	PostMetadata as PostMetadataType,
+	Person as PersonType,
 } from './model';
 import { newSchema } from './schema';
 
@@ -28,6 +29,7 @@ let BlogOwner: PersistentModelConstructor<InstanceType<typeof BlogOwnerType>>;
 let Comment: PersistentModelConstructor<InstanceType<typeof CommentType>>;
 let Nested: NonModelTypeConstructor<InstanceType<typeof NestedType>>;
 let Post: PersistentModelConstructor<InstanceType<typeof PostType>>;
+let Person: PersistentModelConstructor<InstanceType<typeof PersonType>>;
 let PostAuthorJoin: PersistentModelConstructor<InstanceType<
 	typeof PostAuthorJoinType
 >>;
@@ -101,6 +103,7 @@ function setUpSchema(beforeSetUp?: Function) {
 		Comment,
 		Nested,
 		Post,
+		Person,
 		PostAuthorJoin,
 		PostMetadata,
 	} = <
@@ -111,6 +114,7 @@ function setUpSchema(beforeSetUp?: Function) {
 			Comment: typeof Comment;
 			Nested: typeof Nested;
 			Post: typeof Post;
+			Person: typeof Person;
 			PostAuthorJoin: typeof PostAuthorJoin;
 			PostMetadata: typeof PostMetadata;
 		}
@@ -277,6 +281,85 @@ describe('AsyncStorage tests', () => {
 		const q1 = await DataStore.query(Comment, c1.id);
 
 		expect(q1.post.id).toEqual(p.id);
+	});
+
+	test('query with sort on a single field', async () => {
+		const p1 = new Person({
+			firstName: 'John',
+			lastName: 'Snow',
+		});
+
+		const p2 = new Person({
+			firstName: 'Clem',
+			lastName: 'Fandango',
+		});
+
+		const p3 = new Person({
+			firstName: 'Beezus',
+			lastName: 'Fuffoon',
+		});
+
+		const p4 = new Person({
+			firstName: 'Meow Meow',
+			lastName: 'Fuzzyface',
+		});
+
+		await DataStore.save(p1);
+		await DataStore.save(p2);
+		await DataStore.save(p3);
+		await DataStore.save(p4);
+
+		const sortedPersons = await DataStore.query(Person, null, {
+			page: 0,
+			limit: 20,
+			sort: s => s.firstName('DESCENDING'),
+		});
+
+		expect(sortedPersons[0].firstName).toEqual('Meow Meow');
+		expect(sortedPersons[1].firstName).toEqual('John');
+		expect(sortedPersons[2].firstName).toEqual('Clem');
+		expect(sortedPersons[3].firstName).toEqual('Beezus');
+	});
+
+	test('query with sort on multiple fields', async () => {
+		const p1 = new Person({
+			firstName: 'John',
+			lastName: 'Snow',
+			username: 'johnsnow',
+		});
+		const p2 = new Person({
+			firstName: 'John',
+			lastName: 'Umber',
+			username: 'smalljohnumber',
+		});
+
+		const p3 = new Person({
+			firstName: 'John',
+			lastName: 'Umber',
+			username: 'greatjohnumber',
+		});
+
+		await DataStore.save(p1);
+		await DataStore.save(p2);
+		await DataStore.save(p3);
+
+		const sortedPersons = await DataStore.query(
+			Person,
+			c => c.username('ne', undefined),
+			{
+				page: 0,
+				limit: 20,
+				sort: s =>
+					s
+						.firstName('ASCENDING')
+						.lastName('ASCENDING')
+						.username('ASCENDING'),
+			}
+		);
+
+		expect(sortedPersons[0].username).toEqual('johnsnow');
+		expect(sortedPersons[1].username).toEqual('greatjohnumber');
+		expect(sortedPersons[2].username).toEqual('smalljohnumber');
 	});
 
 	test('delete 1:1 function', async () => {

--- a/packages/datastore/__tests__/indexeddb.test.ts
+++ b/packages/datastore/__tests__/indexeddb.test.ts
@@ -2,7 +2,7 @@ import Dexie from 'dexie';
 import 'dexie-export-import';
 import 'fake-indexeddb/auto';
 import * as idb from 'idb';
-import { DataStore } from '../src/index';
+import { DataStore, SortDirection } from '../src/index';
 import { DATASTORE, SYNC, USER } from '../src/util';
 import {
 	Author,
@@ -322,7 +322,7 @@ describe('Indexed db storage test', () => {
 		const sortedPersons = await DataStore.query(Person, null, {
 			page: 0,
 			limit: 20,
-			sort: s => s.firstName('DESCENDING'),
+			sort: s => s.firstName(SortDirection.DESCENDING),
 		});
 
 		expect(sortedPersons[0].firstName).toEqual('Meow Meow');
@@ -361,9 +361,9 @@ describe('Indexed db storage test', () => {
 				limit: 20,
 				sort: s =>
 					s
-						.firstName('ASCENDING')
-						.lastName('ASCENDING')
-						.username('ASCENDING'),
+						.firstName(SortDirection.ASCENDING)
+						.lastName(SortDirection.ASCENDING)
+						.username(SortDirection.ASCENDING),
 			}
 		);
 

--- a/packages/datastore/__tests__/indexeddb.test.ts
+++ b/packages/datastore/__tests__/indexeddb.test.ts
@@ -13,6 +13,7 @@ import {
 	Post,
 	PostAuthorJoin,
 	PostMetadata,
+	Person,
 } from './model';
 let db: idb.IDBPDatabase;
 
@@ -60,6 +61,7 @@ describe('Indexed db storage test', () => {
 			`${USER}_Blog`,
 			`${USER}_BlogOwner`,
 			`${USER}_Comment`,
+			`${USER}_Person`,
 			`${USER}_Post`,
 			`${USER}_PostAuthorJoin`,
 		];
@@ -289,6 +291,85 @@ describe('Indexed db storage test', () => {
 		const q1 = await DataStore.query(Comment, c1.id);
 
 		expect(q1.post.id).toEqual(p.id);
+	});
+
+	test('query with sort on a single field', async () => {
+		const p1 = new Person({
+			firstName: 'John',
+			lastName: 'Snow',
+		});
+
+		const p2 = new Person({
+			firstName: 'Clem',
+			lastName: 'Fandango',
+		});
+
+		const p3 = new Person({
+			firstName: 'Beezus',
+			lastName: 'Fuffoon',
+		});
+
+		const p4 = new Person({
+			firstName: 'Meow Meow',
+			lastName: 'Fuzzyface',
+		});
+
+		await DataStore.save(p1);
+		await DataStore.save(p2);
+		await DataStore.save(p3);
+		await DataStore.save(p4);
+
+		const sortedPersons = await DataStore.query(Person, null, {
+			page: 0,
+			limit: 20,
+			sort: s => s.firstName('DESCENDING'),
+		});
+
+		expect(sortedPersons[0].firstName).toEqual('Meow Meow');
+		expect(sortedPersons[1].firstName).toEqual('John');
+		expect(sortedPersons[2].firstName).toEqual('Clem');
+		expect(sortedPersons[3].firstName).toEqual('Beezus');
+	});
+
+	test('query with sort on multiple fields', async () => {
+		const p1 = new Person({
+			firstName: 'John',
+			lastName: 'Snow',
+			username: 'johnsnow',
+		});
+		const p2 = new Person({
+			firstName: 'John',
+			lastName: 'Umber',
+			username: 'smalljohnumber',
+		});
+
+		const p3 = new Person({
+			firstName: 'John',
+			lastName: 'Umber',
+			username: 'greatjohnumber',
+		});
+
+		await DataStore.save(p1);
+		await DataStore.save(p2);
+		await DataStore.save(p3);
+
+		const sortedPersons = await DataStore.query(
+			Person,
+			c => c.username('ne', undefined),
+			{
+				page: 0,
+				limit: 20,
+				sort: s =>
+					s
+						.firstName('ASCENDING')
+						.lastName('ASCENDING')
+						.username('ASCENDING'),
+			}
+		);
+
+		expect(sortedPersons[0].username).toEqual('johnsnow');
+		expect(sortedPersons[1].username).toEqual('greatjohnumber');
+		expect(sortedPersons[2].username).toEqual('smalljohnumber');
 	});
 
 	test('delete 1:1 function', async () => {

--- a/packages/datastore/__tests__/model.ts
+++ b/packages/datastore/__tests__/model.ts
@@ -98,6 +98,13 @@ declare class BlogOwnerModel {
 	): BlogOwnerModel;
 }
 
+declare class PersonModel {
+	readonly id: string;
+	readonly firstName: string;
+	readonly lastName: string;
+	readonly username?: string;
+}
+
 const {
 	Author,
 	Post,
@@ -105,6 +112,7 @@ const {
 	Blog,
 	BlogOwner,
 	PostAuthorJoin,
+	Person,
 	PostMetadata,
 	Nested,
 } = initSchema(newSchema) as {
@@ -114,6 +122,7 @@ const {
 	Blog: PersistentModelConstructor<BlogModel>;
 	BlogOwner: PersistentModelConstructor<BlogOwnerModel>;
 	PostAuthorJoin: PersistentModelConstructor<PostAuthorJoinModel>;
+	Person: PersistentModelConstructor<PersonModel>;
 	PostMetadata: NonModelTypeConstructor<PostMetadataType>;
 	Nested: NonModelTypeConstructor<NestedType>;
 };
@@ -125,6 +134,7 @@ export {
 	Blog,
 	BlogOwner,
 	PostAuthorJoin,
+	Person,
 	PostMetadata,
 	Nested,
 };

--- a/packages/datastore/__tests__/schema.ts
+++ b/packages/datastore/__tests__/schema.ts
@@ -323,6 +323,47 @@ export const newSchema: Schema = {
 				},
 			},
 		},
+		Person: {
+			syncable: true,
+			name: 'Person',
+			pluralName: 'Persons',
+			attributes: [
+				{
+					type: 'model',
+					properties: {},
+				},
+			],
+			fields: {
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				firstName: {
+					name: 'firstName',
+					isArray: false,
+					type: 'String',
+					isRequired: true,
+					attributes: [],
+				},
+				lastName: {
+					name: 'lastName',
+					isArray: false,
+					type: 'String',
+					isRequired: true,
+					attributes: [],
+				},
+				username: {
+					name: 'username',
+					isArray: false,
+					type: 'String',
+					isRequired: false,
+					attributes: [],
+				},
+			},
+		},
 	},
 	enums: {},
 	nonModels: {

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -18,8 +18,8 @@
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",
 		"build:cjs:watch": "node ./build es5 --watch",
-		"build:esm:watch": "node ./build es6 --watch",
-		"build": "npm run clean && npm run build:esm && npm run build:cjs",
+		"build:esm:watch": "rimraf lib-esm && node ./build es6 --watch",
+		"build": "yarn clean && yarn build:esm && npm run build:cjs",
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint '{__tests__,src}/**/*.ts'"

--- a/packages/datastore/src/predicates/index.ts
+++ b/packages/datastore/src/predicates/index.ts
@@ -10,6 +10,8 @@ import {
 } from '../types';
 import { exhaustiveCheck } from '../util';
 
+export { ModelSortPredicateCreator } from './sort';
+
 const predicatesAllSet = new WeakSet<ProducerModelPredicate<any>>();
 
 export function isPredicatesAll(
@@ -109,10 +111,8 @@ export class ModelPredicateCreator {
 						ModelPredicateCreator.predicateGroupsMap
 							.get(receiver)
 							.predicates.push({ field, operator, operand });
-
 						return receiver;
 					};
-
 					return result;
 				},
 			})
@@ -144,6 +144,7 @@ export class ModelPredicateCreator {
 		return ModelPredicateCreator.predicateGroupsMap.get(predicate);
 	}
 
+	// transforms cb-style predicate into Proxy
 	static createFromExisting<T extends PersistentModel>(
 		modelDefinition: SchemaModel,
 		existing: ProducerModelPredicate<T>

--- a/packages/datastore/src/predicates/sort.ts
+++ b/packages/datastore/src/predicates/sort.ts
@@ -1,0 +1,85 @@
+import {
+	PersistentModel,
+	SchemaModel,
+	SortPredicate,
+	ProducerSortPredicate,
+	SortDirection,
+	SortPredicatesGroup,
+} from '../types';
+
+export class ModelSortPredicateCreator {
+	private static sortPredicateGroupsMap = new WeakMap<
+		SortPredicate<any>,
+		SortPredicatesGroup<any>
+	>();
+
+	private static createPredicateBuilder<T extends PersistentModel>(
+		modelDefinition: SchemaModel
+	) {
+		const { name: modelName } = modelDefinition;
+		const fieldNames = new Set<keyof T>(Object.keys(modelDefinition.fields));
+
+		let handler: ProxyHandler<SortPredicate<T>>;
+		const predicate = new Proxy(
+			{} as SortPredicate<T>,
+			(handler = {
+				get(_target, propertyKey, receiver: SortPredicate<T>) {
+					const field = propertyKey as keyof T;
+
+					if (!fieldNames.has(field)) {
+						throw new Error(
+							`Invalid field for model. field: ${field}, model: ${modelName}`
+						);
+					}
+
+					const result = (sortDirection: SortDirection) => {
+						ModelSortPredicateCreator.sortPredicateGroupsMap
+							.get(receiver)
+							.push({ field, sortDirection });
+
+						return receiver;
+					};
+					return result;
+				},
+			})
+		);
+
+		ModelSortPredicateCreator.sortPredicateGroupsMap.set(predicate, []);
+
+		return predicate;
+	}
+
+	static isValidPredicate<T extends PersistentModel>(
+		predicate: any
+	): predicate is SortPredicate<T> {
+		return ModelSortPredicateCreator.sortPredicateGroupsMap.has(predicate);
+	}
+
+	static getPredicates<T extends PersistentModel>(
+		predicate: SortPredicate<T>,
+		throwOnInvalid: boolean = true
+	): SortPredicatesGroup<T> {
+		if (
+			throwOnInvalid &&
+			!ModelSortPredicateCreator.isValidPredicate(predicate)
+		) {
+			throw new Error('The predicate is not valid');
+		}
+
+		return ModelSortPredicateCreator.sortPredicateGroupsMap.get(predicate);
+	}
+
+	// transforms cb-style predicate into Proxy
+	static createFromExisting<T extends PersistentModel>(
+		modelDefinition: SchemaModel,
+		existing: ProducerSortPredicate<T>
+	) {
+		if (!existing || !modelDefinition) {
+			return undefined;
+		}
+
+		return existing(
+			ModelSortPredicateCreator.createPredicateBuilder(modelDefinition)
+		);
+	}
+}

--- a/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
+++ b/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
@@ -233,7 +233,7 @@ export class AsyncStorageAdapter implements Adapter {
 	async query<T extends PersistentModel>(
 		modelConstructor: PersistentModelConstructor<T>,
 		predicate?: ModelPredicate<T>,
-		pagination?: PaginationInput
+		pagination?: PaginationInput<T>
 	): Promise<T[]> {
 		const storeName = this.getStorenameForModel(modelConstructor);
 		const namespaceName = this.namespaceResolver(modelConstructor);
@@ -281,9 +281,9 @@ export class AsyncStorageAdapter implements Adapter {
 		return await this.load(namespaceName, modelConstructor.name, all);
 	}
 
-	private inMemoryPagination<T>(
+	private inMemoryPagination<T extends PersistentModel>(
 		records: T[],
-		pagination?: PaginationInput
+		pagination?: PaginationInput<T>
 	): T[] {
 		if (pagination) {
 			const { page = 0, limit = 0 } = pagination;
@@ -381,7 +381,10 @@ export class AsyncStorageAdapter implements Adapter {
 				const isValid = validatePredicate(fromDB, type, predicateObjs);
 				if (!isValid) {
 					const msg = 'Conditional update failed';
-					logger.error(msg, { model: fromDB, condition: predicateObjs });
+					logger.error(msg, {
+						model: fromDB,
+						condition: predicateObjs,
+					});
 
 					throw new Error(msg);
 				}

--- a/packages/datastore/src/storage/adapter/AsyncStorageDatabase.ts
+++ b/packages/datastore/src/storage/adapter/AsyncStorageDatabase.ts
@@ -240,7 +240,7 @@ class AsyncStorageDatabase {
 	 */
 	async getAll<T extends PersistentModel>(
 		storeName: string,
-		pagination?: PaginationInput
+		pagination?: PaginationInput<T>
 	): Promise<T[]> {
 		const collection = this.getCollectionIndex(storeName);
 

--- a/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
+++ b/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
@@ -357,7 +357,7 @@ class IndexedDBAdapter implements Adapter {
 	async query<T extends PersistentModel>(
 		modelConstructor: PersistentModelConstructor<T>,
 		predicate?: ModelPredicate<T>,
-		pagination?: PaginationInput
+		pagination?: PaginationInput<T>
 	): Promise<T[]> {
 		await this.checkPrivate();
 		const storeName = this.getStorenameForModel(modelConstructor);
@@ -410,9 +410,9 @@ class IndexedDBAdapter implements Adapter {
 		);
 	}
 
-	private inMemoryPagination<T>(
+	private inMemoryPagination<T extends PersistentModel>(
 		records: T[],
-		pagination?: PaginationInput
+		pagination?: PaginationInput<T>
 	): T[] {
 		if (pagination) {
 			const { page = 0, limit = 0 } = pagination;
@@ -426,9 +426,9 @@ class IndexedDBAdapter implements Adapter {
 		return records;
 	}
 
-	private async enginePagination<T>(
+	private async enginePagination<T extends PersistentModel>(
 		storeName: string,
-		pagination?: PaginationInput
+		pagination?: PaginationInput<T>
 	): Promise<T[]> {
 		let result: T[];
 

--- a/packages/datastore/src/storage/adapter/index.ts
+++ b/packages/datastore/src/storage/adapter/index.ts
@@ -22,7 +22,7 @@ export interface Adapter extends SystemComponent {
 	query<T extends PersistentModel>(
 		modelConstructor: PersistentModelConstructor<T>,
 		predicate?: ModelPredicate<T>,
-		pagination?: PaginationInput
+		pagination?: PaginationInput<T>
 	): Promise<T[]>;
 	queryOne<T extends PersistentModel>(
 		modelConstructor: PersistentModelConstructor<T>,

--- a/packages/datastore/src/storage/adapter/indexeddb.ts
+++ b/packages/datastore/src/storage/adapter/indexeddb.ts
@@ -1,7 +1,10 @@
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import * as idb from 'idb';
 import { ModelInstanceCreator } from '../../datastore/datastore';
-import { ModelPredicateCreator } from '../../predicates';
+import {
+	ModelPredicateCreator,
+	ModelSortPredicateCreator,
+} from '../../predicates';
 import {
 	InternalSchema,
 	isPredicateObj,
@@ -24,6 +27,7 @@ import {
 	isPrivateMode,
 	traverseModel,
 	validatePredicate,
+	sortCompareFunction,
 } from '../../util';
 import { Adapter } from './index';
 import { tsIndexSignature } from '@babel/types';
@@ -358,11 +362,12 @@ class IndexedDBAdapter implements Adapter {
 	async query<T extends PersistentModel>(
 		modelConstructor: PersistentModelConstructor<T>,
 		predicate?: ModelPredicate<T>,
-		pagination?: PaginationInput
+		pagination?: PaginationInput<T>
 	): Promise<T[]> {
 		await this.checkPrivate();
 		const storeName = this.getStorenameForModel(modelConstructor);
 		const namespaceName = this.namespaceResolver(modelConstructor);
+		const sortSpecified = pagination && pagination.sort;
 
 		if (predicate) {
 			const predicates = ModelPredicateCreator.getPredicates(predicate);
@@ -404,6 +409,15 @@ class IndexedDBAdapter implements Adapter {
 			}
 		}
 
+		if (sortSpecified) {
+			const all = <T[]>await this.db.getAll(storeName);
+			return await this.load(
+				namespaceName,
+				modelConstructor.name,
+				this.inMemoryPagination(all, pagination)
+			);
+		}
+
 		return await this.load(
 			namespaceName,
 			modelConstructor.name,
@@ -411,11 +425,22 @@ class IndexedDBAdapter implements Adapter {
 		);
 	}
 
-	private inMemoryPagination<T>(
+	private inMemoryPagination<T extends PersistentModel>(
 		records: T[],
-		pagination?: PaginationInput
+		pagination?: PaginationInput<T>
 	): T[] {
 		if (pagination) {
+			if (pagination.sort) {
+				const sortPredicates = ModelSortPredicateCreator.getPredicates(
+					pagination.sort
+				);
+
+				if (sortPredicates.length) {
+					const compareFn = sortCompareFunction(sortPredicates);
+					records.sort(compareFn);
+				}
+			}
+
 			const { page = 0, limit = 0 } = pagination;
 			const start = Math.max(0, page * limit) || 0;
 
@@ -427,9 +452,9 @@ class IndexedDBAdapter implements Adapter {
 		return records;
 	}
 
-	private async enginePagination<T>(
+	private async enginePagination<T extends PersistentModel>(
 		storeName: string,
-		pagination?: PaginationInput
+		pagination?: PaginationInput<T>
 	): Promise<T[]> {
 		let result: T[];
 

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -181,7 +181,7 @@ class StorageClass implements StorageFacade {
 	async query<T extends PersistentModel>(
 		modelConstructor: PersistentModelConstructor<T>,
 		predicate?: ModelPredicate<T>,
-		pagination?: PaginationInput
+		pagination?: PaginationInput<T>
 	): Promise<T[]> {
 		await this.init();
 
@@ -333,7 +333,7 @@ class ExclusiveStorage implements StorageFacade {
 	async query<T extends PersistentModel>(
 		modelConstructor: PersistentModelConstructor<T>,
 		predicate?: ModelPredicate<T>,
-		pagination?: PaginationInput
+		pagination?: PaginationInput<T>
 	): Promise<T[]> {
 		return this.runExclusive<T[]>(storage =>
 			storage.query<T>(modelConstructor, predicate, pagination)

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -168,6 +168,8 @@ type ModelField = {
 export type NonModelTypeConstructor<T> = {
 	new (init: T): T;
 };
+
+// Class for model
 export type PersistentModelConstructor<T extends PersistentModel> = {
 	new (init: ModelInit<T>): T;
 	copyOf(src: T, mutator: (draft: MutableModel<T>) => void): T;
@@ -176,6 +178,8 @@ export type TypeConstructorMap = Record<
 	string,
 	PersistentModelConstructor<any> | NonModelTypeConstructor<any>
 >;
+
+// Instance of model
 export type PersistentModel = Readonly<{ id: string } & Record<string, any>>;
 export type ModelInit<T> = Omit<T, 'id'>;
 type DeepWritable<T> = {
@@ -210,11 +214,13 @@ export type SubscriptionMessage<T extends PersistentModel> = {
 //#endregion
 
 //#region Predicates
+
 export type PredicateExpression<M extends PersistentModel, FT> = TypeName<
 	FT
 > extends keyof MapTypeToOperands<FT>
 	? (
 			operator: keyof MapTypeToOperands<FT>[TypeName<FT>],
+			// make the operand type match the type they're trying to filter on
 			operand: MapTypeToOperands<FT>[TypeName<FT>][keyof MapTypeToOperands<
 				FT
 			>[TypeName<FT>]]
@@ -337,9 +343,44 @@ export type GraphQLCondition = Partial<
 
 //#region Pagination
 
-export type PaginationInput = {
+export type ProducerPaginationInput<T extends PersistentModel> = {
+	sort?: ProducerSortPredicate<T>;
 	limit?: number;
 	page?: number;
+};
+
+export type PaginationInput<T extends PersistentModel> = {
+	sort?: SortPredicate<T>;
+	limit?: number;
+	page?: number;
+};
+
+export type ProducerSortPredicate<M extends PersistentModel> = (
+	condition: SortPredicate<M>
+) => SortPredicate<M>;
+
+export type SortPredicate<T extends PersistentModel> = {
+	[K in keyof T]-?: SortPredicateExpression<T, NonNullable<T[K]>>;
+};
+
+export type SortPredicateExpression<M extends PersistentModel, FT> = TypeName<
+	FT
+> extends keyof MapTypeToOperands<FT>
+	? (sortDirection: keyof typeof SortDirection) => SortPredicate<M>
+	: never;
+
+export enum SortDirection {
+	ASCENDING = 'ASCENDING',
+	DESCENDING = 'DESCENDING',
+}
+
+export type SortPredicatesGroup<
+	T extends PersistentModel
+> = SortPredicateObject<T>[];
+
+export type SortPredicateObject<T extends PersistentModel> = {
+	field: keyof T;
+	sortDirection: keyof typeof SortDirection;
 };
 
 //#endregion

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -16,6 +16,8 @@ import {
 	RelationshipType,
 	RelationType,
 	SchemaNamespace,
+	SortPredicatesGroup,
+	SortDirection,
 } from './types';
 
 export const exhaustiveCheck = (obj: never, throwOnError: boolean = true) => {
@@ -401,4 +403,29 @@ export function getNow() {
 	} else {
 		return Date.now();
 	}
+}
+
+export function sortCompareFunction<T extends PersistentModel>(
+	sortPredicates: SortPredicatesGroup<T>
+) {
+	return function compareFunction(a, b) {
+		// enable multi-field sort by iterating over predicates until
+		// a comparison returns -1 or 1
+		for (const predicate of sortPredicates) {
+			const { field, sortDirection } = predicate;
+
+			// reverse result when direction is descending
+			const sortMultiplier = sortDirection === SortDirection.ASCENDING ? 1 : -1;
+
+			if (a[field] < b[field]) {
+				return -1 * sortMultiplier;
+			}
+
+			if (a[field] > b[field]) {
+				return 1 * sortMultiplier;
+			}
+		}
+
+		return 0;
+	};
 }


### PR DESCRIPTION
* Enables passing a sort predicate to `DataStore.query`

E.g.,
```typescript
import { DataStore, Predicates, SortDirection } from '@aws-amplify/datastore';

await DataStore.query(User, Predicates.ALL, {
  page: 0,
  limit: 50,
  sort: (s) => s.lastName(SortDirection.ASCENDING),
});
```
* The sort predicate is chainable, allowing for multi-field sort: `s.lastName('ASCENDING').age('DESCENDING')`
* Full TypeScript Intellisense support, like with the query predicate




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
