### PR TITLE
fix(@aws-amplify/predictions): decode Uint8Array as UTF-8 (#7448)

### DIFF
--- a/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
@@ -207,7 +207,7 @@ export class AmazonAIConvertPredictionsProvider extends AbstractConvertPredictio
 			Buffer.from(message.data)
 		);
 		const transcribeMessageJson = JSON.parse(
-			String.fromCharCode.apply(String, transcribeMessage.body)
+			toUtf8(transcribeMessage.body)
 		);
 		if (transcribeMessage.headers[':message-type'].value === 'exception') {
 			logger.debug(


### PR DESCRIPTION
_Issue #, if available:_
Fixes #7448

_Description of changes:_
Replaced `String.fromCharCode` with `toUtf8` so that Uint8Array is converted to string as UTF-8.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
