### PR TITLE
chore: updating typescript definition for initialAuthState

### DIFF
--- a/packages/amplify-ui-components/src/components.d.ts
+++ b/packages/amplify-ui-components/src/components.d.ts
@@ -59,7 +59,9 @@ export namespace Components {
         /**
           * Initial starting state of the Authenticator component. E.g. If `signup` is passed the default component is set to AmplifySignUp
          */
-        "initialAuthState": AuthState.SignIn | AuthState.SignUp;
+        "initialAuthState": | AuthState.SignIn
+		| AuthState.SignUp
+		| AuthState.ForgotPassword;
         /**
           * Username Alias is used to setup authentication with `username`, `email` or `phone_number`
          */
@@ -1573,7 +1575,9 @@ declare namespace LocalJSX {
         /**
           * Initial starting state of the Authenticator component. E.g. If `signup` is passed the default component is set to AmplifySignUp
          */
-        "initialAuthState"?: AuthState.SignIn | AuthState.SignUp;
+        "initialAuthState"?: | AuthState.SignIn
+		| AuthState.SignUp
+		| AuthState.ForgotPassword;
         /**
           * Username Alias is used to setup authentication with `username`, `email` or `phone_number`
          */

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/amplify-authenticator.tsx
@@ -44,8 +44,10 @@ const logger = new Logger('Authenticator');
 })
 export class AmplifyAuthenticator {
 	/** Initial starting state of the Authenticator component. E.g. If `signup` is passed the default component is set to AmplifySignUp */
-	@Prop() initialAuthState: AuthState.SignIn | AuthState.SignUp =
-		AuthState.SignIn;
+	@Prop() initialAuthState:
+		| AuthState.SignIn
+		| AuthState.SignUp
+		| AuthState.ForgotPassword = AuthState.SignIn;
 	/** Federated credentials & configuration. */
 	@Prop() federated: FederatedConfig;
 	/** Username Alias is used to setup authentication with `username`, `email` or `phone_number`  */

--- a/packages/amplify-ui-components/src/components/amplify-authenticator/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-authenticator/readme.md
@@ -5,13 +5,13 @@
 
 ## Properties
 
-| Property                | Attribute            | Description                                                                                                                     | Type                                                | Default            |
-| ----------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ------------------ |
-| `federated`             | --                   | Federated credentials & configuration.                                                                                          | `FederatedConfig`                                   | `undefined`        |
-| `handleAuthStateChange` | --                   | Callback for Authenticator state machine changes                                                                                | `(nextAuthState: AuthState, data?: object) => void` | `() => {}`         |
-| `hideToast`             | `hide-toast`         | Hide amplify-toast for auth errors                                                                                              | `boolean`                                           | `false`            |
-| `initialAuthState`      | `initial-auth-state` | Initial starting state of the Authenticator component. E.g. If `signup` is passed the default component is set to AmplifySignUp | `AuthState.SignIn \| AuthState.SignUp`              | `AuthState.SignIn` |
-| `usernameAlias`         | `username-alias`     | Username Alias is used to setup authentication with `username`, `email` or `phone_number`                                       | `"email" \| "phone_number" \| "username"`           | `undefined`        |
+| Property                | Attribute            | Description                                                                                                                     | Type                                                               | Default            |
+| ----------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------ |
+| `federated`             | --                   | Federated credentials & configuration.                                                                                          | `FederatedConfig`                                                  | `undefined`        |
+| `handleAuthStateChange` | --                   | Callback for Authenticator state machine changes                                                                                | `(nextAuthState: AuthState, data?: object) => void`                | `() => {}`         |
+| `hideToast`             | `hide-toast`         | Hide amplify-toast for auth errors                                                                                              | `boolean`                                                          | `false`            |
+| `initialAuthState`      | `initial-auth-state` | Initial starting state of the Authenticator component. E.g. If `signup` is passed the default component is set to AmplifySignUp | `AuthState.ForgotPassword \| AuthState.SignIn \| AuthState.SignUp` | `AuthState.SignIn` |
+| `usernameAlias`         | `username-alias`     | Username Alias is used to setup authentication with `username`, `email` or `phone_number`                                       | `"email" \| "phone_number" \| "username"`                          | `undefined`        |
 
 
 ## Slots


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR updates the TypeScript definition for our `initialAuthState` to include `AuthState.ForgotPassword` as an accepted initial state. Interestingly, we already have a test covering this use.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-js/issues/7668

#### Description of how you validated changes

Tested locally in a sample app. We already have a unit test for this specific case of setting `ForgotPassword` as the initial state.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
