### PR TITLE
chore(amazon-cognito-identity-js): deprecate getMFAOptions

### DIFF
--- a/packages/amazon-cognito-identity-js/README.md
+++ b/packages/amazon-cognito-identity-js/README.md
@@ -724,16 +724,28 @@ cognitoUser.forgetDevice({
 
 ```
 
-**Use case 24.** Retrieve the MFA Options for the user in case MFA is optional.
+**Use case 24.** Retrieve the MFA settings for the user.
 
 ```javascript
-cognitoUser.getMFAOptions(function(err, mfaOptions) {
+cognitoUser.getUserData((err, data) => {
 	if (err) {
 		alert(err.message || JSON.stringify(err));
 		return;
 	}
-	console.log('MFA options for user ' + mfaOptions);
+	const { PreferredMfaSetting, UserMFASettingList } = data;
+	console.log(
+		JSON.stringify({ PreferredMfaSetting, UserMFASettingList }, null, 2)
+	);
 });
+```
+
+E.g.
+
+```json
+{
+	"PreferredMfaSetting": "SMS_MFA",
+	"UserMFASettingList": ["SMS_MFA"]
+}
 ```
 
 **Use case 25.** Authenticating a user with a passwordless custom flow.

--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -1182,7 +1182,7 @@ export default class CognitoUser {
 	}
 
 	/**
-	 * This was previously used by an authenticated user to get the MFAOptions,
+	 * This was previously used by an authenticated user to get MFAOptions,
 	 * but no longer returns a meaningful response. Refer to the documentation for
 	 * how to setup and use MFA: https://docs.amplify.aws/lib/auth/mfa/q/platform/js
 	 * @deprecated

--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -1182,7 +1182,10 @@ export default class CognitoUser {
 	}
 
 	/**
-	 * This is used by an authenticated user to get the MFAOptions
+	 * This was previously used by an authenticated user to get the MFAOptions,
+	 * but no longer returns a meaningful response. Refer to the documentation for
+	 * how to setup and use MFA: https://docs.amplify.aws/lib/auth/mfa/q/platform/js
+	 * @deprecated
 	 * @param {nodeCallback<MFAOptions>} callback Called on success or error.
 	 * @returns {void}
 	 */

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -328,7 +328,10 @@ export class AuthClass {
 				validationData = [];
 				Object.keys(validationDataObject).map(key => {
 					validationData.push(
-						new CognitoUserAttribute({ Name: key, Value: validationDataObject[key] })
+						new CognitoUserAttribute({
+							Name: key,
+							Value: validationDataObject[key],
+						})
 					);
 				});
 			}
@@ -650,8 +653,9 @@ export class AuthClass {
 	}
 
 	/**
-	 * get user current preferred mfa option
-	 * this method doesn't work with totp, we need to deprecate it.
+	 * This was previously used by an authenticated user to get MFAOptions,
+	 * but no longer returns a meaningful response. Refer to the documentation for
+	 * how to setup and use MFA: https://docs.amplify.aws/lib/auth/mfa/q/platform/js
 	 * @deprecated
 	 * @param {CognitoUser} user - the current user
 	 * @return - A promise resolves the current preferred mfa option if success


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

PR #2707 from Feb. 2019 (two years ago) indicated that `getMFAOptions()` was not returning meaningful values. Currently, [`MFAOptions`](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_GetUser.html#CognitoUserPools-GetUser-response-MFAOptions) is no longer supported *at all*. Hence, the method needs to be deprecated.

The [corresponding method in `auth`](https://github.com/aws-amplify/amplify-js/blob/main/packages/auth/src/Auth.ts#L652-L658) is *already* deprecated.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Two incidents where customers were expecting this method to behave meaningfully: #2707, #3330

#### Description of how you validated changes

No functional changes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] ~~Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)~~ (no functional changes)
- [x] Relevant documentation is changed or added (and PR referenced)

Notably, [tests do still exist for these methods](https://github.com/aws-amplify/amplify-js/search?q=getMFAOptions&type=code). Since these methods are simply marked as deprecated for now, I'm leaving those tests in on the off-chance any customers are actually calling these methods. (If anyone is depending on the broken behavior, let's not allow it to break *differently.*)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
