### PR TITLE
fix(@aws-amplify/datastore): add additional type check to util.objectsEqual

### DIFF
--- a/packages/datastore/__tests__/util.test.ts
+++ b/packages/datastore/__tests__/util.test.ts
@@ -67,6 +67,25 @@ describe('datastore util', () => {
 		expect(objectsEqual(new Set([null]), new Set([undefined]), true)).toEqual(
 			false
 		);
+
+		// should return false for non-object types
+		expect(objectsEqual(null, undefined)).toEqual(false);
+		expect(objectsEqual(null, undefined, true)).toEqual(false);
+
+		expect(objectsEqual(undefined, undefined)).toEqual(false);
+		expect(objectsEqual(undefined, undefined, true)).toEqual(false);
+
+		expect(objectsEqual(null, null)).toEqual(false);
+		expect(objectsEqual(null, null, true)).toEqual(false);
+
+		expect(objectsEqual('string' as any, 'string' as any)).toEqual(false);
+		expect(objectsEqual('string' as any, 'string' as any, true)).toEqual(false);
+
+		expect(objectsEqual(123 as any, 123 as any)).toEqual(false);
+		expect(objectsEqual(123 as any, 123 as any, true)).toEqual(false);
+
+		expect(objectsEqual(true as any, true as any)).toEqual(false);
+		expect(objectsEqual(true as any, true as any, true)).toEqual(false);
 	});
 
 	test('isAWSDate', () => {

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -474,6 +474,14 @@ export function objectsEqual(
 	let a = objA;
 	let b = objB;
 
+	if (typeof a !== 'object' || typeof b !== 'object') {
+		return false;
+	}
+
+	if (a === null || b === null) {
+		return false;
+	}
+
 	if (
 		(Array.isArray(a) && !Array.isArray(b)) ||
 		(Array.isArray(b) && !Array.isArray(a))


### PR DESCRIPTION
Add a type check to `util.objectsEqual` to ensure we're only attempting to compare 2 objects

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
