### PR TITLE
fix(@aws-amplify/datastore): coerce undefined field values to null

### DIFF
--- a/packages/datastore/__tests__/storage.test.ts
+++ b/packages/datastore/__tests__/storage.test.ts
@@ -121,6 +121,32 @@ describe('Storage tests', () => {
 				expect(modelUpdate.element.optionalField1).toBeNull();
 			});
 
+			test('updating value with undefined gets saved as null', async () => {
+				const classes = initSchema(testSchema());
+
+				const { Model } = classes as {
+					Model: PersistentModelConstructor<Model>;
+				};
+
+				const model = await DataStore.save(
+					new Model({
+						field1: 'Some value',
+						optionalField1: 'Some optional value',
+						dateCreated: new Date().toISOString(),
+					})
+				);
+
+				await DataStore.save(
+					Model.copyOf(model, draft => {
+						draft.optionalField1 = undefined;
+					})
+				);
+
+				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+
+				expect(modelUpdate.element.optionalField1).toBeNull();
+			});
+
 			test('list (destructured)', async () => {
 				const classes = initSchema(testSchema());
 

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -332,6 +332,7 @@ class StorageClass implements StorageFacade {
 
 			// check field values by value. Ignore unchanged fields
 			if (!valuesEqual(source[key], originalElement[key])) {
+				// if the field was updated to 'undefined', replace with 'null' for compatibility with JSON and GraphQL
 				updatedElement[key] =
 					originalElement[key] === undefined ? null : originalElement[key];
 				if (key in compositeKeys) {

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -332,8 +332,8 @@ class StorageClass implements StorageFacade {
 
 			// check field values by value. Ignore unchanged fields
 			if (!valuesEqual(source[key], originalElement[key])) {
-				updatedElement[key] = originalElement[key];
-
+				updatedElement[key] =
+					originalElement[key] === undefined ? null : originalElement[key];
 				if (key in compositeKeys) {
 					// include all of the fields that comprise the composite key
 					for (const compositeField of compositeKeys[key]) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
A customer pointed out that if we define the value of a model's field as `undefined`, the mutation doesn't persist. However, if passed as `null`, it would work fine. So this one-liner just checks to see if a pre-existing field's passed value is `undefined` and coerces that value to `null`.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/7565


#### Description of how you validated changes
I tested the changes linked to a local sample app. Screenshots attached.

*Example* (with requested change) of explicitly setting the value of an existing field to `undefined`:

<img width="1792" alt="Screen Shot 2021-05-18 at 1 08 13 PM" src="https://user-images.githubusercontent.com/16296496/118722041-7ea17580-b7e0-11eb-8952-bce84d21c95a.png">

*Example* (with requested change) of explicitly setting the value of a NEW field - (doesn't coerce to `null` because the key doesn't exist on the model yet):

<img width="1792" alt="Screen Shot 2021-05-18 at 1 12 35 PM" src="https://user-images.githubusercontent.com/16296496/118722063-86611a00-b7e0-11eb-9cfe-fc2fc1679500.png">



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
