### PR TITLE
fix(@aws-amplify/ui-components): flatten `injectGlobalPaths` array

### DIFF
--- a/packages/amplify-ui-components/stencil.config.ts
+++ b/packages/amplify-ui-components/stencil.config.ts
@@ -24,7 +24,7 @@ export const config: Config = {
     }),
     nodePolyfills(),
     sass({
-      injectGlobalPaths: [['src/global/breakpoint.scss', '*']],
+      injectGlobalPaths: ['src/global/breakpoint.scss'],
     }),
   ],
   nodeResolve: {


### PR DESCRIPTION
_Issue #, if available:_ Reverts #7168

_Description of changes:_ This reflects the `injectGlobalPaths` behavior change from the latest `stencil-sass` release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
