### PR TITLE
fix(@aws-amplify/ui-components): handle federated user in checkContact

### DIFF
--- a/packages/amplify-ui-components/src/common/auth-helpers.ts
+++ b/packages/amplify-ui-components/src/common/auth-helpers.ts
@@ -1,4 +1,4 @@
-import { Auth } from '@aws-amplify/auth';
+import { Auth, CognitoUser } from '@aws-amplify/auth';
 import { Logger, isEmpty } from '@aws-amplify/core';
 import { AuthState, ChallengeName, CognitoUserInterface, AuthStateHandler } from './types/auth-types';
 import { dispatchToastHubEvent } from './helpers';
@@ -11,6 +11,14 @@ export async function checkContact(user: CognitoUserInterface, handleAuthStateCh
   if (!Auth || typeof Auth.verifiedContact !== 'function') {
     throw new Error(NO_AUTH_MODULE_FOUND);
   }
+
+  // If `user` is a federated user, we shouldn't call `verifiedContact`
+  // since `user` isn't `CognitoUser`
+  if (!(user instanceof CognitoUser)) {
+    handleAuthStateChange(AuthState.SignedIn, user);
+    return;
+  }
+
   try {
     const data = await Auth.verifiedContact(user);
     if (!isEmpty(data.verified) || isEmpty(data.unverified)) {

--- a/packages/amplify-ui-components/src/common/auth-helpers.ts
+++ b/packages/amplify-ui-components/src/common/auth-helpers.ts
@@ -14,7 +14,7 @@ export async function checkContact(user: CognitoUserInterface, handleAuthStateCh
 
   // If `user` is a federated user, we shouldn't call `verifiedContact`
   // since `user` isn't `CognitoUser`
-  if (!(user instanceof CognitoUser)) {
+  if (!isCognitoUser(user)) {
     handleAuthStateChange(AuthState.SignedIn, user);
     return;
   }
@@ -71,4 +71,8 @@ export const handleSignIn = async (username: string, password: string, handleAut
     }
     dispatchToastHubEvent(error);
   }
+};
+
+export const isCognitoUser = (user: CognitoUserInterface) => {
+  return user instanceof CognitoUser;
 };


### PR DESCRIPTION
_Issue #, if available:_
#7554 

_Description of changes:_
When using the Amplify UI Components, `Auth.verifiedContact(...)` is being called after signing in to check whether the user should be routed to the app or the "Verify Contact" screen. However, this causes a problem when using Identity Pool federation because the `user` is [not actually a `CognitoUser`](https://docs.amplify.aws/lib/auth/advanced/q/platform/js#identity-pool-federation) and `verifiedContact` calls `user.getSession` (via [`userSession`](https://github.com/aws-amplify/amplify-js/blob/843183b094281b42ec829b010dd41d214899c23d/packages/auth/src/Auth.ts#L1389)) which doesn't exist.

This PR checks to make sure `user` is an instance of `CognitoUser` before calling `Auth.verifiedContact` and changes the auth state to "signed in" if it is not an instance.


I tested with a federated user as well as regular user and validated the behavior.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
