### PR TITLE
ci: enable production integration testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ commands:
           command: |
             cd ~/amplify-js-samples-staging
             ~/amplify-js/.circleci/retry-yarn-script.sh -s 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >> << parameters.browser >> dev' -n 3
-       - run:
+      - run:
           name: 'Run cypress tests for << parameters.test_name >> sample on prod'
           command: |
             cd ~/amplify-js-samples-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,10 +106,15 @@ commands:
             echo "Current NPM registry: " $(yarn config get registry)
             ~/amplify-js/.circleci/retry-yarn-script.sh -s 'install' -n 3
       - run:
-          name: 'Run cypress tests for << parameters.test_name >> Sample'
+          name: 'Run cypress tests for << parameters.test_name >> sample on dev'
           command: |
             cd ~/amplify-js-samples-staging
-            ~/amplify-js/.circleci/retry-yarn-script.sh -s 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >> << parameters.browser >>' -n 3
+            ~/amplify-js/.circleci/retry-yarn-script.sh -s 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >> << parameters.browser >> dev' -n 3
+       - run:
+          name: 'Run cypress tests for << parameters.test_name >> sample on prod'
+          command: |
+            cd ~/amplify-js-samples-staging
+            ~/amplify-js/.circleci/retry-yarn-script.sh -s 'ci:test << parameters.framework >> << parameters.category >> << parameters.sample_name >> << parameters.spec >> << parameters.browser >> prod' -n 3
       - store_artifacts:
           path: ~/amplify-js-samples-staging/cypress/videos
       - store_artifacts:

--- a/packages/aws-amplify-react/package.json
+++ b/packages/aws-amplify-react/package.json
@@ -1,108 +1,120 @@
 {
-  "name": "aws-amplify-react",
-  "version": "4.2.6",
-  "description": "AWS Amplify is a JavaScript library for Frontend and mobile developers building cloud-enabled applications.",
-  "main": "./lib/index.js",
-  "module": "./lib-esm/index.js",
-  "typings": "./lib-esm/index.d.ts",
-  "sideEffects": false,
-  "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage --updateSnapshot --maxWorkers 2",
-    "build-with-test": "npm test && npm run build",
-    "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
-    "build:esm": "node ./build es6",
-    "build:cjs:watch": "node ./build es5 --watch",
-    "build:esm:watch": "node ./build es6 --watch",
-    "build": "npm run clean && npm run build:cjs && npm run build:esm",
-    "clean": "rimraf lib-esm lib dist",
-    "watch": "yarn run clean && babel src --presets babel-preset-react --out-dir dist --copy-files --watch",
-    "cypress": "cypress run",
-    "cypress:open": "cypress open",
-    "format": "echo \"Not implemented\"",
-    "lint": "tslint 'src/**/*.ts'"
-  },
-  "devDependencies": {
-    "@types/enzyme": "^3.1.0",
-    "@types/enzyme-adapter-react-16": "^1.0.3",
-    "@types/react": "^16.0.41",
-    "@types/react-dom": "^16.0.11",
-    "aws-amplify": "^3.3.2",
-    "enzyme": "^3.1.0",
-    "enzyme-adapter-react-16": "^1.0.3",
-    "enzyme-to-json": "^3.2.1",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "react-test-renderer": "^16.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/aws-amplify/amplify-js.git"
-  },
-  "author": "Amazon Web Services",
-  "license": "Apache-2.0",
-  "jest": {
-    "globals": {
-      "ts-jest": {
-        "diagnostics": false,
-        "tsConfig": {
-          "lib": [
-            "es5",
-            "es2015",
-            "dom",
-            "esnext.asynciterable",
-            "es2017.object"
-          ],
-          "allowJs": true,
-          "jsx": "react"
-        }
-      }
-    },
-    "transform": {
-      "^.+\\.(js|jsx|ts|tsx)$": "ts-jest"
-    },
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ],
-    "timers": "fake",
-    "setupTestFrameworkScriptFile": "./test_Setup/enzymeSetup.ts",
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ],
-    "testEnvironment": "jsdom",
-    "testURL": "http://localhost/",
-    "coverageThreshold": {
-      "global": {
-        "branches": 70,
-        "functions": 75,
-        "lines": 75,
-        "statements": 75
-      }
-    },
-    "coveragePathIgnorePatterns": [
-      "/node_modules/"
-    ],
-    "moduleNameMapper": {
-      "\\.(css|less|scss|sass)$": "<rootDir>/__mocks__/styleMock.ts"
-    }
-  },
-  "dependencies": {
-    "qrcode.react": "^0.8.0",
-    "regenerator-runtime": "^0.11.1"
-  },
-  "peerDependencies": {
-    "@aws-amplify/analytics": "^3.0.0",
-    "@aws-amplify/api": "^3.0.0",
-    "@aws-amplify/auth": "^3.0.0",
-    "@aws-amplify/core": "^3.0.0",
-    "@aws-amplify/interactions": "^3.0.0",
-    "@aws-amplify/storage": "^3.0.0",
-    "@aws-amplify/ui": "^2.0.0",
-    "@aws-amplify/xr": "^2.0.0"
-  }
+	"name": "aws-amplify-react",
+	"version": "4.2.6",
+	"description": "AWS Amplify is a JavaScript library for Frontend and mobile developers building cloud-enabled applications.",
+	"main": "./lib/index.js",
+	"module": "./lib-esm/index.js",
+	"typings": "./lib-esm/index.d.ts",
+	"sideEffects": [
+		"./src/Storage/index.ts",
+		"./src/Storage/S3Album.ts",
+		"./src/index.ts",
+		"./lib-esm/Storage/index.js",
+		"./lib-esm/Storage/S3Album.js",
+		"./lib-esm/index.js",
+		"./lib/Storage/index.js",
+		"./lib/Storage/S3Album.js",
+		"./lib/index.js",
+		"./dist/aws-amplify-react.js",
+		"./dist/aws-amplify-react.min.js"
+	],
+	"scripts": {
+		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage --updateSnapshot --maxWorkers 2",
+		"build-with-test": "npm test && npm run build",
+		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
+		"build:esm": "node ./build es6",
+		"build:cjs:watch": "node ./build es5 --watch",
+		"build:esm:watch": "node ./build es6 --watch",
+		"build": "npm run clean && npm run build:cjs && npm run build:esm",
+		"clean": "rimraf lib-esm lib dist",
+		"watch": "yarn run clean && babel src --presets babel-preset-react --out-dir dist --copy-files --watch",
+		"cypress": "cypress run",
+		"cypress:open": "cypress open",
+		"format": "echo \"Not implemented\"",
+		"lint": "tslint 'src/**/*.ts'"
+	},
+	"devDependencies": {
+		"@types/enzyme": "^3.1.0",
+		"@types/enzyme-adapter-react-16": "^1.0.3",
+		"@types/react": "^16.0.41",
+		"@types/react-dom": "^16.0.11",
+		"aws-amplify": "^3.3.2",
+		"enzyme": "^3.1.0",
+		"enzyme-adapter-react-16": "^1.0.3",
+		"enzyme-to-json": "^3.2.1",
+		"react": "^16.0.0",
+		"react-dom": "^16.0.0",
+		"react-test-renderer": "^16.0.0"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git"
+	},
+	"author": "Amazon Web Services",
+	"license": "Apache-2.0",
+	"jest": {
+		"globals": {
+			"ts-jest": {
+				"diagnostics": false,
+				"tsConfig": {
+					"lib": [
+						"es5",
+						"es2015",
+						"dom",
+						"esnext.asynciterable",
+						"es2017.object"
+					],
+					"allowJs": true,
+					"jsx": "react"
+				}
+			}
+		},
+		"transform": {
+			"^.+\\.(js|jsx|ts|tsx)$": "ts-jest"
+		},
+		"testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+		"moduleFileExtensions": [
+			"ts",
+			"tsx",
+			"js",
+			"jsx",
+			"json",
+			"node"
+		],
+		"timers": "fake",
+		"setupTestFrameworkScriptFile": "./test_Setup/enzymeSetup.ts",
+		"snapshotSerializers": [
+			"enzyme-to-json/serializer"
+		],
+		"testEnvironment": "jsdom",
+		"testURL": "http://localhost/",
+		"coverageThreshold": {
+			"global": {
+				"branches": 70,
+				"functions": 75,
+				"lines": 75,
+				"statements": 75
+			}
+		},
+		"coveragePathIgnorePatterns": [
+			"/node_modules/"
+		],
+		"moduleNameMapper": {
+			"\\.(css|less|scss|sass)$": "<rootDir>/__mocks__/styleMock.ts"
+		}
+	},
+	"dependencies": {
+		"qrcode.react": "^0.8.0",
+		"regenerator-runtime": "^0.11.1"
+	},
+	"peerDependencies": {
+		"@aws-amplify/analytics": "^3.0.0",
+		"@aws-amplify/api": "^3.0.0",
+		"@aws-amplify/auth": "^3.0.0",
+		"@aws-amplify/core": "^3.0.0",
+		"@aws-amplify/interactions": "^3.0.0",
+		"@aws-amplify/storage": "^3.0.0",
+		"@aws-amplify/ui": "^2.0.0",
+		"@aws-amplify/xr": "^2.0.0"
+	}
 }


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ This PR updates integration tests to run on both dev builds and prod builds. This also resolves sideEffects regression in `aws-amplify-react` that was found along the way.

I considered creating a separate job for prod testing, but this was inefficient because we would have to run `persist_to_workspace` for each of our sample to transition from dev to prod. 

I've tested that all our browser integration tests pass on both prod and dev with the accompanying PR on samples repo. See [link](https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/6281/workflows/197a14ea-5ea6-466b-ad02-e4045e05d9b9) to see what this looks like on circleCI!

![Screen Shot 2020-09-29 at 10 28 47 AM](https://user-images.githubusercontent.com/43682783/94594663-95d62780-023e-11eb-8f74-7061d6e6ce73.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
