### PR TITLE
fix(@aws-amplify/datastore): export SortDirection and syncExpression

### DIFF
--- a/packages/aws-amplify/__tests__/exports-test.ts
+++ b/packages/aws-amplify/__tests__/exports-test.ts
@@ -19,6 +19,8 @@ describe('aws-amplify', () => {
 			  "graphqlOperation",
 			  "DataStore",
 			  "Predicates",
+			  "SortDirection",
+			  "syncExpression",
 			  "PubSub",
 			  "Cache",
 			  "Interactions",

--- a/packages/aws-amplify/src/index.ts
+++ b/packages/aws-amplify/src/index.ts
@@ -33,7 +33,12 @@ export {
 export { Auth } from '@aws-amplify/auth';
 export { Storage, StorageClass } from '@aws-amplify/storage';
 export { API, APIClass, graphqlOperation } from '@aws-amplify/api';
-export { DataStore, Predicates } from '@aws-amplify/datastore';
+export {
+	DataStore,
+	Predicates,
+	SortDirection,
+	syncExpression,
+} from '@aws-amplify/datastore';
 export { PubSub } from '@aws-amplify/pubsub';
 export { default as Cache } from '@aws-amplify/cache';
 export { Interactions } from '@aws-amplify/interactions';


### PR DESCRIPTION
Fixes https://github.com/aws-amplify/amplify-js/issues/7101

export `SortDirection` and `syncExpression` from `aws-amplify`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
