### PR TITLE
chore(amazon-cognito-identity-js): bump isomorphic-unfetch dep version

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -70,7 +70,7 @@
     "buffer": "4.9.2",
     "crypto-js": "^4.0.0",
     "fast-base64-decode": "^1.0.0",
-    "isomorphic-unfetch": "^3.0.0",
+    "isomorphic-unfetch": "^3.1.0",
     "js-cookie": "^2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Bumps `isomorphic-unfetch` dependency from `3.0.0` to `3.1.1` to fix bug within Service Workers that rely on the `unfetch` package.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/6868


#### Description of how you validated changes
- Ran `yarn test` from root of `amazon-cognito-identity-js` and `amplify-js` root
- Ran some methods within a linked local sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
