### PR TITLE
fix(aws-amplify) : federated sign provider undefined error.

### DIFF
--- a/packages/aws-amplify/src/index.ts
+++ b/packages/aws-amplify/src/index.ts
@@ -30,7 +30,7 @@ export {
 	AmazonPersonalizeProvider,
 } from '@aws-amplify/analytics';
 
-export { Auth } from '@aws-amplify/auth';
+export { Auth, CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
 export { Storage, StorageClass } from '@aws-amplify/storage';
 export { API, APIClass, graphqlOperation } from '@aws-amplify/api';
 export {


### PR DESCRIPTION
_Issue #, if available:_
#7477 
_Description of changes:_
The way I see it, amplify library seem to be unified with `amplify-aws`.  
But when I use `Auth.federatedSignIn({provider: "Google"})` with typescript. 
There is some error like,
```
Type "Google" is not assignable to type "CognitoHostedUIIdentityProvider".
```
So, I have researched some reference, and I know I can use `@aws-amplify/auth` with #3611  like,

```typescript
import {CognitoHostedUIIdentityProvider} from "@aws-amplify/Auth";
```
But What I am thinking is that It is useful to export `CognitoHostedUIIdentityProvider` from `aws-amplify`. 
And when I check `aws-amplify` package, there is many provider enum. So I fix it.
[packages/aws-amplify/src/index.ts | line 33]
### Before
```typescript
export { Auth } from '@aws-amplify/auth';
```

### After
```typescript
export { Auth , CognitoHostedUIIdentityProvider} from '@aws-amplify/auth';
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
