### PR TITLE
fix(@aws-amplify/datastore): use Auth storage for OIDC 

### DIFF
--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -24,7 +24,7 @@ import {
 	INTERNAL_AWS_APPSYNC_REALTIME_PUBSUB_PROVIDER,
 } from '@aws-amplify/core';
 import PubSub from '@aws-amplify/pubsub';
-import Auth from '@aws-amplify/auth';
+import Auth, { getAuthStorage } from '@aws-amplify/auth';
 import Cache from '@aws-amplify/cache';
 import { GraphQLOptions, GraphQLResult } from './types';
 import { RestClient } from '@aws-amplify/api-rest';
@@ -139,7 +139,16 @@ export class GraphQLAPIClass {
 				}
 				break;
 			case 'OPENID_CONNECT':
-				const federatedInfo = await this.Cache.getItem('federatedInfo');
+				// backwards compatibility
+				let federatedInfo = await Cache.getItem('federatedInfo');
+
+				if (!federatedInfo) {
+					const authConfig = Auth.configure();
+					const authStorage = getAuthStorage(authConfig);
+					federatedInfo = JSON.parse(
+						authStorage.getItem('aws-amplify-federatedInfo')
+					);
+				}
 
 				if (!federatedInfo || !federatedInfo.token) {
 					throw new Error('No federated jwt');

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -24,6 +24,7 @@ import { AuthErrorStrings } from './common/AuthErrorStrings';
  * @deprecated use named import
  */
 export default Auth;
+export * from './utils';
 export {
 	Auth,
 	CognitoUser,

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -51,6 +51,7 @@ export interface AuthOptions {
 	identityPoolRegion?: string;
 	clientMetadata?: any;
 	endpoint?: string;
+	ssr?: boolean;
 }
 
 export enum CognitoHostedUIIdentityProvider {

--- a/packages/auth/src/utils/AuthStorageUtils.ts
+++ b/packages/auth/src/utils/AuthStorageUtils.ts
@@ -1,0 +1,40 @@
+import { CookieStorage } from 'amazon-cognito-identity-js';
+import { Logger, UniversalStorage, StorageHelper } from '@aws-amplify/core';
+import { AuthOptions } from '../types';
+
+const logger = new Logger('AuthStorageUtils');
+
+/**
+ * @private
+ * Internal use of Amplify only
+ */
+export function getAuthStorage(config: AuthOptions) {
+	let storage;
+	if (!config.storage) {
+		// backwards compatibility
+		if (config.cookieStorage) storage = new CookieStorage(config.cookieStorage);
+		else {
+			storage = config.ssr
+				? new UniversalStorage()
+				: new StorageHelper().getStorage();
+		}
+	} else {
+		if (!isValidAuthStorage(config.storage)) {
+			logger.error('The storage in the Auth config is not valid!');
+			throw new Error('Empty storage object');
+		}
+		storage = config.storage;
+	}
+	return storage;
+}
+
+function isValidAuthStorage(obj) {
+	// We need to check if the obj has the functions of Storage
+	return (
+		!!obj &&
+		typeof obj.getItem === 'function' &&
+		typeof obj.setItem === 'function' &&
+		typeof obj.removeItem === 'function' &&
+		typeof obj.clear === 'function'
+	);
+}

--- a/packages/auth/src/utils/index.ts
+++ b/packages/auth/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './AuthStorageUtils';

--- a/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
@@ -27,7 +27,7 @@ import {
 	NonRetryableError,
 } from '@aws-amplify/core';
 import Cache from '@aws-amplify/cache';
-import Auth from '@aws-amplify/auth';
+import Auth, { getAuthStorage } from '@aws-amplify/auth';
 import { AbstractPubSubProvider } from './PubSubProvider';
 import { CONTROL_MSG } from '../index';
 
@@ -780,7 +780,16 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 	}
 
 	private async _awsRealTimeOPENIDHeader({ host }) {
-		const federatedInfo = await Cache.getItem('federatedInfo');
+		// backwards compatibility
+		let federatedInfo = await Cache.getItem('federatedInfo');
+
+		if (!federatedInfo) {
+			const authConfig = Auth.configure();
+			const authStorage = getAuthStorage(authConfig);
+			federatedInfo = JSON.parse(
+				authStorage.getItem('aws-amplify-federatedInfo')
+			);
+		}
 
 		if (!federatedInfo || !federatedInfo.token) {
 			throw new Error('No federated jwt');


### PR DESCRIPTION
_Issue #, if available:_
#6585 

_Description of changes:_
When using OIDC with DataStore & API (GraphQL), the federated token wasn't properly being retrieved. This PR will check `Cache` for backwards compatibility but fallback to using Auth storage via a new `getAuthStorage` utility (needed so that other internal packages can reference the appropriate storage mechanism).

**Before:**
![Screen Shot 2020-09-23 at 11 57 50 AM](https://user-images.githubusercontent.com/17091790/94057144-122abf80-fd94-11ea-8d6e-51f3078fc0f0.png)

**After:**
![after](https://user-images.githubusercontent.com/17091790/94057127-0dfea200-fd94-11ea-87ac-e6b28570ef53.gif)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
