### PR TITLE
fix(@aws-amplify/datastore): align AWSTime validation with AppSync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,6 +583,13 @@ jobs:
     steps:
       - integ_test_rn_ios
 
+  integ_rn_ios_storage_multipart_progress:
+    executor: macos-executor
+    <<: *test_env_vars
+    working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/MultiPartUploadWithProgress
+    steps:
+      - integ_test_rn_ios
+
   integ_rn_ios_push_notifications:
     executor: macos-executor
     <<: *test_env_vars
@@ -594,6 +601,13 @@ jobs:
     executor: macos-executor
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
+    steps:
+      - integ_test_rn_android
+
+  integ_rn_android_storage_multipart_progress:
+    executor: macos-executor
+    <<: *test_env_vars
+    working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/MultiPartUploadWithProgress
     steps:
       - integ_test_rn_android
 
@@ -805,6 +819,12 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
+      - integ_rn_ios_storage_multipart_progress:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
       - integ_rn_ios_push_notifications:
           requires:
             - integ_setup
@@ -812,6 +832,12 @@ workflows:
           filters:
             <<: *releasable_branches
       - integ_rn_android_storage:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_rn_android_storage_multipart_progress:
           requires:
             - integ_setup
             - build
@@ -843,8 +869,12 @@ workflows:
             - integ_angular_auth
             - integ_vue_auth
             - integ_rn_ios_storage
+            # Removing this until AWS SDK issue is resolved: https://github.com/aws/aws-sdk-js-v3/issues/2000
+            # - integ_rn_ios_storage_multipart_progress
             - integ_rn_ios_push_notifications
             - integ_rn_android_storage
+            # Removing this until AWS SDK issue is resolved: https://github.com/aws/aws-sdk-js-v3/issues/2000
+            # - integ_rn_android_storage_multipart_progress
             - integ_datastore_auth
       - post_release:
           filters:

--- a/packages/datastore/__tests__/util.test.ts
+++ b/packages/datastore/__tests__/util.test.ts
@@ -121,7 +121,7 @@ describe('datastore util', () => {
 	});
 
 	test('isAWSEmail', () => {
-		const valid = ['a@b', 'a@b.c', 'jeff@amazon.com'];
+		const valid = ['a@b', 'a@b.c', 'john@doe.com'];
 		const invalid = [
 			'',
 			'@',

--- a/packages/datastore/__tests__/util.test.ts
+++ b/packages/datastore/__tests__/util.test.ts
@@ -8,7 +8,7 @@ import {
 	isAWSURL,
 	isAWSPhone,
 	isAWSIPAddress,
-} from "../src/util";
+} from '../src/util';
 
 describe('datastore util', () => {
 	test('isAWSDate', () => {
@@ -43,6 +43,10 @@ describe('datastore util', () => {
 			'12:30',
 			'12:30Z',
 			'12:30:24Z',
+			'12:30:24.1Z',
+			'12:30:24.12Z',
+			'12:30:24.123Z',
+			'12:30:24.1234Z',
 			'12:30:24-07:00',
 			'12:30:24.500+05:30',
 			'12:30:24.500+05:30:00',
@@ -72,6 +76,11 @@ describe('datastore util', () => {
 			'2021-01-11T12:30',
 			'2021-01-11T12:30Z',
 			'2021-01-11T12:30:24Z',
+			'2021-01-11T12:30:24.5Z',
+			'2021-01-11T12:30:24.50Z',
+			'2021-01-11T12:30:24.500Z',
+			'2021-01-11T12:30:24.5000Z',
+			'2021-02-09T06:19:04.49Z',
 			'2021-01-11T12:30:24-07:00',
 			'2021-01-11T12:30:24.500+05:30',
 			'2021-01-11T12:30:24.500+05:30:00',
@@ -101,18 +110,8 @@ describe('datastore util', () => {
 	});
 
 	test('isAWSTimestamp', () => {
-		const valid = [
-			0,
-			123,
-			123456,
-			123456789,
-		];
-		const invalid = [
-			-1,
-			-123,
-			-123456,
-			-1234567
-		];
+		const valid = [0, 123, 123456, 123456789];
+		const invalid = [-1, -123, -123456, -1234567];
 		valid.forEach(test => {
 			expect(isAWSTimestamp(test)).toBe(true);
 		});
@@ -122,11 +121,7 @@ describe('datastore util', () => {
 	});
 
 	test('isAWSEmail', () => {
-		const valid = [
-			'a@b',
-			'a@b.c',
-			'jeff@amazon.com',
-		];
+		const valid = ['a@b', 'a@b.c', 'jeff@amazon.com'];
 		const invalid = [
 			'',
 			'@',
@@ -177,17 +172,8 @@ describe('datastore util', () => {
 	});
 
 	test('isAWSURL', () => {
-		const valid = [
-			'http://localhost/',
-			'schema://anything',
-			'smb://a/b/c?d=e',
-		];
-		const invalid = [
-			'',
-			'//',
-			'//example',
-			'example',
-		];
+		const valid = ['http://localhost/', 'schema://anything', 'smb://a/b/c?d=e'];
+		const invalid = ['', '//', '//example', 'example'];
 		valid.forEach(test => {
 			expect(isAWSURL(test)).toBe(true);
 		});
@@ -204,13 +190,7 @@ describe('datastore util', () => {
 			'123-456-7890',
 			'+44123456789',
 		];
-		const invalid = [
-			'',
-			'+',
-			'+-',
-			'a',
-			'bad-number',
-		];
+		const invalid = ['', '+', '+-', 'a', 'bad-number'];
 		valid.forEach(test => {
 			expect(isAWSPhone(test)).toBe(true);
 		});

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -439,13 +439,13 @@ export const isAWSDate = (val: string): boolean => {
 };
 
 export const isAWSTime = (val: string): boolean => {
-	return !!/^\d{2}:\d{2}(:\d{2}(.\d{3})?)?(Z|[+-]\d{2}:\d{2}($|:\d{2}))?$/.exec(
+	return !!/^\d{2}:\d{2}(:\d{2}(.\d+)?)?(Z|[+-]\d{2}:\d{2}($|:\d{2}))?$/.exec(
 		val
 	);
 };
 
 export const isAWSDateTime = (val: string): boolean => {
-	return !!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(.\d{3})?)?(Z|[+-]\d{2}:\d{2}($|:\d{2}))?$/.exec(
+	return !!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(.\d+)?)?(Z|[+-]\d{2}:\d{2}($|:\d{2}))?$/.exec(
 		val
 	);
 };


### PR DESCRIPTION
Currently, we're only allowing a 3-digit millisecond (the `SSS` in `HH:mm:ss.SSSZ`) in our AWSTime and AWSDateTime validators. We throw an error when the number of millisecond digits is anything other than 3.

AppSync doesn't care how many digits are in the millisecond. Any number `>= 1` is valid. This PR aligns the clientside validation logic with that.

Reviewers: the actual changes are [here](https://github.com/aws-amplify/amplify-js/pull/7717/files#diff-89f8afda2fb41bbdaea63170a71ab23374df7b81bef86a6f7cf1eb9af0baea78R442) and [here](https://github.com/aws-amplify/amplify-js/pull/7717/files#diff-89f8afda2fb41bbdaea63170a71ab23374df7b81bef86a6f7cf1eb9af0baea78R448). I've added tests around this too. 
Ignore the formatting changes, my guess is that this was due to the way the original contributor of this code had their formatter configured.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
