### PR TITLE
Cypress image bump for js test executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
 
   js-test-executor:
     docker:
-      - image: cypress/included:4.12.1
+      - image: cypress/included:5.2.0
       - image: verdaccio/verdaccio
     resource_class: large
 


### PR DESCRIPTION
_Description of changes:_
- Use Cypress 5.2 image for CircleCI js tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
