### PR TITLE
fix(@aws-amplify/ui-components): remove hosted ui check

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
@@ -9,7 +9,6 @@ import {
 import {
 	AUTH_CHANNEL,
 	NO_AUTH_MODULE_FOUND,
-	REDIRECTED_FROM_HOSTED_UI,
 	AUTHENTICATOR_AUTHSTATE,
 	UI_AUTH_CHANNEL,
 	TOAST_AUTH_ERROR_EVENT,
@@ -93,9 +92,7 @@ export class AmplifyAuthenticator {
 		Hub.listen(AUTH_CHANNEL, this.handleExternalAuthEvent);
 
 		appendToCognitoUserAgent('amplify-authenticator');
-		const byHostedUI = localStorage.getItem(REDIRECTED_FROM_HOSTED_UI);
-		localStorage.removeItem(REDIRECTED_FROM_HOSTED_UI);
-		if (byHostedUI !== 'true') await this.checkUser();
+		await this.checkUser();
 	}
 
 	private async checkUser(): Promise<void> {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Removes hostedui redirection check from `amplify-authenticator`. This is based on @ericclemmons's observation here: https://github.com/aws-amplify/amplify-js/issues/7081#issuecomment-845277842. 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Fixes #7081


#### Description of how you validated changes
I don't think this needs to be manually validated. `checkUser` is **required** to initiate the correct auth state for the `authenticator`. We should run `checkUser` unconditionally, which is what this PR does. 


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
