### PR TITLE
feat(@aws-amplify/datastore): include custom pk in update/delete mutations

### DIFF
--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -48,12 +48,19 @@ export declare class Profile {
 	public readonly lastName: string;
 }
 
-export declare class PostComposite {
+export declare class PostKeys {
 	public readonly id: string;
 	public readonly title: string;
 	public readonly description: string;
 	public readonly created: string;
 	public readonly sort: number;
+}
+
+export declare class PostCustomPK {
+	public readonly id: string;
+	public readonly postId: number;
+	public readonly title: string;
+	public readonly description?: string;
 }
 
 export function testSchema(): Schema {
@@ -306,8 +313,8 @@ export function testSchema(): Schema {
 					},
 				],
 			},
-			PostComposite: {
-				name: 'PostComposite',
+			PostKeys: {
+				name: 'PostKeys',
 				fields: {
 					id: {
 						name: 'id',
@@ -346,7 +353,7 @@ export function testSchema(): Schema {
 					},
 				},
 				syncable: true,
-				pluralName: 'PostComposites',
+				pluralName: 'PostKeys',
 				attributes: [
 					{
 						type: 'model',
@@ -355,7 +362,7 @@ export function testSchema(): Schema {
 					{
 						type: 'key',
 						properties: {
-							name: 'titleSort',
+							name: 'titleCreatedSort',
 							fields: ['title', 'created', 'sort'],
 						},
 					},
@@ -363,7 +370,54 @@ export function testSchema(): Schema {
 						type: 'key',
 						properties: {
 							name: 'descSort',
-							fields: ['description', 'created', 'sort'],
+							fields: ['description', 'sort'],
+						},
+					},
+				],
+			},
+			PostCustomPK: {
+				name: 'PostCustomPK',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					postId: {
+						name: 'postId',
+						isArray: false,
+						type: 'Int',
+						isRequired: true,
+						attributes: [],
+					},
+					title: {
+						name: 'title',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					description: {
+						name: 'description',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'PostCustomPKS',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							fields: ['postId'],
 						},
 					},
 				],

--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -48,7 +48,7 @@ export declare class Profile {
 	public readonly lastName: string;
 }
 
-export declare class PostKeys {
+export declare class PostComposite {
 	public readonly id: string;
 	public readonly title: string;
 	public readonly description: string;
@@ -61,6 +61,20 @@ export declare class PostCustomPK {
 	public readonly postId: number;
 	public readonly title: string;
 	public readonly description?: string;
+}
+
+export declare class PostCustomPKSort {
+	public readonly id: string;
+	public readonly postId: number;
+	public readonly title: string;
+	public readonly description?: string;
+}
+export declare class PostCustomPKComposite {
+	public readonly id: string;
+	public readonly postId: number;
+	public readonly title: string;
+	public readonly description?: string;
+	public readonly sort: number;
 }
 
 export function testSchema(): Schema {
@@ -313,8 +327,8 @@ export function testSchema(): Schema {
 					},
 				],
 			},
-			PostKeys: {
-				name: 'PostKeys',
+			PostComposite: {
+				name: 'PostComposite',
 				fields: {
 					id: {
 						name: 'id',
@@ -353,7 +367,7 @@ export function testSchema(): Schema {
 					},
 				},
 				syncable: true,
-				pluralName: 'PostKeys',
+				pluralName: 'PostComposites',
 				attributes: [
 					{
 						type: 'model',
@@ -364,13 +378,6 @@ export function testSchema(): Schema {
 						properties: {
 							name: 'titleCreatedSort',
 							fields: ['title', 'created', 'sort'],
-						},
-					},
-					{
-						type: 'key',
-						properties: {
-							name: 'descSort',
-							fields: ['description', 'sort'],
 						},
 					},
 				],
@@ -418,6 +425,107 @@ export function testSchema(): Schema {
 						type: 'key',
 						properties: {
 							fields: ['postId'],
+						},
+					},
+				],
+			},
+			PostCustomPKSort: {
+				name: 'PostCustomPKSort',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					postId: {
+						name: 'postId',
+						isArray: false,
+						type: 'Int',
+						isRequired: true,
+						attributes: [],
+					},
+					title: {
+						name: 'title',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					description: {
+						name: 'description',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'PostCustomPKSorts',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							fields: ['id', 'postId'],
+						},
+					},
+				],
+			},
+			PostCustomPKComposite: {
+				name: 'PostCustomPKComposite',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					postId: {
+						name: 'postId',
+						isArray: false,
+						type: 'Int',
+						isRequired: true,
+						attributes: [],
+					},
+					title: {
+						name: 'title',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					description: {
+						name: 'description',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					sort: {
+						name: 'sort',
+						isArray: false,
+						type: 'Int',
+						isRequired: true,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'PostCustomPKComposites',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							fields: ['id', 'postId', 'sort'],
 						},
 					},
 				],

--- a/packages/datastore/__tests__/mutation.test.ts
+++ b/packages/datastore/__tests__/mutation.test.ts
@@ -87,7 +87,7 @@ describe('MutationProcessor', () => {
 				'{}'
 			);
 
-			expect(input.id).not.toBeUndefined();
+			expect(input.id).toEqual(deletePost.id);
 			expect(input.postId).toEqual(100);
 		});
 	});

--- a/packages/datastore/__tests__/storage.test.ts
+++ b/packages/datastore/__tests__/storage.test.ts
@@ -8,8 +8,10 @@ import {
 	Model,
 	Post,
 	Comment,
-	PostKeys,
+	PostComposite,
 	PostCustomPK,
+	PostCustomPKSort,
+	PostCustomPKComposite,
 	testSchema,
 } from './helpers';
 
@@ -458,12 +460,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [
-					[_post1Save],
-					[commentSave],
-					[_post2Save],
-					[commentUpdate],
-				] = zenNext.mock.calls;
+				const [, [commentSave], , [commentUpdate]] = zenNext.mock.calls;
 
 				expect(commentSave.element.postId).toEqual(post.id);
 				expect(commentUpdate.element.postId).toEqual(anotherPost.id);
@@ -471,25 +468,22 @@ describe('Storage tests', () => {
 
 			test('composite key', async () => {
 				const classes = initSchema(testSchema());
-
-				// model has 2 keys defined (1: composite & 2: hk + sort)
+				// model has a GSI with a composite key defined:
 				// @key(name: "titleSort", fields: ["title", "created", "sort"])
-				// @key(name: "descSort", fields: ["description", "sort"])
 
-				// updating any of the fields that comprise a key should
-				// include all of the other fields in that key
+				// updating any of the fields that comprise the sort portion of the composite key [1..n]
+				// should include all of the other fields in that key
 
-				// if a field is in multiple keys (e.g., sort above)
-				// we should include all of the fields from all of the keys that
-				// fields is part of (sort updated => sort, title, created, description are included)
-				const { PostKeys } = classes as {
-					PostKeys: PersistentModelConstructor<PostKeys>;
+				// updating the hash key [0] should NOT include the other fields in that key
+
+				const { PostComposite } = classes as {
+					PostComposite: PersistentModelConstructor<PostComposite>;
 				};
 
 				const createdTimestamp = String(Date.now());
 
 				const post = await DataStore.save(
-					new PostKeys({
+					new PostComposite({
 						title: 'New Post',
 						description: 'Desc',
 						created: createdTimestamp,
@@ -497,44 +491,48 @@ describe('Storage tests', () => {
 					})
 				);
 
+				// `sort` is part of the key's composite sort key.
+				// `created` should also be included in the mutation input
 				const updated1 = await DataStore.save(
-					PostKeys.copyOf(post, updated => {
-						updated.title = 'Updated';
-					})
-				);
-
-				const updated2 = await DataStore.save(
-					PostKeys.copyOf(updated1, updated => {
-						updated.description = 'Updated Desc';
-					})
-				);
-
-				await DataStore.save(
-					PostKeys.copyOf(updated2, updated => {
+					PostComposite.copyOf(post, updated => {
 						updated.sort = 101;
 					})
 				);
 
+				// `title` is the HK, so `sort` and `created` should NOT be included in the input
+				const updated2 = await DataStore.save(
+					PostComposite.copyOf(updated1, updated => {
+						updated.title = 'Updated Title';
+					})
+				);
+
+				// `description` does not belong to a key. No other fields should be included
+				await DataStore.save(
+					PostComposite.copyOf(updated2, updated => {
+						updated.description = 'Updated Desc';
+					})
+				);
+
 				const [
-					[_post1Save],
-					[postUpdate],
+					,
+					[postUpdate1],
 					[postUpdate2],
 					[postUpdate3],
 				] = zenNext.mock.calls;
 
-				expect(postUpdate.element.title).toEqual('Updated');
-				expect(postUpdate.element.created).toEqual(createdTimestamp);
-				expect(postUpdate.element.sort).toEqual(100);
-				expect(postUpdate.element.description).toBeUndefined();
+				expect(postUpdate1.element.title).toBeUndefined();
+				expect(postUpdate1.element.created).toEqual(createdTimestamp);
+				expect(postUpdate1.element.sort).toEqual(101);
+				expect(postUpdate1.element.description).toBeUndefined();
 
-				expect(postUpdate2.element.description).toEqual('Updated Desc');
-				expect(postUpdate2.element.sort).toEqual(100);
+				expect(postUpdate2.element.title).toEqual('Updated Title');
 				expect(postUpdate2.element.created).toBeUndefined();
-				expect(postUpdate2.element.title).toBeUndefined();
+				expect(postUpdate2.element.sort).toBeUndefined();
+				expect(postUpdate2.element.description).toBeUndefined();
 
-				expect(postUpdate3.element.created).toEqual(createdTimestamp);
-				expect(postUpdate3.element.sort).toEqual(101);
-				expect(postUpdate3.element.title).toEqual('Updated');
+				expect(postUpdate3.element.title).toBeUndefined();
+				expect(postUpdate3.element.created).toBeUndefined();
+				expect(postUpdate3.element.sort).toBeUndefined();
 				expect(postUpdate3.element.description).toEqual('Updated Desc');
 			});
 
@@ -561,9 +559,73 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[_post1Save], [postUpdate]] = zenNext.mock.calls;
+				const [, [postUpdate]] = zenNext.mock.calls;
 
 				expect(postUpdate.element.postId).toEqual(100);
+				expect(postUpdate.element.title).toEqual('Updated');
+				expect(postUpdate.element.description).toBeUndefined();
+			});
+
+			test('custom pk - with sort', async () => {
+				const classes = initSchema(testSchema());
+
+				// model has a custom pk (hk + sort key) defined via @key(fields: ["id", "postId"])
+				// all of the fields in the PK should always be included in the mutation input
+				const { PostCustomPKSort } = classes as {
+					PostCustomPKSort: PersistentModelConstructor<PostCustomPKSort>;
+				};
+
+				const post = await DataStore.save(
+					new PostCustomPKSort({
+						postId: 100,
+						title: 'New Post',
+						description: 'Desc',
+					})
+				);
+
+				await DataStore.save(
+					PostCustomPKSort.copyOf(post, updated => {
+						updated.title = 'Updated';
+					})
+				);
+
+				const [, [postUpdate]] = zenNext.mock.calls;
+
+				expect(postUpdate.element.postId).toEqual(100);
+				expect(postUpdate.element.title).toEqual('Updated');
+				expect(postUpdate.element.description).toBeUndefined();
+			});
+
+			test('custom pk - with composite', async () => {
+				const classes = initSchema(testSchema());
+
+				// model has a custom pk (hk + composite key) defined via @key(fields: ["id", "postId", "sort"])
+				// all of the fields in the PK should always be included in the mutation input
+				const { PostCustomPKComposite } = classes as {
+					PostCustomPKComposite: PersistentModelConstructor<
+						PostCustomPKComposite
+					>;
+				};
+
+				const post = await DataStore.save(
+					new PostCustomPKComposite({
+						postId: 100,
+						title: 'New Post',
+						description: 'Desc',
+						sort: 1,
+					})
+				);
+
+				await DataStore.save(
+					PostCustomPKComposite.copyOf(post, updated => {
+						updated.title = 'Updated';
+					})
+				);
+
+				const [, [postUpdate]] = zenNext.mock.calls;
+
+				expect(postUpdate.element.postId).toEqual(100);
+				expect(postUpdate.element.sort).toEqual(1);
 				expect(postUpdate.element.title).toEqual('Updated');
 				expect(postUpdate.element.description).toBeUndefined();
 			});

--- a/packages/datastore/__tests__/util.test.ts
+++ b/packages/datastore/__tests__/util.test.ts
@@ -279,6 +279,95 @@ describe('datastore util', () => {
 		expected = [new Set(['a', 'b', 'c', 'd', 'x', 'y', 'z'])];
 
 		expect(processCompositeKeys(attributes)).toEqual(expected);
+
+		attributes = [
+			{
+				type: 'key',
+				properties: {
+					name: '1',
+					fields: ['hk', 'a', 'b', 'c'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '2',
+					fields: ['hk', 'a', 'b', 'd'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '3',
+					fields: ['hk', 'x', 'y', 'z'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '4',
+					fields: ['hk', '1', '2', '3'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '5',
+					fields: ['hk', 'a', 'x'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '6',
+					fields: ['hk', 'l', 'm', 'n'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '7',
+					fields: ['hk', '8', '9', '10'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '8',
+					fields: ['hk', 'a', 'y'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '9',
+					fields: ['hk', 'h', 'j', 'k'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '10',
+					fields: ['hk', '9', '3'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '11',
+					fields: ['hk', 'h', 'r', 'q'],
+				},
+			},
+		];
+
+		expected = [
+			new Set(['a', 'b', 'c', 'd', 'x', 'y', 'z']),
+			new Set(['1', '2', '3', '9', '8', '10']),
+			new Set(['l', 'm', 'n']),
+			new Set(['h', 'j', 'k', 'r', 'q']),
+		];
+
+		expect(processCompositeKeys(attributes)).toEqual(expected);
 	});
 
 	test('isAWSDate', () => {

--- a/packages/datastore/__tests__/util.test.ts
+++ b/packages/datastore/__tests__/util.test.ts
@@ -10,25 +10,43 @@ import {
 	isAWSIPAddress,
 	validatePredicateField,
 	valuesEqual,
+	processCompositeKeys,
 } from '../src/util';
 
 describe('datastore util', () => {
-
 	test('validatePredicateField', () => {
-		expect(validatePredicateField(undefined, 'contains', 'test')).toEqual(false);
+		expect(validatePredicateField(undefined, 'contains', 'test')).toEqual(
+			false
+		);
 		expect(validatePredicateField(null, 'contains', 'test')).toEqual(false);
-		expect(validatePredicateField('some test', 'contains', 'test')).toEqual(true);
+		expect(validatePredicateField('some test', 'contains', 'test')).toEqual(
+			true
+		);
 
-		expect(validatePredicateField(undefined, 'beginsWith', 'test')).toEqual(false);
+		expect(validatePredicateField(undefined, 'beginsWith', 'test')).toEqual(
+			false
+		);
 		expect(validatePredicateField(null, 'beginsWith', 'test')).toEqual(false);
-		expect(validatePredicateField('some test', 'beginsWith', 'test')).toEqual(false);
-		expect(validatePredicateField('testing', 'beginsWith', 'test')).toEqual(true);
+		expect(validatePredicateField('some test', 'beginsWith', 'test')).toEqual(
+			false
+		);
+		expect(validatePredicateField('testing', 'beginsWith', 'test')).toEqual(
+			true
+		);
 
-		expect(validatePredicateField(undefined, 'notContains', 'test')).toEqual(true);
+		expect(validatePredicateField(undefined, 'notContains', 'test')).toEqual(
+			true
+		);
 		expect(validatePredicateField(null, 'notContains', 'test')).toEqual(true);
-		expect(validatePredicateField('abcdef', 'notContains', 'test')).toEqual(true);
-		expect(validatePredicateField('test', 'notContains', 'test')).toEqual(false);
-		expect(validatePredicateField('testing', 'notContains', 'test')).toEqual(false);
+		expect(validatePredicateField('abcdef', 'notContains', 'test')).toEqual(
+			true
+		);
+		expect(validatePredicateField('test', 'notContains', 'test')).toEqual(
+			false
+		);
+		expect(validatePredicateField('testing', 'notContains', 'test')).toEqual(
+			false
+		);
 	});
 
 	test('valuesEqual', () => {
@@ -121,6 +139,146 @@ describe('datastore util', () => {
 		expect(valuesEqual(true, true)).toEqual(true);
 		expect(valuesEqual(true, false)).toEqual(false);
 		expect(valuesEqual(true, true, true)).toEqual(true);
+	});
+
+	test('processCompositeKeys', () => {
+		let attributes = [
+			{
+				type: 'model',
+				properties: {},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '1',
+					fields: ['hk', 'a'],
+				},
+			},
+		];
+
+		let expected = [];
+
+		expect(processCompositeKeys(attributes)).toEqual(expected);
+
+		attributes = [
+			{
+				type: 'model',
+				properties: {},
+			},
+		];
+
+		expected = [];
+
+		expect(processCompositeKeys(attributes)).toEqual(expected);
+
+		attributes = [
+			{
+				type: 'model',
+				properties: {},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '1',
+					fields: ['hk', 'a', 'b'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '2',
+					fields: ['hk', 'a', 'b'],
+				},
+			},
+		];
+
+		expected = [new Set(['a', 'b'])];
+
+		expect(processCompositeKeys(attributes)).toEqual(expected);
+
+		attributes = [
+			{
+				type: 'key',
+				properties: {
+					name: '1',
+					fields: ['hk', 'a', 'b', 'c'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '2',
+					fields: ['hk', 'a', 'b', 'd'],
+				},
+			},
+		];
+
+		expected = [new Set(['a', 'b', 'c', 'd'])];
+
+		expect(processCompositeKeys(attributes)).toEqual(expected);
+
+		attributes = [
+			{
+				type: 'key',
+				properties: {
+					name: '1',
+					fields: ['hk', 'a', 'b', 'c'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '2',
+					fields: ['hk', 'a', 'b', 'd'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '3',
+					fields: ['hk', 'x', 'y', 'z'],
+				},
+			},
+		];
+
+		expected = [new Set(['a', 'b', 'c', 'd']), new Set(['x', 'y', 'z'])];
+
+		expect(processCompositeKeys(attributes)).toEqual(expected);
+
+		attributes = [
+			{
+				type: 'key',
+				properties: {
+					name: '1',
+					fields: ['hk', 'a', 'b', 'c'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '2',
+					fields: ['hk', 'a', 'b', 'd'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '3',
+					fields: ['hk', 'x', 'y', 'z'],
+				},
+			},
+			{
+				type: 'key',
+				properties: {
+					name: '4',
+					fields: ['hk', 'a', 'x'],
+				},
+			},
+		];
+
+		expected = [new Set(['a', 'b', 'c', 'd', 'x', 'y', 'z'])];
+
+		expect(processCompositeKeys(attributes)).toEqual(expected);
 	});
 
 	test('isAWSDate', () => {

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -52,7 +52,7 @@ import {
 } from '../types';
 import {
 	DATASTORE,
-	establishRelation,
+	establishRelationAndKeys,
 	exhaustiveCheck,
 	isModelConstructor,
 	monotonicUlidFactory,
@@ -157,9 +157,12 @@ const initSchema = (userSchema: Schema) => {
 	};
 
 	Object.keys(schema.namespaces).forEach(namespace => {
-		schema.namespaces[namespace].relationships = establishRelation(
+		const [relations, keys] = establishRelationAndKeys(
 			schema.namespaces[namespace]
 		);
+
+		schema.namespaces[namespace].relationships = relations;
+		schema.namespaces[namespace].keys = keys;
 
 		const modelAssociations = new Map<string, string[]>();
 

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -321,7 +321,6 @@ class StorageClass implements StorageFacade {
 		const { fields } = this.schema.namespaces[namespace].models[
 			modelConstructor.name
 		];
-
 		const { primaryKey, compositeKeys = {} } = this.schema.namespaces[
 			namespace
 		].keys[modelConstructor.name];

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -321,7 +321,7 @@ class StorageClass implements StorageFacade {
 		const { fields } = this.schema.namespaces[namespace].models[
 			modelConstructor.name
 		];
-		const { primaryKey, compositeKeys = {} } = this.schema.namespaces[
+		const { primaryKey, compositeKeys = [] } = this.schema.namespaces[
 			namespace
 		].keys[modelConstructor.name];
 
@@ -340,10 +340,12 @@ class StorageClass implements StorageFacade {
 				updatedElement[key] =
 					originalElement[key] === undefined ? null : originalElement[key];
 
-				if (key in compositeKeys) {
+				for (const fieldSet of compositeKeys) {
 					// include all of the fields that comprise the composite key
-					for (const compositeField of compositeKeys[key]) {
-						updatedElement[compositeField] = originalElement[compositeField];
+					if (fieldSet.has(key)) {
+						for (const compositeField of fieldSet) {
+							updatedElement[compositeField] = originalElement[compositeField];
+						}
 					}
 				}
 			}

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -428,7 +428,7 @@ class MutationProcessor {
 
 		// include all the fields that comprise a custom PK if one is specified
 		const deleteInput = {};
-		if (primaryKey) {
+		if (primaryKey && primaryKey.length) {
 			for (const pkField of primaryKey) {
 				deleteInput[pkField] = parsedData[pkField];
 			}

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -416,6 +416,7 @@ class MutationProcessor {
 		condition: string
 	): [string, Record<string, any>, GraphQLCondition, string, SchemaModel] {
 		const modelDefinition = this.schema.namespaces[namespaceName].models[model];
+		const { primaryKey } = this.schema.namespaces[namespaceName].keys[model];
 
 		const queriesTuples = this.typeQuery.get(modelDefinition);
 
@@ -424,11 +425,20 @@ class MutationProcessor {
 		);
 
 		const { _version, ...parsedData } = <ModelInstanceMetadata>JSON.parse(data);
-		const pk = modelDefinition.primaryKey ? modelDefinition.primaryKey : 'id';
+
+		// include all the fields that comprise a custom PK if one is specified
+		const deleteInput = {};
+		if (primaryKey) {
+			for (const pkField of primaryKey) {
+				deleteInput[pkField] = parsedData[pkField];
+			}
+		} else {
+			deleteInput['id'] = parsedData.id;
+		}
 
 		const filteredData =
 			operation === TransformerMutationType.DELETE
-				? <ModelInstanceMetadata>{ [pk]: parsedData[pk] } // For DELETE mutations, only PK is sent
+				? <ModelInstanceMetadata>deleteInput // For DELETE mutations, only PK is sent
 				: Object.values(modelDefinition.fields)
 						.filter(({ name, type, association }) => {
 							// connections

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -424,10 +424,11 @@ class MutationProcessor {
 		);
 
 		const { _version, ...parsedData } = <ModelInstanceMetadata>JSON.parse(data);
+		const pk = modelDefinition.primaryKey ? modelDefinition.primaryKey : 'id';
 
 		const filteredData =
 			operation === TransformerMutationType.DELETE
-				? <ModelInstanceMetadata>{ id: parsedData.id } // For DELETE mutations, only ID is sent
+				? <ModelInstanceMetadata>{ [pk]: parsedData[pk] } // For DELETE mutations, only PK is sent
 				: Object.values(modelDefinition.fields)
 						.filter(({ name, type, association }) => {
 							// connections

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -76,7 +76,7 @@ export function isTargetNameAssociation(
 	return obj && obj.targetName;
 }
 
-type ModelAttributes = ModelAttribute[];
+export type ModelAttributes = ModelAttribute[];
 type ModelAttribute = { type: string; properties?: Record<string, any> };
 
 type ModelAttributeKey = {
@@ -572,9 +572,7 @@ export type RelationshipType = {
 //#region Key type
 export type KeyType = {
 	primaryKey?: string[];
-	compositeKeys?: {
-		[key: string]: string[];
-	};
+	compositeKeys?: Set<string>[];
 };
 
 export type ModelKeys = {

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -22,6 +22,7 @@ export type UserSchema = {
 	models: SchemaModels;
 	nonModels?: SchemaNonModels;
 	relationships?: RelationshipType;
+	keys?: ModelKeys;
 	enums: SchemaEnums;
 	modelTopologicalOrdering?: Map<string, string[]>;
 };
@@ -40,10 +41,6 @@ export type SchemaModel = {
 	attributes?: ModelAttributes;
 	fields: ModelFields;
 	syncable?: boolean;
-	primaryKey?: string;
-	modelKeys?: {
-		[key: string]: string[];
-	};
 };
 export function isSchemaModel(obj: any): obj is SchemaModel {
 	return obj && (<SchemaModel>obj).pluralName !== undefined;
@@ -100,7 +97,7 @@ type ModelAttributePrimaryKey = {
 type ModelAttributeCompositeKey = {
 	type: 'key';
 	properties: {
-		name?: string;
+		name: string;
 		fields: [string, string, string, string?, string?];
 	};
 };
@@ -122,10 +119,14 @@ export function isModelAttributePrimaryKey(
 	return isModelAttributeKey(attr) && attr.properties.name === undefined;
 }
 
-export function isModelAttributeKeyWithFields(
+export function isModelAttributeCompositeKey(
 	attr: ModelAttribute
 ): attr is ModelAttributeCompositeKey {
-	return isModelAttributeKey(attr) && attr.properties.fields.length > 1;
+	return (
+		isModelAttributeKey(attr) &&
+		attr.properties.name !== undefined &&
+		attr.properties.fields.length > 2
+	);
 }
 
 export type ModelAttributeAuthProperty = {
@@ -564,6 +565,20 @@ export type RelationType = {
 
 export type RelationshipType = {
 	[modelName: string]: { indexes: string[]; relationTypes: RelationType[] };
+};
+
+//#endregion
+
+//#region Key type
+export type KeyType = {
+	primaryKey?: string[];
+	compositeKeys?: {
+		[key: string]: string[];
+	};
+};
+
+export type ModelKeys = {
+	[modelName: string]: KeyType;
 };
 
 //#endregion

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -40,7 +40,8 @@ export type SchemaModel = {
 	attributes?: ModelAttributes;
 	fields: ModelFields;
 	syncable?: boolean;
-	compositeKeys?: {
+	primaryKey?: string;
+	modelKeys?: {
 		[key: string]: string[];
 	};
 };
@@ -81,6 +82,14 @@ export function isTargetNameAssociation(
 type ModelAttributes = ModelAttribute[];
 type ModelAttribute = { type: string; properties?: Record<string, any> };
 
+type ModelAttributeKey = {
+	type: 'key';
+	properties: {
+		name?: string;
+		fields: string[];
+	};
+};
+
 type ModelAttributePrimaryKey = {
 	type: 'key';
 	properties: {
@@ -96,27 +105,27 @@ type ModelAttributeCompositeKey = {
 	};
 };
 
-export function isModelAttributePrimaryKey(
+export function isModelAttributeKey(
 	attr: ModelAttribute
-): attr is ModelAttributePrimaryKey {
+): attr is ModelAttributeKey {
 	return (
 		attr.type === 'key' &&
 		attr.properties &&
-		attr.properties.name === undefined &&
 		attr.properties.fields &&
 		attr.properties.fields.length > 0
 	);
 }
 
-export function isModelAttributeCompositeKey(
+export function isModelAttributePrimaryKey(
+	attr: ModelAttribute
+): attr is ModelAttributePrimaryKey {
+	return isModelAttributeKey(attr) && attr.properties.name === undefined;
+}
+
+export function isModelAttributeKeyWithFields(
 	attr: ModelAttribute
 ): attr is ModelAttributeCompositeKey {
-	return (
-		attr.type === 'key' &&
-		attr.properties &&
-		attr.properties.fields &&
-		attr.properties.fields.length > 2
-	);
+	return isModelAttributeKey(attr) && attr.properties.fields.length > 1;
 }
 
 export type ModelAttributeAuthProperty = {

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -15,7 +15,6 @@ import {
 	RelationshipType,
 	RelationType,
 	ModelKeys,
-	KeyType,
 	SchemaNamespace,
 	SortPredicatesGroup,
 	SortDirection,

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -210,10 +210,10 @@ export const processCompositeKeys = (
 			return combined;
 		}, []);
 
-	let initial = combineIntersecting(compositeKeyFields);
+	const initial = combineIntersecting(compositeKeyFields);
 	// a single pass pay not be enough to correctly combine all the fields
 	// call the function once more to get a final merged list of sets
-	let combined = combineIntersecting(initial);
+	const combined = combineIntersecting(initial);
 
 	return combined;
 };


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Expands on this PR: https://github.com/aws-amplify/amplify-js/pull/8253

If the model has a custom primary key defined, always include it in the update and delete mutation input.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
N/A


#### Description of how you validated changes
* Added and ran unit tests 
* Validated against sample apps


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
