### PR TITLE
fix(@aws-amplify/datastore): handle sync query unauthorized

### DIFF
--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -142,14 +142,14 @@ class SyncProcessor {
 						variables,
 					});
 				} catch (error) {
-					if (this.partialDataFeatureFlagEnabled()) {
-						const hasItems = Boolean(
-							error &&
-								error.data &&
-								error.data[opName] &&
-								error.data[opName].items
-						);
+					const hasItems = Boolean(
+						error &&
+							error.data &&
+							error.data[opName] &&
+							error.data[opName].items
+					);
 
+					if (this.partialDataFeatureFlagEnabled()) {
 						if (hasItems) {
 							const result = error;
 							result.data[opName].items = result.data[opName].items.filter(
@@ -178,12 +178,26 @@ class SyncProcessor {
 					);
 					if (unauthorized) {
 						const result = error;
-						result.data[opName].items = result.data[opName].items.filter(
-							item => item !== null
-						);
+
+						const opResultDefaults = {
+							items: [],
+							nextToken: null,
+							startedAt: null,
+						};
+
+						if (hasItems) {
+							result.data[opName].items = result.data[opName].items.filter(
+								item => item !== null
+							);
+						} else {
+							result.data[opName] = {
+								...opResultDefaults,
+								...result.data[opName],
+							};
+						}
 						logger.warn(
 							'queryError',
-							'User is unauthorized, some items could not be returned.'
+							`User is unauthorized to query ${opName}, some items could not be returned.`
 						);
 						return result;
 					} else {


### PR DESCRIPTION
Fixes a bug where the sync engine breaks when a sync query returns an `unauthorized` error. 
The expected behavior for DataStore is that an unauthorized error on a model should not break syncing for other models.

Currently, when a sync query request returns unauthorized, we get the following unhandled error
```
error on  TypeError: Cannot read property 'items' of null
```
on [this line](https://github.com/aws-amplify/amplify-js/blob/main/packages/datastore/src/sync/processors/sync.ts#L181). 

An unauthorized query response typically won't return any `items`, so this PR adds a check to see if `items` are defined before attempting to iterate over them. If not defined, we return an empty list (`items: []`) and `nextToken: null` to signal to the `retrievePage` method that it shouldn't attempt to retrieve additional pages via this query.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
