### PR TITLE
fix(@aws-amplify/ui-components): including handleInputChange in amplify-confirm-sign-in fields only when not specified

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-confirm-sign-in/amplify-confirm-sign-in.spec.ts
+++ b/packages/amplify-ui-components/src/components/amplify-confirm-sign-in/amplify-confirm-sign-in.spec.ts
@@ -70,6 +70,17 @@ describe('amplify-confirm-sign-in spec:', () => {
 			expect(retVal[0].type).toBe('code');
 			expect(retVal[0].handleInputChange).toBeDefined();
 			expect(typeof retVal[0].handleInputChange).toBe('function');
+
+			const formFields = [{
+				type: 'code',
+				handleInputChange: () => {},
+			}];
+			retVal = confirmSignIn.constructFormFieldOptions(formFields);
+			expect(retVal).toHaveLength(1);
+			expect(retVal[0].type).toBe('code');
+			expect(retVal[0].handleInputChange).toBeDefined();
+			expect(typeof retVal[0].handleInputChange).toBe('function');
+			expect(retVal[0].handleInputChange).toBe(formFields[0].handleInputChange);
 		});
 	});
 	describe('Render logic ->', () => {

--- a/packages/amplify-ui-components/src/components/amplify-confirm-sign-in/amplify-confirm-sign-in.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-confirm-sign-in/amplify-confirm-sign-in.tsx
@@ -137,8 +137,8 @@ export class AmplifyConfirmSignIn {
 			} else {
 				// This is a code input field. Attach input handler.
 				content.push({
-					...(formField as FormFieldType), // `inputProps` will be passed over here.
 					handleInputChange: event => this.handleCodeChange(event),
+					...(formField as FormFieldType), // `inputProps` will be passed over here.
 				});
 			}
 		});


### PR DESCRIPTION
Ref. https://github.com/aws-amplify/amplify-js/pull/8255#issuecomment-866642875

Cc: @hannesj

#### Description of changes
Including handleInputChange in amplify-confirm-sign-in fields only when not specified


#### Issue #, if available
https://github.com/aws-amplify/amplify-js/pull/8255#issuecomment-866642875

#### Checklist
- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
