### PR TITLE
deps(@aws-amplify/core): bump universal cookie to ^4.0.4

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,7 @@
 		"@aws-sdk/types": "1.0.0-gamma.6",
 		"@aws-sdk/util-hex-encoding": "1.0.0-gamma.6",
 		"@aws-sdk/util-user-agent-browser": "1.0.0-gamma.7",
-		"universal-cookie": "^4.0.3",
+		"universal-cookie": "^4.0.4",
 		"url": "^0.11.0",
 		"zen-observable-ts": "0.8.19"
 	},


### PR DESCRIPTION
_Issue #, if available:_ #6826.

_Description of changes:_ `universal-cookie: 4.0.4` resolves `require is not undefined` error that appeared when using Amplify with Rollup. I confirmed that this fixes the rollup errors in our docs as well.

Customers should already have `4.0.4` because we have `universal-cookie: ^4.0.3`, but I wanted to get the resolved version specified in `package.json`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.