### PR TITLE
aws-amplify-angular: adding a `fromHub` rxjs operator for angular

### DIFF
--- a/packages/aws-amplify-angular/index.ts
+++ b/packages/aws-amplify-angular/index.ts
@@ -1,3 +1,4 @@
 export { AmplifyAngularModule } from './src/aws-amplify-angular.module';
 export { AmplifyIonicModule } from './src/aws-amplify-ionic-module';
 export { AmplifyService, AmplifyModules } from './src/providers';
+export { fromHub } from './src/utils';

--- a/packages/aws-amplify-angular/src/__tests__/utils.spec.ts
+++ b/packages/aws-amplify-angular/src/__tests__/utils.spec.ts
@@ -1,0 +1,20 @@
+import { Hub, HubPayload } from '@aws-amplify/core';
+import { fromHub } from '../utils';
+
+describe('fromHub', () => {
+	it('should emit a HubCapsule event when subscribed to the channel and eventName', done => {
+		const payload: HubPayload = {
+			event: 'customOAuthState',
+			data: 'some state',
+			message: 'some message state',
+		};
+		fromHub('auth', 'customOAuthState').subscribe(c => {
+			expect(c.channel).toEqual('auth');
+			expect(c.payload.data).toEqual('some state');
+			expect(c.payload.event).toEqual('customOAuthState');
+			done();
+		});
+
+		Hub.dispatch('auth', payload, 'Auth', Symbol.for('amplify_default'));
+	});
+});

--- a/packages/aws-amplify-angular/src/utils.ts
+++ b/packages/aws-amplify-angular/src/utils.ts
@@ -1,0 +1,44 @@
+// tslint:disable
+/*
+ * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+// tslint:enable
+import { HubCapsule, Hub } from '@aws-amplify/core';
+import { Observable } from 'rxjs';
+
+/**
+ * Enables usage of Hub as an RXJS operator
+ * Example usage:
+ *
+ * fromHub('Auth', 'customOAuthState').subscribe((capsule: HubCapsule) => {
+ * 	console.log(capsule.payload.data);
+ * });
+ * @param channel Hub channel
+ * @param eventName Event in hub channel you want to subscribe to
+ */
+export function fromHub(
+	channel: string,
+	eventName: string
+): Observable<HubCapsule> {
+	return new Observable<HubCapsule>(subscriber => {
+		function listener(data: HubCapsule) {
+			switch (data.payload.event) {
+				case eventName:
+					subscriber.next(data);
+					break;
+			}
+		}
+		Hub.listen(channel, listener);
+
+		return () => Hub.remove(channel, listener);
+	});
+}


### PR DESCRIPTION
This branch introduces a `fromHub` RXJS operator modeled after the `fromEvent` operator. This operator makes using the `Hub` easier for development by allowing the `Hub` to be used as an `Observable`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
