### PR TITLE
fix(predictions-identify): update detectFacesCommand parameters to include all facial attributes (including Emotions types) in the result

### DIFF
--- a/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
@@ -367,8 +367,8 @@ export class AmazonAIIdentifyPredictionsProvider extends AbstractIdentifyPredict
 				return Promise.reject(err);
 			});
 
-		const param = { Image: inputImage };
-
+		const param = { Attributes: ['ALL'], Image: inputImage };
+			
 		if (
 			isIdentifyCelebrities(input.entities) &&
 			input.entities.celebrityDetection
@@ -452,12 +452,14 @@ export class AmazonAIIdentifyPredictionsProvider extends AbstractIdentifyPredict
 						'EyesOpen',
 						'MouthOpen',
 					];
-					const faceAttributes = makeCamelCase(detail, attributeKeys);
 					if (detail.Emotions) {
 						faceAttributes['emotions'] = detail.Emotions.map(
 							emotion => emotion.Type
 						);
 					}
+					
+					const faceAttributes = makeCamelCase(detail, attributeKeys);
+
 					return {
 						boundingBox: makeCamelCase(detail.BoundingBox),
 						landmarks: makeCamelCaseArray(detail.Landmarks),


### PR DESCRIPTION
Issue #, if available:
[#7740](https://github.com/aws-amplify/amplify-js/issues/7740)

Description of changes:
The context for the undefined problem can be found in the [issue](https://github.com/aws-amplify/amplify-js/issues/7740). As per the documentation for Rekognition JS Client Library [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Rekognition.html), by default Rekognition will only send back boundingBox and landmarks, which is why Amplify **Predictions** identify result shows undefined in attributes, **ageRange**, and missing **Emotions attribute**. To fix this, I have made the required changes as specified in the Rekognition client documentation [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Rekognition.html).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.