### PR TITLE
feat(@aws-amplify/datastore): add local validations to AppSync scalars

### DIFF
--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -68,6 +68,7 @@ describe('DataStore tests', () => {
 
 			const model = new Model({
 				field1: 'something',
+				dateCreated: new Date().toISOString(),
 			});
 
 			expect(model).toBeInstanceOf(Model);
@@ -86,6 +87,7 @@ describe('DataStore tests', () => {
 			const now = Date.now();
 			const model = new LocalModel({
 				field1: 'something',
+				dateCreated: new Date().toISOString(),
 			});
 
 			expect(model).toBeInstanceOf(LocalModel);
@@ -149,6 +151,7 @@ describe('DataStore tests', () => {
 
 			const model = new Model({
 				field1: 'something',
+				dateCreated: new Date().toISOString(),
 			});
 
 			expect(() => {
@@ -163,6 +166,7 @@ describe('DataStore tests', () => {
 
 			const model1 = new Model({
 				field1: 'something',
+				dateCreated: new Date().toISOString(),
 			});
 
 			const model2 = Model.copyOf(model1, draft => {
@@ -185,6 +189,7 @@ describe('DataStore tests', () => {
 
 			const model1 = new Model({
 				field1: 'something',
+				dateCreated: new Date().toISOString(),
 			});
 
 			const model2 = Model.copyOf(model1, draft => {
@@ -202,6 +207,7 @@ describe('DataStore tests', () => {
 
 			const model1 = new Model({
 				field1: 'something',
+				dateCreated: new Date().toISOString(),
 				optionalField1: undefined,
 			});
 
@@ -215,6 +221,7 @@ describe('DataStore tests', () => {
 
 			const model1 = new Model({
 				field1: 'something',
+				dateCreated: new Date().toISOString(),
 				optionalField1: null,
 			});
 
@@ -228,6 +235,7 @@ describe('DataStore tests', () => {
 
 			const model1 = new Model({
 				field1: 'something',
+				dateCreated: new Date().toISOString(),
 				optionalField1: 'something-else',
 			});
 
@@ -249,6 +257,7 @@ describe('DataStore tests', () => {
 
 			const model1 = new Model({
 				field1: 'something',
+				dateCreated: new Date().toISOString(),
 			});
 
 			const model2 = Model.copyOf(model1, draft => {
@@ -364,6 +373,7 @@ describe('DataStore tests', () => {
 
 			model = new Model({
 				field1: 'Some value',
+				dateCreated: new Date().toISOString(),
 			});
 
 			const result = await DataStore.save(model);
@@ -373,22 +383,41 @@ describe('DataStore tests', () => {
 
 		test('Instantiation validations', async () => {
 			expect(() => {
-				new Model({ field1: undefined });
+				new Model({
+					field1: undefined,
+					dateCreated: new Date().toISOString(),
+				});
 			}).toThrowError('Field field1 is required');
 
 			expect(() => {
-				new Model({ field1: null });
+				new Model({
+					field1: null,
+					dateCreated: new Date().toISOString(),
+				});
 			}).toThrowError('Field field1 is required');
 
 			expect(() => {
-				new Model({ field1: <any>1234 });
+				new Model({
+					field1: <any>1234,
+					dateCreated: new Date().toISOString(),
+				});
 			}).toThrowError(
 				'Field field1 should be of type string, number received. 1234'
+			);
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					dateCreated: 'not-a-date',
+				});
+			}).toThrowError(
+				'Field dateCreated should be of type AWSDateTime, validation failed. not-a-date'
 			);
 
 			expect(
 				new Model({
 					field1: 'someField',
+					dateCreated: new Date().toISOString(),
 					metadata: new Metadata({
 						author: 'Some author',
 						tags: undefined,
@@ -401,6 +430,7 @@ describe('DataStore tests', () => {
 			expect(() => {
 				new Model({
 					field1: 'someField',
+					dateCreated: new Date().toISOString(),
 					metadata: new Metadata({
 						author: 'Some author',
 						tags: undefined,
@@ -415,6 +445,101 @@ describe('DataStore tests', () => {
 			expect(() => {
 				new Model({
 					field1: 'someField',
+					dateCreated: new Date().toISOString(),
+					emails: null,
+					ips: null,
+				});
+			}).not.toThrow();
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					dateCreated: new Date().toISOString(),
+					emails: [null],
+				});
+			}).toThrowError(
+				'All elements in the emails array should be of type string, [object] received. '
+			);
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					dateCreated: new Date().toISOString(),
+					ips: [null],
+				});
+			}).toThrowError(
+				'All elements in the ips array should be of type string | null | undefined, [object] received. '
+			);
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					dateCreated: new Date().toISOString(),
+					ips: ['1.1.1.1'],
+				});
+			}).not.toThrow();
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					dateCreated: new Date().toISOString(),
+					ips: ['not.an.ip'],
+				});
+			}).toThrowError(
+				`All elements in the ips array should be of type AWSIPAddress, validation failed for one or more elements. not.an.ip`
+			);
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					dateCreated: new Date().toISOString(),
+					ips: ['1.1.1.1', 'not.an.ip'],
+				});
+			}).toThrowError(
+				`All elements in the ips array should be of type AWSIPAddress, validation failed for one or more elements. 1.1.1.1,not.an.ip`
+			);
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					dateCreated: new Date().toISOString(),
+					emails: ['test@example.com'],
+				});
+			}).not.toThrow();
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					dateCreated: new Date().toISOString(),
+					emails: [],
+					ips: [],
+				});
+			}).not.toThrow();
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					dateCreated: new Date().toISOString(),
+					emails: ['not-an-email'],
+				});
+			}).toThrowError(
+				'All elements in the emails array should be of type AWSEmail, validation failed for one or more elements. not-an-email'
+			);
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					dateCreated: new Date().toISOString(),
+					ips: ['not-an-ip'],
+				});
+			}).toThrowError(
+				'All elements in the ips array should be of type AWSIPAddress, validation failed for one or more elements. not-an-ip'
+			);
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					dateCreated: new Date().toISOString(),
 					metadata: new Metadata({
 						author: 'Some author',
 						tags: undefined,
@@ -427,6 +552,7 @@ describe('DataStore tests', () => {
 			expect(() => {
 				new Model({
 					field1: 'someField',
+					dateCreated: new Date().toISOString(),
 					metadata: new Metadata({
 						author: 'Some author',
 						tags: undefined,
@@ -442,6 +568,7 @@ describe('DataStore tests', () => {
 			expect(() => {
 				new Model({
 					field1: 'someField',
+					dateCreated: new Date().toISOString(),
 					metadata: new Metadata({
 						author: 'Some author',
 						tags: [<any>1234],
@@ -461,7 +588,10 @@ describe('DataStore tests', () => {
 				Model.copyOf(<any>undefined, d => d);
 			}).toThrow('The source object is not a valid model');
 			expect(() => {
-				const source = new Model({ field1: 'something' });
+				const source = new Model({
+					field1: 'something',
+					dateCreated: new Date().toISOString(),
+				});
 				Model.copyOf(source, d => (d.field1 = <any>1234));
 			}).toThrow(
 				'Field field1 should be of type string, number received. 1234'
@@ -490,7 +620,10 @@ describe('DataStore tests', () => {
 			);
 
 			await expect(
-				DataStore.delete(new Model({ field1: 'somevalue' }), <any>{})
+				DataStore.delete(new Model({
+					field1: 'somevalue',
+					dateCreated: new Date().toISOString(),
+				}), <any>{})
 			).rejects.toThrow('Invalid criteria');
 		});
 
@@ -569,6 +702,7 @@ describe('DataStore tests', () => {
 
 			model = new Model({
 				field1: 'Some value',
+				dateCreated: new Date().toISOString(),
 			});
 		});
 
@@ -652,7 +786,10 @@ describe('DataStore tests', () => {
 				});
 			});
 			test('subscribe to model instance', async () => {
-				const model = new Model({ field1: 'somevalue' });
+				const model = new Model({
+					field1: 'somevalue',
+					dateCreated: new Date().toISOString(),
+				});
 
 				DataStore.observe(model).subscribe(({ element, model }) => {
 					expectType<PersistentModelConstructor<Model>>(model);
@@ -683,7 +820,10 @@ describe('DataStore tests', () => {
 
 		describe('Observe with generic type', () => {
 			test('subscribe to model instance', async () => {
-				const model = new Model({ field1: 'somevalue' });
+				const model = new Model({
+					field1: 'somevalue',
+					dateCreated: new Date().toISOString(),
+				});
 
 				DataStore.observe<Model>(model).subscribe(({ element, model }) => {
 					expectType<PersistentModelConstructor<Model>>(model);
@@ -722,6 +862,9 @@ declare class Model {
 	public readonly id: string;
 	public readonly field1: string;
 	public readonly optionalField1?: string;
+  public readonly dateCreated: string;
+  public readonly emails?: string[];
+  public readonly ips?: (string | null)[];
 	public readonly metadata?: Metadata;
 
 	constructor(init: ModelInit<Model>);
@@ -767,6 +910,29 @@ function testSchema(): Schema {
 						isArray: false,
 						type: 'String',
 						isRequired: false,
+					},
+					dateCreated: {
+							name: 'dateCreated',
+							isArray: false,
+							type: 'AWSDateTime',
+							isRequired: true,
+							attributes: []
+					},
+					emails: {
+							name: 'emails',
+							isArray: true,
+							type: 'AWSEmail',
+							isRequired: true,
+							attributes: [],
+							isArrayNullable: true
+					},
+					ips: {
+							name: 'ips',
+							isArray: true,
+							type: 'AWSIPAddress',
+							isRequired: false,
+							attributes: [],
+							isArrayNullable: true
 					},
 					metadata: {
 						name: 'metadata',

--- a/packages/datastore/__tests__/util.test.ts
+++ b/packages/datastore/__tests__/util.test.ts
@@ -1,0 +1,251 @@
+import {
+	isAWSDate,
+	isAWSDateTime,
+	isAWSEmail,
+	isAWSTime,
+	isAWSTimestamp,
+	isAWSJSON,
+	isAWSURL,
+	isAWSPhone,
+	isAWSIPAddress,
+} from "../src/util";
+
+describe('datastore util', () => {
+	test('isAWSDate', () => {
+		const valid = [
+			'2020-01-01',
+			'1979-01-01Z',
+			'2021-01-01+05:30',
+			'2021-01-01-05:30:12',
+		];
+		const invalid = [
+			'',
+			'2021-01-1',
+			'201-01-50',
+			'2021-01-112',
+			'2021-01-01+5:30',
+			'2021-01-01+05:3',
+			'2021-01-01+05:3.',
+			'2021-01-01-05:30:12Z',
+			// '2021-99-99',
+			// '2021-01-21+99:02'
+		];
+		valid.forEach(test => {
+			expect(isAWSDate(test)).toBe(true);
+		});
+		invalid.forEach(test => {
+			expect(isAWSDate(test)).toBe(false);
+		});
+	});
+
+	test('isAWSTime', () => {
+		const valid = [
+			'12:30',
+			'12:30Z',
+			'12:30:24Z',
+			'12:30:24-07:00',
+			'12:30:24.500+05:30',
+			'12:30:24.500+05:30:00',
+		];
+		const invalid = [
+			'',
+			'1:30',
+			'12:30.Z',
+			'120:30:242Z',
+			'12:30:242Z',
+			'12:30:24-07:00Z',
+			'12:30:24.500+05:3',
+			'12:30.500+05:30',
+			'12:30:.500Z',
+			'12:30:24.500+5:30:00',
+		];
+		valid.forEach(test => {
+			expect(isAWSTime(test)).toBe(true);
+		});
+		invalid.forEach(test => {
+			expect(isAWSTime(test)).toBe(false);
+		});
+	});
+
+	test('isAWSDateTime', () => {
+		const valid = [
+			'2021-01-11T12:30',
+			'2021-01-11T12:30Z',
+			'2021-01-11T12:30:24Z',
+			'2021-01-11T12:30:24-07:00',
+			'2021-01-11T12:30:24.500+05:30',
+			'2021-01-11T12:30:24.500+05:30:00',
+		];
+		const invalid = [
+			'',
+			'2021-01-11T1:30',
+			'2021-01-11T12:30.Z',
+			'2021-01-11T120:30:242Z',
+			'2021-01-11T12:30:242Z',
+			'2021-01-11T12:30:24-07:00Z',
+			'2021-01-11T12:30:24.500+05:3',
+			'2021-01-11T12:30.500+05:30',
+			'2021-01-11T12:30:.500Z',
+			'2021-01-11T12:30:24.500+5:30:00',
+			'2021-1-11T12:30Z',
+			'2021-01-11T1:30Z',
+			'2021-01-11T1:3',
+			'20211-01-11T12:30:.500Z',
+		];
+		valid.forEach(test => {
+			expect(isAWSDateTime(test)).toBe(true);
+		});
+		invalid.forEach(test => {
+			expect(isAWSDateTime(test)).toBe(false);
+		});
+	});
+
+	test('isAWSTimestamp', () => {
+		const valid = [
+			0,
+			123,
+			123456,
+			123456789,
+		];
+		const invalid = [
+			-1,
+			-123,
+			-123456,
+			-1234567
+		];
+		valid.forEach(test => {
+			expect(isAWSTimestamp(test)).toBe(true);
+		});
+		invalid.forEach(test => {
+			expect(isAWSTimestamp(test)).toBe(false);
+		});
+	});
+
+	test('isAWSEmail', () => {
+		const valid = [
+			'a@b',
+			'a@b.c',
+			'jeff@amazon.com',
+		];
+		const invalid = [
+			'',
+			'@',
+			'a',
+			'a@',
+			'a@@',
+			'@a',
+			'@@',
+			'a @b.c',
+			'a@ b.c',
+			'a@b. c',
+		];
+		valid.forEach(test => {
+			expect(isAWSEmail(test)).toBe(true);
+		});
+		invalid.forEach(test => {
+			expect(isAWSEmail(test)).toBe(false);
+		});
+	});
+
+	test('isAWSJSON', () => {
+		const valid = [
+			'{"upvotes": 10}',
+			'{}',
+			'[1,2,3]',
+			'[]',
+			'"AWSJSON example string"',
+			'1',
+			'0',
+			'-1',
+			'true',
+			'false',
+		];
+		const invalid = [
+			'',
+			'#',
+			'2020-01-01',
+			'{a: 1}',
+			'{‘a’: 1}',
+			'Unquoted string',
+		];
+		valid.forEach(test => {
+			expect(isAWSJSON(test)).toBe(true);
+		});
+		invalid.forEach(test => {
+			expect(isAWSJSON(test)).toBe(false);
+		});
+	});
+
+	test('isAWSURL', () => {
+		const valid = [
+			'http://localhost/',
+			'schema://anything',
+			'smb://a/b/c?d=e',
+		];
+		const invalid = [
+			'',
+			'//',
+			'//example',
+			'example',
+		];
+		valid.forEach(test => {
+			expect(isAWSURL(test)).toBe(true);
+		});
+		invalid.forEach(test => {
+			expect(isAWSURL(test)).toBe(false);
+		});
+	});
+
+	test('isAWSPhone', () => {
+		const valid = [
+			'+10000000000',
+			'+100 00 00',
+			'000 00000',
+			'123-456-7890',
+			'+44123456789',
+		];
+		const invalid = [
+			'',
+			'+',
+			'+-',
+			'a',
+			'bad-number',
+		];
+		valid.forEach(test => {
+			expect(isAWSPhone(test)).toBe(true);
+		});
+		invalid.forEach(test => {
+			expect(isAWSPhone(test)).toBe(false);
+		});
+	});
+
+	test('isAWSIPAddress', () => {
+		const valid = [
+			'127.0.0.1',
+			'123.123.123.123',
+			'1.1.1.1',
+			'::',
+			'::1',
+			'2001:db8:a0b:12f0::1',
+			'::ffff:10.0.0.1',
+			'0064:ff9b:0000:0000:0000:0000:1234:5678',
+		];
+		const invalid = [
+			'',
+			':',
+			'1.',
+			'test',
+			'999.1.1.1',
+			'-1.1.1.1',
+			'1111.111.111.111',
+			'1.0.0',
+			'::ffff:10.0.0',
+		];
+		valid.forEach(test => {
+			expect(isAWSIPAddress(test)).toBe(true);
+		});
+		invalid.forEach(test => {
+			expect(isAWSIPAddress(test)).toBe(false);
+		});
+	});
+});

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -255,6 +255,7 @@ const validateModelFields = (modelDefinition: SchemaModel | SchemaNonModel) => (
 
 		if (isGraphQLScalarType(type)) {
 			const jsType = GraphQLScalarType.getJSType(type);
+			const validateScalar = GraphQLScalarType.getValidationFunction(type);
 
 			if (isArray) {
 				let errorTypeText: string = jsType;
@@ -280,11 +281,38 @@ const validateModelFields = (modelDefinition: SchemaModel | SchemaNonModel) => (
 						`All elements in the ${name} array should be of type ${errorTypeText}, [${elemTypes}] received. ${v}`
 					);
 				}
+
+				if (
+					validateScalar &&
+					!isNullOrUndefined(v)
+				) {
+					const validationStatus = (<[]>v).map(
+						e => {
+							if (!isNullOrUndefined(e)) {
+								return validateScalar(e);
+							} else if (isNullOrUndefined(e) && !isRequired) {
+								return true;
+							} else {
+								return false;
+							}
+						}
+					);
+
+					if (!validationStatus.every(s => s)) {
+						throw new Error(
+							`All elements in the ${name} array should be of type ${type}, validation failed for one or more elements. ${v}`
+						);
+					}
+				}
 			} else if (!isRequired && v === undefined) {
 				return;
 			} else if (typeof v !== jsType && v !== null) {
 				throw new Error(
 					`Field ${name} should be of type ${jsType}, ${typeof v} received. ${v}`
+				);
+			} else if (!isNullOrUndefined(v) && validateScalar && !validateScalar(v)) {
+				throw new Error(
+					`Field ${name} should be of type ${type}, validation failed. ${v}`
 				);
 			}
 		}
@@ -1165,7 +1193,7 @@ class DataStore {
 			if (map.has(modelDefinition)) {
 				const { name } = modelDefinition;
 				logger.warn(
-					`You can only utilize one Sync Expression per model. 
+					`You can only utilize one Sync Expression per model.
           Subsequent sync expressions for the ${name} model will be ignored.`
 				);
 				return map;

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -1,5 +1,16 @@
 import { ModelInstanceCreator } from './datastore/datastore';
-import { exhaustiveCheck } from './util';
+import {
+	exhaustiveCheck,
+	isAWSDate,
+	isAWSTime,
+	isAWSDateTime,
+	isAWSTimestamp,
+	isAWSEmail,
+	isAWSJSON,
+	isAWSURL,
+	isAWSPhone,
+	isAWSIPAddress,
+} from './util';
 import { PredicateAll } from './predicates';
 
 //#region Schema types
@@ -85,7 +96,7 @@ export enum GraphQLScalarType {
 
 export namespace GraphQLScalarType {
 	export function getJSType(
-		scalar: keyof Omit<typeof GraphQLScalarType, 'getJSType'>
+		scalar: keyof Omit<typeof GraphQLScalarType, 'getJSType' | 'getValidationFunction'>
 	): 'string' | 'number' | 'boolean' {
 		switch (scalar) {
 			case 'Boolean':
@@ -109,6 +120,33 @@ export namespace GraphQLScalarType {
 				exhaustiveCheck(scalar);
 		}
 	}
+
+	export function getValidationFunction(
+		scalar: keyof Omit<typeof GraphQLScalarType, 'getJSType' | 'getValidationFunction'>
+	): ((val: string | number) => boolean) | undefined {
+		switch (scalar) {
+			case 'AWSDate':
+				return isAWSDate;
+			case 'AWSTime':
+				return isAWSTime;
+			case 'AWSDateTime':
+				return isAWSDateTime;
+			case 'AWSTimestamp':
+				return isAWSTimestamp;
+			case 'AWSEmail':
+				return isAWSEmail;
+			case 'AWSJSON':
+				return isAWSJSON;
+			case 'AWSURL':
+				return isAWSURL;
+			case 'AWSPhone':
+				return isAWSPhone;
+			case 'AWSIPAddress':
+				return isAWSIPAddress;
+			default:
+				return undefined;
+		}
+	}
 }
 
 export type AuthorizationRule = {
@@ -123,7 +161,7 @@ export type AuthorizationRule = {
 
 export function isGraphQLScalarType(
 	obj: any
-): obj is keyof Omit<typeof GraphQLScalarType, 'getJSType'> {
+): obj is keyof Omit<typeof GraphQLScalarType, 'getJSType' | 'getValidationFunction'> {
 	return obj && GraphQLScalarType[obj] !== undefined;
 }
 
@@ -154,7 +192,7 @@ export function isEnumFieldType(obj: any): obj is EnumFieldType {
 type ModelField = {
 	name: string;
 	type:
-		| keyof Omit<typeof GraphQLScalarType, 'getJSType'>
+		| keyof Omit<typeof GraphQLScalarType, 'getJSType' | 'getValidationFunction'>
 		| ModelFieldType
 		| NonModelFieldType
 		| EnumFieldType;

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -433,3 +433,49 @@ export function sortCompareFunction<T extends PersistentModel>(
 		return 0;
 	};
 }
+
+export const isAWSDate = (val: string): boolean => {
+	return !!/^\d{4}-\d{2}-\d{2}(Z|[+-]\d{2}:\d{2}($|:\d{2}))?$/.exec(val);
+};
+
+export const isAWSTime = (val: string): boolean => {
+	return !!/^\d{2}:\d{2}(:\d{2}(.\d{3})?)?(Z|[+-]\d{2}:\d{2}($|:\d{2}))?$/.exec(val);
+};
+
+export const isAWSDateTime = (val: string): boolean => {
+	return !!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(.\d{3})?)?(Z|[+-]\d{2}:\d{2}($|:\d{2}))?$/.exec(val);
+};
+
+export const isAWSTimestamp = (val: number): boolean => {
+	return !!/^\d+$/.exec(String(val));
+};
+
+export const isAWSEmail = (val: string): boolean => {
+	return !!/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.exec(val);
+};
+
+export const isAWSJSON = (val: string): boolean => {
+	try {
+		JSON.parse(val);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+export const isAWSURL = (val: string): boolean => {
+	try {
+		return !!new URL(val);
+	} catch {
+		return false;
+	}
+};
+
+export const isAWSPhone = (val: string): boolean => {
+	return !!/^\+?\d[\d\s-]+$/.exec(val);
+};
+
+export const isAWSIPAddress = (val: string): boolean => {
+	return !!/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.exec(val) ||
+		!!/(?:^|(?<=\s))(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))(?=\s|$)/.exec(val);
+};


### PR DESCRIPTION
_Issue #, if available:_
Relates to #5963

_Description of changes:_
Perform some basic local validations for all [AppSync Defined Scalars](https://docs.aws.amazon.com/appsync/latest/devguide/scalars.html). Currently there are no validations on these fields so one can store anything in e.g. `AWSDateTime` field locally. During datastore sync, AppSync does validations and graphql requests will fail. 

This PR uses basic regex to validate all the fields listed. However, some of the fields could use better validations. e.g. `2020-99-99T00:00:00Z` will pass validation with the current regex, We cannot use the built-in date function because AppSync supports non-standard ISO 8601 standard:

> The seconds field in the timezone offset will be considered valid even though it is not part of the ISO 8601 standard. 

Ideally, we should reuse AppSync's validation logic here for parity but having basic validations is much better than no validations : )

Screenshot of example validation error:
![image](https://user-images.githubusercontent.com/5880908/99348491-b8141b00-2867-11eb-8aad-99e6dc9482be.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
