### PR TITLE
Update to Auth.configure(config?) for retrieving the config

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.tsx
@@ -22,7 +22,7 @@ export class AmplifyAuth0Button {
 
   private handleLoad = () => {
     // @ts-ignore Property 'auth0' does not exist on type '{}'.
-    const { oauth = {} } = Auth.configure({});
+    const { oauth = {} } = Auth.configure();
     // @ts-ignore Property 'auth0' does not exist on type '{}'.
     const { config = oauth.auth0 } = this;
 

--- a/packages/amplify-ui-components/src/components/amplify-federated-buttons/amplify-federated-buttons.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-federated-buttons/amplify-federated-buttons.tsx
@@ -24,7 +24,7 @@ export class AmplifyFederatedButtons {
       throw new Error(NO_AUTH_MODULE_FOUND);
     }
 
-    const { oauth = {} } = Auth.configure({});
+    const { oauth = {} } = Auth.configure();
 
     // backward compatibility
     if (oauth['domain']) {

--- a/packages/amplify-ui-components/src/components/amplify-federated-sign-in/amplify-federated-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-federated-sign-in/amplify-federated-sign-in.tsx
@@ -22,7 +22,7 @@ export class AmplifyFederatedSignIn {
       throw new Error(NO_AUTH_MODULE_FOUND);
     }
 
-    const { oauth = {} } = Auth.configure({});
+    const { oauth = {} } = Auth.configure();
 
     // backward compatibility
     if (oauth['domain']) {

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -125,7 +125,7 @@ export class AuthClass {
 		return 'Auth';
 	}
 
-	configure(config) {
+	configure(config?) {
 		if (!config) return this._config || {};
 		logger.debug('configure Auth');
 		const conf = Object.assign(


### PR DESCRIPTION
_Issue #, if available:_ #6786 


- `Auth.configure({})` was being used for retrieving the config, **but this resets `Auth` back to defaults. (Breaking `Amplify.configure({ ssr: true })`)**.

- Updates signature to `Amplify.configure(config?)`.

- Reproduced via https://github.com/aws-amplify/amplify-js-samples-staging/pull/160


### Before

(Notice `Auth._storage` changes on render)

![Screen Shot 2020-09-14 at 3 25 45 PM](https://user-images.githubusercontent.com/15182/93147186-715a4700-f6a5-11ea-8f27-951429be29bd.png)

### After

(Notice `Auth._storage` is the same shape)

![Screen Shot 2020-09-14 at 4 05 35 PM](https://user-images.githubusercontent.com/15182/93147094-64d5ee80-f6a5-11ea-922b-846d6367cd76.png)


Closes #6786

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
