### PR TITLE
fix(@aws-amplify/datastore): check auth config before getting token

### DIFF
--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -255,6 +255,15 @@ class SubscriptionProcessor {
 				}
 
 				try {
+					// Checking for `region` in Auth config to see if Auth is configured
+					// before attempting to get federated token. We're using `region` because
+					// it will be there regardless of user/identity pool being present.
+					// See `parseMobileHubConfig` in `Parser.ts` for more info.
+					const { region } = Auth.configure();
+					if (!region) {
+						throw 'Auth is not configured';
+					}
+
 					let token;
 					// backwards compatibility
 					const federatedInfo = await Cache.getItem('federatedInfo');

--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -255,12 +255,11 @@ class SubscriptionProcessor {
 				}
 
 				try {
-					// Checking for `region` in Auth config to see if Auth is configured
-					// before attempting to get federated token. We're using `region` because
-					// it will be there regardless of user/identity pool being present.
-					// See `parseMobileHubConfig` in `Parser.ts` for more info.
-					const { region } = Auth.configure();
-					if (!region) {
+					// Checking for the Cognito region in config to see if Auth is configured
+					// before attempting to get federated token. We're using the Cognito region
+					// because it will be there regardless of user/identity pool being present.
+					const { aws_cognito_region, Auth: AuthConfig } = this.amplifyConfig;
+					if (!aws_cognito_region || (AuthConfig && !AuthConfig.region)) {
 						throw 'Auth is not configured';
 					}
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
![image](https://user-images.githubusercontent.com/17091790/100940729-5b427280-34ad-11eb-944e-6de8f24e1f49.png)

This fixes an Auth error that shows in the console when using DataStore with API Key and the Auth category isn't configured. The error is showing because we are calling `Auth.currentAuthenticatedUser()`. As the code comment says, we're checking if Auth is configured first with `Auth.configure()` before attempting to get the OIDC token below. If it's not configured, we're just throwing an error as a string to the `catch` to be logged with `logger.debug`, as opposed to the `logger.error` currently being used in `Auth.currentAuthenticatedUser()`.

For reference, this is where `region` is set for Auth:
https://github.com/aws-amplify/amplify-js/blob/main/packages/core/src/Parser.ts#L19-L29

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
