### PR TITLE
feat: make sign in button full width if not sign up button present

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-sign-in/__snapshots__/amplify-sign-in.spec.ts.snap
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/__snapshots__/amplify-sign-in.spec.ts.snap
@@ -21,13 +21,15 @@ exports[`amplify-sign-in spec: Render logic -> should render a \`sign in\` form 
               </amplify-button>
             </span>
           </slot>
-          <slot name="primary-footer-content">
-            <amplify-button data-test="sign-in-sign-in-button" type="submit">
-              <span>
-                Sign In
-              </span>
-            </amplify-button>
-          </slot>
+          <div>
+            <slot name="primary-footer-content">
+              <amplify-button data-test="sign-in-sign-in-button" type="submit">
+                <span>
+                  Sign In
+                </span>
+              </amplify-button>
+            </slot>
+          </div>
         </slot>
       </div>
     </amplify-form-section>
@@ -56,13 +58,15 @@ exports[`amplify-sign-in spec: amplify-sign-in stories stories withEmptyFederate
               </amplify-button>
             </span>
           </slot>
-          <slot name="primary-footer-content">
-            <amplify-button data-test="sign-in-sign-in-button" type="submit">
-              <span>
-                Sign In
-              </span>
-            </amplify-button>
-          </slot>
+          <div>
+            <slot name="primary-footer-content">
+              <amplify-button data-test="sign-in-sign-in-button" type="submit">
+                <span>
+                  Sign In
+                </span>
+              </amplify-button>
+            </slot>
+          </div>
         </slot>
       </div>
     </amplify-form-section>
@@ -94,13 +98,15 @@ exports[`amplify-sign-in spec: amplify-sign-in stories stories withFederated 1`]
               </amplify-button>
             </span>
           </slot>
-          <slot name="primary-footer-content">
-            <amplify-button data-test="sign-in-sign-in-button" type="submit">
-              <span>
-                Sign In
-              </span>
-            </amplify-button>
-          </slot>
+          <div>
+            <slot name="primary-footer-content">
+              <amplify-button data-test="sign-in-sign-in-button" type="submit">
+                <span>
+                  Sign In
+                </span>
+              </amplify-button>
+            </slot>
+          </div>
         </slot>
       </div>
     </amplify-form-section>

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.scss
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.scss
@@ -40,3 +40,7 @@
 		margin-bottom: 15px;
 	}
 }
+
+.full-width-footer-content {
+	width: 100%;
+}

--- a/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-sign-in/amplify-sign-in.tsx
@@ -299,8 +299,8 @@ export class AmplifySignIn {
 					<amplify-auth-fields formFields={this.newFormFields} />
 					<div slot="amplify-form-section-footer" class="sign-in-form-footer">
 						<slot name="footer">
-							<slot name="secondary-footer-content">
-								{!this.hideSignUp ? (
+							{!this.hideSignUp && (
+								<slot name="secondary-footer-content">
 									<span>
 										{I18n.get(Translations.NO_ACCOUNT_TEXT)}{' '}
 										<amplify-button
@@ -313,24 +313,24 @@ export class AmplifySignIn {
 											{I18n.get(Translations.CREATE_ACCOUNT_TEXT)}
 										</amplify-button>
 									</span>
-								) : (
-									<span></span>
-								)}
-							</slot>
+								</slot>
+							)}
 
-							<slot name="primary-footer-content">
-								<amplify-button
-									type="submit"
-									disabled={this.loading}
-									data-test="sign-in-sign-in-button"
-								>
-									{this.loading ? (
-										<amplify-loading-spinner />
-									) : (
-										<span>{I18n.get(this.submitButtonText)}</span>
-									)}
-								</amplify-button>
-							</slot>
+							<div class={this.hideSignUp ? 'full-width-footer-content' : ''}>
+								<slot name="primary-footer-content">
+									<amplify-button
+										type="submit"
+										disabled={this.loading}
+										data-test="sign-in-sign-in-button"
+									>
+										{this.loading ? (
+											<amplify-loading-spinner />
+										) : (
+											<span>{I18n.get(this.submitButtonText)}</span>
+										)}
+									</amplify-button>
+								</slot>
+							</div>
 						</slot>
 					</div>
 				</amplify-form-section>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This change detects if the `hideSignUp` property is enabled on the `AmplifySignIn` component and, if so, will render the "Sign In" button with the full width of the component container.

Sreenshot - 
<img width="597" alt="Screen Shot 2021-06-14 at 9 27 48 AM" src="https://user-images.githubusercontent.com/17255334/121950308-4c673300-cd0e-11eb-9467-5c3e5254cfd2.png">

<img width="527" alt="Screen Shot 2021-06-14 at 12 45 29 PM" src="https://user-images.githubusercontent.com/17255334/121950384-6bfe5b80-cd0e-11eb-9574-09a584fc74d6.png">


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-js/issues/7564

#### Description of how you validated changes

Testing locally in a sample app.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
