### PR TITLE
Add proper types for challengeName

### DIFF
--- a/packages/amazon-cognito-identity-js/index.d.ts
+++ b/packages/amazon-cognito-identity-js/index.d.ts
@@ -14,6 +14,12 @@ declare module 'amazon-cognito-identity-js' {
 
 	export type ClientMetadata = { [key: string]: string } | undefined;
 
+	export type AuthChallengeName =
+		| 'NEW_PASSWORD_REQUIRED'
+		| 'SMS_MFA'
+		| 'SOFTWARE_TOKEN_MFA'
+		| 'MFA_SETUP';
+
 	export interface IAuthenticationCallback {
 		onSuccess: (
 			session: CognitoUserSession,
@@ -24,11 +30,11 @@ declare module 'amazon-cognito-identity-js' {
 			userAttributes: any,
 			requiredAttributes: any
 		) => void;
-		mfaRequired?: (challengeName: any, challengeParameters: any) => void;
-		totpRequired?: (challengeName: any, challengeParameters: any) => void;
+		mfaRequired?: (challengeName: AuthChallengeName, challengeParameters: any) => void;
+		totpRequired?: (challengeName: AuthChallengeName, challengeParameters: any) => void;
 		customChallenge?: (challengeParameters: any) => void;
-		mfaSetup?: (challengeName: any, challengeParameters: any) => void;
-		selectMFAType?: (challengeName: any, challengeParameters: any) => void;
+		mfaSetup?: (challengeName: AuthChallengeName, challengeParameters: any) => void;
+		selectMFAType?: (challengeName: AuthChallengeName, challengeParameters: any) => void;
 	}
 
 	export interface IMfaSettings {
@@ -82,6 +88,7 @@ declare module 'amazon-cognito-identity-js' {
 		): string;
 		public getCachedDeviceKeyAndPassword(): void;
 
+		public challengeName: AuthChallengeName;
 		public getSession(
 			callback:
 				| ((error: Error, session: null) => void)
@@ -185,12 +192,12 @@ declare module 'amazon-cognito-identity-js' {
 				onSuccess: (session: CognitoUserSession) => void;
 				onFailure: (err: any) => void;
 				mfaRequired?: (
-					challengeName: any,
+					challengeName: AuthChallengeName,
 					challengeParameters: any
 				) => void;
 				customChallenge?: (challengeParameters: any) => void;
 				mfaSetup?: (
-					challengeName: any,
+					challengeName: AuthChallengeName,
 					challengeParameters: any
 				) => void;
 			},
@@ -259,11 +266,11 @@ declare module 'amazon-cognito-identity-js' {
 				onSuccess: (session: CognitoUserSession) => void;
 				onFailure: (err: any) => void;
 				mfaRequired?: (
-					challengeName: any,
+					challengeName: AuthChallengeName,
 					challengeParameters: any
 				) => void;
 				totpRequired?: (
-					challengeName: any,
+					challengeName: AuthChallengeName,
 					challengeParameters: any
 				) => void;
 			}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
I added in a new union type `AuthChallengeName`, that contains the possible valid challenge names. This was needed for the CognitoUser type as `challengeName` was missing from this type. I added the new property `challengeName` to CognitoUser with a type of `AuthChallengeName`. There are also a couple callback functions within `completeNewPasswordChallenge`, `sendMFASelectionAnswer` and IAuthenticationCallback that take a challengeName as a parameter.

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
#3733 and #6974
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Validated manually through my current project to make sure the new property and union were available.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes (Is this needed for a declaration file change?)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
