### PR TITLE
Remove Throwing Exceptions for GraphQL Errors

### DIFF
--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -286,7 +286,7 @@ export class GraphQLAPIClass {
 		if (!endpoint) {
 			const error = new GraphQLError('No graphql endpoint provided.');
 
-			throw {
+			return {
 				data: {},
 				errors: [error],
 			};
@@ -306,12 +306,6 @@ export class GraphQLAPIClass {
 				data: {},
 				errors: [new GraphQLError(err.message)],
 			};
-		}
-
-		const { errors } = response;
-
-		if (errors && errors.length) {
-			throw response;
 		}
 
 		return response;


### PR DESCRIPTION
_Description of changes:_

I know this will probably cause an issue and I'm very open to adding any additional needed documentation but here is my reasoning:
This PR changes the throwing of exceptions when an error happens. Exceptions should be treated differently than errors which are already returned by the function. A developer should be responsible for handling the error; they can throw if encountered but are not forced to do so.

Before this change, a developer using [field-level auth](https://docs.amplify.aws/cli/graphql-transformer/auth#field-level-authorization) will have to catch to get the expected data result. An example of what this would prevent is listed here [https://gist.github.com/DavidBrear/96b29a426ebbfd0ab643fbf1e78b36e9](https://gist.github.com/DavidBrear/96b29a426ebbfd0ab643fbf1e78b36e9)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
