### PR TITLE
fix(@aws-amplify/datastore): fix sel. sync delta

### DIFF
--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -737,7 +737,7 @@ export class SyncEngine {
 				);
 			} else {
 				const prevSyncPredicate = modelMetadata.lastSyncPredicate
-					? JSON.stringify(modelMetadata.lastSyncPredicate)
+					? modelMetadata.lastSyncPredicate
 					: null;
 				const syncPredicateUpdated = prevSyncPredicate !== lastSyncPredicate;
 


### PR DESCRIPTION
`modelMetadata.lastSyncPredicate` is already a stringified object here. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
