### PR TITLE
fix(@aws-amplify/datastore): add implicit owner to selection set

### DIFF
--- a/packages/datastore/__tests__/schema.ts
+++ b/packages/datastore/__tests__/schema.ts
@@ -410,3 +410,157 @@ export const newSchema: Schema = {
 	},
 	version: 'a66372d29356c40e7cd29e41527cead7',
 };
+
+export const implicitOwnerSchema = {
+	models: {
+		Post: {
+			name: 'Post',
+			fields: {
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				title: {
+					name: 'title',
+					isArray: false,
+					type: 'String',
+					isRequired: true,
+					attributes: [],
+				},
+			},
+			syncable: true,
+			pluralName: 'Posts',
+			attributes: [
+				{
+					type: 'model',
+					properties: {},
+				},
+				{
+					type: 'auth',
+					properties: {
+						rules: [
+							{
+								provider: 'userPools',
+								ownerField: 'owner',
+								allow: 'owner',
+								identityClaim: 'cognito:username',
+								operations: ['create', 'update', 'delete', 'read'],
+							},
+						],
+					},
+				},
+			],
+		},
+	},
+	enums: {},
+	nonModels: {},
+	version: '0e29e95012de2d43cf8329d731a5cfb2',
+};
+
+export const explicitOwnerSchema = {
+	models: {
+		Post: {
+			name: 'Post',
+			fields: {
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				title: {
+					name: 'title',
+					isArray: false,
+					type: 'String',
+					isRequired: true,
+					attributes: [],
+				},
+				owner: {
+					name: 'owner',
+					isArray: false,
+					type: 'String',
+					isRequired: false,
+					attributes: [],
+				},
+			},
+			syncable: true,
+			pluralName: 'Posts',
+			attributes: [
+				{
+					type: 'model',
+					properties: {},
+				},
+				{
+					type: 'auth',
+					properties: {
+						rules: [
+							{
+								provider: 'userPools',
+								ownerField: 'owner',
+								allow: 'owner',
+								identityClaim: 'cognito:username',
+								operations: ['create', 'update', 'delete', 'read'],
+							},
+						],
+					},
+				},
+			],
+		},
+	},
+	enums: {},
+	nonModels: {},
+	version: '0e29e95012de2d43cf8329d731a5cfb2',
+};
+
+export const groupSchema = {
+	models: {
+		Post: {
+			name: 'Post',
+			fields: {
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				title: {
+					name: 'title',
+					isArray: false,
+					type: 'String',
+					isRequired: true,
+					attributes: [],
+				},
+			},
+			syncable: true,
+			pluralName: 'Posts',
+			attributes: [
+				{
+					type: 'model',
+					properties: {},
+				},
+				{
+					type: 'auth',
+					properties: {
+						rules: [
+							{
+								groupClaim: 'cognito:groups',
+								provider: 'userPools',
+								allow: 'groups',
+								groups: ['Admin'],
+								operations: ['create', 'update', 'delete', 'read'],
+							},
+						],
+					},
+				},
+			],
+		},
+	},
+	enums: {},
+	nonModels: {},
+	version: '0e29e95012de2d43cf8329d731a5cfb2',
+};

--- a/packages/datastore/src/sync/utils.ts
+++ b/packages/datastore/src/sync/utils.ts
@@ -58,9 +58,14 @@ function generateSelectionSet(
 ): string {
 	const scalarFields = getScalarFields(modelDefinition);
 	const nonModelFields = getNonModelFields(namespace, modelDefinition);
+	const implicitOwnerField = getImplicitOwnerField(
+		modelDefinition,
+		scalarFields
+	);
 
 	let scalarAndMetadataFields = Object.values(scalarFields)
 		.map(({ name }) => name)
+		.concat(implicitOwnerField)
 		.concat(nonModelFields);
 
 	if (isSchemaModel(modelDefinition)) {
@@ -72,6 +77,29 @@ function generateSelectionSet(
 	const result = scalarAndMetadataFields.join('\n');
 
 	return result;
+}
+
+function getImplicitOwnerField(
+	modelDefinition: SchemaModel | SchemaNonModel,
+	scalarFields: ModelFields
+) {
+	if (!scalarFields.owner && isOwnerBasedModel(modelDefinition)) {
+		return ['owner'];
+	}
+	return [];
+}
+
+function isOwnerBasedModel(modelDefinition: SchemaModel | SchemaNonModel) {
+	return (
+		isSchemaModel(modelDefinition) &&
+		modelDefinition.attributes &&
+		modelDefinition.attributes.some(
+			attr =>
+				attr.properties &&
+				attr.properties.rules &&
+				attr.properties.rules.some(rule => rule.allow === 'owner')
+		)
+	);
 }
 
 function getScalarFields(

--- a/packages/datastore/src/sync/utils.ts
+++ b/packages/datastore/src/sync/utils.ts
@@ -52,7 +52,7 @@ export function getMetadataFields(): ReadonlyArray<string> {
 	return metadataFields;
 }
 
-function generateSelectionSet(
+export function generateSelectionSet(
 	namespace: SchemaNamespace,
 	modelDefinition: SchemaModel | SchemaNonModel
 ): string {


### PR DESCRIPTION
_Description of changes:_
Current Behavior: When using a type with implicit owner, the `owner` field does not get added to the selection set, which means that subscriptions won't come through for the owner.
- Changes: Add `owner` to selection set when using implicit owner auth so subscriptions will work correctly. 

```gql
type Post @model @auth(rules: [{ allow: owner }]) {
  id: ID!
  title: String!
}
```

```gql
# Before
mutation operation($input: CreatePostInput!) {
    createPost(input: $input) {
        id
        title
        _version
        _lastChangedAt
        _deleted
    }
}

# After
mutation operation($input: CreatePostInput!) {
    createPost(input: $input) {
        id
        title
        owner
        _version
        _lastChangedAt
        _deleted
    }
}
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
