### PR TITLE
docs(CONTRIBUTING.md): update verdaccio instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ Verdaccio is a lightweight private npm proxy registry built in Node.js. Install 
 To publish in Verdaccio, start a verdaccio instance and then,
 
 ```
-npm set registry http://localhost:4873/
+yarn config set registry http://localhost:4873/
 yarn lerna publish --skip-git --force-publish
 ```
 
@@ -157,13 +157,13 @@ To publish a local version of a specific package,
 
 ```
 cd packages/<category>
-npm publish --registry http://localhost:4873 (http://localhost:4873/)
+yarn publish --registry http://localhost:4873/
 ```
 
-Once you are done with Verdaccio, you can reset to npm registry by doing,
+Once you are done with Verdaccio, you can reset to the default registry by doing,
 
 ```
-npm set registry https://registry.npmjs.com/
+yarn config set registry https://registry.yarnpkg.com
 ```
 
 # Pull Requests


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
The current verdaccio publish instructions do not work. This is because lerna is using yarn not npm. This PR updates docs so contributors can get verdaccio set up without surprises.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
