### PR TITLE
feat(@aws-amplify/amplify-ui-components): authenticator slotted toast

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-authenticator/__snapshots__/amplify-authenticator.spec.ts.snap
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/__snapshots__/amplify-authenticator.spec.ts.snap
@@ -3,7 +3,6 @@
 exports[`amplify-authenticator spec: Render logic -> should render a \`forgot password\` if initialAuthState is \`forgotpassword\` 1`] = `
 <amplify-authenticator initial-auth-state="forgotpassword">
   <mock:shadow-root>
-    <slot name="notification"></slot>
     <div class="auth-container">
       <slot name="forgot-password">
         <amplify-forgot-password></amplify-forgot-password>
@@ -16,7 +15,6 @@ exports[`amplify-authenticator spec: Render logic -> should render a \`forgot pa
 exports[`amplify-authenticator spec: Render logic -> should render a \`sign in\` by default 1`] = `
 <amplify-authenticator>
   <mock:shadow-root>
-    <slot name="notification"></slot>
     <div class="auth-container">
       <slot name="sign-in">
         <amplify-sign-in></amplify-sign-in>
@@ -29,7 +27,6 @@ exports[`amplify-authenticator spec: Render logic -> should render a \`sign in\`
 exports[`amplify-authenticator spec: Render logic -> should render a \`sign up\` if initialAuthState is \`signup\` 1`] = `
 <amplify-authenticator initial-auth-state="signup">
   <mock:shadow-root>
-    <slot name="notification"></slot>
     <div class="auth-container">
       <slot name="sign-up">
         <amplify-sign-up></amplify-sign-up>

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/__snapshots__/amplify-authenticator.spec.ts.snap
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/__snapshots__/amplify-authenticator.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`amplify-authenticator spec: Render logic -> should render a \`forgot password\` if initialAuthState is \`forgotpassword\` 1`] = `
 <amplify-authenticator initial-auth-state="forgotpassword">
   <mock:shadow-root>
-    <slot name="alert"></slot>
+    <slot name="notification"></slot>
     <div class="auth-container">
       <slot name="forgot-password">
         <amplify-forgot-password></amplify-forgot-password>
@@ -16,7 +16,7 @@ exports[`amplify-authenticator spec: Render logic -> should render a \`forgot pa
 exports[`amplify-authenticator spec: Render logic -> should render a \`sign in\` by default 1`] = `
 <amplify-authenticator>
   <mock:shadow-root>
-    <slot name="alert"></slot>
+    <slot name="notification"></slot>
     <div class="auth-container">
       <slot name="sign-in">
         <amplify-sign-in></amplify-sign-in>
@@ -29,7 +29,7 @@ exports[`amplify-authenticator spec: Render logic -> should render a \`sign in\`
 exports[`amplify-authenticator spec: Render logic -> should render a \`sign up\` if initialAuthState is \`signup\` 1`] = `
 <amplify-authenticator initial-auth-state="signup">
   <mock:shadow-root>
-    <slot name="alert"></slot>
+    <slot name="notification"></slot>
     <div class="auth-container">
       <slot name="sign-up">
         <amplify-sign-up></amplify-sign-up>

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/__snapshots__/amplify-authenticator.spec.ts.snap
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/__snapshots__/amplify-authenticator.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`amplify-authenticator spec: Render logic -> should render a \`forgot password\` if initialAuthState is \`forgotpassword\` 1`] = `
 <amplify-authenticator initial-auth-state="forgotpassword">
   <mock:shadow-root>
+    <slot name="alert"></slot>
     <div class="auth-container">
       <slot name="forgot-password">
         <amplify-forgot-password></amplify-forgot-password>
@@ -15,6 +16,7 @@ exports[`amplify-authenticator spec: Render logic -> should render a \`forgot pa
 exports[`amplify-authenticator spec: Render logic -> should render a \`sign in\` by default 1`] = `
 <amplify-authenticator>
   <mock:shadow-root>
+    <slot name="alert"></slot>
     <div class="auth-container">
       <slot name="sign-in">
         <amplify-sign-in></amplify-sign-in>
@@ -27,6 +29,7 @@ exports[`amplify-authenticator spec: Render logic -> should render a \`sign in\`
 exports[`amplify-authenticator spec: Render logic -> should render a \`sign up\` if initialAuthState is \`signup\` 1`] = `
 <amplify-authenticator initial-auth-state="signup">
   <mock:shadow-root>
+    <slot name="alert"></slot>
     <div class="auth-container">
       <slot name="sign-up">
         <amplify-sign-up></amplify-sign-up>

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
@@ -34,6 +34,7 @@ const logger = new Logger('Authenticator');
  * @slot totp-setup - Content placed inside of the totp-setup workflow for when a user opts to use TOTP MFA
  * @slot greetings - Content placed inside of the greetings navigation for when a user is signed in
  * @slot loading - Content placed inside of the loading workflow for when the app is loading
+ * @slot notification - Component for displaying auth messages
  */
 @Component({
   tag: 'amplify-authenticator',
@@ -187,7 +188,7 @@ export class AmplifyAuthenticator {
   render() {
     return (
       <Host>
-        <slot name="alert">
+        <slot name="notification">
           {this.toastMessage && (
             <amplify-toast
               message={this.toastMessage}

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
@@ -34,7 +34,7 @@ const logger = new Logger('Authenticator');
  * @slot totp-setup - Content placed inside of the totp-setup workflow for when a user opts to use TOTP MFA
  * @slot greetings - Content placed inside of the greetings navigation for when a user is signed in
  * @slot loading - Content placed inside of the loading workflow for when the app is loading
- * @slot notification - Component for displaying auth messages
+ * @slot notification - Component for displaying auth error messages
  */
 @Component({
   tag: 'amplify-authenticator',
@@ -188,8 +188,8 @@ export class AmplifyAuthenticator {
   render() {
     return (
       <Host>
-        <slot name="notification">
-          {this.toastMessage && (
+        {this.toastMessage && (
+          <slot name="notification">
             <amplify-toast
               message={this.toastMessage}
               handleClose={() => {
@@ -197,8 +197,8 @@ export class AmplifyAuthenticator {
               }}
               data-test="authenticator-error"
             />
-          )}
-        </slot>
+          </slot>
+        )}
         {this.authState === AuthState.SignedIn ? (
           [<slot name="greetings"></slot>, <slot></slot>]
         ) : (

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
@@ -187,15 +187,17 @@ export class AmplifyAuthenticator {
   render() {
     return (
       <Host>
-        {this.toastMessage ? (
-          <amplify-toast
-            message={this.toastMessage}
-            handleClose={() => {
-              this.toastMessage = '';
-            }}
-            data-test="authenticator-error"
-          />
-        ) : null}
+        <slot name="alert">
+          {this.toastMessage && (
+            <amplify-toast
+              message={this.toastMessage}
+              handleClose={() => {
+                this.toastMessage = '';
+              }}
+              data-test="authenticator-error"
+            />
+          )}
+        </slot>
         {this.authState === AuthState.SignedIn ? (
           [<slot name="greetings"></slot>, <slot></slot>]
         ) : (

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/readme.md
@@ -22,6 +22,7 @@
 | `"forgot-password"`      | Content placed inside of the forgot password workflow for when a user wants to reset their password                    |
 | `"greetings"`            | Content placed inside of the greetings navigation for when a user is signed in                                         |
 | `"loading"`              | Content placed inside of the loading workflow for when the app is loading                                              |
+| `"notification"`         | Component for displaying auth messages                                                                                 |
 | `"require-new-password"` | Content placed inside of the require new password workflow for when a user is required to update their password        |
 | `"sign-in"`              | Content placed inside of the sign in workflow for when a user wants to sign into their account                         |
 | `"sign-up"`              | Content placed inside of the sign up workflow for when a user wants to register a new account                          |

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/readme.md
@@ -22,7 +22,7 @@
 | `"forgot-password"`      | Content placed inside of the forgot password workflow for when a user wants to reset their password                    |
 | `"greetings"`            | Content placed inside of the greetings navigation for when a user is signed in                                         |
 | `"loading"`              | Content placed inside of the loading workflow for when the app is loading                                              |
-| `"notification"`         | Component for displaying auth messages                                                                                 |
+| `"notification"`         | Component for displaying auth error messages                                                                           |
 | `"require-new-password"` | Content placed inside of the require new password workflow for when a user is required to update their password        |
 | `"sign-in"`              | Content placed inside of the sign in workflow for when a user wants to sign into their account                         |
 | `"sign-up"`              | Content placed inside of the sign up workflow for when a user wants to register a new account                          |


### PR DESCRIPTION
_Issue #, if available:_ #6479

_Description of changes:_
Following discussions on PR #7129 and issue #6479, this PR offers a slotted approach to toast customisation in the `amplify-authenticator` component.

**This PR has been updated. The example is the same however.**

~Rather than just wrapping the `amplify-toast` in a slot however, this PR introduces a new component: `amplify-auth-alert`.~

~Introducing this component has the following benefits:~

- ~Removes the `handleToastEvent` logic from `amplify-authenticator`, therefore reducing the logic/responsibility in this component.~
- ~`amplify-auth-alert` can be used outside/without the `amplify-authenticator` if desired.~
- ~Provides a clean example of an alert component in `amplify-auth-alert` for anyone looking to roll their own alert component.~

React (ts) example:
```ts
import React, { useState, useEffect } from 'react';
import { Hub, HubCallback } from '@aws-amplify/core';
import {
  AmplifyAuthenticator,
} from '@aws-amplify/ui-react';
import {
 UI_AUTH_CHANNEL, TOAST_AUTH_ERROR_EVENT
} from '@aws-amplify/ui-components';

const MyAlert: React.FC<{ slot: string }> = ({ slot }) => {
  const [alertMessage, setAlertMessage] = useState('');

  const handleToastErrors: HubCallback = ({ payload }) => {
    if (payload.event === TOAST_AUTH_ERROR_EVENT && payload.message) {
      setAlertMessage(payload.message);
    }
  };

  useEffect(() => {
    Hub.listen(UI_AUTH_CHANNEL, handleToastErrors);
    return () => Hub.remove(UI_AUTH_CHANNEL, handleToastErrors);
  });

  return (<span slot={slot}>{alertMessage}</span>);
};

const MyAuth: React.FC = ({ children }) => {
  return (
    <>
      <AmplifyAuthenticator>
        <MyAlert slot="notification" />
        // ...........
      </AmplifyAuthenticator>
    </>
  );
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
