### PR TITLE
chore(aws-amplify-react-native)!: bump amplify peerDep to 4.x.x

### DIFF
--- a/packages/aws-amplify-react-native/package.json
+++ b/packages/aws-amplify-react-native/package.json
@@ -31,7 +31,7 @@
 		"buffer": "^5.2.1"
 	},
 	"peerDependencies": {
-		"aws-amplify": "3.x.x",
+		"aws-amplify": "4.x.x",
 		"graphql": "^14.0.0"
 	},
 	"repository": {


### PR DESCRIPTION
BREAKING CHANGE: bumping peer dep to a new major version containing breaking change for RN

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
