### PR TITLE
fix: make graphql client upgradeable #6865

### DIFF
--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -49,7 +49,7 @@
     "@aws-amplify/cache": "^3.1.31",
     "@aws-amplify/core": "^3.6.0",
     "@aws-amplify/pubsub": "^3.2.4",
-    "graphql": "14.0.0",
+    "graphql": "^14.0.0",
     "uuid": "^3.2.1",
     "zen-observable-ts": "0.8.19"
   },

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -48,7 +48,7 @@
     "@aws-amplify/auth": "^3.4.6",
     "@aws-amplify/cache": "^3.1.31",
     "@aws-amplify/core": "^3.6.0",
-    "graphql": "14.0.0",
+    "graphql": "^14.0.0",
     "paho-mqtt": "^1.1.0",
     "uuid": "^3.2.1",
     "zen-observable-ts": "0.8.19"


### PR DESCRIPTION
_Issue #, if available:_ #6865 

_Description of changes:_

Allows `graphql` client to be upgraded - minor and patch versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
