### PR TITLE
feat(@aws-amplify/ui-components): Remove Shadow DOM

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-amazon-button/amplify-amazon-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-amazon-button/amplify-amazon-button.tsx
@@ -11,7 +11,6 @@ const logger = new Logger('amplify-amazon-button');
 
 @Component({
   tag: 'amplify-amazon-button',
-  shadow: true,
 })
 export class AmplifyAmazonButton {
   /** App-specific client ID from Google */

--- a/packages/amplify-ui-components/src/components/amplify-amazon-button/amplify-amazon-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-amazon-button/amplify-amazon-button.tsx
@@ -11,6 +11,7 @@ const logger = new Logger('amplify-amazon-button');
 
 @Component({
   tag: 'amplify-amazon-button',
+  scoped: true,
 })
 export class AmplifyAmazonButton {
   /** App-specific client ID from Google */

--- a/packages/amplify-ui-components/src/components/amplify-auth-fields/amplify-auth-fields.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-auth-fields/amplify-auth-fields.tsx
@@ -5,6 +5,7 @@ import componentFieldMapping from './component-field-mapping';
 @Component({
   tag: 'amplify-auth-fields',
   styleUrl: 'amplify-auth-fields.scss',
+  scoped: true,
 })
 export class AmplifyAuthFields {
   /**

--- a/packages/amplify-ui-components/src/components/amplify-auth-fields/amplify-auth-fields.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-auth-fields/amplify-auth-fields.tsx
@@ -5,7 +5,6 @@ import componentFieldMapping from './component-field-mapping';
 @Component({
   tag: 'amplify-auth-fields',
   styleUrl: 'amplify-auth-fields.scss',
-  shadow: true,
 })
 export class AmplifyAuthFields {
   /**

--- a/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.tsx
@@ -10,7 +10,6 @@ const logger = new Logger('amplify-auth0-button');
 
 @Component({
   tag: 'amplify-auth0-button',
-  shadow: true,
 })
 export class AmplifyAuth0Button {
   /** See: https://auth0.com/docs/libraries/auth0js/v9#available-parameters */

--- a/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-auth0-button/amplify-auth0-button.tsx
@@ -10,6 +10,7 @@ const logger = new Logger('amplify-auth0-button');
 
 @Component({
   tag: 'amplify-auth0-button',
+  scoped: true,
 })
 export class AmplifyAuth0Button {
   /** See: https://auth0.com/docs/libraries/auth0js/v9#available-parameters */

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.scss
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.scss
@@ -11,7 +11,8 @@
  * @prop --container-justify: `justify-content` property of a flex container
  * @prop --container-align: `align-items` property of a flex container
  */
-:host {
+:host,
+amplify-authenticator {
   --background-color: var(--amplify-background-color);
   --width: 28.75rem;
   --min-width: 20rem;

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
@@ -38,7 +38,6 @@ const logger = new Logger('Authenticator');
 @Component({
   tag: 'amplify-authenticator',
   styleUrl: 'amplify-authenticator.scss',
-  shadow: true,
 })
 export class AmplifyAuthenticator {
   /** Initial starting state of the Authenticator component. E.g. If `signup` is passed the default component is set to AmplifySignUp */

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
@@ -38,6 +38,7 @@ const logger = new Logger('Authenticator');
 @Component({
   tag: 'amplify-authenticator',
   styleUrl: 'amplify-authenticator.scss',
+  scoped: true,
 })
 export class AmplifyAuthenticator {
   /** Initial starting state of the Authenticator component. E.g. If `signup` is passed the default component is set to AmplifySignUp */

--- a/packages/amplify-ui-components/src/components/amplify-button/amplify-button.scss
+++ b/packages/amplify-ui-components/src/components/amplify-button/amplify-button.scss
@@ -15,7 +15,8 @@
  * @prop --padding: Padding within the button
  * @prop --width: Width of the button
  */
-:host {
+:host,
+amplify-button {
   --background-color: var(--amplify-primary-color);
   --background-color-active: var(--amplify-primary-shade);
   --background-color-disable: var(--amplify-primary-tint);

--- a/packages/amplify-ui-components/src/components/amplify-button/amplify-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-button/amplify-button.tsx
@@ -9,7 +9,6 @@ import { IconNameType } from '../amplify-icon/icons';
 @Component({
   tag: 'amplify-button',
   styleUrl: 'amplify-button.scss',
-  shadow: true,
 })
 export class AmplifyButton {
   @Element() el!: HTMLAmplifyButtonElement;

--- a/packages/amplify-ui-components/src/components/amplify-button/amplify-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-button/amplify-button.tsx
@@ -9,6 +9,7 @@ import { IconNameType } from '../amplify-icon/icons';
 @Component({
   tag: 'amplify-button',
   styleUrl: 'amplify-button.scss',
+  scoped: true,
 })
 export class AmplifyButton {
   @Element() el!: HTMLAmplifyButtonElement;

--- a/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.scss
+++ b/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.scss
@@ -11,7 +11,8 @@
  * @prop --user-dot-color: Base color of user loading message animation
  */
 @import 'animation.scss';
-:host {
+:host,
+amplify-chatbot {
   --width: 28.75rem;
   --height: 37.5rem;
   --header-color: var(--amplify-secondary-color);

--- a/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.tsx
@@ -43,7 +43,6 @@ interface ChatError {
 @Component({
   tag: 'amplify-chatbot',
   styleUrl: 'amplify-chatbot.scss',
-  shadow: true,
 })
 export class AmplifyChatbot {
   /** Name of the bot */

--- a/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.tsx
@@ -43,6 +43,7 @@ interface ChatError {
 @Component({
   tag: 'amplify-chatbot',
   styleUrl: 'amplify-chatbot.scss',
+  scoped: true,
 })
 export class AmplifyChatbot {
   /** Name of the bot */

--- a/packages/amplify-ui-components/src/components/amplify-checkbox/amplify-checkbox.scss
+++ b/packages/amplify-ui-components/src/components/amplify-checkbox/amplify-checkbox.scss
@@ -1,7 +1,8 @@
 /**
  * @prop --font-family: Text font family
  */
-:host {
+:host,
+amplify-checkbox {
   --font-family: var(--amplify-font-family);
 }
 

--- a/packages/amplify-ui-components/src/components/amplify-checkbox/amplify-checkbox.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-checkbox/amplify-checkbox.tsx
@@ -3,7 +3,6 @@ import { Component, Prop, h } from '@stencil/core';
 @Component({
   tag: 'amplify-checkbox',
   styleUrl: 'amplify-checkbox.scss',
-  shadow: true,
 })
 export class AmplifyCheckbox {
   /** Name of the checkbox */

--- a/packages/amplify-ui-components/src/components/amplify-checkbox/amplify-checkbox.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-checkbox/amplify-checkbox.tsx
@@ -3,6 +3,7 @@ import { Component, Prop, h } from '@stencil/core';
 @Component({
   tag: 'amplify-checkbox',
   styleUrl: 'amplify-checkbox.scss',
+  scoped: true,
 })
 export class AmplifyCheckbox {
   /** Name of the checkbox */

--- a/packages/amplify-ui-components/src/components/amplify-code-field/amplify-code-field.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-code-field/amplify-code-field.tsx
@@ -5,6 +5,7 @@ import { Translations } from '../../common/Translations';
 
 @Component({
   tag: 'amplify-code-field',
+  scoped: true,
 })
 export class AmplifyCodeField {
   /** Based on the type of field e.g. sign in, sign up, forgot password, etc. */

--- a/packages/amplify-ui-components/src/components/amplify-code-field/amplify-code-field.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-code-field/amplify-code-field.tsx
@@ -5,7 +5,6 @@ import { Translations } from '../../common/Translations';
 
 @Component({
   tag: 'amplify-code-field',
-  shadow: true,
 })
 export class AmplifyCodeField {
   /** Based on the type of field e.g. sign in, sign up, forgot password, etc. */

--- a/packages/amplify-ui-components/src/components/amplify-confirm-sign-in/amplify-confirm-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-confirm-sign-in/amplify-confirm-sign-in.tsx
@@ -16,7 +16,6 @@ import { checkContact } from '../../common/auth-helpers';
 
 @Component({
   tag: 'amplify-confirm-sign-in',
-  shadow: true,
 })
 export class AmplifyConfirmSignIn {
   /** Fires when confirm sign in form is submitted */

--- a/packages/amplify-ui-components/src/components/amplify-confirm-sign-in/amplify-confirm-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-confirm-sign-in/amplify-confirm-sign-in.tsx
@@ -16,6 +16,7 @@ import { checkContact } from '../../common/auth-helpers';
 
 @Component({
   tag: 'amplify-confirm-sign-in',
+  scoped: true,
 })
 export class AmplifyConfirmSignIn {
   /** Fires when confirm sign in form is submitted */

--- a/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
@@ -29,7 +29,6 @@ import { handleSignIn } from '../../common/auth-helpers';
 
 @Component({
   tag: 'amplify-confirm-sign-up',
-  shadow: true,
 })
 export class AmplifyConfirmSignUp {
   /** Fires when sign up form is submitted */

--- a/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-confirm-sign-up/amplify-confirm-sign-up.tsx
@@ -29,6 +29,7 @@ import { handleSignIn } from '../../common/auth-helpers';
 
 @Component({
   tag: 'amplify-confirm-sign-up',
+  scoped: true,
 })
 export class AmplifyConfirmSignUp {
   /** Fires when sign up form is submitted */

--- a/packages/amplify-ui-components/src/components/amplify-container/amplify-container.scss
+++ b/packages/amplify-ui-components/src/components/amplify-container/amplify-container.scss
@@ -1,4 +1,5 @@
-:host {
+:host,
+amplify-container {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/amplify-ui-components/src/components/amplify-container/amplify-container.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-container/amplify-container.tsx
@@ -6,6 +6,7 @@ import { Component, h, Host } from '@stencil/core';
 @Component({
   tag: 'amplify-container',
   styleUrl: 'amplify-container.scss',
+  scoped: true,
 })
 export class AmplifyContainer {
   render() {

--- a/packages/amplify-ui-components/src/components/amplify-container/amplify-container.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-container/amplify-container.tsx
@@ -6,7 +6,6 @@ import { Component, h, Host } from '@stencil/core';
 @Component({
   tag: 'amplify-container',
   styleUrl: 'amplify-container.scss',
-  shadow: true,
 })
 export class AmplifyContainer {
   render() {

--- a/packages/amplify-ui-components/src/components/amplify-country-dial-code/amplify-country-dial-code.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-country-dial-code/amplify-country-dial-code.tsx
@@ -5,7 +5,6 @@ import { COUNTRY_DIAL_CODE_SUFFIX } from '../../common/constants';
 
 @Component({
   tag: 'amplify-country-dial-code',
-  shadow: true,
 })
 export class AmplifyCountryDialCode {
   /** The ID of the field.  Should match with its corresponding input's ID. */

--- a/packages/amplify-ui-components/src/components/amplify-country-dial-code/amplify-country-dial-code.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-country-dial-code/amplify-country-dial-code.tsx
@@ -5,6 +5,7 @@ import { COUNTRY_DIAL_CODE_SUFFIX } from '../../common/constants';
 
 @Component({
   tag: 'amplify-country-dial-code',
+  scoped: true,
 })
 export class AmplifyCountryDialCode {
   /** The ID of the field.  Should match with its corresponding input's ID. */

--- a/packages/amplify-ui-components/src/components/amplify-email-field/amplify-email-field.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-email-field/amplify-email-field.tsx
@@ -5,6 +5,7 @@ import { Translations } from '../../common/Translations';
 
 @Component({
   tag: 'amplify-email-field',
+  scoped: true,
 })
 export class AmplifyEmailField {
   /** Based on the type of field e.g. sign in, sign up, forgot password, etc. */

--- a/packages/amplify-ui-components/src/components/amplify-email-field/amplify-email-field.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-email-field/amplify-email-field.tsx
@@ -5,7 +5,6 @@ import { Translations } from '../../common/Translations';
 
 @Component({
   tag: 'amplify-email-field',
-  shadow: true,
 })
 export class AmplifyEmailField {
   /** Based on the type of field e.g. sign in, sign up, forgot password, etc. */

--- a/packages/amplify-ui-components/src/components/amplify-facebook-button/amplify-facebook-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-facebook-button/amplify-facebook-button.tsx
@@ -11,6 +11,7 @@ const logger = new Logger('amplify-facebook-button');
 
 @Component({
   tag: 'amplify-facebook-button',
+  scoped: true,
 })
 export class AmplifyFacebookButton {
   /** App-specific client ID from Facebook */

--- a/packages/amplify-ui-components/src/components/amplify-facebook-button/amplify-facebook-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-facebook-button/amplify-facebook-button.tsx
@@ -11,7 +11,6 @@ const logger = new Logger('amplify-facebook-button');
 
 @Component({
   tag: 'amplify-facebook-button',
-  shadow: true,
 })
 export class AmplifyFacebookButton {
   /** App-specific client ID from Facebook */

--- a/packages/amplify-ui-components/src/components/amplify-federated-buttons/amplify-federated-buttons.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-federated-buttons/amplify-federated-buttons.tsx
@@ -7,7 +7,6 @@ import { AuthState, FederatedConfig, AuthStateHandler } from '../../common/types
 
 @Component({
   tag: 'amplify-federated-buttons',
-  shadow: true,
 })
 export class AmplifyFederatedButtons {
   /** The current authentication state. */

--- a/packages/amplify-ui-components/src/components/amplify-federated-buttons/amplify-federated-buttons.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-federated-buttons/amplify-federated-buttons.tsx
@@ -7,6 +7,7 @@ import { AuthState, FederatedConfig, AuthStateHandler } from '../../common/types
 
 @Component({
   tag: 'amplify-federated-buttons',
+  scoped: true,
 })
 export class AmplifyFederatedButtons {
   /** The current authentication state. */

--- a/packages/amplify-ui-components/src/components/amplify-federated-sign-in/amplify-federated-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-federated-sign-in/amplify-federated-sign-in.tsx
@@ -9,7 +9,6 @@ const logger = new Logger('amplify-federated-sign-in');
 
 @Component({
   tag: 'amplify-federated-sign-in',
-  shadow: true,
 })
 export class AmplifyFederatedSignIn {
   /** The current authentication state. */

--- a/packages/amplify-ui-components/src/components/amplify-federated-sign-in/amplify-federated-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-federated-sign-in/amplify-federated-sign-in.tsx
@@ -9,6 +9,7 @@ const logger = new Logger('amplify-federated-sign-in');
 
 @Component({
   tag: 'amplify-federated-sign-in',
+  scoped: true,
 })
 export class AmplifyFederatedSignIn {
   /** The current authentication state. */

--- a/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
@@ -25,7 +25,6 @@ const logger = new Logger('ForgotPassword');
 
 @Component({
   tag: 'amplify-forgot-password',
-  shadow: true,
 })
 export class AmplifyForgotPassword {
   /** The header text of the forgot password section */

--- a/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
@@ -25,6 +25,7 @@ const logger = new Logger('ForgotPassword');
 
 @Component({
   tag: 'amplify-forgot-password',
+  scoped: true,
 })
 export class AmplifyForgotPassword {
   /** The header text of the forgot password section */

--- a/packages/amplify-ui-components/src/components/amplify-form-field/amplify-form-field.scss
+++ b/packages/amplify-ui-components/src/components/amplify-form-field/amplify-form-field.scss
@@ -1,4 +1,5 @@
-:host {
+:host,
+amplify-form-field {
   --label-font-size: var(--amplify-text-md);
   --description-font-size: var(--amplify-text-sm);
 }

--- a/packages/amplify-ui-components/src/components/amplify-form-field/amplify-form-field.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-form-field/amplify-form-field.tsx
@@ -7,6 +7,7 @@ import { TextFieldTypes } from '../../common/types/ui-types';
 @Component({
   tag: 'amplify-form-field',
   styleUrl: 'amplify-form-field.scss',
+  scoped: true,
 })
 export class AmplifyFormField {
   /** The ID of the field. Should match with its corresponding input's ID. */

--- a/packages/amplify-ui-components/src/components/amplify-form-field/amplify-form-field.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-form-field/amplify-form-field.tsx
@@ -7,7 +7,6 @@ import { TextFieldTypes } from '../../common/types/ui-types';
 @Component({
   tag: 'amplify-form-field',
   styleUrl: 'amplify-form-field.scss',
-  shadow: true,
 })
 export class AmplifyFormField {
   /** The ID of the field. Should match with its corresponding input's ID. */

--- a/packages/amplify-ui-components/src/components/amplify-form-section/amplify-form-section.scss
+++ b/packages/amplify-ui-components/src/components/amplify-form-section/amplify-form-section.scss
@@ -8,7 +8,8 @@
  * @prop --font-family: Text font family within the footer
  * @prop --font-weight: Text weight within the footer
  */
-:host {
+:host,
+amplify-form-section {
   --header-color: var(--amplify-secondary-color);
   --header-size: var(--amplify-text-md-sub);
   --subtitle-size: var(--amplify-grey);

--- a/packages/amplify-ui-components/src/components/amplify-form-section/amplify-form-section.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-form-section/amplify-form-section.tsx
@@ -8,7 +8,6 @@ import { Component, Prop, h, FunctionalComponent, Listen } from '@stencil/core';
 @Component({
   tag: 'amplify-form-section',
   styleUrl: 'amplify-form-section.scss',
-  shadow: true,
 })
 export class AmplifyFormSection {
   /** (Required) Function called upon submission of form */

--- a/packages/amplify-ui-components/src/components/amplify-form-section/amplify-form-section.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-form-section/amplify-form-section.tsx
@@ -8,6 +8,7 @@ import { Component, Prop, h, FunctionalComponent, Listen } from '@stencil/core';
 @Component({
   tag: 'amplify-form-section',
   styleUrl: 'amplify-form-section.scss',
+  scoped: true,
 })
 export class AmplifyFormSection {
   /** (Required) Function called upon submission of form */

--- a/packages/amplify-ui-components/src/components/amplify-google-button/amplify-google-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-google-button/amplify-google-button.tsx
@@ -10,6 +10,7 @@ const logger = new Logger('amplify-google-button');
 
 @Component({
   tag: 'amplify-google-button',
+  scoped: true,
 })
 export class AmplifyGoogleButton {
   /** Auth state change handler for this component

--- a/packages/amplify-ui-components/src/components/amplify-google-button/amplify-google-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-google-button/amplify-google-button.tsx
@@ -10,7 +10,6 @@ const logger = new Logger('amplify-google-button');
 
 @Component({
   tag: 'amplify-google-button',
-  shadow: true,
 })
 export class AmplifyGoogleButton {
   /** Auth state change handler for this component

--- a/packages/amplify-ui-components/src/components/amplify-greetings/amplify-greetings.scss
+++ b/packages/amplify-ui-components/src/components/amplify-greetings/amplify-greetings.scss
@@ -3,7 +3,8 @@
  * @prop --border-color: Border color of the container
  * @prop --font-family: Font family of the text
  */
-:host {
+:host,
+amplify-greetings {
   --background-color: var(--amplify-white);
   --border-color: var(--amplify-light-grey);
   --font-family: var(--amplify-font-family);

--- a/packages/amplify-ui-components/src/components/amplify-greetings/amplify-greetings.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-greetings/amplify-greetings.tsx
@@ -10,6 +10,7 @@ import { dispatchAuthStateChangeEvent } from '../../common/helpers';
 @Component({
   tag: 'amplify-greetings',
   styleUrl: 'amplify-greetings.scss',
+  scoped: true,
 })
 export class AmplifyGreetings {
   /** Username displayed in the greetings */

--- a/packages/amplify-ui-components/src/components/amplify-greetings/amplify-greetings.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-greetings/amplify-greetings.tsx
@@ -10,7 +10,6 @@ import { dispatchAuthStateChangeEvent } from '../../common/helpers';
 @Component({
   tag: 'amplify-greetings',
   styleUrl: 'amplify-greetings.scss',
-  shadow: true,
 })
 export class AmplifyGreetings {
   /** Username displayed in the greetings */

--- a/packages/amplify-ui-components/src/components/amplify-hint/amplify-hint.scss
+++ b/packages/amplify-ui-components/src/components/amplify-hint/amplify-hint.scss
@@ -4,7 +4,8 @@
  * @prop --font-size: Font size of the text
  * @prop --font-weight: Font weight of the text
  */
-:host {
+:host,
+amplify-hint {
   --color: var(--amplify-grey);
   --font-family: var(--amplify-font-family);
   --font-size: var(--amplify-text-xs);

--- a/packages/amplify-ui-components/src/components/amplify-hint/amplify-hint.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-hint/amplify-hint.tsx
@@ -6,7 +6,6 @@ import { Component, h } from '@stencil/core';
 @Component({
   tag: 'amplify-hint',
   styleUrl: 'amplify-hint.scss',
-  shadow: true,
 })
 export class AmplifyHint {
   render() {

--- a/packages/amplify-ui-components/src/components/amplify-hint/amplify-hint.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-hint/amplify-hint.tsx
@@ -6,6 +6,7 @@ import { Component, h } from '@stencil/core';
 @Component({
   tag: 'amplify-hint',
   styleUrl: 'amplify-hint.scss',
+  scoped: true,
 })
 export class AmplifyHint {
   render() {

--- a/packages/amplify-ui-components/src/components/amplify-icon-button/amplify-icon-button.scss
+++ b/packages/amplify-ui-components/src/components/amplify-icon-button/amplify-icon-button.scss
@@ -2,7 +2,8 @@
  * @prop --button-color: Text color of the button
  * @prop --button-background-hover: Background color of the button when it's hovered
  */
-:host {
+:host,
+amplify-icon-button {
   --button-color: var(--amplify-secondary-contrast);
   --button-background-hover: var(--amplify-secondary-color);
 }

--- a/packages/amplify-ui-components/src/components/amplify-icon-button/amplify-icon-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-icon-button/amplify-icon-button.tsx
@@ -4,7 +4,6 @@ import { IconNameType } from '../amplify-icon/icons';
 @Component({
   tag: 'amplify-icon-button',
   styleUrl: 'amplify-icon-button.scss',
-  shadow: true,
 })
 export class AmplifyIconButton {
   /**  The name of the icon used inside of the button */

--- a/packages/amplify-ui-components/src/components/amplify-icon-button/amplify-icon-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-icon-button/amplify-icon-button.tsx
@@ -4,6 +4,7 @@ import { IconNameType } from '../amplify-icon/icons';
 @Component({
   tag: 'amplify-icon-button',
   styleUrl: 'amplify-icon-button.scss',
+  scoped: true,
 })
 export class AmplifyIconButton {
   /**  The name of the icon used inside of the button */

--- a/packages/amplify-ui-components/src/components/amplify-icon/amplify-icon.scss
+++ b/packages/amplify-ui-components/src/components/amplify-icon/amplify-icon.scss
@@ -3,7 +3,8 @@
  * @prop --height: Height of the icon
  * @prop --icon-fill-color: Fill color of the icon
  */
-:host {
+:host,
+amplify-icon {
   --width: auto;
   --height: auto;
   --icon-fill-color: var(--amplify-white);

--- a/packages/amplify-ui-components/src/components/amplify-input/amplify-input.scss
+++ b/packages/amplify-ui-components/src/components/amplify-input/amplify-input.scss
@@ -5,7 +5,8 @@
  * @prop --border-color-focus: Border color of the input when focused on
  * @prop --margin: Margin around the input
  */
-:host {
+:host,
+amplify-input {
   --color: var(--amplify-secondary-color);
   --background-color: var(--amplify-secondary-contrast);
   --border-color: var(--amplify-light-grey);

--- a/packages/amplify-ui-components/src/components/amplify-label/amplify-label.scss
+++ b/packages/amplify-ui-components/src/components/amplify-label/amplify-label.scss
@@ -1,7 +1,8 @@
 /**
  * @prop --label-color: Text color within the label
  */
-:host {
+:host,
+amplify-label {
   --label-color: var(--amplify-secondary-color);
 }
 

--- a/packages/amplify-ui-components/src/components/amplify-label/amplify-label.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-label/amplify-label.tsx
@@ -6,6 +6,7 @@ import { Component, Prop, h } from '@stencil/core';
 @Component({
   tag: 'amplify-label',
   styleUrl: 'amplify-label.scss',
+  scoped: true,
 })
 export class AmplifyLabel {
   /** Reflects the value of the for content property of html element */

--- a/packages/amplify-ui-components/src/components/amplify-label/amplify-label.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-label/amplify-label.tsx
@@ -6,7 +6,6 @@ import { Component, Prop, h } from '@stencil/core';
 @Component({
   tag: 'amplify-label',
   styleUrl: 'amplify-label.scss',
-  shadow: true,
 })
 export class AmplifyLabel {
   /** Reflects the value of the for content property of html element */

--- a/packages/amplify-ui-components/src/components/amplify-link/amplify-link.scss
+++ b/packages/amplify-ui-components/src/components/amplify-link/amplify-link.scss
@@ -1,4 +1,5 @@
-:host {
+:host,
+amplify-link {
   --link-color: var(--amplify-primary-color);
   --link-hover: var(--amplify-primary-tint);
   --link-active: var(--amplify-primary-shade);

--- a/packages/amplify-ui-components/src/components/amplify-link/amplify-link.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-link/amplify-link.tsx
@@ -3,7 +3,6 @@ import { Component, Element, Prop, h } from '@stencil/core';
 @Component({
   tag: 'amplify-link',
   styleUrl: 'amplify-link.scss',
-  shadow: true,
 })
 export class AmplifyLink {
   @Element() el: HTMLAmplifyLinkElement;

--- a/packages/amplify-ui-components/src/components/amplify-link/amplify-link.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-link/amplify-link.tsx
@@ -3,6 +3,7 @@ import { Component, Element, Prop, h } from '@stencil/core';
 @Component({
   tag: 'amplify-link',
   styleUrl: 'amplify-link.scss',
+  scoped: true,
 })
 export class AmplifyLink {
   @Element() el: HTMLAmplifyLinkElement;

--- a/packages/amplify-ui-components/src/components/amplify-loading-spinner/amplify-loading-spinner.scss
+++ b/packages/amplify-ui-components/src/components/amplify-loading-spinner/amplify-loading-spinner.scss
@@ -1,4 +1,5 @@
-:host {
+:host,
+amplify-loading-spinner {
   --spinner-circle-fill: var(--amplify-smoke-white);
   --spinner-bar-fill: var(--amplify-primary-color);
   --width: 0.875rem;

--- a/packages/amplify-ui-components/src/components/amplify-loading-spinner/amplify-loading-spinner.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-loading-spinner/amplify-loading-spinner.tsx
@@ -3,7 +3,6 @@ import { Component, h } from '@stencil/core';
 @Component({
   tag: 'amplify-loading-spinner',
   styleUrl: 'amplify-loading-spinner.scss',
-  shadow: true,
 })
 export class AmplifyLoadingSpinner {
   render() {

--- a/packages/amplify-ui-components/src/components/amplify-loading-spinner/amplify-loading-spinner.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-loading-spinner/amplify-loading-spinner.tsx
@@ -3,6 +3,7 @@ import { Component, h } from '@stencil/core';
 @Component({
   tag: 'amplify-loading-spinner',
   styleUrl: 'amplify-loading-spinner.scss',
+  scoped: true,
 })
 export class AmplifyLoadingSpinner {
   render() {

--- a/packages/amplify-ui-components/src/components/amplify-nav/amplify-nav.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-nav/amplify-nav.tsx
@@ -3,6 +3,7 @@ import { Component, h } from '@stencil/core';
 @Component({
   tag: 'amplify-nav',
   styleUrl: 'amplify-nav.scss',
+  scoped: true,
 })
 export class AmplifyNav {
   render() {

--- a/packages/amplify-ui-components/src/components/amplify-nav/amplify-nav.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-nav/amplify-nav.tsx
@@ -3,7 +3,6 @@ import { Component, h } from '@stencil/core';
 @Component({
   tag: 'amplify-nav',
   styleUrl: 'amplify-nav.scss',
-  shadow: true,
 })
 export class AmplifyNav {
   render() {

--- a/packages/amplify-ui-components/src/components/amplify-oauth-button/amplify-oauth-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-oauth-button/amplify-oauth-button.tsx
@@ -7,6 +7,7 @@ import { Translations } from '../../common/Translations';
 
 @Component({
   tag: 'amplify-oauth-button',
+  scoped: true,
 })
 export class AmplifyOAuthButton {
   /** Federated credentials & configuration. */

--- a/packages/amplify-ui-components/src/components/amplify-oauth-button/amplify-oauth-button.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-oauth-button/amplify-oauth-button.tsx
@@ -7,7 +7,6 @@ import { Translations } from '../../common/Translations';
 
 @Component({
   tag: 'amplify-oauth-button',
-  shadow: true,
 })
 export class AmplifyOAuthButton {
   /** Federated credentials & configuration. */

--- a/packages/amplify-ui-components/src/components/amplify-password-field/amplify-password-field.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-password-field/amplify-password-field.tsx
@@ -5,6 +5,7 @@ import { Translations } from '../../common/Translations';
 
 @Component({
   tag: 'amplify-password-field',
+  scoped: true,
 })
 export class AmplifyPasswordField {
   /** Based on the type of field e.g. sign in, sign up, forgot password, etc. */

--- a/packages/amplify-ui-components/src/components/amplify-password-field/amplify-password-field.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-password-field/amplify-password-field.tsx
@@ -5,7 +5,6 @@ import { Translations } from '../../common/Translations';
 
 @Component({
   tag: 'amplify-password-field',
-  shadow: true,
 })
 export class AmplifyPasswordField {
   /** Based on the type of field e.g. sign in, sign up, forgot password, etc. */

--- a/packages/amplify-ui-components/src/components/amplify-phone-field/amplify-phone-field.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-phone-field/amplify-phone-field.tsx
@@ -6,7 +6,6 @@ import { PHONE_SUFFIX } from '../../common/constants';
 @Component({
   tag: 'amplify-phone-field',
   styleUrl: 'amplify-phone-field.scss',
-  shadow: true,
 })
 export class AmplifyPhoneField {
   /** Based on the type of field e.g. sign in, sign up, forgot password, etc. */

--- a/packages/amplify-ui-components/src/components/amplify-phone-field/amplify-phone-field.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-phone-field/amplify-phone-field.tsx
@@ -6,6 +6,7 @@ import { PHONE_SUFFIX } from '../../common/constants';
 @Component({
   tag: 'amplify-phone-field',
   styleUrl: 'amplify-phone-field.scss',
+  scoped: true,
 })
 export class AmplifyPhoneField {
   /** Based on the type of field e.g. sign in, sign up, forgot password, etc. */

--- a/packages/amplify-ui-components/src/components/amplify-photo-picker/amplify-photo-picker.scss
+++ b/packages/amplify-ui-components/src/components/amplify-photo-picker/amplify-photo-picker.scss
@@ -1,4 +1,5 @@
-:host {
+:host,
+amplify-photo-picker {
   --object-fit: cover;
   --hint-color: var(--amplify-grey);
   --header-color: var(--amplify-secondary-color);

--- a/packages/amplify-ui-components/src/components/amplify-photo-picker/amplify-photo-picker.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-photo-picker/amplify-photo-picker.tsx
@@ -5,7 +5,6 @@ import { Translations } from '../../common/Translations';
 @Component({
   tag: 'amplify-photo-picker',
   styleUrl: 'amplify-photo-picker.scss',
-  shadow: true,
 })
 export class AmplifyPhotoPicker {
   /** Title string value */

--- a/packages/amplify-ui-components/src/components/amplify-photo-picker/amplify-photo-picker.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-photo-picker/amplify-photo-picker.tsx
@@ -5,6 +5,7 @@ import { Translations } from '../../common/Translations';
 @Component({
   tag: 'amplify-photo-picker',
   styleUrl: 'amplify-photo-picker.scss',
+  scoped: true,
 })
 export class AmplifyPhotoPicker {
   /** Title string value */

--- a/packages/amplify-ui-components/src/components/amplify-picker/amplify-picker.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-picker/amplify-picker.tsx
@@ -5,6 +5,7 @@ import { Translations } from '../../common/Translations';
 @Component({
   tag: 'amplify-picker',
   styleUrl: 'amplify-picker.scss',
+  scoped: true,
 })
 export class AmplifyPicker {
   /** Picker button text */

--- a/packages/amplify-ui-components/src/components/amplify-picker/amplify-picker.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-picker/amplify-picker.tsx
@@ -5,7 +5,6 @@ import { Translations } from '../../common/Translations';
 @Component({
   tag: 'amplify-picker',
   styleUrl: 'amplify-picker.scss',
-  shadow: true,
 })
 export class AmplifyPicker {
   /** Picker button text */

--- a/packages/amplify-ui-components/src/components/amplify-radio-button/amplify-radio-button.scss
+++ b/packages/amplify-ui-components/src/components/amplify-radio-button/amplify-radio-button.scss
@@ -1,4 +1,5 @@
-:host {
+:host,
+amplify-radio-button {
   --font-family: var(--amplify-font-family);
 }
 

--- a/packages/amplify-ui-components/src/components/amplify-require-new-password/amplify-require-new-password.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-require-new-password/amplify-require-new-password.tsx
@@ -20,6 +20,7 @@ const logger = new Logger('amplify-require-new-password');
 
 @Component({
   tag: 'amplify-require-new-password',
+  scoped: true,
 })
 export class AmplifyRequireNewPassword {
   /** The header text of the forgot password section */

--- a/packages/amplify-ui-components/src/components/amplify-require-new-password/amplify-require-new-password.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-require-new-password/amplify-require-new-password.tsx
@@ -20,7 +20,6 @@ const logger = new Logger('amplify-require-new-password');
 
 @Component({
   tag: 'amplify-require-new-password',
-  shadow: true,
 })
 export class AmplifyRequireNewPassword {
   /** The header text of the forgot password section */

--- a/packages/amplify-ui-components/src/components/amplify-s3-album/amplify-s3-album.scss
+++ b/packages/amplify-ui-components/src/components/amplify-s3-album/amplify-s3-album.scss
@@ -1,7 +1,8 @@
 /**
  * @prop --overlay-bg-color: Image overlay color on hover
  */
-:host {
+:host,
+amplify-s3-album {
   --overlay-bg-color: rgba(0, 0, 0, 0.15);
 }
 

--- a/packages/amplify-ui-components/src/components/amplify-s3-album/amplify-s3-album.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-s3-album/amplify-s3-album.tsx
@@ -12,7 +12,6 @@ const logger = new Logger('S3Album');
 @Component({
   tag: 'amplify-s3-album',
   styleUrl: 'amplify-s3-album.scss',
-  shadow: true,
 })
 export class AmplifyS3Album {
   /** String representing directory location of image files to be listed */

--- a/packages/amplify-ui-components/src/components/amplify-s3-album/amplify-s3-album.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-s3-album/amplify-s3-album.tsx
@@ -12,6 +12,7 @@ const logger = new Logger('S3Album');
 @Component({
   tag: 'amplify-s3-album',
   styleUrl: 'amplify-s3-album.scss',
+  scoped: true,
 })
 export class AmplifyS3Album {
   /** String representing directory location of image files to be listed */

--- a/packages/amplify-ui-components/src/components/amplify-s3-image/amplify-s3-image.scss
+++ b/packages/amplify-ui-components/src/components/amplify-s3-image/amplify-s3-image.scss
@@ -2,7 +2,8 @@
  * @prop --height: Image height
  * @prop --width: Image width
  */
-:host {
+:host,
+amplify-s3-image {
   height: inherit;
   width: inherit;
 

--- a/packages/amplify-ui-components/src/components/amplify-s3-image/amplify-s3-image.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-s3-image/amplify-s3-image.tsx
@@ -8,6 +8,7 @@ const logger = new Logger('S3Image');
 @Component({
   tag: 'amplify-s3-image',
   styleUrl: 'amplify-s3-image.scss',
+  scoped: true,
 })
 export class AmplifyS3Image {
   /** The key of the image object in S3 */

--- a/packages/amplify-ui-components/src/components/amplify-s3-image/amplify-s3-image.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-s3-image/amplify-s3-image.tsx
@@ -8,7 +8,6 @@ const logger = new Logger('S3Image');
 @Component({
   tag: 'amplify-s3-image',
   styleUrl: 'amplify-s3-image.scss',
-  shadow: true,
 })
 export class AmplifyS3Image {
   /** The key of the image object in S3 */

--- a/packages/amplify-ui-components/src/components/amplify-s3-text-picker/amplify-s3-text-picker.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-s3-text-picker/amplify-s3-text-picker.tsx
@@ -8,6 +8,7 @@ const logger = new Logger('S3TextPicker');
 
 @Component({
   tag: 'amplify-s3-text-picker',
+  scoped: true,
 })
 export class AmplifyS3TextPicker {
   /** String representing directory location to text file */

--- a/packages/amplify-ui-components/src/components/amplify-s3-text-picker/amplify-s3-text-picker.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-s3-text-picker/amplify-s3-text-picker.tsx
@@ -8,7 +8,6 @@ const logger = new Logger('S3TextPicker');
 
 @Component({
   tag: 'amplify-s3-text-picker',
-  shadow: true,
 })
 export class AmplifyS3TextPicker {
   /** String representing directory location to text file */

--- a/packages/amplify-ui-components/src/components/amplify-s3-text/amplify-s3-text.scss
+++ b/packages/amplify-ui-components/src/components/amplify-s3-text/amplify-s3-text.scss
@@ -4,7 +4,8 @@
  * @prop --text-color: Font color of the text
  * @prop --font-size: Font size of the text
  */
-:host {
+:host,
+amplify-s3-text {
   --container-color: var(--amplify-smoke-white);
   --border-color: var(--amplify-light-grey);
   --font-size: var(--amplify-text-md);

--- a/packages/amplify-ui-components/src/components/amplify-s3-text/amplify-s3-text.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-s3-text/amplify-s3-text.tsx
@@ -9,6 +9,7 @@ const logger = new Logger('S3Text');
 @Component({
   tag: 'amplify-s3-text',
   styleUrl: 'amplify-s3-text.scss',
+  scoped: true,
 })
 export class AmplifyS3Text {
   /** The key of the text object in S3 */

--- a/packages/amplify-ui-components/src/components/amplify-s3-text/amplify-s3-text.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-s3-text/amplify-s3-text.tsx
@@ -9,7 +9,6 @@ const logger = new Logger('S3Text');
 @Component({
   tag: 'amplify-s3-text',
   styleUrl: 'amplify-s3-text.scss',
-  shadow: true,
 })
 export class AmplifyS3Text {
   /** The key of the text object in S3 */

--- a/packages/amplify-ui-components/src/components/amplify-section/amplify-section.scss
+++ b/packages/amplify-ui-components/src/components/amplify-section/amplify-section.scss
@@ -2,7 +2,8 @@
  * @prop --font-family: Font family of the text within the container
  * @prop --background-color: Background color of the container
  */
-:host {
+:host,
+amplify-section {
   --font-family: var(--amplify-font-family);
   --background-color: var(--amplify-background-color);
 }

--- a/packages/amplify-ui-components/src/components/amplify-section/amplify-section.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-section/amplify-section.tsx
@@ -3,7 +3,6 @@ import { Component, Element, Prop, h } from '@stencil/core';
 @Component({
   tag: 'amplify-section',
   styleUrl: 'amplify-section.scss',
-  shadow: true,
 })
 export class AmplifySection {
   @Element() el: HTMLAmplifySectionElement;

--- a/packages/amplify-ui-components/src/components/amplify-section/amplify-section.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-section/amplify-section.tsx
@@ -3,6 +3,7 @@ import { Component, Element, Prop, h } from '@stencil/core';
 @Component({
   tag: 'amplify-section',
   styleUrl: 'amplify-section.scss',
+  scoped: true,
 })
 export class AmplifySection {
   @Element() el: HTMLAmplifySectionElement;

--- a/packages/amplify-ui-components/src/components/amplify-select-mfa-type/amplify-select-mfa-type.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-select-mfa-type/amplify-select-mfa-type.tsx
@@ -13,6 +13,7 @@ const logger = new Logger('SelectMFAType');
 
 @Component({
   tag: 'amplify-select-mfa-type',
+  scoped: true,
 })
 export class AmplifySelectMFAType {
   /** Types of MFA options */

--- a/packages/amplify-ui-components/src/components/amplify-select-mfa-type/amplify-select-mfa-type.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-select-mfa-type/amplify-select-mfa-type.tsx
@@ -13,7 +13,6 @@ const logger = new Logger('SelectMFAType');
 
 @Component({
   tag: 'amplify-select-mfa-type',
-  shadow: true,
 })
 export class AmplifySelectMFAType {
   /** Types of MFA options */

--- a/packages/amplify-ui-components/src/components/amplify-select/amplify-select.scss
+++ b/packages/amplify-ui-components/src/components/amplify-select/amplify-select.scss
@@ -5,7 +5,8 @@
  * @prop --border-focus: Border color of the input container when focused on
  * @prop --background-image: Image of the icon displayed next to text. Defaults to an upside down triangle.
  */
-:host {
+:host,
+amplify-select {
   --color: var(--amplify-secondary-color);
   --background-color: var(--amplify-secondary-contrast);
   --border-color: var(--amplify-light-grey);

--- a/packages/amplify-ui-components/src/components/amplify-select/amplify-select.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-select/amplify-select.tsx
@@ -13,6 +13,7 @@ const logger = new Logger('amplify-select');
 @Component({
   tag: 'amplify-select',
   styleUrl: 'amplify-select.scss',
+  scoped: true,
 })
 export class AmplifySelect {
   /** The options of the select input. Must be an Array of Objects with an Object shape of {label: string, value: string|number} */

--- a/packages/amplify-ui-components/src/components/amplify-select/amplify-select.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-select/amplify-select.tsx
@@ -13,7 +13,6 @@ const logger = new Logger('amplify-select');
 @Component({
   tag: 'amplify-select',
   styleUrl: 'amplify-select.scss',
-  shadow: true,
 })
 export class AmplifySelect {
   /** The options of the select input. Must be an Array of Objects with an Object shape of {label: string, value: string|number} */

--- a/packages/amplify-ui-components/src/components/amplify-sign-in-button/amplify-sign-in-button.scss
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in-button/amplify-sign-in-button.scss
@@ -1,4 +1,5 @@
-:host {
+:host,
+amplify-sign-in-button {
   --button-color: var(--amplify-secondary-color);
   --amazon-button-background: var(--amplify-primary-color);
   --amazon-button-color: var(--amplify-primary-contrast);

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.scss
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.scss
@@ -4,7 +4,8 @@
  * @prop --footer-color: Font color of the footer
  * @prop --footer-wegight: Font weight of the footer
  */
-:host {
+:host,
+amplify-sign-in {
   --footer-size: var(--amplify-text-sm);
   --footer-color: var(--amplify-grey);
   --footer-font-family: var(--amplify-font-family);

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
@@ -31,6 +31,7 @@ import { SignInAttributes } from './amplify-sign-in-interface';
 @Component({
   tag: 'amplify-sign-in',
   styleUrl: 'amplify-sign-in.scss',
+  scoped: true,
 })
 export class AmplifySignIn {
   /** Fires when sign in form is submitted */

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
@@ -31,7 +31,6 @@ import { SignInAttributes } from './amplify-sign-in-interface';
 @Component({
   tag: 'amplify-sign-in',
   styleUrl: 'amplify-sign-in.scss',
-  shadow: true,
 })
 export class AmplifySignIn {
   /** Fires when sign in form is submitted */

--- a/packages/amplify-ui-components/src/components/amplify-sign-out/amplify-sign-out.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-out/amplify-sign-out.tsx
@@ -11,7 +11,6 @@ import { Translations } from '../../common/Translations';
  */
 @Component({
   tag: 'amplify-sign-out',
-  shadow: true,
 })
 export class AmplifySignOut {
   /** Auth state change handler for this component */

--- a/packages/amplify-ui-components/src/components/amplify-sign-out/amplify-sign-out.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-out/amplify-sign-out.tsx
@@ -11,6 +11,7 @@ import { Translations } from '../../common/Translations';
  */
 @Component({
   tag: 'amplify-sign-out',
+  scoped: true,
 })
 export class AmplifySignOut {
   /** Auth state change handler for this component */

--- a/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.scss
+++ b/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.scss
@@ -4,7 +4,8 @@
  * @prop --footer-color: Font color of the footer
  * @prop --footer-weight: Font weight of the footer
  */
-:host {
+:host,
+amplify-sign-up {
   --footer-font-family: var(--amplify-font-family);
   --footer-font-size: var(--amplify-text-sm);
   --footer-color: var(--amplify-grey);

--- a/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
@@ -29,6 +29,7 @@ import { handleSignIn } from '../../common/auth-helpers';
 @Component({
   tag: 'amplify-sign-up',
   styleUrl: 'amplify-sign-up.scss',
+  scoped: true,
 })
 export class AmplifySignUp {
   /** Fires when sign up form is submitted */

--- a/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
@@ -29,7 +29,6 @@ import { handleSignIn } from '../../common/auth-helpers';
 @Component({
   tag: 'amplify-sign-up',
   styleUrl: 'amplify-sign-up.scss',
-  shadow: true,
 })
 export class AmplifySignUp {
   /** Fires when sign up form is submitted */

--- a/packages/amplify-ui-components/src/components/amplify-strike/amplify-strike.scss
+++ b/packages/amplify-ui-components/src/components/amplify-strike/amplify-strike.scss
@@ -3,7 +3,8 @@
  * @prop --border-color: Color of the horizontal rules
  * @prop --content-background: Background color of the container placed between the horizontal rules
  */
-:host {
+:host,
+amplify-strike {
   --color: var(--amplify-grey);
   --border-color: var(--amplify-light-grey);
   --content-background: var(--amplify-white);

--- a/packages/amplify-ui-components/src/components/amplify-toast/amplify-toast.scss
+++ b/packages/amplify-ui-components/src/components/amplify-toast/amplify-toast.scss
@@ -5,7 +5,8 @@
  * @prop --close-icon-color: Fill color of the close icon
  * @prop --close-icon-hover: Fill color of the close icon when hovering
  */
-:host {
+:host,
+amplify-toast {
   --background-color: var(--amplify-secondary-tint);
   --color: var(--amplify-white);
   --font-size: var(--amplify-text-sm);

--- a/packages/amplify-ui-components/src/components/amplify-toast/amplify-toast.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-toast/amplify-toast.tsx
@@ -6,6 +6,7 @@ import { Component, Prop, h } from '@stencil/core';
 @Component({
   tag: 'amplify-toast',
   styleUrl: 'amplify-toast.scss',
+  scoped: true,
 })
 export class AmplifyToast {
   /** Used in order to add a dismissable `x` for the Toast component */

--- a/packages/amplify-ui-components/src/components/amplify-toast/amplify-toast.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-toast/amplify-toast.tsx
@@ -6,7 +6,6 @@ import { Component, Prop, h } from '@stencil/core';
 @Component({
   tag: 'amplify-toast',
   styleUrl: 'amplify-toast.scss',
-  shadow: true,
 })
 export class AmplifyToast {
   /** Used in order to add a dismissable `x` for the Toast component */

--- a/packages/amplify-ui-components/src/components/amplify-tooltip/amplify-tooltip.scss
+++ b/packages/amplify-ui-components/src/components/amplify-tooltip/amplify-tooltip.scss
@@ -4,7 +4,8 @@
  * @prop --color: Text color within the tooltip
  * @prop --border-color: Border color of the tooltip
  */
-:host {
+:host,
+amplify-tooltip {
   --font-family: var(--amplify-font-family);
   --background-color: var(--amplify-secondary-color);
   --color: var(--amplify-secondary-contrast);

--- a/packages/amplify-ui-components/src/components/amplify-tooltip/amplify-tooltip.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-tooltip/amplify-tooltip.tsx
@@ -6,6 +6,7 @@ import { Component, h, Prop } from '@stencil/core';
 @Component({
   tag: 'amplify-tooltip',
   styleUrl: 'amplify-tooltip.scss',
+  scoped: true,
 })
 export class AmplifyTooltip {
   /** (Required) The text in the tooltip */

--- a/packages/amplify-ui-components/src/components/amplify-tooltip/amplify-tooltip.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-tooltip/amplify-tooltip.tsx
@@ -6,7 +6,6 @@ import { Component, h, Prop } from '@stencil/core';
 @Component({
   tag: 'amplify-tooltip',
   styleUrl: 'amplify-tooltip.scss',
-  shadow: true,
 })
 export class AmplifyTooltip {
   /** (Required) The text in the tooltip */

--- a/packages/amplify-ui-components/src/components/amplify-totp-setup/amplify-totp-setup.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-totp-setup/amplify-totp-setup.tsx
@@ -14,6 +14,7 @@ const logger = new Logger('TOTP');
 @Component({
   tag: 'amplify-totp-setup',
   styleUrl: 'amplify-totp-setup.scss',
+  scoped: true,
 })
 export class AmplifyTOTPSetup {
   private inputProps: object = {

--- a/packages/amplify-ui-components/src/components/amplify-totp-setup/amplify-totp-setup.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-totp-setup/amplify-totp-setup.tsx
@@ -14,7 +14,6 @@ const logger = new Logger('TOTP');
 @Component({
   tag: 'amplify-totp-setup',
   styleUrl: 'amplify-totp-setup.scss',
-  shadow: true,
 })
 export class AmplifyTOTPSetup {
   private inputProps: object = {

--- a/packages/amplify-ui-components/src/components/amplify-username-field/amplify-username-field.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-username-field/amplify-username-field.tsx
@@ -5,6 +5,7 @@ import { Translations } from '../../common/Translations';
 
 @Component({
   tag: 'amplify-username-field',
+  scoped: true,
 })
 export class AmplifyUsernameField {
   /** Based on the type of field e.g. sign in, sign up, forgot password, etc. */

--- a/packages/amplify-ui-components/src/components/amplify-username-field/amplify-username-field.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-username-field/amplify-username-field.tsx
@@ -5,7 +5,6 @@ import { Translations } from '../../common/Translations';
 
 @Component({
   tag: 'amplify-username-field',
-  shadow: true,
 })
 export class AmplifyUsernameField {
   /** Based on the type of field e.g. sign in, sign up, forgot password, etc. */

--- a/packages/amplify-ui-components/src/components/amplify-verify-contact/amplify-verify-contact.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-verify-contact/amplify-verify-contact.tsx
@@ -10,6 +10,7 @@ const logger = new Logger('AmplifyVerifyContact');
 
 @Component({
   tag: 'amplify-verify-contact',
+  scoped: true,
 })
 export class AmplifyVerifyContact {
   /** Authentication state handler */

--- a/packages/amplify-ui-components/src/components/amplify-verify-contact/amplify-verify-contact.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-verify-contact/amplify-verify-contact.tsx
@@ -10,7 +10,6 @@ const logger = new Logger('AmplifyVerifyContact');
 
 @Component({
   tag: 'amplify-verify-contact',
-  shadow: true,
 })
 export class AmplifyVerifyContact {
   /** Authentication state handler */


### PR DESCRIPTION
## Why?

Read this fam:
> https://github.com/aws-amplify/amplify-js/discussions/7486

### What did it look like?

> ![Screen Shot 2021-02-09 at 4 38 23 PM](https://user-images.githubusercontent.com/15182/107570615-a4dec600-6b9e-11eb-80a4-90a1dd72eb42.png)

### What does it look like with this PR?

Not quite the same: some CSS variables and display values aren't propagating correctly with `scoped: true`.

> ![Screen Shot 2021-02-10 at 3 43 25 PM](https://user-images.githubusercontent.com/15182/107576427-f8a0dd80-6ba5-11eb-8c54-a36975d5b228.png)

## What next?

I'm considering punting on this due to time constraints & resolving this independent of v1.

Removing the Shadow DOM will allow customers to override styles, yes, but greater customization will be at the component/slot level.

With `scoped: true`, the HTML structure slightly changes, which _could_ be considered a breaking change. Same for CSS classes! (But I don't think that's reasonable because they're not documented APIs)

Without exhaustive visual regression testing (manual or otherwise), changing or removing `shadow: true`  is **risky**.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
