### PR TITLE
Use the default export of "events"

### DIFF
--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -29,7 +29,7 @@ import { S3RequestPresigner } from '@aws-sdk/s3-request-presigner';
 import { StorageOptions, StorageProvider } from '../types';
 import { AxiosHttpHandler } from './axios-http-handler';
 import { AWSS3ProviderManagedUpload } from './AWSS3ProviderManagedUpload';
-import * as events from 'events';
+import EventEmitter from 'events';
 
 const logger = new Logger('AWSS3Provider');
 
@@ -290,7 +290,7 @@ export class AWSS3Provider implements StorageProvider {
 			}
 		}
 
-		const emitter = new events.EventEmitter();
+		const emitter = new EventEmitter();
 		const uploader = new AWSS3ProviderManagedUpload(params, opt, emitter);
 
 		if (acl) {


### PR DESCRIPTION
Event library does not have a named export for EventEmitter. Using the star import pattern breaks builds in some bundlers such as snowpack.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ √] PR description included
- [ √] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
