### PR TITLE
deps: bump dexie to 3.0.3

### DIFF
--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -43,7 +43,7 @@
 	"devDependencies": {
 		"@react-native-community/netinfo": "4.7.0",
 		"@types/uuid": "3.4.5",
-		"dexie": "3.0.2",
+		"dexie": "3.0.3",
 		"dexie-export-import": "1.0.0-rc.2",
 		"fake-indexeddb": "3.0.0"
 	},


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ This bumps `dexie` to `3.0.3` to resolve datastore unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
