### PR TITLE
fix(@aws-amplify/ui-components): display friendly error for empty password

### DIFF
--- a/packages/amplify-ui-components/src/common/auth-helpers.ts
+++ b/packages/amplify-ui-components/src/common/auth-helpers.ts
@@ -57,7 +57,7 @@ export const handleSignIn = async (username: string, password: string, handleAut
       logger.debug('the user requires a new password');
       handleAuthStateChange(AuthState.ForgotPassword, { username });
     } else if (error.code === 'InvalidParameterException' && password === '') {
-      logger.debug('No password was passed and custom auth lambda triggers are not configured.', error);
+      logger.debug('Empty password was passed, with no custom auth lambda triggers configured', error);
       error.message = 'Password cannot be empty.';
     }
     dispatchToastHubEvent(error);

--- a/packages/amplify-ui-components/src/common/auth-helpers.ts
+++ b/packages/amplify-ui-components/src/common/auth-helpers.ts
@@ -57,7 +57,7 @@ export const handleSignIn = async (username: string, password: string, handleAut
       logger.debug('the user requires a new password');
       handleAuthStateChange(AuthState.ForgotPassword, { username });
     } else if (error.code === 'InvalidParameterException' && password === '') {
-      logger.debug('No password was passed and custom auth lambda triggers are not configured.');
+      logger.debug('No password was passed and custom auth lambda triggers are not configured.', error);
       error.message = 'Password cannot be empty.'; // make error message friendly to end users.
     }
     dispatchToastHubEvent(error);

--- a/packages/amplify-ui-components/src/common/auth-helpers.ts
+++ b/packages/amplify-ui-components/src/common/auth-helpers.ts
@@ -57,7 +57,7 @@ export const handleSignIn = async (username: string, password: string, handleAut
       logger.debug('the user requires a new password');
       handleAuthStateChange(AuthState.ForgotPassword, { username });
     } else if (error.code === 'InvalidParameterException' && password === '') {
-      logger.debug('Empty password was passed, with no custom auth lambda triggers configured', error);
+      logger.debug('Password cannot be empty');
       error.message = 'Password cannot be empty.';
     }
     dispatchToastHubEvent(error);

--- a/packages/amplify-ui-components/src/common/auth-helpers.ts
+++ b/packages/amplify-ui-components/src/common/auth-helpers.ts
@@ -50,13 +50,16 @@ export const handleSignIn = async (username: string, password: string, handleAut
       await checkContact(user, handleAuthStateChange);
     }
   } catch (error) {
-    dispatchToastHubEvent(error);
     if (error.code === 'UserNotConfirmedException') {
       logger.debug('the user is not confirmed');
       handleAuthStateChange(AuthState.ConfirmSignUp, { username });
     } else if (error.code === 'PasswordResetRequiredException') {
       logger.debug('the user requires a new password');
       handleAuthStateChange(AuthState.ForgotPassword, { username });
+    } else if (error.code === 'InvalidParameterException' && password === '') {
+      logger.debug('No password was passed and custom auth lambda triggers are not configured.');
+      error.message = 'Password cannot be empty.'; // make error message friendly to end users.
     }
+    dispatchToastHubEvent(error);
   }
 };

--- a/packages/amplify-ui-components/src/common/auth-helpers.ts
+++ b/packages/amplify-ui-components/src/common/auth-helpers.ts
@@ -58,7 +58,7 @@ export const handleSignIn = async (username: string, password: string, handleAut
       handleAuthStateChange(AuthState.ForgotPassword, { username });
     } else if (error.code === 'InvalidParameterException' && password === '') {
       logger.debug('No password was passed and custom auth lambda triggers are not configured.', error);
-      error.message = 'Password cannot be empty.'; // make error message friendly to end users.
+      error.message = 'Password cannot be empty.';
     }
     dispatchToastHubEvent(error);
   }


### PR DESCRIPTION
_Issue #, if available:_ Fixes #5623 

_Description of changes:_ Displays "password cannot be empty" message on sign in attempts without a password, if custom lambda triggers are not configured.

**Problem**
If `password` is empty on `Auth.signIn()`, `Auth` assumes that the client is on a custom auth flow with lambda triggers set up. This is not the case for UI users who just forgot to put a password (or mistakenly pressed enter early). They would get "Custom auth lambda trigger is not configured for the user pool." error instead, which is unreadable to end users. 

**Solution**
This PR detects if the error is due to empty password on custom auth flow, and changes the message to "Password cannot be empty" for readability. 

![Screen Shot 2020-12-14 at 10 25 02 AM](https://user-images.githubusercontent.com/43682783/102119909-abe39500-3df6-11eb-9046-a00780128d01.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
