### PR TITLE
chore: pin @babel/types causing ui-angular build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
 		"winston": "^3.2.1"
 	},
 	"resolutions": {
+		"@babel/types": "7.12.10",
 		"@types/babel__traverse": "7.0.8",
 		"@types/react": "16.9.10",
 		"terser": "4.6.7",


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Fixes build error in `@aws-amplify/ui-angular` introduced by the latest version of `@babel/types`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
