### PR TITLE
Ui components/bug/fix button loading

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
@@ -239,6 +239,7 @@ export class AmplifyConfirmSignUp {
           headerText={I18n.get(this.headerText)}
           submitButtonText={I18n.get(this.submitButtonText)}
           handleSubmit={this.handleSubmit}
+          loading={this.loading}
           secondaryFooterContent={
             <div>
               <span>

--- a/packages/amplify-ui-components/src/components/amplify-form-section/__snapshots__/amplify-form-section.spec.ts.snap
+++ b/packages/amplify-ui-components/src/components/amplify-form-section/__snapshots__/amplify-form-section.spec.ts.snap
@@ -65,36 +65,3 @@ exports[`amplify-form-section spec: Render logic -> should render a form section
   </mock:shadow-root>
 </amplify-form-section>
 `;
-
-exports[`amplify-form-section spec: Render logic -> should render form section 1`] = `
-<amplify-form-section>
-  <mock:shadow-root>
-    <form>
-      <amplify-section>
-        <div>
-          <slot name="amplify-form-section-header">
-            <div class="form-section-header">
-              <h3 class="header" data-test="form-section-header-section"></h3>
-              <div class="subtitle">
-                <slot name="subtitle"></slot>
-              </div>
-            </div>
-          </slot>
-        </div>
-        <slot></slot>
-        <div>
-          <slot name="amplify-form-section-footer">
-            <div class="form-section-footer">
-              <amplify-button data-test="form-section-form-section-button" type="submit">
-                <span>
-                  Submit
-                </span>
-              </amplify-button>
-            </div>
-          </slot>
-        </div>
-      </amplify-section>
-    </form>
-  </mock:shadow-root>
-</amplify-form-section>
-`;

--- a/packages/amplify-ui-components/src/components/amplify-form-section/amplify-form-section.spec.ts
+++ b/packages/amplify-ui-components/src/components/amplify-form-section/amplify-form-section.spec.ts
@@ -32,14 +32,5 @@ describe('amplify-form-section spec:', () => {
 
       expect(page.root).toMatchSnapshot();
     });
-
-    it('should render form section', async () => {
-      const page = await newSpecPage({
-        components: [AmplifyFormSection],
-        html: `<amplify-form-section></amplify-form-section>`,
-      });
-
-      expect(page.root).toMatchSnapshot();
-    });
   });
 });

--- a/packages/amplify-ui-components/src/components/amplify-form-section/amplify-form-section.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-form-section/amplify-form-section.tsx
@@ -51,7 +51,11 @@ export class AmplifyFormSection {
           <div>
             <slot name="amplify-form-section-footer">
               <div class="form-section-footer">
-                <amplify-button type="submit" data-test={this.testDataPrefix + '-' + this.testDataPrefix + '-button'}>
+                <amplify-button
+                  type="submit"
+                  disabled={this.loading}
+                  data-test={this.testDataPrefix + '-' + this.testDataPrefix + '-button'}
+                >
                   {this.loading ? <amplify-loading-spinner /> : <span>{this.submitButtonText}</span>}
                 </amplify-button>
                 {this.secondaryFooterContent}

--- a/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
@@ -341,7 +341,7 @@ export class AmplifySignUp {
                 </span>
               </slot>
               <slot name="primary-footer-content">
-                <amplify-button type="submit" data-test="sign-up-create-account-button">
+                <amplify-button type="submit" disabled={this.loading} data-test="sign-up-create-account-button">
                   {this.loading ? <amplify-loading-spinner /> : <span>{I18n.get(this.submitButtonText)}</span>}
                 </amplify-button>
               </slot>

--- a/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
@@ -115,6 +115,9 @@ export class AmplifySignUp {
     if (!Auth || typeof Auth.signUp !== 'function') {
       throw new Error(NO_AUTH_MODULE_FOUND);
     }
+
+    this.loading = true;
+
     if (this.phoneNumber.phoneNumberValue) {
       try {
         this.signUpAttributes.attributes.phone_number = composePhoneNumberInput(this.phoneNumber);
@@ -145,6 +148,8 @@ export class AmplifySignUp {
       }
     } catch (error) {
       dispatchToastHubEvent(error);
+    } finally {
+      this.loading = false;
     }
   }
 


### PR DESCRIPTION
Fix a few minor bugs related to the behavior of buttons on forms while in the `loading` state:

* amplify-form-section: disable the submit button when `loading` is true
* amplify-confirm-sign-up: propagate the `loading` flag to amplify-form-section
* amplify-sign-up: set the loading flag before making the HTTP request, and clear it afterwards
* amplify-sign-up: disable the submit button when `loading` is true

Also removed a duplicate test case I found.

I tried extending the e2e test for amplify-form-section to add some assertions about the button's `disabled`, but I couldn't find a way to make the e2e tests run. It looks like they are somehow excluded but I couldn't find where that is configured. They don't appear to run on CircleCI either.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
