### PR TITLE
fix(aws-amplify-react-native): respect user provided theme in react-native withAuthenticator HOC

### DIFF
--- a/packages/aws-amplify-react-native/src/Auth/index.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/index.tsx
@@ -58,7 +58,7 @@ interface IWithAuthenticatorState {
 
 export function withAuthenticator<Props extends object>(
 	Comp: React.ComponentType<Props>,
-	includeGreetings = false,
+	includeGreetings: boolean | { [index: string]: any } = false,
 	authenticatorComponents = [],
 	federated = null,
 	theme: AmplifyThemeType = null,
@@ -80,6 +80,9 @@ export function withAuthenticator<Props extends object>(
 			this.authConfig = {};
 
 			if (typeof includeGreetings === 'object' && includeGreetings !== null) {
+				if (includeGreetings.theme) {
+					theme = includeGreetings.theme;
+				}
 				this.authConfig = Object.assign(this.authConfig, includeGreetings);
 			} else {
 				this.authConfig = {


### PR DESCRIPTION



_Description of changes:_  This PR addresses an issue with the `aws-amplify-react-native` `withAuthenticator` HOC where, following the implementation outlined in our documentation, a user provided theme would be ignored. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
