### PR TITLE
feat(storage): optional exact config with tests

### DIFF
--- a/packages/storage/__tests__/Storage-unit-test.ts
+++ b/packages/storage/__tests__/Storage-unit-test.ts
@@ -228,7 +228,7 @@ describe('Storage', () => {
 		test('vault level is always private', () => {
 			const storage = StorageCategory;
 			expect.assertions(3);
-			storage.vault.configure = jest.fn().mockImplementation(configure => {
+			storage.vault.configure = jest.fn().mockImplementation((configure) => {
 				expect(configure).toEqual({
 					AWSS3: { bucket: 'bucket', level: 'private', region: 'region' },
 				});
@@ -456,6 +456,48 @@ describe('Storage', () => {
 					region: 'WD3',
 				},
 				customPrefix: {},
+			});
+		});
+
+		test('should add exact to AWSS3 provider object if is defined', () => {
+			const storage = new StorageClass();
+			const awsconfig = {
+				aws_user_files_s3_bucket: 'i_am_a_bucket',
+				aws_user_files_s3_bucket_region: 'IAD',
+			};
+
+			storage.configure(awsconfig);
+			const config = storage.configure({
+				exact: true,
+			});
+
+			expect(config).toEqual({
+				AWSS3: {
+					bucket: 'i_am_a_bucket',
+					region: 'IAD',
+					exact: true,
+				},
+			});
+		});
+
+		test('should not add exact to AWSS3 provider object if value is undefined', () => {
+			const storage = new StorageClass();
+			const awsconfig = {
+				aws_user_files_s3_bucket: 'you_dont_know_this_bucket',
+				aws_user_files_s3_bucket_region: 'WD3',
+			};
+
+			storage.configure(awsconfig);
+			const config = storage.configure({
+				exact: undefined,
+			});
+
+			expect(config).toEqual({
+				AWSS3: {
+					bucket: 'you_dont_know_this_bucket',
+					region: 'WD3',
+				},
+				exact: {},
 			});
 		});
 	});

--- a/packages/storage/src/Storage.ts
+++ b/packages/storage/src/Storage.ts
@@ -73,7 +73,7 @@ export class Storage {
 	 */
 	public getPluggable(providerName: string) {
 		const pluggable = this._pluggables.find(
-			pluggable => pluggable.getProviderName() === providerName
+			(pluggable) => pluggable.getProviderName() === providerName
 		);
 		if (pluggable === undefined) {
 			logger.debug('No plugin found with providerName', providerName);
@@ -87,7 +87,7 @@ export class Storage {
 	 */
 	public removePluggable(providerName: string) {
 		this._pluggables = this._pluggables.filter(
-			pluggable => pluggable.getProviderName() !== providerName
+			(pluggable) => pluggable.getProviderName() !== providerName
 		);
 		return;
 	}
@@ -110,6 +110,7 @@ export class Storage {
 			'region',
 			'level',
 			'track',
+			'exact',
 			'customPrefix',
 			'serverSideEncryption',
 			'SSECustomerAlgorithm',
@@ -119,9 +120,9 @@ export class Storage {
 		];
 
 		const isInStorageArrayKeys = (k: string) =>
-			storageArrayKeys.some(x => x === k);
+			storageArrayKeys.some((x) => x === k);
 		const checkConfigKeysFromArray = (k: string[]) =>
-			k.find(k => isInStorageArrayKeys(k));
+			k.find((k) => isInStorageArrayKeys(k));
 
 		if (
 			storageKeysFromConfig &&
@@ -139,7 +140,7 @@ export class Storage {
 		});
 
 		// only update new values for each provider
-		Object.keys(amplifyConfig.Storage).forEach(providerName => {
+		Object.keys(amplifyConfig.Storage).forEach((providerName) => {
 			if (typeof amplifyConfig.Storage[providerName] !== 'string') {
 				this._config[providerName] = {
 					...this._config[providerName],
@@ -148,7 +149,7 @@ export class Storage {
 			}
 		});
 
-		this._pluggables.forEach(pluggable => {
+		this._pluggables.forEach((pluggable) => {
 			pluggable.configure(this._config[pluggable.getProviderName()]);
 		});
 
@@ -169,7 +170,7 @@ export class Storage {
 	public async get(key: string, config?): Promise<String | Object> {
 		const { provider = DEFAULT_PROVIDER } = config || {};
 		const prov = this._pluggables.find(
-			pluggable => pluggable.getProviderName() === provider
+			(pluggable) => pluggable.getProviderName() === provider
 		);
 		if (prov === undefined) {
 			logger.debug('No plugin found with providerName', provider);
@@ -189,7 +190,7 @@ export class Storage {
 	public async put(key: string, object, config?): Promise<Object> {
 		const { provider = DEFAULT_PROVIDER } = config || {};
 		const prov = this._pluggables.find(
-			pluggable => pluggable.getProviderName() === provider
+			(pluggable) => pluggable.getProviderName() === provider
 		);
 		if (prov === undefined) {
 			logger.debug('No plugin found with providerName', provider);
@@ -207,7 +208,7 @@ export class Storage {
 	public async remove(key: string, config?): Promise<any> {
 		const { provider = DEFAULT_PROVIDER } = config || {};
 		const prov = this._pluggables.find(
-			pluggable => pluggable.getProviderName() === provider
+			(pluggable) => pluggable.getProviderName() === provider
 		);
 		if (prov === undefined) {
 			logger.debug('No plugin found with providerName', provider);
@@ -225,7 +226,7 @@ export class Storage {
 	public async list(path, config?): Promise<any> {
 		const { provider = DEFAULT_PROVIDER } = config || {};
 		const prov = this._pluggables.find(
-			pluggable => pluggable.getProviderName() === provider
+			(pluggable) => pluggable.getProviderName() === provider
 		);
 		if (prov === undefined) {
 			logger.debug('No plugin found with providerName', provider);

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -298,7 +298,7 @@ export class AWSS3Provider implements StorageProvider {
 		}
 
 		try {
-			emitter.on('sendProgress', progress => {
+			emitter.on('sendProgress', (progress) => {
 				if (progressCallback) {
 					if (typeof progressCallback === 'function') {
 						progressCallback(progress);
@@ -418,7 +418,7 @@ export class AWSS3Provider implements StorageProvider {
 			const response = await s3.send(listObjectsCommand);
 			let list = [];
 			if (response && response.Contents) {
-				list = response.Contents.map(item => {
+				list = response.Contents.map((item) => {
 					return {
 						key: item.Key.substr(prefix.length),
 						eTag: item.ETag,
@@ -454,7 +454,7 @@ export class AWSS3Provider implements StorageProvider {
 	 */
 	_ensureCredentials() {
 		return Credentials.get()
-			.then(credentials => {
+			.then((credentials) => {
 				if (!credentials) return false;
 				const cred = Credentials.shear(credentials);
 				logger.debug('set credentials for storage', cred);
@@ -462,7 +462,7 @@ export class AWSS3Provider implements StorageProvider {
 
 				return true;
 			})
-			.catch(error => {
+			.catch((error) => {
 				logger.warn('ensure credentials error', error);
 				return false;
 			});
@@ -475,7 +475,9 @@ export class AWSS3Provider implements StorageProvider {
 		const { credentials, level } = config;
 
 		const customPrefix = config.customPrefix || {};
-		const identityId = config.identityId || credentials.identityId;
+		const identityId = config.exact
+			? ''
+			: config.identityId || credentials.identityId;
 		const privatePath =
 			(customPrefix.private !== undefined ? customPrefix.private : 'private/') +
 			identityId +


### PR DESCRIPTION
_Issue #, if available:_
fix #7715 
_Description of changes:_
- Allows user to set a boolean **exact** property so that they can upload S3 objects without the cognito user id added to the key. 
- Unit tests for the above functionality. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
