### PR TITLE
fix(@aws-amplify/datastore): fix validation for array with optional element

### DIFF
--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -908,8 +908,8 @@ function testSchema(): Schema {
 						isArray: true,
 						type: 'String',
 						isRequired: false,
+						isArrayNullable: true,
 						attributes: [],
-						isArrayNullable: true
 					}
 				},
 			},

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -472,6 +472,30 @@ describe('DataStore tests', () => {
 						author: 'Some author',
 						rewards: [],
 						nominations: [],
+						misc: [undefined],
+					}),
+				});
+			}).not.toThrow();
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					metadata: new Metadata({
+						author: 'Some author',
+						rewards: [],
+						nominations: [],
+						misc: [undefined, null],
+					}),
+				});
+			}).not.toThrow();
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					metadata: new Metadata({
+						author: 'Some author',
+						rewards: [],
+						nominations: [],
 						misc: [null, 'ok'],
 					}),
 				});
@@ -489,7 +513,7 @@ describe('DataStore tests', () => {
 				});
 			}).toThrowError(
 				'All elements in the misc array should be of type string | null | undefined, [null,number] received. ,123'
-			)
+			);
 
 			expect(
 				new Model(<any>{ extraAttribute: 'some value', field1: 'some value' })

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -458,7 +458,7 @@ describe('DataStore tests', () => {
 					emails: [null],
 				});
 			}).toThrowError(
-				'All elements in the emails array should be of type string, [object] received. '
+				'All elements in the emails array should be of type string, [null] received. '
 			);
 
 			expect(() => {
@@ -467,9 +467,7 @@ describe('DataStore tests', () => {
 					dateCreated: new Date().toISOString(),
 					ips: [null],
 				});
-			}).toThrowError(
-				'All elements in the ips array should be of type string | null | undefined, [object] received. '
-			);
+			}).not.toThrow();
 
 			expect(() => {
 				new Model({
@@ -583,6 +581,7 @@ describe('DataStore tests', () => {
 			expect(() => {
 				new Model({
 					field1: 'someField',
+					dateCreated: new Date().toISOString(),
 					metadata: new Metadata({
 						author: 'Some author',
 						rewards: [],
@@ -595,6 +594,7 @@ describe('DataStore tests', () => {
 			expect(() => {
 				new Model({
 					field1: 'someField',
+					dateCreated: new Date().toISOString(),
 					metadata: new Metadata({
 						author: 'Some author',
 						rewards: [],
@@ -607,6 +607,7 @@ describe('DataStore tests', () => {
 			expect(() => {
 				new Model({
 					field1: 'someField',
+					dateCreated: new Date().toISOString(),
 					metadata: new Metadata({
 						author: 'Some author',
 						rewards: [],
@@ -619,6 +620,7 @@ describe('DataStore tests', () => {
 			expect(() => {
 				new Model({
 					field1: 'someField',
+					dateCreated: new Date().toISOString(),
 					metadata: new Metadata({
 						author: 'Some author',
 						rewards: [],
@@ -631,6 +633,7 @@ describe('DataStore tests', () => {
 			expect(() => {
 				new Model({
 					field1: 'someField',
+					dateCreated: new Date().toISOString(),
 					metadata: new Metadata({
 						author: 'Some author',
 						rewards: [],

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -409,7 +409,7 @@ describe('DataStore tests', () => {
 					}),
 				});
 			}).toThrowError(
-				'All elements in the rewards array should be of type string, [object] received. '
+				'All elements in the rewards array should be of type string, [null] received. '
 			);
 
 			expect(() => {
@@ -488,7 +488,7 @@ describe('DataStore tests', () => {
 					}),
 				});
 			}).toThrowError(
-				'All elements in the misc array should be of type string | null | undefined, [object,number] received. ,123'
+				'All elements in the misc array should be of type string | null | undefined, [null,number] received. ,123'
 			)
 
 			expect(

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -453,6 +453,44 @@ describe('DataStore tests', () => {
 				'All elements in the tags array should be of type string | null | undefined, [number] received. 1234'
 			);
 
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					metadata: new Metadata({
+						author: 'Some author',
+						rewards: [],
+						nominations: [],
+						misc: [null],
+					}),
+				});
+			}).not.toThrow();
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					metadata: new Metadata({
+						author: 'Some author',
+						rewards: [],
+						nominations: [],
+						misc: [null, 'ok'],
+					}),
+				});
+			}).not.toThrow();
+
+			expect(() => {
+				new Model({
+					field1: 'someField',
+					metadata: new Metadata({
+						author: 'Some author',
+						rewards: [],
+						nominations: [],
+						misc: [null, <any>123],
+					}),
+				});
+			}).toThrowError(
+				'All elements in the misc array should be of type string | null | undefined, [object,number] received. ,123'
+			)
+
 			expect(
 				new Model(<any>{ extraAttribute: 'some value', field1: 'some value' })
 			).toHaveProperty('extraAttribute');
@@ -738,6 +776,7 @@ export declare class Metadata {
 	readonly rewards: string[];
 	readonly penNames?: string[];
 	readonly nominations: string[];
+	readonly misc?: (string | null)[];
 	constructor(init: Metadata);
 }
 
@@ -839,6 +878,14 @@ function testSchema(): Schema {
 						type: 'String',
 						isRequired: false,
 						attributes: [],
+					},
+					misc: {
+						name: 'misc',
+						isArray: true,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+						isArrayNullable: true
 					}
 				},
 			},

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -271,7 +271,7 @@ const validateModelFields = (modelDefinition: SchemaModel | SchemaNonModel) => (
 				if (
 					!isNullOrUndefined(v) &&
 					(<[]>v).some(
-						e => typeof e !== jsType || (isNullOrUndefined(e) && isRequired)
+						e => isNullOrUndefined(e) ? isRequired : typeof e !== jsType
 					)
 				) {
 					const elemTypes = (<[]>v).map(e => typeof e).join(',');
@@ -1165,7 +1165,7 @@ class DataStore {
 			if (map.has(modelDefinition)) {
 				const { name } = modelDefinition;
 				logger.warn(
-					`You can only utilize one Sync Expression per model. 
+					`You can only utilize one Sync Expression per model.
           Subsequent sync expressions for the ${name} model will be ignored.`
 				);
 				return map;

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -274,7 +274,7 @@ const validateModelFields = (modelDefinition: SchemaModel | SchemaNonModel) => (
 						e => isNullOrUndefined(e) ? isRequired : typeof e !== jsType
 					)
 				) {
-					const elemTypes = (<[]>v).map(e => typeof e).join(',');
+					const elemTypes = (<[]>v).map(e => e === null ? 'null' : typeof e).join(',');
 
 					throw new Error(
 						`All elements in the ${name} array should be of type ${errorTypeText}, [${elemTypes}] received. ${v}`


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
1. Update error message to show `[null]` instead of `[object]` for `[null]`s.
2. The current test suite does not handle scenarios for something like
    ```
    misc: [String]
    ``` 
    `amplify codegen models` generates the following type:
    ```
    readonly misc?: (string | null)[];
    ```
    and schema:
    ```
    "misc": {
        "name": "misc",
        "isArray": true,
        "type": "String",
        "isRequired": false,
        "attributes": [],
        "isArrayNullable": true
    },
    ```
    With the current validation function, setting `misc: [null]` throws an exception stating 
    ```
    All elements in the rewards array should be of type string | null | undefined , [null] received. 
    ```
    This is clearly a mistake because `[null]` should pass validation. 

**To summarize**, this PR (1) fixes the datastore validation logic for arrays with optional elements and (2) updates error message to show `[null]` instead of `[object]` where applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
