### PR TITLE
fix(@aws-amplify/datastore): extend Lookup type to allow Predicates.ALL

### DIFF
--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -1,5 +1,6 @@
 import { ModelInstanceCreator } from './datastore/datastore';
 import { exhaustiveCheck } from './util';
+import { PredicateAll } from './predicates';
 
 //#region Schema types
 export type Schema = UserSchema & {
@@ -482,7 +483,10 @@ type Option1<T extends PersistentModel> = [ModelPredicate<T> | undefined];
 type Option<T extends PersistentModel> = Option0 | Option1<T>;
 
 type Lookup<T extends PersistentModel> = {
-	0: ProducerModelPredicate<T> | Promise<ProducerModelPredicate<T>>;
+	0:
+		| ProducerModelPredicate<T>
+		| Promise<ProducerModelPredicate<T>>
+		| typeof PredicateAll;
 	1: ModelPredicate<T> | undefined;
 };
 


### PR DESCRIPTION
Explicitly allow `Predicates.ALL` as a return type.
Fixes https://github.com/aws-amplify/amplify-js/issues/7217

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
