### PR TITLE
fix(@aws-amplify/ui-components): Get autofill data on `componentDidLoad`

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-input/amplify-input.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-input/amplify-input.tsx
@@ -36,6 +36,7 @@ export class AmplifyInput {
 	 */
 	private setAutoCompleteValue(value: string) {
 		const input = this.el.querySelector('input');
+		if (!input) return;
 		input.value = value;
 		// dispatch an input event from this element to the parent form
 		input.dispatchEvent(new Event('input'));
@@ -79,7 +80,9 @@ export class AmplifyInput {
 			input.value = '';
 			this.autoCompleted = false;
 		});
+	}
 
+	componentDidLoad() {
 		// no-op if this field already has been autofilled or already has an value
 		if (this.autoCompleted || this.value) return;
 

--- a/packages/amplify-ui-components/src/components/amplify-input/amplify-input.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-input/amplify-input.tsx
@@ -77,7 +77,7 @@ export class AmplifyInput {
 			 * which is the existing behavior.
 			 */
 			const input = this.el.querySelector('input');
-			input.value = '';
+			if (input) input.value = '';
 			this.autoCompleted = false;
 		});
 	}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
On Vue 3 specifically, autofill with `amplify-auth-conatainer` was failing because it was trying to get the reference to the `input` before it has materialized. This PR moves this logic to `componentDidLoad` so that `autofill` is attempted after the component is fully loaded. Also adds a basic null check.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
follows up #8181 

#### Description of how you validated changes
Did a `yarn link` with a vue 3 authenticator sample and validated that the inputs get autofilled.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
