### PR TITLE
added rekognition customlabels feature to amplify predictions category

### DIFF
--- a/packages/predictions/src/Predictions.ts
+++ b/packages/predictions/src/Predictions.ts
@@ -11,6 +11,8 @@ import {
 	IdentifyTextOutput,
 	IdentifyLabelsOutput,
 	IdentifyLabelsInput,
+	IdentifyCustomLabelsOutput,
+	IdentifyCustomLabelsInput,
 	IdentifyEntitiesInput,
 	IdentifyEntitiesOutput,
 	InterpretTextOutput,
@@ -169,14 +171,25 @@ export class PredictionsClass {
 		options?: ProviderOptions
 	): Promise<IdentifyLabelsOutput>;
 	public identify(
+		input: IdentifyCustomLabelsInput,
+		options?: ProviderOptions
+	): Promise<IdentifyCustomLabelsOutput>;
+	public identify(
 		input: IdentifyEntitiesInput,
 		options?: ProviderOptions
 	): Promise<IdentifyEntitiesOutput>;
 	public identify(
-		input: IdentifyTextInput | IdentifyLabelsInput | IdentifyEntitiesInput,
+		input:
+			| IdentifyTextInput
+			| IdentifyLabelsInput
+			| IdentifyCustomLabelsInput
+			| IdentifyEntitiesInput,
 		options: ProviderOptions
 	): Promise<
-		IdentifyTextOutput | IdentifyLabelsOutput | IdentifyEntitiesOutput
+		| IdentifyTextOutput
+		| IdentifyLabelsOutput
+		| IdentifyCustomLabelsOutput
+		| IdentifyEntitiesOutput
 	> {
 		const pluggableToExecute = this.getPluggableToExecute(
 			this._identifyPluggables,

--- a/packages/predictions/src/Providers/AmazonAIPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIPredictionsProvider.ts
@@ -11,6 +11,8 @@ import {
 	IdentifyTextOutput,
 	IdentifyLabelsInput,
 	IdentifyLabelsOutput,
+	IdentifyCustomLabelsInput,
+	IdentifyCustomLabelsOutput,
 	IdentifyEntitiesInput,
 	IdentifyEntitiesOutput,
 	TranslateTextOutput,
@@ -58,9 +60,16 @@ export class AmazonAIPredictionsProvider extends AbstractPredictionsProvider {
 	}
 
 	identify(
-		input: IdentifyTextInput | IdentifyLabelsInput | IdentifyEntitiesInput
+		input:
+			| IdentifyTextInput
+			| IdentifyLabelsInput
+			| IdentifyCustomLabelsInput
+			| IdentifyEntitiesInput
 	): Promise<
-		IdentifyTextOutput | IdentifyLabelsOutput | IdentifyEntitiesOutput
+		| IdentifyTextOutput
+		| IdentifyLabelsOutput
+		| IdentifyCustomLabelsOutput
+		| IdentifyEntitiesOutput
 	> {
 		return this.identifyProvider.identify(input);
 	}

--- a/packages/predictions/src/types/Predictions.ts
+++ b/packages/predictions/src/types/Predictions.ts
@@ -216,6 +216,14 @@ export interface IdentifyLabelsInput {
 	};
 }
 
+export interface IdentifyCustomLabelsInput {
+	customlabels: {
+		source: IdentifySource;
+		projectVersionArn: string;
+		type: 'LABELS';
+	};
+}
+
 export interface Point {
 	x?: Number;
 	y?: Number;
@@ -237,6 +245,13 @@ export interface IdentifyLabelsOutput {
 		metadata?: Object;
 	}[];
 	unsafe?: 'YES' | 'NO' | 'UNKNOWN';
+}
+
+export interface IdentifyCustomLabelsOutput {
+	customlabels?: {
+		name: string;
+		metadata?: Object;
+	}[];
 }
 
 export interface IdentifyEntitiesInput {
@@ -338,6 +353,13 @@ export function isIdentifyTextInput(obj: any): obj is IdentifyTextInput {
 
 export function isIdentifyLabelsInput(obj: any): obj is IdentifyLabelsInput {
 	const key: keyof IdentifyLabelsInput = 'labels';
+	return obj && obj.hasOwnProperty(key);
+}
+
+export function isIdentifyCustomLabelsInput(
+	obj: any
+): obj is IdentifyCustomLabelsInput {
+	const key: keyof IdentifyCustomLabelsInput = 'customlabels';
 	return obj && obj.hasOwnProperty(key);
 }
 

--- a/packages/predictions/src/types/Providers/AbstractIdentifyPredictionsProvider.ts
+++ b/packages/predictions/src/types/Providers/AbstractIdentifyPredictionsProvider.ts
@@ -1,13 +1,16 @@
 import { AbstractPredictionsProvider } from './AbstractPredictionsProvider';
 import {
 	IdentifyLabelsInput,
+	IdentifyCustomLabelsInput,
 	IdentifyEntitiesInput,
 	isIdentifyLabelsInput,
+	isIdentifyCustomLabelsInput,
 	isIdentifyEntitiesInput,
 	IdentifyTextInput,
 	isIdentifyTextInput,
 	IdentifyTextOutput,
 	IdentifyLabelsOutput,
+	IdentifyCustomLabelsOutput,
 	IdentifyEntitiesOutput,
 } from '../Predictions';
 import { Logger } from '@aws-amplify/core';
@@ -19,9 +22,16 @@ export abstract class AbstractIdentifyPredictionsProvider extends AbstractPredic
 	}
 
 	identify(
-		input: IdentifyTextInput | IdentifyLabelsInput | IdentifyEntitiesInput
+		input:
+			| IdentifyTextInput
+			| IdentifyLabelsInput
+			| IdentifyCustomLabelsInput
+			| IdentifyEntitiesInput
 	): Promise<
-		IdentifyTextOutput | IdentifyLabelsOutput | IdentifyEntitiesOutput
+		| IdentifyTextOutput
+		| IdentifyLabelsOutput
+		| IdentifyCustomLabelsOutput
+		| IdentifyEntitiesOutput
 	> {
 		if (isIdentifyTextInput(input)) {
 			logger.debug('identifyText');
@@ -29,6 +39,9 @@ export abstract class AbstractIdentifyPredictionsProvider extends AbstractPredic
 		} else if (isIdentifyLabelsInput(input)) {
 			logger.debug('identifyLabels');
 			return this.identifyLabels(input);
+		} else if (isIdentifyCustomLabelsInput(input)) {
+			logger.debug('identifyCustomLabels');
+			return this.identifyCustomLabels(input);
 		} else if (isIdentifyEntitiesInput(input)) {
 			logger.debug('identifyEntities');
 			return this.identifyEntities(input);
@@ -45,6 +58,12 @@ export abstract class AbstractIdentifyPredictionsProvider extends AbstractPredic
 		input: IdentifyLabelsInput
 	): Promise<IdentifyLabelsOutput> {
 		throw new Error('identifyLabels is not implemented by this provider');
+	}
+
+	protected identifyCustomLabels(
+		input: IdentifyCustomLabelsInput
+	): Promise<IdentifyCustomLabelsOutput> {
+		throw new Error('identifyCustomLabels is not implemented by this provider');
 	}
 
 	protected identifyEntities(


### PR DESCRIPTION
Background:
Currently AWS Amplify predictions category is only supporting standard labels from Rekognition. While with custom labels there is a whole new spectrum of Machine Learning that we can add to our client applications. In this change I added the feature to support custom label requests from predictions identify. 

_Description of changes:_
I have made a new types for customLabels input and output. 
There is a check added that when there is a request with the param **customlabel** that the function **identifyCustomLabels** is called. This function is an abstraction of identifyLabels.

_Unit test:
I am not an expert in creating unit tests. I tried to create a few, but therefor the model needs to run otherwise the test fails. So there is still some work to do to mock this service. 

_Repo:
here is a react app repo to test the app. Replace the arn with a model arn that you create.
https://github.com/rpostulart/customlabelsApp


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
