### PR TITLE
fix(@aws-amplify/ui-vue): exclude external types in tsconfig

### DIFF
--- a/packages/amplify-ui-vue/tsconfig.json
+++ b/packages/amplify-ui-vue/tsconfig.json
@@ -17,7 +17,8 @@
 		"removeComments": false,
 		"sourceMap": true,
 		"jsx": "react",
-		"target": "es2015"
+		"target": "es2015",
+		"types": []
 	},
 	"include": ["src/**/*.ts", "src/**/*.tsx"],
 	"exclude": ["**/__tests__/**"],


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
We're getting a [build error](https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/7921/workflows/020a3b7c-d11e-4075-b47f-71f764afa117/jobs/41430) in this package due to a change in the types of an upstream dependency. Since we're not actually utilizing any of these dependencies in the source of this package, I'm adding `types: []` to ignore the external types when building ui-vue.



#### Description of how you validated changes
* built all the packages in the repo locally without errors


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
