### PR TITLE
ci: add docker hub auth to config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ executors:
   build-executor:
     docker:
       - image: cypress/base:12
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_ACCESS_TOKEN
+
     resource_class: large
     working_directory: ~/amplify-js
 
@@ -13,6 +17,9 @@ executors:
     docker:
       - image: cypress/included:5.2.0
       - image: verdaccio/verdaccio
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_ACCESS_TOKEN
     resource_class: large
 
   macos-executor:


### PR DESCRIPTION
Adding Docker Hub authentication to our CircleCI pipeline to accommodate [this change](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress) in Docker's ToS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
