### PR TITLE
deps(@aws-amplify/ui-components): add `@types/react` to the resolution list

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
 	"resolutions": {
 		"@types/babel__traverse": "7.0.8",
 		"terser": "4.6.7",
-		"npm-packlist": "1.1.12"
+		"npm-packlist": "1.1.12",
+		"@types/react": "16.9.10"
 	},
 	"jest": {
 		"resetMocks": true,

--- a/package.json
+++ b/package.json
@@ -93,9 +93,9 @@
 	},
 	"resolutions": {
 		"@types/babel__traverse": "7.0.8",
+		"@types/react": "16.9.10",
 		"terser": "4.6.7",
-		"npm-packlist": "1.1.12",
-		"@types/react": "16.9.10"
+		"npm-packlist": "1.1.12"
 	},
 	"jest": {
 		"resetMocks": true,


### PR DESCRIPTION
_Issue #, if available:_ closes #7247 

_Description of changes:_ With the latest `@types/react` major release (`17.x.x`), `yarn build` is failing due to conflicting `@types/react` versions among sub-dependencies. This pr adds `@types/react` to `resolutions` to use `16.x.x` version. Once sub-dependencies are updated to use `17.x.x`, this change should be reverted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
