### PR TITLE
fix(@aws-amplify/datastore): updates with composite keys

### DIFF
--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -48,6 +48,14 @@ export declare class Profile {
 	public readonly lastName: string;
 }
 
+export declare class PostComposite {
+	public readonly id: string;
+	public readonly title: string;
+	public readonly description: string;
+	public readonly created: string;
+	public readonly sort: number;
+}
+
 export function testSchema(): Schema {
 	return {
 		enums: {},
@@ -295,6 +303,68 @@ export function testSchema(): Schema {
 					{
 						type: 'model',
 						properties: {},
+					},
+				],
+			},
+			PostComposite: {
+				name: 'PostComposite',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					title: {
+						name: 'title',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					description: {
+						name: 'description',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					created: {
+						name: 'created',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					sort: {
+						name: 'sort',
+						isArray: false,
+						type: 'Int',
+						isRequired: false,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'PostComposites',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							name: 'titleSort',
+							fields: ['title', 'created', 'sort'],
+						},
+					},
+					{
+						type: 'key',
+						properties: {
+							name: 'descSort',
+							fields: ['description', 'created', 'sort'],
+						},
 					},
 				],
 			},

--- a/packages/datastore/__tests__/storage.test.ts
+++ b/packages/datastore/__tests__/storage.test.ts
@@ -4,7 +4,7 @@ import {
 	initSchema as initSchemaType,
 } from '../src/datastore/datastore';
 import { PersistentModelConstructor } from '../src/types';
-import { Model, Post, Comment, testSchema } from './helpers';
+import { Model, Post, Comment, PostComposite, testSchema } from './helpers';
 
 let initSchema: typeof initSchemaType;
 let DataStore: typeof DataStoreType;
@@ -434,6 +434,75 @@ describe('Storage tests', () => {
 
 				expect(commentSave.element.postId).toEqual(post.id);
 				expect(commentUpdate.element.postId).toEqual(anotherPost.id);
+			});
+
+			test('composite key', async () => {
+				const classes = initSchema(testSchema());
+
+				// model has 2 composite keys defined
+				// @key(name: "titleSort", fields: ["title", "created", "sort"])
+				// @key(name: "descSort", fields: ["description", "created", "sort"])
+
+				// updating any of the fields that comprise the composite key should
+				// include all of the other fields in that key
+
+				// if a field is in multiple composite keys (e.g., sort above)
+				// we should include all of the fields from all of the keys that
+				// fields is part of (sort updated => sort, title, created, description are included)
+				const { PostComposite } = classes as {
+					PostComposite: PersistentModelConstructor<PostComposite>;
+				};
+
+				const createdTimestamp = String(Date.now());
+
+				const post = await DataStore.save(
+					new PostComposite({
+						title: 'New Post',
+						description: 'Desc',
+						created: createdTimestamp,
+						sort: 100,
+					})
+				);
+
+				const updated1 = await DataStore.save(
+					PostComposite.copyOf(post, updated => {
+						updated.title = 'Updated';
+					})
+				);
+
+				const updated2 = await DataStore.save(
+					PostComposite.copyOf(updated1, updated => {
+						updated.description = 'Updated Desc';
+					})
+				);
+
+				await DataStore.save(
+					PostComposite.copyOf(updated2, updated => {
+						updated.sort = 101;
+					})
+				);
+
+				const [
+					[_post1Save],
+					[postUpdate],
+					[postUpdate2],
+					[postUpdate3],
+				] = zenNext.mock.calls;
+
+				expect(postUpdate.element.title).toEqual('Updated');
+				expect(postUpdate.element.created).toEqual(createdTimestamp);
+				expect(postUpdate.element.sort).toEqual(100);
+				expect(postUpdate.element.description).toBeUndefined();
+
+				expect(postUpdate2.element.description).toEqual('Updated Desc');
+				expect(postUpdate2.element.created).toEqual(createdTimestamp);
+				expect(postUpdate2.element.sort).toEqual(100);
+				expect(postUpdate2.element.title).toBeUndefined();
+
+				expect(postUpdate3.element.created).toEqual(createdTimestamp);
+				expect(postUpdate3.element.sort).toEqual(101);
+				expect(postUpdate3.element.title).toEqual('Updated');
+				expect(postUpdate3.element.description).toEqual('Updated Desc');
 			});
 		});
 	});

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -318,9 +318,9 @@ class StorageClass implements StorageFacade {
 		const modelConstructor = Object.getPrototypeOf(model)
 			.constructor as PersistentModelConstructor<T>;
 		const namespace = this.namespaceResolver(modelConstructor);
-		const { fields } = this.schema.namespaces[namespace].models[
-			modelConstructor.name
-		];
+		const { fields, compositeKeys = {} } = this.schema.namespaces[
+			namespace
+		].models[modelConstructor.name];
 		// set original values for these fields
 		updatedFields.forEach((field: string) => {
 			const targetName: any = isTargetNameAssociation(
@@ -333,6 +333,13 @@ class StorageClass implements StorageFacade {
 			// check field values by value. Ignore unchanged fields
 			if (!valuesEqual(source[key], originalElement[key])) {
 				updatedElement[key] = originalElement[key];
+
+				if (key in compositeKeys) {
+					// include all of the fields that comprise the composite key
+					for (const compositeField of compositeKeys[key]) {
+						updatedElement[compositeField] = originalElement[compositeField];
+					}
+				}
 			}
 		});
 

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -40,6 +40,9 @@ export type SchemaModel = {
 	attributes?: ModelAttributes;
 	fields: ModelFields;
 	syncable?: boolean;
+	compositeKeys?: {
+		[key: string]: string[];
+	};
 };
 export function isSchemaModel(obj: any): obj is SchemaModel {
 	return obj && (<SchemaModel>obj).pluralName !== undefined;
@@ -77,6 +80,55 @@ export function isTargetNameAssociation(
 
 type ModelAttributes = ModelAttribute[];
 type ModelAttribute = { type: string; properties?: Record<string, any> };
+
+type ModelAttributePrimaryKey = {
+	type: 'key';
+	properties: {
+		fields: string[];
+	};
+};
+
+type ModelAttributeCompositeKey = {
+	type: 'key';
+	properties: {
+		name?: string;
+		fields: [
+			string,
+			string,
+			string,
+			string?,
+			string?,
+			string?,
+			string?,
+			string?,
+			string?,
+			string?
+		];
+	};
+};
+
+export function isModelAttributePrimaryKey(
+	attr: ModelAttribute
+): attr is ModelAttributePrimaryKey {
+	return (
+		attr.type === 'key' &&
+		attr.properties &&
+		attr.properties.name === undefined &&
+		attr.properties.fields &&
+		attr.properties.fields.length > 0
+	);
+}
+
+export function isModelAttributeCompositeKey(
+	attr: ModelAttribute
+): attr is ModelAttributeCompositeKey {
+	return (
+		attr.type === 'key' &&
+		attr.properties &&
+		attr.properties.fields &&
+		attr.properties.fields.length > 2
+	);
+}
 
 export type ModelAttributeAuthProperty = {
 	allow: ModelAttributeAuthAllow;

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -92,18 +92,7 @@ type ModelAttributeCompositeKey = {
 	type: 'key';
 	properties: {
 		name?: string;
-		fields: [
-			string,
-			string,
-			string,
-			string?,
-			string?,
-			string?,
-			string?,
-			string?,
-			string?,
-			string?
-		];
+		fields: [string, string, string, string?, string?];
 	};
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Include all fields that comprise a composite key in the update mutation request input if any of those fields was changed

For example:
```gql
type Post
  @model
  @key(name: "titleSort", fields: ["title", "created", "sort"]) {
  id: ID!
  title: String!
  description: String
  created: String
  sort: Int
}
```

Performing the following update:

```js
await DataStore.save(Post.copyOf(post, updated => {
  updated.title = 'Updated';
}));
```

Should include `title`, `created`, and `sort` in the GraphQL mutation input even though the latter 2 fields are unchanged.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#7714 



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
~- [ ] Relevant documentation is changed or added (and PR referenced)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
