### PR TITLE
chore(release): major version [ci skip]

### DIFF
--- a/packages/amplify-ui-storybook/package.json
+++ b/packages/amplify-ui-storybook/package.json
@@ -10,7 +10,7 @@
 		"@types/node": "^12.0.0",
 		"@types/react": "^16.9.0",
 		"@types/react-dom": "^16.9.0",
-		"aws-amplify": "3.4.1",
+		"aws-amplify": "4.0.0",
 		"react": "^16.12.0",
 		"react-app-polyfill": "^1.0.6",
 		"react-dom": "^16.12.0",

--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -39,7 +39,7 @@
 		"@types/zen-observable": "^0.5.3",
 		"angular2-template-loader": "^0.6.2",
 		"awesome-typescript-loader": "^4.0.1",
-		"aws-amplify": "3.4.1",
+		"aws-amplify": "4.0.0",
 		"babel-core": "^6.26.3",
 		"babel-plugin-lodash": "^3.3.4",
 		"babel-preset-env": "^1.7.0",

--- a/packages/aws-amplify-react/package.json
+++ b/packages/aws-amplify-react/package.json
@@ -38,7 +38,7 @@
 		"@types/enzyme-adapter-react-16": "^1.0.3",
 		"@types/react": "^16.0.41",
 		"@types/react-dom": "^16.0.11",
-		"aws-amplify": "3.4.1",
+		"aws-amplify": "4.0.0",
 		"enzyme": "^3.1.0",
 		"enzyme-adapter-react-16": "^1.0.3",
 		"enzyme-to-json": "^3.2.1",

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-amplify",
-  "version": "3.4.1",
+  "version": "4.0.0",
   "description": "AWS Amplify is a JavaScript library for Frontend and mobile developers building cloud-enabled applications.",
   "main": "./lib/index.js",
   "module": "./lib-esm/index.js",


### PR DESCRIPTION
Merging release back into main after doing a manual `publish` that correctly bumps the major version of aws-amplify. 
(the version had failed to bump correctly in CI)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
