### PR TITLE
fix(@aws-amplify/datastore): improve IDB query performance

### DIFF
--- a/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
+++ b/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
@@ -1,5 +1,4 @@
-import Adapter from '../src/storage/adapter/IndexedDBAdapter';
-import 'fake-indexeddb/auto';
+import AsyncStorageAdapter from '../src/storage/adapter/AsyncStorageAdapter';
 import {
 	DataStore as DataStoreType,
 	initSchema as initSchemaType,
@@ -11,18 +10,24 @@ import { Predicates } from '../src/predicates';
 let initSchema: typeof initSchemaType;
 let DataStore: typeof DataStoreType;
 // using any to get access to private methods
-const IDBAdapter = <any>Adapter;
+const ASAdapter = <any>AsyncStorageAdapter;
 
-describe('IndexedDBAdapter tests', () => {
+describe('AsyncStorageAdapter tests', () => {
 	describe('Query', () => {
 		let Model: PersistentModelConstructor<Model>;
 		let model1Id: string;
-		const spyOnGet = jest.spyOn(IDBAdapter, 'getOne');
-		const spyOnGetAll = jest.spyOn(IDBAdapter, 'getAll');
-		const spyOnEngine = jest.spyOn(IDBAdapter, 'enginePagination');
-		const spyOnMemory = jest.spyOn(IDBAdapter, 'inMemoryPagination');
+		const spyOnGet = jest.spyOn(ASAdapter, 'getOne');
+		const spyOnGetAll = jest.spyOn(ASAdapter, 'getAll');
+		const spyOnMemory = jest.spyOn(ASAdapter, 'inMemoryPagination');
 
 		beforeAll(async () => {
+			jest.doMock('../src/storage/adapter/getDefaultAdapter', () => {
+				return () =>
+					// we're returning a new instance of AsyncStorageAdapter in getDefaultAdapter/index.ts:13
+					// adding a mock to return default instead, so that we can spy on its methods
+					require('../src/storage/adapter/AsyncStorageAdapter').default;
+			});
+
 			({ initSchema, DataStore } = require('../src/datastore/datastore'));
 
 			const classes = initSchema(testSchema());
@@ -55,24 +60,37 @@ describe('IndexedDBAdapter tests', () => {
 			jest.clearAllMocks();
 		});
 
-		it('Should call _get & inMemoryPagination for query by id', async () => {
+		it('Should call db.get for query by id', async () => {
 			const result = await DataStore.query(Model, model1Id);
 
 			expect(result.field1).toEqual('Some value');
 			expect(spyOnGet).toHaveBeenCalled();
 			expect(spyOnGetAll).not.toHaveBeenCalled();
-			expect(spyOnEngine).not.toHaveBeenCalled();
-			expect(spyOnMemory).toHaveBeenCalled();
+			expect(spyOnMemory).not.toHaveBeenCalled();
 		});
 
-		it('Should call getAll & inMemoryPagination for query with a predicate', async () => {
+		it('Should call getAll for query with a predicate', async () => {
 			const results = await DataStore.query(Model, c =>
-				c.field1('eq', 'another value')
+				c.field1('contains', 'value')
 			);
 
-			expect(results.length).toEqual(1);
+			expect(results.length).toEqual(3);
 			expect(spyOnGetAll).toHaveBeenCalled();
-			expect(spyOnEngine).not.toHaveBeenCalled();
+			expect(spyOnMemory).not.toHaveBeenCalled();
+		});
+
+		it('Should call getAll & inMemoryPagination for query with a predicate and sort', async () => {
+			const results = await DataStore.query(
+				Model,
+				c => c.field1('contains', 'value'),
+				{
+					sort: s => s.dateCreated(SortDirection.DESCENDING),
+				}
+			);
+
+			expect(results.length).toEqual(3);
+			expect(results[0].field1).toEqual('a third value');
+			expect(spyOnGetAll).toHaveBeenCalled();
 			expect(spyOnMemory).toHaveBeenCalled();
 		});
 
@@ -84,19 +102,17 @@ describe('IndexedDBAdapter tests', () => {
 			expect(results.length).toEqual(3);
 			expect(results[0].field1).toEqual('a third value');
 			expect(spyOnGetAll).toHaveBeenCalled();
-			expect(spyOnEngine).not.toHaveBeenCalled();
 			expect(spyOnMemory).toHaveBeenCalled();
 		});
 
-		it('Should call enginePagination for query with pagination but no sort or predicate', async () => {
+		it('Should call getAll & inMemoryPagination for query with pagination but no sort or predicate', async () => {
 			const results = await DataStore.query(Model, Predicates.ALL, {
 				limit: 1,
 			});
 
 			expect(results.length).toEqual(1);
-			expect(spyOnGetAll).not.toHaveBeenCalled();
-			expect(spyOnEngine).toHaveBeenCalled();
-			expect(spyOnMemory).not.toHaveBeenCalled();
+			expect(spyOnGetAll).toHaveBeenCalled();
+			expect(spyOnMemory).toHaveBeenCalled();
 		});
 
 		it('Should call getAll for query without predicate and pagination', async () => {
@@ -104,7 +120,6 @@ describe('IndexedDBAdapter tests', () => {
 
 			expect(results.length).toEqual(3);
 			expect(spyOnGetAll).toHaveBeenCalled();
-			expect(spyOnEngine).not.toHaveBeenCalled();
 			expect(spyOnMemory).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
+++ b/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
@@ -16,7 +16,7 @@ describe('AsyncStorageAdapter tests', () => {
 	describe('Query', () => {
 		let Model: PersistentModelConstructor<Model>;
 		let model1Id: string;
-		const spyOnGetOne = jest.spyOn(ASAdapter, 'getOne');
+		const spyOnGetOne = jest.spyOn(ASAdapter, 'getById');
 		const spyOnGetAll = jest.spyOn(ASAdapter, 'getAll');
 		const spyOnMemory = jest.spyOn(ASAdapter, 'inMemoryPagination');
 
@@ -60,7 +60,7 @@ describe('AsyncStorageAdapter tests', () => {
 			jest.clearAllMocks();
 		});
 
-		it('Should call db.get for query by id', async () => {
+		it('Should call getById for query by id', async () => {
 			const result = await DataStore.query(Model, model1Id);
 
 			expect(result.field1).toEqual('Some value');
@@ -76,7 +76,7 @@ describe('AsyncStorageAdapter tests', () => {
 
 			expect(results.length).toEqual(3);
 			expect(spyOnGetAll).toHaveBeenCalled();
-			expect(spyOnMemory).not.toHaveBeenCalled();
+			expect(spyOnMemory).toHaveBeenCalled();
 		});
 
 		it('Should call getAll & inMemoryPagination for query with a predicate and sort', async () => {

--- a/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
+++ b/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
@@ -16,7 +16,7 @@ describe('AsyncStorageAdapter tests', () => {
 	describe('Query', () => {
 		let Model: PersistentModelConstructor<Model>;
 		let model1Id: string;
-		const spyOnGet = jest.spyOn(ASAdapter, 'getOne');
+		const spyOnGetOne = jest.spyOn(ASAdapter, 'getOne');
 		const spyOnGetAll = jest.spyOn(ASAdapter, 'getAll');
 		const spyOnMemory = jest.spyOn(ASAdapter, 'inMemoryPagination');
 
@@ -64,7 +64,7 @@ describe('AsyncStorageAdapter tests', () => {
 			const result = await DataStore.query(Model, model1Id);
 
 			expect(result.field1).toEqual('Some value');
-			expect(spyOnGet).toHaveBeenCalled();
+			expect(spyOnGetOne).toHaveBeenCalled();
 			expect(spyOnGetAll).not.toHaveBeenCalled();
 			expect(spyOnMemory).not.toHaveBeenCalled();
 		});

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -1,5 +1,4 @@
 import 'fake-indexeddb/auto';
-import FDBCursor from 'fake-indexeddb/build/FDBCursor';
 import { decodeTime } from 'ulid';
 import uuidValidate from 'uuid-validate';
 import Observable from 'zen-observable-ts';

--- a/packages/datastore/__tests__/IndexedDBAdapter.test.ts
+++ b/packages/datastore/__tests__/IndexedDBAdapter.test.ts
@@ -17,7 +17,7 @@ describe('IndexedDBAdapter tests', () => {
 	describe('Query', () => {
 		let Model: PersistentModelConstructor<Model>;
 		let model1Id: string;
-		const spyOnGet = jest.spyOn(IDBAdapter, 'getOne');
+		const spyOnGetOne = jest.spyOn(IDBAdapter, 'getOne');
 		const spyOnGetAll = jest.spyOn(IDBAdapter, 'getAll');
 		const spyOnEngine = jest.spyOn(IDBAdapter, 'enginePagination');
 		const spyOnMemory = jest.spyOn(IDBAdapter, 'inMemoryPagination');
@@ -55,11 +55,11 @@ describe('IndexedDBAdapter tests', () => {
 			jest.clearAllMocks();
 		});
 
-		it('Should call _get & inMemoryPagination for query by id', async () => {
+		it('Should call getOne & inMemoryPagination for query by id', async () => {
 			const result = await DataStore.query(Model, model1Id);
 
 			expect(result.field1).toEqual('Some value');
-			expect(spyOnGet).toHaveBeenCalled();
+			expect(spyOnGetOne).toHaveBeenCalled();
 			expect(spyOnGetAll).not.toHaveBeenCalled();
 			expect(spyOnEngine).not.toHaveBeenCalled();
 			expect(spyOnMemory).toHaveBeenCalled();

--- a/packages/datastore/__tests__/IndexedDBAdapter.test.ts
+++ b/packages/datastore/__tests__/IndexedDBAdapter.test.ts
@@ -1,0 +1,99 @@
+import Adapter from '../src/storage/adapter/IndexedDBAdapter';
+import 'fake-indexeddb/auto';
+import {
+	DataStore as DataStoreType,
+	initSchema as initSchemaType,
+} from '../src/datastore/datastore';
+import { PersistentModelConstructor, SortDirection } from '../src/types';
+import { Model, testSchema } from './helpers';
+import { Predicates } from '../src/predicates';
+
+let initSchema: typeof initSchemaType;
+let DataStore: typeof DataStoreType;
+// using any to get access to private methods
+const IDBAdapter = <any>Adapter;
+
+describe('IndexedDBAdapter tests', () => {
+	describe('Query', () => {
+		let Model: PersistentModelConstructor<Model>;
+		const spyOnGetAll = jest.spyOn(IDBAdapter, 'getAll');
+		const spyOnEngine = jest.spyOn(IDBAdapter, 'enginePagination');
+		const spyOnMemory = jest.spyOn(IDBAdapter, 'inMemoryPagination');
+
+		beforeAll(async () => {
+			({ initSchema, DataStore } = require('../src/datastore/datastore'));
+
+			const classes = initSchema(testSchema());
+
+			({ Model } = classes as {
+				Model: PersistentModelConstructor<Model>;
+			});
+
+			await DataStore.save(
+				new Model({
+					field1: 'Some value',
+					dateCreated: new Date().toISOString(),
+				})
+			);
+			await DataStore.save(
+				new Model({
+					field1: 'another value',
+					dateCreated: new Date().toISOString(),
+				})
+			);
+			await DataStore.save(
+				new Model({
+					field1: 'a third value',
+					dateCreated: new Date().toISOString(),
+				})
+			);
+		});
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
+
+		test('Should call getAll & inMemoryPagination for query with a predicate', async () => {
+			const results = await DataStore.query(Model, (c) =>
+				c.field1('eq', 'another value')
+			);
+
+			expect(results.length).toEqual(1);
+			expect(spyOnGetAll).toHaveBeenCalled();
+			expect(spyOnEngine).not.toHaveBeenCalled();
+			expect(spyOnMemory).toHaveBeenCalled();
+		});
+
+		test('Should call getAll & inMemoryPagination for query with sort', async () => {
+			const results = await DataStore.query(Model, Predicates.ALL, {
+				sort: (s) => s.dateCreated(SortDirection.DESCENDING),
+			});
+
+			expect(results.length).toEqual(3);
+			expect(results[0].field1).toEqual('a third value');
+			expect(spyOnGetAll).toHaveBeenCalled();
+			expect(spyOnEngine).not.toHaveBeenCalled();
+			expect(spyOnMemory).toHaveBeenCalled();
+		});
+
+		test('Should call enginePagination for query with pagination but no sort or predicate', async () => {
+			const results = await DataStore.query(Model, Predicates.ALL, {
+				limit: 1,
+			});
+
+			expect(results.length).toEqual(1);
+			expect(spyOnGetAll).not.toHaveBeenCalled();
+			expect(spyOnEngine).toHaveBeenCalled();
+			expect(spyOnMemory).not.toHaveBeenCalled();
+		});
+
+		test('Should call getAll for query without predicate and pagination', async () => {
+			const results = await DataStore.query(Model);
+
+			expect(results.length).toEqual(3);
+			expect(spyOnGetAll).toHaveBeenCalled();
+			expect(spyOnEngine).not.toHaveBeenCalled();
+			expect(spyOnMemory).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/datastore/__tests__/IndexedDBAdapter.test.ts
+++ b/packages/datastore/__tests__/IndexedDBAdapter.test.ts
@@ -17,7 +17,7 @@ describe('IndexedDBAdapter tests', () => {
 	describe('Query', () => {
 		let Model: PersistentModelConstructor<Model>;
 		let model1Id: string;
-		const spyOnGetOne = jest.spyOn(IDBAdapter, 'getOne');
+		const spyOnGetOne = jest.spyOn(IDBAdapter, 'getById');
 		const spyOnGetAll = jest.spyOn(IDBAdapter, 'getAll');
 		const spyOnEngine = jest.spyOn(IDBAdapter, 'enginePagination');
 		const spyOnMemory = jest.spyOn(IDBAdapter, 'inMemoryPagination');
@@ -55,14 +55,14 @@ describe('IndexedDBAdapter tests', () => {
 			jest.clearAllMocks();
 		});
 
-		it('Should call getOne & inMemoryPagination for query by id', async () => {
+		it('Should call getById for query by id', async () => {
 			const result = await DataStore.query(Model, model1Id);
 
 			expect(result.field1).toEqual('Some value');
 			expect(spyOnGetOne).toHaveBeenCalled();
 			expect(spyOnGetAll).not.toHaveBeenCalled();
 			expect(spyOnEngine).not.toHaveBeenCalled();
-			expect(spyOnMemory).toHaveBeenCalled();
+			expect(spyOnMemory).not.toHaveBeenCalled();
 		});
 
 		it('Should call getAll & inMemoryPagination for query with a predicate', async () => {

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -760,7 +760,10 @@ class DataStore {
 			predicate: ModelPredicateCreator.getPredicates(predicate, false),
 			pagination: {
 				...pagination,
-				sort: ModelSortPredicateCreator.getPredicates(pagination.sort, false),
+				sort: ModelSortPredicateCreator.getPredicates(
+					pagination && pagination.sort,
+					false
+				),
 			},
 		});
 
@@ -1121,9 +1124,13 @@ class DataStore {
 	private processPagination<T extends PersistentModel>(
 		modelDefinition: SchemaModel,
 		paginationProducer: ProducerPaginationInput<T>
-	): PaginationInput<T> {
+	): PaginationInput<T> | undefined {
 		let sortPredicate: SortPredicate<T>;
 		const { limit, page, sort } = paginationProducer || {};
+
+		if (limit === undefined && page === undefined && sort === undefined) {
+			return undefined;
+		}
 
 		if (page !== undefined && limit === undefined) {
 			throw new Error('Limit is required when requesting a page');

--- a/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
+++ b/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
@@ -447,7 +447,7 @@ class IndexedDBAdapter implements Adapter {
 		records: T[],
 		pagination?: PaginationInput<T>
 	): T[] {
-		if (pagination) {
+		if (pagination && records.length > 1) {
 			if (pagination.sort) {
 				const sortPredicates = ModelSortPredicateCreator.getPredicates(
 					pagination.sort

--- a/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
+++ b/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
@@ -395,6 +395,13 @@ class IndexedDBAdapter implements Adapter {
 		return await this.load(namespaceName, modelConstructor.name, records);
 	}
 
+	private async getOne<T extends PersistentModel>(
+		id: string,
+		storeName: string
+	): Promise<T> {
+		return await this._get(id, storeName);
+	}
+
 	private async getAll<T extends PersistentModel>(
 		storeName: string
 	): Promise<T[]> {
@@ -420,7 +427,7 @@ class IndexedDBAdapter implements Adapter {
 			if (idPredicate) {
 				const { operand: id } = idPredicate;
 
-				const record = <any>await this._get(storeName, id);
+				const record = <any>await this.getOne(storeName, id);
 
 				if (record) {
 					const [x] = await this.load(namespaceName, modelConstructor.name, [

--- a/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
+++ b/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
@@ -16,6 +16,7 @@ import {
 	PersistentModel,
 	PersistentModelConstructor,
 	PredicateObject,
+	PredicatesGroup,
 	QueryOne,
 	RelationType,
 } from '../../types';
@@ -371,35 +372,44 @@ class IndexedDBAdapter implements Adapter {
 		const storeName = this.getStorenameForModel(modelConstructor);
 		const namespaceName = this.namespaceResolver(modelConstructor);
 
-		const hasPredicate = !!predicate;
+		const predicates =
+			predicate && ModelPredicateCreator.getPredicates(predicate);
+		const queryById = predicates && this.idFromPredicate(predicates);
 		const hasSort = pagination && pagination.sort;
 		const hasPagination = pagination && pagination.limit;
 
-		let records: T[];
+		const records: T[] = await (async () => {
+			if (queryById) {
+				const record = await this.getById(storeName, queryById);
+				return record ? [record] : [];
+			}
 
-		if (hasPredicate) {
-			const filtered = await this.filterOnPredicate(
-				modelConstructor,
-				predicate
-			);
-			records = this.inMemoryPagination(filtered, pagination);
-		} else if (hasSort) {
-			const all = await this.getAll(storeName);
-			records = <T[]>this.inMemoryPagination(all, pagination);
-		} else if (hasPagination) {
-			records = await this.enginePagination(storeName, pagination);
-		} else {
-			records = await this.getAll(storeName);
-		}
+			if (predicates) {
+				const filtered = await this.filterOnPredicate(storeName, predicates);
+				return this.inMemoryPagination(filtered, pagination);
+			}
+
+			if (hasSort) {
+				const all = await this.getAll(storeName);
+				return this.inMemoryPagination(all, pagination);
+			}
+
+			if (hasPagination) {
+				return this.enginePagination(storeName, pagination);
+			}
+
+			return this.getAll(storeName);
+		})();
 
 		return await this.load(namespaceName, modelConstructor.name, records);
 	}
 
-	private async getOne<T extends PersistentModel>(
-		id: string,
-		storeName: string
+	private async getById<T extends PersistentModel>(
+		storeName: string,
+		id: string
 	): Promise<T> {
-		return await this._get(id, storeName);
+		const record = <T>await this._get(storeName, id);
+		return record;
 	}
 
 	private async getAll<T extends PersistentModel>(
@@ -408,46 +418,32 @@ class IndexedDBAdapter implements Adapter {
 		return await this.db.getAll(storeName);
 	}
 
-	private async filterOnPredicate<T extends PersistentModel>(
-		modelConstructor: PersistentModelConstructor<T>,
-		predicate: ModelPredicate<T>
+	private idFromPredicate<T extends PersistentModel>(
+		predicates: PredicatesGroup<T>
 	) {
-		const storeName = this.getStorenameForModel(modelConstructor);
-		const namespaceName = this.namespaceResolver(modelConstructor);
+		const { predicates: predicateObjs } = predicates;
+		const idPredicate =
+			predicateObjs.length === 1 &&
+			(predicateObjs.find(
+				p => isPredicateObj(p) && p.field === 'id' && p.operator === 'eq'
+			) as PredicateObject<T>);
 
-		const predicates = ModelPredicateCreator.getPredicates(predicate);
-		if (predicates) {
-			const { predicates: predicateObjs, type } = predicates;
-			const idPredicate =
-				predicateObjs.length === 1 &&
-				(predicateObjs.find(
-					p => isPredicateObj(p) && p.field === 'id' && p.operator === 'eq'
-				) as PredicateObject<T>);
+		return idPredicate && idPredicate.operand;
+	}
 
-			if (idPredicate) {
-				const { operand: id } = idPredicate;
+	private async filterOnPredicate<T extends PersistentModel>(
+		storeName: string,
+		predicates: PredicatesGroup<T>
+	) {
+		const { predicates: predicateObjs, type } = predicates;
 
-				const record = <any>await this.getOne(storeName, id);
+		const all = <T[]>await this.getAll(storeName);
 
-				if (record) {
-					const [x] = await this.load(namespaceName, modelConstructor.name, [
-						record,
-					]);
+		const filtered = predicateObjs
+			? all.filter(m => validatePredicate(m, type, predicateObjs))
+			: all;
 
-					return [x];
-				}
-				return [];
-			}
-
-			// TODO: Use indices if possible
-			const all = <T[]>await this.getAll(storeName);
-
-			const filtered = predicateObjs
-				? all.filter(m => validatePredicate(m, type, predicateObjs))
-				: all;
-
-			return filtered;
-		}
+		return filtered;
 	}
 
 	private inMemoryPagination<T extends PersistentModel>(


### PR DESCRIPTION
This PR fixes a bug where calling `DataStore.query(Post)` _without_ a pagination object would use the cursor-based fetch from IndexedDB, as opposed to `getAll()`, which is optimized specifically for getting all the records. This was having a negative effect on the performance of `DataStore.query` when retrieving all the items for a given model.

The pagination object was getting initialized to `{limit: undefined, page: undefined, sort: undefined}` in the `DataStore.processPagination` private method, therefore `pagination` always had a truthy value in the conditional checks that determine which retrieval method to utilize. This gets fixed [here](https://github.com/aws-amplify/amplify-js/pull/7746/files#diff-10866b5ac7d469b38dd9928d9d7056a3a402904fef591ea8cfe773b4d75d63efR1131-R1134).

Also:
* Refactored `IndexedDBAdapater.query` to make it easier to test
* Added test coverage for IndexedDBAdapter, which ensures the correct retrieval method is used for all of the different combinations of parameters passed to `IndexedDBAdapter.query`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
