### PR TITLE
#8205 Makes conversion of 'true' string to boolean for user attributes case insensitive

### DIFF
--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -3089,7 +3089,7 @@ describe('auth unit test', () => {
 			spyon.mockClear();
 		});
 
-		test('happy case with unverified', async () => {
+		test('happy case with verified', async () => {
 			const spyon = jest
 				.spyOn(Auth.prototype, 'userAttributes')
 				.mockImplementationOnce(() => {
@@ -3110,6 +3110,46 @@ describe('auth unit test', () => {
 							{
 								Name: 'phone_number_verified',
 								Value: true,
+							},
+						]);
+					});
+				});
+
+			const auth = new Auth(authOptions);
+			const user = new CognitoUser({
+				Username: 'username',
+				Pool: userPool,
+			});
+
+			expect(await auth.verifiedContact(user)).toEqual({
+				unverified: {},
+				verified: { email: 'email@amazon.com', phone_number: '+12345678901' },
+			});
+
+			spyon.mockClear();
+		});
+
+		test('happy case with verified as strings', async () => {
+			const spyon = jest
+				.spyOn(Auth.prototype, 'userAttributes')
+				.mockImplementationOnce(() => {
+					return new Promise((res: any, rej) => {
+						res([
+							{
+								Name: 'email',
+								Value: 'email@amazon.com',
+							},
+							{
+								Name: 'phone_number',
+								Value: '+12345678901',
+							},
+							{
+								Name: 'email_verified',
+								Value: 'true',
+							},
+							{
+								Name: 'phone_number_verified',
+								Value: 'True',
 							},
 						]);
 					});

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -2137,14 +2137,17 @@ export class AuthClass {
 					attribute.Name === 'email_verified' ||
 					attribute.Name === 'phone_number_verified'
 				) {
-					obj[attribute.Name] =
-						attribute.Value === 'true' || attribute.Value === true;
+					obj[attribute.Name] = this.isTruthyString(attribute.Value) || attribute.Value === true;
 				} else {
 					obj[attribute.Name] = attribute.Value;
 				}
 			});
 		}
 		return obj;
+	}
+
+	private isTruthyString(value: any): boolean {
+		return typeof value.toLowerCase === 'function' && value.toLowerCase() === 'true';
 	}
 
 	private createCognitoUser(username: string): CognitoUser {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Ignores case when converting a string representing a boolean in user attributes to a boolean value. This allows the user attributes `email_verified` and `phone_number_verified` to have the value `True` written in Cognito without breaking the sign in flow.

#### Issue #, if available
[8205](https://github.com/aws-amplify/amplify-js/issues/8205)



#### Description of how you validated changes
I validated the changes by adding unit tests.


#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
