### PR TITLE
Display password policy in forgot password component

### DIFF
--- a/packages/aws-amplify-angular/src/components/authenticator/authenticator/authenticator.component.core.ts
+++ b/packages/aws-amplify-angular/src/components/authenticator/authenticator/authenticator.component.core.ts
@@ -49,6 +49,7 @@ const template = `
     <amplify-auth-forgot-password-core
       *ngIf="!shouldHide('ForgotPassword')"
       [authState]="authState"
+      [signUpConfig]="_signUpConfig"
       [usernameAttributes]="_usernameAttributes"
       [hide]="hide"
     ></amplify-auth-forgot-password-core>

--- a/packages/aws-amplify-angular/src/components/authenticator/forgot-password-component/forgot-password.component.core.ts
+++ b/packages/aws-amplify-angular/src/components/authenticator/forgot-password-component/forgot-password.component.core.ts
@@ -63,6 +63,7 @@ const template = `
         placeholder="{{ this.amplifyService.i18n().get('Password') }}"
         data-test="${auth.forgotPassword.newPasswordInput}"
       />
+			<div class="amplify-form-extra-details">{{passwordPolicy}}</div>
       </div>
       <div class="amplify-form-actions">
         <div class="amplify-form-cell-right">
@@ -120,6 +121,7 @@ export class ForgotPasswordComponentCore implements OnInit {
 	_authState: AuthState;
 	_show: boolean;
 	_usernameAttributes: string = 'username';
+	_signUpConfig: any;
 	username: string;
 	code: string;
 	password: string;
@@ -129,6 +131,7 @@ export class ForgotPasswordComponentCore implements OnInit {
 	local_phone_number: string;
 	country_code: string = '1';
 	email: string;
+	passwordPolicy: string;
 
 	constructor(@Inject(AmplifyService) public amplifyService: AmplifyService) {
 		this.logger = this.amplifyService.logger('ForgotPasswordComponent');
@@ -145,6 +148,13 @@ export class ForgotPasswordComponentCore implements OnInit {
 			data.authState.user && data.authState.user.username
 				? data.authState.user.username
 				: '';
+		
+    if (data.signUpConfig) {
+      this._signUpConfig = data.signUpConfig;
+      if (this._signUpConfig.passwordPolicy) {
+        this.passwordPolicy = this._signUpConfig.passwordPolicy;
+      }
+    }
 	}
 
 	@Input() hide: string[] = [];
@@ -182,6 +192,16 @@ export class ForgotPasswordComponentCore implements OnInit {
 	set usernameAttributes(usernameAttributes: string) {
 		this._usernameAttributes = usernameAttributes;
 	}
+
+  @Input()
+  set signUpConfig(signUpConfig: any) {
+    if (signUpConfig) {
+      this._signUpConfig = signUpConfig;
+      if (this._signUpConfig.passwordPolicy) {
+        this.passwordPolicy = this._signUpConfig.passwordPolicy;
+      }
+    }
+  }
 
 	setCode(code: string) {
 		this.code = code;


### PR DESCRIPTION
#### Description of changes
Added signUpConfig as input to forgot password component and display `signUpConfig.passwordPolicy` beneath the new password input.

If present, page will render the passwordPolicy string below the new password input.

If not present, page will render same as current.

#### Issue #, if available
Similar issue closed after same implementation on the signup component: [#2576](https://github.com/aws-amplify/amplify-js/issues/2576)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
