### PR TITLE
fix(@aws-amplify/datastore): switch log to debug so RN doesn't show warning

### DIFF
--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -277,7 +277,7 @@ class SubscriptionProcessor {
 						);
 					}
 				} catch (err) {
-					logger.warn('error getting OIDC JWT', err);
+					logger.debug('error getting OIDC JWT', err);
 					// best effort to get oidc jwt
 				}
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
`logger.warn` causes a yellow warning to show up in React Native, but this error show only show when debugging is enabled.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
