### PR TITLE
fix(@aws-amplify/auth, amazon-cognito-identity-js): Include clientMetadata for token refresh

### DIFF
--- a/packages/amazon-cognito-identity-js/index.d.ts
+++ b/packages/amazon-cognito-identity-js/index.d.ts
@@ -63,6 +63,10 @@ declare module 'amazon-cognito-identity-js' {
 		Storage?: ICognitoStorage;
 	}
 
+	export interface GetSessionOptions {
+		clientMetadata: Record<string, string>;
+	}
+
 	export class CognitoUser {
 		constructor(data: ICognitoUserData);
 
@@ -76,12 +80,13 @@ declare module 'amazon-cognito-identity-js' {
 		public setAuthenticationFlowType(
 			authenticationFlowType: string
 		): string;
-        public getCachedDeviceKeyAndPassword(): void;
+		public getCachedDeviceKeyAndPassword(): void;
 
 		public getSession(
 			callback:
 				| ((error: Error, session: null) => void)
-				| ((error: null, session: CognitoUserSession) => void)
+				| ((error: null, session: CognitoUserSession) => void),
+			options: GetSessionOptions
 		): void;
 		public refreshSession(
 			refreshToken: CognitoRefreshToken,

--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -1220,17 +1220,24 @@ export default class CognitoUser {
 	 * PRIVATE ONLY: This is an internal only method and should not
 	 * be directly called by the consumers.
 	 */
-	refreshSessionIfPossible() {
+	refreshSessionIfPossible(options = {}) {
 		// best effort, if not possible
 		return new Promise(resolve => {
 			const refresh = this.signInUserSession.getRefreshToken();
 			if (refresh && refresh.getToken()) {
-				this.refreshSession(refresh, resolve);
+				this.refreshSession(refresh, resolve, options.clientMetadata);
 			} else {
 				resolve();
 			}
 		});
 	}
+
+	/**
+	 * @typedef {Object} GetUserDataOptions 
+	 * @property {boolean} bypassCache - force getting data from Cognito service
+	 * @property {Record<string, string>} clientMetadata - clientMetadata for getSession
+	*/
+
 
 	/**
 	 * This is used by an authenticated users to get the userData
@@ -1258,7 +1265,7 @@ export default class CognitoUser {
 		if (this.isFetchUserDataAndTokenRequired(params)) {
 			this.fetchUserData()
 				.then(data => {
-					return this.refreshSessionIfPossible().then(() => data);
+					return this.refreshSessionIfPossible(params).then(() => data);
 				})
 				.then(data => callback(null, data))
 				.catch(callback);
@@ -1357,13 +1364,19 @@ export default class CognitoUser {
 	}
 
 	/**
+	 * @typedef {Object} GetSessionOptions 
+	 * @property {Record<string, string>} clientMetadata - clientMetadata for getSession
+	*/
+
+	/**
 	 * This is used to get a session, either from the session object
 	 * or from  the local storage, or by using a refresh token
 	 *
 	 * @param {nodeCallback<CognitoUserSession>} callback Called on success or error.
+	 * @param {GetSessionOptions} options
 	 * @returns {void}
 	 */
-	getSession(callback) {
+	getSession(callback, options) {
 		if (this.username == null) {
 			return callback(
 				new Error('Username is null. Cannot retrieve a new session'),
@@ -1375,9 +1388,8 @@ export default class CognitoUser {
 			return callback(null, this.signInUserSession);
 		}
 
-		const keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}.${
-			this.username
-		}`;
+		const keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}.${this.username
+			}`;
 		const idTokenKey = `${keyPrefix}.idToken`;
 		const accessTokenKey = `${keyPrefix}.accessToken`;
 		const refreshTokenKey = `${keyPrefix}.refreshToken`;
@@ -1415,7 +1427,7 @@ export default class CognitoUser {
 				);
 			}
 
-			this.refreshSession(refreshToken, callback);
+			this.refreshSession(refreshToken, callback, options.clientMetadata);
 		} else {
 			callback(
 				new Error('Local storage is missing an ID Token, Please authenticate'),
@@ -1540,9 +1552,8 @@ export default class CognitoUser {
 	 * @returns {void}
 	 */
 	cacheDeviceKeyAndPassword() {
-		const keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}.${
-			this.username
-		}`;
+		const keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}.${this.username
+			}`;
 		const deviceKeyKey = `${keyPrefix}.deviceKey`;
 		const randomPasswordKey = `${keyPrefix}.randomPasswordKey`;
 		const deviceGroupKeyKey = `${keyPrefix}.deviceGroupKey`;
@@ -1557,9 +1568,8 @@ export default class CognitoUser {
 	 * @returns {void}
 	 */
 	getCachedDeviceKeyAndPassword() {
-		const keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}.${
-			this.username
-		}`;
+		const keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}.${this.username
+			}`;
 		const deviceKeyKey = `${keyPrefix}.deviceKey`;
 		const randomPasswordKey = `${keyPrefix}.randomPasswordKey`;
 		const deviceGroupKeyKey = `${keyPrefix}.deviceGroupKey`;
@@ -1576,9 +1586,8 @@ export default class CognitoUser {
 	 * @returns {void}
 	 */
 	clearCachedDeviceKeyAndPassword() {
-		const keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}.${
-			this.username
-		}`;
+		const keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}.${this.username
+			}`;
 		const deviceKeyKey = `${keyPrefix}.deviceKey`;
 		const randomPasswordKey = `${keyPrefix}.randomPasswordKey`;
 		const deviceGroupKeyKey = `${keyPrefix}.deviceGroupKey`;

--- a/packages/auth/__tests__/auth-refresh-token-test.ts
+++ b/packages/auth/__tests__/auth-refresh-token-test.ts
@@ -1,0 +1,321 @@
+import { AuthClass as Auth } from '../src/Auth';
+
+import {
+	CognitoUserPool,
+	CognitoUser,
+	CognitoUserSession,
+	CognitoIdToken,
+	CognitoAccessToken,
+	CognitoUserAttribute,
+} from 'amazon-cognito-identity-js';
+
+import { AuthOptions } from '../src/types';
+
+const clientMetadata = {
+	test: 'i need to be send for token refresh',
+};
+
+const authOptions: AuthOptions = {
+	userPoolId: 'us-west-2_0xxxxxxxx',
+	userPoolWebClientId: 'awsUserPoolsWebClientId',
+	region: 'region',
+	identityPoolId: 'awsCognitoIdentityPoolId',
+	mandatorySignIn: false,
+	clientMetadata,
+};
+
+describe('Refresh token', () => {
+	it('currentUserPoolUser  user.getSession using ClientMetadata from config', async () => {
+		// configure with client metadata
+		const auth = new Auth(authOptions);
+
+		expect.assertions(1);
+
+		const getSessionSpy = jest
+			.spyOn(CognitoUser.prototype, 'getSession')
+			.mockImplementation(
+				// @ts-ignore
+				(
+					callback: (error: Error, session: CognitoUserSession) => void,
+					options: any
+				) => {
+					expect(options.clientMetadata).toEqual({
+						...clientMetadata,
+					});
+					const session = new CognitoUserSession({
+						AccessToken: new CognitoAccessToken({ AccessToken: 'accesstoken' }),
+						IdToken: new CognitoIdToken({ IdToken: 'Idtoken' }),
+					});
+					callback(null, session);
+				}
+			);
+
+		jest
+			.spyOn(CognitoUserPool.prototype, 'getCurrentUser')
+			.mockImplementation(() => {
+				return new CognitoUser({
+					Pool: new CognitoUserPool({
+						ClientId: authOptions.userPoolWebClientId,
+						UserPoolId: authOptions.userPoolId,
+					}),
+					Username: 'username',
+				});
+			});
+		await auth.currentUserPoolUser();
+	});
+
+	it('userSession  user.getSession using ClientMetadata from config', async () => {
+		// configure with client metadata
+		const auth = new Auth(authOptions);
+
+		expect.assertions(2);
+
+		const getSessionSpy = jest
+			.spyOn(CognitoUser.prototype, 'getSession')
+			.mockImplementation(
+				// @ts-ignore
+				(
+					callback: (error: Error, session: CognitoUserSession) => void,
+					options: any
+				) => {
+					expect(options.clientMetadata).toEqual({
+						...clientMetadata,
+					});
+					const session = new CognitoUserSession({
+						AccessToken: new CognitoAccessToken({ AccessToken: 'accesstoken' }),
+						IdToken: new CognitoIdToken({ IdToken: 'Idtoken' }),
+					});
+					callback(null, session);
+				}
+			);
+
+		jest
+			.spyOn(CognitoUserPool.prototype, 'getCurrentUser')
+			.mockImplementation(() => {
+				return new CognitoUser({
+					Pool: new CognitoUserPool({
+						ClientId: authOptions.userPoolWebClientId,
+						UserPoolId: authOptions.userPoolId,
+					}),
+					Username: 'username',
+				});
+			});
+		const user = await auth.currentUserPoolUser();
+
+		await auth.userSession(user);
+	});
+
+	it('cognitoIdentitySignOut user.getSession using ClientMetadata from config', async () => {
+		// configure with client metadata
+		const auth = new Auth(authOptions);
+
+		expect.assertions(2);
+
+		jest.spyOn(CognitoUser.prototype, 'getSession').mockImplementation(
+			// @ts-ignore
+			(
+				callback: (error: Error, session: CognitoUserSession) => void,
+				options: any
+			) => {
+				expect(options.clientMetadata).toEqual({
+					...clientMetadata,
+				});
+				const session = new CognitoUserSession({
+					AccessToken: new CognitoAccessToken({ AccessToken: 'accesstoken' }),
+					IdToken: new CognitoIdToken({ IdToken: 'Idtoken' }),
+				});
+				callback(null, session);
+			}
+		);
+
+		jest
+			.spyOn(CognitoUser.prototype, 'globalSignOut')
+			.mockImplementation(({ onSuccess, onFailure }) => {
+				onSuccess('');
+			});
+
+		jest
+			.spyOn(CognitoUserPool.prototype, 'getCurrentUser')
+			.mockImplementation(() => {
+				return new CognitoUser({
+					Pool: new CognitoUserPool({
+						ClientId: authOptions.userPoolWebClientId,
+						UserPoolId: authOptions.userPoolId,
+					}),
+					Username: 'username',
+				});
+			});
+		const user = await auth.currentUserPoolUser();
+
+		// @ts-ignore
+		await auth.cognitoIdentitySignOut({ global: true }, user);
+	});
+
+	it('currentUserPoolUser user.getUserData using ClientMetadata from config', async () => {
+		// configure with client metadata
+		const auth = new Auth(authOptions);
+
+		expect.assertions(1);
+
+		jest.spyOn(CognitoUser.prototype, 'getSession').mockImplementation(
+			// @ts-ignore
+			(
+				callback: (error: Error, session: CognitoUserSession) => void,
+				options: any
+			) => {
+				const session = new CognitoUserSession({
+					AccessToken: new CognitoAccessToken({
+						AccessToken:
+							'a.ewogICJzdWIiOiAic3ViIiwKICAiZXZlbnRfaWQiOiAieHh4eHgiLAogICJ0b2tlbl91c2UiOiAiYWNjZXNzIiwKICAic2NvcGUiOiAiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLAogICJhdXRoX3RpbWUiOiAxNjExNzc2ODA3LAogICJpc3MiOiAiaHR0cHM6Ly9jb2duaXRvLWlkcC51cy1lYXN0LTEuYW1hem9uYXdzLmNvbS91cy1lYXN0LTFfenp6enp6enp6IiwKICAiZXhwIjogMTYxMTc4MDQwNywKICAiaWF0IjogMTYxMTc3NjgwNywKICAianRpIjogImFhYWFhIiwKICAiY2xpZW50X2lkIjogInh4eHh4eHh4IiwKICAidXNlcm5hbWUiOiAidXNlcm5hbWUiCn0.a',
+					}),
+					IdToken: new CognitoIdToken({ IdToken: 'Idtoken' }),
+				});
+				callback(null, session);
+			}
+		);
+
+		jest
+			.spyOn(CognitoUser.prototype, 'getUserData')
+			.mockImplementation((callback, params) => {
+				expect(params.clientMetadata).toEqual(clientMetadata);
+
+				callback(null, {
+					MFAOptions: [],
+					PreferredMfaSetting: 'NOMFA',
+					UserAttributes: [],
+					UserMFASettingList: [],
+					Username: 'username',
+				});
+			});
+
+		jest
+			.spyOn(CognitoUserPool.prototype, 'getCurrentUser')
+			.mockImplementation(() => {
+				return new CognitoUser({
+					Pool: new CognitoUserPool({
+						ClientId: authOptions.userPoolWebClientId,
+						UserPoolId: authOptions.userPoolId,
+					}),
+					Username: 'username',
+				});
+			});
+
+		const user = await auth.currentUserPoolUser();
+	});
+
+	it('getPreferredMFA user.getUserData using ClientMetadata from config', async () => {
+		// configure with client metadata
+		const auth = new Auth(authOptions);
+
+		expect.assertions(2);
+
+		jest.spyOn(CognitoUser.prototype, 'getSession').mockImplementation(
+			// @ts-ignore
+			(
+				callback: (error: Error, session: CognitoUserSession) => void,
+				options: any
+			) => {
+				const session = new CognitoUserSession({
+					AccessToken: new CognitoAccessToken({
+						AccessToken:
+							'a.ewogICJzdWIiOiAic3ViIiwKICAiZXZlbnRfaWQiOiAieHh4eHgiLAogICJ0b2tlbl91c2UiOiAiYWNjZXNzIiwKICAic2NvcGUiOiAiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLAogICJhdXRoX3RpbWUiOiAxNjExNzc2ODA3LAogICJpc3MiOiAiaHR0cHM6Ly9jb2duaXRvLWlkcC51cy1lYXN0LTEuYW1hem9uYXdzLmNvbS91cy1lYXN0LTFfenp6enp6enp6IiwKICAiZXhwIjogMTYxMTc4MDQwNywKICAiaWF0IjogMTYxMTc3NjgwNywKICAianRpIjogImFhYWFhIiwKICAiY2xpZW50X2lkIjogInh4eHh4eHh4IiwKICAidXNlcm5hbWUiOiAidXNlcm5hbWUiCn0.a',
+					}),
+					IdToken: new CognitoIdToken({ IdToken: 'Idtoken' }),
+				});
+				callback(null, session);
+			}
+		);
+
+		jest
+			.spyOn(CognitoUser.prototype, 'getUserData')
+			.mockImplementation((callback, params) => {
+				expect(params.clientMetadata).toEqual(clientMetadata);
+
+				callback(null, {
+					MFAOptions: [],
+					PreferredMfaSetting: 'NOMFA',
+					UserAttributes: [],
+					UserMFASettingList: [],
+					Username: 'username',
+				});
+			});
+
+		jest
+			.spyOn(CognitoUserPool.prototype, 'getCurrentUser')
+			.mockImplementation(() => {
+				return new CognitoUser({
+					Pool: new CognitoUserPool({
+						ClientId: authOptions.userPoolWebClientId,
+						UserPoolId: authOptions.userPoolId,
+					}),
+					Username: 'username',
+				});
+			});
+
+		const user = await auth.currentUserPoolUser();
+
+		await auth.getPreferredMFA(user);
+	});
+
+	it('setPreferredMFA user.getUserData using ClientMetadata from config', async () => {
+		// configure with client metadata
+		const auth = new Auth(authOptions);
+
+		expect.assertions(3);
+
+		jest.spyOn(CognitoUser.prototype, 'getSession').mockImplementation(
+			// @ts-ignore
+			(
+				callback: (error: Error, session: CognitoUserSession) => void,
+				options: any
+			) => {
+				const session = new CognitoUserSession({
+					AccessToken: new CognitoAccessToken({
+						AccessToken:
+							'a.ewogICJzdWIiOiAic3ViIiwKICAiZXZlbnRfaWQiOiAieHh4eHgiLAogICJ0b2tlbl91c2UiOiAiYWNjZXNzIiwKICAic2NvcGUiOiAiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLAogICJhdXRoX3RpbWUiOiAxNjExNzc2ODA3LAogICJpc3MiOiAiaHR0cHM6Ly9jb2duaXRvLWlkcC51cy1lYXN0LTEuYW1hem9uYXdzLmNvbS91cy1lYXN0LTFfenp6enp6enp6IiwKICAiZXhwIjogMTYxMTc4MDQwNywKICAiaWF0IjogMTYxMTc3NjgwNywKICAianRpIjogImFhYWFhIiwKICAiY2xpZW50X2lkIjogInh4eHh4eHh4IiwKICAidXNlcm5hbWUiOiAidXNlcm5hbWUiCn0.a',
+					}),
+					IdToken: new CognitoIdToken({ IdToken: 'Idtoken' }),
+				});
+				callback(null, session);
+			}
+		);
+
+		jest
+			.spyOn(CognitoUser.prototype, 'getUserData')
+			.mockImplementation((callback, params) => {
+				expect(params.clientMetadata).toEqual(clientMetadata);
+
+				callback(null, {
+					MFAOptions: [],
+					PreferredMfaSetting: 'NOMFA',
+					UserAttributes: [],
+					UserMFASettingList: [],
+					Username: 'username',
+				});
+			});
+
+		jest
+			.spyOn(CognitoUserPool.prototype, 'getCurrentUser')
+			.mockImplementation(() => {
+				return new CognitoUser({
+					Pool: new CognitoUserPool({
+						ClientId: authOptions.userPoolWebClientId,
+						UserPoolId: authOptions.userPoolId,
+					}),
+					Username: 'username',
+				});
+			});
+
+		jest
+			.spyOn(CognitoUser.prototype, 'setUserMfaPreference')
+			.mockImplementation(
+				(smsMfaSettings, softwareTokenMfaSettings, callback) => {
+					callback();
+				}
+			);
+
+		const user = await auth.currentUserPoolUser();
+
+		await auth.setPreferredMFA(user, 'SMS');
+	});
+});


### PR DESCRIPTION
Include client metadata from `Auth.configure` to be send also for token refresh

### Use case that is fixing
```jsx
Auth.configure(awsconfig);
Auth.configure({
  clientMetadata: {
    test: 'this should be on refresh token as well'
  }
})

function App() {
  async function signIn() {
    const user = await Auth.signIn({
      username: 'xxxxx',
      password: 'yyyy',
    })
  }

  async function currentUser() {
    const user = await Auth.currentAuthenticatedUser({ bypassCache: true });
  }
  return (
    <div className="App">
      <header className="App-header">
        <button onClick={signIn}>sign in</button>
        <button onClick={currentUser}>refresh token</button>
      </header>
    </div>
  );
}
```

When refreshing the token when doing `Auth.currentAuthenticatedUser` Amplify is not sending `ClientMetadata` param to Cognito service.

_Issue #, if available:_
#6731 
_Description of changes:_
`CognitoUser` in `amazon-cognito-identity-js` has been added a `clientMetadata` param for `getSession` and `getUserData` functions in order to be used for `refreshSession`.

`Auth` category on `@aws-amplify/auth` has been added `clientMetadata` from `this._config` to be used in `getSession` and `getUserData` operations.

Also added type safety for `CognitoUserPool` type in `Auth` category


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
