### PR TITLE
fix(@aws-amplify/datastore):  correct reachability unsubscribe behavior

### DIFF
--- a/packages/datastore/src/sync/datastoreConnectivity.ts
+++ b/packages/datastore/src/sync/datastoreConnectivity.ts
@@ -15,6 +15,7 @@ export default class DataStoreConnectivity {
 	private connectionStatus: ConnectionStatus;
 	private observer: ZenObservable.SubscriptionObserver<ConnectionStatus>;
 	private subscription: ZenObservable.Subscription;
+	private timeout: ReturnType<typeof setTimeout>;
 	constructor() {
 		this.connectionStatus = {
 			online: false,
@@ -38,6 +39,7 @@ export default class DataStoreConnectivity {
 			});
 
 			return () => {
+				clearTimeout(this.timeout);
 				this.unsubscribe();
 			};
 		});
@@ -45,6 +47,7 @@ export default class DataStoreConnectivity {
 
 	unsubscribe() {
 		if (this.subscription) {
+			clearTimeout(this.timeout);
 			this.subscription.unsubscribe();
 		}
 	}
@@ -53,7 +56,7 @@ export default class DataStoreConnectivity {
 		if (this.observer && typeof this.observer.next === 'function') {
 			this.observer.next({ online: false }); // Notify network issue from the socket
 
-			setTimeout(() => {
+			this.timeout = setTimeout(() => {
 				const observerResult = { ...this.connectionStatus }; // copyOf status
 				this.observer.next(observerResult);
 			}, RECONNECTING_IN); // giving time for socket cleanup and network status stabilization


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

### Current Behavior

Currently, unsubscribing the Reachability observer in the DataStoreConnectivity class does not stop it from continuing to send messages that are consumed by the SyncEngine. This is due to a `setTimeout` that does not get canceled upon calling `DataStoreConnectivity.unsubcribe()`. (See https://github.com/aws-amplify/amplify-js/blob/main/packages/datastore/src/sync/datastoreConnectivity.ts#L46-L61 for context). 

This results in the `setTimeout` callback continuing to send messages to the SyncEngine, causing it to attempt to restart at inappropriate times. Additional context is in the linked issue, but here's a summary:

1. Network connectivity is lost
2. `DataStore.stop` is called as a result of some user action shortly thereafter (within 5 seconds of network connectivity loss)
3. SyncEngine unsubscribes all subscriptions, stops the sync process, disposes of WebSockets, etc.
4. `setTimeout` callback gets invoked, which sends a message to the SyncEngine 
5. SyncEngine attempts to start back up, even though `DataStore.stop` had been sent and there's still no network connectivity

One of the undesirable side effects is that this will cause duplicate AppSync subscriptions to be created after network connectivity is restored and `DataStore.start` is called via the app code.

### PR Changes

Cancels the `setTimeout` whenever `DataStoreConnectivity.unsubcribe()` is executed, preventing it from sending additional messages.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/7036


#### Description of how you validated changes
* Manually validated this in a sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
