### PR TITLE
fix(@aws-amplify/ui-components) update injectGlobalPaths

### DIFF
--- a/packages/amplify-ui-components/stencil.config.ts
+++ b/packages/amplify-ui-components/stencil.config.ts
@@ -24,7 +24,7 @@ export const config: Config = {
     }),
     nodePolyfills(),
     sass({
-      injectGlobalPaths: ['src/global/breakpoint.scss'],
+      injectGlobalPaths: [['src/global/breakpoint.scss', '*']],
     }),
   ],
   nodeResolve: {


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ `stencil-sass` [recently updated](https://github.com/ionic-team/stencil-sass/pull/36) the `injectGlobalPath` config option to use `@use` instead of `@import`. You can see [link](https://github.com/ionic-team/stencil-sass/commit/46133575019cf30154618d02fac14207e46a4756) to read about the changes. This PR updates `stencil.config.ts` in `ui-components` to reflect this. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
