### PR TITLE
feat(datastore): support IndexedDB Adapter on web worker

### DIFF
--- a/packages/core/src/JS.ts
+++ b/packages/core/src/JS.ts
@@ -162,6 +162,15 @@ export const makeQuerablePromise = promise => {
 	return result;
 };
 
+export const isWebWorker = () => {
+	if (typeof self === 'undefined') {
+		return false;
+	}
+	const selfContext = self as { WorkerGlobalScope? };
+	return typeof selfContext.WorkerGlobalScope !== 'undefined' &&
+		self instanceof selfContext.WorkerGlobalScope;
+};
+
 export const browserOrNode = () => {
 	const isBrowser =
 		typeof window !== 'undefined' && typeof window.document !== 'undefined';
@@ -268,6 +277,7 @@ export class JS {
 	static isTextFile = isTextFile;
 	static generateRandomString = generateRandomString;
 	static makeQuerablePromise = makeQuerablePromise;
+	static isWebWorker = isWebWorker;
 	static browserOrNode = browserOrNode;
 	static transferKeyToLowerCase = transferKeyToLowerCase;
 	static transferKeyToUpperCase = transferKeyToUpperCase;

--- a/packages/datastore/src/storage/adapter/getDefaultAdapter/index.ts
+++ b/packages/datastore/src/storage/adapter/getDefaultAdapter/index.ts
@@ -1,10 +1,10 @@
-import { browserOrNode } from '@aws-amplify/core';
+import { browserOrNode, isWebWorker } from '@aws-amplify/core';
 import { Adapter } from '..';
 
 const getDefaultAdapter: () => Adapter = () => {
 	const { isBrowser } = browserOrNode();
 
-	if (isBrowser && window.indexedDB) {
+	if ((isBrowser && window.indexedDB) || (isWebWorker() && self.indexedDB)) {
 		return require('../indexeddb').default;
 	}
 


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/issues/6870

_Description of changes:_
* Add `isWebWorker` function to @aws-amplify/core to check if running on web worker or not
* Add isWebWorker condition in DataStore getDefaultAdapter

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.