### PR TITLE
fix(@aws-amplify/datastore): handle groupClaim as plain string

### DIFF
--- a/packages/datastore/__tests__/subscription.test.ts
+++ b/packages/datastore/__tests__/subscription.test.ts
@@ -565,6 +565,85 @@ describe('sync engine subscription module', () => {
 			)
 		).toEqual(authInfo);
 	});
+	test('groups authorization with groupClaim (plain string)', () => {
+		const model: SchemaModel = {
+			syncable: true,
+			name: 'Post',
+			pluralName: 'Posts',
+			attributes: [
+				{ type: 'model', properties: {} },
+				{
+					type: 'auth',
+					properties: {
+						rules: [
+							{
+								provider: 'userPools',
+								ownerField: 'owner',
+								allow: 'groups',
+								groups: ['mygroup'],
+								groupClaim: 'custom:group',
+								identityClaim: 'cognito:username',
+								operations: ['create', 'update', 'delete', 'read'],
+							},
+						],
+					},
+				},
+			],
+			fields: {
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				title: {
+					name: 'title',
+					isArray: false,
+					type: 'String',
+					isRequired: true,
+					attributes: [],
+				},
+				owner: {
+					name: 'owner',
+					isArray: false,
+					type: 'String',
+					isRequired: false,
+					attributes: [],
+				},
+			},
+		};
+		const tokenPayload = {
+			sub: 'xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx',
+			'custom:group': 'mygroup',
+			email_verified: true,
+			iss: 'https://cognito-idp.us-west-2.amazonaws.com/us-west-2_XXXXXXXXX',
+			phone_number_verified: false,
+			'cognito:username': 'user1',
+			aud: '6l99pm4b729dn8c7bj7d3t1lnc',
+			event_id: 'b4c25daa-0c03-4617-aab8-e5c74403536b',
+			token_use: 'id',
+			auth_time: 1578541322,
+			phone_number: '+12068220398',
+			exp: 1578544922,
+			iat: 1578541322,
+			email: 'user1@user.com',
+		};
+		const authInfo = {
+			authMode: 'AMAZON_COGNITO_USER_POOLS',
+			isOwner: false,
+		};
+
+		expect(
+			// @ts-ignore
+			SubscriptionProcessor.prototype.getAuthorizationInfo(
+				model,
+				USER_CREDENTIALS.auth,
+				GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
+				tokenPayload
+			)
+		).toEqual(authInfo);
+	});
 	test('public iam authorization for unauth user', () => {
 		const model: SchemaModel = {
 			syncable: true,

--- a/packages/datastore/src/sync/utils.ts
+++ b/packages/datastore/src/sync/utils.ts
@@ -462,7 +462,12 @@ export function getUserGroupsFromToken(
 	let userGroups: string[] | string = token[rule.groupClaim] || [];
 
 	if (typeof userGroups === 'string') {
-		const parsedGroups = JSON.parse(userGroups);
+		let parsedGroups;
+		try {
+			parsedGroups = JSON.parse(userGroups);
+		} catch (e) {
+			parsedGroups = userGroups;
+		}
 		userGroups = [].concat(parsedGroups);
 	}
 


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/issues/7206#issuecomment-732061640

_Description of changes:_
Continuing from https://github.com/aws-amplify/amplify-js/pull/7208, this will add additional handling for a `groupClaim` as a plain string, which is currently throwing a `JSON.parse` error.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
