### PR TITLE
Fix error when input type is checkbox

### DIFF
--- a/packages/aws-amplify-react/src/Auth/AuthPiece.tsx
+++ b/packages/aws-amplify-react/src/Auth/AuthPiece.tsx
@@ -202,7 +202,7 @@ export class AuthPiece<
 		this.inputs = this.inputs || {};
 		const { name, value, type, checked } = evt.target;
 		const check_type = ['radio', 'checkbox'].includes(type);
-		this.inputs[name] = check_type ? checked : value;
+		this.inputs[name] = check_type ? `${checked}` : value;
 		this.inputs['checkedValue'] = check_type ? value : null;
 	}
 

--- a/packages/aws-amplify-react/src/Widget/SelectMFAType.tsx
+++ b/packages/aws-amplify-react/src/Widget/SelectMFAType.tsx
@@ -75,7 +75,7 @@ export class SelectMFAType extends React.Component<
 		const { name, value, type, checked } = evt.target;
 		// @ts-ignore
 		const check_type = ['radio', 'checkbox'].includes(type);
-		this.inputs[value] = check_type ? checked : value;
+		this.inputs[value] = check_type ? `${checked}` : value;
 	}
 
 	verify() {

--- a/packages/aws-amplify-react/src/Widget/TOTPSetupComp.tsx
+++ b/packages/aws-amplify-react/src/Widget/TOTPSetupComp.tsx
@@ -81,7 +81,7 @@ export class TOTPSetupComp extends React.Component<
 		const { name, value, type, checked } = evt.target;
 		// @ts-ignore
 		const check_type = ['radio', 'checkbox'].includes(type);
-		this.inputs[name] = check_type ? checked : value;
+		this.inputs[name] = check_type ? `${checked}` : value;
 	}
 
 	setup() {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Extending the SignUp class to implement a custom sign up field like the following:

```
    this.signUpFields = [
       ....
      {
        label: 'Terms',
        key: 'custom:terms', // Key on the user pool
        required: true,
        displayOrder: 4,
        type: 'checkbox'
      },
     ....
```
Ends in the error:
```
 error: Cannot convert TRUE_VALUE to string
```

That seems to be because the checkbox value is a `true` boolean that cannot be converted to a string. With this change instead of leaving JS to make that cast to a string, we force it so in the case of a `true` boolean `"true"` as a string will be set.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

I validated the changes manually and the issue with the boolean values dissapeared.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
