### PR TITLE
fix(aws-amplify-react-native): Added Keyboard.dismiss() to display e…

### DIFF
--- a/packages/aws-amplify-react-native/src/Auth/AuthPiece.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/AuthPiece.tsx
@@ -12,7 +12,7 @@
  */
 
 import React from 'react';
-
+import { Keyboard } from 'react-native';
 import { Auth, Logger, JS, I18n } from 'aws-amplify';
 
 import AmplifyTheme, { AmplifyThemeType } from '../AmplifyTheme';
@@ -161,6 +161,7 @@ export default class AuthPiece<
 			this.props.errorMessage || this.props.messageMap || AmplifyMessageMap;
 		msg = typeof map === 'string' ? map : map(msg);
 		this.setState({ error: msg });
+		Keyboard.dismiss();
 	}
 
 	render() {


### PR DESCRIPTION
…rrors

_Issue #, if available: #7501
Keyboard is hidding error message:
<img src="https://user-images.githubusercontent.com/52170580/103813907-ae13ca80-5015-11eb-94b6-a3b904ff54da.gif" height="400"/>
_Description of changes:
Added Keyboard.dismiss() to the error() method on AuthPiece to prevent keyboard from covering the error message

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
