### PR TITLE
fix: corrects setting an item universally

### DIFF
--- a/packages/core/src/UniversalStorage/index.ts
+++ b/packages/core/src/UniversalStorage/index.ts
@@ -104,7 +104,7 @@ export class UniversalStorage implements Storage {
 			// `httpOnly` cannot be set via JavaScript: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#JavaScript_access_using_Document.cookie
 			sameSite: true,
 			// Allow unsecure requests to http://localhost:3000/ when in development.
-			secure: window.location.hostname === 'localhost' ? false : true,
+			secure: isBrowser && window.location.hostname === 'localhost' ? false : true,
 		});
 	}
 }


### PR DESCRIPTION
#### This change correctly tests the environment before settings a value within the universal storage class

#### There is no issue number, this is a fairly small succinct change

#### There is an absence of unit tests for the universal storage class, so I had to verify manually. Given the atomic size of the change, I think this should suffice.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
