### PR TITLE
Hosted UI vue redirect url parse #8337

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,12 @@ Config
 lerna-debug.log
 node_modules
 packages/*/node_modules/**
-packages/**/lib/
-packages/**/lib-esm/
-packages/**/dist/
-packages/**/es/
-packages/**/esm/
-packages/**/cjs/
+# packages/**/lib/
+# packages/**/lib-esm/
+# packages/**/dist/
+# packages/**/es/
+# packages/**/esm/
+# packages/**/cjs/
 .DS_Store
 .vscode
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,12 @@ Config
 lerna-debug.log
 node_modules
 packages/*/node_modules/**
-# packages/**/lib/
-# packages/**/lib-esm/
-# packages/**/dist/
-# packages/**/es/
-# packages/**/esm/
-# packages/**/cjs/
+packages/**/lib/
+packages/**/lib-esm/
+packages/**/dist/
+packages/**/es/
+packages/**/esm/
+packages/**/cjs/
 .DS_Store
 .vscode
 .idea

--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -2989,6 +2989,19 @@ describe('auth unit test', () => {
 				null,
 				(options.oauth as AwsCognitoOAuthOpts).redirectSignIn
 			);
+
+			const url_slash = `${
+				(options.oauth as AwsCognitoOAuthOpts).redirectSignIn
+			}#/access_token=${token}&state=${state}`;
+
+			await (auth as any)._handleAuthResponse(url_slash);
+
+			expect(handleAuthResponseSpy).toHaveBeenCalledWith(url_slash);
+			expect(replaceStateSpy).toHaveBeenCalledWith(
+				{},
+				null,
+				(options.oauth as AwsCognitoOAuthOpts).redirectSignIn
+			);
 		});
 
 		test('No User Pools', async () => {

--- a/packages/auth/__tests__/oauth-test.ts
+++ b/packages/auth/__tests__/oauth-test.ts
@@ -184,5 +184,71 @@ describe('OAuth', () => {
 				idToken: mockIdToken,
 			});
 		});
+		test('Implicit Flow returns for "#" and "#/" urls', async () => {
+			const redirectSignIn = 'https://test.com';
+			const currentUrl = 'https://test.com';
+
+			const config = {
+				domain: '',
+				clientID: '',
+				scope: '',
+				redirectUri: '',
+				audience: '',
+				responseType: 'implicit',
+				returnTo: '',
+				redirectSignIn,
+			};
+			const oAuth = new OAuth({
+				scopes: [],
+				config,
+				cognitoClientId: '',
+			});
+			const mockAccessToken = 'mockAccessToken';
+			// const mockRefreshToken = 'mockRefreshToken';
+			const mockIdToken = 'mockIdToken';
+			// const token = 'XXXX.YYY.ZZZ';
+			const mockState = 'STATEABC';
+			const implicit_url_1 = `${
+				redirectSignIn
+			}#access_token=${mockAccessToken}&state=${mockState}&id_token=${mockIdToken}`;
+
+			fetchMockReturn({
+				access_token: mockAccessToken,
+				refresh_token: null,
+				state: mockState,
+				id_token: mockIdToken,
+			});
+
+			const handleResponse_1 = await oAuth.handleAuthResponse(
+				implicit_url_1
+			);
+			expect(handleResponse_1).toEqual({
+				accessToken: mockAccessToken,
+				refreshToken: null,
+				state: mockState,
+				idToken: mockIdToken,
+			});
+
+			const implicit_url_2 = `${
+				redirectSignIn
+			}#/access_token=${mockAccessToken}&state=${mockState}&id_token=${mockIdToken}`;
+
+			fetchMockReturn({
+				access_token: mockAccessToken,
+				refresh_token: null,
+				state: mockState,
+				id_token: mockIdToken,
+			});
+
+			const handleResponse_2 = await oAuth.handleAuthResponse(
+				implicit_url_2
+			);
+			expect(handleResponse_2).toEqual({
+				accessToken: mockAccessToken,
+				refreshToken: null,
+				state: mockState,
+				idToken: mockIdToken,
+			});
+		});
 	});
 });

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -2006,7 +2006,7 @@ export class AuthClass {
 				.find(([k]) => k === 'code' || k === 'error');
 
 			const hasTokenOrError = !!(parse(currentUrl).hash || '#')
-				.substr(1)
+				.replace(/^#[\/]?/g,'')
 				.split('&')
 				.map(entry => entry.split('='))
 				.find(([k]) => k === 'access_token' || k === 'error');

--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -196,7 +196,7 @@ export default class OAuth {
 	private async _handleImplicitFlow(currentUrl: string) {
 		// hash is `null` if `#` doesn't exist on URL
 		const { id_token, access_token } = (parse(currentUrl).hash || '#')
-			.substr(1) // Remove # from returned code
+			.replace(/^#[\/]?/g,'') // Remove # from returned code
 			.split('&')
 			.map(pairings => pairings.split('='))
 			.reduce((accum, [k, v]) => ({ ...accum, [k]: v }), {
@@ -219,7 +219,7 @@ export default class OAuth {
 			const urlParams = currentUrl
 				? ({
 						...(parse(currentUrl).hash || '#')
-							.substr(1)
+							.replace(/^#[\/]?/g,'')
 							.split('&')
 							.map(entry => entry.split('='))
 							.reduce((acc, [k, v]) => ((acc[k] = v), acc), {}),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Simply replaced the `.substr(1)` at the end of redirect url parsing with a hash to a `.replace` call that takes a regex pattern matching both '#' and '#/'
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

main isssue [here](https://github.com/aws-amplify/amplify-js/issues/8337)

I tracked my work running down the bug pretty throughouly there. 

#### Description of how you validated changes

I tested in browser, and against my current dev project for which I am trying to use amplify.  Furthermore, it passed all current tests.  I did not write any new tests, because as far (as I could tell), such tests would require a much finer scope of testing that is already present, and the current tests salsify that previous builds are not broken.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
