### PR TITLE
Add alt text to S3Image for aws-amplify-react

### DIFF
--- a/packages/aws-amplify-react/__tests__/Storage/S3Image-test.tsx
+++ b/packages/aws-amplify-react/__tests__/Storage/S3Image-test.tsx
@@ -38,6 +38,12 @@ describe('S3Image', () => {
 			expect(wrapper).toMatchSnapshot();
 		});
 
+		test('render with alt text', () => {
+			const wrapper = shallow(<S3Image alt="alternative text" />);
+
+			expect(wrapper).toMatchSnapshot();
+		});
+
 		test('render with translate text', () => {
 			const wrapper = shallow(<S3Image translate="translate" />);
 

--- a/packages/aws-amplify-react/__tests__/Storage/__snapshots__/S3Image-test.tsx.snap
+++ b/packages/aws-amplify-react/__tests__/Storage/__snapshots__/S3Image-test.tsx.snap
@@ -337,6 +337,29 @@ exports[`S3Image render test render with src exist 1`] = `
 </div>
 `;
 
+exports[`S3Image render test render with alt text 1`] = `
+<div
+  style={Object {}}
+>
+  <div
+    onClick={[Function]}
+    style={
+      Object {
+        "position": "relative",
+      }
+    }
+  >
+    <img
+      alt="alternative text"
+      onError={[Function]}
+      onLoad={[Function]}
+      src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
+    />
+    <div />
+  </div>
+</div>
+`;
+
 exports[`S3Image render test render with translate text 1`] = `
 <div
   style={Object {}}

--- a/packages/aws-amplify-react/src/Storage/S3Image.tsx
+++ b/packages/aws-amplify-react/src/Storage/S3Image.tsx
@@ -40,6 +40,7 @@ export interface IS3ImageProps {
 	picker?: any;
 	selected?: any;
 	src?: any;
+	alt?: any;
 	style?: any;
 	theme?: any;
 	track?: any;
@@ -203,7 +204,7 @@ export class S3Image extends React.Component<IS3ImageProps, IS3ImageState> {
 			return null;
 		}
 
-		const { className, selected } = this.props;
+		const { className, selected, alt } = this.props;
 		const containerStyle: React.CSSProperties = { position: 'relative' };
 		return (
 			<div style={containerStyle} onClick={this.handleClick}>
@@ -211,6 +212,7 @@ export class S3Image extends React.Component<IS3ImageProps, IS3ImageState> {
 					className={className}
 					style={theme.photoImg}
 					src={src}
+					alt={alt}
 					onLoad={this.handleOnLoad}
 					onError={this.handleOnError}
 				/>


### PR DESCRIPTION
_Issue #6396 

_Description of changes:_
Add `alt` attribute to `S3Image` component from `aws-amplify-react`.

```jsx
<S3Image alt="Hello World" />
```

turns into

```html
<img alt="Hello World" />
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
