### PR TITLE
use conditional type for `graphql`

### DIFF
--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -187,10 +187,10 @@ export class APIClass {
 	 * @param {object} additionalHeaders headers to merge in after any `graphql_headers` set in the config
 	 * @returns {Promise<GraphQLResult> | Observable<object>}
 	 */
-	graphql(
+	graphql<Operation, Data extends object = object>(
 		options: GraphQLOptions,
 		additionalHeaders?: { [key: string]: string }
-	): Promise<GraphQLResult> | Observable<object> {
+	): Operation extends 'query' | 'mutation' ? Promise<GraphQLResult<Data>> : Observable<Data> {
 		return this._graphqlApi.graphql(options, additionalHeaders);
 	}
 }


### PR DESCRIPTION
I had a hard time to cast the result of `graphql` in ts.

This PR make it use the conditional type instead of union type, so we can:
```ts
interface MyData {
    foo: string
    bar: number
}

async getFoo() {
    return (
        await API.graphql<'query', MyData>(
            graphqlOperation(getUserMeta, { id: userMetaId })
        )
    ).data.foo
}
```
