### PR TITLE
fix(@aws-amplify/datastore): remove netinfo from peer deps to prevent npm7 error

### DIFF
--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -58,9 +58,6 @@
 		"zen-observable-ts": "0.8.19",
 		"zen-push": "0.2.1"
 	},
-	"peerDependencies": {
-		"@react-native-community/netinfo": "^5.5.0"
-	},
 	"jest": {
 		"globals": {
 			"ts-jest": {


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws-amplify/amplify-js/issues/7348

_Description of changes:_ 
NPM 7 attempts to automatically install peer dependencies and errors out when there are conflicts. 

This means it'll always attempt to install `@react-native-community/netinfo`, even though it's only required for react-native apps. 

The docs [already specify](https://docs.amplify.aws/lib/datastore/getting-started/q/platform/js#option-1-platform-integration) netinfo as a required package for RN. 

This PR removes netinfo as a peer dependency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
