### PR TITLE
fix(6774): fixed 'signIn' not being called on successful totp verification.

### DIFF
--- a/packages/auth/__tests__/totp-unit-test.ts
+++ b/packages/auth/__tests__/totp-unit-test.ts
@@ -9,7 +9,6 @@ jest.mock('amazon-cognito-identity-js/lib/CognitoUserSession', () => {
 	CognitoUserSession.prototype.getIdToken = () => {
 		return {
 			getJwtToken: () => {
-				jest;
 				return null;
 			},
 		};

--- a/packages/auth/__tests__/totp-unit-test.ts
+++ b/packages/auth/__tests__/totp-unit-test.ts
@@ -9,6 +9,7 @@ jest.mock('amazon-cognito-identity-js/lib/CognitoUserSession', () => {
 	CognitoUserSession.prototype.getIdToken = () => {
 		return {
 			getJwtToken: () => {
+				jest;
 				return null;
 			},
 		};
@@ -172,6 +173,10 @@ jest.mock('amazon-cognito-identity-js/lib/CognitoUser', () => {
 		callback(null, {
 			PreferredMfaSetting: 'SMS_MFA',
 		});
+	};
+
+	CognitoUser.prototype.getUsername = () => {
+		return 'testUsername';
 	};
 
 	return CognitoUser;
@@ -346,12 +351,17 @@ describe('auth unit test', () => {
 			const auth = new Auth(authOptions);
 
 			const spyon = jest.spyOn(CognitoUser.prototype, 'verifySoftwareToken');
+			const spyon2 = jest.spyOn(CognitoUser.prototype, 'getUsername');
+
 			expect(await auth.verifyTotpToken(user, 'challengeAnswer')).toBe(
 				'Success'
 			);
+
 			expect(spyon).toBeCalled();
+			expect(spyon2).toBeCalled();
 
 			spyon.mockClear();
+			spyon2.mockClear();
 		});
 
 		test('err case', async () => {

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -896,6 +896,11 @@ export class AuthClass {
 					return;
 				},
 				onSuccess: data => {
+					dispatchAuthEvent(
+						'signIn',
+						user,
+						`A user ${user.getUsername()} has been signed in`
+					);
 					logger.debug('verifyTotpToken success', data);
 					res(data);
 					return;


### PR DESCRIPTION
Issue #6774 

_Description of changes:_

Added a `dispatchAuthEvent` call inside the `onSuccess` callback of `verifyTotpToken`.
Mocked `CognitoUser.getUsername()` and adapted the current 'totp-unit-test' to work with the addition.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
