### PR TITLE
Amplify UI components/fix phone number input new pw

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-require-new-password/amplify-require-new-password.spec.ts
+++ b/packages/amplify-ui-components/src/components/amplify-require-new-password/amplify-require-new-password.spec.ts
@@ -2,6 +2,7 @@ import { I18n } from '@aws-amplify/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { AmplifyRequireNewPassword } from './amplify-require-new-password';
 import { Translations } from '../../common/Translations';
+import { COUNTRY_DIAL_CODE_DEFAULT } from '../../common/constants';
 
 describe('amplify-require-new-password spec:', () => {
 	describe('Component logic ->', () => {
@@ -28,6 +29,12 @@ describe('amplify-require-new-password spec:', () => {
 		it('should evaluate `submitButtonText` to `Change` by default', () => {
 			expect(requireNewPassword.submitButtonText).toEqual(
 				I18n.get(Translations.CHANGE_PASSWORD_ACTION)
+			);
+		});
+
+		it('should evaluate `phoneNumber` with a valid country code by default', () => {
+			expect(requireNewPassword.phoneNumber.countryDialCodeValue).toEqual(
+				COUNTRY_DIAL_CODE_DEFAULT
 			);
 		});
 	});

--- a/packages/amplify-ui-components/src/components/amplify-require-new-password/amplify-require-new-password.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-require-new-password/amplify-require-new-password.tsx
@@ -83,14 +83,11 @@ export class AmplifyRequireNewPassword {
 
 	async setCurrentUser(): Promise<void> {
 		if (!this.user) {
-			console.log('checking for user..');
 			// Check for authenticated user
 			try {
 				const user = await Auth.currentAuthenticatedUser();
-				console.log('got user! - ', user);
 				if (user) this.currentUser = user;
 			} catch (error) {
-				console.log('no user! - ', error);
 				dispatchToastHubEvent(error);
 			}
 		} else {
@@ -148,13 +145,7 @@ export class AmplifyRequireNewPassword {
 		this.loading = true;
 		try {
 			if (this.requiredAttributes['phone_number']) {
-				console.log('got a phone number!!!!');
-				console.log(this.requiredAttributes);
-
 				this.formatPhoneNumber(event);
-
-				console.log('new phone number!!');
-				console.log(this.requiredAttributes['phone_number']);
 			}
 
 			const user = await Auth.completeNewPassword(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR basically takes over an older PR that was submitted, but not updated, a few months ago - https://github.com/aws-amplify/amplify-js/pull/7802

It fixes the phone number formatting on the "require new password" form. Description from the other PR - 

""
This issue occurs when creating a new cognito user with temporary password and without a phoneNumber. If phoneNumber is an required field, the amplify-require-new-password component will contain a dialCode dropdown and a phoneNumber input. Both the dropdown and input field overrides the required phone_numberfield, and only way to proceed is to enter the entire dialCode + phoneNumber in the input field.

This issue was fixed using same helper functions handlePhoneNumberChange and composePhoneNumberInput as used in components (sign-up, sign-in, forgot-password, confirm-sign-up)
""


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Issue - https://github.com/aws-amplify/amplify-js/issues/7175

#### Description of how you validated changes

`yarn test` and local testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
