### PR TITLE
fix(predictions-identify): update detectFacesCommand parameters to include all facial attributes in the result

### DIFF
--- a/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
@@ -367,7 +367,7 @@ export class AmazonAIIdentifyPredictionsProvider extends AbstractIdentifyPredict
 				return Promise.reject(err);
 			});
 
-		const param = { Image: inputImage };
+		const param = { Attributes: ['ALL'], Image: inputImage };
 
 		if (
 			isIdentifyCelebrities(input.entities) &&


### PR DESCRIPTION
_Issue #, if available:_
#7740 

_Description of changes:_
The context for the `undefined` problem can be found in the [issue](https://github.com/aws-amplify/amplify-js/issues/7740). As per the documentation for Rekognition JS Client Library [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Rekognition.html), by default Rekognition will only send back `boundingBox` and `landmarks`, which is why Amplify Predictions `identify` result shows `undefined` in `attributes`, `ageRange`, etc. To fix this, I have made the required changes as specified in the Rekognition client documentation [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Rekognition.html).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
