### PR TITLE
feat: enable hub listening of token refresh & refresh failure events

### DIFF
--- a/packages/amazon-cognito-identity-js/index.d.ts
+++ b/packages/amazon-cognito-identity-js/index.d.ts
@@ -2,6 +2,9 @@ declare module 'amazon-cognito-identity-js' {
 	//import * as AWS from "aws-sdk";
 
 	export type NodeCallback<E, T> = (err?: E, result?: T) => void;
+	export namespace NodeCallback {
+		export type Any = NodeCallback<Error | undefined, any>;
+	}
 
 	export interface CodeDeliveryDetails {
 		AttributeName: string;
@@ -75,7 +78,9 @@ declare module 'amazon-cognito-identity-js' {
 		): string;
 
 		public getSession(
-			callback: ((error: Error, session: null) => void) | ((error: null, session: CognitoUserSession) => void)
+			callback:
+				| ((error: Error, session: null) => void)
+				| ((error: null, session: CognitoUserSession) => void)
 		): void;
 		public refreshSession(
 			refreshToken: CognitoRefreshToken,
@@ -221,7 +226,10 @@ declare module 'amazon-cognito-identity-js' {
 		public enableMFA(callback: NodeCallback<Error, string>): void;
 		public disableMFA(callback: NodeCallback<Error, string>): void;
 		public getMFAOptions(callback: NodeCallback<Error, MFAOption[]>): void;
-		public getUserData(callback: NodeCallback<Error, UserData>, params?: any): void;
+		public getUserData(
+			callback: NodeCallback<Error, UserData>,
+			params?: any
+		): void;
 		public associateSoftwareToken(callbacks: {
 			associateSecretCode: (secretCode: string) => void;
 			onFailure: (err: any) => void;
@@ -276,7 +284,7 @@ declare module 'amazon-cognito-identity-js' {
 
 	export class CognitoUserAttribute implements ICognitoUserAttributeData {
 		constructor(data: ICognitoUserAttributeData);
-		
+
 		Name: string;
 		Value: string;
 
@@ -304,7 +312,12 @@ declare module 'amazon-cognito-identity-js' {
 	}
 
 	export class CognitoUserPool {
-		constructor(data: ICognitoUserPoolData);
+		constructor(
+			data: ICognitoUserPoolData,
+			wrapRefreshSessionCallback?: (
+				target: NodeCallback.Any
+			) => NodeCallback.Any
+		);
 
 		public getUserPoolId(): string;
 		public getClientId(): string;

--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -1377,7 +1377,7 @@ export default class CognitoUser {
 
 		const keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}.${
 			this.username
-			}`;
+		}`;
 		const idTokenKey = `${keyPrefix}.idToken`;
 		const accessTokenKey = `${keyPrefix}.accessToken`;
 		const refreshTokenKey = `${keyPrefix}.refreshToken`;
@@ -1434,6 +1434,9 @@ export default class CognitoUser {
 	 * @returns {void}
 	 */
 	refreshSession(refreshToken, callback, clientMetadata) {
+		const wrappedCallback = this.pool.wrapRefreshSessionCallback
+			? this.pool.wrapRefreshSessionCallback(callback)
+			: callback;
 		const authParameters = {};
 		authParameters.REFRESH_TOKEN = refreshToken.getToken();
 		const keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}`;
@@ -1460,7 +1463,7 @@ export default class CognitoUser {
 				if (err.code === 'NotAuthorizedException') {
 					this.clearCachedUser();
 				}
-				return callback(err, null);
+				return wrappedCallback(err, null);
 			}
 			if (authResult) {
 				const authenticationResult = authResult.AuthenticationResult;
@@ -1476,7 +1479,7 @@ export default class CognitoUser {
 					authenticationResult
 				);
 				this.cacheTokens();
-				return callback(null, this.signInUserSession);
+				return wrappedCallback(null, this.signInUserSession);
 			}
 			return undefined;
 		});
@@ -1539,7 +1542,7 @@ export default class CognitoUser {
 	cacheDeviceKeyAndPassword() {
 		const keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}.${
 			this.username
-			}`;
+		}`;
 		const deviceKeyKey = `${keyPrefix}.deviceKey`;
 		const randomPasswordKey = `${keyPrefix}.randomPasswordKey`;
 		const deviceGroupKeyKey = `${keyPrefix}.deviceGroupKey`;
@@ -1556,7 +1559,7 @@ export default class CognitoUser {
 	getCachedDeviceKeyAndPassword() {
 		const keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}.${
 			this.username
-			}`;
+		}`;
 		const deviceKeyKey = `${keyPrefix}.deviceKey`;
 		const randomPasswordKey = `${keyPrefix}.randomPasswordKey`;
 		const deviceGroupKeyKey = `${keyPrefix}.deviceGroupKey`;
@@ -1575,7 +1578,7 @@ export default class CognitoUser {
 	clearCachedDeviceKeyAndPassword() {
 		const keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}.${
 			this.username
-			}`;
+		}`;
 		const deviceKeyKey = `${keyPrefix}.deviceKey`;
 		const randomPasswordKey = `${keyPrefix}.randomPasswordKey`;
 		const deviceGroupKeyKey = `${keyPrefix}.deviceGroupKey`;

--- a/packages/amazon-cognito-identity-js/src/CognitoUserPool.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUserPool.js
@@ -35,7 +35,7 @@ export default class CognitoUserPool {
 	 *        to support cognito advanced security features. By default, this
 	 *        flag is set to true.
 	 */
-	constructor(data) {
+	constructor(data, wrapRefreshSessionCallback) {
 		const {
 			UserPoolId,
 			ClientId,
@@ -64,6 +64,10 @@ export default class CognitoUserPool {
 			AdvancedSecurityDataCollectionFlag !== false;
 
 		this.storage = data.Storage || new StorageHelper().getStorage();
+
+		if (wrapRefreshSessionCallback) {
+			this.wrapRefreshSessionCallback = wrapRefreshSessionCallback;
+		}
 	}
 
 	/**
@@ -143,9 +147,7 @@ export default class CognitoUserPool {
 	 * @returns {CognitoUser} the user retrieved from storage
 	 */
 	getCurrentUser() {
-		const lastUserKey = `CognitoIdentityServiceProvider.${
-			this.clientId
-		}.LastAuthUser`;
+		const lastUserKey = `CognitoIdentityServiceProvider.${this.clientId}.LastAuthUser`;
 
 		const lastAuthUser = this.storage.getItem(lastUserKey);
 		if (lastAuthUser) {

--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -239,7 +239,6 @@ import {
 } from '@aws-amplify/core';
 import { AuthError, NoUserPoolError } from '../src/Errors';
 import { AuthErrorTypes } from '../src/types/Auth';
-import { reject } from 'q';
 
 const authOptions: AuthOptions = {
 	userPoolId: 'awsUserPoolsId',

--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -711,11 +711,11 @@ describe('auth unit test', () => {
 				return new Promise(resolve => {
 					Hub.listen('auth', capsule => {
 						switch (capsule.payload.event) {
-							case 'token_refresh': {
+							case 'tokenRefresh': {
 								return resolve(true);
 							}
 
-							case 'token_refresh_failure': {
+							case 'tokenRefresh_failure': {
 								return resolve(capsule.payload.data);
 							}
 

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -263,7 +263,7 @@ export class AuthClass {
 			return callback(error, data);
 		};
 		return wrapped;
-	};
+	} // prettier-ignore
 
 	/**
 	 * Sign up with username, password and other attributes like phone, email

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -61,6 +61,7 @@ import {
 	CognitoIdToken,
 	CognitoRefreshToken,
 	CognitoAccessToken,
+	NodeCallback,
 } from 'amazon-cognito-identity-js';
 
 import { parse } from 'url';
@@ -83,8 +84,6 @@ typeof Symbol.for === 'function'
 const dispatchAuthEvent = (event: string, data: any, message: string) => {
 	Hub.dispatch('auth', { event, data, message }, 'Auth', AMPLIFY_SYMBOL);
 };
-
-type NodeCallback = (error: Error, data: any) => any;
 
 /**
  * Provide authentication steps
@@ -250,8 +249,8 @@ export class AuthClass {
 		return this._config;
 	}
 
-	private wrapRefreshSessionCallback = (callback: NodeCallback) => {
-		const wrapped: NodeCallback = (error, data) => {
+	private wrapRefreshSessionCallback = (callback: NodeCallback.Any) => {
+		const wrapped: NodeCallback.Any = (error, data) => {
 			if (data) {
 				dispatchAuthEvent('token_refresh', undefined, `New token retrieved`);
 			} else {

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -252,10 +252,10 @@ export class AuthClass {
 	wrapRefreshSessionCallback = (callback: NodeCallback.Any) => {
 		const wrapped: NodeCallback.Any = (error, data) => {
 			if (data) {
-				dispatchAuthEvent('token_refresh', undefined, `New token retrieved`);
+				dispatchAuthEvent('tokenRefresh', undefined, `New token retrieved`);
 			} else {
 				dispatchAuthEvent(
-					'token_refresh_failure',
+					'tokenRefresh_failure',
 					error,
 					`Failed to retrieve new token`
 				);

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -249,7 +249,7 @@ export class AuthClass {
 		return this._config;
 	}
 
-	private wrapRefreshSessionCallback = (callback: NodeCallback.Any) => {
+	wrapRefreshSessionCallback = (callback: NodeCallback.Any) => {
 		const wrapped: NodeCallback.Any = (error, data) => {
 			if (data) {
 				dispatchAuthEvent('token_refresh', undefined, `New token retrieved`);


### PR DESCRIPTION
_Issue #, if available:_ #6352 

A cleaner implementation to that of #6983 

_Description of changes:_

```ts
Hub.listen('auth', (data) => {
  switch (data.payload.event) {
    case 'tokenRefresh': {
      logger.log("New token has been process");
      break;
    }
    case 'tokenRefresh_failure': {
      logger.log("Failed to retrieve new token");
      break;
    }
  }
});
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
