### PR TITLE
chore(@aws-amplify/aws-amplify-react-native): migrate to community Pi…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -936,6 +936,7 @@ releasable_branches: &releasable_branches
       - main
       - ui-components/main
       - 1.0-stable
+      - migrate-rn-picker
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"publish:1.0-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-1.0 --message 'chore(release): Publish [ci skip]' --no-verify-access",
 		"publish:ui-components/main": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=ui-preview --preid=ui-preview --exact --no-verify-access",
 		"publish:native": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=native --preid=native --exact --no-verify-access",
+		"publish:migrate-rn-picker": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=migrate-rn-picker --preid=migrate-rn-picker --exact --no-verify-access",
 		"publish:verdaccio": "lerna publish --no-push --canary minor --dist-tag=unstable --preid=unstable --exact --force-publish --yes --no-verify-access"
 	},
 	"husky": {

--- a/packages/aws-amplify-react-native/package.json
+++ b/packages/aws-amplify-react-native/package.json
@@ -21,9 +21,9 @@
 		"@babel/preset-env": "^7.9.6",
 		"@babel/preset-react": "^7.9.4",
 		"@babel/preset-typescript": "^7.9.0",
+		"@react-native-picker/picker": "^1.9.11",
 		"@types/react-native": "^0.62.5",
 		"babel-jest": "^21.2.0",
-		"react": "^16.0.0",
 		"rimraf": "^2.6.2"
 	},
 	"dependencies": {
@@ -32,7 +32,8 @@
 	},
 	"peerDependencies": {
 		"aws-amplify": "4.x.x",
-		"graphql": "^14.0.0"
+		"graphql": "^14.0.0",
+		"react": "^17.0.1"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/aws-amplify-react-native/src/AmplifyUI.tsx
+++ b/packages/aws-amplify-react-native/src/AmplifyUI.tsx
@@ -15,7 +15,6 @@ import React, { Component, FC } from 'react';
 import {
 	Image,
 	Keyboard,
-	Picker,
 	Platform,
 	Text,
 	TextInput,
@@ -27,6 +26,7 @@ import {
 	TextInputProperties,
 	TouchableOpacityProps,
 } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import { I18n } from 'aws-amplify';
 import AmplifyTheme, {
 	AmplifyThemeType,
@@ -36,7 +36,7 @@ import AmplifyTheme, {
 import countryDialCodes from './CountryDialCodes';
 import TEST_ID from './AmplifyTestIDs';
 import icons from './icons';
-import { setTestId } from './Utils'
+import { setTestId } from './Utils';
 
 interface IContainerProps {
 	theme?: AmplifyThemeType;
@@ -85,6 +85,9 @@ interface IPhoneState {
 	phone: string;
 }
 
+// ensure that longer Picker values render without truncation on Android
+const minWidth = { minWidth: Platform.OS === 'android' ? 16 : 0 };
+
 export class PhoneField extends Component<IPhoneProps, IPhoneState> {
 	constructor(props: IPhoneProps) {
 		super(props);
@@ -116,7 +119,7 @@ export class PhoneField extends Component<IPhoneProps, IPhoneState> {
 				</Text>
 				<View style={theme.phoneContainer}>
 					<Picker
-						style={theme.picker}
+						style={[theme.picker, minWidth]}
 						selectedValue={this.state.dialCode}
 						itemStyle={theme.pickerItem}
 						onValueChange={dialCode => {
@@ -204,7 +207,10 @@ export const ErrorRow: FC<IErrorRowProps> = props => {
 	return (
 		<View style={theme.errorRow}>
 			<Image source={icons.warning} style={theme.errorRowIcon} />
-			<Text style={theme.errorRowText} {...setTestId(TEST_ID.AUTH.ERROR_ROW_TEXT)}>
+			<Text
+				style={theme.errorRowText}
+				{...setTestId(TEST_ID.AUTH.ERROR_ROW_TEXT)}
+			>
 				{props.children}
 			</Text>
 		</View>

--- a/packages/aws-amplify-react-native/src/Auth/VerifyContact.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/VerifyContact.tsx
@@ -12,7 +12,8 @@
  */
 
 import React from 'react';
-import { View, Picker } from 'react-native';
+import { View } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import { Auth, I18n, Logger } from 'aws-amplify';
 import {
 	AmplifyButton,
@@ -26,7 +27,7 @@ import {
 import AuthPiece, { IAuthPieceProps, IAuthPieceState } from './AuthPiece';
 import { AmplifyThemeType } from '../AmplifyTheme';
 import TEST_ID from '../AmplifyTestIDs';
-import { setTestId } from '../Utils'
+import { setTestId } from '../Utils';
 
 const logger = new Logger('VerifyContact');
 


### PR DESCRIPTION
…cker component (#8493)

#### Description of changes

**This is a preliminary PR that will publish a tagged version of _aws-amplify-react-native_ for a customer to test against, once confirmed a PR against _main_ will follow**

- migrate deprecated React Native `Picker` component to [community version](https://github.com/react-native-picker/picker)
- update `Picker` style in Android `PhoneField` component to prevent truncation of rendered value
- add temporary `publish:migrate-rn-picker` script in _package.json_

#### Issue #, if available
https://github.com/aws-amplify/amplify-js/issues/8493



#### Description of how you validated changes
Manually tested on Android and iOS using both expo and vanilla React Native

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
