### PR TITLE
fix(@aws-amplify/datastore): unsubscribe connectivity on stop/clear

### DIFF
--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -1065,6 +1065,10 @@ class DataStore {
 
 		await this.storage.clear();
 
+		if (this.sync) {
+			this.sync.unsubscribeConnectivity();
+		}
+
 		this.initialized = undefined; // Should re-initialize when start() is called.
 		this.storage = undefined;
 		this.sync = undefined;
@@ -1078,6 +1082,10 @@ class DataStore {
 
 		if (syncSubscription && !syncSubscription.closed) {
 			syncSubscription.unsubscribe();
+		}
+
+		if (this.sync) {
+			this.sync.unsubscribeConnectivity();
 		}
 
 		this.initialized = undefined; // Should re-initialize when start() is called.

--- a/packages/datastore/src/sync/datastoreConnectivity.ts
+++ b/packages/datastore/src/sync/datastoreConnectivity.ts
@@ -14,6 +14,7 @@ type ConnectionStatus = {
 export default class DataStoreConnectivity {
 	private connectionStatus: ConnectionStatus;
 	private observer: ZenObservable.SubscriptionObserver<ConnectionStatus>;
+	private subscription: ZenObservable.Subscription;
 	constructor() {
 		this.connectionStatus = {
 			online: false,
@@ -28,7 +29,7 @@ export default class DataStoreConnectivity {
 			this.observer = observer;
 			// Will be used to forward socket connection changes, enhancing Reachability
 
-			const subs = ReachabilityMonitor.subscribe(({ online }) => {
+			this.subscription = ReachabilityMonitor.subscribe(({ online }) => {
 				this.connectionStatus.online = online;
 
 				const observerResult = { ...this.connectionStatus }; // copyOf status
@@ -37,9 +38,15 @@ export default class DataStoreConnectivity {
 			});
 
 			return () => {
-				subs.unsubscribe();
+				this.unsubscribe();
 			};
 		});
+	}
+
+	unsubscribe() {
+		if (this.subscription) {
+			this.subscription.unsubscribe();
+		}
 	}
 
 	socketDisconnected() {


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/issues/7312

_Description of changes:_
Currently when calling `DataStore.stop()` or `DataStore.clear()`, the `DataStoreConnectivity` observer is not unsubscribed, leading to the subscriptions getting [initialized](https://github.com/aws-amplify/amplify-js/blob/main/packages/datastore/src/sync/index.ts#L164-L166) again if the network connection goes from offline to online. This is problematic because `stop/clear` implies that all DataStore functionality should be halted.

In the case of the related issue, it is leading to duplicate sync queries and subscriptions being made.

This PR will properly unsubscribe the sync engine after calling `DataStore.stop()` or `DataStore.clear()`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
