### PR TITLE
chore: add RN storage multi-part w/ progress to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -871,7 +871,6 @@ workflows:
             - integ_rn_ios_storage
             # Removing this until AWS SDK issue is resolved: https://github.com/aws/aws-sdk-js-v3/issues/2000
             # - integ_rn_ios_storage_multipart_progress
-            - integ_rn_ios_storage
             - integ_rn_ios_push_notifications
             - integ_rn_android_storage
             # Removing this until AWS SDK issue is resolved: https://github.com/aws/aws-sdk-js-v3/issues/2000

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,6 +583,13 @@ jobs:
     steps:
       - integ_test_rn_ios
 
+  integ_rn_ios_storage_multipart_progress:
+    executor: macos-executor
+    <<: *test_env_vars
+    working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/MultiPartUploadWithProgress
+    steps:
+      - integ_test_rn_ios
+
   integ_rn_ios_push_notifications:
     executor: macos-executor
     <<: *test_env_vars
@@ -594,6 +601,13 @@ jobs:
     executor: macos-executor
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
+    steps:
+      - integ_test_rn_android
+
+  integ_rn_android_storage_multipart_progress:
+    executor: macos-executor
+    <<: *test_env_vars
+    working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/MultiPartUploadWithProgress
     steps:
       - integ_test_rn_android
 
@@ -805,6 +819,12 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
+      - integ_rn_ios_storage_multipart_progress:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
       - integ_rn_ios_push_notifications:
           requires:
             - integ_setup
@@ -812,6 +832,12 @@ workflows:
           filters:
             <<: *releasable_branches
       - integ_rn_android_storage:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_rn_android_storage_multipart_progress:
           requires:
             - integ_setup
             - build
@@ -843,8 +869,13 @@ workflows:
             - integ_angular_auth
             - integ_vue_auth
             - integ_rn_ios_storage
+            # Removing this until AWS SDK issue is resolved: https://github.com/aws/aws-sdk-js-v3/issues/2000
+            # - integ_rn_ios_storage_multipart_progress
+            - integ_rn_ios_storage
             - integ_rn_ios_push_notifications
             - integ_rn_android_storage
+            # Removing this until AWS SDK issue is resolved: https://github.com/aws/aws-sdk-js-v3/issues/2000
+            # - integ_rn_android_storage_multipart_progress
             - integ_datastore_auth
       - post_release:
           filters:


### PR DESCRIPTION
_Description of changes:_
- add integration test for React Native Storage multi-part upload with progress reporting
- https://github.com/aws-amplify/amplify-js-samples-staging/pull/197

Note: this test will fail until https://github.com/aws/aws-sdk-js-v3/issues/2000 is resolved, since unstable is currently using the latest version of the AWS SDK. I have verified that the tests pass on latest however.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
