### PR TITLE
fix(@aws-amplify/datastore): fix hasOne delete

### DIFF
--- a/packages/datastore/__tests__/IndexedDBAdapter.test.ts
+++ b/packages/datastore/__tests__/IndexedDBAdapter.test.ts
@@ -5,7 +5,7 @@ import {
 	initSchema as initSchemaType,
 } from '../src/datastore/datastore';
 import { PersistentModelConstructor, SortDirection } from '../src/types';
-import { Model, testSchema } from './helpers';
+import { Model, User, Profile, testSchema } from './helpers';
 import { Predicates } from '../src/predicates';
 
 let initSchema: typeof initSchemaType;
@@ -106,6 +106,53 @@ describe('IndexedDBAdapter tests', () => {
 			expect(spyOnGetAll).toHaveBeenCalled();
 			expect(spyOnEngine).not.toHaveBeenCalled();
 			expect(spyOnMemory).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Delete', () => {
+		let User: PersistentModelConstructor<User>;
+		let Profile: PersistentModelConstructor<Profile>;
+		let profile1Id: string;
+		let user1Id: string;
+
+		beforeAll(async () => {
+			({ initSchema, DataStore } = require('../src/datastore/datastore'));
+
+			const classes = initSchema(testSchema());
+
+			({ User } = classes as {
+				User: PersistentModelConstructor<User>;
+			});
+
+			({ Profile } = classes as {
+				Profile: PersistentModelConstructor<Profile>;
+			});
+
+			({ id: profile1Id } = await DataStore.save(
+				new Profile({ firstName: 'Rick', lastName: 'Bob' })
+			));
+
+			({ id: user1Id } = await DataStore.save(
+				new User({ name: 'test', profileID: profile1Id })
+			));
+		});
+
+		it('Should perform a cascading delete on a record with a Has One relationship', async () => {
+			let user = await DataStore.query(User, user1Id);
+			let profile = await DataStore.query(Profile, profile1Id);
+
+			// double-checking that both of the records exist at first
+			expect(user.id).toEqual(user1Id);
+			expect(profile.id).toEqual(profile1Id);
+
+			await DataStore.delete(User, user1Id);
+
+			user = await DataStore.query(User, user1Id);
+			profile = await DataStore.query(Profile, profile1Id);
+
+			// both should be undefined, even though we only explicitly deleted the user
+			expect(user).toBeUndefined;
+			expect(profile).toBeUndefined;
 		});
 	});
 });

--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -37,6 +37,17 @@ export declare class Comment {
 	public readonly post: Post;
 }
 
+export declare class User {
+	public readonly id: string;
+	public readonly name: string;
+	public readonly profileID: string;
+}
+export declare class Profile {
+	public readonly id: string;
+	public readonly firstName: string;
+	public readonly lastName: string;
+}
+
 export function testSchema(): Schema {
 	return {
 		enums: {},
@@ -204,6 +215,88 @@ export function testSchema(): Schema {
 						isRequired: true,
 					},
 				},
+			},
+			User: {
+				name: 'User',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					name: {
+						name: 'name',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					profileID: {
+						name: 'profileID',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					profile: {
+						name: 'profile',
+						isArray: false,
+						type: {
+							model: 'Profile',
+						},
+						isRequired: false,
+						attributes: [],
+						association: {
+							connectionType: 'HAS_ONE',
+							associatedWith: 'id',
+							targetName: 'profileID',
+						},
+					},
+				},
+				syncable: true,
+				pluralName: 'Users',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+				],
+			},
+			Profile: {
+				name: 'Profile',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					firstName: {
+						name: 'firstName',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					lastName: {
+						name: 'lastName',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'Profiles',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+				],
 			},
 		},
 		nonModels: {

--- a/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
+++ b/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
@@ -486,7 +486,7 @@ export class AsyncStorageAdapter implements Adapter {
 		deleteQueue: { storeName: string; items: T[] }[]
 	): Promise<void> {
 		for await (const rel of relations) {
-			const { relationType, modelName } = rel;
+			const { relationType, modelName, targetName } = rel;
 			const storeName = this.getStorename(nameSpace, modelName);
 
 			const index: string =
@@ -506,9 +506,14 @@ export class AsyncStorageAdapter implements Adapter {
 			switch (relationType) {
 				case 'HAS_ONE':
 					for await (const model of models) {
+						const hasOneIndex = index || 'byId';
+
+						const hasOneCustomField = targetName in model;
+						const value = hasOneCustomField ? model[targetName] : model.id;
+
 						const allRecords = await this.db.getAll(storeName);
 						const recordToDelete = allRecords.filter(
-							childItem => childItem[index] === model.id
+							childItem => childItem[hasOneIndex] === value
 						);
 
 						await this.deleteTraverse(

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -58,6 +58,7 @@ export type ModelAssociation = AssociatedWith | TargetNameAssociation;
 type AssociatedWith = {
 	connectionType: 'HAS_MANY' | 'HAS_ONE';
 	associatedWith: string;
+	targetName?: string;
 };
 export function isAssociatedWith(obj: any): obj is AssociatedWith {
 	return obj && obj.associatedWith;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Allow deleting records that have a **Has One** relation. Perform a cascading delete.

**Note:** This library bugfix relies on a recent Codegen change, and in order to work correctly, [this feature flag](https://docs.amplify.aws/cli/reference/feature-flags#useAppsyncModelgenPlugin) needs to be set to `true`. Starting 5/1 this will be the default CLI/Codegen behavior for new projects.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/6560


#### Description of how you validated changes
* Created unit tests for both of the JS Storage Adapters
* Manually validated in a sample
* Created an e2e test: https://github.com/aws-amplify/amplify-js-samples-staging/pull/216


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
~Relevant documentation is changed or added (and PR referenced)~ N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
