### PR TITLE
fix(@aws-amplify/datastore): keep syncing when subs disabled

### DIFF
--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -396,7 +396,10 @@ class SubscriptionProcessor {
 														subscriptionReadyCallback();
 													}
 
-													if (message.includes('"errorType":"Unauthorized"')) {
+													if (
+														message.includes('"errorType":"Unauthorized"') ||
+														message.includes('"errorType":"OperationDisabled"')
+													) {
 														return;
 													}
 


### PR DESCRIPTION
e2e test: https://github.com/aws-amplify/amplify-js-samples-staging/pull/207

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.