### PR TITLE
chore: generate TS source maps with build:watch

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -147,7 +147,7 @@ function reportWatchStatusChanged(diagnostic, newLine, options, errorCount) {
 	logger.info(ts.formatDiagnostic(diagnostic, formatHost));
 }
 
-async function buildES5(typeScriptCompiler) {
+async function buildES5(typeScriptCompiler, watchMode) {
 	const jsx = ['@aws-amplify/ui-react', 'aws-amplify-react'].includes(
 		packageInfo.name
 	)
@@ -166,7 +166,6 @@ async function buildES5(typeScriptCompiler) {
 		],
 		downlevelIteration: true,
 		jsx: jsx,
-		sourceMap: true,
 		target: 'es5',
 		module: 'commonjs',
 		moduleResolution: 'node',
@@ -179,6 +178,13 @@ async function buildES5(typeScriptCompiler) {
 		types: ['node'],
 		outDir: pkgTscES5OutDir,
 	};
+
+	if (watchMode) {
+		compilerOptions.inlineSourceMap = true;
+		compilerOptions.inlineSources = true;
+	} else {
+		compilerOptions.sourceMap = true;
+	}
 
 	compilerOptions = ts.convertCompilerOptionsFromJson(compilerOptions);
 	const include = [pkgSrcDir];
@@ -198,7 +204,7 @@ async function buildES5(typeScriptCompiler) {
 	});
 }
 
-function buildES6(typeScriptCompiler) {
+function buildES6(typeScriptCompiler, watchMode) {
 	const jsx = ['@aws-amplify/ui-react', 'aws-amplify-react'].includes(
 		packageInfo.name
 	)
@@ -217,7 +223,6 @@ function buildES6(typeScriptCompiler) {
 		],
 		downlevelIteration: true,
 		jsx: jsx,
-		sourceMap: true,
 		target: 'es5',
 		module: 'es2015',
 		moduleResolution: 'node',
@@ -230,6 +235,13 @@ function buildES6(typeScriptCompiler) {
 		types: ['node'],
 		outDir: pkgTscES6OutDir,
 	};
+
+	if (watchMode) {
+		compilerOptions.inlineSourceMap = true;
+		compilerOptions.inlineSources = true;
+	} else {
+		compilerOptions.sourceMap = true;
+	}
 
 	compilerOptions = ts.convertCompilerOptionsFromJson(compilerOptions);
 	const include = [pkgSrcDir];
@@ -255,8 +267,9 @@ function build(type, watchMode) {
 	var typeScriptCompiler = watchMode
 		? runTypeScriptWithWatchMode
 		: runTypeScriptWithoutWatchMode;
-	if (type === 'es5') buildES5(typeScriptCompiler);
-	if (type === 'es6') buildES6(typeScriptCompiler);
+
+	if (type === 'es5') buildES5(typeScriptCompiler, watchMode);
+	if (type === 'es6') buildES6(typeScriptCompiler, watchMode);
 }
 
 module.exports = build;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Force generating TypeScript source maps when building the library in **watch mode**. 

Currently, when linking the library into a sample app, we can only see the transpiled JS code if we inspect the code in the Sources tab in Dev Tools. This makes it very difficult to debug library issues.

This change allows us to see the original TypeScript code, as well as set breakpoints and step through, inspect values, etc.

The change only applies when we build the lib in **watch mode** e.g., `yarn build:watch`, `yarn build:esm:watch`, `yarn build:watch --scope @aws-amplify/core`, etc. 

The standard build script `yarn build`, i.e., the one we use in CI is unaffected by this.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
n/a


#### Description of how you validated changes

1. Link aws-amplify in sample app
2. Run `yarn build:watch` from the library dir
3. Go to dev tools > sources; open a TypeScript source file and set a breakpoint
4. Execute action that would trigger the breakpoint
5. Breakpoint gets triggered, able to inspect values, etc.
6. Run `yarn build` from the library dir
7. Go to dev tools > sources; TypeScript files are no longer visible/not being mapped (same as current behavior)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [n/a] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [n/a] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
