### PR TITLE
 refresh cached user after deleting attributes

### DIFF
--- a/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
@@ -1505,6 +1505,47 @@ describe('getUserAttributes()', () => {
 	});
 });
 
+describe('deleteAttributes()', () => {
+	const callback = jest.fn();
+	const cognitoUser = new CognitoUser({ ...userDefaults });
+	cognitoUser.setSignInUserSession(vCognitoUserSession);
+
+	afterAll(() => {
+		jest.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		callback.mockClear();
+	});
+
+	test('happy path for deleteAttrbutes should call getUserData to update cache', () => {
+		netRequestMockSuccess(true);
+
+		const getUserDataSpy = jest
+			.spyOn(cognitoUser, 'getUserData')
+			.mockImplementationOnce(cb => cb());
+
+		cognitoUser.deleteAttributes([], callback);
+		expect(getUserDataSpy).toBeCalled();
+		console.log('test', cognitoUser);
+		expect(callback.mock.calls[0][1]).toEqual('SUCCESS');
+	});
+
+	test('client request throws an error', () => {
+		netRequestMockSuccess(false);
+		cognitoUser.deleteAttributes([], callback);
+		expect(callback.mock.calls[0][0]).toMatchObject(new Error('Network Error'));
+	});
+
+	test('having an invalid user session should callback with a new error', () => {
+		cognitoUser.setSignInUserSession(ivCognitoUserSession);
+		cognitoUser.deleteAttributes([], callback);
+		expect(callback.mock.calls[0][0]).toMatchObject(
+			new Error('User is not authenticated')
+		);
+	});
+});
+
 describe('getCognitoUserSession()', () => {
 	const cognitoUser = new CognitoUser({ ...userDefaults });
 	const idToken = new CognitoIdToken();

--- a/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
@@ -1527,7 +1527,6 @@ describe('deleteAttributes()', () => {
 
 		cognitoUser.deleteAttributes([], callback);
 		expect(getUserDataSpy).toBeCalled();
-		console.log('test', cognitoUser);
 		expect(callback.mock.calls[0][1]).toEqual('SUCCESS');
 	});
 

--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -1339,7 +1339,11 @@ export default class CognitoUser {
 				if (err) {
 					return callback(err, null);
 				}
-				return callback(null, 'SUCCESS');
+
+				// update cached user
+				return this.getUserData(() => callback(null, 'SUCCESS'), {
+					bypassCache: true,
+				});
 			}
 		);
 		return undefined;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This is to follow the previous fix(https://github.com/aws-amplify/amplify-js/pull/5394) for the sibling call `updateAttributes`, to update the cached data if delete action succeed.

It calls the [`getUserData`](https://github.com/aws-amplify/amplify-js/blob/main/packages/amazon-cognito-identity-js/src/CognitoUser.js#L1251), which encapsulate the logic of refreshing local cache. Notice it will fire another network request to fetch most updated data from server side, because
   1. delete api does not return anything if succeed
   2. it is not easy to capture all side effects without talking to the server side. For example, deleting `email` will toggle `email_verified` to `false`.
   2. local cached data can be in different places (localStorage or  in memory)

This is a required fix before we can merge external contributor's PR on adding `deleteUserAttributes` on Auth class.
https://github.com/aws-amplify/amplify-js/pull/7342


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/3119

#### Description of how you validated changes
unit test and local test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
