### PR TITLE
pass on props from withAutenticator to wrapped component

### DIFF
--- a/packages/amplify-ui-react/src/withAuthenticator.tsx
+++ b/packages/amplify-ui-react/src/withAuthenticator.tsx
@@ -10,23 +10,23 @@ import { Logger } from '@aws-amplify/core';
 
 const logger = new Logger('withAuthenticator');
 
-export function withAuthenticator(
-	Component: ComponentType,
+export function withAuthenticator<Props>(
+	Component: ComponentType<Props>,
 	authenticatorProps?: ComponentPropsWithRef<typeof AmplifyAuthenticator>
 ) {
-	const AppWithAuthenticator: FunctionComponent = props => {
+	const AppWithAuthenticator: FunctionComponent<Props> = props => {
 		const [signedIn, setSignedIn] = React.useState(false);
 
 		React.useEffect(() => {
 			appendToCognitoUserAgent('withAuthenticator');
-			
+
 			// checkUser returns an "unsubscribe" function to stop side-effects
 			return checkUser();
 		}, []);
 
 		function checkUser() {
 			setUser();
-			
+
 			return onAuthUIStateChange(authState => {
 				if (authState === AuthState.SignedIn) {
 					setSignedIn(true);
@@ -43,7 +43,7 @@ export function withAuthenticator(
 			} catch (err) {
 				logger.debug(err);
 			}
-		};
+		}
 
 		if (!signedIn) {
 			return (
@@ -52,7 +52,7 @@ export function withAuthenticator(
 				</AmplifyContainer>
 			);
 		}
-		return <Component />;
+		return <Component {...props} />;
 	};
 
 	return AppWithAuthenticator;


### PR DESCRIPTION
Issue #7055

Description of changes:

With this change, the `withAuthenticator` now passes along the props that were intended for the wrapped component. This makes it possible to use it for example in nextjs page routes which are server rended using `getServerSideProps`

Note: I've tried to add a unit test that checks this behavior, but I could not get the tests working. What I've found is that this effect https://github.com/aws-amplify/amplify-js/blob/958f61ef2918728cc46b9b210d60e868edd87f39/packages/amplify-ui-react/src/withAuthenticator.tsx#L20-L25 never runs in tests and since the initial `signedIn` value is `false`, it will always render the markup for the authenticator.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
