### PR TITLE
fix(aws-amplify-angular): remove util import to fix ng-12 build error

### DIFF
--- a/packages/aws-amplify-angular/src/components/interactions/chatbot/chatbot.component.core.ts
+++ b/packages/aws-amplify-angular/src/components/interactions/chatbot/chatbot.component.core.ts
@@ -23,7 +23,6 @@ import {
 	Inject,
 } from '@angular/core';
 import { AmplifyService } from '../../../providers/amplify.service';
-import { isUndefined } from 'util';
 import { chatBot } from '../../../assets/data-test-attributes';
 require('./aws-lex-audio.js');
 
@@ -141,13 +140,11 @@ export class ChatbotComponentCore implements OnInit {
 		this.botName = data.bot;
 		this.chatTitle = data.title;
 		this.clearComplete = data.clearComplete;
-		this.conversationModeOn = isUndefined(data.conversationModeOn)
-			? false
-			: data.conversationModeOn;
-		this.voiceEnabled = isUndefined(data.voiceEnabled)
-			? false
-			: data.voiceEnabled;
-		this.textEnabled = isUndefined(data.textEnabled) ? true : data.textEnabled;
+		this.conversationModeOn =
+			data.conversationModeOn === undefined ? false : data.conversationModeOn;
+		this.voiceEnabled =
+			data.voiceEnabled === undefined ? false : data.voiceEnabled;
+		this.textEnabled = data.textEnabled === undefined ? true : data.textEnabled;
 		this.voiceConfig = data.voiceConfig || this.voiceConfig;
 		this.performOnComplete = this.performOnComplete.bind(this);
 		this.amplifyService


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Remove unneeded `util` import that's causing a build error in Angular 12

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/8347


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
