### PR TITLE
chore: bump bundle limits for crypto-js@4 bump

### DIFF
--- a/.github/actions/bundle-size-action/cra/package.json
+++ b/.github/actions/bundle-size-action/cra/package.json
@@ -30,7 +30,7 @@
 			},
 			{
 				"path": "build/static/js/2.*.chunk.js",
-				"maxSize": "90kB"
+				"maxSize": "220kB"
 			}
 		]
 	},

--- a/.github/actions/bundle-size-action/next/package.json
+++ b/.github/actions/bundle-size-action/next/package.json
@@ -19,7 +19,7 @@
 			},
 			{
 				"path": ".next/static/chunks/pages/Amplify+Auth-*.js",
-				"maxSize": "40kB"
+				"maxSize": "175kB"
 			},
 			{
 				"path": ".next/static/chunks/pages/Amplify+Storage-*.js",

--- a/.github/actions/bundle-size-action/webpack4/package.json
+++ b/.github/actions/bundle-size-action/webpack4/package.json
@@ -19,7 +19,7 @@
       },
       {
         "path": "dist/amazon-cognito-identity-js.js.min.js",
-        "maxSize": "150kB"
+        "maxSize": "155kB"
       },
       {
         "path": "dist/Amplify.js.min.js",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Some bundle size checks are failing after upgrading to `crypto-js@4`. This PR bumps those limits to prevent us from becoming blind to other bundle size spikes. A GH issues will be created for us to re-examine our usage of `crypto-js@4` and try to tamp bundle size back down.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

No changes to library codebase. Tested new bundle limits with `rm -rf node_modules && yarn && yarn calculate` for each `bundle-size-action`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
