### PR TITLE
fix: Add files with Amplify.register to sideEffects array

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -5,7 +5,13 @@
 	"main": "./lib/index.js",
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
-	"sideEffects": false,
+	"sideEffects": [
+		"./src/Analytics.ts",
+		"./lib/Analytics.js",
+		"./lib-esm/Analytics.js",
+		"./dist/aws-amplify-analytics.js",
+		"./dist/aws-amplify-analytics.min.js"
+	],
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -8,7 +8,13 @@
   "react-native": {
     "./lib/index": "./lib-esm/index.js"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/GraphQLAPI.ts",
+    "./lib/GraphQLAPI.js",
+    "./lib-esm/GraphQLAPI.js",
+    "./dist/aws-amplify-api-graphql.js",
+    "./dist/aws-amplify-api-graphql.min.js"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -8,7 +8,13 @@
   "react-native": {
     "./lib/index": "./lib-esm/index.js"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/RestAPI.ts",
+    "./lib/RestAPI.js",
+    "./lib-esm/RestAPI.js",
+    "./dist/aws-amplify-api-rest.js",
+    "./dist/aws-amplify-api-rest.min.js"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,7 +8,13 @@
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js"
 	},
-	"sideEffects": false,
+	"sideEffects": [
+		"./src/API.ts",
+		"./lib/API.js",
+		"./lib-esm/API.js",
+		"./dist/aws-amplify-api.js",
+		"./dist/aws-amplify-api.min.js"
+	],
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -8,7 +8,13 @@
   "react-native": {
     "./lib/index": "./lib-esm/index.js"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/Auth.ts",
+    "./lib/Auth.js",
+    "./lib-esm/Auth.js",
+    "./dist/aws-amplify-auth.js",
+    "./dist/aws-amplify-auth.min.js"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -8,7 +8,16 @@
   "react-native": {
     "./lib/index": "./lib-esm/reactnative.js"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/reactnative.ts",
+    "./src/index.ts",
+    "./lib/index.js",
+    "./lib/reactnative.js",
+    "./lib-esm/index.js",
+    "./lib-esm/reactnative.js",
+    "./dist/aws-amplify-cache.js",
+    "./dist/aws-amplify-cache.min.js"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,16 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"sideEffects": false,
+	"sideEffects": [
+		"./src/I18n/index.ts",
+		"./src/Credentials.ts",
+		"./lib/I18n/index.js",
+		"./lib/Credentials.js",
+		"./lib-esm/I18n/index.js",
+		"./lib-esm/Credentials.js",
+		"./dist/aws-amplify-core.min.js",
+		"./dist/aws-amplify-core.js"
+	],
 	"scripts": {
 		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
 		"build-with-test": "npm test && npm run build",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -11,7 +11,13 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"sideEffects": false,
+	"sideEffects": [
+		"./src/datastore/datastore.ts",
+		"./lib/datastore/datastore.js",
+		"./lib-esm/datastore/datastore.js",
+		"./dist/aws-amplify-datastore.min.js",
+		"./dist/aws-amplify-datastore.js"
+	],
 	"scripts": {
 		"test": "npm run lint && jest -w 1 --coverage",
 		"build-with-test": "npm test && npm run build",

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -8,7 +8,13 @@
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js"
 	},
-	"sideEffects": false,
+	"sideEffects": [
+		"./src/Interactions.ts",
+		"./lib/Interactions.js",
+		"./lib-esm/Interactions.js",
+		"./dist/aws-amplify-interactions.min.js",
+		"./dist/aws-amplify-interactions.js"
+	],
 	"publishConfig": {
 		"access": "public"
 	},

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -8,7 +8,13 @@
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js"
 	},
-	"sideEffects": false,
+	"sideEffects": [
+		"./src/Predictions.ts",
+		"./lib/Predictions.js",
+		"./lib-esm/Predictions.js",
+		"./dist/aws-amplify-predictions.min.js",
+		"./dist/aws-amplify-predictions.js"
+	],
 	"scripts": {
 		"test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2",
 		"build-with-test": "npm run clean && npm test && tsc && webpack -p",

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -8,7 +8,13 @@
   "react-native": {
     "./lib/index": "./lib-esm/index.js"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/PubSub.ts",
+    "./lib/PubSub.js",
+    "./lib-esm/PubSub.js",
+    "./dist/aws-amplify-pubsub.min.js",
+    "./dist/aws-amplify-pubsub.js"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -8,7 +8,13 @@
   "react-native": {
     "./lib/index": "./lib-esm/index.js"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/index.ts",
+    "./lib/index.js",
+    "./lib-esm/index.js",
+    "./dist/aws-amplify-storage.min.js",
+    "./dist/aws-amplify-storage.js"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -8,7 +8,13 @@
   "react-native": {
     "./lib/index": "./lib-esm/index.js"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/XR.ts",
+    "./lib/XR.js",
+    "./lib-esm/XR.js",
+    "./dist/aws-amplify-xr.min.js",
+    "./dist/aws-amplify-xr.js"
+  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
_Issue #, if available:_
Related to #6844

_Description of changes:_
This PR adds files that call `Amplify.configure()` to the `"sideEffects"` key in `package.json`.

The purpose of this is to *hint* bundlers to not remove the categories registration when creating the bundle.

Tests were done with an angular 9 application in production mode using `@aws-amplify/auth`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
