### PR TITLE
deps: update AWS SDK packages to latest RC versions

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -45,11 +45,11 @@
 	"dependencies": {
 		"@aws-amplify/cache": "3.1.36",
 		"@aws-amplify/core": "3.8.3",
-		"@aws-sdk/client-firehose": "1.0.0-gamma.8",
-		"@aws-sdk/client-kinesis": "1.0.0-gamma.8",
-		"@aws-sdk/client-personalize-events": "1.0.0-gamma.8",
-		"@aws-sdk/client-pinpoint": "1.0.0-gamma.8",
-		"@aws-sdk/util-utf8-browser": "1.0.0-gamma.6",
+		"@aws-sdk/client-firehose": "1.0.0-rc.6",
+		"@aws-sdk/client-kinesis": "1.0.0-rc.6",
+		"@aws-sdk/client-personalize-events": "1.0.0-rc.6",
+		"@aws-sdk/client-pinpoint": "1.0.0-rc.6",
+		"@aws-sdk/util-utf8-browser": "1.0.0-rc.3",
 		"lodash": "^4.17.20",
 		"uuid": "^3.2.1"
 	},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,13 +54,13 @@
 		"react-native": "0.59.0"
 	},
 	"dependencies": {
-		"@aws-crypto/sha256-js": "1.0.0-alpha.0",
-		"@aws-sdk/client-cognito-identity": "1.0.0-gamma.8",
-		"@aws-sdk/credential-provider-cognito-identity": "1.0.0-gamma.8",
-		"@aws-sdk/node-http-handler": "1.0.0-gamma.7",
-		"@aws-sdk/types": "1.0.0-gamma.6",
-		"@aws-sdk/util-hex-encoding": "1.0.0-gamma.6",
-		"@aws-sdk/util-user-agent-browser": "1.0.0-gamma.7",
+		"@aws-crypto/sha256-js": "1.0.0",
+		"@aws-sdk/client-cognito-identity": "1.0.0-rc.6",
+		"@aws-sdk/credential-provider-cognito-identity": "1.0.0-rc.6",
+		"@aws-sdk/node-http-handler": "1.0.0-rc.5",
+		"@aws-sdk/types": "1.0.0-rc.3",
+		"@aws-sdk/util-hex-encoding": "1.0.0-rc.3",
+		"@aws-sdk/util-user-agent-browser": "1.0.0-rc.5",
 		"universal-cookie": "^4.0.4",
 		"url": "^0.11.0",
 		"zen-observable-ts": "0.8.19"

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -42,7 +42,7 @@
 	"homepage": "https://aws-amplify.github.io/",
 	"dependencies": {
 		"@aws-amplify/core": "3.8.3",
-		"@aws-sdk/client-lex-runtime-service": "1.0.0-gamma.8"
+		"@aws-sdk/client-lex-runtime-service": "1.0.0-rc.6"
 	},
 	"jest": {
 		"globals": {

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -42,13 +42,13 @@
 	"dependencies": {
 		"@aws-amplify/core": "3.8.3",
 		"@aws-amplify/storage": "3.3.11",
-		"@aws-sdk/client-comprehend": "1.0.0-gamma.8",
-		"@aws-sdk/client-polly": "1.0.0-gamma.8",
-		"@aws-sdk/client-rekognition": "1.0.0-gamma.8",
-		"@aws-sdk/client-textract": "1.0.0-gamma.8",
-		"@aws-sdk/client-translate": "1.0.0-gamma.8",
-		"@aws-sdk/eventstream-marshaller": "1.0.0-gamma.7",
-		"@aws-sdk/util-utf8-node": "1.0.0-gamma.6",
+		"@aws-sdk/client-comprehend": "1.0.0-rc.6",
+		"@aws-sdk/client-polly": "1.0.0-rc.6",
+		"@aws-sdk/client-rekognition": "1.0.0-rc.6",
+		"@aws-sdk/client-textract": "1.0.0-rc.6",
+		"@aws-sdk/client-translate": "1.0.0-rc.6",
+		"@aws-sdk/eventstream-marshaller": "1.0.0-rc.5",
+		"@aws-sdk/util-utf8-node": "1.0.0-rc.3",
 		"uuid": "^3.2.1"
 	},
 	"jest": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -42,10 +42,10 @@
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
     "@aws-amplify/core": "3.8.3",
-    "@aws-sdk/client-s3": "1.0.0-gamma.8",
-    "@aws-sdk/s3-request-presigner": "1.0.0-gamma.7",
-    "@aws-sdk/util-create-request": "1.0.0-gamma.7",
-    "@aws-sdk/util-format-url": "1.0.0-gamma.7",
+    "@aws-sdk/client-s3": "1.0.0-rc.6",
+    "@aws-sdk/s3-request-presigner": "1.0.0-rc.6",
+    "@aws-sdk/util-create-request": "1.0.0-rc.5",
+    "@aws-sdk/util-format-url": "1.0.0-rc.5",
     "axios": "0.19.0",
     "events": "^3.1.0",
     "sinon": "^7.5.0"


### PR DESCRIPTION
This PR bumps AWS SDK dependencies from "gamma" preview versions to the latest RC versions.  This is specifically helpful to pick up the following PRs that fix sourcemap problems in SDK packages:
* https://github.com/aws/aws-sdk-js-v3/pull/1462
* https://github.com/aws/aws-sdk-js-crypto-helpers/pull/169

_Issue #, if available:_
n/a

_Description of changes:_
Dependency updates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
