### PR TITLE
fix: remove RN-specific peerDeps to correctly hoist core in npm@7

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -94,8 +94,5 @@
     "react-native": "^0.59.0",
     "rimraf": "^2.5.4",
     "webpack": "^3.5.5"
-  },
-  "peerDependencies": {
-    "@react-native-async-storage/async-storage": "^1.13.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,9 +63,6 @@
 		"universal-cookie": "^4.0.4",
 		"zen-observable-ts": "0.8.19"
 	},
-	"peerDependencies": {
-		"@react-native-async-storage/async-storage": "^1.13.0"
-	},
 	"jest": {
 		"globals": {
 			"ts-jest": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Including an RN peer dependency in the package.json of @aws-amplify/core prevents npm@7 from hoisting @aws-amplify/core into e.g., my-app/node_modules/@aws-amplify/core. The RN peer deps cause /core to conflict with newer versions of React, since npm@7 will attempt to auto-install peer deps. 

This PR removes RN-specific peer deps from core and amazon-cognito-identity-js.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/8333


#### Description of how you validated changes
* Published to local verdaccio registry; installed into CRA app with --use-npm & npm@7; confirmed /core is getting hoisted correctly


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
