### PR TITLE
fix(@aws-amplify/datastore): log subscription error instead of throwing

### DIFF
--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -466,6 +466,7 @@ class SubscriptionProcessor {
 															}`
 														);
 														logger.warn(message);
+														return;
 													} else {
 														logger.debug(
 															`${operation} subscription failed with authMode: ${

--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -465,7 +465,7 @@ class SubscriptionProcessor {
 																]
 															}`
 														);
-														throw message;
+														logger.warn(message);
 													} else {
 														logger.debug(
 															`${operation} subscription failed with authMode: ${


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
When a subscription fails to connect due to an authorization error, we don't need to throw an error since the subscription cleanup is already taking place and there is no place for a customer to catch this error directly. Instead, we can just log a warning with the message to let the developer know that the authorization failed.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
