### PR TITLE
fix(@aws-amplify/datastore): fix default error/conflict handler

### DIFF
--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -833,7 +833,7 @@ class DataStore {
 		const conflictHandlerIsDefault: () => boolean = () =>
 			this.conflictHandler === defaultConflictHandler;
 
-		if (configDataStore) {
+		if (configDataStore && configDataStore.conflictHandler) {
 			return configDataStore.conflictHandler;
 		}
 		if (conflictHandlerIsDefault() && config.conflictHandler) {
@@ -849,7 +849,7 @@ class DataStore {
 		const errorHandlerIsDefault: () => boolean = () =>
 			this.errorHandler === defaultErrorHandler;
 
-		if (configDataStore) {
+		if (configDataStore && configDataStore.errorHandler) {
 			return configDataStore.errorHandler;
 		}
 		if (errorHandlerIsDefault() && config.errorHandler) {

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -362,7 +362,7 @@ class MutationProcessor {
 								throw new NonRetryableError('RetryMutation');
 							} else {
 								try {
-									this.errorHandler({
+									await this.errorHandler({
 										localModel: this.modelInstanceCreator(
 											modelConstructor,
 											variables.input


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The default error and conflict handler in DataStore were getting overwritten and set to `undefined`. This was causing console errors when mutation errors and unhandled mutation conflicts occurred (unless the handlers were explicitly set via `DataStore.configure`): 
> `this.errorHandler` is not a function

This PR fixes the default behavior, preventing the default handlers from being overwritten

Also: allow the `errorHandler` to be async (like `conflictHandler`) so that customers can perform custom async handling logic if needed before the MutationProcessor attempts to process the next record in the queue.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
N/A


#### Description of how you validated changes
Tested in a sample app. No longer getting the `this.errorHandler` is not a function error when a custom error handler is not explicitly set via `DataStore.configure`. Same goes for the conflict handler.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
