### PR TITLE
Modify package.json fields to optimize skypack scores

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -63,6 +63,10 @@
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "types": "./index.d.ts",
+  "exports": {
+    "import": "./es/index.js",
+    "require": "./lib/index.js"
+  },
   "dependencies": {
     "buffer": "4.9.1",
     "crypto-js": "^3.3.0",

--- a/packages/amplify-ui-angular/package.json
+++ b/packages/amplify-ui-angular/package.json
@@ -9,6 +9,7 @@
 		"type": "git",
 		"url": "https://github.com/aws-amplify/amplify-js.git"
 	},
+	"keywords": ["aws", "amplify", "library", "ui", "user", "interface", "components", "angular"],
 	"scripts": {
 		"build": "npm run build.ng",
 		"build.link": "npm run build && node scripts/link-copy.js",
@@ -27,6 +28,9 @@
 	"module": "dist/fesm5.js",
 	"main": "dist/fesm5.js",
 	"types": "dist/core.d.ts",
+	"exports": {
+    "import": "./build/es5/index.js"
+  },
 	"files": [
 		"dist/"
 	],

--- a/packages/amplify-ui-components/package.json
+++ b/packages/amplify-ui-components/package.json
@@ -8,6 +8,11 @@
   "es2017": "dist/esm/index.mjs",
   "unpkg": "dist/amplify-ui-components/amplify-ui-components.js",
   "types": "dist/types/index.d.ts",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
+  "keywords": ["aws", "amplify", "library", "ui", "user", "interface", "components"],
   "collection": "dist/collection/collection-manifest.json",
   "files": [
     "dist/",

--- a/packages/amplify-ui-react/package.json
+++ b/packages/amplify-ui-react/package.json
@@ -24,6 +24,12 @@
 	"main": "./lib/index.js",
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
+	"types": "./lib-esm/index.d.ts",
+	"exports": {
+    "import": "./dist/lib-esm/index.js",
+    "require": "./dist/lib/index.js"
+	},
+	"keywords": ["aws", "amplify", "library", "ui", "user", "interface", "components", "react"],
 	"devDependencies": {
 		"@types/react": "^16.0.41",
 		"@types/react-dom": "^16.0.11",

--- a/packages/amplify-ui-vue/package.json
+++ b/packages/amplify-ui-vue/package.json
@@ -9,6 +9,10 @@
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
+	"exports": {
+    "require": "./dist/index.js"
+	},
+	"keywords": ["aws", "amplify", "library", "ui", "user", "interface", "vue"],
 	"files": [
 		"dist/"
 	],

--- a/packages/amplify-ui/package.json
+++ b/packages/amplify-ui/package.json
@@ -3,9 +3,13 @@
   "version": "2.0.2",
   "main": "dist/aws-amplify-ui.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    "require": "./lib/index.js"
+  },
   "publishConfig": {
     "access": "public"
   },
+  "keywords": ["aws", "amplify", "library", "ui", "user", "interface", "components"],
   "scripts": {
     "format": "echo \"Not implemented\"",
     "test": "webpack",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -5,6 +5,11 @@
 	"main": "./lib/index.js",
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
+	"types": "./lib-esm/index.d.ts",
+	"exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
 	"sideEffects": [
 		"./src/Analytics.ts",
 		"./lib/Analytics.js",
@@ -15,6 +20,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"keywords": ["aws", "amplify", "library", "analytics"],
 	"scripts": {
 		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
 		"test:watch": "tslint 'src/**/*.ts' && jest -w 1 --watch",

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -5,6 +5,11 @@
   "main": "./lib/index.js",
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
+  "types": "./lib-esm/index.d.ts",
+  "exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
   "react-native": {
     "./lib/index": "./lib-esm/index.js"
   },
@@ -18,6 +23,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": ["aws", "amplify", "library", "graphql", "api"],
   "scripts": {
     "test": "tslint 'src/**/*.ts' && jest --coverage",
     "build-with-test": "npm test && npm run build",

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -5,6 +5,11 @@
   "main": "./lib/index.js",
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
+  "types": "./lib-esm/index.d.ts",
+  "exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
   "react-native": {
     "./lib/index": "./lib-esm/index.js"
   },
@@ -18,6 +23,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": ["aws", "amplify", "library", "rest", "api"],
   "scripts": {
     "test": "tslint 'src/**/*.ts' && jest --coverage",
     "build-with-test": "npm test && npm run build",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -5,9 +5,14 @@
 	"main": "./lib/index.js",
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
+	"types": "./lib/index.d.ts",
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js"
 	},
+	"exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
 	"sideEffects": [
 		"./src/API.ts",
 		"./lib/API.js",
@@ -18,6 +23,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"keywords": ["aws", "amplify", "library", "api"],
 	"scripts": {
 		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
 		"build-with-test": "npm test && npm run build",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -5,6 +5,11 @@
   "main": "./lib/index.js",
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
+  "types": "./lib-esm/index.d.ts",
+  "exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
   "react-native": {
     "./lib/index": "./lib-esm/index.js"
   },
@@ -18,6 +23,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": ["aws", "amplify", "library", "auth"],
   "scripts": {
     "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
     "build-with-test": "npm test && npm run build",

--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -5,6 +5,10 @@
 	"main": "bundles/aws-amplify-angular.umd.js",
 	"module": "dist/index.js",
 	"typings": "dist/index.d.ts",
+	"types": "dist/index.d.ts",
+	"exports": {
+    "import": "./dist/index.js"
+  },
 	"scripts": {
 		"cleantemp": "rimraf coverage dist tmp docs",
 		"ngcompile": "node_modules/.bin/ngc -p tsconfig-aot.json",
@@ -25,6 +29,7 @@
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",
+	"keywords": ["aws", "amplify", "library", "angular"],
 	"devDependencies": {
 		"@angular/common": "^5.2.6",
 		"@angular/compiler": "^5.2.9",

--- a/packages/aws-amplify-react-native/package.json
+++ b/packages/aws-amplify-react-native/package.json
@@ -3,6 +3,10 @@
 	"version": "4.2.7",
 	"description": "AWS Amplify is a JavaScript library for Frontend and mobile developers building cloud-enabled applications.",
 	"main": "dist/index.js",
+	"exports": {
+    "require": "./dist/index.js"
+	},
+	"keywords": ["aws", "amplify", "library", "react", "native", "react-native"],
 	"scripts": {
 		"test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2",
 		"build": "npm run clean && babel src --out-dir dist --extensions '.ts,.tsx,.js,.jsx' --copy-files",

--- a/packages/aws-amplify-react/package.json
+++ b/packages/aws-amplify-react/package.json
@@ -5,6 +5,11 @@
 	"main": "./lib/index.js",
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
+	"types": "./lib-esm/index.d.ts",
+	"exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
 	"sideEffects": [
 		"./src/Storage/index.ts",
 		"./src/Storage/S3Album.ts",
@@ -18,6 +23,7 @@
 		"./dist/aws-amplify-react.js",
 		"./dist/aws-amplify-react.min.js"
 	],
+	"keywords": ["aws", "amplify", "library", "react"],
 	"scripts": {
 		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage --updateSnapshot --maxWorkers 2",
 		"build-with-test": "npm test && npm run build",

--- a/packages/aws-amplify-vue/package.json
+++ b/packages/aws-amplify-vue/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "private": false,
   "author": "Amazon Web Services",
+  "keywords": ["aws", "amplify", "library", "vue"],
   "scripts": {
     "serve": "vue-cli-service serve",
     "lint": "vue-cli-service lint",

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -5,10 +5,16 @@
   "main": "./lib/index.js",
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
+  "types": "./lib-esm/index.d.ts",
+  "exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
   "react-native": {
     "./lib/index": "./lib-esm/index.js"
   },
   "sideEffects": false,
+  "keywords": ["aws", "amplify", "library"],
   "scripts": {
     "test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2",
     "build-with-test": "npm run clean && npm test && tsc && webpack -p",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -5,6 +5,12 @@
   "main": "./lib/index.js",
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
+  "types": "./lib-esm/index.d.ts",
+  "exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
+  "keywords": ["aws", "amplify", "library", "cache"],
   "react-native": {
     "./lib/index": "./lib-esm/reactnative.js"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,11 @@
 	"main": "./lib/index.js",
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
+	"types": "./lib-esm/index.d.ts",
+	"exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
 	"publishConfig": {
 		"access": "public"
 	},
@@ -18,6 +23,7 @@
 		"./dist/aws-amplify-core.min.js",
 		"./dist/aws-amplify-core.js"
 	],
+	"keywords": ["aws", "amplify", "library", "core"],
 	"scripts": {
 		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
 		"build-with-test": "npm test && npm run build",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -5,6 +5,11 @@
 	"main": "./lib/index.js",
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
+	"types": "./lib-esm/index.d.ts",
+	"exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js"
 	},
@@ -18,6 +23,7 @@
 		"./dist/aws-amplify-datastore.min.js",
 		"./dist/aws-amplify-datastore.js"
 	],
+	"keywords": ["aws", "amplify", "library", "datastore", "data", "store"],
 	"scripts": {
 		"test": "npm run lint && jest -w 1 --coverage",
 		"build-with-test": "npm test && npm run build",

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -5,6 +5,11 @@
 	"main": "./lib/index.js",
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
+	"types": "./lib-esm/index.d.ts",
+	"exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js"
 	},
@@ -18,6 +23,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"keywords": ["aws", "amplify", "library", "interactions"],
 	"scripts": {
 		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
 		"build-with-test": "npm run clean && npm test && tsc && webpack",

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -5,6 +5,11 @@
 	"main": "./lib/index.js",
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
+	"types": "./lib-esm/index.d.ts",
+	"exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js"
 	},
@@ -15,6 +20,7 @@
 		"./dist/aws-amplify-predictions.min.js",
 		"./dist/aws-amplify-predictions.js"
 	],
+	"keywords": ["aws", "amplify", "library", "predictions"],
 	"scripts": {
 		"test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2",
 		"build-with-test": "npm run clean && npm test && tsc && webpack -p",

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -5,6 +5,11 @@
   "main": "./lib/index.js",
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
+  "types": "./lib-esm/index.d.ts",
+  "exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
   "react-native": {
     "./lib/index": "./lib-esm/index.js"
   },
@@ -18,6 +23,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": ["aws", "amplify", "library", "pubsub", "publish", "subscribe"],
   "scripts": {
     "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
     "build-with-test": "npm run clean && npm test && tsc && webpack",

--- a/packages/pushnotification/package.json
+++ b/packages/pushnotification/package.json
@@ -5,9 +5,14 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "typings": "./lib/index.d.ts",
+  "types": "./lib/index.d.ts",
+  "exports": {
+    "require": "./lib/index.js"
+  },
   "publishConfig": {
     "access": "public"
   },
+  "keywords": ["aws", "amplify", "library", "push", "notifications"],
   "scripts": {
     "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
     "build-with-test": "npm test && npm run build",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -5,6 +5,11 @@
   "main": "./lib/index.js",
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
+  "types": "./lib-esm/index.d.ts",
+  "exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
   "react-native": {
     "./lib/index": "./lib-esm/index.js"
   },
@@ -18,6 +23,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": ["aws", "amplify", "library", "storage", "s3"],
   "scripts": {
     "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
     "build-with-test": "npm test && npm run build",

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -5,6 +5,11 @@
   "main": "./lib/index.js",
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
+  "types": "./lib-esm/index.d.ts",
+  "exports": {
+    "import": "./lib-esm/index.js",
+    "require": "./lib/index.js"
+  },
   "react-native": {
     "./lib/index": "./lib-esm/index.js"
   },
@@ -18,6 +23,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "keywords": ["aws", "amplify", "library", "xr", "vr", "virtual", "reality"],
   "scripts": {
     "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
     "build-with-test": "npm test && npm run build",


### PR DESCRIPTION
[Skypack](https://www.skypack.dev/) is pretty cool!

This PR includes subtle changes (`"typings" -> "types"`, export maps, keywords) in certain packages' `package.json`s. This'll ensure that we check off remaining scoring boxes.

Take a look at [the current @aws-amplify/core page](https://www.skypack.dev/view/@aws-amplify/core)