### PR TITLE
feat: adding border radius to amplify-button

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-button/amplify-button.scss
+++ b/packages/amplify-ui-components/src/components/amplify-button/amplify-button.scss
@@ -5,6 +5,7 @@
  * @prop --color: Text color within the button
  * @prop --border-width: Border width of the button
  * @prop --border-color: Border color of the button
+ * @prop --border-radius: Border radius of the button
  * @prop --border-style: Border style of the button
  * @prop --link-color: Text color within an anchor variant button
  * @prop --link-hover: Text color within an anchor variant button when hovering
@@ -23,6 +24,7 @@ amplify-button {
 	--border-width: 0;
 	--border-color: initial;
 	--border-style: initial;
+	--border-radius: initial;
 	--link-color: var(--amplify-primary-color);
 	--link-hover: var(--amplify-primary-tint);
 	--link-active: var(--amplify-primary-shade);
@@ -63,6 +65,7 @@ amplify-button {
 	border-width: var(--border-width);
 	border-color: var(--border-color);
 	border-style: var(--border-style);
+	border-radius: var(--border-radius);
 
 	&:active {
 		opacity: 1;

--- a/packages/amplify-ui-components/src/components/amplify-button/readme.md
+++ b/packages/amplify-ui-components/src/components/amplify-button/readme.md
@@ -29,6 +29,7 @@
 | `--background-color-active`  | Background color of the button when it's active          |
 | `--background-color-disable` | Background color of the button when it's disabled        |
 | `--border-color`             | Border color of the button                               |
+| `--border-radius`            | Border radius of the button                              |
 | `--border-style`             | Border style of the button                               |
 | `--border-width`             | Border width of the button                               |
 | `--color`                    | Text color within the button                             |


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adds a border radius prop to the `amplify-button` scss.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Original pull request here - https://github.com/aws-amplify/amplify-js/pull/7904

^^ comes from another contributor. However, the PR hasn't been updated with the requested changes and it's been a few months. I'm resubmitting it now so we can get it merged and knock off an issue in our milestone.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
