### PR TITLE
fix(@aws-amplify/core): #7941 Session could not contain identifyPoolId

### DIFF
--- a/packages/core/__tests__/Credentials-test.ts
+++ b/packages/core/__tests__/Credentials-test.ts
@@ -9,9 +9,16 @@ const user = {
 	},
 };
 
+const token = {
+	getJwtToken: () => 'token',
+};
+
 const authClass = {
 	getModuleName() {
 		return 'Auth';
+	},
+	getIdToken() {
+		return token;
 	},
 	currentUserCredentials() {
 		return Promise.resolve('cred');
@@ -164,6 +171,36 @@ describe('Credentials test', () => {
 			const credentials = new Credentials(null);
 
 			expect(await credentials.get()).toBe('cred');
+		});
+	});
+
+	describe('set credentials from session', () => {
+		let credentials: Credentials;
+
+		beforeAll(() => {
+			const credentials = new Credentials(null);
+			Amplify.register(authClass);
+			Amplify.register(credentials);
+		});
+
+		test('session could not contain identifyPoolId', async () => {
+			const config = {
+				region: 'region',
+				// identityPoolId: null,
+			};
+
+			Amplify.configure(config);
+
+			expect.assertions(1);
+			try {
+				expect(await credentials.set(authClass, 'session')).resolves.toBe(
+					'cred'
+				);
+			} catch (err) {
+				expect(err.message).not.toEqual(
+					'No Cognito Federated Identity pool provided'
+				);
+			}
 		});
 	});
 });

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -404,7 +404,7 @@ export class CredentialsClass {
 		const { region, userPoolId, identityPoolId } = this._config;
 		if (!identityPoolId) {
 			logger.debug('No Cognito Federated Identity pool provided');
-			return Promise.reject('No Cognito Federated Identity pool provided');
+			// return Promise.reject('No Cognito Federated Identity pool provided');
 		}
 		if (!region) {
 			logger.debug('region is not configured for getting the credentials');
@@ -421,7 +421,7 @@ export class CredentialsClass {
 			customUserAgent: getAmplifyUserAgent(),
 		});
 
-		/* 
+		/*
 			Retreiving identityId with GetIdCommand to mimic the behavior in the following code in aws-sdk-v3:
 			https://git.io/JeDxU
 


### PR DESCRIPTION
_Issue #7941, if available:_

_Description of changes:_

Due to `identityPoolId` not required in getting session, I'll try to create work around

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
