### PR TITLE
deps: bump axios to 0.21.1

### DIFF
--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
     "@aws-amplify/core": "3.8.8",
-    "axios": "0.19.0"
+    "axios": "0.21.1"
   },
   "jest": {
     "globals": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -46,7 +46,7 @@
     "@aws-sdk/s3-request-presigner": "1.0.0-rc.4",
     "@aws-sdk/util-create-request": "1.0.0-rc.4",
     "@aws-sdk/util-format-url": "1.0.0-rc.4",
-    "axios": "0.19.0",
+    "axios": "0.21.1",
     "events": "^3.1.0",
     "sinon": "^7.5.0"
   },


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ This bump is in response to a medium secuirty vulnerability with axios described in https://github.com/axios/axios/pull/3410. This PR bumps axios to 0.21.1 in which the security patch is released. 

Looking at the [changelog](https://github.com/axios/axios/blob/hotfix/0.21.1/CHANGELOG.md) from 0.19.0 to 0.21.1, I don't see any commits that would cause regression, but it would be great if anyone else can confirm this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
