### PR TITLE
fix(@aws-amplify/datastore): fix syncExpression types

### DIFF
--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -546,7 +546,7 @@ class DataStore {
 	private storage: Storage;
 	private sync: SyncEngine;
 	private syncPageSize: number;
-	private syncExpressions: SyncExpression<any>[];
+	private syncExpressions: SyncExpression[];
 	private syncPredicates: WeakMap<
 		SchemaModel,
 		ModelPredicate<any>
@@ -1103,8 +1103,8 @@ class DataStore {
 
 		const syncPredicates = await Promise.all(
 			this.syncExpressions.map(
-				async <T extends PersistentModel>(
-					syncExpression: SyncExpression<T>
+				async (
+					syncExpression: SyncExpression
 				): Promise<[SchemaModel, ModelPredicate<any>]> => {
 					const { modelConstructor, conditionProducer } = await syncExpression;
 					const modelDefinition = getModelDefinition(modelConstructor);


### PR DESCRIPTION
Fixes #7088 

Tested the following sync expressions in **TS** and **JS**. No errors and Intellisense works as expected in each case:
```js
syncExpression(User, () => {
	return (c) => c.jobTitle('eq', 'someVal');
}),
syncExpression(User, async () => {
	return (c) => c.jobTitle('eq', 'someVal');
}),
syncExpression(User, (c) => c.jobTitle('eq', 'someVal')),
```

cc @harrysolovay - let me know if you have any suggestions on how to improve the types further (: 
I would prefer to get rid of the `| undefined` [here](https://github.com/aws-amplify/amplify-js/compare/main...iartemiev:syncExpression-type-fix?expand=1#diff-11db1320cd9ef8ce406ca63de04c6f9104cb7674410c8d33fed7731155d13230R481) and [here](https://github.com/aws-amplify/amplify-js/compare/main...iartemiev:syncExpression-type-fix?expand=1#diff-11db1320cd9ef8ce406ca63de04c6f9104cb7674410c8d33fed7731155d13230R486) but couldn't figure out how to make that happen. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
