### PR TITLE
Empty `newFormfFields` array on rebuild

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
@@ -91,7 +91,7 @@ export class AmplifyForgotPassword {
 					this.handleFormFieldInputWithCallback(event, field);
 				newFields.push(newField);
 			});
-			this.newFormFields = [];
+			this.newFormFields = newFields;
 		}
 	}
 

--- a/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
@@ -84,13 +84,14 @@ export class AmplifyForgotPassword {
 		if (this.formFields.length === 0) {
 			this.buildDefaultFormFields();
 		} else {
-			this.newFormFields = [];
+			const newFields = [];
 			this.formFields.forEach(field => {
 				const newField = { ...field };
 				newField['handleInputChange'] = event =>
 					this.handleFormFieldInputWithCallback(event, field);
-				this.newFormFields.push(newField);
+				newFields.push(newField);
 			});
+			this.newFormFields = [];
 		}
 	}
 

--- a/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-forgot-password/amplify-forgot-password.tsx
@@ -84,6 +84,7 @@ export class AmplifyForgotPassword {
 		if (this.formFields.length === 0) {
 			this.buildDefaultFormFields();
 		} else {
+			this.newFormFields = [];
 			this.formFields.forEach(field => {
 				const newField = { ...field };
 				newField['handleInputChange'] = event =>
@@ -255,7 +256,11 @@ export class AmplifyForgotPassword {
 		this.loading = true;
 		try {
 			const { userInput, code, password } = this.forgotPasswordAttrs;
-			const data = await Auth.forgotPasswordSubmit(userInput.trim(), code, password);
+			const data = await Auth.forgotPasswordSubmit(
+				userInput.trim(),
+				code,
+				password
+			);
 			logger.debug(data);
 			this.handleAuthStateChange(AuthState.SignIn);
 			this.delivery = null;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Empties `newFormFields` whenever we call `buildFormFields` so that we don't add duplicate fields.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Closes #8629.



#### Description of how you validated changes
Validated with local linking.

Not sure why this isn't very reproducible on 1.2.7 (likely some nuance of when these components get re-rendered based on the `newFormFields`), but I confirmed internally that this patch prevents the array from getting duplicate entries.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
