### PR TITLE
fix(@aws-amplify/auth): No Auth module registered in Amplify

### DIFF
--- a/packages/core/__tests__/Credentials-test.ts
+++ b/packages/core/__tests__/Credentials-test.ts
@@ -26,6 +26,30 @@ const cacheClass = {
 };
 
 describe('Credentials test', () => {
+	describe('.Auth', () => {
+		it('should be undefined by default', async () => {
+			const credentials = new Credentials(null);
+
+			expect(credentials.Auth).toBeUndefined();
+
+			expect(credentials.get()).rejects.toMatchInlineSnapshot(
+				`"No Auth module registered in Amplify"`
+			);
+		});
+
+		it('should be Amplify.Auth if configured through Amplify', () => {
+			const credentials = new Credentials(null);
+
+			Amplify.register(authClass);
+			Amplify.register(credentials);
+
+			Amplify.configure({});
+
+			expect(credentials.Auth).toBe(authClass);
+			expect(credentials.get()).resolves.toBe('cred');
+		});
+	});
+
 	describe('configure test', () => {
 		test('happy case', () => {
 			const config = {


### PR DESCRIPTION
_Issue #, if available:_ Fixes #6750

- Introduced by #6146, `Credentials` referenced `Amplify.Auth` for deferring to `Auth.currentUserCredentials()`, but only when `Auth` was imported/registered.

- The bug was that `Auth = Amplify.Auth` only worked when `Auth` was already imported & registered _first_, which wasn't always the case.

- Instead, `this.Auth` is preferred over `Amplify.Auth` within the `_keepAlive` function at run-time, rather than when constructed.  This ensures that `this.Auth` wins for SSR, but `Amplify.Auth` is always the latest reference.

---


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
