### PR TITLE
chore: deploy native tag for React Native

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -657,7 +657,7 @@ releasable_branches: &releasable_branches
       - main
       - ui-components/main
       - 1.0-stable
-      -native
+      - native
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -657,6 +657,7 @@ releasable_branches: &releasable_branches
       - main
       - ui-components/main
       - 1.0-stable
+      -native
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"publish:release": "lerna publish --conventional-commits --yes --message 'chore(release): Publish [ci skip]'",
 		"publish:1.0-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-1.0 --message 'chore(release): Publish [ci skip]'",
 		"publish:ui-components/main": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=ui-preview --preid=ui-preview --exact",
+		"publish:native": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=native --preid=native --exact",
 		"publish:verdaccio": "lerna publish --no-push --canary minor --dist-tag=unstable --preid=unstable --exact --force-publish --yes"
 	},
 	"husky": {


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
This adds a new `native` tag in NPM that will be used primarily for the community to test React Native changes before going to `main`, with the first changes to be tested being the AsyncStorage upgrade: https://github.com/aws-amplify/amplify-js/pull/7118

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
