### PR TITLE
fix(@aws-amplify/ui-componets): Use constant for empty password error

### DIFF
--- a/packages/amplify-ui-components/src/common/auth-helpers.ts
+++ b/packages/amplify-ui-components/src/common/auth-helpers.ts
@@ -3,6 +3,7 @@ import { Logger, isEmpty } from '@aws-amplify/core';
 import { AuthState, ChallengeName, CognitoUserInterface, AuthStateHandler } from './types/auth-types';
 import { dispatchToastHubEvent } from './helpers';
 import { NO_AUTH_MODULE_FOUND } from '../common/constants';
+import { Translations } from '../common/Translations';
 
 const logger = new Logger('auth-helpers');
 
@@ -58,7 +59,7 @@ export const handleSignIn = async (username: string, password: string, handleAut
       handleAuthStateChange(AuthState.ForgotPassword, { username });
     } else if (error.code === 'InvalidParameterException' && password === '') {
       logger.debug('Password cannot be empty');
-      error.message = 'Password cannot be empty.';
+      error.message = Translations.EMPTY_PASSWORD;
     }
     dispatchToastHubEvent(error);
   }

--- a/packages/amplify-ui-components/src/common/auth-helpers.ts
+++ b/packages/amplify-ui-components/src/common/auth-helpers.ts
@@ -57,7 +57,7 @@ export const handleSignIn = async (username: string, password: string, handleAut
       logger.debug('the user requires a new password');
       handleAuthStateChange(AuthState.ForgotPassword, { username });
     } else if (error.code === 'InvalidParameterException' && password === '') {
-      logger.debug('No password was passed and custom auth lambda triggers are not configured.', error);
+      logger.debug('Empty password was passed, with no custom auth lambda triggers configured', error);
       error.message = 'Password cannot be empty.';
     }
     dispatchToastHubEvent(error);

--- a/packages/amplify-ui-components/src/common/auth-helpers.ts
+++ b/packages/amplify-ui-components/src/common/auth-helpers.ts
@@ -57,7 +57,7 @@ export const handleSignIn = async (username: string, password: string, handleAut
       logger.debug('the user requires a new password');
       handleAuthStateChange(AuthState.ForgotPassword, { username });
     } else if (error.code === 'InvalidParameterException' && password === '') {
-      logger.debug('No password was passed and custom auth lambda triggers are not configured.');
+      logger.debug('No password was passed and custom auth lambda triggers are not configured.', error);
       error.message = 'Password cannot be empty.'; // make error message friendly to end users.
     }
     dispatchToastHubEvent(error);

--- a/packages/amplify-ui-components/src/common/auth-helpers.ts
+++ b/packages/amplify-ui-components/src/common/auth-helpers.ts
@@ -57,7 +57,7 @@ export const handleSignIn = async (username: string, password: string, handleAut
       logger.debug('the user requires a new password');
       handleAuthStateChange(AuthState.ForgotPassword, { username });
     } else if (error.code === 'InvalidParameterException' && password === '') {
-      logger.debug('Empty password was passed, with no custom auth lambda triggers configured', error);
+      logger.debug('Password cannot be empty');
       error.message = 'Password cannot be empty.';
     }
     dispatchToastHubEvent(error);

--- a/packages/amplify-ui-components/src/common/auth-helpers.ts
+++ b/packages/amplify-ui-components/src/common/auth-helpers.ts
@@ -50,13 +50,16 @@ export const handleSignIn = async (username: string, password: string, handleAut
       await checkContact(user, handleAuthStateChange);
     }
   } catch (error) {
-    dispatchToastHubEvent(error);
     if (error.code === 'UserNotConfirmedException') {
       logger.debug('the user is not confirmed');
       handleAuthStateChange(AuthState.ConfirmSignUp, { username });
     } else if (error.code === 'PasswordResetRequiredException') {
       logger.debug('the user requires a new password');
       handleAuthStateChange(AuthState.ForgotPassword, { username });
+    } else if (error.code === 'InvalidParameterException' && password === '') {
+      logger.debug('No password was passed and custom auth lambda triggers are not configured.');
+      error.message = 'Password cannot be empty.'; // make error message friendly to end users.
     }
+    dispatchToastHubEvent(error);
   }
 };

--- a/packages/amplify-ui-components/src/common/auth-helpers.ts
+++ b/packages/amplify-ui-components/src/common/auth-helpers.ts
@@ -58,7 +58,7 @@ export const handleSignIn = async (username: string, password: string, handleAut
       handleAuthStateChange(AuthState.ForgotPassword, { username });
     } else if (error.code === 'InvalidParameterException' && password === '') {
       logger.debug('No password was passed and custom auth lambda triggers are not configured.', error);
-      error.message = 'Password cannot be empty.'; // make error message friendly to end users.
+      error.message = 'Password cannot be empty.';
     }
     dispatchToastHubEvent(error);
   }


### PR DESCRIPTION
_Issue #, if available:_ #5623, follows up #7401 

_Description of changes:_ Use translatable constants for empty password error message.

Usage:
```jsx
import { I18n } from 'aws-amplify';
import { Translations } from '@aws-amplify/ui-components';

I18n.putVocabulariesForLanguage('en-US', {
	[Translations.EMPTY_PASSWORD]: 'Custom Empty Password Translation',
});
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
