### PR TITLE
correct the unmount lifecyle for amplify-authenticator

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
@@ -206,7 +206,7 @@ export class AmplifyAuthenticator {
 		return <slot name={slotName}>{slotIsEmpty && authComponent}</slot>;
 	}
 
-	componentWillUnload() {
+	disconnectedCallback() {
 		Hub.remove(AUTH_CHANNEL, this.handleExternalAuthEvent);
 		if (!this.hideToast) Hub.remove(UI_AUTH_CHANNEL, this.handleToastEvent);
 		return onAuthUIStateChange;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fix the memory leak issue by using the correct lifecycle method to remove event listener when component is unmounted from DOM.

It seems there is no such lifecycle hook called `componentWillUnload`. Based on the stencil doc https://stenciljs.com/docs/component-lifecycle#disconnectedcallback, it should be `disconnectedCallback`.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Fixes #6840


#### Description of how you validated changes
- run it locally to see the lifecycle is called and `handleExternalAuthEvent` is being removed from Hub, and thus fix the memory leak issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
