### PR TITLE
fix(@aws-amplify/datastore): update mutation input - diff with DB instead of patches

### DIFF
--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -389,13 +389,12 @@ describe('DataStore tests', () => {
 			const result = await DataStore.save(model);
 
 			const [settingsSave, modelCall] = <any>save.mock.calls;
-			const [_model, _condition, _mutator, patches] = modelCall;
+			const [_model, _condition, _mutator] = modelCall;
 
 			expect(result).toMatchObject(model);
-			expect(patches).toBeUndefined();
 		});
 
-		test('Save returns the updated model and patches', async () => {
+		test('Save returns the updated model', async () => {
 			let model: Model;
 			const save = jest.fn(() => [model]);
 			const query = jest.fn(() => [model]);
@@ -438,17 +437,12 @@ describe('DataStore tests', () => {
 			const result = await DataStore.save(model);
 
 			const [settingsSave, modelSave, modelUpdate] = <any>save.mock.calls;
-			const [_model, _condition, _mutator, patches] = modelUpdate;
-
-			const expectedPatches = [
-				{ op: 'replace', path: ['field1'], value: 'edited' },
-			];
+			const [_model, _condition, _mutator] = modelUpdate;
 
 			expect(result).toMatchObject(model);
-			expect(patches).toMatchObject(expectedPatches);
 		});
 
-		test('Save returns the updated model and patches - list field', async () => {
+		test('Save returns the updated model - list field', async () => {
 			let model: Model;
 			const save = jest.fn(() => [model]);
 			const query = jest.fn(() => [model]);
@@ -505,27 +499,8 @@ describe('DataStore tests', () => {
 				save.mock.calls
 			);
 
-			const [_model, _condition, _mutator, patches] = modelUpdate;
-			const [_model2, _condition2, _mutator2, patches2] = modelUpdate2;
-
-			const expectedPatches = [
-				{
-					op: 'replace',
-					path: ['emails'],
-					value: ['john@doe.com', 'jane@doe.com', 'joe@doe.com'],
-				},
-			];
-
-			const expectedPatches2 = [
-				{
-					op: 'add',
-					path: ['emails', 3],
-					value: 'joe@doe.com',
-				},
-			];
-
-			expect(patches).toMatchObject(expectedPatches);
-			expect(patches2).toMatchObject(expectedPatches2);
+			const [_model, _condition, _mutator] = modelUpdate;
+			const [_model2, _condition2, _mutator2] = modelUpdate2;
 		});
 
 		test('Instantiation validations', async () => {

--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -16,7 +16,6 @@ export declare class Model {
 		mutator: (draft: MutableModel<Model>) => void | Model
 	): Model;
 }
-
 export declare class Metadata {
 	readonly author: string;
 	readonly tags?: string[];
@@ -25,6 +24,17 @@ export declare class Metadata {
 	readonly nominations?: string[];
 	readonly misc?: (string | null)[];
 	constructor(init: Metadata);
+}
+
+export declare class Post {
+	public readonly id: string;
+	public readonly title: string;
+}
+
+export declare class Comment {
+	public readonly id: string;
+	public readonly content: string;
+	public readonly post: Post;
 }
 
 export function testSchema(): Schema {
@@ -87,6 +97,94 @@ export function testSchema(): Schema {
 						attributes: [],
 					},
 				},
+			},
+			Post: {
+				name: 'Post',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					title: {
+						name: 'title',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					comments: {
+						name: 'comments',
+						isArray: true,
+						type: {
+							model: 'Comment',
+						},
+						isRequired: true,
+						attributes: [],
+						isArrayNullable: true,
+						association: {
+							connectionType: 'HAS_MANY',
+							associatedWith: 'postId',
+						},
+					},
+				},
+				syncable: true,
+				pluralName: 'Posts',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+				],
+			},
+			Comment: {
+				name: 'Comment',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					content: {
+						name: 'content',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					post: {
+						name: 'post',
+						isArray: false,
+						type: {
+							model: 'Post',
+						},
+						isRequired: false,
+						attributes: [],
+						association: {
+							connectionType: 'BELONGS_TO',
+							targetName: 'postId',
+						},
+					},
+				},
+				syncable: true,
+				pluralName: 'Comments',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							name: 'byPost',
+							fields: ['postId'],
+						},
+					},
+				],
 			},
 			LocalModel: {
 				name: 'LocalModel',

--- a/packages/datastore/__tests__/storage.test.ts
+++ b/packages/datastore/__tests__/storage.test.ts
@@ -4,211 +4,328 @@ import {
 	initSchema as initSchemaType,
 } from '../src/datastore/datastore';
 import { PersistentModelConstructor } from '../src/types';
-import { Model, testSchema } from './helpers';
+import { Model, Post, Comment, testSchema } from './helpers';
 
 let initSchema: typeof initSchemaType;
 let DataStore: typeof DataStoreType;
 
 describe('Storage tests', () => {
 	describe('Update', () => {
-		let zenNext;
+		describe('Only include changed fields', () => {
+			let zenNext;
 
-		beforeEach(() => {
-			jest.resetModules();
-			jest.resetAllMocks();
+			beforeEach(() => {
+				jest.resetModules();
+				jest.resetAllMocks();
 
-			zenNext = jest.fn();
+				zenNext = jest.fn();
 
-			jest.doMock('zen-push', () => {
-				class zenPush {
-					constructor() {}
-					next = zenNext;
-				}
+				jest.doMock('zen-push', () => {
+					class zenPush {
+						constructor() {}
+						next = zenNext;
+					}
 
-				return zenPush;
+					return zenPush;
+				});
+
+				({ initSchema, DataStore } = require('../src/datastore/datastore'));
 			});
 
-			({ initSchema, DataStore } = require('../src/datastore/datastore'));
-		});
+			test('scalar', async () => {
+				const classes = initSchema(testSchema());
 
-		test('Only include changed fields - scalar', async () => {
-			const classes = initSchema(testSchema());
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
 
-			const { Model } = classes as {
-				Model: PersistentModelConstructor<Model>;
-			};
+				const dateCreated = new Date().toISOString();
 
-			const dateCreated = new Date().toISOString();
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						dateCreated,
+					})
+				);
 
-			const model = await DataStore.save(
-				new Model({
-					field1: 'Some value',
-					dateCreated,
-				})
-			);
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						draft.field1 = 'edited';
+					})
+				);
 
-			await DataStore.save(
-				Model.copyOf(model, draft => {
-					draft.field1 = 'edited';
-				})
-			);
+				const [_settingsSave, [modelSave], [modelUpdate]] = zenNext.mock.calls;
 
-			const [_settingsSave, [modelSave], [modelUpdate]] = zenNext.mock.calls;
+				// Save should include
+				expect(modelSave.element.dateCreated).toEqual(dateCreated);
 
-			// Save should include
-			expect(modelSave.element.dateCreated).toEqual(dateCreated);
+				// Update mutation should only include updated fields
+				// => dateCreated should be undefined
+				expect(modelUpdate.element.dateCreated).toBeUndefined();
+				expect(modelUpdate.element.field1).toEqual('edited');
+			});
 
-			// Update mutation should only include updated fields
-			// => dateCreated should be undefined
-			expect(modelUpdate.element.dateCreated).toBeUndefined();
-			expect(modelUpdate.element.field1).toEqual('edited');
-		});
+			test('list (destructured)', async () => {
+				const classes = initSchema(testSchema());
 
-		test('Only include changed fields - list (destructured)', async () => {
-			const classes = initSchema(testSchema());
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
 
-			const { Model } = classes as {
-				Model: PersistentModelConstructor<Model>;
-			};
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						dateCreated: new Date().toISOString(),
+						emails: ['john@doe.com', 'jane@doe.com'],
+					})
+				);
 
-			const model = await DataStore.save(
-				new Model({
-					field1: 'Some value',
-					dateCreated: new Date().toISOString(),
-					emails: ['john@doe.com', 'jane@doe.com'],
-				})
-			);
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						draft.emails = [...draft.emails, 'joe@doe.com'];
+					})
+				);
 
-			await DataStore.save(
-				Model.copyOf(model, draft => {
-					draft.emails = [...draft.emails, 'joe@doe.com'];
-				})
-			);
+				const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
 
-			const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const expectedValueEmails = [
+					'john@doe.com',
+					'jane@doe.com',
+					'joe@doe.com',
+				];
 
-			const expectedValueEmails = [
-				'john@doe.com',
-				'jane@doe.com',
-				'joe@doe.com',
-			];
+				expect(modelUpdate.element.dateCreated).toBeUndefined();
+				expect(modelUpdate.element.field1).toBeUndefined();
+				expect(modelUpdate.element.emails).toMatchObject(expectedValueEmails);
+			});
 
-			expect(modelUpdate.element.dateCreated).toBeUndefined();
-			expect(modelUpdate.element.field1).toBeUndefined();
-			expect(modelUpdate.element.emails).toMatchObject(expectedValueEmails);
-		});
+			test('list (push)', async () => {
+				const classes = initSchema(testSchema());
 
-		test('Only include changed fields - list (push)', async () => {
-			const classes = initSchema(testSchema());
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
 
-			const { Model } = classes as {
-				Model: PersistentModelConstructor<Model>;
-			};
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						dateCreated: new Date().toISOString(),
+						emails: ['john@doe.com', 'jane@doe.com'],
+					})
+				);
 
-			const model = await DataStore.save(
-				new Model({
-					field1: 'Some value',
-					dateCreated: new Date().toISOString(),
-					emails: ['john@doe.com', 'jane@doe.com'],
-				})
-			);
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						draft.emails.push('joe@doe.com');
+					})
+				);
 
-			await DataStore.save(
-				Model.copyOf(model, draft => {
-					draft.emails.push('joe@doe.com');
-				})
-			);
+				const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
 
-			const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const expectedValueEmails = [
+					'john@doe.com',
+					'jane@doe.com',
+					'joe@doe.com',
+				];
 
-			const expectedValueEmails = [
-				'john@doe.com',
-				'jane@doe.com',
-				'joe@doe.com',
-			];
+				expect(modelUpdate.element.dateCreated).toBeUndefined();
+				expect(modelUpdate.element.field1).toBeUndefined();
+				expect(modelUpdate.element.emails).toMatchObject(expectedValueEmails);
+			});
 
-			expect(modelUpdate.element.dateCreated).toBeUndefined();
-			expect(modelUpdate.element.field1).toBeUndefined();
-			expect(modelUpdate.element.emails).toMatchObject(expectedValueEmails);
-		});
+			test('list unchanged', async () => {
+				const classes = initSchema(testSchema());
 
-		test('Only include changed fields - custom type (destructured)', async () => {
-			const classes = initSchema(testSchema());
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
 
-			const { Model } = classes as {
-				Model: PersistentModelConstructor<Model>;
-			};
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						dateCreated: new Date().toISOString(),
+						emails: ['john@doe.com', 'jane@doe.com'],
+					})
+				);
 
-			const model = await DataStore.save(
-				new Model({
-					field1: 'Some value',
-					dateCreated: new Date().toISOString(),
-					metadata: {
-						author: 'some author',
-						rewards: [],
-						penNames: [],
-					},
-				})
-			);
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						draft.field1 = 'Updated value';
+						// same as above. should not be included in mutation input
+						draft.emails = ['john@doe.com', 'jane@doe.com'];
+					})
+				);
 
-			await DataStore.save(
-				Model.copyOf(model, draft => {
-					draft.metadata = {
-						...draft.metadata,
-						penNames: ['bob'],
-					};
-				})
-			);
+				const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
 
-			const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
+				expect(modelUpdate.element.dateCreated).toBeUndefined();
+				expect(modelUpdate.element.field1).toEqual('Updated value');
+				expect(modelUpdate.element.emails).toBeUndefined();
+			});
 
-			const expectedValueMetadata = {
-				author: 'some author',
-				rewards: [],
-				penNames: ['bob'],
-			};
+			test('custom type (destructured)', async () => {
+				const classes = initSchema(testSchema());
 
-			expect(modelUpdate.element.dateCreated).toBeUndefined();
-			expect(modelUpdate.element.field1).toBeUndefined();
-			expect(modelUpdate.element.metadata).toMatchObject(expectedValueMetadata);
-		});
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
 
-		test('Only include changed fields - custom type (accessor)', async () => {
-			const classes = initSchema(testSchema());
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						dateCreated: new Date().toISOString(),
+						metadata: {
+							author: 'some author',
+							rewards: [],
+							penNames: [],
+						},
+					})
+				);
 
-			const { Model } = classes as {
-				Model: PersistentModelConstructor<Model>;
-			};
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						draft.metadata = {
+							...draft.metadata,
+							penNames: ['bob'],
+						};
+					})
+				);
 
-			const model = await DataStore.save(
-				new Model({
-					field1: 'Some value',
-					dateCreated: new Date().toISOString(),
-					metadata: {
-						author: 'some author',
-						rewards: [],
-						penNames: [],
-					},
-				})
-			);
+				const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
 
-			await DataStore.save(
-				Model.copyOf(model, draft => {
-					draft.metadata.penNames = ['bob'];
-				})
-			);
+				const expectedValueMetadata = {
+					author: 'some author',
+					rewards: [],
+					penNames: ['bob'],
+				};
 
-			const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
+				expect(modelUpdate.element.dateCreated).toBeUndefined();
+				expect(modelUpdate.element.field1).toBeUndefined();
+				expect(modelUpdate.element.metadata).toMatchObject(
+					expectedValueMetadata
+				);
+			});
 
-			const expectedValueMetadata = {
-				author: 'some author',
-				rewards: [],
-				penNames: ['bob'],
-			};
+			test('custom type (accessor)', async () => {
+				const classes = initSchema(testSchema());
 
-			expect(modelUpdate.element.dateCreated).toBeUndefined();
-			expect(modelUpdate.element.field1).toBeUndefined();
-			expect(modelUpdate.element.metadata).toMatchObject(expectedValueMetadata);
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
+
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						dateCreated: new Date().toISOString(),
+						metadata: {
+							author: 'some author',
+							rewards: [],
+							penNames: [],
+						},
+					})
+				);
+
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						draft.metadata.penNames = ['bob'];
+					})
+				);
+
+				const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
+
+				const expectedValueMetadata = {
+					author: 'some author',
+					rewards: [],
+					penNames: ['bob'],
+				};
+
+				expect(modelUpdate.element.dateCreated).toBeUndefined();
+				expect(modelUpdate.element.field1).toBeUndefined();
+				expect(modelUpdate.element.metadata).toMatchObject(
+					expectedValueMetadata
+				);
+			});
+
+			test('custom type unchanged', async () => {
+				const classes = initSchema(testSchema());
+
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
+
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						dateCreated: new Date().toISOString(),
+						metadata: {
+							author: 'some author',
+							rewards: [],
+							penNames: [],
+						},
+					})
+				);
+
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						draft.field1 = 'Updated value';
+						draft.metadata = {
+							author: 'some author',
+							rewards: [],
+							penNames: [],
+						};
+					})
+				);
+
+				const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
+
+				expect(modelUpdate.element.dateCreated).toBeUndefined();
+				expect(modelUpdate.element.field1).toEqual('Updated value');
+				expect(modelUpdate.element.metadata).toBeUndefined();
+			});
+
+			test('relation', async () => {
+				const classes = initSchema(testSchema());
+
+				const { Post, Comment } = classes as {
+					Post: PersistentModelConstructor<Post>;
+					Comment: PersistentModelConstructor<Comment>;
+				};
+
+				const post = await DataStore.save(
+					new Post({
+						title: 'New Post',
+					})
+				);
+
+				const comment = await DataStore.save(
+					new Comment({
+						content: 'Hello world',
+						post,
+					})
+				);
+
+				const anotherPost = await DataStore.save(
+					new Post({
+						title: 'Another Post',
+					})
+				);
+
+				await DataStore.save(
+					Comment.copyOf(comment, updated => {
+						updated.post = anotherPost;
+					})
+				);
+
+				const [
+					[_post1Save],
+					[commentSave],
+					[_post2Save],
+					[commentUpdate],
+				] = zenNext.mock.calls;
+
+				expect(commentSave.element.postId).toEqual(post.id);
+				expect(commentUpdate.element.postId).toEqual(anotherPost.id);
+			});
 		});
 	});
 });

--- a/packages/datastore/src/storage/adapter/index.ts
+++ b/packages/datastore/src/storage/adapter/index.ts
@@ -14,7 +14,7 @@ export interface Adapter extends SystemComponent {
 	save<T extends PersistentModel>(
 		model: T,
 		condition?: ModelPredicate<T>
-	): Promise<[T, OpType.INSERT | OpType.UPDATE][]>;
+	): Promise<[T, OpType.INSERT | OpType.UPDATE, T?][]>;
 	delete: <T extends PersistentModel>(
 		modelOrModelConstructor: T | PersistentModelConstructor<T>,
 		condition?: ModelPredicate<T>

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -434,6 +434,34 @@ export function sortCompareFunction<T extends PersistentModel>(
 	};
 }
 
+export function getUpdateMutationInput<T extends PersistentModel>(
+	original: T,
+	updated: T
+): { [key: string]: any } {
+	const mutationInput: { [key: string]: any } = {
+		id: original.id,
+		_version: original._version,
+		_lastChangedAt: original._lastChangedAt,
+		_deleted: original._deleted,
+	};
+
+	for (const field in original) {
+		let originalValue: any = original[field];
+		let updatedValue: any = updated[field];
+
+		if (typeof originalValue === 'object') {
+			originalValue = JSON.stringify(originalValue);
+			updatedValue = JSON.stringify(updatedValue);
+		}
+
+		if (originalValue !== updatedValue) {
+			mutationInput[field] = updated[field];
+		}
+	}
+
+	return mutationInput;
+}
+
 export const isAWSDate = (val: string): boolean => {
 	return !!/^\d{4}-\d{2}-\d{2}(Z|[+-]\d{2}:\d{2}($|:\d{2}))?$/.exec(val);
 };


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/aws-amplify/amplify-js/issues/7840

This PR changes the way we derive the correct update mutation input when using DataStore. Relying on Immer patches makes it difficult to resolve field data for connections and to include the correct fields when updating relational data. E.g., in the linked issue. Using a diff between the updated record and the previous record is a simpler and more reliable approach.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
