### PR TITLE
#8173 UI react with authenticator props

### DIFF
--- a/packages/amplify-ui-react/__tests__/withAuthenticator-test.tsx
+++ b/packages/amplify-ui-react/__tests__/withAuthenticator-test.tsx
@@ -12,4 +12,20 @@ describe('withAuthenticator', () => {
 			`"<amplify-container><amplify-authenticator></amplify-authenticator></amplify-container>"`
 		);
 	});
+
+	it('should pass through props to the wrapped component', () => {
+		const Dummy = ({ prop1 }) => <div>{prop1}</div>;
+		const mockProp = 'mockProp';
+
+		const useStateSpy = jest.spyOn(React, 'useState');
+		useStateSpy.mockReturnValue([true, () => {}]);
+
+		const Wrapped = withAuthenticator(Dummy);
+
+		expect(renderToStaticMarkup(<Wrapped prop1={mockProp}/>)).toMatchInlineSnapshot(
+			`"<div>${mockProp}</div>"`
+		);
+
+		useStateSpy.mockRestore();
+	});
 });

--- a/packages/amplify-ui-react/src/withAuthenticator.tsx
+++ b/packages/amplify-ui-react/src/withAuthenticator.tsx
@@ -10,11 +10,11 @@ import { Logger } from '@aws-amplify/core';
 
 const logger = new Logger('withAuthenticator');
 
-export function withAuthenticator(
-	Component: ComponentType,
+export function withAuthenticator<T extends object>(
+	Component: ComponentType<T>,
 	authenticatorProps?: ComponentPropsWithRef<typeof AmplifyAuthenticator>
 ) {
-	const AppWithAuthenticator: FunctionComponent = props => {
+	const AppWithAuthenticator: FunctionComponent<T> = props => {
 		const [signedIn, setSignedIn] = React.useState(false);
 
 		React.useEffect(() => {
@@ -52,7 +52,8 @@ export function withAuthenticator(
 				</AmplifyContainer>
 			);
 		}
-		return <Component />;
+
+		return <Component {...props} />;
 	};
 
 	return AppWithAuthenticator;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
support passing props to the wrapped component of withAuthenticator HOC.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. --> 
Fixes #8173


#### Description of how you validated changes
- add a tiny unit test, run yarn run test --scope @aws-amplify/ui-components
- test the customer [repro](https://github.com/ctjlewis/aws-amplify-test/commit/00cbf31cb5dc900b50004e11909fa7166e5a4cb6)


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
