### PR TITLE
Add configuration for duplicate-packages integ tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -725,6 +725,23 @@ jobs:
           spec: << parameters.scenario >>
           browser: firefox
 
+  integ_duplicate_packages:
+    parameters:
+      browser:
+        type: string
+    executor: js-test-executor
+    <<: *test_env_vars
+    working_directory: ~/amplify-js-samples-staging/samples/react/version-conflict/duplicate-packages
+    steps:
+      - prepare_test_env
+      - integ_test_js:
+          test_name: 'Duplicate Package Errors'
+          framework: react
+          category: version-conflict
+          sample_name: duplicate-packages
+          spec: duplicate-packages
+          browser: << parameters.browser >>
+
   deploy:
     executor: macos-executor
     working_directory: ~/amplify-js
@@ -771,6 +788,7 @@ releasable_branches: &releasable_branches
       - ui-components/main
       - 1.0-stable
       - native
+      - version-upgrade-circle
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]
@@ -971,6 +989,15 @@ workflows:
           matrix:
             parameters:
               <<: *datastore_auth_scenarios
+      - integ_duplicate_packages:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+          matrix:
+            parameters:
+              <<: *test_browsers
       - deploy:
           filters:
             <<: *releasable_branches
@@ -995,6 +1022,7 @@ workflows:
             - integ_rn_android_storage
             - integ_rn_android_storage_multipart_progress
             - integ_datastore_auth
+            - integ_duplicate_packages
       - post_release:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -788,7 +788,6 @@ releasable_branches: &releasable_branches
       - ui-components/main
       - 1.0-stable
       - native
-      - version-upgrade-circle
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Configures CircleCI to run new integration tests used to capture various errors caused by duplicate packages. Please see [docs PR 3215](https://github.com/aws-amplify/docs/pull/3135) and [js PR 8083](https://github.com/aws-amplify/amplify-js/pull/8083) for documentation regarding this error.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
[docs PR 3215](https://github.com/aws-amplify/docs/pull/3135)
[js PR 8083](https://github.com/aws-amplify/amplify-js/pull/8083)

#### Description of how you validated changes
Ran an integration test workflow in our CircleCI pipeline to ensure config changes properly run the `duplicate-packages` Cypress tests:
https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/7763/workflows/8240bb12-7cca-49eb-9c9f-9890116371cc

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- ~Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)~
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
