### PR TITLE
fix: user pool authDetails accept hash secret parameter

### DIFF
--- a/packages/amazon-cognito-identity-js/index.d.ts
+++ b/packages/amazon-cognito-identity-js/index.d.ts
@@ -47,6 +47,7 @@ declare module 'amazon-cognito-identity-js' {
 
 		public getUsername(): string;
 		public getPassword(): string;
+		public getSecretHash(): string | null;
 		public getValidationData(): any[];
 	}
 
@@ -70,16 +71,12 @@ declare module 'amazon-cognito-identity-js' {
 	export class CognitoUser {
 		constructor(data: ICognitoUserData);
 
-		public setSignInUserSession(
-			signInUserSession: CognitoUserSession
-		): void;
+		public setSignInUserSession(signInUserSession: CognitoUserSession): void;
 		public getSignInUserSession(): CognitoUserSession | null;
 		public getUsername(): string;
 
 		public getAuthenticationFlowType(): string;
-		public setAuthenticationFlowType(
-			authenticationFlowType: string
-		): string;
+		public setAuthenticationFlowType(authenticationFlowType: string): string;
 		public getCachedDeviceKeyAndPassword(): void;
 
 		public getSession(
@@ -164,7 +161,10 @@ declare module 'amazon-cognito-identity-js' {
 		public sendMFACode(
 			confirmationCode: string,
 			callbacks: {
-				onSuccess: (session: CognitoUserSession, userConfirmationNecessary?: boolean) => void;
+				onSuccess: (
+					session: CognitoUserSession,
+					userConfirmationNecessary?: boolean
+				) => void;
 				onFailure: (err: any) => void;
 			},
 			mfaType?: string,
@@ -184,15 +184,9 @@ declare module 'amazon-cognito-identity-js' {
 			callbacks: {
 				onSuccess: (session: CognitoUserSession) => void;
 				onFailure: (err: any) => void;
-				mfaRequired?: (
-					challengeName: any,
-					challengeParameters: any
-				) => void;
+				mfaRequired?: (challengeName: any, challengeParameters: any) => void;
 				customChallenge?: (challengeParameters: any) => void;
-				mfaSetup?: (
-					challengeName: any,
-					challengeParameters: any
-				) => void;
+				mfaSetup?: (challengeName: any, challengeParameters: any) => void;
 			},
 			clientMetadata?: ClientMetadata
 		): void;
@@ -258,14 +252,8 @@ declare module 'amazon-cognito-identity-js' {
 			callbacks: {
 				onSuccess: (session: CognitoUserSession) => void;
 				onFailure: (err: any) => void;
-				mfaRequired?: (
-					challengeName: any,
-					challengeParameters: any
-				) => void;
-				totpRequired?: (
-					challengeName: any,
-					challengeParameters: any
-				) => void;
+				mfaRequired?: (challengeName: any, challengeParameters: any) => void;
+				totpRequired?: (challengeName: any, challengeParameters: any) => void;
 			}
 		): void;
 	}

--- a/packages/amazon-cognito-identity-js/src/AuthenticationDetails.js
+++ b/packages/amazon-cognito-identity-js/src/AuthenticationDetails.js
@@ -32,12 +32,12 @@ export default class AuthenticationDetails {
 			Password,
 			AuthParameters,
 			ClientMetadata,
+			SecretHash,
 		} = data || {};
 		this.validationData = ValidationData || {};
 		this.authParameters = AuthParameters || {};
-		this.clientMetadata = ClientMetadata || {};
-		this.username = Username;
-		this.password = Password;
+		this.clientMetadata = ClientMetadata;
+		this.secretHash = SecretHash ? SecretHash : null;
 	}
 
 	/**
@@ -52,6 +52,13 @@ export default class AuthenticationDetails {
 	 */
 	getPassword() {
 		return this.password;
+	}
+
+	/**
+	 * @returns {string} the record's secret hash
+	 */
+	getSecretHash() {
+		return this.secretHash;
 	}
 
 	/**

--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -251,6 +251,10 @@ export default class CognitoUser {
 			authParameters.DEVICE_KEY = this.deviceKey;
 		}
 
+		if (authDetails.getSecretHash()) {
+			authParameters.SECRET_HASH = authDetails.getSecretHash();
+		}
+
 		authParameters.USERNAME = this.username;
 		authenticationHelper.getLargeAValue((errOnAValue, aValue) => {
 			// getLargeAValue callback start
@@ -323,6 +327,10 @@ export default class CognitoUser {
 							challengeParameters.SECRET_BLOCK;
 						challengeResponses.TIMESTAMP = dateNow;
 						challengeResponses.PASSWORD_CLAIM_SIGNATURE = signatureString;
+
+						if (authDetails.getSecretHash()) {
+							challengeResponses.SECRET_HASH = authDetails.getSecretHash();
+						}
 
 						if (this.deviceKey != null) {
 							challengeResponses.DEVICE_KEY = this.deviceKey;
@@ -398,6 +406,9 @@ export default class CognitoUser {
 		const authParameters = {};
 		authParameters.USERNAME = this.username;
 		authParameters.PASSWORD = authDetails.getPassword();
+		if (authDetails.getSecretHash()) {
+			authParameters.SECRET_HASH = authDetails.getSecretHash();
+		}
 		if (!authParameters.PASSWORD) {
 			callback.onFailure(new Error('PASSWORD parameter is required'));
 			return;
@@ -522,7 +533,7 @@ export default class CognitoUser {
 		authenticationHelper.generateHashDevice(
 			dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceGroupKey,
 			dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceKey,
-			errGenHash => {
+			(errGenHash) => {
 				if (errGenHash) {
 					return callback.onFailure(errGenHash);
 				}
@@ -604,7 +615,7 @@ export default class CognitoUser {
 
 		const finalUserAttributes = {};
 		if (requiredAttributeData) {
-			Object.keys(requiredAttributeData).forEach(key => {
+			Object.keys(requiredAttributeData).forEach((key) => {
 				finalUserAttributes[userAttributesPrefix + key] =
 					requiredAttributeData[key];
 			});
@@ -779,7 +790,7 @@ export default class CognitoUser {
 		if (this.getUserContextData()) {
 			jsonReq.UserContextData = this.getUserContextData();
 		}
-		this.client.request('ConfirmSignUp', jsonReq, err => {
+		this.client.request('ConfirmSignUp', jsonReq, (err) => {
 			if (err) {
 				return callback(err, null);
 			}
@@ -899,7 +910,7 @@ export default class CognitoUser {
 					dataAuthenticate.AuthenticationResult.NewDeviceMetadata
 						.DeviceGroupKey,
 					dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceKey,
-					errGenHash => {
+					(errGenHash) => {
 						if (errGenHash) {
 							return callback.onFailure(errGenHash);
 						}
@@ -978,7 +989,7 @@ export default class CognitoUser {
 				AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
 				ClientMetadata: clientMetadata,
 			},
-			err => {
+			(err) => {
 				if (err) {
 					return callback(err, null);
 				}
@@ -1012,7 +1023,7 @@ export default class CognitoUser {
 				MFAOptions: mfaOptions,
 				AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
 			},
-			err => {
+			(err) => {
 				if (err) {
 					return callback(err, null);
 				}
@@ -1041,7 +1052,7 @@ export default class CognitoUser {
 				SoftwareTokenMfaSettings: softwareTokenMfaSettings,
 				AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
 			},
-			err => {
+			(err) => {
 				if (err) {
 					return callback(err, null);
 				}
@@ -1070,7 +1081,7 @@ export default class CognitoUser {
 				MFAOptions: mfaOptions,
 				AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
 			},
-			err => {
+			(err) => {
 				if (err) {
 					return callback(err, null);
 				}
@@ -1097,7 +1108,7 @@ export default class CognitoUser {
 				AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
 				ClientMetadata: clientMetadata,
 			},
-			err => {
+			(err) => {
 				if (err) {
 					return callback(err, null);
 				}
@@ -1130,7 +1141,7 @@ export default class CognitoUser {
 				UserAttributes: attributes,
 				ClientMetadata: clientMetadata,
 			},
-			err => {
+			(err) => {
 				if (err) {
 					return callback(err, null);
 				}
@@ -1223,7 +1234,7 @@ export default class CognitoUser {
 	 */
 	refreshSessionIfPossible(options = {}) {
 		// best effort, if not possible
-		return new Promise(resolve => {
+		return new Promise((resolve) => {
 			const refresh = this.signInUserSession.getRefreshToken();
 			if (refresh && refresh.getToken()) {
 				this.refreshSession(refresh, resolve, options.clientMetadata);
@@ -1255,7 +1266,7 @@ export default class CognitoUser {
 
 		if (!userData) {
 			this.fetchUserData()
-				.then(data => {
+				.then((data) => {
 					callback(null, data);
 				})
 				.catch(callback);
@@ -1264,10 +1275,10 @@ export default class CognitoUser {
 
 		if (this.isFetchUserDataAndTokenRequired(params)) {
 			this.fetchUserData()
-				.then(data => {
+				.then((data) => {
 					return this.refreshSessionIfPossible(params).then(() => data);
 				})
-				.then(data => callback(null, data))
+				.then((data) => callback(null, data))
 				.catch(callback);
 			return;
 		}
@@ -1309,7 +1320,7 @@ export default class CognitoUser {
 	 * be directly called by the consumers.
 	 */
 	fetchUserData() {
-		return this.createGetUserRequest().then(data => {
+		return this.createGetUserRequest().then((data) => {
 			this.cacheUserData(data);
 			return data;
 		});
@@ -1332,7 +1343,7 @@ export default class CognitoUser {
 				UserAttributeNames: attributeList,
 				AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
 			},
-			err => {
+			(err) => {
 				if (err) {
 					return callback(err, null);
 				}
@@ -1691,7 +1702,7 @@ export default class CognitoUser {
 		if (this.getUserContextData()) {
 			jsonReq.UserContextData = this.getUserContextData();
 		}
-		this.client.request('ConfirmForgotPassword', jsonReq, err => {
+		this.client.request('ConfirmForgotPassword', jsonReq, (err) => {
 			if (err) {
 				return callback.onFailure(err);
 			}
@@ -1754,7 +1765,7 @@ export default class CognitoUser {
 				Code: confirmationCode,
 				AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
 			},
-			err => {
+			(err) => {
 				if (err) {
 					return callback.onFailure(err);
 				}
@@ -1811,7 +1822,7 @@ export default class CognitoUser {
 				AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
 				DeviceKey: deviceKey,
 			},
-			err => {
+			(err) => {
 				if (err) {
 					return callback.onFailure(err);
 				}
@@ -1831,7 +1842,7 @@ export default class CognitoUser {
 	forgetDevice(callback) {
 		this.forgetSpecificDevice(this.deviceKey, {
 			onFailure: callback.onFailure,
-			onSuccess: result => {
+			onSuccess: (result) => {
 				this.deviceKey = null;
 				this.deviceGroupKey = null;
 				this.randomPassword = null;
@@ -1860,7 +1871,7 @@ export default class CognitoUser {
 				DeviceKey: this.deviceKey,
 				DeviceRememberedStatus: 'remembered',
 			},
-			err => {
+			(err) => {
 				if (err) {
 					return callback.onFailure(err);
 				}
@@ -1889,7 +1900,7 @@ export default class CognitoUser {
 				DeviceKey: this.deviceKey,
 				DeviceRememberedStatus: 'not_remembered',
 			},
-			err => {
+			(err) => {
 				if (err) {
 					return callback.onFailure(err);
 				}
@@ -1948,7 +1959,7 @@ export default class CognitoUser {
 			{
 				AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
 			},
-			err => {
+			(err) => {
 				if (err) {
 					return callback.onFailure(err);
 				}


### PR DESCRIPTION
#### Description of changes
AuthenticationDetails may now receive an extra attribute called SecretHash, in the case the pool have a client_secret.  authenticateUserDefaultAuth function and authenticateUserPlainUsernamePassword were modified to send the SECRET_HASH value to the corresponding endpoints.


#### Issue #, if available
The library doesn't work when user pool have a client_secret. This library fix this, allowing client send the SECRET_HASH value corresponding for the username.
This value can be calculated with the user and client_secret with the following code:

const crypto = require("crypto");
const hashSecret = (clientSecret, username, clientId) =>
  crypto
    .createHmac("SHA256", clientSecret)
    .update(username + clientId)
    .digest("base64");
