### PR TITLE
fix(aws-amplify): Amplify.register is called per-instance, not per-import

### DIFF
--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -75,6 +75,7 @@ export class AnalyticsClass {
 		Hub.listen('auth', listener);
 		Hub.listen('storage', listener);
 		Hub.listen('analytics', listener);
+		Amplify.register(this);
 	}
 
 	public getModuleName() {
@@ -401,4 +402,3 @@ const sendEvents = () => {
 };
 
 export const Analytics = new AnalyticsClass();
-Amplify.register(Analytics);

--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -78,7 +78,7 @@ export class AnalyticsClass {
 		Hub.listen('analytics', listener);
 
 		// Register module each time on the client, but not on the server to prevent memory leaks
-		if (browserOrNode().isBrowser) {
+		if (!browserOrNode().isNode) {
 			Amplify.register(this);
 		}
 	}

--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -15,6 +15,7 @@ import {
 	Amplify,
 	ConsoleLogger as Logger,
 	Hub,
+	browserOrNode,
 	Parser,
 } from '@aws-amplify/core';
 import { AWSPinpointProvider } from './Providers/AWSPinpointProvider';
@@ -75,7 +76,11 @@ export class AnalyticsClass {
 		Hub.listen('auth', listener);
 		Hub.listen('storage', listener);
 		Hub.listen('analytics', listener);
-		Amplify.register(this);
+
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (browserOrNode().isBrowser) {
+			Amplify.register(this);
+		}
 	}
 
 	public getModuleName() {

--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -57,6 +57,7 @@ export class GraphQLAPIClass {
 	 */
 	constructor(options) {
 		this._options = options;
+		Amplify.register(this);
 		logger.debug('API Options', this._options);
 	}
 
@@ -378,4 +379,3 @@ export class GraphQLAPIClass {
 }
 
 export const GraphQLAPI = new GraphQLAPIClass(null);
-Amplify.register(GraphQLAPI);

--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -60,7 +60,7 @@ export class GraphQLAPIClass {
 		this._options = options;
 
 		// Register module each time on the client, but not on the server to prevent memory leaks
-		if (browserOrNode().isBrowser) {
+		if (!browserOrNode().isNode) {
 			Amplify.register(this);
 		}
 

--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -18,6 +18,7 @@ import { parse } from 'graphql/language/parser';
 import Observable from 'zen-observable-ts';
 import {
 	Amplify,
+	browserOrNode,
 	ConsoleLogger as Logger,
 	Constants,
 	Credentials,
@@ -57,7 +58,12 @@ export class GraphQLAPIClass {
 	 */
 	constructor(options) {
 		this._options = options;
-		Amplify.register(this);
+
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (browserOrNode().isBrowser) {
+			Amplify.register(this);
+		}
+
 		logger.debug('API Options', this._options);
 	}
 

--- a/packages/api-rest/src/RestAPI.ts
+++ b/packages/api-rest/src/RestAPI.ts
@@ -38,6 +38,7 @@ export class RestAPIClass {
 	 */
 	constructor(options) {
 		this._options = options;
+		Amplify.register(this);
 		logger.debug('API Options', this._options);
 	}
 
@@ -336,4 +337,3 @@ export class RestAPIClass {
 }
 
 export const RestAPI = new RestAPIClass(null);
-Amplify.register(RestAPI);

--- a/packages/api-rest/src/RestAPI.ts
+++ b/packages/api-rest/src/RestAPI.ts
@@ -41,7 +41,7 @@ export class RestAPIClass {
 		this._options = options;
 
 		// Register module each time on the client, but not on the server to prevent memory leaks
-		if (browserOrNode().isBrowser) {
+		if (!browserOrNode().isNode) {
 			Amplify.register(this);
 		}
 

--- a/packages/api-rest/src/RestAPI.ts
+++ b/packages/api-rest/src/RestAPI.ts
@@ -13,6 +13,7 @@
 import { RestClient } from './RestClient';
 import {
 	Amplify,
+	browserOrNode,
 	ConsoleLogger as Logger,
 	Credentials,
 } from '@aws-amplify/core';
@@ -38,7 +39,12 @@ export class RestAPIClass {
 	 */
 	constructor(options) {
 		this._options = options;
-		Amplify.register(this);
+
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (browserOrNode().isBrowser) {
+			Amplify.register(this);
+		}
+
 		logger.debug('API Options', this._options);
 	}
 

--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -20,6 +20,7 @@ import {
 } from '@aws-amplify/api-graphql';
 import {
 	Amplify,
+	browserOrNode,
 	ConsoleLogger as Logger,
 	Credentials,
 } from '@aws-amplify/core';
@@ -52,7 +53,12 @@ export class APIClass {
 		this._options = options;
 		this._restApi = new RestAPIClass(options);
 		this._graphqlApi = new GraphQLAPIClass(options);
-		Amplify.register(this);
+
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (browserOrNode().isBrowser) {
+			Amplify.register(this);
+		}
+
 		logger.debug('API Options', this._options);
 	}
 

--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -55,7 +55,7 @@ export class APIClass {
 		this._graphqlApi = new GraphQLAPIClass(options);
 
 		// Register module each time on the client, but not on the server to prevent memory leaks
-		if (browserOrNode().isBrowser) {
+		if (!browserOrNode().isNode) {
 			Amplify.register(this);
 		}
 

--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -52,6 +52,7 @@ export class APIClass {
 		this._options = options;
 		this._restApi = new RestAPIClass(options);
 		this._graphqlApi = new GraphQLAPIClass(options);
+		Amplify.register(this);
 		logger.debug('API Options', this._options);
 	}
 
@@ -196,4 +197,3 @@ export class APIClass {
 }
 
 export const API = new APIClass(null);
-Amplify.register(API);

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -43,6 +43,7 @@ import {
 	Parser,
 	JS,
 	UniversalStorage,
+	browserOrNode,
 } from '@aws-amplify/core';
 import {
 	CookieStorage,
@@ -120,7 +121,11 @@ export class AuthClass {
 					break;
 			}
 		});
-		Amplify.register(this);
+
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (browserOrNode().isBrowser) {
+			Amplify.register(this);
+		}
 	}
 
 	public getModuleName() {
@@ -1522,7 +1527,7 @@ export class AuthClass {
 		resolve: () => void,
 		reject: (reason?: any) => void
 	) {
-		const { isBrowser } = JS.browserOrNode();
+		const { isBrowser } = browserOrNode();
 
 		if (isBrowser) {
 			this.oAuthSignOutRedirectOrReject(reject);
@@ -1890,7 +1895,7 @@ export class AuthClass {
 			);
 
 			const currentUrl =
-				URL || (JS.browserOrNode().isBrowser ? window.location.href : '');
+				URL || (browserOrNode().isBrowser ? window.location.href : '');
 
 			const hasCodeOrError = !!(parse(currentUrl).query || '')
 				.split('&')

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -43,7 +43,6 @@ import {
 	Parser,
 	JS,
 	UniversalStorage,
-	browserOrNode,
 } from '@aws-amplify/core';
 import {
 	CookieStorage,
@@ -123,7 +122,7 @@ export class AuthClass {
 		});
 
 		// Register module each time on the client, but not on the server to prevent memory leaks
-		if (browserOrNode().isBrowser) {
+		if (JS.browserOrNode().isBrowser) {
 			Amplify.register(this);
 		}
 	}
@@ -1527,7 +1526,7 @@ export class AuthClass {
 		resolve: () => void,
 		reject: (reason?: any) => void
 	) {
-		const { isBrowser } = browserOrNode();
+		const { isBrowser } = JS.browserOrNode();
 
 		if (isBrowser) {
 			this.oAuthSignOutRedirectOrReject(reject);
@@ -1895,7 +1894,7 @@ export class AuthClass {
 			);
 
 			const currentUrl =
-				URL || (browserOrNode().isBrowser ? window.location.href : '');
+				URL || (JS.browserOrNode().isBrowser ? window.location.href : '');
 
 			const hasCodeOrError = !!(parse(currentUrl).query || '')
 				.split('&')

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -120,6 +120,7 @@ export class AuthClass {
 					break;
 			}
 		});
+		Amplify.register(this);
 	}
 
 	public getModuleName() {
@@ -2085,5 +2086,3 @@ export class AuthClass {
 }
 
 export const Auth = new AuthClass(null);
-
-Amplify.register(Auth);

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -17,6 +17,7 @@ import {
 	GetIdCommand,
 } from '@aws-sdk/client-cognito-identity';
 import { CredentialProvider } from '@aws-sdk/types';
+import { browserOrNode } from '../lib-esm';
 
 const logger = new Logger('Credentials');
 
@@ -40,6 +41,11 @@ export class CredentialsClass {
 		this.configure(config);
 		this._refreshHandlers['google'] = GoogleOAuth.refreshGoogleToken;
 		this._refreshHandlers['facebook'] = FacebookOAuth.refreshFacebookToken;
+
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (browserOrNode().isBrowser) {
+			Amplify.register(this);
+		}
 	}
 
 	public getModuleName() {
@@ -545,8 +551,6 @@ export class CredentialsClass {
 }
 
 export const Credentials = new CredentialsClass(null);
-
-Amplify.register(Credentials);
 
 /**
  * @deprecated use named import

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -1,6 +1,6 @@
 import { ConsoleLogger as Logger } from './Logger';
 import { StorageHelper } from './StorageHelper';
-import { makeQuerablePromise } from './JS';
+import { makeQuerablePromise, browserOrNode } from './JS';
 import { FacebookOAuth, GoogleOAuth } from './OAuthHelper';
 import { jitteredExponentialRetry } from './Util';
 import { ICredentials } from './types';
@@ -17,7 +17,6 @@ import {
 	GetIdCommand,
 } from '@aws-sdk/client-cognito-identity';
 import { CredentialProvider } from '@aws-sdk/types';
-import { browserOrNode } from '../lib-esm';
 
 const logger = new Logger('Credentials');
 

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -42,7 +42,7 @@ export class CredentialsClass {
 		this._refreshHandlers['facebook'] = FacebookOAuth.refreshFacebookToken;
 
 		// Register module each time on the client, but not on the server to prevent memory leaks
-		if (browserOrNode().isBrowser) {
+		if (!browserOrNode().isNode) {
 			Amplify.register(this);
 		}
 	}

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -524,6 +524,10 @@ class DataStore {
 	private sync: SyncEngine;
 	private syncPageSize: number;
 
+	constructor() {
+		Amplify.register(this);
+	}
+
 	getModuleName() {
 		return 'DataStore';
 	}
@@ -1047,6 +1051,5 @@ class DataStore {
 }
 
 const instance = new DataStore();
-Amplify.register(instance);
 
 export { DataStore as DataStoreClass, initSchema, instance as DataStore };

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -532,7 +532,7 @@ class DataStore {
 
 	constructor() {
 		// Register module each time on the client, but not on the server to prevent memory leaks
-		if (browserOrNode().isBrowser) {
+		if (!browserOrNode().isNode) {
 			Amplify.register(this);
 		}
 	}

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -1,4 +1,10 @@
-import { Amplify, ConsoleLogger as Logger, Hub, JS } from '@aws-amplify/core';
+import {
+	Amplify,
+	browserOrNode,
+	ConsoleLogger as Logger,
+	Hub,
+	JS,
+} from '@aws-amplify/core';
 import { Draft, immerable, produce, setAutoFreeze } from 'immer';
 import { v4 as uuid4 } from 'uuid';
 import Observable, { ZenObservable } from 'zen-observable-ts';
@@ -525,7 +531,10 @@ class DataStore {
 	private syncPageSize: number;
 
 	constructor() {
-		Amplify.register(this);
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (browserOrNode().isBrowser) {
+			Amplify.register(this);
+		}
 	}
 
 	getModuleName() {

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -35,6 +35,7 @@ export class InteractionsClass {
 		this._options = options;
 		logger.debug('Interactions Options', this._options);
 		this._pluggables = {};
+		Amplify.register(this);
 	}
 
 	public getModuleName() {
@@ -147,4 +148,3 @@ export class InteractionsClass {
 }
 
 export const Interactions = new InteractionsClass(null);
-Amplify.register(Interactions);

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -17,7 +17,11 @@ import {
 	InteractionsMessage,
 	InteractionsResponse,
 } from './types';
-import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
+import {
+	Amplify,
+	browserOrNode,
+	ConsoleLogger as Logger,
+} from '@aws-amplify/core';
 import { AWSLexProvider } from './Providers';
 const logger = new Logger('Interactions');
 
@@ -35,7 +39,11 @@ export class InteractionsClass {
 		this._options = options;
 		logger.debug('Interactions Options', this._options);
 		this._pluggables = {};
-		Amplify.register(this);
+
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (browserOrNode().isBrowser) {
+			Amplify.register(this);
+		}
 	}
 
 	public getModuleName() {

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -41,7 +41,7 @@ export class InteractionsClass {
 		this._pluggables = {};
 
 		// Register module each time on the client, but not on the server to prevent memory leaks
-		if (browserOrNode().isBrowser) {
+		if (!browserOrNode().isNode) {
 			Amplify.register(this);
 		}
 	}

--- a/packages/predictions/src/Predictions.ts
+++ b/packages/predictions/src/Predictions.ts
@@ -42,6 +42,7 @@ export class PredictionsClass {
 		this._convertPluggables = [];
 		this._identifyPluggables = [];
 		this._interpretPluggables = [];
+		Amplify.register(this);
 	}
 
 	public getModuleName() {
@@ -246,4 +247,3 @@ export class PredictionsClass {
 }
 
 export const Predictions = new PredictionsClass({});
-Amplify.register(Predictions);

--- a/packages/predictions/src/Predictions.ts
+++ b/packages/predictions/src/Predictions.ts
@@ -22,7 +22,11 @@ import {
 	AbstractInterpretPredictionsProvider,
 	AbstractPredictionsProvider,
 } from './types/Providers';
-import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
+import {
+	Amplify,
+	browserOrNode,
+	ConsoleLogger as Logger,
+} from '@aws-amplify/core';
 
 const logger = new Logger('Predictions');
 
@@ -42,7 +46,11 @@ export class PredictionsClass {
 		this._convertPluggables = [];
 		this._identifyPluggables = [];
 		this._interpretPluggables = [];
-		Amplify.register(this);
+
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (browserOrNode().isBrowser) {
+			Amplify.register(this);
+		}
 	}
 
 	public getModuleName() {

--- a/packages/predictions/src/Predictions.ts
+++ b/packages/predictions/src/Predictions.ts
@@ -48,7 +48,7 @@ export class PredictionsClass {
 		this._interpretPluggables = [];
 
 		// Register module each time on the client, but not on the server to prevent memory leaks
-		if (browserOrNode().isBrowser) {
+		if (!browserOrNode().isNode) {
 			Amplify.register(this);
 		}
 	}

--- a/packages/pubsub/src/PubSub.ts
+++ b/packages/pubsub/src/PubSub.ts
@@ -73,7 +73,11 @@ export class PubSubClass {
 		logger.debug('PubSub Options', this._options);
 		this._pluggables = [];
 		this.subscribe = this.subscribe.bind(this);
-		Amplify.register(this);
+
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (browserOrNode().isBrowser) {
+			Amplify.register(this);
+		}
 	}
 
 	public getModuleName() {

--- a/packages/pubsub/src/PubSub.ts
+++ b/packages/pubsub/src/PubSub.ts
@@ -75,7 +75,7 @@ export class PubSubClass {
 		this.subscribe = this.subscribe.bind(this);
 
 		// Register module each time on the client, but not on the server to prevent memory leaks
-		if (browserOrNode().isBrowser) {
+		if (!browserOrNode().isNode) {
 			Amplify.register(this);
 		}
 	}

--- a/packages/pubsub/src/PubSub.ts
+++ b/packages/pubsub/src/PubSub.ts
@@ -73,6 +73,7 @@ export class PubSubClass {
 		logger.debug('PubSub Options', this._options);
 		this._pluggables = [];
 		this.subscribe = this.subscribe.bind(this);
+		Amplify.register(this);
 	}
 
 	public getModuleName() {
@@ -183,4 +184,3 @@ export class PubSubClass {
 }
 
 export const PubSub = new PubSubClass(null);
-Amplify.register(PubSub);

--- a/packages/pushnotification/__tests__/PushNotification-test.ts
+++ b/packages/pushnotification/__tests__/PushNotification-test.ts
@@ -73,7 +73,7 @@ describe('PushNotification:', () => {
 			// Spy should be at 0 (it was already called on import)
 			expect(registerSpy).toHaveBeenCalledTimes(0);
 
-			// Global Amplify will always reference last registered intance
+			// Global Amplify will always reference last registered instance
 			const NewPushNotification = new PushNotification(null);
 			expect(Amplify.Pushnotification).toEqual(NewPushNotification);
 

--- a/packages/pushnotification/__tests__/PushNotification-test.ts
+++ b/packages/pushnotification/__tests__/PushNotification-test.ts
@@ -1,3 +1,14 @@
+jest.mock('@aws-amplify/core', () => ({
+	__esModule: true,
+	...jest.requireActual('@aws-amplify/core'),
+	browserOrNode() {
+		return {
+			isBrowser: true,
+			isNode: false,
+		};
+	},
+}));
+
 import { DeviceEventEmitter, Platform, NativeModules } from 'react-native';
 import Amplify from 'aws-amplify';
 import PushNotificationIOS from '@react-native-community/push-notification-ios';

--- a/packages/pushnotification/__tests__/PushNotification-test.ts
+++ b/packages/pushnotification/__tests__/PushNotification-test.ts
@@ -73,12 +73,12 @@ describe('PushNotification:', () => {
 			// Spy should be at 0 (it was already called on import)
 			expect(registerSpy).toHaveBeenCalledTimes(0);
 
-			// Global Amplify should keep original instance, not new instances
+			// Global Amplify will always reference last registered intance
 			const NewPushNotification = new PushNotification(null);
-			expect(Amplify.Pushnotification).not.toEqual(NewPushNotification);
+			expect(Amplify.Pushnotification).toEqual(NewPushNotification);
 
-			// Amplify.register should not have been called for the new instance
-			expect(registerSpy).toHaveBeenCalledTimes(0);
+			// Amplify.register should be called for the new instance
+			expect(registerSpy).toHaveBeenCalledTimes(1);
 			registerSpy.mockClear();
 		});
 	});

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -19,7 +19,12 @@ import {
 	AppState,
 } from 'react-native';
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
-import { Amplify, ConsoleLogger as Logger, JS } from '@aws-amplify/core';
+import {
+	Amplify,
+	browserOrNode,
+	ConsoleLogger as Logger,
+	isEmpty,
+} from '@aws-amplify/core';
 
 const logger = new Logger('Notification');
 
@@ -57,7 +62,10 @@ export default class PushNotification {
 
 		this._notificationOpenedHandlers = [];
 
-		Amplify.register(this);
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (browserOrNode().isBrowser) {
+			Amplify.register(this);
+		}
 	}
 
 	getModuleName() {
@@ -65,7 +73,7 @@ export default class PushNotification {
 	}
 
 	configure(config) {
-		if (JS.isEmpty(config)) return this._config;
+		if (isEmpty(config)) return this._config;
 		let conf = config ? config.PushNotification || config : {};
 
 		if (config['aws_mobile_analytics_app_id']) {

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -62,7 +62,10 @@ export default class PushNotification {
 
 		this._notificationOpenedHandlers = [];
 
-		Amplify.register(this);
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (!browserOrNode().isNode) {
+			Amplify.register(this);
+		}
 	}
 
 	getModuleName() {

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -62,10 +62,7 @@ export default class PushNotification {
 
 		this._notificationOpenedHandlers = [];
 
-		// Register module each time on the client, but not on the server to prevent memory leaks
-		if (browserOrNode().isBrowser) {
-			Amplify.register(this);
-		}
+		Amplify.register(this);
 	}
 
 	getModuleName() {

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -56,6 +56,8 @@ export default class PushNotification {
 		this._iosInitialized = false;
 
 		this._notificationOpenedHandlers = [];
+
+		Amplify.register(this);
 	}
 
 	getModuleName() {

--- a/packages/pushnotification/src/index.ts
+++ b/packages/pushnotification/src/index.ts
@@ -10,11 +10,9 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import { Amplify } from '@aws-amplify/core';
 import NotificationClass from './PushNotification';
 
 const _instance = new NotificationClass(null);
 const PushNotification = _instance;
-Amplify.register(PushNotification);
 
 export default PushNotification;

--- a/packages/storage/src/Storage.ts
+++ b/packages/storage/src/Storage.ts
@@ -53,7 +53,7 @@ export class Storage {
 		this.list = this.list.bind(this);
 
 		// Register module each time on the client, but not on the server to prevent memory leaks
-		if (browserOrNode().isBrowser) {
+		if (!browserOrNode().isNode) {
 			Amplify.register(this);
 		}
 	}

--- a/packages/storage/src/Storage.ts
+++ b/packages/storage/src/Storage.ts
@@ -11,7 +11,12 @@
  * and limitations under the License.
  */
 
-import { ConsoleLogger as Logger, Parser } from '@aws-amplify/core';
+import {
+	Amplify,
+	browserOrNode,
+	ConsoleLogger as Logger,
+	Parser,
+} from '@aws-amplify/core';
 import { AWSS3Provider } from './providers';
 import { StorageProvider } from './types';
 
@@ -46,7 +51,11 @@ export class Storage {
 		this.put = this.put.bind(this);
 		this.remove = this.remove.bind(this);
 		this.list = this.list.bind(this);
-		Amplify.register(this);
+
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (browserOrNode().isBrowser) {
+			Amplify.register(this);
+		}
 	}
 
 	public getModuleName() {

--- a/packages/storage/src/Storage.ts
+++ b/packages/storage/src/Storage.ts
@@ -46,6 +46,7 @@ export class Storage {
 		this.put = this.put.bind(this);
 		this.remove = this.remove.bind(this);
 		this.list = this.list.bind(this);
+		Amplify.register(this);
 	}
 
 	public getModuleName() {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -13,7 +13,7 @@
 
 import { Storage as StorageClass } from './Storage';
 
-import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
+import { ConsoleLogger as Logger } from '@aws-amplify/core';
 
 const logger = new Logger('Storage');
 
@@ -48,7 +48,6 @@ const getInstance = () => {
 };
 
 export const Storage: StorageClass = getInstance();
-Amplify.register(Storage);
 
 /**
  * @deprecated use named import

--- a/packages/xr/src/XR.ts
+++ b/packages/xr/src/XR.ts
@@ -38,6 +38,7 @@ export class XRClass {
 
 		// Add default provider
 		this.addPluggable(new SumerianProvider());
+		Amplify.register(this);
 	}
 
 	/**
@@ -211,4 +212,3 @@ export class XRClass {
 }
 
 export const XR = new XRClass(null);
-Amplify.register(XR);

--- a/packages/xr/src/XR.ts
+++ b/packages/xr/src/XR.ts
@@ -44,7 +44,7 @@ export class XRClass {
 		this.addPluggable(new SumerianProvider());
 
 		// Register module each time on the client, but not on the server to prevent memory leaks
-		if (browserOrNode().isBrowser) {
+		if (!browserOrNode().isNode) {
 			Amplify.register(this);
 		}
 	}

--- a/packages/xr/src/XR.ts
+++ b/packages/xr/src/XR.ts
@@ -10,7 +10,11 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
+import {
+	Amplify,
+	browserOrNode,
+	ConsoleLogger as Logger,
+} from '@aws-amplify/core';
 import { XRProvider, XROptions, SceneOptions } from './types';
 import { SumerianProvider } from './Providers/SumerianProvider';
 import { XRProviderNotConfigured } from './Errors';
@@ -38,7 +42,11 @@ export class XRClass {
 
 		// Add default provider
 		this.addPluggable(new SumerianProvider());
-		Amplify.register(this);
+
+		// Register module each time on the client, but not on the server to prevent memory leaks
+		if (browserOrNode().isBrowser) {
+			Amplify.register(this);
+		}
 	}
 
 	/**


### PR DESCRIPTION
_Issue #, if available:_ Fixes #6761, Fixes #6836 

Introduced by #6146, `Amplify.register` was moved to per-import (so that `Amplify.Auth` was always the same singleton) rather than per-instance (so that each `req` creating `new Auth` on the server wouldn't create memory leaks for the lifetime of the server!).

`withSSRContext` explicitly registers modules to a _new_ `amplify` instance:

https://github.com/aws-amplify/amplify-js/blob/26ce5dfb0270009fc10f003f5627046ddaf5ae4e/packages/aws-amplify/src/withSSRContext.ts#L34-L40

This PR reverts:

1. 167c787990727093bc1cfb53efa80fb57f9f0467
2. (Partially) fd830eb2598476b0d54b97990533472c0da110ca

For validation, I ran **production** builds of Next.js, CRA, & Angular (https://github.com/aws-amplify/amplify-js-samples-staging/pull/166).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
