### PR TITLE
fix(@aws-amplify/datastore): consecutive saves

### DIFF
--- a/.github/actions/bundle-size-action/webpack/package.json
+++ b/.github/actions/bundle-size-action/webpack/package.json
@@ -47,7 +47,7 @@
       },
       {
         "path": "dist/withSSRContext+Storage.js.min.js",
-        "maxSize": "180kB"
+        "maxSize": "181kB"
       }
     ]
   },

--- a/packages/datastore/__tests__/outbox.test.ts
+++ b/packages/datastore/__tests__/outbox.test.ts
@@ -12,7 +12,11 @@ import {
 	TransformerMutationType,
 	createMutationInstanceFromModelOperation,
 } from '../src/sync/utils';
-import { PersistentModelConstructor, InternalSchema } from '../src/types';
+import {
+	PersistentModelConstructor,
+	InternalSchema,
+	SchemaModel,
+} from '../src/types';
 import { MutationEvent } from '../src/sync/';
 
 let initSchema: typeof initSchemaType;
@@ -48,7 +52,12 @@ describe('Outbox tests', () => {
 
 	it('Should return the create mutation from Outbox.peek', async () => {
 		await Storage.runExclusive(async s => {
-			let head = await outbox.peek(s);
+			let head;
+
+			while (!head) {
+				head = await outbox.peek(s);
+			}
+
 			const modelData: ModelType = JSON.parse(head.data);
 
 			expect(head.modelId).toEqual(modelId);
@@ -62,7 +71,11 @@ describe('Outbox tests', () => {
 				_deleted: false,
 			};
 
-			await processMutationResponse(s, response);
+			await processMutationResponse(
+				s,
+				response,
+				TransformerMutationType.CREATE
+			);
 
 			head = await outbox.peek(s);
 			expect(head).toBeFalsy();
@@ -82,7 +95,11 @@ describe('Outbox tests', () => {
 
 		await Storage.runExclusive(async s => {
 			// this mutation is now "in progress"
-			const head = await outbox.peek(s);
+			let head;
+
+			while (!head) {
+				head = await outbox.peek(s);
+			}
 			const modelData: ModelType = JSON.parse(head.data);
 
 			expect(head.modelId).toEqual(modelId);
@@ -130,7 +147,11 @@ describe('Outbox tests', () => {
 		await Storage.runExclusive(async s => {
 			// process mutation response, which dequeues updatedModel1
 			// and syncs its version to the remaining item in the mutation queue
-			await processMutationResponse(s, response);
+			await processMutationResponse(
+				s,
+				response,
+				TransformerMutationType.UPDATE
+			);
 
 			const inProgress = await outbox.peek(s);
 			const inProgressData = JSON.parse(inProgress.data);
@@ -147,7 +168,11 @@ describe('Outbox tests', () => {
 				_deleted: false,
 			};
 
-			await processMutationResponse(s, response2);
+			await processMutationResponse(
+				s,
+				response2,
+				TransformerMutationType.UPDATE
+			);
 
 			const head = await outbox.peek(s);
 			expect(head).toBeFalsy();
@@ -167,7 +192,11 @@ describe('Outbox tests', () => {
 
 		await Storage.runExclusive(async s => {
 			// this mutation is now "in progress"
-			const head = await outbox.peek(s);
+			let head;
+
+			while (!head) {
+				head = await outbox.peek(s);
+			}
 			const modelData: ModelType = JSON.parse(head.data);
 
 			expect(head.modelId).toEqual(modelId);
@@ -208,7 +237,11 @@ describe('Outbox tests', () => {
 		await Storage.runExclusive(async s => {
 			// process mutation response, which dequeues updatedModel1
 			// but SHOULD NOT sync the _version, since the data in the response is different
-			await processMutationResponse(s, response);
+			await processMutationResponse(
+				s,
+				response,
+				TransformerMutationType.UPDATE
+			);
 
 			const inProgress = await outbox.peek(s);
 			const inProgressData = JSON.parse(inProgress.data);
@@ -221,10 +254,48 @@ describe('Outbox tests', () => {
 			expect(inProgressData._version).toEqual(oldVersion);
 
 			// same response as above,
-			await processMutationResponse(s, response);
+			await processMutationResponse(
+				s,
+				response,
+				TransformerMutationType.UPDATE
+			);
 
 			const head = await outbox.peek(s);
 			expect(head).toBeFalsy();
+		});
+	});
+
+	// https://github.com/aws-amplify/amplify-js/issues/7888
+	it('Should retain the fields from the create mutation in the queue when it gets merged with an enqueued update mutation', async () => {
+		const field1 = 'Some value';
+		const currentTimestamp = new Date().toISOString();
+		const optionalField1 = 'Optional value';
+
+		const newModel = new Model({
+			field1,
+			dateCreated: currentTimestamp,
+		});
+
+		const mutationEvent = await createMutationEvent(newModel);
+		({ modelId } = mutationEvent);
+
+		await outbox.enqueue(Storage, mutationEvent);
+
+		const updatedModel = Model.copyOf(newModel, updated => {
+			updated.optionalField1 = optionalField1;
+		});
+
+		const updateMutationEvent = await createMutationEvent(updatedModel);
+
+		await outbox.enqueue(Storage, updateMutationEvent);
+
+		await Storage.runExclusive(async s => {
+			const head = await outbox.peek(s);
+			const headData = JSON.parse(head.data);
+
+			expect(headData.field1).toEqual(field1);
+			expect(headData.dateCreated).toEqual(currentTimestamp);
+			expect(headData.optionalField1).toEqual(optionalField1);
 		});
 	});
 });
@@ -249,9 +320,33 @@ async function instantiateOutbox(): Promise<void> {
 	Storage = <StorageType>DataStore.storage;
 	anyStorage = Storage;
 
+	const namespaceResolver = anyStorage.storage.namespaceResolver.bind(
+		anyStorage
+	);
+
 	({ modelInstanceCreator } = anyStorage.storage);
 
-	outbox = new MutationEventOutbox(schema, null, MutationEvent, ownSymbol);
+	const getModelDefinition = (
+		modelConstructor: PersistentModelConstructor<any>
+	): SchemaModel => {
+		const namespaceName = namespaceResolver(modelConstructor);
+
+		const modelDefinition =
+			schema.namespaces[namespaceName].models[modelConstructor.name];
+
+		return modelDefinition;
+	};
+
+	const userClasses = {};
+	userClasses['Model'] = Model;
+
+	outbox = new MutationEventOutbox(
+		schema,
+		userClasses,
+		MutationEvent,
+		ownSymbol,
+		getModelDefinition
+	);
 	merger = new ModelMerger(outbox, ownSymbol);
 }
 
@@ -277,8 +372,12 @@ async function createMutationEvent(model): Promise<MutationEvent> {
 	);
 }
 
-async function processMutationResponse(storage, record): Promise<void> {
-	await outbox.dequeue(storage, record);
+async function processMutationResponse(
+	storage,
+	record,
+	recordOp
+): Promise<void> {
+	await outbox.dequeue(storage, record, recordOp);
 
 	const modelConstructor = Model as PersistentModelConstructor<any>;
 	const model = modelInstanceCreator(modelConstructor, record);

--- a/packages/datastore/__tests__/util.test.ts
+++ b/packages/datastore/__tests__/util.test.ts
@@ -40,6 +40,33 @@ describe('datastore util', () => {
 		expect(objectsEqual(map1, map2)).toEqual(true);
 		map2.set('b', 2);
 		expect(objectsEqual(map1, map2)).toEqual(false);
+
+		// nullish - treat null and undefined as equal in Objects and Maps
+		expect(objectsEqual({ a: 1, b: null }, { a: 1 }, true)).toEqual(true);
+		expect(
+			objectsEqual({ a: 1, b: null }, { a: 1, b: undefined }, true)
+		).toEqual(true);
+		expect(objectsEqual({ a: 1, b: false }, { a: 1 }, true)).toEqual(false);
+
+		const map3 = new Map();
+		map3.set('a', null);
+		const map4 = new Map();
+
+		expect(objectsEqual(map3, map4, true)).toEqual(true);
+
+		const map5 = new Map();
+		map5.set('a', false);
+		const map6 = new Map();
+
+		expect(objectsEqual(map5, map6, true)).toEqual(false);
+
+		// should not attempt nullish comparison for arrays/sets
+		expect(objectsEqual([null], [], true)).toEqual(false);
+		expect(objectsEqual([null], [undefined], true)).toEqual(false);
+		expect(objectsEqual(new Set([null]), new Set([]), true)).toEqual(false);
+		expect(objectsEqual(new Set([null]), new Set([undefined]), true)).toEqual(
+			false
+		);
 	});
 
 	test('isAWSDate', () => {

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -96,10 +96,10 @@ const isValidModelConstructor = <T extends PersistentModel>(
 const namespaceResolver: NamespaceResolver = modelConstructor =>
 	modelNamespaceMap.get(modelConstructor);
 
-// exporting for testing purposes
+// exporting syncClasses for testing outbox.test.ts
 export let syncClasses: TypeConstructorMap;
-let dataStoreClasses: TypeConstructorMap;
 let userClasses: TypeConstructorMap;
+let dataStoreClasses: TypeConstructorMap;
 let storageClasses: TypeConstructorMap;
 
 const initSchema = (userSchema: Schema) => {

--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -115,9 +115,10 @@ export class SyncEngine {
 
 		this.outbox = new MutationEventOutbox(
 			this.schema,
-			this.namespaceResolver,
+			this.userModelClasses,
 			MutationEvent,
-			ownSymbol
+			ownSymbol,
+			this.getModelDefinition.bind(this)
 		);
 
 		this.modelMerger = new ModelMerger(this.outbox, ownSymbol);

--- a/packages/datastore/src/sync/outbox.ts
+++ b/packages/datastore/src/sync/outbox.ts
@@ -89,7 +89,7 @@ class MutationEventOutbox {
 	public async dequeue(
 		storage: StorageClass,
 		record?: PersistentModel,
-		recordOp?: string
+		recordOp?: TransformerMutationType
 	): Promise<MutationEvent> {
 		const head = await this.peek(storage);
 

--- a/packages/datastore/src/sync/outbox.ts
+++ b/packages/datastore/src/sync/outbox.ts
@@ -7,10 +7,11 @@ import {
 } from '../storage/storage';
 import {
 	InternalSchema,
-	NamespaceResolver,
+	TypeConstructorMap,
 	PersistentModel,
 	PersistentModelConstructor,
 	QueryOne,
+	SchemaModel,
 } from '../types';
 import { SYNC, objectsEqual } from '../util';
 import { TransformerMutationType } from './utils';
@@ -22,16 +23,19 @@ class MutationEventOutbox {
 
 	constructor(
 		private readonly schema: InternalSchema,
-		private readonly namespaceResolver: NamespaceResolver,
+		private readonly userModelClasses: TypeConstructorMap,
 		private readonly MutationEvent: PersistentModelConstructor<MutationEvent>,
-		private readonly ownSymbol: Symbol
+		private readonly ownSymbol: Symbol,
+		private readonly getModelDefinition: (
+			modelConstructor: PersistentModelConstructor<any>
+		) => SchemaModel
 	) {}
 
 	public async enqueue(
 		storage: Storage,
 		mutationEvent: MutationEvent
 	): Promise<void> {
-		return storage.runExclusive(async s => {
+		storage.runExclusive(async s => {
 			const mutationEventModelDefinition = this.schema.namespaces[SYNC].models[
 				'MutationEvent'
 			];
@@ -84,12 +88,13 @@ class MutationEventOutbox {
 
 	public async dequeue(
 		storage: StorageClass,
-		record?: PersistentModel
+		record?: PersistentModel,
+		recordOp?: string
 	): Promise<MutationEvent> {
 		const head = await this.peek(storage);
 
 		if (record) {
-			await this.syncOutboxVersionsOnDequeue(storage, record, head);
+			await this.syncOutboxVersionsOnDequeue(storage, record, head, recordOp);
 		}
 
 		await storage.delete(head);
@@ -139,27 +144,43 @@ class MutationEventOutbox {
 		return result;
 	}
 
-	// applies _version from the AppSync mutation response to other items in the mutation queue with the same id
+	// applies _version from the AppSync mutation response to other items
+	// in the mutation queue with the same id
 	// see https://github.com/aws-amplify/amplify-js/pull/7354 for more details
 	private async syncOutboxVersionsOnDequeue(
 		storage: StorageClass,
 		record: PersistentModel,
-		head: PersistentModel
+		head: PersistentModel,
+		recordOp: string
 	): Promise<void> {
-		const { _version, _lastChangedAt, ...incomingData } = record;
-		const {
-			_version: __version,
-			_lastChangedAt: __lastChangedAt,
-			...outgoingData
-		} = JSON.parse(head.data);
-
-		if (head.operation !== TransformerMutationType.UPDATE) {
+		if (head.operation !== recordOp) {
 			return;
 		}
 
+		const { _version, _lastChangedAt, _deleted, ...incomingData } = record;
+
+		let data;
+
+		if (recordOp !== TransformerMutationType.UPDATE) {
+			data = JSON.parse(head.data);
+		} else {
+			data = await this.getUpdateRecord(storage, head);
+		}
+
+		if (!data) {
+			return;
+		}
+
+		const {
+			_version: __version,
+			_lastChangedAt: __lastChangedAt,
+			_deleted: __deleted,
+			...outgoingData
+		} = data;
+
 		// Don't sync the version when the data in the response does not match the data
 		// in the request, i.e., when there's a handled conflict
-		if (!objectsEqual(incomingData, outgoingData)) {
+		if (!objectsEqual(incomingData, outgoingData, true)) {
 			return;
 		}
 
@@ -198,6 +219,35 @@ class MutationEventOutbox {
 				async m => await storage.save(m, undefined, this.ownSymbol)
 			)
 		);
+	}
+
+	private async getUpdateRecord(
+		storage: StorageClass,
+		head: PersistentModel
+	): Promise<PersistentModel> {
+		const modelConstructor = <PersistentModelConstructor<PersistentModel>>(
+			this.userModelClasses[head.model]
+		);
+
+		const modelDefinition = this.getModelDefinition(modelConstructor);
+
+		if (!(modelConstructor && head && head.modelId)) {
+			return;
+		}
+
+		const results = <any>await storage.query(
+			modelConstructor,
+			ModelPredicateCreator.createFromExisting(modelDefinition, c =>
+				c.id('eq', head.modelId)
+			)
+		);
+
+		const fromDb = results[0];
+
+		// merge data from the mutationEvent with data from the query
+		// so that we can perform a comparison to determine whether
+		// the request record matches the response
+		return { ...fromDb, ...JSON.parse(head.data) };
 	}
 }
 

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -163,7 +163,7 @@ class MutationProcessor {
 			await this.storage.runExclusive(async storage => {
 				// using runExclusive to prevent possible race condition
 				// when another record gets enqueued between dequeue and peek
-				await this.outbox.dequeue(storage, record);
+				await this.outbox.dequeue(storage, record, operation);
 				hasMore = (await this.outbox.peek(storage)) !== undefined;
 			});
 

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -260,7 +260,6 @@ export enum OpType {
 export type SubscriptionMessage<T extends PersistentModel> = {
 	opType: OpType;
 	element: T;
-	fromDb?: T;
 	model: PersistentModelConstructor<T>;
 	condition: PredicatesGroup<T> | null;
 };

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -260,6 +260,7 @@ export enum OpType {
 export type SubscriptionMessage<T extends PersistentModel> = {
 	opType: OpType;
 	element: T;
+	fromDb?: T;
 	model: PersistentModelConstructor<T>;
 	condition: PredicatesGroup<T> | null;
 };

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -464,7 +464,13 @@ export function getUpdateMutationInput<T extends PersistentModel>(
 
 // deep compare any 2 objects (including arrays, Sets, and Maps)
 // returns true if equal
-export function objectsEqual(objA: object, objB: object): boolean {
+// if nullish is true, treat undefined and null values as equal
+// to normalize for GQL response values for undefined fields
+export function objectsEqual(
+	objA: object,
+	objB: object,
+	nullish: boolean = false
+): boolean {
 	let a = objA;
 	let b = objB;
 
@@ -488,7 +494,7 @@ export function objectsEqual(objA: object, objB: object): boolean {
 	const aKeys = Object.keys(a);
 	const bKeys = Object.keys(b);
 
-	if (aKeys.length !== bKeys.length) {
+	if (!nullish && aKeys.length !== bKeys.length) {
 		return false;
 	}
 
@@ -501,7 +507,19 @@ export function objectsEqual(objA: object, objB: object): boolean {
 				return false;
 			}
 		} else if (aVal !== bVal) {
-			return false;
+			if (nullish) {
+				if (
+					// returns false if it's NOT a nullish match
+					!(
+						(aVal === undefined || aVal === null) &&
+						(bVal === undefined || bVal === null)
+					)
+				) {
+					return false;
+				}
+			} else {
+				return false;
+			}
 		}
 	}
 	return true;

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -507,7 +507,8 @@ export function objectsEqual(
 				return false;
 			}
 		} else if (aVal !== bVal) {
-			if (nullish) {
+			// nullish comparison should only apply to objects and Maps
+			if (nullish && !Array.isArray(a) && !(a instanceof Set)) {
 				if (
 					// returns false if it's NOT a nullish match
 					!(


### PR DESCRIPTION
Issue #, if available:
#7888, #7950, #8012

* Allow consecutive updates to work correctly with the changes in the [update mutation input PR](https://github.com/aws-amplify/amplify-js/pull/7935)

* Enable consecutive saves (other than updates). E.g.,
  1. Create new record, then immediately update
  2. Create new record, wait for sync to complete, then update 3 times consecutively
  3. Create new record, then immediately delete

* Updated unit tests

* Added e2e tests for all these scenarios: https://github.com/aws-amplify/amplify-js-samples-staging/pull/211


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
