### PR TITLE
fix(@aws-amplify/auth): Fix binding for Auth.currentCredentials

### DIFF
--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -2371,7 +2371,7 @@ describe('auth unit test', () => {
 				});
 
 			const spyon3 = jest
-				.spyOn(Auth.prototype, 'currentCredentials')
+				.spyOn(auth, 'currentCredentials')
 				.mockImplementationOnce(() => {
 					return Promise.resolve({
 						identityId: 'identityId',

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1348,7 +1348,6 @@ export class AuthClass {
 	 * @return - A promise resolves to be current user's credentials
 	 */
 	public async currentUserCredentials(): Promise<ICredentials> {
-		const that = this;
 		logger.debug('Getting current user credentials');
 
 		try {

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -103,6 +103,7 @@ export class AuthClass {
 	 */
 	constructor(config: AuthOptions) {
 		this.configure(config);
+		this.currentCredentials = this.currentCredentials.bind(this);
 		this.currentUserCredentials = this.currentUserCredentials.bind(this);
 
 		Hub.listen('auth', ({ payload }) => {


### PR DESCRIPTION
_Issue #, if available:_ Fixes #6806 

- `Auth.currentCredentials` wasn't bound to `this` like `Auth.currentUserCredentials` are. This caused the error "`this is undefined`".

- Customers should use `Auth.currentUserCredentials` instead, and in the meantime. (`Auth.currentCredentials` is likely to be deprecated)

- I recommend customers configure with `Amplify.configure` instead of `Auth.configure` as well.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
