### PR TITLE
ci: minor improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,5 @@
 # Javascript Node CircleCI 2.1 configuration file
 #
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
 version: 2.1
 
 executors:
@@ -19,7 +17,7 @@ executors:
 
   macos-executor:
     macos:
-      xcode: 11.4.1
+      xcode: 11.5.0
 
 test_env_vars: &test_env_vars
   environment:
@@ -29,20 +27,6 @@ test_env_vars: &test_env_vars
     NPM_EMAIL: circleci@amplify.js
 
 commands:
-  restore_pods:
-    steps:
-      - restore_cache:
-          keys:
-            - v1-storage-app-pods-{{ checksum "ios/Podfile.lock" }}
-            - v1-storage-app-pods-
-
-  save_pods:
-    steps:
-      - save_cache:
-          key: v1-storage-app-pods-{{ checksum "ios/Podfile.lock" }}
-          paths:
-            - ios/Pods
-
   publish_to_verdaccio:
     steps:
       - run:
@@ -138,13 +122,11 @@ commands:
           command: |
             echo "Current NPM registry: " $(yarn config get registry)
             ~/amplify-js/.circleci/retry-yarn-script.sh -s 'install --frozen-lockfile --non-interactive' -n 3
-      - restore_pods
       - run:
           name: Install CocoaPods
           command: |
             cd ios
             pod install
-      - save_pods
       - run:
           background: true
           command: xcrun simctl boot "iPhone 11" || true
@@ -279,10 +261,22 @@ jobs:
     executor: build-executor
     steps:
       - checkout
-      - run: yarn config set workspaces-experimental true
-      - run: yarn --frozen-lockfile
-      - run: yarn run bootstrap
-      - run: yarn run build
+      - run:
+          name: yarn install --non-interactive
+          # temporarily rename .yarnrc before installing so that we can generate a yarn.lock artifact
+          command: |
+            mv .yarnrc ._yarnrc
+            yarn
+      - run: yarn build
+      # storing yarn.lock as an artifact, so that we can quickly get a dependency diff
+      # with the last working build in the event that some upstream deps break the build in the future
+      - store_artifacts:
+          path: yarn.lock
+      - run:
+          name: delete lockfile after persisting
+          command: |
+            mv ._yarnrc .yarnrc
+            rm yarn.lock
       - save_cache:
           key: amplify-ssh-deps-{{ .Branch }}
           paths:
@@ -300,8 +294,8 @@ jobs:
       - run:
           name: 'Run Amplify JS unit tests'
           command: |
-            yarn run test
-            yarn run coverage
+            yarn test
+            yarn coverage
 
   integ_setup:
     executor: build-executor

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ packages/**/cjs/
 *.log
 .npm/
 packages/**/cypress/videos/
+yarn.lock


### PR DESCRIPTION
Just some minor improvements:
* Generate and store yarn.lock as an artifact (then delete it from source)
  * This will allow us to more easily debug dependency-related build issues by diff'ing against the lockfile from the last known working build. We've spent entire days simply trying to pinpoint which upstream dependency got updated with breaking changes. This should expedite that process if it happens again.
* Remove save_cache/restore_cache steps for CocoaPods in RN integ test jobs. More trouble than it's worth, causes issues when RN itself and RN-deps are upgraded in the sample apps. 
* Upgrade the macOS executor to XCode 11.5.0 (this is the latest we can use until we upgrade our Android emulator)
* Test run for pipeline changes: https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/6296/workflows/7ba7fbe0-22f7-460a-a962-7f61906ee7c5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
