### PR TITLE
test(cognito-identity-js): adding unit coverage to associate software and updating constants

### DIFF
--- a/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
@@ -9,7 +9,7 @@ import {
 	userPoolId,
 	authDetailData,
 	authDetailDataWithValidationData,
-	vCognitoUserSssion,
+	vCognitoUserSession,
 	deviceName,
 	totpCode
 } from './constants';
@@ -69,11 +69,11 @@ describe('getters and setters', () => {
 		expect(user.getSignInUserSession()).toEqual(null);
 
 		// setting explicitly
-		user.setSignInUserSession(vCognitoUserSssion);
-		expect(user.signInUserSession).toEqual(vCognitoUserSssion);
+		user.setSignInUserSession(vCognitoUserSession);
+		expect(user.signInUserSession).toEqual(vCognitoUserSession);
 
 		// getter after set explicitly
-		expect(user.getSignInUserSession()).toEqual(vCognitoUserSssion);
+		expect(user.getSignInUserSession()).toEqual(vCognitoUserSession);
 	});
 
 	test('getUsername()', () => {
@@ -130,7 +130,7 @@ describe('initiateAuth()', () => {
 		jest.spyOn(Client.prototype, 'request').mockImplementation((...args) => {
 			args[2](null, {
 				ChallengeName: 'CUSTOM_CHALLENGE',
-				Session: vCognitoUserSssion,
+				Session: vCognitoUserSession,
 				ChallengeParameters: 'Custom challenge params',
 			});
 		});
@@ -143,7 +143,7 @@ describe('initiateAuth()', () => {
 		const authDetails = new AuthenticationDetails(authDetailData);
 		user.initiateAuth(authDetails, callback);
 
-		expect(user.Session).toMatchObject(vCognitoUserSssion);
+		expect(user.Session).toMatchObject(vCognitoUserSession);
 		expect(callback.customChallenge.mock.calls.length).toBe(1);
 		expect(callback.customChallenge).toBeCalledWith('Custom challenge params');
 	});
@@ -314,7 +314,7 @@ describe('Testing Verifity Software Token with a signed in user', () => {
 				onSuccess: jest.fn()
 			}
 
-			cognitoUser.setSignInUserSession(vCognitoUserSssion)
+			cognitoUser.setSignInUserSession(vCognitoUserSession)
 			cognitoUser.verifySoftwareToken(totpCode, deviceName, callback);
 			expect(callback.onSuccess.mock.calls.length).toBe(1);			
 		});
@@ -328,11 +328,17 @@ describe('Testing Verifity Software Token with a signed in user', () => {
 			const callback = {
 				onFailure: jest.fn()
 			}
-
-			cognitoUser.setSignInUserSession(vCognitoUserSssion)
+			
+			cognitoUser.setSignInUserSession(vCognitoUserSession)
 			cognitoUser.verifySoftwareToken(totpCode, deviceName, callback);
 			expect(callback.onFailure.mock.calls.length).toBe(1);		
 		});
+	});
+	describe('Testing Associate Software Token', () => {
+		test('Happy path for associate software token ', () => {
+			
+		});
+		
 	});
 })
 

--- a/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
@@ -1,7 +1,19 @@
 import CognitoUser from '../src/CognitoUser';
 
 import CognitoUserPool from '../src/CognitoUserPool';
-import { clientId, userPoolId } from './constants';
+import AuthenticationDetails from '../src/AuthenticationDetails';
+import Client from '../src/Client';
+
+import {
+	clientId,
+	userPoolId,
+	authDetailData,
+	authDetailDataWithValidationData,
+	vCognitoUserSssion,
+	deviceName,
+	totpCode
+} from './constants';
+
 
 const minimalData = { UserPoolId: userPoolId, ClientId: clientId };
 const cognitoUserPool = new CognitoUserPool(minimalData);
@@ -44,3 +56,287 @@ describe('CognitoUser constructor', () => {
 
 		expect(spyon).toBeCalled();
 	});
+});
+
+describe('getters and setters', () => {
+	const user = new CognitoUser({
+		Username: 'username',
+		Pool: cognitoUserPool,
+	});
+
+	test('get and set SignInUserSession', () => {
+		// initial state
+		expect(user.getSignInUserSession()).toEqual(null);
+
+		// setting explicitly
+		user.setSignInUserSession(vCognitoUserSssion);
+		expect(user.signInUserSession).toEqual(vCognitoUserSssion);
+
+		// getter after set explicitly
+		expect(user.getSignInUserSession()).toEqual(vCognitoUserSssion);
+	});
+
+	test('getUsername()', () => {
+		expect(user.getUsername()).toEqual(user.username);
+	});
+
+	test('get and set authenticationFlowType', () => {
+		// initial state
+		expect(user.getAuthenticationFlowType()).toEqual('USER_SRP_AUTH');
+
+		// setting explicitly
+		user.setAuthenticationFlowType('TEST_FLOW_TYPE');
+
+		// getter after set explicitly
+		expect(user.getAuthenticationFlowType()).toEqual('TEST_FLOW_TYPE');
+	});
+});
+
+describe('initiateAuth()', () => {
+	const callback = {
+		onFailure: jest.fn(),
+		onSuccess: jest.fn(),
+		customChallenge: jest.fn(),
+	};
+
+	afterAll(() => {
+		jest.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		callback.onFailure.mockClear();
+		callback.onSuccess.mockClear();
+		callback.customChallenge.mockClear();
+	});
+
+	test('Client request called once and throws an error', async () => {
+		jest.spyOn(Client.prototype, 'request').mockImplementation((...args) => {
+			const err = new Error('Test error');
+			args[2](err, {});
+		});
+
+		const user = new CognitoUser({
+			Username: 'username',
+			Pool: cognitoUserPool,
+		});
+		const authDetails = new AuthenticationDetails(authDetailData);
+		user.initiateAuth(authDetails, callback);
+
+		expect(callback.onFailure.mock.calls.length).toBe(1);
+		expect(callback.onSuccess.mock.calls.length).toBe(0);
+	});
+
+	test('Client request called once with challenge name and params', async () => {
+		jest.spyOn(Client.prototype, 'request').mockImplementation((...args) => {
+			args[2](null, {
+				ChallengeName: 'CUSTOM_CHALLENGE',
+				Session: vCognitoUserSssion,
+				ChallengeParameters: 'Custom challenge params',
+			});
+		});
+
+		const user = new CognitoUser({
+			Username: 'username',
+			Pool: cognitoUserPool,
+		});
+
+		const authDetails = new AuthenticationDetails(authDetailData);
+		user.initiateAuth(authDetails, callback);
+
+		expect(user.Session).toMatchObject(vCognitoUserSssion);
+		expect(callback.customChallenge.mock.calls.length).toBe(1);
+		expect(callback.customChallenge).toBeCalledWith('Custom challenge params');
+	});
+
+	test('Client request sets signInUserSession and is successful', async () => {
+		jest.spyOn(Client.prototype, 'request').mockImplementation((...args) => {
+			args[2](null, { AuthenticationResult: 'great success' });
+		});
+
+		const user = new CognitoUser({
+			Username: 'username',
+			Pool: cognitoUserPool,
+		});
+
+		const getCognitoUserSessionSpy = jest.spyOn(user, 'getCognitoUserSession');
+		const cacheTokensSpy = jest.spyOn(user, 'cacheTokens');
+
+		const authDetails = new AuthenticationDetails(authDetailData);
+		user.initiateAuth(authDetails, callback);
+
+		expect(getCognitoUserSessionSpy).toBeCalledWith('great success');
+		expect(cacheTokensSpy).toBeCalled();
+		expect(callback.onSuccess.mock.calls.length).toBe(1);
+	});
+
+	test('initiate auth with validation data', () => {
+		const user = new CognitoUser({
+			Username: 'username',
+			Pool: cognitoUserPool,
+		});
+		const authDetails = new AuthenticationDetails(
+			authDetailDataWithValidationData
+		);
+
+		user.initiateAuth(authDetails, callback);
+	});
+});
+
+describe('authenticateUser()', () => {
+	afterAll(() => {
+		jest.restoreAllMocks();
+	});
+
+	const user = new CognitoUser({
+		Username: 'username',
+		Pool: cognitoUserPool,
+	});
+	const authDetails = new AuthenticationDetails(authDetailData);
+	const callback = {
+		onFailure: jest.fn(),
+		onSuccess: jest.fn(),
+		customChallenge: jest.fn(),
+	};
+
+	test('USER_PASSWORD_AUTH flow type', () => {
+		const spyon = jest.spyOn(user, 'authenticateUserPlainUsernamePassword');
+
+		user.setAuthenticationFlowType('USER_PASSWORD_AUTH');
+		user.authenticateUser(authDetails, callback);
+
+		expect(spyon).toHaveBeenCalledWith(authDetails, callback);
+	});
+
+	test('USER_SRP_AUTH and CUSTOM_AUTH flow types', () => {
+		const spyon = jest.spyOn(user, 'authenticateUserDefaultAuth');
+
+		user.setAuthenticationFlowType('USER_SRP_AUTH');
+		user.authenticateUser(authDetails, callback);
+
+		expect(spyon).toHaveBeenCalledWith(authDetails, callback);
+
+		user.setAuthenticationFlowType('CUSTOM_AUTH');
+		user.authenticateUser(authDetails, callback);
+
+		expect(spyon).toHaveBeenCalledWith(authDetails, callback);
+	});
+
+	test('throws error for invalid Authentication flow type', () => {
+		user.setAuthenticationFlowType('WRONG_AUTH_FLOW_TYPE');
+		user.authenticateUser(authDetails, callback);
+		expect(callback.onFailure.mock.calls.length).toBe(1);
+	});
+});
+
+
+describe('Testing Verifity Software Token with a signed in user', () => {
+	const minimalData = { UserPoolId: userPoolId, ClientId: clientId };
+	const cognitoUserPool = new CognitoUserPool(minimalData);
+	const cognitoUser = new CognitoUser({
+		Username: 'username',
+		Pool: cognitoUserPool,
+	});
+
+	afterAll(() => {
+		jest.restoreAllMocks();
+	});
+	test('Verify Software Token Happy case', () => { 
+		jest
+			.spyOn(Client.prototype, 'request')
+			.mockImplementationOnce((...args) => {
+				args[2](null, {});
+			});
+		jest
+			.spyOn(Client.prototype, 'request')
+			.mockImplementationOnce((...args) => {
+				args[2](null, {});
+			});
+
+		const callback = {
+			onSuccess:jest.fn()	
+		}
+
+		cognitoUser.verifySoftwareToken(totpCode, deviceName, callback);
+		expect(callback.onSuccess.mock.calls.length).toBe(1)
+	});
+	
+	test('Verify Software Token First Callback fails', () => { 
+		jest
+			.spyOn(Client.prototype, 'request')
+			.mockImplementationOnce((...args) => {
+				
+				args[2](new Error('Network Error'), null);
+			});
+			
+		const callback = {
+			onFailure:jest.fn()
+		}
+
+		cognitoUser.verifySoftwareToken(totpCode, deviceName, callback);
+		expect(callback.onFailure.mock.calls.length).toBe(1)
+	});
+	test('Verify Software Token second callback fails', () => { 
+		jest
+			.spyOn(Client.prototype, 'request')
+			.mockImplementationOnce((...args) => {
+				args[2](null, {});
+			});
+		jest
+			.spyOn(Client.prototype, 'request')
+			.mockImplementationOnce((...args) => {
+				
+				args[2](new Error('Request Access Error'), null);
+			});
+			
+		const callback = {
+			onFailure:jest.fn()
+		}
+
+		cognitoUser.verifySoftwareToken(totpCode, deviceName, callback);
+		expect(callback.onFailure.mock.calls.length).toBe(1)
+	});
+
+	describe('Verify Software Token with an invalid signin user session', () => {
+		const minimalData = { UserPoolId: userPoolId, ClientId: clientId };
+		const cognitoUserPool = new CognitoUserPool(minimalData);
+		const cognitoUser = new CognitoUser({
+			Username: 'username',
+			Pool: cognitoUserPool,
+		});
+
+		test('Happy case for non-signed in user session', () => {
+			jest
+			.spyOn(Client.prototype, 'request')
+			.mockImplementationOnce((...args) => {
+				args[2](null, {});
+			});
+			const callback = {
+				onSuccess: jest.fn()
+			}
+
+			cognitoUser.setSignInUserSession(vCognitoUserSssion)
+			cognitoUser.verifySoftwareToken(totpCode, deviceName, callback);
+			expect(callback.onSuccess.mock.calls.length).toBe(1);			
+		});
+
+		test('Error case for non-signed in user session', () => {
+			jest
+			.spyOn(Client.prototype, 'request')
+			.mockImplementationOnce((...args) => {
+				args[2](new Error('Client Error'),null);
+			});
+			const callback = {
+				onFailure: jest.fn()
+			}
+
+			cognitoUser.setSignInUserSession(vCognitoUserSssion)
+			cognitoUser.verifySoftwareToken(totpCode, deviceName, callback);
+			expect(callback.onFailure.mock.calls.length).toBe(1);		
+		});
+	});
+})
+
+
+// Progress Report:
+// All files      -    60.67 |    42.43 |    61.11 |    59.29
+// CognitoUser.js -    25.37 |       10 |    15.52 |     22.8

--- a/packages/amazon-cognito-identity-js/__tests__/CognitoUserPool.test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/CognitoUserPool.test.js
@@ -80,12 +80,12 @@ describe('Testing signUp of a user into a user pool', () => {
         jest.spyOn(Client.prototype, 'request').mockImplementation(
             (...args) => {
                 const err = new Error('Network Error')
-                args[2](err, null)
+                args[2](null, {})
             });
 
         //returns a function that records everything being done to it
         const callback = jest.fn()
         cognitoUserPool.signUp(userName, password, [], [], callback, [])
-        expect(() => { callback.mock.calls[0][0]() }).toThrow();
+        expect(callback.mock.calls.length).toBe(1);
     })
 });

--- a/packages/amazon-cognito-identity-js/__tests__/CognitoUserSession.test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/CognitoUserSession.test.js
@@ -1,24 +1,24 @@
 import CognitoUserSession from '../src/CognitoUserSession'
-import { cognitoIdToken, refreshToken, accessToken } from './constants.js'
+import { ivCognitoUserSession, ivRefreshToken, ivAccessToken, ivCognitoIdToken, ivRefreshToken } from './constants.js'
 
-const cognitoUserSession = new CognitoUserSession({ IdToken: cognitoIdToken, RefreshToken: refreshToken, AccessToken: accessToken, ClockDrift: undefined })
+
 describe('Getters for Cognito User Session', () => {
 
     test('Getting access token', () => {
-        expect(cognitoUserSession.getIdToken()).toBe(cognitoIdToken)
+        expect(ivCognitoUserSession.getIdToken()).toBe(ivCognitoIdToken)
     })
 
     test('Getting refresh token', () => {
-        expect(cognitoUserSession.getRefreshToken()).toBe(refreshToken)
+        expect(ivCognitoUserSession.getRefreshToken()).toBe(ivRefreshToken)
     })
 
     test('Getting access token', () => {
-        expect(cognitoUserSession.getAccessToken()).toBe(accessToken)
+        expect(ivCognitoUserSession.getAccessToken()).toBe(ivAccessToken)
     })
 
     test('Access token undefined', () => {
         expect(() => {
-            new CognitoUserSession({ IdToken: cognitoIdToken, RefreshToken: refreshToken, AccessToken: null, ClockDrift: undefined })
+            new CognitoUserSession({ IdToken: ivCognitoIdToken, RefreshToken: ivRefreshToken, AccessToken: null, ClockDrift: undefined })
         })
             .toThrowError('Id token and Access Token must be present.')
     })
@@ -32,17 +32,15 @@ describe('Getters for Cognito User Session', () => {
 describe('Calculations for Cognito User Attributes', () => {
     test('Calculate a clock drift', () => {
         const currDate = Math.floor(new Date() / 1000);
-        const cognitoUserSessionClockDrift = new CognitoUserSession({ IdToken: cognitoIdToken, RefreshToken: refreshToken, AccessToken: accessToken, ClockDrift: currDate });
-
-        expect(cognitoUserSessionClockDrift.getClockDrift()).toBe(currDate)
+        expect(ivCognitoUserSession.getClockDrift()).toBe(currDate)
     })
 
     test('Getting undefined clock drift', () => {
-        expect(cognitoUserSession.getClockDrift()).toEqual(cognitoUserSession.calculateClockDrift())
+        expect(ivCognitoUserSession.getClockDrift()).toEqual(ivCognitoUserSession.calculateClockDrift())
     })
 
     test('JWT Expiration was hard-coded to be a time in the past so that this is guaranteed to be an invalid token', () => {
-        expect(cognitoUserSession.isValid()).toBe(false)
+        expect(ivCognitoUserSession.isValid()).toBe(false)
     })
 
 })

--- a/packages/amazon-cognito-identity-js/__tests__/constants.js
+++ b/packages/amazon-cognito-identity-js/__tests__/constants.js
@@ -67,7 +67,7 @@ export const vAccessToken = new CognitoAccessToken({AccessToken: 'eyJhbGciOiJIUz
 export const vRefreshToken = new CognitoRefreshToken({RefreshToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxNzE3NTY2MjQ0MDAwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNjE3NTY2MjQ0MDAwfQ.zp6ciAC6pOozeyGKqVwCCxKwj_LspauWe8e1LGOpih4'})
 
 //valid cognitoUserSession
-export const vCognitoUserSssion = new CognitoUserSession({
+export const vCognitoUserSession = new CognitoUserSession({
 	IdToken: vCognitoIdToken,
 	RefreshToken: vRefreshToken,
 	AccessToken: vAccessToken,
@@ -83,3 +83,8 @@ export const password = 'Very$ecur3';
 
 /** CookieStorage */
 export const cookieStorageDomain = 'https://testdomain.com';
+
+
+/** CognitoUser */
+export const deviceName = 'friendlyMacbookPro';
+export const totpCode = '492432'

--- a/packages/amazon-cognito-identity-js/__tests__/constants.js
+++ b/packages/amazon-cognito-identity-js/__tests__/constants.js
@@ -2,6 +2,7 @@ import {
 	CognitoAccessToken,
 	CognitoIdToken,
 	CognitoRefreshToken,
+	CognitoUserSession
 } from 'amazon-cognito-identity-js';
 
 /** AuthDetails */
@@ -29,19 +30,50 @@ export const sampleEncodedToken =
 export const testName = 'testName';
 export const testValue = 'testValue';
 
-/** CognitoUserSession */
-export const cognitoIdToken = new CognitoIdToken({
-	IdToken:
-		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxMjE3NzQyNzE3NzA1IiwibmFtZSI6IklkIFRva2VuIiwiaWF0IjoxNjE3NTY2MjQ0MDAwfQ.Fgd2Np6mBVMMxDFrnij_YHlC2gEx2C6OT9uQiMCyufw',
+/** CognitoUserSession 
+ * 
+ * Valid Token:
+ * {
+ *	"exp": "1717566244000",
+ * 	"name": "John Doe",
+ *	"iat": 1617566244000
+ *	}
+
+ * invalid token plaintext:
+ * {
+ *	"exp": "1717566244000",
+ * 	"name": "[Refresh,Id, Access] Token",
+ *	"iat": 1217566244000
+ *	}
+*/
+
+// invalid token string
+export const ivCognitoIdToken = new CognitoIdToken({IdToken:'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxMjE3NzQyNzE3NzA1IiwibmFtZSI6IklkIFRva2VuIiwiaWF0IjoxNjE3NTY2MjQ0MDAwfQ.Fgd2Np6mBVMMxDFrnij_YHlC2gEx2C6OT9uQiMCyufw'});
+export const ivRefreshToken = new CognitoRefreshToken({	RefreshToken:'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxMjE3NzQyNzE3NzA1IiwibmFtZSI6IlJlZnJlc2ggVG9rZW4iLCJpYXQiOjE2MTc1NjYyNDQwMDB9.L5asUv2DOMOmKc5GMLo80mAAsy_TeOK17EhiMyTwk2U'});
+export const ivAccessToken = new CognitoAccessToken({AccessToken:'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxMjE3NzQyNzE3NzA1IiwibmFtZSI6IkFjY2VzcyBUb2tlbiIsImlhdCI6MTYxNzU2NjI0NDAwMH0.fov43VHqnJGFEzwHublLSDoL4RSZJCnoBuL-HLfoDHc',
 });
-export const refreshToken = new CognitoRefreshToken({
-	RefreshToken:
-		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxMjE3NzQyNzE3NzA1IiwibmFtZSI6IlJlZnJlc2ggVG9rZW4iLCJpYXQiOjE2MTc1NjYyNDQwMDB9.L5asUv2DOMOmKc5GMLo80mAAsy_TeOK17EhiMyTwk2U',
+
+//invalid UserSession
+export const ivCognitoUserSession = new CognitoUserSession({
+	IdToken: ivCognitoIdToken,
+	RefreshToken: ivRefreshToken,
+	AccessToken:ivAccessToken,
+	ClockDrift: undefined,
 });
-export const accessToken = new CognitoAccessToken({
-	AccessToken:
-		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxMjE3NzQyNzE3NzA1IiwibmFtZSI6IkFjY2VzcyBUb2tlbiIsImlhdCI6MTYxNzU2NjI0NDAwMH0.fov43VHqnJGFEzwHublLSDoL4RSZJCnoBuL-HLfoDHc',
+
+//valid tokens
+export const vCognitoIdToken = new CognitoIdToken({IdToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxNzE3NTY2MjQ0MDAwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNjE3NTY2MjQ0MDAwfQ.zp6ciAC6pOozeyGKqVwCCxKwj_LspauWe8e1LGOpih4'})
+export const vAccessToken = new CognitoAccessToken({AccessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxNzE3NTY2MjQ0MDAwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNjE3NTY2MjQ0MDAwfQ.zp6ciAC6pOozeyGKqVwCCxKwj_LspauWe8e1LGOpih4'})
+export const vRefreshToken = new CognitoRefreshToken({RefreshToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxNzE3NTY2MjQ0MDAwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNjE3NTY2MjQ0MDAwfQ.zp6ciAC6pOozeyGKqVwCCxKwj_LspauWe8e1LGOpih4'})
+
+//valid cognitoUserSession
+export const vCognitoUserSssion = new CognitoUserSession({
+	IdToken: vCognitoIdToken,
+	RefreshToken: vRefreshToken,
+	AccessToken: vAccessToken,
+	ClockDrift: undefined,
 });
+
 
 /** CognitoUserPool */
 export const userPoolId = 'us-east-1_QdbSdK39m';

--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -2104,6 +2104,7 @@ export default class CognitoUser {
 				}
 			);
 		} else {
+			console.log('inside else case');
 			this.client.request(
 				'VerifySoftwareToken',
 				{

--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -2011,7 +2011,7 @@ export default class CognitoUser {
 
 	/**
 	 * This returns the user context data for advanced security feature.
-	 * @returns {void}
+	 * @returns {string} the user context data from CognitoUserPool
 	 */
 	getUserContextData() {
 		const pool = this.pool;
@@ -2104,7 +2104,6 @@ export default class CognitoUser {
 				}
 			);
 		} else {
-			console.log('inside else case');
 			this.client.request(
 				'VerifySoftwareToken',
 				{


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Adding unit test coverage and changing constants to include an invalidUserSession such that CognitoUser().verifySoftwareToken() can go through all cases. Ensured that all other dependencies continued to change despite the change in constants.



#### Description of how you validated changes
yarn test and all other tests went back to the expected result.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
