### PR TITLE
fix(@aws-amplify/datastore): fix OIDC group auth rules

### DIFF
--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -129,7 +129,7 @@ class SubscriptionProcessor {
 		);
 
 		const validCognitoGroup = groupAuthRules.find(groupAuthRule => {
-			// validate token agains groupClaim
+			// validate token against groupClaim
 			const userGroups: string[] =
 				cognitoTokenPayload[groupAuthRule.groupClaim] || [];
 
@@ -151,11 +151,11 @@ class SubscriptionProcessor {
 		);
 
 		const validOidcGroup = groupAuthRules.find(groupAuthRule => {
-			// validate token agains groupClaim
+			// validate token against groupClaim
 			const userGroups: string[] =
 				oidcTokenPayload[groupAuthRule.groupClaim] || [];
 
-			userGroups.find(userGroup => {
+			return userGroups.find(userGroup => {
 				return groupAuthRule.groups.find(group => group === userGroup);
 			});
 		});


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
OIDC group authorization for subscriptions was failing because we weren't returning the value from `userGroups.find()`, so `validOidcGroup` was always `undefined`. Due to this, OIDC group authorization was never being returned from `getAuthorizationInfo`. Also see line 136 for proper usage (with user pools).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
