### PR TITLE
fix(@aws-amplify/analytics): send events when autoSessionRecord is disabled

### DIFF
--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -99,6 +99,11 @@ export class AnalyticsClass {
 			this._disabled = true;
 		}
 
+		// turn on the autoSessionRecord if not specified
+		if (this._config['autoSessionRecord'] === undefined) {
+			this._config['autoSessionRecord'] = true;
+		}
+
 		this._pluggables.forEach(pluggable => {
 			// for backward compatibility
 			const providerConfig =
@@ -109,17 +114,13 @@ export class AnalyticsClass {
 
 			pluggable.configure({
 				disabled: this._config['disabled'],
+				autoSessionRecord: this._config['autoSessionRecord'],
 				...providerConfig,
 			});
 		});
 
 		if (this._pluggables.length === 0) {
 			this.addPluggable(new AWSPinpointProvider());
-		}
-
-		// turn on the autoSessionRecord if not specified
-		if (this._config['autoSessionRecord'] === undefined) {
-			this._config['autoSessionRecord'] = true;
 		}
 
 		dispatchAnalyticsEvent(

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -119,6 +119,10 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 		const conf = config || {};
 		this._config = Object.assign({}, this._config, conf);
 
+		// If autoSessionRecord is enabled, we need to wait for the endpoint to be
+		// updated before sending any events. See `sendEvents` in `Analytics.ts`
+		this._endpointGenerating = !!config['autoSessionRecord'];
+
 		if (this._config.appId && !this._config.disabled) {
 			if (!this._config.endpointId) {
 				const cacheKey = this.getProviderName() + '_' + this._config.appId;


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
When `autoSessionRecord` is disabled, custom events are never being sent because `_endpointGenerating` is defaulted to true which causes the buffer to pause indefinitely due to this block of code in `_initBuffer`:
```js
if (this._endpointGenerating) {
  this._buffer.pause();
}
```

My assumption is that this was originally added to make sure the endpoint was updated with `immediate: true` before sending the initial session events. See `sendEvents` in `Analytics.ts` for more context.

This PR will set `_endpointGenerating` dynamically based on if `autoSessionRecord` is enabled or not.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
