### PR TITLE
fix(@aws-amplify/ui-components): Use dark neutrals rather than Amplify brand colors

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-button/amplify-button.scss
+++ b/packages/amplify-ui-components/src/components/amplify-button/amplify-button.scss
@@ -63,6 +63,7 @@
   border-width: var(--border-width);
   border-color: var(--border-color);
   border-style: var(--border-style);
+  border-radius: 3px;
 
   &:active {
     opacity: 1;

--- a/packages/amplify-ui-components/src/global/theme.ts
+++ b/packages/amplify-ui-components/src/global/theme.ts
@@ -32,10 +32,10 @@ if (browserOrNode().isBrowser) {
       --amplify-text-xxl: 2.5rem;
 
       /* Colors */
-      --amplify-primary-color: #ff9900;
+      --amplify-primary-color: #222;
       --amplify-primary-contrast: var(--amplify-white);
-      --amplify-primary-tint: #ffac31;
-      --amplify-primary-shade: #e88b01;
+      --amplify-primary-tint: #333;
+      --amplify-primary-shade: #111;
 
       --amplify-secondary-color: #152939;
       --amplify-secondary-contrast: var(--amplify-white);

--- a/packages/amplify-ui-components/src/global/theme.ts
+++ b/packages/amplify-ui-components/src/global/theme.ts
@@ -49,6 +49,12 @@ if (browserOrNode().isBrowser) {
 
       --amplify-background-color: var(--amplify-white);
 
+      /* Amplify Brand */
+      --amplify-brand-color: #ff9900;
+      --amplify-brand-contrast: var(--amplify-white);
+      --amplify-brand-tint: #ffac31;
+      --amplify-brand-shade: #e88b01;
+
       /* Neutral */
       --amplify-grey: #828282;
       --amplify-light-grey: #c4c4c4;

--- a/packages/amplify-ui-components/src/global/theme.ts
+++ b/packages/amplify-ui-components/src/global/theme.ts
@@ -20,7 +20,7 @@ if (browserOrNode().isBrowser) {
     document.createTextNode(`
     :root {
       /* Typography */
-      --amplify-font-family: 'Amazon Ember', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+      --amplify-font-family: 'Inter var', 'Amazon Ember', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 
       --amplify-text-xxs: 0.75rem;
       --amplify-text-xs: 0.81rem;


### PR DESCRIPTION
_Issue #, if available:_ #7585

`<AmplifyAuthenticator>` lives in _customer applications_, but we style it with Amplify's brand colors. These aren't accessible by default (contrast ratio), and stand out in many designs vs. "blending in" tot he app around it.

> ![Screen Shot 2021-01-29 at 3 43 21 PM](https://user-images.githubusercontent.com/15182/106330509-357ce400-6238-11eb-8445-005b7a05cb3c.png)

- [x] Used neutral colors by default (nearly black)
- [x] Prefer `Inter var` (from Tailwind UI), `Amazon Ember`, as these are installed deliberately by customers or devices.
- [x] Use Tailwind's `font-sans` `font-family`, which is optimized for system defaults across platforms:

    https://tailwindcss.com/docs/font-family

- [x] 🤕  I cut myself on those buttons, so they're rounded at `3px` instead of `0`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
