### PR TITLE
feat(@aws-amplify/datastore): expose timestamp fields and prevent writing to read-only fields

### DIFF
--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -561,9 +561,9 @@ describe('DataStore tests', () => {
 				field1: 'something',
 				dateCreated: new Date().toISOString(),
 				createdAt: '2021-06-03T20:56:23.201Z',
-			});
+			} as any);
 
-			expect(DataStore.save(model)).rejects.toThrowError(
+			await expect(DataStore.save(model)).rejects.toThrowError(
 				'createdAt is read-only.'
 			);
 
@@ -573,18 +573,18 @@ describe('DataStore tests', () => {
 			});
 
 			model = Model.copyOf(model, draft => {
-				draft.createdAt = '2021-06-03T20:56:23.201Z';
+				(draft as any).createdAt = '2021-06-03T20:56:23.201Z';
 			});
 
-			expect(DataStore.save(model)).rejects.toThrowError(
+			await expect(DataStore.save(model)).rejects.toThrowError(
 				'createdAt is read-only.'
 			);
 
 			model = Model.copyOf(model, draft => {
-				draft.updatedAt = '2021-06-03T20:56:23.201Z';
+				(draft as any).updatedAt = '2021-06-03T20:56:23.201Z';
 			});
 
-			expect(DataStore.save(model)).rejects.toThrowError(
+			await expect(DataStore.save(model)).rejects.toThrowError(
 				'updatedAt is read-only.'
 			);
 		});

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -528,6 +528,67 @@ describe('DataStore tests', () => {
 			expect(patches2).toMatchObject(expectedPatches2);
 		});
 
+		test('Read-only fields cannot be overwritten', async () => {
+			let model: Model;
+			const save = jest.fn(() => [model]);
+			const query = jest.fn(() => [model]);
+
+			jest.resetModules();
+			jest.doMock('../src/storage/storage', () => {
+				const mock = jest.fn().mockImplementation(() => {
+					const _mock = {
+						init: jest.fn(),
+						save,
+						query,
+						runExclusive: jest.fn(fn => fn.bind(this, _mock)()),
+					};
+
+					return _mock;
+				});
+
+				(<any>mock).getNamespace = () => ({ models: {} });
+
+				return { ExclusiveStorage: mock };
+			});
+
+			({ initSchema, DataStore } = require('../src/datastore/datastore'));
+
+			const classes = initSchema(testSchema());
+
+			const { Model } = classes as { Model: PersistentModelConstructor<Model> };
+
+			model = new Model({
+				field1: 'something',
+				dateCreated: new Date().toISOString(),
+				createdAt: '2021-06-03T20:56:23.201Z',
+			});
+
+			expect(DataStore.save(model)).rejects.toThrowError(
+				'createdAt is read-only.'
+			);
+
+			model = new Model({
+				field1: 'something',
+				dateCreated: new Date().toISOString(),
+			});
+
+			model = Model.copyOf(model, draft => {
+				draft.createdAt = '2021-06-03T20:56:23.201Z';
+			});
+
+			expect(DataStore.save(model)).rejects.toThrowError(
+				'createdAt is read-only.'
+			);
+
+			model = Model.copyOf(model, draft => {
+				draft.updatedAt = '2021-06-03T20:56:23.201Z';
+			});
+
+			expect(DataStore.save(model)).rejects.toThrowError(
+				'updatedAt is read-only.'
+			);
+		});
+
 		test('Instantiation validations', async () => {
 			expect(() => {
 				new Model({

--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -8,6 +8,8 @@ export declare class Model {
 	public readonly emails?: string[];
 	public readonly ips?: (string | null)[];
 	public readonly metadata?: Metadata;
+	public readonly createdAt?: string;
+	public readonly updatedAt?: string;
 
 	constructor(init: ModelInit<Model>);
 
@@ -135,6 +137,22 @@ export function testSchema(): Schema {
 						},
 						isRequired: false,
 						attributes: [],
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: false,
+						attributes: [],
+						isReadOnly: true,
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: false,
+						attributes: [],
+						isReadOnly: true,
 					},
 				},
 			},

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -407,7 +407,7 @@ const createModelClass = <T extends PersistentModel>(
 			const model = produce(
 				source,
 				draft => {
-					fn(<MutableModel<T>>draft);
+					fn(<MutableModel<T>>(draft as unknown));
 					draft.id = source.id;
 					const modelValidator = validateModelFields(modelDefinition);
 					Object.entries(draft).forEach(([k, v]) => {

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -275,7 +275,7 @@ export function isEnumFieldType(obj: any): obj is EnumFieldType {
 	return false;
 }
 
-type ModelField = {
+export type ModelField = {
 	name: string;
 	type:
 		| keyof Omit<
@@ -287,6 +287,7 @@ type ModelField = {
 		| EnumFieldType;
 	isArray: boolean;
 	isRequired?: boolean;
+	isReadOnly?: boolean;
 	isArrayNullable?: boolean;
 	association?: ModelAssociation;
 	attributes?: ModelAttributes[];

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -300,24 +300,55 @@ export type NonModelTypeConstructor<T> = {
 };
 
 // Class for model
-export type PersistentModelConstructor<T extends PersistentModel> = {
-	new (init: ModelInit<T>): T;
-	copyOf(src: T, mutator: (draft: MutableModel<T>) => void): T;
+export type PersistentModelConstructor<
+	T extends PersistentModel,
+	K extends PersistentModelMetaData = {
+		readOnlyFields: 'createdAt' | 'updatedAt';
+	}
+> = {
+	new (init: ModelInit<T, K | null>): T;
+	copyOf(src: T, mutator: (draft: MutableModel<T, K>) => void): T;
 };
 export type TypeConstructorMap = Record<
 	string,
-	PersistentModelConstructor<any> | NonModelTypeConstructor<any>
+	| PersistentModelConstructor<any, PersistentModelMetaData>
+	| NonModelTypeConstructor<any>
 >;
 
 // Instance of model
-export type PersistentModel = Readonly<{ id: string } & Record<string, any>>;
-export type ModelInit<T> = Omit<T, 'id'>;
+export type PersistentModelMetaData = {
+	readOnlyFields: string;
+};
+
+// export type PersistentModel = Readonly<{ id: string } & Record<string, any>>;
+export type PersistentModel<
+	K extends PersistentModelMetaData = {
+		readOnlyFields: 'createdAt' | 'updatedAt';
+	}
+> = Readonly<({ id: string } | K['readOnlyFields']) & Record<string, any>>;
+
+// ModelInit<SimpleModel, SimpleModelMetaData>
+export type ModelInit<
+	T,
+	K extends PersistentModelMetaData = {
+		readOnlyFields: 'createdAt' | 'updatedAt';
+	}
+> = Omit<T, 'id' | K['readOnlyFields']>;
 type DeepWritable<T> = {
 	-readonly [P in keyof T]: T[P] extends TypeName<T[P]>
 		? T[P]
 		: DeepWritable<T[P]>;
 };
-export type MutableModel<T> = Omit<DeepWritable<T>, 'id'>;
+
+export type MutableModel<
+	T extends Record<string, any>,
+	K extends PersistentModelMetaData = {
+		readOnlyFields: 'createdAt' | 'updatedAt';
+	}
+	// This provides Intellisense with ALL of the properties, regardless of read-only
+	// but will throw a linting error if trying to overwrite a read-only property
+> = Readonly<Pick<T, 'id' | K['readOnlyFields']>> &
+	DeepWritable<Omit<T, 'id' | K['readOnlyFields']>>;
 
 export type ModelInstanceMetadata = {
 	id: string;
@@ -338,7 +369,7 @@ export enum OpType {
 export type SubscriptionMessage<T extends PersistentModel> = {
 	opType: OpType;
 	element: T;
-	model: PersistentModelConstructor<T>;
+	model: PersistentModelConstructor<T, PersistentModelMetaData>;
 	condition: PredicatesGroup<T> | null;
 };
 //#endregion

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -275,7 +275,7 @@ export function isEnumFieldType(obj: any): obj is EnumFieldType {
 	return false;
 }
 
-export type ModelField = {
+type ModelField = {
 	name: string;
 	type:
 		| keyof Omit<
@@ -306,13 +306,13 @@ export type PersistentModelConstructor<
 		readOnlyFields: 'createdAt' | 'updatedAt';
 	}
 > = {
-	new (init: ModelInit<T, K | null>): T;
+	new (init: ModelInit<T, K>): T;
 	copyOf(src: T, mutator: (draft: MutableModel<T, K>) => void): T;
 };
+
 export type TypeConstructorMap = Record<
 	string,
-	| PersistentModelConstructor<any, PersistentModelMetaData>
-	| NonModelTypeConstructor<any>
+	PersistentModelConstructor<any> | NonModelTypeConstructor<any>
 >;
 
 // Instance of model
@@ -320,14 +320,7 @@ export type PersistentModelMetaData = {
 	readOnlyFields: string;
 };
 
-// export type PersistentModel = Readonly<{ id: string } & Record<string, any>>;
-export type PersistentModel<
-	K extends PersistentModelMetaData = {
-		readOnlyFields: 'createdAt' | 'updatedAt';
-	}
-> = Readonly<({ id: string } | K['readOnlyFields']) & Record<string, any>>;
-
-// ModelInit<SimpleModel, SimpleModelMetaData>
+export type PersistentModel = Readonly<{ id: string } & Record<string, any>>;
 export type ModelInit<
 	T,
 	K extends PersistentModelMetaData = {
@@ -347,8 +340,8 @@ export type MutableModel<
 	}
 	// This provides Intellisense with ALL of the properties, regardless of read-only
 	// but will throw a linting error if trying to overwrite a read-only property
-> = Readonly<Pick<T, 'id' | K['readOnlyFields']>> &
-	DeepWritable<Omit<T, 'id' | K['readOnlyFields']>>;
+> = DeepWritable<Omit<T, 'id' | K['readOnlyFields']>> &
+	Readonly<Pick<T, 'id' | K['readOnlyFields']>>;
 
 export type ModelInstanceMetadata = {
 	id: string;
@@ -369,7 +362,7 @@ export enum OpType {
 export type SubscriptionMessage<T extends PersistentModel> = {
 	opType: OpType;
 	element: T;
-	model: PersistentModelConstructor<T, PersistentModelMetaData>;
+	model: PersistentModelConstructor<T>;
 	condition: PredicatesGroup<T> | null;
 };
 //#endregion


### PR DESCRIPTION
(updated PR due to messy git/branch issues)

--------
[start of original PR]

### Problem

Currently, if the `"addtimestampfields": true` flag is defined in an Amplify project via `cli.json`, when a user runs `amplify codegen models`, the outputted code in `schema.js` will have these timestamp fields added (with values managed by AppSync):
```js
"createdAt": {
    "name": "createdAt",
    "isArray": false,
    "type": "AWSDateTime",
    "isRequired": false,
    "attributes": [],
    "isReadOnly": true
},
"updatedAt": {
    "name": "updatedAt",
    "isArray": false,
    "type": "AWSDateTime",
    "isRequired": false,
    "attributes": [],
    "isReadOnly": true
}
```

Codegen has been updated to add these fields ([aws-amplify/amplify-codegen#114](https://github.com/aws-amplify/amplify-codegen/pull/114)) but the current implementation of Amplify JS datastore doesn't expose these fields to the customer. 

Additionally, these fields (and potentially others down the road) are defined with the `isReadOnly` flag set to `true`, meaning the user should not be able to modify the values of these fields with data input to a mutation, and we don't currently have anything in place to check for this `isReadOnly` flag on the input fields.

### Solution

We can't rely on the timestamp's field names to be `createdAt` or `updatedAt` since custom labels can be generated with code like:
```gql
type Post @model(timestamps:{createdAt: "createdOn", updatedAt: "updatedOn"} {
  id: ID!
}
```
so we need to check for the `isReadOnly` flag added by codegen on all fields regardless of their defined label.

This PR adds the `isReadOnly` property to the `@ModelField` interface - which codegen will set to `true` for timestamp fields (regardless of their label). This will ensure that they still get requested in the selection set, and read in the response, but they just won't be able to be modified.

Codegen will now produce a model and its associated meta data types like the following in the `index.d.ts`:
```
type PostMetaData = {
	readOnlyFields: 'createdAt' | 'updatedAt';
};

export declare class Post {
	readonly id: string;
	readonly title: string;
	readonly status: PostStatus | keyof typeof PostStatus;
	readonly color?: string;
	readonly content?: string;
	readonly comments?: (Comment | null)[];
	readonly createdAt?: string;
	readonly updatedAt?: string;
	constructor(init: ModelInit<Post, PostMetaData>);
	static copyOf(
		source: Post,
		mutator: (
			draft: MutableModel<Post, PostMetaData>
		) => MutableModel<Post, PostMetaData> | void
	): Post;
}
```

### DX Typescript Enhancements

To provide an optimal developer experience, changes have been implemented (with the dedicated help of TS gurus @manueliglesias and @iartemiev 🙏) to catch these read-only properties within Intellisense and only provide hints where it logically applies.

In the user's app (if it is a TS project), when instantiating a new model Intellisense will omit any read-only properties:
<img width="798" alt="Screen Shot 2021-06-29 at 11 23 03 AM" src="https://user-images.githubusercontent.com/16296496/123854057-03e57300-d8d3-11eb-8fa7-be1d4dfcf035.png">



However, when using `[Model].copyOf`, Intellisense will provide hints including these read-only properties for any use case that involves reading this data (i.e. `console.log(draft.createdAt)`:
<img width="745" alt="Screen Shot 2021-06-29 at 12 21 21 PM" src="https://user-images.githubusercontent.com/16296496/123855317-a0f4db80-d8d4-11eb-8ce1-272dbb2ff71a.png">
<img width="581" alt="Screen Shot 2021-06-29 at 11 26 35 AM" src="https://user-images.githubusercontent.com/16296496/123855793-25475e80-d8d5-11eb-8367-cc1efca215cd.png">


But since the user won't be able to overwrite these read-only properties, we want to make sure to throw a linting error if they try:
<img width="778" alt="Screen Shot 2021-06-29 at 11 25 27 AM" src="https://user-images.githubusercontent.com/16296496/123855845-355f3e00-d8d5-11eb-9bf5-e954554a0380.png">
<img width="779" alt="Screen Shot 2021-06-29 at 11 26 10 AM" src="https://user-images.githubusercontent.com/16296496/123855851-37290180-d8d5-11eb-9e3c-97957ecc3828.png">
<img width="716" alt="Screen Shot 2021-06-29 at 11 26 20 AM" src="https://user-images.githubusercontent.com/16296496/123855853-37c19800-d8d5-11eb-8a32-6ca030e4efe6.png">



<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Associated Codegen Changes: https://github.com/aws-amplify/amplify-codegen/pull/185

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
