### PR TITLE
fix(@aws-amplify/core): error TS2322 on ConsoleLogger.LOG_LEVEL

### DIFF
--- a/packages/core/src/Logger/ConsoleLogger.ts
+++ b/packages/core/src/Logger/ConsoleLogger.ts
@@ -38,7 +38,7 @@ export class ConsoleLogger implements Logger {
 		this.level = level;
 	}
 
-	static LOG_LEVEL = null;
+	static LOG_LEVEL: string | null = null;
 
 	_padding(n) {
 		return n < 10 ? '0' + n : '' + n;
@@ -64,7 +64,7 @@ export class ConsoleLogger implements Logger {
 	 */
 	_log(type: string, ...msg) {
 		let logger_level_name = this.level;
-		if (ConsoleLogger.LOG_LEVEL) {
+		if (ConsoleLogger.LOG_LEVEL !== null) {
 			logger_level_name = ConsoleLogger.LOG_LEVEL;
 		}
 		if (typeof (<any>window) !== 'undefined' && (<any>window).LOG_LEVEL) {


### PR DESCRIPTION
_Description of changes:_

Fixes a TypeScript compilation error:

```
node_modules/@aws-amplify/core/src/Logger/ConsoleLogger.ts:68:4 - error TS2322: Type 'null' is not assignable to type 'string'.

68              logger_level_name = ConsoleLogger.LOG_LEVEL;
                ~~~~~~~~~~~~~~~~~
```

Without this fix, the error occurs in TypeScript 4.1.2 with the following `tsconfig.json`:

```json
{
  "compilerOptions": {
    "lib": ["dom", "es2019"],
    "target": "es2015",
    "module": "es2020",
    "moduleResolution": "node",
    "strict": true,
    "esModuleInterop": true,
    "forceConsistentCasingInFileNames": true,
    "noImplicitAny": false,
    "noUnusedLocals": true,
    "noUnusedParameters": true,
    "removeComments": false,
    "preserveConstEnums": true,
    "preserveSymlinks": true,
    "resolveJsonModule": true,
    "skipLibCheck": true
  }
}
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
