### PR TITLE
fix(@aws-amplify/auth): passing redirectUri to the urlOpener after signOut 

### DIFF
--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -291,7 +291,7 @@ export default class OAuth {
 		);
 		logger.debug(`Signing out from ${oAuthLogoutEndpoint}`);
 
-		return this._urlOpener(oAuthLogoutEndpoint);
+		return this._urlOpener(oAuthLogoutEndpoint, signout_uri);
 	}
 
 	private _generateState(length: number) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
It passes in the redirectUri after sign out which is in parity with the urlOpener signature when sign in. 
The difference in parameters are evident between these two lines: 

Sign in, https://github.com/aws-amplify/amplify-js/blob/1e0887bdc45e178f04229c888051ecf10d2bfabc/packages/auth/src/OAuth/OAuth.ts#L117
Sign out, https://github.com/aws-amplify/amplify-js/blob/1e0887bdc45e178f04229c888051ecf10d2bfabc/packages/auth/src/OAuth/OAuth.ts#L294 


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/8673



#### Description of how you validated changes
Tested it on ios simulator 



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
