### PR TITLE
fix(@aws-amplify/datastore): consecutive saves 2

### DIFF
--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -438,7 +438,7 @@ describe('DataStore tests', () => {
 			const result = await DataStore.save(model);
 
 			const [settingsSave, modelSave, modelUpdate] = <any>save.mock.calls;
-			const [_model, _condition, _mutator, patches] = modelUpdate;
+			const [_model, _condition, _mutator, [patches]] = modelUpdate;
 
 			const expectedPatches = [
 				{ op: 'replace', path: ['field1'], value: 'edited' },
@@ -505,8 +505,8 @@ describe('DataStore tests', () => {
 				save.mock.calls
 			);
 
-			const [_model, _condition, _mutator, patches] = modelUpdate;
-			const [_model2, _condition2, _mutator2, patches2] = modelUpdate2;
+			const [_model, _condition, _mutator, [patches]] = modelUpdate;
+			const [_model2, _condition2, _mutator2, [patches2]] = modelUpdate2;
 
 			const expectedPatches = [
 				{

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -389,12 +389,13 @@ describe('DataStore tests', () => {
 			const result = await DataStore.save(model);
 
 			const [settingsSave, modelCall] = <any>save.mock.calls;
-			const [_model, _condition, _mutator] = modelCall;
+			const [_model, _condition, _mutator, patches] = modelCall;
 
 			expect(result).toMatchObject(model);
+			expect(patches).toBeUndefined();
 		});
 
-		test('Save returns the updated model', async () => {
+		test('Save returns the updated model and patches', async () => {
 			let model: Model;
 			const save = jest.fn(() => [model]);
 			const query = jest.fn(() => [model]);
@@ -437,12 +438,17 @@ describe('DataStore tests', () => {
 			const result = await DataStore.save(model);
 
 			const [settingsSave, modelSave, modelUpdate] = <any>save.mock.calls;
-			const [_model, _condition, _mutator] = modelUpdate;
+			const [_model, _condition, _mutator, patches] = modelUpdate;
+
+			const expectedPatches = [
+				{ op: 'replace', path: ['field1'], value: 'edited' },
+			];
 
 			expect(result).toMatchObject(model);
+			expect(patches).toMatchObject(expectedPatches);
 		});
 
-		test('Save returns the updated model - list field', async () => {
+		test('Save returns the updated model and patches - list field', async () => {
 			let model: Model;
 			const save = jest.fn(() => [model]);
 			const query = jest.fn(() => [model]);
@@ -499,8 +505,27 @@ describe('DataStore tests', () => {
 				save.mock.calls
 			);
 
-			const [_model, _condition, _mutator] = modelUpdate;
-			const [_model2, _condition2, _mutator2] = modelUpdate2;
+			const [_model, _condition, _mutator, patches] = modelUpdate;
+			const [_model2, _condition2, _mutator2, patches2] = modelUpdate2;
+
+			const expectedPatches = [
+				{
+					op: 'replace',
+					path: ['emails'],
+					value: ['john@doe.com', 'jane@doe.com', 'joe@doe.com'],
+				},
+			];
+
+			const expectedPatches2 = [
+				{
+					op: 'add',
+					path: ['emails', 3],
+					value: 'joe@doe.com',
+				},
+			];
+
+			expect(patches).toMatchObject(expectedPatches);
+			expect(patches2).toMatchObject(expectedPatches2);
 		});
 
 		test('Instantiation validations', async () => {

--- a/packages/datastore/__tests__/outbox.test.ts
+++ b/packages/datastore/__tests__/outbox.test.ts
@@ -342,10 +342,9 @@ async function instantiateOutbox(): Promise<void> {
 
 	outbox = new MutationEventOutbox(
 		schema,
-		userClasses,
 		MutationEvent,
-		ownSymbol,
-		getModelDefinition
+		modelInstanceCreator,
+		ownSymbol
 	);
 	merger = new ModelMerger(outbox, ownSymbol);
 }

--- a/packages/datastore/__tests__/storage.test.ts
+++ b/packages/datastore/__tests__/storage.test.ts
@@ -133,36 +133,6 @@ describe('Storage tests', () => {
 				expect(modelUpdate.element.emails).toMatchObject(expectedValueEmails);
 			});
 
-			test('list unchanged', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
-
-				const model = await DataStore.save(
-					new Model({
-						field1: 'Some value',
-						dateCreated: new Date().toISOString(),
-						emails: ['john@doe.com', 'jane@doe.com'],
-					})
-				);
-
-				await DataStore.save(
-					Model.copyOf(model, draft => {
-						draft.field1 = 'Updated value';
-						// same as above. should not be included in mutation input
-						draft.emails = ['john@doe.com', 'jane@doe.com'];
-					})
-				);
-
-				const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
-
-				expect(modelUpdate.element.dateCreated).toBeUndefined();
-				expect(modelUpdate.element.field1).toEqual('Updated value');
-				expect(modelUpdate.element.emails).toBeUndefined();
-			});
-
 			test('custom type (destructured)', async () => {
 				const classes = initSchema(testSchema());
 
@@ -244,43 +214,6 @@ describe('Storage tests', () => {
 				expect(modelUpdate.element.metadata).toMatchObject(
 					expectedValueMetadata
 				);
-			});
-
-			test('custom type unchanged', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
-
-				const model = await DataStore.save(
-					new Model({
-						field1: 'Some value',
-						dateCreated: new Date().toISOString(),
-						metadata: {
-							author: 'some author',
-							rewards: [],
-							penNames: [],
-						},
-					})
-				);
-
-				await DataStore.save(
-					Model.copyOf(model, draft => {
-						draft.field1 = 'Updated value';
-						draft.metadata = {
-							author: 'some author',
-							rewards: [],
-							penNames: [],
-						};
-					})
-				);
-
-				const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
-
-				expect(modelUpdate.element.dateCreated).toBeUndefined();
-				expect(modelUpdate.element.field1).toEqual('Updated value');
-				expect(modelUpdate.element.metadata).toBeUndefined();
 			});
 
 			test('relation', async () => {

--- a/packages/datastore/__tests__/storage.test.ts
+++ b/packages/datastore/__tests__/storage.test.ts
@@ -65,6 +65,62 @@ describe('Storage tests', () => {
 				expect(modelUpdate.element.field1).toEqual('edited');
 			});
 
+			test('scalar - unchanged', async () => {
+				const classes = initSchema(testSchema());
+
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
+
+				const dateCreated = new Date().toISOString();
+
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						dateCreated,
+					})
+				);
+
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						draft.field1 = 'Some value';
+					})
+				);
+
+				const [[_modelSave], modelUpdate] = zenNext.mock.calls;
+
+				expect(modelUpdate).toBeUndefined();
+				expect(modelUpdate).toBeUndefined();
+
+				expect(true).toBeTruthy();
+			});
+
+			test('update by nulling previous value', async () => {
+				const classes = initSchema(testSchema());
+
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
+
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						optionalField1: 'Some optional value',
+						dateCreated: new Date().toISOString(),
+					})
+				);
+
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						draft.optionalField1 = null;
+					})
+				);
+
+				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+
+				expect(modelUpdate.element.optionalField1).toBeNull();
+			});
+
 			test('list (destructured)', async () => {
 				const classes = initSchema(testSchema());
 
@@ -86,7 +142,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
 
 				const expectedValueEmails = [
 					'john@doe.com',
@@ -120,7 +176,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
 
 				const expectedValueEmails = [
 					'john@doe.com',
@@ -131,6 +187,89 @@ describe('Storage tests', () => {
 				expect(modelUpdate.element.dateCreated).toBeUndefined();
 				expect(modelUpdate.element.field1).toBeUndefined();
 				expect(modelUpdate.element.emails).toMatchObject(expectedValueEmails);
+			});
+
+			test('update with changed field and list unchanged', async () => {
+				const classes = initSchema(testSchema());
+
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
+
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						dateCreated: new Date().toISOString(),
+						emails: ['john@doe.com', 'jane@doe.com'],
+					})
+				);
+
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						draft.field1 = 'Updated value';
+						// same as above. should not be included in mutation input
+						draft.emails = ['john@doe.com', 'jane@doe.com'];
+					})
+				);
+
+				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+
+				expect(modelUpdate.element.dateCreated).toBeUndefined();
+				expect(modelUpdate.element.field1).toEqual('Updated value');
+				expect(modelUpdate.element.emails).toBeUndefined();
+			});
+
+			test('update with list unchanged', async () => {
+				const classes = initSchema(testSchema());
+
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
+
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						dateCreated: new Date().toISOString(),
+						emails: ['john@doe.com', 'jane@doe.com'],
+					})
+				);
+
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						// same as above. should not result in mutation event
+						draft.emails = ['john@doe.com', 'jane@doe.com'];
+					})
+				);
+
+				const [[_modelSave], modelUpdate] = zenNext.mock.calls;
+
+				expect(modelUpdate).toBeUndefined();
+			});
+
+			test('update by nulling list', async () => {
+				const classes = initSchema(testSchema());
+
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
+
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						dateCreated: new Date().toISOString(),
+						emails: ['john@doe.com', 'jane@doe.com'],
+					})
+				);
+
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						draft.emails = null;
+					})
+				);
+
+				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+
+				expect(modelUpdate.element.emails).toBeNull();
 			});
 
 			test('custom type (destructured)', async () => {
@@ -161,7 +300,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
 
 				const expectedValueMetadata = {
 					author: 'some author',
@@ -201,7 +340,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
 
 				const expectedValueMetadata = {
 					author: 'some author',
@@ -214,6 +353,43 @@ describe('Storage tests', () => {
 				expect(modelUpdate.element.metadata).toMatchObject(
 					expectedValueMetadata
 				);
+			});
+
+			test('custom type unchanged', async () => {
+				const classes = initSchema(testSchema());
+
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
+
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						dateCreated: new Date().toISOString(),
+						metadata: {
+							author: 'some author',
+							rewards: [],
+							penNames: [],
+						},
+					})
+				);
+
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						draft.field1 = 'Updated value';
+						draft.metadata = {
+							author: 'some author',
+							rewards: [],
+							penNames: [],
+						};
+					})
+				);
+
+				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+
+				expect(modelUpdate.element.dateCreated).toBeUndefined();
+				expect(modelUpdate.element.field1).toEqual('Updated value');
+				expect(modelUpdate.element.metadata).toBeUndefined();
 			});
 
 			test('relation', async () => {

--- a/packages/datastore/__tests__/util.test.ts
+++ b/packages/datastore/__tests__/util.test.ts
@@ -62,6 +62,20 @@ describe('datastore util', () => {
 
 		expect(valuesEqual(map5, map6, true)).toEqual(false);
 
+		// array nullish
+		expect(valuesEqual([null], [], true)).toEqual(true);
+		expect(valuesEqual([null], [undefined], true)).toEqual(true);
+		expect(valuesEqual(new Set([null]), new Set([]), true)).toEqual(true);
+		expect(valuesEqual(new Set([null]), new Set([undefined]), true)).toEqual(
+			true
+		);
+		expect(valuesEqual([null], [], false)).toEqual(false);
+		expect(valuesEqual([null], [undefined], false)).toEqual(false);
+		expect(valuesEqual(new Set([null]), new Set([]), false)).toEqual(false);
+		expect(valuesEqual(new Set([null]), new Set([undefined]), false)).toEqual(
+			false
+		);
+
 		// primitive types
 		expect(valuesEqual(null, undefined)).toEqual(false);
 		expect(valuesEqual(null, undefined, true)).toEqual(true);

--- a/packages/datastore/__tests__/util.test.ts
+++ b/packages/datastore/__tests__/util.test.ts
@@ -62,13 +62,17 @@ describe('datastore util', () => {
 
 		expect(valuesEqual(map5, map6, true)).toEqual(false);
 
-		// array nullish
-		expect(valuesEqual([null], [], true)).toEqual(true);
+		// array nullish explicit undefined
 		expect(valuesEqual([null], [undefined], true)).toEqual(true);
-		expect(valuesEqual(new Set([null]), new Set([]), true)).toEqual(true);
+		expect(valuesEqual([undefined], [null], true)).toEqual(true);
 		expect(valuesEqual(new Set([null]), new Set([undefined]), true)).toEqual(
 			true
 		);
+
+		// empty list [] should not equal [null]
+		expect(valuesEqual([null], [], true)).toEqual(false);
+		expect(valuesEqual(new Set([null]), new Set([]), true)).toEqual(false);
+
 		expect(valuesEqual([null], [], false)).toEqual(false);
 		expect(valuesEqual([null], [undefined], false)).toEqual(false);
 		expect(valuesEqual(new Set([null]), new Set([]), false)).toEqual(false);

--- a/packages/datastore/__tests__/util.test.ts
+++ b/packages/datastore/__tests__/util.test.ts
@@ -1,5 +1,5 @@
 import {
-	objectsEqual,
+	valuesEqual,
 	isAWSDate,
 	isAWSDateTime,
 	isAWSEmail,
@@ -12,22 +12,22 @@ import {
 } from '../src/util';
 
 describe('datastore util', () => {
-	test('objectsEqual', () => {
-		expect(objectsEqual({}, {})).toEqual(true);
-		expect(objectsEqual([], [])).toEqual(true);
-		expect(objectsEqual([], {})).toEqual(false);
-		expect(objectsEqual([1, 2, 3], [1, 2, 3])).toEqual(true);
-		expect(objectsEqual([1, 2, 3], [1, 2, 3, 4])).toEqual(false);
-		expect(objectsEqual({ a: 1 }, { a: 1 })).toEqual(true);
-		expect(objectsEqual({ a: 1 }, { a: 2 })).toEqual(false);
+	test('valuesEqual', () => {
+		expect(valuesEqual({}, {})).toEqual(true);
+		expect(valuesEqual([], [])).toEqual(true);
+		expect(valuesEqual([], {})).toEqual(false);
+		expect(valuesEqual([1, 2, 3], [1, 2, 3])).toEqual(true);
+		expect(valuesEqual([1, 2, 3], [1, 2, 3, 4])).toEqual(false);
+		expect(valuesEqual({ a: 1 }, { a: 1 })).toEqual(true);
+		expect(valuesEqual({ a: 1 }, { a: 2 })).toEqual(false);
 		expect(
-			objectsEqual({ a: [{ b: 2 }, { c: 3 }] }, { a: [{ b: 2 }, { c: 3 }] })
+			valuesEqual({ a: [{ b: 2 }, { c: 3 }] }, { a: [{ b: 2 }, { c: 3 }] })
 		).toEqual(true);
 		expect(
-			objectsEqual({ a: [{ b: 2 }, { c: 3 }] }, { a: [{ b: 2 }, { c: 4 }] })
+			valuesEqual({ a: [{ b: 2 }, { c: 3 }] }, { a: [{ b: 2 }, { c: 4 }] })
 		).toEqual(false);
-		expect(objectsEqual(new Set([1, 2, 3]), new Set([1, 2, 3]))).toEqual(true);
-		expect(objectsEqual(new Set([1, 2, 3]), new Set([1, 2, 3, 4]))).toEqual(
+		expect(valuesEqual(new Set([1, 2, 3]), new Set([1, 2, 3]))).toEqual(true);
+		expect(valuesEqual(new Set([1, 2, 3]), new Set([1, 2, 3, 4]))).toEqual(
 			false
 		);
 
@@ -37,55 +37,53 @@ describe('datastore util', () => {
 		const map2 = new Map();
 		map2.set('a', 1);
 
-		expect(objectsEqual(map1, map2)).toEqual(true);
+		expect(valuesEqual(map1, map2)).toEqual(true);
 		map2.set('b', 2);
-		expect(objectsEqual(map1, map2)).toEqual(false);
+		expect(valuesEqual(map1, map2)).toEqual(false);
 
 		// nullish - treat null and undefined as equal in Objects and Maps
-		expect(objectsEqual({ a: 1, b: null }, { a: 1 }, true)).toEqual(true);
+		expect(valuesEqual({ a: 1, b: null }, { a: 1 }, true)).toEqual(true);
+		expect(valuesEqual({ a: 1 }, { a: 1, b: null }, true)).toEqual(true);
+		expect(valuesEqual({ a: 1 }, { a: 1, b: 2 }, true)).toEqual(false);
 		expect(
-			objectsEqual({ a: 1, b: null }, { a: 1, b: undefined }, true)
+			valuesEqual({ a: 1, b: null }, { a: 1, b: undefined }, true)
 		).toEqual(true);
-		expect(objectsEqual({ a: 1, b: false }, { a: 1 }, true)).toEqual(false);
+		expect(valuesEqual({ a: 1, b: false }, { a: 1 }, true)).toEqual(false);
 
 		const map3 = new Map();
 		map3.set('a', null);
 		const map4 = new Map();
 
-		expect(objectsEqual(map3, map4, true)).toEqual(true);
+		expect(valuesEqual(map3, map4, true)).toEqual(true);
 
 		const map5 = new Map();
 		map5.set('a', false);
 		const map6 = new Map();
 
-		expect(objectsEqual(map5, map6, true)).toEqual(false);
+		expect(valuesEqual(map5, map6, true)).toEqual(false);
 
-		// should not attempt nullish comparison for arrays/sets
-		expect(objectsEqual([null], [], true)).toEqual(false);
-		expect(objectsEqual([null], [undefined], true)).toEqual(false);
-		expect(objectsEqual(new Set([null]), new Set([]), true)).toEqual(false);
-		expect(objectsEqual(new Set([null]), new Set([undefined]), true)).toEqual(
-			false
-		);
+		// primitive types
+		expect(valuesEqual(null, undefined)).toEqual(false);
+		expect(valuesEqual(null, undefined, true)).toEqual(true);
+		expect(valuesEqual(undefined, null, true)).toEqual(true);
 
-		// should return false for non-object types
-		expect(objectsEqual(null, undefined)).toEqual(false);
-		expect(objectsEqual(null, undefined, true)).toEqual(false);
+		expect(valuesEqual(undefined, undefined)).toEqual(true);
+		expect(valuesEqual(undefined, undefined, true)).toEqual(true);
 
-		expect(objectsEqual(undefined, undefined)).toEqual(false);
-		expect(objectsEqual(undefined, undefined, true)).toEqual(false);
+		expect(valuesEqual(null, null)).toEqual(true);
+		expect(valuesEqual(null, null, true)).toEqual(true);
 
-		expect(objectsEqual(null, null)).toEqual(false);
-		expect(objectsEqual(null, null, true)).toEqual(false);
+		expect(valuesEqual('string', 'string')).toEqual(true);
+		expect(valuesEqual('string', 'string2')).toEqual(false);
+		expect(valuesEqual('string', 'string', true)).toEqual(true);
 
-		expect(objectsEqual('string' as any, 'string' as any)).toEqual(false);
-		expect(objectsEqual('string' as any, 'string' as any, true)).toEqual(false);
+		expect(valuesEqual(123, 123)).toEqual(true);
+		expect(valuesEqual(123, 1234)).toEqual(false);
+		expect(valuesEqual(123, 123, true)).toEqual(true);
 
-		expect(objectsEqual(123 as any, 123 as any)).toEqual(false);
-		expect(objectsEqual(123 as any, 123 as any, true)).toEqual(false);
-
-		expect(objectsEqual(true as any, true as any)).toEqual(false);
-		expect(objectsEqual(true as any, true as any, true)).toEqual(false);
+		expect(valuesEqual(true, true)).toEqual(true);
+		expect(valuesEqual(true, false)).toEqual(false);
+		expect(valuesEqual(true, true, true)).toEqual(true);
 	});
 
 	test('isAWSDate', () => {

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -86,7 +86,13 @@ const modelNamespaceMap = new WeakMap<
 	PersistentModelConstructor<any>,
 	string
 >();
-const modelPatchesMap = new WeakMap<PersistentModel, Patch[]>();
+// stores data for crafting the correct update mutation input for a model
+// Patch[] - array of changed fields and metadata
+// PersistentModel - the source model, used for diffing object-type fields
+const modelPatchesMap = new WeakMap<
+	PersistentModel,
+	[Patch[], PersistentModel]
+>();
 
 const getModelDefinition = (
 	modelConstructor: PersistentModelConstructor<any>
@@ -404,7 +410,9 @@ const createModelClass = <T extends PersistentModel>(
 				p => (patches = p)
 			);
 
-			patches.length && modelPatchesMap.set(model, patches);
+			if (patches.length) {
+				modelPatchesMap.set(model, [patches, source]);
+			}
 
 			return model;
 		}
@@ -782,7 +790,7 @@ class DataStore {
 
 		// Immer patches for constructing a correct update mutation input
 		// Allows us to only include changed fields for updates
-		const patches = modelPatchesMap.get(model);
+		const patchesTuple = modelPatchesMap.get(model);
 
 		const modelConstructor: PersistentModelConstructor<T> = model
 			? <PersistentModelConstructor<T>>model.constructor
@@ -803,7 +811,7 @@ class DataStore {
 		);
 
 		const [savedModel] = await this.storage.runExclusive(async s => {
-			await s.save(model, producedCondition, undefined, patches);
+			await s.save(model, producedCondition, undefined, patchesTuple);
 
 			return s.query(
 				modelConstructor,

--- a/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
+++ b/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
@@ -97,7 +97,7 @@ export class AsyncStorageAdapter implements Adapter {
 	async save<T extends PersistentModel>(
 		model: T,
 		condition?: ModelPredicate<T>
-	): Promise<[T, OpType.INSERT | OpType.UPDATE, T?][]> {
+	): Promise<[T, OpType.INSERT | OpType.UPDATE][]> {
 		const modelConstructor = Object.getPrototypeOf(model)
 			.constructor as PersistentModelConstructor<T>;
 		const storeName = this.getStorenameForModel(modelConstructor);
@@ -133,7 +133,7 @@ export class AsyncStorageAdapter implements Adapter {
 			}
 		}
 
-		const result: [T, OpType.INSERT | OpType.UPDATE, T?][] = [];
+		const result: [T, OpType.INSERT | OpType.UPDATE][] = [];
 
 		for await (const resItem of connectionStoreNames) {
 			const { storeName, item, instance } = resItem;
@@ -145,11 +145,7 @@ export class AsyncStorageAdapter implements Adapter {
 			if (id === model.id || opType === OpType.INSERT) {
 				await this.db.save(item, storeName);
 
-				if (opType === OpType.UPDATE) {
-					result.push([instance, opType, fromDB]);
-				} else {
-					result.push([instance, opType]);
-				}
+				result.push([instance, opType]);
 			}
 		}
 

--- a/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
+++ b/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
@@ -206,7 +206,7 @@ class IndexedDBAdapter implements Adapter {
 	async save<T extends PersistentModel>(
 		model: T,
 		condition?: ModelPredicate<T>
-	): Promise<[T, OpType.INSERT | OpType.UPDATE, T?][]> {
+	): Promise<[T, OpType.INSERT | OpType.UPDATE][]> {
 		await this.checkPrivate();
 		const modelConstructor = Object.getPrototypeOf(model)
 			.constructor as PersistentModelConstructor<T>;
@@ -250,7 +250,7 @@ class IndexedDBAdapter implements Adapter {
 			}
 		}
 
-		const result: [T, OpType.INSERT | OpType.UPDATE, T?][] = [];
+		const result: [T, OpType.INSERT | OpType.UPDATE][] = [];
 
 		for await (const resItem of connectionStoreNames) {
 			const { storeName, item, instance } = resItem;
@@ -266,11 +266,7 @@ class IndexedDBAdapter implements Adapter {
 				const key = await store.index('byId').getKey(item.id);
 				await store.put(item, key);
 
-				if (opType === OpType.UPDATE) {
-					result.push([instance, opType, fromDB]);
-				} else {
-					result.push([instance, opType]);
-				}
+				result.push([instance, opType]);
 			}
 		}
 

--- a/packages/datastore/src/storage/adapter/index.ts
+++ b/packages/datastore/src/storage/adapter/index.ts
@@ -14,7 +14,7 @@ export interface Adapter extends SystemComponent {
 	save<T extends PersistentModel>(
 		model: T,
 		condition?: ModelPredicate<T>
-	): Promise<[T, OpType.INSERT | OpType.UPDATE, T?][]>;
+	): Promise<[T, OpType.INSERT | OpType.UPDATE][]>;
 	delete: <T extends PersistentModel>(
 		modelOrModelConstructor: T | PersistentModelConstructor<T>,
 		condition?: ModelPredicate<T>

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -2,7 +2,7 @@ import { Logger, Mutex } from '@aws-amplify/core';
 import Observable, { ZenObservable } from 'zen-observable-ts';
 import PushStream from 'zen-push';
 import { Patch } from 'immer';
-import { DataStore, ModelInstanceCreator } from '../datastore/datastore';
+import { ModelInstanceCreator } from '../datastore/datastore';
 import { ModelPredicateCreator } from '../predicates';
 import {
 	InternalSchema,
@@ -114,20 +114,20 @@ class StorageClass implements StorageFacade {
 		result.forEach(r => {
 			const [originalElement, opType] = r;
 
-			// true when save is called by the Mutator
+			// truthy when save is called by the Merger
 			const syncResponse = !!mutator;
 
-			// an update without patches means no fields were changed
-			// => don't create mutationEvent
-			// unless the save is coming from the Mutator (i.e., from an AppSync response)
 			let updateMutationInput;
+			// don't attempt to calc mutation input when storage.save
+			// is called by Merger, i.e., when processing an AppSync response
 			if (opType === OpType.UPDATE && !syncResponse) {
 				updateMutationInput = this.getUpdateMutationInput(
 					model,
 					originalElement,
 					patchesTuple
 				);
-
+				// // an update without changed user fields
+				// => don't create mutationEvent
 				if (updateMutationInput === null) {
 					return result;
 				}

--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -52,9 +52,9 @@ export declare class MutationEvent {
 	public readonly id: string;
 	public readonly model: string;
 	public readonly operation: TransformerMutationType;
-	public readonly data: string;
 	public readonly modelId: string;
 	public readonly condition: string;
+	public data: string;
 }
 
 declare class ModelMetadata {
@@ -115,10 +115,9 @@ export class SyncEngine {
 
 		this.outbox = new MutationEventOutbox(
 			this.schema,
-			this.userModelClasses,
 			MutationEvent,
-			ownSymbol,
-			this.getModelDefinition.bind(this)
+			modelInstanceCreator,
+			ownSymbol
 		);
 
 		this.modelMerger = new ModelMerger(this.outbox, ownSymbol);

--- a/packages/datastore/src/sync/outbox.ts
+++ b/packages/datastore/src/sync/outbox.ts
@@ -12,7 +12,7 @@ import {
 	PersistentModelConstructor,
 	QueryOne,
 } from '../types';
-import { SYNC, objectsEqual } from '../util';
+import { SYNC, valuesEqual } from '../util';
 import { TransformerMutationType } from './utils';
 
 // TODO: Persist deleted ids
@@ -158,14 +158,7 @@ class MutationEventOutbox {
 		}
 
 		const { _version, _lastChangedAt, _deleted, ...incomingData } = record;
-
 		const data = JSON.parse(head.data);
-
-		// if (recordOp !== TransformerMutationType.UPDATE) {
-		// 	data = JSON.parse(head.data);
-		// } else {
-		// 	data = await this.getUpdateRecord(storage, head);
-		// }
 
 		if (!data) {
 			return;
@@ -180,7 +173,7 @@ class MutationEventOutbox {
 
 		// Don't sync the version when the data in the response does not match the data
 		// in the request, i.e., when there's a handled conflict
-		if (!objectsEqual(incomingData, outgoingData, true)) {
+		if (!valuesEqual(incomingData, outgoingData, true)) {
 			return;
 		}
 

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -491,7 +491,8 @@ export function valuesEqual(
 	const aKeys = Object.keys(a);
 	const bKeys = Object.keys(b);
 
-	if (aKeys.length !== bKeys.length && !nullish) {
+	// last condition is to ensure that [] !== [null] even if nullish. However [undefined] === [null] when nullish
+	if (aKeys.length !== bKeys.length && (!nullish || Array.isArray(a))) {
 		return false;
 	}
 

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -434,34 +434,6 @@ export function sortCompareFunction<T extends PersistentModel>(
 	};
 }
 
-export function getUpdateMutationInput<T extends PersistentModel>(
-	original: T,
-	updated: T
-): { [key: string]: any } {
-	const mutationInput: { [key: string]: any } = {
-		id: original.id,
-		_version: original._version,
-		_lastChangedAt: original._lastChangedAt,
-		_deleted: original._deleted,
-	};
-
-	for (const field in original) {
-		let originalValue: any = original[field];
-		let updatedValue: any = updated[field];
-
-		if (typeof originalValue === 'object') {
-			originalValue = JSON.stringify(originalValue);
-			updatedValue = JSON.stringify(updatedValue);
-		}
-
-		if (originalValue !== updatedValue) {
-			mutationInput[field] = updated[field];
-		}
-	}
-
-	return mutationInput;
-}
-
 // deep compare any 2 objects (including arrays, Sets, and Maps)
 // returns true if equal
 // if nullish is true, treat undefined and null values as equal


### PR DESCRIPTION
Re-work of https://github.com/aws-amplify/amplify-js/pull/8000
Addresses issues in comments

Issue #, if available:
#7888, #7950, #8012

* Allow consecutive updates to work correctly with the changes in the [update mutation input PR](https://github.com/aws-amplify/amplify-js/pull/7935)

* Enable the follow workflows:
 1. Create new Post, then immediately update
 2. Create new Post, then immediately update with a different field
  3. Create new Post, wait for sync to complete, then update 10 times consecutively
  4. Create new Post, then immediately delete
  5. Create new Post with Comment, reassign Comment to a different Post
  6. Consecutive updates with conditions

* Updated unit tests

* Added e2e tests for all these scenarios: https://github.com/aws-amplify/amplify-js-samples-staging/pull/212

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
