### PR TITLE
fix(@aws-amplify/datastore): handle merging queued create with incoming update

### DIFF
--- a/packages/datastore/src/sync/outbox.ts
+++ b/packages/datastore/src/sync/outbox.ts
@@ -56,10 +56,14 @@ class MutationEventOutbox {
 				if (incomingMutationType === TransformerMutationType.DELETE) {
 					await s.delete(this.MutationEvent, predicate);
 				} else {
-					// first gets updated with incoming's data, condition intentionally skipped
+					// first gets updated with the incoming mutation's data, condition intentionally skipped
+
+					// we need to merge the fields for a create and update mutation to prevent
+					// data loss, since update mutations only include changed fields
+					const merged = this.mergeUserFields(first, mutationEvent);
 					await s.save(
 						this.MutationEvent.copyOf(first, draft => {
-							draft.data = mutationEvent.data;
+							draft.data = merged.data;
 						}),
 						undefined,
 						this.ownSymbol


### PR DESCRIPTION
Adds support for one more use case to the work in https://github.com/aws-amplify/amplify-js/pull/8038

Create Post, then create another Post and immediately update another field

e2e test PR updated to include this scenario.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
