### PR TITLE
chore(@aws-amplify/ui-storybook) Add `CI=true` to storybook test script

### DIFF
--- a/packages/amplify-ui-storybook/package.json
+++ b/packages/amplify-ui-storybook/package.json
@@ -17,7 +17,7 @@
 		"react-scripts": "3.4.1"
 	},
 	"scripts": {
-		"test": "react-scripts test --passWithNoTests",
+		"test": "CI=true react-scripts test --passWithNoTests",
 		"start": "start-storybook -p 3000 -s public",
 		"prebuild": "rimraf dist",
 		"build-storybook": "build-storybook -s public -o dist --quiet"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
`yarn test` on local dev was hanging because `ui-storybook` tests were running on watch mode. Passing `CI=true` resolves this. There are other workarounds (https://github.com/facebook/create-react-app/issues/6899#issuecomment-510115970), but passing `CI=true` seems the cleanest way.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Ran `yarn test` locally.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
