### PR TITLE
add support for Cognito/Pinpoint integration via AnalyticsMetadata pa…

### DIFF
--- a/packages/amazon-cognito-identity-js/index.d.ts
+++ b/packages/amazon-cognito-identity-js/index.d.ts
@@ -296,11 +296,16 @@ declare module 'amazon-cognito-identity-js' {
 		codeDeliveryDetails: CodeDeliveryDetails;
 	}
 
+	export interface ICognitoAnalyticsMetadata {
+		analyticsEndpointId: string;
+	}
+
 	export interface ICognitoUserPoolData {
 		UserPoolId: string;
 		ClientId: string;
 		endpoint?: string;
 		Storage?: ICognitoStorage;
+		AnalyticsMetadata?: ICognitoAnalyticsMetadata;
 		AdvancedSecurityDataCollectionFlag?: boolean;
 	}
 

--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -420,6 +420,7 @@ export default class CognitoUser {
 			ClientId: this.pool.getClientId(),
 			AuthParameters: authParameters,
 			ClientMetadata: clientMetaData,
+			AnalyticsMetadata: this.pool.analyticsMetadata,
 		};
 		if (this.getUserContextData(this.username)) {
 			jsonReq.UserContextData = this.getUserContextData(this.username);
@@ -618,6 +619,7 @@ export default class CognitoUser {
 			ChallengeResponses: finalUserAttributes,
 			Session: this.Session,
 			ClientMetadata: clientMetadata,
+			AnalyticsMetadata: this.pool.analyticsMetadata,
 		};
 		if (this.getUserContextData()) {
 			jsonReq.UserContextData = this.getUserContextData();
@@ -672,6 +674,7 @@ export default class CognitoUser {
 				ClientId: this.pool.getClientId(),
 				ChallengeResponses: authParameters,
 				ClientMetadata: clientMetadata,
+				AnalyticsMetadata: this.pool.analyticsMetadata,
 			};
 			if (this.getUserContextData()) {
 				jsonReq.UserContextData = this.getUserContextData();
@@ -775,6 +778,7 @@ export default class CognitoUser {
 			Username: this.username,
 			ForceAliasCreation: forceAliasCreation,
 			ClientMetadata: clientMetadata,
+			AnalyticsMetadata: this.pool.analyticsMetadata,
 		};
 		if (this.getUserContextData()) {
 			jsonReq.UserContextData = this.getUserContextData();
@@ -817,6 +821,7 @@ export default class CognitoUser {
 			ClientId: this.pool.getClientId(),
 			Session: this.Session,
 			ClientMetadata: clientMetadata,
+			AnalyticsMetadata: this.pool.analyticsMetadata,
 		};
 		if (this.getUserContextData()) {
 			jsonReq.UserContextData = this.getUserContextData();
@@ -863,6 +868,7 @@ export default class CognitoUser {
 			ClientId: this.pool.getClientId(),
 			Session: this.Session,
 			ClientMetadata: clientMetadata,
+			AnalyticsMetadata: this.pool.analyticsMetadata,
 		};
 		if (this.getUserContextData()) {
 			jsonReq.UserContextData = this.getUserContextData();
@@ -1470,6 +1476,7 @@ export default class CognitoUser {
 			AuthFlow: 'REFRESH_TOKEN_AUTH',
 			AuthParameters: authParameters,
 			ClientMetadata: clientMetadata,
+			AnalyticsMetadata: this.pool.analyticsMetadata,
 		};
 		if (this.getUserContextData()) {
 			jsonReq.UserContextData = this.getUserContextData();
@@ -1658,6 +1665,7 @@ export default class CognitoUser {
 			ClientId: this.pool.getClientId(),
 			Username: this.username,
 			ClientMetadata: clientMetadata,
+			AnalyticsMetadata: this.pool.analyticsMetadata,
 		};
 		if (this.getUserContextData()) {
 			jsonReq.UserContextData = this.getUserContextData();
@@ -1690,6 +1698,7 @@ export default class CognitoUser {
 			ConfirmationCode: confirmationCode,
 			Password: newPassword,
 			ClientMetadata: clientMetadata,
+			AnalyticsMetadata: this.pool.analyticsMetadata,
 		};
 		if (this.getUserContextData()) {
 			jsonReq.UserContextData = this.getUserContextData();

--- a/packages/amazon-cognito-identity-js/src/CognitoUserPool.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUserPool.js
@@ -30,6 +30,7 @@ export default class CognitoUserPool {
 	 * @param {object} data.fetchOptions Optional options for fetch API.
 	 *        (only credentials option is supported)
 	 * @param {object} data.Storage Optional storage object.
+	 * @param {object} data.AnalyticsMetadata Optional AnalyticsMetadata object for Pinpoint endpoint management
 	 * @param {boolean} data.AdvancedSecurityDataCollectionFlag Optional:
 	 *        boolean flag indicating if the data collection is enabled
 	 *        to support cognito advanced security features. By default, this
@@ -64,6 +65,7 @@ export default class CognitoUserPool {
 			AdvancedSecurityDataCollectionFlag !== false;
 
 		this.storage = data.Storage || new StorageHelper().getStorage();
+		this.analyticsMetadata = data.AnalyticsMetadata || null;
 
 		if (wrapRefreshSessionCallback) {
 			this.wrapRefreshSessionCallback = wrapRefreshSessionCallback;
@@ -115,6 +117,7 @@ export default class CognitoUserPool {
 			UserAttributes: userAttributes,
 			ValidationData: validationData,
 			ClientMetadata: clientMetadata,
+			AnalyticsMetadata: this.analyticsMetadata,
 		};
 		if (this.getUserContextData(username)) {
 			jsonReq.UserContextData = this.getUserContextData(username);

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -150,6 +150,7 @@ export class AuthClass {
 			refreshHandlers,
 			identityPoolRegion,
 			clientMetadata,
+			analyticsMetadata,
 			endpoint,
 		} = this._config;
 
@@ -178,6 +179,7 @@ export class AuthClass {
 			const userPoolData: ICognitoUserPoolData = {
 				UserPoolId: userPoolId,
 				ClientId: userPoolWebClientId,
+				AnalyticsMetadata: analyticsMetadata,
 				endpoint,
 			};
 			userPoolData.Storage = this._storage;

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -14,6 +14,7 @@
 import {
 	ICookieStorageData,
 	ICognitoStorage,
+	ICognitoAnalyticsMetadata,
 } from 'amazon-cognito-identity-js';
 
 /**
@@ -49,6 +50,7 @@ export interface AuthOptions {
 	authenticationFlowType?: string;
 	identityPoolRegion?: string;
 	clientMetadata?: any;
+	analyticsMetadata?: ICognitoAnalyticsMetadata;
 	endpoint?: string;
 }
 


### PR DESCRIPTION
This PR is a first-cut draft with minimal support to enable Cognito Analytics integration with Pinpoint.

For Cognito Analytics to work, it is not enough to enable it on the Cognito resource; you also need to include the AnalyticsMetadata parameter in Cognito API calls. Otherwise, email/phone endpoints will not be automatically created in Pinpoint for your users when they sign up. However, Amplify abstracts away all calls to the Cognito API, and it does not currently support the inclusion of that parameter, so Amplify developers are left with no simple way to communicate with their customers using Pinpoint.

Amplify already supports the creation and maintenance of Cognito and Pinpoint resources. In order to achieve full integration, it should support enabling Analytics on the user pool, as well as automatically including the metadata parameter in its Cognito API calls. This PR addresses the latter; it enables the use of the metadata parameter as a step towards the larger goal of fully automating the complete integration.

With this changeset in place, you can manually enable Cognito Analytics in the Cognito console under General Settings / Analytics, and add the following code snippet near the top of your main app source to configure the Auth service:

```
import {Auth} from 'aws-amplify';

Auth.configure({
  analyticsMetadata: {
    AnalyticsEndpointId: awsmobile.aws_mobile_analytics_app_id,
  },
});
```

Then your Cognito users will automatically have their Pinpoint endpoints created.

#### Description of changes
This change adds the analyticsMetadata config parameter to the Auth service so that it can be configured as shown above. That value then gets pushed into the `CognitoUserPool` provided by the `amazon-cognito-identity-js` package, and the value from the pool then gets used as the `AnalyticsMetadata` parameter in Cognito API requests where it is supported. Note that many of these requests happen from methods on `CognitoUser` so it simply gets the value through its existing `pool` attribute.

This is a minimal change with low risk for breakage and high impact in terms of opening up integration between Cognito and Pinpoint.

#### Issue #, if available
Issue #7675 

#### Description of how you validated changes
To validate these changes, I manually stepped through user signUp and email address verification and confirmed that the Pinpoint endpoint was created. More thorough testing and feedback from the community would be helpful and appreciated.

`yarn test` is failing for me with an `UnhandledPromiseRejection` in `@aws-amplify/core` but I believe that has something to do with my local environment and does not appear to be related to these changes. If anyone can verify this PR as non-breaking, that would be greatly appreciated.

I cannot think of any useful automated tests to add or change since this is an optional parameter that relies on a working environment to properly test. Perhaps we could validate the inclusion of the AnalyticsMetadata value in API requests when the value has been configured in Auth, but the architecture does not appear to lend itself to that test. If anyone can think of anything useful and feasible, please let me know. Otherwise the checklist item related to addition/modification of tests can likely be removed.

Also not sure the best place to add documentation for the steps necessary to enable and configure the integration as described above. Maybe the [Authentication - Getting Started](https://docs.amplify.aws/lib/auth/getting-started/q/platform/js) page? Thoughts and contributions welcome here as well.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
