### PR TITLE
fix(@aws-amplify/auth): fix signIn event message

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -935,7 +935,11 @@ export class AuthClass {
 						} finally {
 							that.user = user;
 
-							dispatchAuthEvent('signIn', user, `${user} has signed in`);
+							dispatchAuthEvent(
+								'signIn',
+								user,
+								`A user ${user.getUsername()} has been signed in`
+							);
 							resolve(user);
 						}
 					},
@@ -976,7 +980,11 @@ export class AuthClass {
 							logger.debug('cannot get cognito credentials', e);
 						} finally {
 							that.user = user;
-							dispatchAuthEvent('signIn', user, `${user} has signed in`);
+							dispatchAuthEvent(
+								'signIn',
+								user,
+								`A user ${user.getUsername()} has been signed in`
+							);
 							resolve(user);
 						}
 					},


### PR DESCRIPTION
_Issue #, if available:_
Relates to #7102 

_Description of changes:_
`${user} has signed in` is being rendered as `[object Object] has signed in` because user is of type `CognitoUser`

It should say `A user ${user.getUsername()} has been signed in`, as seen in:
https://github.com/aws-amplify/amplify-js/blob/5173a9911096627ce1b45067808af249668b260b/packages/auth/src/Auth.ts#L496-L500

Screenshot:
![](https://user-images.githubusercontent.com/5880908/98485186-81446200-21e2-11eb-87a5-344fce35b646.png)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
