### PR TITLE
fix(@aws-amplify/datastore): initialize syncPredicates to empty WeakMap

### DIFF
--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -547,7 +547,10 @@ class DataStore {
 	private sync: SyncEngine;
 	private syncPageSize: number;
 	private syncExpressions: SyncExpression<any>[];
-	private syncPredicates: WeakMap<SchemaModel, ModelPredicate<any>>;
+	private syncPredicates: WeakMap<
+		SchemaModel,
+		ModelPredicate<any>
+	> = new WeakMap<SchemaModel, ModelPredicate<any>>();
 	private syncModelsUpdated: Set<string> = new Set<string>();
 
 	getModuleName() {
@@ -1129,10 +1132,6 @@ class DataStore {
 	private compareSyncPredicates(
 		syncPredicates: [SchemaModel, ModelPredicate<any>][]
 	) {
-		if (!this.syncPredicates) {
-			return;
-		}
-
 		this.syncModelsUpdated = new Set<string>();
 
 		syncPredicates.forEach(([modelDefinition, predicate]) => {


### PR DESCRIPTION
Initialize syncPredicates to an empty `WeakMap` to prevent `undefined` error caught by integ tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
