### PR TITLE
test(cognito-identity-test): adding unit test coverage to StorageHelper

### DIFF
--- a/packages/amazon-cognito-identity-js/__tests__/StorageHelper.test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/StorageHelper.test.js
@@ -1,0 +1,64 @@
+import { throws } from 'assert';
+import { exception } from 'console';
+import StorageHelper from '../src/StorageHelper'
+import { MemoryStorage } from '../src/StorageHelper'
+
+describe('StorageHelper unit test', () => {
+    test('Constructor with local storage and operations defined', () => {
+        var localStorageMock = (function () {
+            var store = {};
+            return {
+                getItem: function (key) {
+                    return store[key];
+                },
+                setItem: function (key, value) {
+                    store[key] = value.toString();
+                },
+                clear: function () {
+                    store = {};
+                },
+                removeItem: function (key) {
+                    delete store[key];
+                }
+            };
+        })();
+        Object.defineProperty(window, 'localStorage', { value: localStorageMock, writable: true });
+        const storageHelper = new StorageHelper()
+
+        expect(storageHelper.getStorage()).toEqual(storageHelper.storageWindow)
+    });
+
+    describe('operations when local storage is undefined', () => {
+
+        test('Checking the constructor catches the exception', () => {
+            window.localStorage = undefined
+            const storageHelper = new StorageHelper()
+            expect(storageHelper.getStorage()).toBe(MemoryStorage)
+        })
+
+        test('Setting items in the MemoryStorage implementation', () => {
+            const storageHelper = new StorageHelper()
+            expect(storageHelper.getStorage().setItem('testKey', 'testValue')).toBe('testValue')
+        })
+        
+        test('Getting items in the MemoryStorage implementation happy path', () => {
+            const storageHelper = new StorageHelper()
+            expect(storageHelper.getStorage().getItem('testKey')).toBe('testValue')
+        })
+
+        test('Getting items in the MemoryStorage implementation does not have key in MemoryStorage', () => {
+            const storageHelper = new StorageHelper()
+            expect(storageHelper.getStorage().getItem('newKey')).toBe(undefined)
+        })
+        
+        test('Removing an item in the MemoryStorage implementation', () => {
+            const storageHelper = new StorageHelper()
+            expect(storageHelper.getStorage().removeItem('testKey')).toBe(true)
+        })
+
+        test('Clearing storage', () => {
+            const storageHelper = new StorageHelper()
+            expect(storageHelper.getStorage().clear()).toEqual({})
+        })
+    });
+});

--- a/packages/amazon-cognito-identity-js/src/StorageHelper.js
+++ b/packages/amazon-cognito-identity-js/src/StorageHelper.js
@@ -18,7 +18,7 @@
 let dataMemory = {};
 
 /** @class */
-class MemoryStorage {
+export class MemoryStorage {
 	/**
 	 * This is used to set a specific item in storage
 	 * @param {string} key - the key for the item
@@ -45,7 +45,7 @@ class MemoryStorage {
 	/**
 	 * This is used to remove an item from storage
 	 * @param {string} key - the key being set
-	 * @returns {string} value - value that was deleted
+	 * @returns {boolean} return true
 	 */
 	static removeItem(key) {
 		return delete dataMemory[key];


### PR DESCRIPTION
#### Description of changes
StorageHelper.js is a utility function that allows the other files within cognito-identity-js to interact with the local storage of a browser and these unit tests provide 100% coverage that the functions perform as expected. The removeItem(key) function within StorageHelper.js has some unexpected behavior in that it returns true regardless of if the key exists within the storage object.


#### Description of how you validated changes
After running yarn test, I was able to see full coverage for the changes


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
