### PR TITLE
fix(@aws-amplify/auth): Disallow simultaneous Auth.signIn attempts

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -96,6 +96,7 @@ export class AuthClass {
 	private _storage;
 	private _storageSync;
 	private oAuthFlowInProgress: boolean = false;
+	private pendingSignIn: ReturnType<AuthClass['signInWithPassword']> | null;
 
 	Credentials = Credentials;
 
@@ -585,14 +586,30 @@ export class AuthClass {
 	private signInWithPassword(
 		authDetails: AuthenticationDetails
 	): Promise<CognitoUser | any> {
+		if (this.pendingSignIn) {
+			throw new Error('Pending sign-in attempt already in progress');
+		}
+
 		const user = this.createCognitoUser(authDetails.getUsername());
 
-		return new Promise((resolve, reject) => {
+		this.pendingSignIn = new Promise((resolve, reject) => {
 			user.authenticateUser(
 				authDetails,
-				this.authCallbacks(user, resolve, reject)
+				this.authCallbacks(
+					user,
+					value => {
+						this.pendingSignIn = null;
+						resolve(value);
+					},
+					error => {
+						this.pendingSignIn = null;
+						reject(error);
+					}
+				)
 			);
 		});
+
+		return this.pendingSignIn;
 	}
 
 	/**


### PR DESCRIPTION
_Issue #, if available:_ Fixes #7161 

See my reproduction here: https://github.com/aws-amplify/amplify-js/issues/7161#issuecomment-740081033


### Quick Fix

Track the `Auth.signIn` attempt and prevent **subsequent** sign-ins from happening until that resolves.

(I originally wanted to _cancel_ the previous ones, favoring the latest sign-in attempt. However, because the mutation of `user` happens _somewhere_ in that promise chain, it's not safe to cancel unless we practically track the state through that entire flow)

Because we **don't** have an understanding _why_ two different accounts would be signed in on the same computer, within milliseconds of each other, in the same browser, this seemed reasonable to prevent mutating `Auth.user`'s `attributes` with those of another.

> ![Kapture 2020-12-10 at 12 53 29](https://user-images.githubusercontent.com/15182/101816625-197d8180-3ad6-11eb-9f95-0738803d6484.gif)

### Root Cause

Ultimately, this problem exists because (1) `Auth.signIn` fetches the current user pool user for `attributes`, (2) which are mutated on the single `Auth.user` instance.

1. `Auth.signIn` calls `Auth.signInWithPassword`:

	https://github.com/aws-amplify/amplify-js/blob/30463fb0b8a7001d722a079da3535093f86c3702/packages/auth/src/Auth.ts#L479-L480

1. Then, `onSuccess`, `this.currentUserPoolUser()` is called:

	https://github.com/aws-amplify/amplify-js/blob/30463fb0b8a7001d722a079da3535093f86c3702/packages/auth/src/Auth.ts#L500-L514

1. But rather than operating on the previously-fetched user session, **further operations** are on the current user pool:

	https://github.com/aws-amplify/amplify-js/blob/30463fb0b8a7001d722a079da3535093f86c3702/packages/auth/src/Auth.ts#L1187

1. This `user` is then mutated:

	https://github.com/aws-amplify/amplify-js/blob/30463fb0b8a7001d722a079da3535093f86c3702/packages/auth/src/Auth.ts#L1243-L1245

1. So when 2 sign-ins take place simultaneously, they both end up racing to the same `currentUserPoolUser` & mutating it.


### Alternative Proposal

Because there are multiple function calls, we can abstract the attribute fetching behavior into _another_ function, mutate & return a provided `user`, then share that logic with a bit of code duplication between `signInWithPassword` and other calls.

I found in my experimentation that this ends up begging for cleanup of wrapped `new Promise()` chains that may be riskier than we'd want.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
