### PR TITLE
feat(@aws-amplify/aws-amplify-react): Trim username input

### DIFF
--- a/packages/aws-amplify-react/src/Auth/AuthPiece.tsx
+++ b/packages/aws-amplify-react/src/Auth/AuthPiece.tsx
@@ -88,8 +88,10 @@ export class AuthPiece<
 		switch (usernameAttributes) {
 			case UsernameAttributes.EMAIL:
 				username = this.inputs.email;
+				break;
 			case UsernameAttributes.PHONE_NUMBER:
 				username = this.phone_number;
+				break;
 			default:
 				username = this.inputs.username || this.state.username;
 		}

--- a/packages/aws-amplify-react/src/Auth/AuthPiece.tsx
+++ b/packages/aws-amplify-react/src/Auth/AuthPiece.tsx
@@ -84,14 +84,16 @@ export class AuthPiece<
 
 	getUsernameFromInput() {
 		const { usernameAttributes = 'username' } = this.props;
+		let username;
 		switch (usernameAttributes) {
 			case UsernameAttributes.EMAIL:
-				return this.inputs.email;
+				username = this.inputs.email;
 			case UsernameAttributes.PHONE_NUMBER:
-				return this.phone_number;
+				username = this.phone_number;
 			default:
-				return this.inputs.username || this.state.username;
+				username = this.inputs.username || this.state.username;
 		}
+		return username ? username.trim() : username;
 	}
 
 	onPhoneNumberChanged(phone_number) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

When user inputs have trailing or leading whitespace, Cognito returns the following error:
```
Value at 'username' failed to satisfy constraint: Member must satisfy regular expression pattern: [\p{L}\p{M}\p{S}\p{N}\p{P}]+
```
This is not readable error to our end users who did not realize they entered the whitespace. This PR will trim the username before returning in the `getUsernameFromInput` function.

#### Description of how you validated changes
![image](https://user-images.githubusercontent.com/16925482/112889737-081bad80-90a4-11eb-895e-03760e4f826f.png)


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
