### PR TITLE
fix(@aws-amplify/datastore): fix import isNullOrUndefined

### DIFF
--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -49,8 +49,8 @@ import {
 	STORAGE,
 	SYNC,
 	USER,
+	isNullOrUndefined,
 } from '../util';
-import { isNullOrUndefined } from 'util';
 
 setAutoFreeze(true);
 
@@ -237,9 +237,18 @@ const validateModelFields = (modelDefinition: SchemaModel | SchemaNonModel) => (
 	const fieldDefinition = modelDefinition.fields[k];
 
 	if (fieldDefinition !== undefined) {
-		const { type, isRequired, isArrayNullable, name, isArray } = fieldDefinition;
+		const {
+			type,
+			isRequired,
+			isArrayNullable,
+			name,
+			isArray,
+		} = fieldDefinition;
 
-		if (((!isArray && isRequired) || (isArray && !isArrayNullable)) && (v === null || v === undefined)) {
+		if (
+			((!isArray && isRequired) || (isArray && !isArrayNullable)) &&
+			(v === null || v === undefined)
+		) {
 			throw new Error(`Field ${name} is required`);
 		}
 
@@ -260,7 +269,9 @@ const validateModelFields = (modelDefinition: SchemaModel | SchemaNonModel) => (
 
 				if (
 					!isNullOrUndefined(v) &&
-					(<[]>v).some(e => typeof e !== jsType || (isNullOrUndefined(e) && isRequired))
+					(<[]>v).some(
+						e => typeof e !== jsType || (isNullOrUndefined(e) && isRequired)
+					)
 				) {
 					const elemTypes = (<[]>v).map(e => typeof e).join(',');
 

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -26,6 +26,10 @@ export const exhaustiveCheck = (obj: never, throwOnError: boolean = true) => {
 	}
 };
 
+export const isNullOrUndefined = (val: any): boolean => {
+	return typeof val === 'undefined' || val === undefined || val === null;
+};
+
 export const validatePredicate = <T extends PersistentModel>(
 	model: T,
 	groupType: keyof PredicateGroups<T>,


### PR DESCRIPTION
I missed [this](https://github.com/aws-amplify/amplify-js/pull/6784/files#diff-0b1030adae876f32132a5bffa1541233R53) while reviewing https://github.com/aws-amplify/amplify-js/pull/6784. It's attempting to import `isNullOrUndefined` from a dependency we don't explicitly install, **utils**.

It got caught in our integ tests, so it wasn't deployed with the bug.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
