### PR TITLE
Datastore/feat/save with id from client

### DIFF
--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -351,7 +351,7 @@ const createModelClass = <T extends PersistentModel>(
 						_lastChangedAt,
 						_deleted,
 					} = modelInstanceMetadata;
-					const _id = init.id || modelInstanceMetadata.id
+					const _id = init.id || modelInstanceMetadata.id;
 
 					const id =
 						// instancesIds is set by modelInstanceCreator, it is accessible only internally

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -347,11 +347,11 @@ const createModelClass = <T extends PersistentModel>(
 						? <ModelInstanceMetadata>(<unknown>init)
 						: <ModelInstanceMetadata>{};
 					const {
-						id: _id,
 						_version,
 						_lastChangedAt,
 						_deleted,
 					} = modelInstanceMetadata;
+					const _id = init.id || modelInstanceMetadata.id
 
 					const id =
 						// instancesIds is set by modelInstanceCreator, it is accessible only internally

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -221,7 +221,7 @@ export type TypeConstructorMap = Record<
 
 // Instance of model
 export type PersistentModel = Readonly<{ id: string } & Record<string, any>>;
-export type ModelInit<T> = Omit<T, 'id'>;
+export type ModelInit<T> = Partial<T>;
 type DeepWritable<T> = {
 	-readonly [P in keyof T]: T[P] extends TypeName<T[P]>
 		? T[P]


### PR DESCRIPTION
**TLDR: This pull request allows model ids to be set from the client.**

According to the amplify-cli docs, it is possible to set the primary key field `id` from the client through the graphql mutation.
The resolver looks like this:
`"id":   $util.dynamodb.toDynamoDBJson($util.defaultIfNullOrBlank($ctx.args.input.id, $util.autoId()))`

Datastore uses the same resolver, however, redefines the id, that has been set with its own newly generated uuid ignoring the one being set in the input of `DataStore.save(Model, { id: ...}`.
To me, it is unclear which advantages this would bring and only see the disadvantage of not having full control over the assignment of ids.

Hence this PR tries to changes this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
