### PR TITLE
feat(@aws-amplify/api-graphql):Return data from GraphQL call inside error response

### DIFF
--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -302,8 +302,14 @@ export class GraphQLAPIClass {
 			if (this._api.isCancel(err)) {
 				throw err;
 			}
+
+			// We can access the data from the error response
+			// because under the hood the API module uses Axios.
+			// https://github.com/axios/axios#handling-errors
+			const errData = err.response.data;
+
 			response = {
-				data: {},
+				data: errData || {},
 				errors: [new GraphQLError(err.message)],
 			};
 		}


### PR DESCRIPTION
_Issue #, if available:_ [#7535](https://github.com/aws-amplify/amplify-js/issues/7535)

_Description of changes:_ Return response data from Axios when GraphQL call has an error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
