### PR TITLE
test(cognito-identity-test): add unit test coverage for DateHelper.js

### DIFF
--- a/packages/amazon-cognito-identity-js/__tests__/DateHelper.test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/DateHelper.test.js
@@ -4,7 +4,7 @@ import DateHelper from '../src/DateHelper'
 describe('DateHelper unit tests', () => {
     test('Expect getNowString() to return the date in the correct format', () => {
         const result = new DateHelper()
-        const year = new Date().getUTCFullYear
+        const year = new Date().getUTCFullYear()
         expect(result.getNowString()).toContain(year);
     })
 });

--- a/packages/amazon-cognito-identity-js/__tests__/DateHelper.test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/DateHelper.test.js
@@ -1,0 +1,10 @@
+import DateHelper from '../src/DateHelper'
+
+// DateHelper is a utility class that provides the date in "ddd MMM D HH:mm:ss UTC YYYY" format.
+describe('DateHelper unit tests', () => {
+    test('Expect getNowString() to return the date in the correct format', () => {
+        const result = new DateHelper()
+        const year = new Date().getUTCFullYear
+        expect(result.getNowString()).toContain(year);
+    })
+});


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Adding unit test coverage for DateHelper.js within cognito-identity-js. The unit test ensures that the getNowString() contains the same year as Date.now() because all other tests like checking the day of the week or time of day varies depending on what time zone is expected.
-->


#### Description of how you validated changes
running yarn test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
