### PR TITLE
fix(aws-amplify-react-native): remove peerDependencies

### DIFF
--- a/packages/aws-amplify-react-native/package.json
+++ b/packages/aws-amplify-react-native/package.json
@@ -32,10 +32,7 @@
 	},
 	"peerDependencies": {
 		"aws-amplify": "3.x.x",
-		"graphql": "^14.0.0",
-		"react-native-fs": "^2.12.1",
-		"react-native-sound": "^0.10.9",
-		"react-native-voice": "^0.2.6"
+		"graphql": "^14.0.0"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
_Issue #, if available:_
#7381 

_Description of changes:_
Due to a recent [update](https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/) with NPM CLI 7.0.0, peer dependencies will get automatically installed. This is causing issues in the `aws-amplify-react-native` library because we have a few outdated peer dependencies that are only used for the [Interaction components](https://docs.amplify.aws/ui/interactions/chatbot/q/framework/react-native). 

Since we already have a callout in the docs for installing the peer dependencies, they are no longer needed in the `package.json`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
