### PR TITLE
Update AsyncStorage library

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -74,6 +74,7 @@
     "@babel/cli": "^7.7.4",
     "@babel/core": "^7.7.4",
     "@babel/preset-env": "^7.7.4",
+    "@react-native-async-storage/async-storage": "^1.13.0",
     "babel-loader": "^8.0.6",
     "cross-env": "^3.1.4",
     "eslint": "^3.19.0",
@@ -90,6 +91,9 @@
     "rimraf": "^2.5.4",
     "webpack": "^3.5.5"
   },
+  "peerDependencies": {
+		"@react-native-async-storage/async-storage": "^1.13.0"
+	},
   "jest": {
     "globals": {
       "ts-jest": {

--- a/packages/amazon-cognito-identity-js/src/StorageHelper-rn.js
+++ b/packages/amazon-cognito-identity-js/src/StorageHelper-rn.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const MEMORY_KEY_PREFIX = '@MemoryStorage:';
 let dataMemory = {};

--- a/packages/cache/__mocks__/AsyncStorage.js
+++ b/packages/cache/__mocks__/AsyncStorage.js
@@ -1,4 +1,6 @@
-const AsyncStorage = jest.genMockFromModule('react-native');
+const AsyncStorage = jest.genMockFromModule(
+	'@react-native-async-storage/async-storage'
+);
 
 var store = {};
 var curSize = 0;

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -46,6 +46,12 @@
   "dependencies": {
     "@aws-amplify/core": "^3.8.2"
   },
+  "devDependencies": {
+    "@react-native-async-storage/async-storage": "^1.13.0"
+  },
+  "peerDependencies": {
+		"@react-native-async-storage/async-storage": "^1.13.0"
+	},
   "jest": {
     "globals": {
       "ts-jest": {

--- a/packages/cache/src/AsyncStorageCache.ts
+++ b/packages/cache/src/AsyncStorageCache.ts
@@ -13,7 +13,7 @@
 
 import { StorageCache } from './StorageCache';
 import { defaultConfig, getCurrTime } from './Utils';
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ICache } from './types';
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,6 +48,7 @@
 	},
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
+		"@react-native-async-storage/async-storage": "^1.13.0",
 		"find": "^0.2.7",
 		"genversion": "^2.2.0",
 		"prepend-file": "^1.3.1",
@@ -64,6 +65,9 @@
 		"universal-cookie": "^4.0.4",
 		"url": "^0.11.0",
 		"zen-observable-ts": "0.8.19"
+	},
+	"peerDependencies": {
+		"@react-native-async-storage/async-storage": "^1.13.0"
 	},
 	"jest": {
 		"globals": {

--- a/packages/core/src/RNComponents/reactnative.ts
+++ b/packages/core/src/RNComponents/reactnative.ts
@@ -11,4 +11,6 @@
  * and limitations under the License.
  */
 
-export { Linking, AppState, AsyncStorage } from 'react-native';
+import { Linking, AppState } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+export { Linking, AppState, AsyncStorage };

--- a/packages/core/src/StorageHelper/reactnative.ts
+++ b/packages/core/src/StorageHelper/reactnative.ts
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const MEMORY_KEY_PREFIX = '@MemoryStorage:';
 let dataMemory = {};

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -41,6 +41,7 @@
 	},
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
+		"@react-native-async-storage/async-storage": "^1.13.0",
 		"@react-native-community/netinfo": "4.7.0",
 		"@types/uuid": "3.4.5",
 		"dexie": "3.0.2",
@@ -59,6 +60,7 @@
 		"zen-push": "0.2.1"
 	},
 	"peerDependencies": {
+		"@react-native-async-storage/async-storage": "^1.13.0",
 		"@react-native-community/netinfo": "^5.5.0"
 	},
 	"jest": {

--- a/packages/datastore/src/storage/adapter/InMemoryStore.native.ts
+++ b/packages/datastore/src/storage/adapter/InMemoryStore.native.ts
@@ -1,6 +1,6 @@
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
-// See: https://reactnative.dev/docs/asyncstorage
+// See: https://react-native-async-storage.github.io/async-storage/
 export function createInMemoryStore() {
 	return AsyncStorage;
 }

--- a/packages/pushnotification/__tests__/PushNotification-test.ts
+++ b/packages/pushnotification/__tests__/PushNotification-test.ts
@@ -11,10 +11,6 @@ jest.mock('react-native', () => ({
 		currentState: 'active',
 		addEventListener: (event, callback) => callback('active'),
 	},
-	AsyncStorage: {
-		getItem: () => new Promise(res => res('item')),
-		setItem: jest.fn(),
-	},
 	DeviceEventEmitter: {
 		addListener: jest.fn(),
 	},
@@ -27,6 +23,11 @@ jest.mock('react-native', () => ({
 	Platform: {
 		OS: defaultPlatform,
 	},
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+	getItem: () => new Promise(res => res('item')),
+	setItem: jest.fn(),
 }));
 
 jest.mock('@react-native-community/push-notification-ios', () => ({

--- a/packages/pushnotification/package.json
+++ b/packages/pushnotification/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "devDependencies": {
+    "@react-native-async-storage/async-storage": "^1.13.0",
     "@types/jest": "^20.0.8",
     "@types/node": "^8.10.15",
     "awesome-typescript-loader": "^3.2.2",
@@ -48,6 +49,7 @@
     "@react-native-community/push-notification-ios": "1.0.3"
   },
   "peerdependencies": {
+    "@react-native-async-storage/async-storage": "^1.13.0",
     "react-native": "^0.55.0"
   },
   "jest": {

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -14,11 +14,11 @@
 import {
 	NativeModules,
 	DeviceEventEmitter,
-	AsyncStorage,
 	Platform,
 	AppState,
 } from 'react-native';
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Amplify, ConsoleLogger as Logger, JS } from '@aws-amplify/core';
 
 const logger = new Logger('Notification');


### PR DESCRIPTION
_Description of changes:_
- Update `AsyncStorage` to use community version (`@react-native-async-storage/async-storage`) instead of deprecated module from React Native.

This is will be a **breaking change** for all React Native customers, since `AsyncStorage` is used in `core` as well as other Amplify packages, so a major version bump might be needed.

React Native customers will also need to manually install `@react-native-async-storage/async-storage` due to how RN currently handles autolinking transitive dependencies. 

_Testing_

In progress - specifically RN CLI apps <0.60 & multiple versions of Expo for mobile & web

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
