### PR TITLE
fix(@aws-amplify/datastore): expose timestamp fields and prevent writing to read-only fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -791,6 +791,22 @@ jobs:
           test_name: 'amazon-cognito-identity-js'
           category: auth
           sample_name: amazon-cognito-identity-js
+  integ_react_device_tracking:
+    parameters:
+      browser:
+        type: string
+    executor: js-test-executor
+    <<: *test_env_vars
+    working_directory: ~/amplify-js-samples-staging/samples/react/auth/device-tracking
+    steps:
+      - prepare_test_env
+      - integ_test_js:
+          test_name: 'cognito-device-tracking'
+          framework: react
+          category: auth
+          sample_name: device-tracking
+          spec: device-tracking
+          browser: << parameters.browser >>
   integ_rn_ios_storage:
     executor: macos-executor
     <<: *test_env_vars
@@ -1132,6 +1148,15 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
+      - integ_react_device_tracking:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+          matrix:
+            parameters:
+              <<: *test_browsers
       - integ_rn_ios_storage:
           requires:
             - integ_setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -812,19 +812,19 @@ jobs:
     steps:
       - integ_test_rn_ios
 
-  integ_rn_android_storage:
-    executor: macos-executor
-    <<: *test_env_vars
-    working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
-    steps:
-      - integ_test_rn_android
+  # integ_rn_android_storage:
+  #   executor: macos-executor
+  #   <<: *test_env_vars
+  #   working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
+  #   steps:
+  #     - integ_test_rn_android
 
-  integ_rn_android_storage_multipart_progress:
-    executor: macos-executor
-    <<: *test_env_vars
-    working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/MultiPartUploadWithProgress
-    steps:
-      - integ_test_rn_android
+  # integ_rn_android_storage_multipart_progress:
+  #   executor: macos-executor
+  #   <<: *test_env_vars
+  #   working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/MultiPartUploadWithProgress
+  #   steps:
+  #     - integ_test_rn_android
 
   integ_datastore_auth:
     parameters:
@@ -1150,18 +1150,18 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
-      - integ_rn_android_storage:
-          requires:
-            - integ_setup
-            - build
-          filters:
-            <<: *releasable_branches
-      - integ_rn_android_storage_multipart_progress:
-          requires:
-            - integ_setup
-            - build
-          filters:
-            <<: *releasable_branches
+      # - integ_rn_android_storage:
+      #     requires:
+      #       - integ_setup
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      # - integ_rn_android_storage_multipart_progress:
+      #     requires:
+      #       - integ_setup
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
       - integ_datastore_auth:
           requires:
             - integ_setup
@@ -1207,9 +1207,9 @@ workflows:
             - integ_vue_auth
             - integ_rn_ios_storage
             - integ_rn_ios_storage_multipart_progress
-            - integ_rn_android_storage_multipart_progress
+            # - integ_rn_android_storage_multipart_progress
             - integ_rn_ios_push_notifications
-            - integ_rn_android_storage
+            # - integ_rn_android_storage
             - integ_datastore_auth
             - integ_duplicate_packages
             - integ_auth_test_cypress_no_ui

--- a/packages/amplify-ui-components/src/components/amplify-confirm-sign-in/amplify-confirm-sign-in.spec.ts
+++ b/packages/amplify-ui-components/src/components/amplify-confirm-sign-in/amplify-confirm-sign-in.spec.ts
@@ -70,6 +70,17 @@ describe('amplify-confirm-sign-in spec:', () => {
 			expect(retVal[0].type).toBe('code');
 			expect(retVal[0].handleInputChange).toBeDefined();
 			expect(typeof retVal[0].handleInputChange).toBe('function');
+
+			const formFields = [{
+				type: 'code',
+				handleInputChange: () => {},
+			}];
+			retVal = confirmSignIn.constructFormFieldOptions(formFields);
+			expect(retVal).toHaveLength(1);
+			expect(retVal[0].type).toBe('code');
+			expect(retVal[0].handleInputChange).toBeDefined();
+			expect(typeof retVal[0].handleInputChange).toBe('function');
+			expect(retVal[0].handleInputChange).toBe(formFields[0].handleInputChange);
 		});
 	});
 	describe('Render logic ->', () => {

--- a/packages/amplify-ui-components/src/components/amplify-confirm-sign-in/amplify-confirm-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-confirm-sign-in/amplify-confirm-sign-in.tsx
@@ -137,8 +137,8 @@ export class AmplifyConfirmSignIn {
 			} else {
 				// This is a code input field. Attach input handler.
 				content.push({
-					...(formField as FormFieldType), // `inputProps` will be passed over here.
 					handleInputChange: event => this.handleCodeChange(event),
+					...(formField as FormFieldType), // `inputProps` will be passed over here.
 				});
 			}
 		});

--- a/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.spec.ts
+++ b/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.spec.ts
@@ -1,3 +1,4 @@
+import { Auth } from '@aws-amplify/auth';
 import { newSpecPage } from '@stencil/core/testing';
 import { AmplifyForgotPassword } from './amplify-forgot-password';
 import { Translations } from '../../common/Translations';
@@ -7,6 +8,10 @@ describe('amplify-forgot-password spec:', () => {
 		let amplifyForgotPassword;
 
 		beforeEach(() => {
+			Auth.forgotPassword = jest.fn().mockResolvedValue({
+				CodeDeliveryDetails: 'CodeDeliveryDetails mocked value',
+			});
+			Auth.forgotPasswordSubmit = jest.fn().mockResolvedValue({});
 			amplifyForgotPassword = new AmplifyForgotPassword();
 		});
 
@@ -26,6 +31,37 @@ describe('amplify-forgot-password spec:', () => {
 
 		it('should render `usernameAlias` as `username` by default', () => {
 			expect(amplifyForgotPassword.usernameAlias).toEqual('username');
+		});
+
+		it('should trim the `userInput` text on `send`', async () => {
+			const event = { preventDefault: jest.fn() };
+			amplifyForgotPassword.forgotPasswordAttrs.userInput = 'foo ';
+			const promise = amplifyForgotPassword.send(event);
+			expect(event.preventDefault).toHaveBeenCalledWith();
+			expect(amplifyForgotPassword.loading).toBe(true);
+			expect(Auth.forgotPassword).toHaveBeenCalledWith(
+				amplifyForgotPassword.forgotPasswordAttrs.userInput.trim());
+			expect(amplifyForgotPassword.delivery).toBe(null);
+			await promise;
+			expect(amplifyForgotPassword.delivery).toBe('CodeDeliveryDetails mocked value');
+			expect(amplifyForgotPassword.loading).toBe(false);
+		});
+
+		it('should trim the `userInput` text on `submit`', async () => {
+			const event = { preventDefault: jest.fn() };
+			amplifyForgotPassword.forgotPasswordAttrs.userInput = 'foo ';
+			amplifyForgotPassword.delivery = 'bar';
+			const promise = amplifyForgotPassword.submit(event);
+			expect(event.preventDefault).toHaveBeenCalledWith();
+			expect(amplifyForgotPassword.loading).toBe(true);
+			expect(Auth.forgotPasswordSubmit).toHaveBeenCalledWith(
+				amplifyForgotPassword.forgotPasswordAttrs.userInput.trim(),
+				amplifyForgotPassword.forgotPasswordAttrs.code,
+				amplifyForgotPassword.forgotPasswordAttrs.password);
+			expect(amplifyForgotPassword.delivery).toBe('bar');
+			await promise;
+			expect(amplifyForgotPassword.delivery).toBeNull();
+			expect(amplifyForgotPassword.loading).toBe(false);
 		});
 	});
 	describe('Render logic ->', () => {

--- a/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
@@ -255,7 +255,7 @@ export class AmplifyForgotPassword {
 		this.loading = true;
 		try {
 			const { userInput, code, password } = this.forgotPasswordAttrs;
-			const data = await Auth.forgotPasswordSubmit(userInput, code, password);
+			const data = await Auth.forgotPasswordSubmit(userInput.trim(), code, password);
 			logger.debug(data);
 			this.handleAuthStateChange(AuthState.SignIn);
 			this.delivery = null;

--- a/packages/amplify-ui-components/src/components/amplify-require-new-password/amplify-require-new-password.spec.ts
+++ b/packages/amplify-ui-components/src/components/amplify-require-new-password/amplify-require-new-password.spec.ts
@@ -2,6 +2,7 @@ import { I18n } from '@aws-amplify/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { AmplifyRequireNewPassword } from './amplify-require-new-password';
 import { Translations } from '../../common/Translations';
+import { COUNTRY_DIAL_CODE_DEFAULT } from '../../common/constants';
 
 describe('amplify-require-new-password spec:', () => {
 	describe('Component logic ->', () => {
@@ -28,6 +29,12 @@ describe('amplify-require-new-password spec:', () => {
 		it('should evaluate `submitButtonText` to `Change` by default', () => {
 			expect(requireNewPassword.submitButtonText).toEqual(
 				I18n.get(Translations.CHANGE_PASSWORD_ACTION)
+			);
+		});
+
+		it('should evaluate `phoneNumber` with a valid country code by default', () => {
+			expect(requireNewPassword.phoneNumber.countryDialCodeValue).toEqual(
+				COUNTRY_DIAL_CODE_DEFAULT
 			);
 		});
 	});

--- a/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-up/amplify-sign-up.tsx
@@ -422,6 +422,7 @@ export class AmplifySignUp {
 								<amplify-button
 									type="submit"
 									data-test="sign-up-create-account-button"
+                  disabled={this.loading}
 								>
 									{this.loading ? (
 										<amplify-loading-spinner />

--- a/packages/auth/__tests__/mockData.ts
+++ b/packages/auth/__tests__/mockData.ts
@@ -1,0 +1,139 @@
+// keeping this so that jest does not complain
+test('should do nothing', () => {});
+
+// device tracking mock device data
+export const mockDeviceArray = [
+	{
+		DeviceAttributes: [
+			{
+				Name: 'device_status',
+				Value: 'valid',
+			},
+			{
+				Name: 'device_name',
+				Value:
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.106 Safari/537.36',
+			},
+			{
+				Name: 'last_ip_used',
+				Value: '45.17.45.126',
+			},
+		],
+		DeviceCreateDate: 1623956729.32,
+		DeviceKey: 'us-east-2_596db07d-793a-4070-8140-27f321ccf01c',
+		DeviceLastAuthenticatedDate: 1623956729,
+		DeviceLastModifiedDate: 1623956730.312,
+	},
+	{
+		DeviceAttributes: [
+			{
+				Name: 'device_status',
+				Value: 'valid',
+			},
+			{
+				Name: 'device_name',
+				Value:
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.106 Safari/537.36',
+			},
+			{
+				Name: 'last_ip_used',
+				Value: '45.17.45.126',
+			},
+		],
+		DeviceCreateDate: 1623956945.271,
+		DeviceKey: 'us-east-2_12ac778f-52a4-4fca-a628-237776159c91',
+		DeviceLastAuthenticatedDate: 1623956945,
+		DeviceLastModifiedDate: 1623956945.904,
+	},
+	{
+		DeviceAttributes: [
+			{
+				Name: 'device_status',
+				Value: 'valid',
+			},
+			{
+				Name: 'device_name',
+				Value:
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36',
+			},
+			{
+				Name: 'last_ip_used',
+				Value: '45.17.45.126',
+			},
+		],
+		DeviceCreateDate: 1623957888.742,
+		DeviceKey: 'us-east-2_4a93aeb3-01af-42d8-891d-ee8aa1549398',
+		DeviceLastAuthenticatedDate: 1623963456,
+		DeviceLastModifiedDate: 1623963457.705,
+	},
+	{
+		DeviceAttributes: [
+			{
+				Name: 'device_status',
+				Value: 'valid',
+			},
+			{
+				Name: 'device_name',
+				Value:
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.106 Safari/537.36',
+			},
+			{
+				Name: 'last_ip_used',
+				Value: '45.17.45.126',
+			},
+		],
+		DeviceCreateDate: 1623957198.984,
+		DeviceKey: 'us-east-2_e0019223-e6b8-453f-a4e7-4e0d69dd4316',
+		DeviceLastAuthenticatedDate: 1623957198,
+		DeviceLastModifiedDate: 1623957199.861,
+	},
+	{
+		DeviceAttributes: [
+			{
+				Name: 'device_status',
+				Value: 'valid',
+			},
+			{
+				Name: 'device_name',
+				Value:
+					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.106 Safari/537.36',
+			},
+			{
+				Name: 'last_ip_used',
+				Value: '45.17.45.126',
+			},
+		],
+		DeviceCreateDate: 1623954284.74,
+		DeviceKey: 'us-east-2_1763f940-7136-4133-8cf5-eb073cad06c9',
+		DeviceLastAuthenticatedDate: 1623954284,
+		DeviceLastModifiedDate: 1623954285.339,
+	},
+];
+
+export const transformedMockData = [
+	{
+		id: 'us-east-2_596db07d-793a-4070-8140-27f321ccf01c',
+		name:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.106 Safari/537.36',
+	},
+	{
+		id: 'us-east-2_12ac778f-52a4-4fca-a628-237776159c91',
+		name:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.106 Safari/537.36',
+	},
+	{
+		id: 'us-east-2_4a93aeb3-01af-42d8-891d-ee8aa1549398',
+		name:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36',
+	},
+	{
+		id: 'us-east-2_e0019223-e6b8-453f-a4e7-4e0d69dd4316',
+		name:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.106 Safari/537.36',
+	},
+	{
+		id: 'us-east-2_1763f940-7136-4133-8cf5-eb073cad06c9',
+		name:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.106 Safari/537.36',
+	},
+];

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "yarn lint && jest -w 1 --coverage",
+    "test": "yarn lint --fix && jest -w 1 --coverage",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -68,7 +68,11 @@ import { parse } from 'url';
 import OAuth from './OAuth/OAuth';
 import { default as urlListener } from './urlListener';
 import { AuthError, NoUserPoolError } from './Errors';
-import { AuthErrorTypes, CognitoHostedUIIdentityProvider } from './types/Auth';
+import {
+	AuthErrorTypes,
+	CognitoHostedUIIdentityProvider,
+	IAuthDevice,
+} from './types/Auth';
 
 const logger = new Logger('AuthClass');
 const USER_ADMIN_SCOPE = 'aws.cognito.signin.user.admin';
@@ -84,6 +88,11 @@ typeof Symbol.for === 'function'
 const dispatchAuthEvent = (event: string, data: any, message: string) => {
 	Hub.dispatch('auth', { event, data, message }, 'Auth', AMPLIFY_SYMBOL);
 };
+
+// Cognito Documentation for max device
+// tslint:disable-next-line:max-line-length
+// https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ListDevices.html#API_ListDevices_RequestSyntax
+const MAX_DEVICES = 60;
 
 /**
  * Provide authentication steps
@@ -2138,7 +2147,8 @@ export class AuthClass {
 					attribute.Name === 'email_verified' ||
 					attribute.Name === 'phone_number_verified'
 				) {
-					obj[attribute.Name] = this.isTruthyString(attribute.Value) || attribute.Value === true;
+					obj[attribute.Name] =
+						this.isTruthyString(attribute.Value) || attribute.Value === true;
 				} else {
 					obj[attribute.Name] = attribute.Value;
 				}
@@ -2148,7 +2158,9 @@ export class AuthClass {
 	}
 
 	private isTruthyString(value: any): boolean {
-		return typeof value.toLowerCase === 'function' && value.toLowerCase() === 'true';
+		return (
+			typeof value.toLowerCase === 'function' && value.toLowerCase() === 'true'
+		);
 	}
 
 	private createCognitoUser(username: string): CognitoUser {
@@ -2194,6 +2206,103 @@ export class AuthClass {
 	private rejectNoUserPool(): Promise<never> {
 		const type = this.noUserPoolErrorHandler(this._config);
 		return Promise.reject(new NoUserPoolError(type));
+	}
+
+	public async rememberDevice(): Promise<string | AuthError> {
+		let currUser;
+
+		try {
+			currUser = await this.currentUserPoolUser();
+		} catch (error) {
+			logger.debug('The user is not authenticated by the error', error);
+			return Promise.reject('The user is not authenticated');
+		}
+
+		currUser.getCachedDeviceKeyAndPassword();
+		return new Promise((res, rej) => {
+			currUser.setDeviceStatusRemembered({
+				onSuccess: data => {
+					res(data);
+				},
+				onFailure: err => {
+					if (err.code === 'InvalidParameterException') {
+						rej(new AuthError(AuthErrorTypes.DeviceConfig));
+					} else if (err.code === 'NetworkError') {
+						rej(new AuthError(AuthErrorTypes.NetworkError));
+					} else {
+						rej(err);
+					}
+				},
+			});
+		});
+	}
+
+	public async forgetDevice(): Promise<void> {
+		let currUser;
+
+		try {
+			currUser = await this.currentUserPoolUser();
+		} catch (error) {
+			logger.debug('The user is not authenticated by the error', error);
+			return Promise.reject('The user is not authenticated');
+		}
+
+		currUser.getCachedDeviceKeyAndPassword();
+		return new Promise((res, rej) => {
+			currUser.forgetDevice({
+				onSuccess: data => {
+					res(data);
+				},
+				onFailure: err => {
+					if (err.code === 'InvalidParameterException') {
+						rej(new AuthError(AuthErrorTypes.DeviceConfig));
+					} else if (err.code === 'NetworkError') {
+						rej(new AuthError(AuthErrorTypes.NetworkError));
+					} else {
+						rej(err);
+					}
+				},
+			});
+		});
+	}
+
+	public async fetchDevices(): Promise<IAuthDevice[]> {
+		let currUser;
+
+		try {
+			currUser = await this.currentUserPoolUser();
+		} catch (error) {
+			logger.debug('The user is not authenticated by the error', error);
+			throw new Error('The user is not authenticated');
+		}
+
+		currUser.getCachedDeviceKeyAndPassword();
+		return new Promise((res, rej) => {
+			const cb = {
+				onSuccess(data) {
+					const deviceList: IAuthDevice[] = data.Devices.map(device => {
+						const deviceInfo: IAuthDevice = {
+							id: device.DeviceKey,
+							name: device.DeviceAttributes.find(
+								({ Name }) => Name === 'device_name'
+							).Value,
+						};
+						return deviceInfo;
+					});
+					res(deviceList);
+				},
+				onFailure: err => {
+					if (err.code === 'InvalidParameterException') {
+						rej(new AuthError(AuthErrorTypes.DeviceConfig));
+					} else if (err.code === 'NetworkError') {
+						rej(new AuthError(AuthErrorTypes.NetworkError));
+					} else {
+						rej(err);
+					}
+				},
+			};
+			currUser.listDevices(MAX_DEVICES, null, cb);
+		});
 	}
 }
 

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -2281,11 +2281,14 @@ export class AuthClass {
 			const cb = {
 				onSuccess(data) {
 					const deviceList: IAuthDevice[] = data.Devices.map(device => {
+						const deviceName =
+							device.DeviceAttributes.find(
+								({ Name }) => Name === 'device_name'
+							) || {};
+
 						const deviceInfo: IAuthDevice = {
 							id: device.DeviceKey,
-							name: device.DeviceAttributes.find(
-								({ Name }) => Name === 'device_name'
-							).Value,
+							name: deviceName.Value,
 						};
 						return deviceInfo;
 					});

--- a/packages/auth/src/Errors.ts
+++ b/packages/auth/src/Errors.ts
@@ -104,6 +104,12 @@ export const authErrorMessages: AuthErrorMessages = {
 	noUserSession: {
 		message: AuthErrorStrings.NO_USER_SESSION,
 	},
+	deviceConfig: {
+		message: AuthErrorStrings.DEVICE_CONFIG,
+	},
+	networkError: {
+		message: AuthErrorStrings.NETWORK_ERROR,
+	},
 	default: {
 		message: AuthErrorStrings.DEFAULT_MSG,
 	},

--- a/packages/auth/src/common/AuthErrorStrings.ts
+++ b/packages/auth/src/common/AuthErrorStrings.ts
@@ -11,4 +11,6 @@ export enum AuthErrorStrings {
 	INVALID_MFA = 'Invalid MFA type',
 	EMPTY_CHALLENGE = 'Challenge response cannot be empty',
 	NO_USER_SESSION = 'Failed to get the session because the user is empty',
+	NETWORK_ERROR = 'Network Error',
+	DEVICE_CONFIG = 'Device tracking has not been configured in this User Pool',
 }

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -199,6 +199,8 @@ export enum AuthErrorTypes {
 	EmptyChallengeResponse = 'emptyChallengeResponse',
 	NoUserSession = 'noUserSession',
 	Default = 'default',
+	DeviceConfig = 'deviceConfig',
+	NetworkError = 'networkError',
 }
 
 export type AuthErrorMessages = { [key in AuthErrorTypes]: AuthErrorMessage };
@@ -219,4 +221,9 @@ export type ClientMetaData =
 
 export function isUsernamePasswordOpts(obj: any): obj is UsernamePasswordOpts {
 	return !!(obj as UsernamePasswordOpts).username;
+}
+
+export interface IAuthDevice {
+	id: string;
+	name: string;
 }

--- a/packages/core/__tests__/Credentials-test.ts
+++ b/packages/core/__tests__/Credentials-test.ts
@@ -184,11 +184,8 @@ describe('Credentials test', () => {
 			const removeItemSpy = jest.spyOn(storageClass, 'removeItem');
 
 			credentials.clear();
-			expect(removeItemSpy).toHaveBeenCalledTimes(2);
+			expect(removeItemSpy).toHaveBeenCalledTimes(1);
 			expect(removeItemSpy).toHaveBeenCalledWith('aws-amplify-federatedInfo');
-			expect(removeItemSpy).toHaveBeenCalledWith(
-				credentials._getCognitoIdentityIdStorageKey(identityPoolId)
-			);
 		});
 	});
 });

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -528,6 +528,67 @@ describe('DataStore tests', () => {
 			expect(patches2).toMatchObject(expectedPatches2);
 		});
 
+		test('Read-only fields cannot be overwritten', async () => {
+			let model: Model;
+			const save = jest.fn(() => [model]);
+			const query = jest.fn(() => [model]);
+
+			jest.resetModules();
+			jest.doMock('../src/storage/storage', () => {
+				const mock = jest.fn().mockImplementation(() => {
+					const _mock = {
+						init: jest.fn(),
+						save,
+						query,
+						runExclusive: jest.fn(fn => fn.bind(this, _mock)()),
+					};
+
+					return _mock;
+				});
+
+				(<any>mock).getNamespace = () => ({ models: {} });
+
+				return { ExclusiveStorage: mock };
+			});
+
+			({ initSchema, DataStore } = require('../src/datastore/datastore'));
+
+			const classes = initSchema(testSchema());
+
+			const { Model } = classes as { Model: PersistentModelConstructor<Model> };
+
+			model = new Model({
+				field1: 'something',
+				dateCreated: new Date().toISOString(),
+				createdAt: '2021-06-03T20:56:23.201Z',
+			});
+
+			expect(DataStore.save(model)).rejects.toThrowError(
+				'createdAt is read-only.'
+			);
+
+			model = new Model({
+				field1: 'something',
+				dateCreated: new Date().toISOString(),
+			});
+
+			model = Model.copyOf(model, draft => {
+				draft.createdAt = '2021-06-03T20:56:23.201Z';
+			});
+
+			expect(DataStore.save(model)).rejects.toThrowError(
+				'createdAt is read-only.'
+			);
+
+			model = Model.copyOf(model, draft => {
+				draft.updatedAt = '2021-06-03T20:56:23.201Z';
+			});
+
+			expect(DataStore.save(model)).rejects.toThrowError(
+				'updatedAt is read-only.'
+			);
+		});
+
 		test('Instantiation validations', async () => {
 			expect(() => {
 				new Model({

--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -8,6 +8,8 @@ export declare class Model {
 	public readonly emails?: string[];
 	public readonly ips?: (string | null)[];
 	public readonly metadata?: Metadata;
+	public readonly createdAt?: string;
+	public readonly updatedAt?: string;
 
 	constructor(init: ModelInit<Model>);
 
@@ -135,6 +137,22 @@ export function testSchema(): Schema {
 						},
 						isRequired: false,
 						attributes: [],
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: false,
+						attributes: [],
+						isReadOnly: true,
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: false,
+						attributes: [],
+						isReadOnly: true,
 					},
 				},
 			},

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -275,7 +275,7 @@ export function isEnumFieldType(obj: any): obj is EnumFieldType {
 	return false;
 }
 
-type ModelField = {
+export type ModelField = {
 	name: string;
 	type:
 		| keyof Omit<
@@ -287,6 +287,7 @@ type ModelField = {
 		| EnumFieldType;
 	isArray: boolean;
 	isRequired?: boolean;
+	isReadOnly?: boolean;
 	isArrayNullable?: boolean;
 	association?: ModelAssociation;
 	attributes?: ModelAttributes[];

--- a/packages/storage/__tests__/providers/AWSS3ProviderManagedUpload-unit-test.ts
+++ b/packages/storage/__tests__/providers/AWSS3ProviderManagedUpload-unit-test.ts
@@ -14,14 +14,16 @@ import {
 	AWSS3ProviderManagedUpload,
 	Part,
 } from '../../src/providers/AWSS3ProviderManagedUpload';
-import { Platform } from '@aws-amplify/core';
 import {
 	S3Client,
 	PutObjectCommand,
 	UploadPartCommand,
 	CompleteMultipartUploadCommand,
 	CreateMultipartUploadCommand,
+	AbortMultipartUploadCommand,
+	ListPartsCommand,
 } from '@aws-sdk/client-s3';
+import { Logger } from "@aws-amplify/core";
 import * as events from 'events';
 import * as sinon from 'sinon';
 
@@ -52,6 +54,24 @@ const testOpts: any = {
 };
 
 const testMinPartSize = 10; // Merely 10 Bytes
+
+/** Extend our test class such that minPartSize is reasonable
+ * and we can mock emit the progress events
+ */
+class TestClass extends AWSS3ProviderManagedUpload {
+	protected minPartSize = testMinPartSize;
+	protected async uploadParts(uploadId: string, parts: Part[]) {
+		// Make service calls and set the event listeners first
+		await super.uploadParts(uploadId, parts);
+		// Now trigger some notifications from the event listeners
+		for (const part of parts) {
+			part.emitter.emit('sendProgress', {
+				// Assume that the notification is send when 100% of part is uploaded
+				loaded: (part.bodyPart as string).length,
+			});
+		}
+	}
+}
 
 afterEach(() => {
 	jest.restoreAllMocks();
@@ -127,24 +147,6 @@ describe('multi part upload tests', () => {
 		const emitter = new events.EventEmitter();
 		const eventSpy = sinon.spy();
 		emitter.on('sendProgress', eventSpy);
-
-		/** Extend our test class such that minPartSize is reasonable
-		 * and we can mock emit the progress events
-		 */
-		class TestClass extends AWSS3ProviderManagedUpload {
-			protected minPartSize = testMinPartSize;
-			protected async uploadParts(uploadId: string, parts: Part[]) {
-				// Make service calls and set the event listeners first from the base impl
-				await super.uploadParts(uploadId, parts);
-				// Now trigger some notifications from the event listeners
-				for (const part of parts) {
-					part.emitter.emit('sendProgress', {
-						// Assume that the notification is sent when 100% of part is uploaded
-						loaded: (part.bodyPart as string).length,
-					});
-				}
-			}
-		}
 
 		// Setup Spy for S3 service calls
 		const s3ServiceCallSpy = jest
@@ -229,24 +231,6 @@ describe('multi part upload tests', () => {
 		const emitter = new events.EventEmitter();
 		const eventSpy = sinon.spy();
 		emitter.on('sendProgress', eventSpy);
-
-		/** Extend our test class such that minPartSize is reasonable
-		 * and we can mock emit the progress events
-		 */
-		class TestClass extends AWSS3ProviderManagedUpload {
-			protected minPartSize = testMinPartSize;
-			protected async uploadParts(uploadId: string, parts: Part[]) {
-				// Make service calls and set the event listeners first
-				await super.uploadParts(uploadId, parts);
-				// Now trigger some notifications from the event listeners
-				for (const part of parts) {
-					part.emitter.emit('sendProgress', {
-						// Assume that the notification is send when 100% of part is uploaded
-						loaded: (part.bodyPart as string).length,
-					});
-				}
-			}
-		}
 
 		// Setup Spy for S3 service calls and introduce a service failure
 		const s3ServiceCallSpy = jest
@@ -337,5 +321,59 @@ describe('multi part upload tests', () => {
 			part: 2,
 			total: testParams.Body.length,
 		});
+	});
+
+	test('error case: cleanup failed', async () => {
+		jest.spyOn(S3Client.prototype, 'send').mockImplementation(async command => {
+			if (command instanceof CreateMultipartUploadCommand) {
+				return Promise.resolve({ UploadId: testUploadId });
+			} else if (command instanceof UploadPartCommand) {
+				return Promise.reject(new Error('failed to upload'));
+			} else if (command instanceof ListPartsCommand) {
+				return Promise.resolve({
+					Parts: [
+						{
+							PartNumber: 1,
+						},
+					],
+				});
+			} else if (command instanceof AbortMultipartUploadCommand) {
+				return Promise.resolve();
+			}
+		});
+		const uploader = new TestClass(
+			testParams,
+			testOpts,
+			new events.EventEmitter()
+		);
+		await expect(uploader.upload()).rejects.toThrow(
+			'Upload was cancelled. Multi Part upload clean up failed'
+		);
+	});
+
+	test('error case: finish multipart upload failed', async () => {
+		jest.spyOn(S3Client.prototype, 'send').mockImplementation(async command => {
+			if (command instanceof CreateMultipartUploadCommand) {
+				return Promise.resolve({ UploadId: testUploadId });
+			} else if (command instanceof UploadPartCommand) {
+				return Promise.resolve({
+					ETag: 'test_etag_' + command.input.PartNumber,
+				});
+			} else if (command instanceof CompleteMultipartUploadCommand) {
+				return Promise.reject('error');
+			}
+		});
+		const loggerSpy = jest.spyOn(Logger.prototype, '_log');
+		const uploader = new TestClass(
+			testParams,
+			testOpts,
+			new events.EventEmitter()
+		);
+		await uploader.upload();
+		expect(loggerSpy).toHaveBeenCalledWith(
+			'ERROR',
+			'error happened while finishing the upload. Cancelling the multipart upload',
+			'error'
+		)
 	});
 });

--- a/packages/storage/__tests__/providers/axios-http-handler.test.ts
+++ b/packages/storage/__tests__/providers/axios-http-handler.test.ts
@@ -5,20 +5,19 @@ import {
 	reactNativeRequestTransformer,
 } from '../../src/providers/axios-http-handler';
 import { HttpRequest } from '@aws-sdk/protocol-http';
-import { Platform } from '@aws-amplify/core';
+import { Platform, Logger } from '@aws-amplify/core';
 
 jest.mock('axios');
+jest.useFakeTimers();
 
 let request: HttpRequest = null;
 
 const options = {};
 
 describe('AxiosHttpHandler', () => {
-	beforeAll(() => {
-		axios.request.mockResolvedValue({});
-	});
-
 	beforeEach(() => {
+		Platform.isReactNative = false;
+		axios.request.mockResolvedValue({});
 		request = {
 			method: 'get',
 			path: '/',
@@ -45,6 +44,20 @@ describe('AxiosHttpHandler', () => {
 				responseType: 'blob',
 				url: 'http://localhost:3000/',
 			});
+		});
+
+		it('should add queryString to path', async () => {
+			const handler = new AxiosHttpHandler();
+			request.query = {
+				key: 'value',
+			};
+			await handler.handle(request, options);
+			expect(axios.request).toHaveBeenCalledWith({
+				headers: {},
+				method: 'get',
+				responseType: 'blob',
+				url: 'http://localhost:3000/?key=value',
+			})
 		});
 
 		it("should update data to null when it's undefined and content-type header is set", async () => {
@@ -75,6 +88,72 @@ describe('AxiosHttpHandler', () => {
 				url: 'http://localhost:3000/',
 				transformRequest: reactNativeRequestTransformer,
 			});
+		});
+
+		it('should attach cancelToken to the request', async () => {
+			const mockCancelToken = jest.fn().mockImplementationOnce(() => ({
+				token: 'token',
+			}));
+			const handler = new AxiosHttpHandler({}, null, mockCancelToken());
+			await handler.handle(request, options);
+
+			expect(axios.request).toHaveBeenLastCalledWith({
+				headers: {},
+				method: 'get',
+				responseType: 'blob',
+				url: 'http://localhost:3000/',
+				cancelToken: 'token',
+			});
+		});
+
+		it('should track upload or download progress if emitter is present', async () => {
+			const mockEmit = jest.fn();
+			const mockEmitter = jest.fn().mockImplementationOnce(() => ({
+				emit: mockEmit,
+			}));
+			const handler = new AxiosHttpHandler({}, mockEmitter());
+			await handler.handle(request, options);
+
+			const lastCall =
+				axios.request.mock.calls[axios.request.mock.calls.length - 1][0];
+
+			expect(lastCall).toStrictEqual({
+				headers: {},
+				method: 'get',
+				responseType: 'blob',
+				url: 'http://localhost:3000/',
+				onUploadProgress: expect.any(Function),
+			});
+
+			// Invoke the request's onUploadProgress function manually
+			lastCall.onUploadProgress({ loaded: 10, total: 100 });
+			expect(mockEmit).toHaveBeenLastCalledWith('sendProgress', {
+				loaded: 10,
+				total: 100,
+			});
+		});
+
+		it('should timeout after requestTimeout', async () => {
+			const handler = new AxiosHttpHandler({ requestTimeout: 1000 });
+			const req = handler.handle(request, options);
+			expect(setTimeout).toHaveBeenCalledTimes(1);
+			expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1000);
+			jest.advanceTimersByTime(1000);
+			await expect(req).rejects.toThrowError(
+				'Request did not complete within 1000 ms'
+			);
+		});
+
+		it('axios request should log and re-throw error', async () => {
+			axios.request = jest
+				.fn()
+				.mockImplementation(() => Promise.reject(new Error('err')));
+			const loggerSpy = jest.spyOn(Logger.prototype, '_log');
+			const handler = new AxiosHttpHandler();
+			await expect(handler.handle(request, options)).rejects.toThrowError(
+				'err'
+			);
+			expect(loggerSpy).toHaveBeenCalledWith('ERROR', 'err');
 		});
 	});
 

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -18,6 +18,7 @@ import {
 	ListObjectsCommand,
 	CopyObjectCommandInput,
 	CopyObjectCommand,
+	PutObjectCommandInput,
 } from '@aws-sdk/client-s3';
 import { formatUrl } from '@aws-sdk/util-format-url';
 import { createRequest } from '@aws-sdk/util-create-request';
@@ -335,7 +336,7 @@ export class AWSS3Provider implements StorageProvider {
 		const final_key = prefix + key;
 		logger.debug('put ' + key + ' to ' + final_key);
 
-		const params: any = {
+		const params: PutObjectCommandInput = {
 			Bucket: bucket,
 			Key: final_key,
 			Body: object,
@@ -383,15 +384,15 @@ export class AWSS3Provider implements StorageProvider {
 		}
 
 		try {
-			emitter.on('sendProgress', progress => {
-				if (progressCallback) {
-					if (typeof progressCallback === 'function') {
+			if (progressCallback) {
+				if (typeof progressCallback === 'function') {
+					emitter.on('sendProgress', progress => {
 						progressCallback(progress);
-					} else {
-						logger.warn('progressCallback should be a function, not a ' + typeof progressCallback);
-					}
+					});
+				} else {
+					logger.warn('progressCallback should be a function, not a ' + typeof progressCallback);
 				}
-			});
+			}
 
 			const response = await uploader.upload();
 

--- a/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
+++ b/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
@@ -54,12 +54,12 @@ export class AWSS3ProviderManagedUpload {
 	private params = null;
 	private opts = null;
 	private completedParts: CompletedPart[] = [];
-	private cancel: boolean = false;
+	private cancel = false;
 
 	// Progress reporting
 	private bytesUploaded = 0;
 	private totalBytesToUpload = 0;
-	private emitter = null;
+	private emitter: events.EventEmitter = null;
 
 	constructor(params: PutObjectRequest, opts, emitter: events.EventEmitter) {
 		this.params = params;
@@ -232,7 +232,7 @@ export class AWSS3ProviderManagedUpload {
 			try {
 				await this.cleanup(uploadId);
 			} catch (error) {
-				errorMessage += error.errorMessage;
+				errorMessage += ` ${error.message}`;
 			}
 			throw new Error(errorMessage);
 		}

--- a/packages/storage/src/providers/axios-http-handler.ts
+++ b/packages/storage/src/providers/axios-http-handler.ts
@@ -156,7 +156,7 @@ export class AxiosHttpHandler implements HttpHandler {
 				})
 				.catch(error => {
 					// Error
-					logger.error(error);
+					logger.error(error.message);
 					throw error;
 				}),
 			requestTimeout(requestTimeoutInMs),


### PR DESCRIPTION
### Problem
Currently, if the `"addtimestampfields": true` flag is defined in an Amplify project via `cli.json`, when a user runs `amplify codegen models`, the outputted code in `schema.js` will have these timestamp fields added (with values managed by AppSync):
```js
"createdAt": {
    "name": "createdAt",
    "isArray": false,
    "type": "AWSDateTime",
    "isRequired": false,
    "attributes": [],
    "isReadOnly": true
},
"updatedAt": {
    "name": "updatedAt",
    "isArray": false,
    "type": "AWSDateTime",
    "isRequired": false,
    "attributes": [],
    "isReadOnly": true
}
```

Codegen has been updated to add these fields ([aws-amplify/amplify-codegen#114](https://github.com/aws-amplify/amplify-codegen/pull/114)) but the current implementation of Amplify JS datastore doesn't expose these fields to the customer. 

Additionally, these fields (and potentially others down the road) are defined with the `isReadOnly` flag set to `true`, meaning the user should not be able to modify the values of these fields with data input to a mutation, and we don't currently have anything in place to check for this `isReadOnly` flag on the input fields.

### Solution

We can't rely on the timestamp's field names to be `createdAt` or `updatedAt` since custom labels can be generated with code like:
```gql
type Post @model(timestamps:{createdAt: "createdOn", updatedAt: "updatedOn"} {
  id: ID!
}
```
so we need to check for the `isReadOnly` flag added by codegen on all fields regardless of their defined label.

This PR adds the `isReadOnly` property to the `@ModelField` interface - which codegen will set to `true` for timestamp fields (regardless of their label). This will ensure that they still get requested in the selection set, and read in the response, but they just won't be able to be modified.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
