### PR TITLE
re-enable rn android tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -828,19 +828,19 @@ jobs:
     steps:
       - integ_test_rn_ios
 
-  # integ_rn_android_storage:
-  #   executor: macos-executor
-  #   <<: *test_env_vars
-  #   working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
-  #   steps:
-  #     - integ_test_rn_android
+  integ_rn_android_storage:
+    executor: macos-executor
+    <<: *test_env_vars
+    working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/StorageApp
+    steps:
+      - integ_test_rn_android
 
-  # integ_rn_android_storage_multipart_progress:
-  #   executor: macos-executor
-  #   <<: *test_env_vars
-  #   working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/MultiPartUploadWithProgress
-  #   steps:
-  #     - integ_test_rn_android
+  integ_rn_android_storage_multipart_progress:
+    executor: macos-executor
+    <<: *test_env_vars
+    working_directory: ~/amplify-js-samples-staging/samples/react-native/storage/MultiPartUploadWithProgress
+    steps:
+      - integ_test_rn_android
 
   integ_datastore_auth:
     parameters:
@@ -1175,18 +1175,18 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
-      # - integ_rn_android_storage:
-      #     requires:
-      #       - integ_setup
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      # - integ_rn_android_storage_multipart_progress:
-      #     requires:
-      #       - integ_setup
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
+      - integ_rn_android_storage:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+      - integ_rn_android_storage_multipart_progress:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
       - integ_datastore_auth:
           requires:
             - integ_setup
@@ -1232,9 +1232,9 @@ workflows:
             - integ_vue_auth
             - integ_rn_ios_storage
             - integ_rn_ios_storage_multipart_progress
-            # - integ_rn_android_storage_multipart_progress
+            - integ_rn_android_storage_multipart_progress
             - integ_rn_ios_push_notifications
-            # - integ_rn_android_storage
+            - integ_rn_android_storage
             - integ_datastore_auth
             - integ_duplicate_packages
             - integ_auth_test_cypress_no_ui


### PR DESCRIPTION
#### Description of changes
Re-enabling the React Native Android tests.
The original issue was from a combination of the Macos version of the CircleCI executor, and a bug in Android emulator 30.7.4 (see: https://issuetracker.google.com/issues/191805460)
The issue has been fixed on July 1st, I manually triggered a CircleCI deploy and the tests ran successfully. https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/8329/workflows/c4eecd81-d0c3-4beb-8317-306edfb736b8

#### Issue #, if available

#### Description of how you validated changes
Manually triggered a CircleCI deploy on another branch.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
