### PR TITLE
feat(@aws-amplify/storage): Allow md5 computation method to be passed into Storage.put

### DIFF
--- a/packages/core/src/UniversalStorage/index.ts
+++ b/packages/core/src/UniversalStorage/index.ts
@@ -78,16 +78,19 @@ export class UniversalStorage implements Storage {
 			// accessToken is required for CognitoUserSession
 			case 'accessToken':
 
+			// refreshToken originates on the client, but SSR pages won't fail when this expires
+			// Note: the new `accessToken` will also be refreshed on the client (since Amplify doesn't set server-side cookies)
+			case 'refreshToken':
+
 			// Required for CognitoUserSession
 			case 'idToken':
-				this.setUniversalItem(key, value);
+				isBrowser
+					? this.setUniversalItem(key, value)
+					: this.setLocalItem(key, value);
 
 			// userData is used when `Auth.currentAuthenticatedUser({ bypassCache: false })`.
 			// Can be persisted to speed up calls to `Auth.currentAuthenticatedUser()`
 			// case 'userData':
-
-			// refreshToken isn't shared with the server so that the client handles refreshing
-			// case 'refreshToken':
 
 			// Ignoring clockDrift on the server for now, but needs testing
 			// case 'clockDrift':

--- a/packages/storage/__tests__/providers/AWSS3Provider-unit-test.ts
+++ b/packages/storage/__tests__/providers/AWSS3Provider-unit-test.ts
@@ -542,11 +542,9 @@ describe('StorageProvider test', () => {
 		test('put object failed', async () => {
 			const storage = new StorageProvider();
 			storage.configure(options);
-			const spyon = jest
-				.spyOn(S3Client.prototype, 'send')
-				.mockImplementationOnce(async params => {
-					throw 'err';
-				});
+			const spyon = jest.spyOn(S3Client.prototype, 'send').mockImplementationOnce(async params => {
+				throw 'err';
+			});
 
 			expect.assertions(1);
 			try {
@@ -636,18 +634,13 @@ describe('StorageProvider test', () => {
 				emit: jest.fn(),
 				on: jest.fn(),
 			};
-			jest
-				.spyOn(events, 'EventEmitter')
-				.mockImplementationOnce(() => mockEventEmitter);
+			jest.spyOn(events, 'EventEmitter').mockImplementationOnce(() => mockEventEmitter);
 			const storage = new StorageProvider();
 			storage.configure(options);
 			await storage.put('key', 'object', {
 				progressCallback: mockCallback,
 			});
-			expect(mockEventEmitter.on).toBeCalledWith(
-				'sendUploadProgress',
-				expect.any(Function)
-			);
+			expect(mockEventEmitter.on).toBeCalledWith('sendUploadProgress', expect.any(Function));
 			const emitterOnFn = mockEventEmitter.on.mock.calls[0][1];
 			// Manually invoke for testing
 			emitterOnFn('arg');
@@ -660,18 +653,13 @@ describe('StorageProvider test', () => {
 				emit: jest.fn(),
 				on: jest.fn(),
 			};
-			jest
-				.spyOn(events, 'EventEmitter')
-				.mockImplementationOnce(() => mockEventEmitter);
+			jest.spyOn(events, 'EventEmitter').mockImplementationOnce(() => mockEventEmitter);
 			const storage = new StorageProvider();
 			storage.configure(options);
 			await storage.put('key', 'object', {
 				progressCallback: ('hello' as unknown) as S3ProviderGetConfig['progressCallback'], // this is intentional
 			});
-			expect(loggerSpy).toHaveBeenCalledWith(
-				'WARN',
-				'progressCallback should be a function, not a string'
-			);
+			expect(loggerSpy).toHaveBeenCalledWith('WARN', 'progressCallback should be a function, not a string');
 		});
 
 		test('credentials not ok', async () => {

--- a/packages/storage/src/common/FileReaderUtils.ts
+++ b/packages/storage/src/common/FileReaderUtils.ts
@@ -1,0 +1,35 @@
+const isTypedArray = (x: unknown): x is ArrayBuffer => {
+	const TypedArray = Object.getPrototypeOf(Uint8Array);
+	return x instanceof TypedArray;
+};
+
+export const readFileToArrayBuffer = async (
+	file: Blob | ArrayBuffer
+): Promise<ArrayBuffer> => {
+	return new Promise<ArrayBuffer>((res, rej) => {
+		if (isTypedArray(file)) {
+			res(file);
+		} else {
+			const fr = new FileReader();
+			fr.onloadend = () => {
+				const result = fr.result;
+				if (isTypedArray(result)) {
+					res(result);
+				} else {
+					const content = atob(
+						result.substr('data:application/octet-stream;base64,'.length)
+					);
+					const buffer = new ArrayBuffer(content.length);
+					const view = new Uint8Array(buffer);
+					view.set(Array.from(content).map(c => c.charCodeAt(0)));
+					res(buffer);
+				}
+			};
+			fr.onerror = () => {
+				rej(fr.error);
+			};
+			// Uses readAsDataURL because readAsArrayBuffer does not work on React Native
+			fr.readAsDataURL(file);
+		}
+	});
+};

--- a/packages/storage/src/common/StorageS3ClientUtils.ts
+++ b/packages/storage/src/common/StorageS3ClientUtils.ts
@@ -1,0 +1,40 @@
+import { getAmplifyUserAgent, ICredentials } from '@aws-amplify/core';
+import { S3Client } from '@aws-sdk/client-s3';
+import { CancelTokenSource } from 'axios';
+import * as events from 'events';
+import { AxiosHttpHandler } from '../providers/axios-http-handler';
+
+const localTestingStorageEndpoint = 'http://localhost:20005';
+
+export const createNewS3Client = (
+	config: {
+		credentials: ICredentials;
+		region?: string;
+		cancelTokenSource?: CancelTokenSource;
+		dangerouslyConnectToHttpEndpointForTesting?: boolean;
+	},
+	emitter?: events.EventEmitter
+): S3Client => {
+	const {
+		region,
+		credentials,
+		cancelTokenSource,
+		dangerouslyConnectToHttpEndpointForTesting,
+	} = config;
+	const localTestingConfig = dangerouslyConnectToHttpEndpointForTesting
+		? {
+				endpoint: localTestingStorageEndpoint,
+				tls: false,
+				bucketEndpoint: false,
+				forcePathStyle: true,
+		  }
+		: {};
+	const s3client = new S3Client({
+		region,
+		credentials,
+		customUserAgent: getAmplifyUserAgent(),
+		...localTestingConfig,
+		requestHandler: new AxiosHttpHandler({}, emitter, cancelTokenSource),
+	});
+	return s3client;
+};

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -33,7 +33,11 @@ import {
 import { formatUrl } from '@aws-sdk/util-format-url';
 import { createRequest } from '@aws-sdk/util-create-request';
 import { S3RequestPresigner } from '@aws-sdk/s3-request-presigner';
-import { AxiosHttpHandler, SEND_DOWNLOAD_PROGRESS_EVENT, SEND_UPLOAD_PROGRESS_EVENT } from './axios-http-handler';
+import {
+	AxiosHttpHandler,
+	SEND_DOWNLOAD_PROGRESS_EVENT,
+	SEND_UPLOAD_PROGRESS_EVENT,
+} from './axios-http-handler';
 import {
 	StorageOptions,
 	StorageProvider,
@@ -59,14 +63,21 @@ import { CancelTokenSource } from 'axios';
 
 const logger = new Logger('AWSS3Provider');
 
-const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' && typeof Symbol.for === 'function'
+const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' &&
+typeof Symbol.for === 'function'
 	? Symbol.for('amplify_default')
 	: '@@amplify_default') as Symbol;
 const SET_CONTENT_LENGTH_HEADER = 'contentLengthMiddleware';
 const DEFAULT_STORAGE_LEVEL = 'public';
 const DEFAULT_PRESIGN_EXPIRATION = 900;
 
-const dispatchStorageEvent = (track: boolean, event: string, attrs: any, metrics: any, message: string): void => {
+const dispatchStorageEvent = (
+	track: boolean,
+	event: string,
+	attrs: any,
+	metrics: any,
+	message: string
+): void => {
 	if (track) {
 		const data = { attrs };
 		if (metrics) {
@@ -165,7 +176,11 @@ export class AWSS3Provider implements StorageProvider {
 			SSECustomerKeyMD5,
 			SSEKMSKeyId,
 		} = opt;
-		const { level: srcLevel = DEFAULT_STORAGE_LEVEL, identityId: srcIdentityId, key: srcKey } = src;
+		const {
+			level: srcLevel = DEFAULT_STORAGE_LEVEL,
+			identityId: srcIdentityId,
+			key: srcKey,
+		} = src;
 		const { level: destLevel = DEFAULT_STORAGE_LEVEL, key: destKey } = dest;
 		if (!srcKey || typeof srcKey !== 'string') {
 			throw new Error(StorageErrorStrings.NO_SRC_KEY);
@@ -293,7 +308,8 @@ export class AWSS3Provider implements StorageProvider {
 
 		// See: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getObject-property
 		if (cacheControl) params.ResponseCacheControl = cacheControl;
-		if (contentDisposition) params.ResponseContentDisposition = contentDisposition;
+		if (contentDisposition)
+			params.ResponseContentDisposition = contentDisposition;
 		if (contentEncoding) params.ResponseContentEncoding = contentEncoding;
 		if (contentLanguage) params.ResponseContentLanguage = contentLanguage;
 		if (contentType) params.ResponseContentType = contentType;
@@ -307,7 +323,10 @@ export class AWSS3Provider implements StorageProvider {
 							progressCallback(progress);
 						});
 					} else {
-						logger.warn('progressCallback should be a function, not a ' + typeof progressCallback);
+						logger.warn(
+							'progressCallback should be a function, not a ' +
+								typeof progressCallback
+						);
 					}
 				}
 				const response = await s3.send(getObjectCommand);
@@ -341,8 +360,18 @@ export class AWSS3Provider implements StorageProvider {
 			const signer = new S3RequestPresigner({ ...s3.config });
 			const request = await createRequest(s3, new GetObjectCommand(params));
 			// Default is 15 mins as defined in V2 AWS SDK
-			const url = formatUrl(await signer.presign(request, { expiresIn: expires || DEFAULT_PRESIGN_EXPIRATION }));
-			dispatchStorageEvent(track, 'getSignedUrl', { method: 'get', result: 'success' }, null, `Signed URL: ${url}`);
+			const url = formatUrl(
+				await signer.presign(request, {
+					expiresIn: expires || DEFAULT_PRESIGN_EXPIRATION,
+				})
+			);
+			dispatchStorageEvent(
+				track,
+				'getSignedUrl',
+				{ method: 'get', result: 'success' },
+				null,
+				`Signed URL: ${url}`
+			);
 			return url;
 		} catch (error) {
 			logger.warn('get signed url error', error);
@@ -375,8 +404,24 @@ export class AWSS3Provider implements StorageProvider {
 		}
 		const opt = Object.assign({}, this._config, config);
 		const { bucket, track, progressCallback } = opt;
-		const { contentType, contentDisposition, contentEncoding, cacheControl, expires, metadata, tagging, acl } = opt;
-		const { serverSideEncryption, SSECustomerAlgorithm, SSECustomerKey, SSECustomerKeyMD5, SSEKMSKeyId } = opt;
+		const {
+			contentType,
+			contentDisposition,
+			contentEncoding,
+			cacheControl,
+			contentMd5,
+			expires,
+			metadata,
+			tagging,
+			acl,
+		} = opt;
+		const {
+			serverSideEncryption,
+			SSECustomerAlgorithm,
+			SSECustomerKey,
+			SSECustomerKeyMD5,
+			SSEKMSKeyId,
+		} = opt;
 		const type = contentType ? contentType : 'binary/octet-stream';
 
 		const prefix = this._prefix(opt);
@@ -422,6 +467,9 @@ export class AWSS3Provider implements StorageProvider {
 		if (SSEKMSKeyId) {
 			params.SSEKMSKeyId = SSEKMSKeyId;
 		}
+		if (contentMd5) {
+			params.ContentMD5 = contentMd5;
+		}
 
 		const emitter = new events.EventEmitter();
 		const uploader = new AWSS3ProviderManagedUpload(params, opt, emitter);
@@ -437,20 +485,35 @@ export class AWSS3Provider implements StorageProvider {
 						progressCallback(progress);
 					});
 				} else {
-					logger.warn('progressCallback should be a function, not a ' + typeof progressCallback);
+					logger.warn(
+						'progressCallback should be a function, not a ' +
+							typeof progressCallback
+					);
 				}
 			}
 
 			const response = await uploader.upload();
 
 			logger.debug('upload result', response);
-			dispatchStorageEvent(track, 'upload', { method: 'put', result: 'success' }, null, `Upload success for ${key}`);
+			dispatchStorageEvent(
+				track,
+				'upload',
+				{ method: 'put', result: 'success' },
+				null,
+				`Upload success for ${key}`
+			);
 			return {
 				key,
 			};
 		} catch (error) {
 			logger.warn('error uploading', error);
-			dispatchStorageEvent(track, 'upload', { method: 'put', result: 'failed' }, null, `Error uploading ${key}`);
+			dispatchStorageEvent(
+				track,
+				'upload',
+				{ method: 'put', result: 'failed' },
+				null,
+				`Error uploading ${key}`
+			);
 			throw error;
 		}
 	}
@@ -461,7 +524,10 @@ export class AWSS3Provider implements StorageProvider {
 	 * @param {S3ProviderRemoveConfig} [config] - Optional configuration for the underlying S3 command
 	 * @return {Promise<S3ProviderRemoveOutput>} - Promise resolves upon successful removal of the object
 	 */
-	public async remove(key: string, config?: S3ProviderRemoveConfig): Promise<S3ProviderRemoveOutput> {
+	public async remove(
+		key: string,
+		config?: S3ProviderRemoveConfig
+	): Promise<S3ProviderRemoveOutput> {
 		const credentialsOK = await this._ensureCredentials();
 		if (!credentialsOK || !this._isWithCredentials(this._config)) {
 			throw new Error(StorageErrorStrings.NO_CREDENTIALS);
@@ -510,7 +576,10 @@ export class AWSS3Provider implements StorageProvider {
 	 * @return {Promise<S3ProviderListOutput>} - Promise resolves to list of keys, eTags, lastModified and file size for
 	 * all objects in path
 	 */
-	public async list(path: string, config?: S3ProviderListConfig): Promise<S3ProviderListOutput> {
+	public async list(
+		path: string,
+		config?: S3ProviderListConfig
+	): Promise<S3ProviderListOutput> {
 		const credentialsOK = await this._ensureCredentials();
 		if (!credentialsOK || !this._isWithCredentials(this._config)) {
 			throw new Error(StorageErrorStrings.NO_CREDENTIALS);
@@ -581,7 +650,9 @@ export class AWSS3Provider implements StorageProvider {
 		}
 	}
 
-	private _isWithCredentials(config: StorageOptions): config is StorageOptions & { credentials: ICredentials } {
+	private _isWithCredentials(
+		config: StorageOptions
+	): config is StorageOptions & { credentials: ICredentials } {
 		return typeof config === 'object' && config.hasOwnProperty('credentials');
 	}
 
@@ -595,10 +666,18 @@ export class AWSS3Provider implements StorageProvider {
 
 		const customPrefix = config.customPrefix || {};
 		const identityId = config.identityId || credentials.identityId;
-		const privatePath = (customPrefix.private !== undefined ? customPrefix.private : 'private/') + identityId + '/';
+		const privatePath =
+			(customPrefix.private !== undefined ? customPrefix.private : 'private/') +
+			identityId +
+			'/';
 		const protectedPath =
-			(customPrefix.protected !== undefined ? customPrefix.protected : 'protected/') + identityId + '/';
-		const publicPath = customPrefix.public !== undefined ? customPrefix.public : 'public/';
+			(customPrefix.protected !== undefined
+				? customPrefix.protected
+				: 'protected/') +
+			identityId +
+			'/';
+		const publicPath =
+			customPrefix.public !== undefined ? customPrefix.public : 'public/';
 
 		switch (level) {
 			case 'private':
@@ -622,7 +701,12 @@ export class AWSS3Provider implements StorageProvider {
 		},
 		emitter?: events.EventEmitter
 	): S3Client {
-		const { region, credentials, cancelTokenSource, dangerouslyConnectToHttpEndpointForTesting } = config;
+		const {
+			region,
+			credentials,
+			cancelTokenSource,
+			dangerouslyConnectToHttpEndpointForTesting,
+		} = config;
 		let localTestingConfig = {};
 
 		if (dangerouslyConnectToHttpEndpointForTesting) {

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -10,7 +10,13 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import { ConsoleLogger as Logger, Credentials, Hub, ICredentials, Parser } from '@aws-amplify/core';
+import {
+	ConsoleLogger as Logger,
+	Credentials,
+	Hub,
+	ICredentials,
+	Parser,
+} from '@aws-amplify/core';
 import {
 	CopyObjectCommand,
 	CopyObjectCommandInput,
@@ -47,18 +53,28 @@ import {
 	StorageProvider,
 } from '../types';
 import { AWSS3ProviderManagedUpload } from './AWSS3ProviderManagedUpload';
-import { SEND_DOWNLOAD_PROGRESS_EVENT, SEND_UPLOAD_PROGRESS_EVENT } from './axios-http-handler';
+import {
+	SEND_DOWNLOAD_PROGRESS_EVENT,
+	SEND_UPLOAD_PROGRESS_EVENT,
+} from './axios-http-handler';
 
 const logger = new Logger('AWSS3Provider');
 
-const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' && typeof Symbol.for === 'function'
+const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' &&
+typeof Symbol.for === 'function'
 	? Symbol.for('amplify_default')
 	: '@@amplify_default') as Symbol;
 const SET_CONTENT_LENGTH_HEADER = 'contentLengthMiddleware';
 const DEFAULT_STORAGE_LEVEL = 'public';
 const DEFAULT_PRESIGN_EXPIRATION = 900;
 
-const dispatchStorageEvent = (track: boolean, event: string, attrs: any, metrics: any, message: string): void => {
+const dispatchStorageEvent = (
+	track: boolean,
+	event: string,
+	attrs: any,
+	metrics: any,
+	message: string
+): void => {
 	if (track) {
 		const data = { attrs };
 		if (metrics) {
@@ -77,7 +93,6 @@ const dispatchStorageEvent = (track: boolean, event: string, attrs: any, metrics
 	}
 };
 
-const localTestingStorageEndpoint = 'http://localhost:20005';
 /**
  * Provide storage methods to use AWS S3
  */
@@ -150,14 +165,18 @@ export class AWSS3Provider implements StorageProvider {
 			bucket,
 			cacheControl,
 			expires,
-			track,
+			track = false,
 			serverSideEncryption,
 			SSECustomerAlgorithm,
 			SSECustomerKey,
 			SSECustomerKeyMD5,
 			SSEKMSKeyId,
 		} = opt;
-		const { level: srcLevel = DEFAULT_STORAGE_LEVEL, identityId: srcIdentityId, key: srcKey } = src;
+		const {
+			level: srcLevel = DEFAULT_STORAGE_LEVEL,
+			identityId: srcIdentityId,
+			key: srcKey,
+		} = src;
 		const { level: destLevel = DEFAULT_STORAGE_LEVEL, key: destKey } = dest;
 		if (!srcKey || typeof srcKey !== 'string') {
 			throw new Error(StorageErrorStrings.NO_SRC_KEY);
@@ -269,7 +288,7 @@ export class AWSS3Provider implements StorageProvider {
 			contentLanguage,
 			contentType,
 			expires,
-			track,
+			track = false,
 			SSECustomerAlgorithm,
 			SSECustomerKey,
 			SSECustomerKeyMD5,
@@ -288,7 +307,8 @@ export class AWSS3Provider implements StorageProvider {
 
 		// See: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getObject-property
 		if (cacheControl) params.ResponseCacheControl = cacheControl;
-		if (contentDisposition) params.ResponseContentDisposition = contentDisposition;
+		if (contentDisposition)
+			params.ResponseContentDisposition = contentDisposition;
 		if (contentEncoding) params.ResponseContentEncoding = contentEncoding;
 		if (contentLanguage) params.ResponseContentLanguage = contentLanguage;
 		if (contentType) params.ResponseContentType = contentType;
@@ -311,7 +331,10 @@ export class AWSS3Provider implements StorageProvider {
 							progressCallback(progress);
 						});
 					} else {
-						logger.warn('progressCallback should be a function, not a ' + typeof progressCallback);
+						logger.warn(
+							'progressCallback should be a function, not a ' +
+								typeof progressCallback
+						);
 					}
 				}
 				const response = await s3.send(getObjectCommand);
@@ -350,7 +373,13 @@ export class AWSS3Provider implements StorageProvider {
 					expiresIn: expires || DEFAULT_PRESIGN_EXPIRATION,
 				})
 			);
-			dispatchStorageEvent(track, 'getSignedUrl', { method: 'get', result: 'success' }, null, `Signed URL: ${url}`);
+			dispatchStorageEvent(
+				track,
+				'getSignedUrl',
+				{ method: 'get', result: 'success' },
+				null,
+				`Signed URL: ${url}`
+			);
 			return url;
 		} catch (error) {
 			logger.warn('get signed url error', error);
@@ -382,7 +411,7 @@ export class AWSS3Provider implements StorageProvider {
 			throw new Error(StorageErrorStrings.NO_CREDENTIALS);
 		}
 		const opt = Object.assign({}, this._config, config);
-		const { bucket, track, progressCallback } = opt;
+		const { bucket, track = false, progressCallback } = opt;
 		const {
 			contentType,
 			contentDisposition,
@@ -394,7 +423,13 @@ export class AWSS3Provider implements StorageProvider {
 			tagging,
 			acl,
 		} = opt;
-		const { serverSideEncryption, SSECustomerAlgorithm, SSECustomerKey, SSECustomerKeyMD5, SSEKMSKeyId } = opt;
+		const {
+			serverSideEncryption,
+			SSECustomerAlgorithm,
+			SSECustomerKey,
+			SSECustomerKeyMD5,
+			SSEKMSKeyId,
+		} = opt;
 		const type = contentType ? contentType : 'binary/octet-stream';
 
 		const prefix = this._prefix(opt);
@@ -442,7 +477,9 @@ export class AWSS3Provider implements StorageProvider {
 		}
 		if (contentMd5) {
 			if (typeof contentMd5 !== 'function') {
-				logger.warn(`contentMd5 should be a function instead of ${typeof contentMd5}`);
+				logger.warn(
+					`contentMd5 should be a function instead of ${typeof contentMd5}`
+				);
 			}
 		}
 
@@ -460,20 +497,35 @@ export class AWSS3Provider implements StorageProvider {
 						progressCallback(progress);
 					});
 				} else {
-					logger.warn('progressCallback should be a function, not a ' + typeof progressCallback);
+					logger.warn(
+						'progressCallback should be a function, not a ' +
+							typeof progressCallback
+					);
 				}
 			}
 
 			const response = await uploader.upload();
 
 			logger.debug('upload result', response);
-			dispatchStorageEvent(track, 'upload', { method: 'put', result: 'success' }, null, `Upload success for ${key}`);
+			dispatchStorageEvent(
+				track,
+				'upload',
+				{ method: 'put', result: 'success' },
+				null,
+				`Upload success for ${key}`
+			);
 			return {
 				key,
 			};
 		} catch (error) {
 			logger.warn('error uploading', error);
-			dispatchStorageEvent(track, 'upload', { method: 'put', result: 'failed' }, null, `Error uploading ${key}`);
+			dispatchStorageEvent(
+				track,
+				'upload',
+				{ method: 'put', result: 'failed' },
+				null,
+				`Error uploading ${key}`
+			);
 			throw error;
 		}
 	}
@@ -484,13 +536,16 @@ export class AWSS3Provider implements StorageProvider {
 	 * @param {S3ProviderRemoveConfig} [config] - Optional configuration for the underlying S3 command
 	 * @return {Promise<S3ProviderRemoveOutput>} - Promise resolves upon successful removal of the object
 	 */
-	public async remove(key: string, config?: S3ProviderRemoveConfig): Promise<S3ProviderRemoveOutput> {
+	public async remove(
+		key: string,
+		config?: S3ProviderRemoveConfig
+	): Promise<S3ProviderRemoveOutput> {
 		const credentialsOK = await this._ensureCredentials();
 		if (!credentialsOK || !this._isWithCredentials(this._config)) {
 			throw new Error(StorageErrorStrings.NO_CREDENTIALS);
 		}
 		const opt = Object.assign({}, this._config, config);
-		const { bucket, track } = opt;
+		const { bucket, track = false } = opt;
 
 		const prefix = this._prefix(opt);
 		const final_key = prefix + key;
@@ -533,13 +588,16 @@ export class AWSS3Provider implements StorageProvider {
 	 * @return {Promise<S3ProviderListOutput>} - Promise resolves to list of keys, eTags, lastModified and file size for
 	 * all objects in path
 	 */
-	public async list(path: string, config?: S3ProviderListConfig): Promise<S3ProviderListOutput> {
+	public async list(
+		path: string,
+		config?: S3ProviderListConfig
+	): Promise<S3ProviderListOutput> {
 		const credentialsOK = await this._ensureCredentials();
 		if (!credentialsOK || !this._isWithCredentials(this._config)) {
 			throw new Error(StorageErrorStrings.NO_CREDENTIALS);
 		}
 		const opt = Object.assign({}, this._config, config);
-		const { bucket, track, maxKeys } = opt;
+		const { bucket, track = false, maxKeys } = opt;
 
 		const prefix = this._prefix(opt);
 		const final_path = prefix + path;
@@ -604,7 +662,9 @@ export class AWSS3Provider implements StorageProvider {
 		}
 	}
 
-	private _isWithCredentials(config: StorageOptions): config is StorageOptions & { credentials: ICredentials } {
+	private _isWithCredentials(
+		config: StorageOptions
+	): config is StorageOptions & { credentials: ICredentials } {
 		return typeof config === 'object' && config.hasOwnProperty('credentials');
 	}
 
@@ -618,10 +678,18 @@ export class AWSS3Provider implements StorageProvider {
 
 		const customPrefix = config.customPrefix || {};
 		const identityId = config.identityId || credentials.identityId;
-		const privatePath = (customPrefix.private !== undefined ? customPrefix.private : 'private/') + identityId + '/';
+		const privatePath =
+			(customPrefix.private !== undefined ? customPrefix.private : 'private/') +
+			identityId +
+			'/';
 		const protectedPath =
-			(customPrefix.protected !== undefined ? customPrefix.protected : 'protected/') + identityId + '/';
-		const publicPath = customPrefix.public !== undefined ? customPrefix.public : 'public/';
+			(customPrefix.protected !== undefined
+				? customPrefix.protected
+				: 'protected/') +
+			identityId +
+			'/';
+		const publicPath =
+			customPrefix.public !== undefined ? customPrefix.public : 'public/';
 
 		switch (level) {
 			case 'private':

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -10,13 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import {
-	ConsoleLogger as Logger,
-	Credentials,
-	Hub,
-	ICredentials,
-	Parser,
-} from '@aws-amplify/core';
+import { ConsoleLogger as Logger, Credentials, Hub, ICredentials, Parser } from '@aws-amplify/core';
 import {
 	CopyObjectCommand,
 	CopyObjectCommandInput,
@@ -53,28 +47,18 @@ import {
 	StorageProvider,
 } from '../types';
 import { AWSS3ProviderManagedUpload } from './AWSS3ProviderManagedUpload';
-import {
-	SEND_DOWNLOAD_PROGRESS_EVENT,
-	SEND_UPLOAD_PROGRESS_EVENT,
-} from './axios-http-handler';
+import { SEND_DOWNLOAD_PROGRESS_EVENT, SEND_UPLOAD_PROGRESS_EVENT } from './axios-http-handler';
 
 const logger = new Logger('AWSS3Provider');
 
-const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' &&
-typeof Symbol.for === 'function'
+const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' && typeof Symbol.for === 'function'
 	? Symbol.for('amplify_default')
 	: '@@amplify_default') as Symbol;
 const SET_CONTENT_LENGTH_HEADER = 'contentLengthMiddleware';
 const DEFAULT_STORAGE_LEVEL = 'public';
 const DEFAULT_PRESIGN_EXPIRATION = 900;
 
-const dispatchStorageEvent = (
-	track: boolean,
-	event: string,
-	attrs: any,
-	metrics: any,
-	message: string
-): void => {
+const dispatchStorageEvent = (track: boolean, event: string, attrs: any, metrics: any, message: string): void => {
 	if (track) {
 		const data = { attrs };
 		if (metrics) {
@@ -173,11 +157,7 @@ export class AWSS3Provider implements StorageProvider {
 			SSECustomerKeyMD5,
 			SSEKMSKeyId,
 		} = opt;
-		const {
-			level: srcLevel = DEFAULT_STORAGE_LEVEL,
-			identityId: srcIdentityId,
-			key: srcKey,
-		} = src;
+		const { level: srcLevel = DEFAULT_STORAGE_LEVEL, identityId: srcIdentityId, key: srcKey } = src;
 		const { level: destLevel = DEFAULT_STORAGE_LEVEL, key: destKey } = dest;
 		if (!srcKey || typeof srcKey !== 'string') {
 			throw new Error(StorageErrorStrings.NO_SRC_KEY);
@@ -308,8 +288,7 @@ export class AWSS3Provider implements StorageProvider {
 
 		// See: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getObject-property
 		if (cacheControl) params.ResponseCacheControl = cacheControl;
-		if (contentDisposition)
-			params.ResponseContentDisposition = contentDisposition;
+		if (contentDisposition) params.ResponseContentDisposition = contentDisposition;
 		if (contentEncoding) params.ResponseContentEncoding = contentEncoding;
 		if (contentLanguage) params.ResponseContentLanguage = contentLanguage;
 		if (contentType) params.ResponseContentType = contentType;
@@ -332,10 +311,7 @@ export class AWSS3Provider implements StorageProvider {
 							progressCallback(progress);
 						});
 					} else {
-						logger.warn(
-							'progressCallback should be a function, not a ' +
-								typeof progressCallback
-						);
+						logger.warn('progressCallback should be a function, not a ' + typeof progressCallback);
 					}
 				}
 				const response = await s3.send(getObjectCommand);
@@ -374,13 +350,7 @@ export class AWSS3Provider implements StorageProvider {
 					expiresIn: expires || DEFAULT_PRESIGN_EXPIRATION,
 				})
 			);
-			dispatchStorageEvent(
-				track,
-				'getSignedUrl',
-				{ method: 'get', result: 'success' },
-				null,
-				`Signed URL: ${url}`
-			);
+			dispatchStorageEvent(track, 'getSignedUrl', { method: 'get', result: 'success' }, null, `Signed URL: ${url}`);
 			return url;
 		} catch (error) {
 			logger.warn('get signed url error', error);
@@ -424,13 +394,7 @@ export class AWSS3Provider implements StorageProvider {
 			tagging,
 			acl,
 		} = opt;
-		const {
-			serverSideEncryption,
-			SSECustomerAlgorithm,
-			SSECustomerKey,
-			SSECustomerKeyMD5,
-			SSEKMSKeyId,
-		} = opt;
+		const { serverSideEncryption, SSECustomerAlgorithm, SSECustomerKey, SSECustomerKeyMD5, SSEKMSKeyId } = opt;
 		const type = contentType ? contentType : 'binary/octet-stream';
 
 		const prefix = this._prefix(opt);
@@ -478,9 +442,7 @@ export class AWSS3Provider implements StorageProvider {
 		}
 		if (contentMd5) {
 			if (typeof contentMd5 !== 'function') {
-				logger.warn(
-					`contentMd5 should be a function instead of ${typeof contentMd5}`
-				);
+				logger.warn(`contentMd5 should be a function instead of ${typeof contentMd5}`);
 			}
 		}
 
@@ -498,35 +460,20 @@ export class AWSS3Provider implements StorageProvider {
 						progressCallback(progress);
 					});
 				} else {
-					logger.warn(
-						'progressCallback should be a function, not a ' +
-							typeof progressCallback
-					);
+					logger.warn('progressCallback should be a function, not a ' + typeof progressCallback);
 				}
 			}
 
 			const response = await uploader.upload();
 
 			logger.debug('upload result', response);
-			dispatchStorageEvent(
-				track,
-				'upload',
-				{ method: 'put', result: 'success' },
-				null,
-				`Upload success for ${key}`
-			);
+			dispatchStorageEvent(track, 'upload', { method: 'put', result: 'success' }, null, `Upload success for ${key}`);
 			return {
 				key,
 			};
 		} catch (error) {
 			logger.warn('error uploading', error);
-			dispatchStorageEvent(
-				track,
-				'upload',
-				{ method: 'put', result: 'failed' },
-				null,
-				`Error uploading ${key}`
-			);
+			dispatchStorageEvent(track, 'upload', { method: 'put', result: 'failed' }, null, `Error uploading ${key}`);
 			throw error;
 		}
 	}
@@ -537,10 +484,7 @@ export class AWSS3Provider implements StorageProvider {
 	 * @param {S3ProviderRemoveConfig} [config] - Optional configuration for the underlying S3 command
 	 * @return {Promise<S3ProviderRemoveOutput>} - Promise resolves upon successful removal of the object
 	 */
-	public async remove(
-		key: string,
-		config?: S3ProviderRemoveConfig
-	): Promise<S3ProviderRemoveOutput> {
+	public async remove(key: string, config?: S3ProviderRemoveConfig): Promise<S3ProviderRemoveOutput> {
 		const credentialsOK = await this._ensureCredentials();
 		if (!credentialsOK || !this._isWithCredentials(this._config)) {
 			throw new Error(StorageErrorStrings.NO_CREDENTIALS);
@@ -589,10 +533,7 @@ export class AWSS3Provider implements StorageProvider {
 	 * @return {Promise<S3ProviderListOutput>} - Promise resolves to list of keys, eTags, lastModified and file size for
 	 * all objects in path
 	 */
-	public async list(
-		path: string,
-		config?: S3ProviderListConfig
-	): Promise<S3ProviderListOutput> {
+	public async list(path: string, config?: S3ProviderListConfig): Promise<S3ProviderListOutput> {
 		const credentialsOK = await this._ensureCredentials();
 		if (!credentialsOK || !this._isWithCredentials(this._config)) {
 			throw new Error(StorageErrorStrings.NO_CREDENTIALS);
@@ -663,9 +604,7 @@ export class AWSS3Provider implements StorageProvider {
 		}
 	}
 
-	private _isWithCredentials(
-		config: StorageOptions
-	): config is StorageOptions & { credentials: ICredentials } {
+	private _isWithCredentials(config: StorageOptions): config is StorageOptions & { credentials: ICredentials } {
 		return typeof config === 'object' && config.hasOwnProperty('credentials');
 	}
 
@@ -679,18 +618,10 @@ export class AWSS3Provider implements StorageProvider {
 
 		const customPrefix = config.customPrefix || {};
 		const identityId = config.identityId || credentials.identityId;
-		const privatePath =
-			(customPrefix.private !== undefined ? customPrefix.private : 'private/') +
-			identityId +
-			'/';
+		const privatePath = (customPrefix.private !== undefined ? customPrefix.private : 'private/') + identityId + '/';
 		const protectedPath =
-			(customPrefix.protected !== undefined
-				? customPrefix.protected
-				: 'protected/') +
-			identityId +
-			'/';
-		const publicPath =
-			customPrefix.public !== undefined ? customPrefix.public : 'public/';
+			(customPrefix.protected !== undefined ? customPrefix.protected : 'protected/') + identityId + '/';
+		const publicPath = customPrefix.public !== undefined ? customPrefix.public : 'public/';
 
 		switch (level) {
 			case 'private':

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -468,7 +468,13 @@ export class AWSS3Provider implements StorageProvider {
 			params.SSEKMSKeyId = SSEKMSKeyId;
 		}
 		if (contentMd5) {
-			params.ContentMD5 = contentMd5;
+			if (typeof contentMd5 === 'function') {
+				params.ContentMD5 = contentMd5(object);
+			} else {
+				logger.warn(
+					`contentMd5 should be a function instead of ${typeof contentMd5}`
+				);
+			}
 		}
 
 		const emitter = new events.EventEmitter();

--- a/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
+++ b/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
@@ -20,7 +20,6 @@ import {
 	CreateMultipartUploadCommand,
 	ListPartsCommand,
 	PutObjectCommand,
-	PutObjectRequest,
 	UploadPartCommand,
 	UploadPartCommandInput,
 	PutObjectCommandInput,
@@ -57,7 +56,7 @@ export class AWSS3ProviderManagedUpload {
 
 	// Data for current upload
 	private body: Blob;
-	private params: PutObjectRequest;
+	private params: PutObjectCommandInput;
 	private opts: S3ProvierManagedUploadOptions;
 	private completedParts: CompletedPart[] = [];
 	private cancel = false;
@@ -67,7 +66,7 @@ export class AWSS3ProviderManagedUpload {
 	private totalBytesToUpload = 0;
 	private emitter: events.EventEmitter = null;
 
-	constructor(params: PutObjectRequest, opts: S3ProvierManagedUploadOptions, emitter: events.EventEmitter) {
+	constructor(params: PutObjectCommandInput, opts: S3ProvierManagedUploadOptions, emitter: events.EventEmitter) {
 		this.params = params;
 		this.opts = opts;
 		this.emitter = emitter;

--- a/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
+++ b/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
@@ -11,7 +11,11 @@
  * and limitations under the License.
  */
 
-import { ConsoleLogger as Logger, Credentials, ICredentials } from '@aws-amplify/core';
+import {
+	ConsoleLogger as Logger,
+	Credentials,
+	ICredentials,
+} from '@aws-amplify/core';
 import {
 	AbortMultipartUploadCommand,
 	CompletedPart,
@@ -28,7 +32,10 @@ import { CancelTokenSource } from 'axios';
 import * as events from 'events';
 import { createNewS3Client } from '../common/StorageS3ClientUtils';
 import { readFileToArrayBuffer } from '../common/FileReaderUtils';
-import { SEND_DOWNLOAD_PROGRESS_EVENT, SEND_UPLOAD_PROGRESS_EVENT } from './axios-http-handler';
+import {
+	SEND_DOWNLOAD_PROGRESS_EVENT,
+	SEND_UPLOAD_PROGRESS_EVENT,
+} from './axios-http-handler';
 
 const logger = new Logger('AWSS3ProviderManagedUpload');
 
@@ -46,7 +53,7 @@ interface S3ProvierManagedUploadOptions {
 	region?: string;
 	cancelTokenSource?: CancelTokenSource;
 	dangerouslyConnectToHttpEndpointForTesting?: boolean;
-	contentMd5?: (data: ArrayBuffer) => string;
+	contentMd5?: (data: any) => string;
 }
 
 export class AWSS3ProviderManagedUpload {
@@ -55,7 +62,7 @@ export class AWSS3ProviderManagedUpload {
 	private queueSize = 4;
 
 	// Data for current upload
-	private body: Blob;
+	private body: string | Blob;
 	private params: PutObjectCommandInput;
 	private opts: S3ProvierManagedUploadOptions;
 	private completedParts: CompletedPart[] = [];
@@ -64,17 +71,21 @@ export class AWSS3ProviderManagedUpload {
 	// Progress reporting
 	private bytesUploaded = 0;
 	private totalBytesToUpload = 0;
-	private emitter: events.EventEmitter = null;
+	private emitter: events.EventEmitter;
 
-	constructor(params: PutObjectCommandInput, opts: S3ProvierManagedUploadOptions, emitter: events.EventEmitter) {
+	constructor(
+		params: PutObjectCommandInput,
+		opts: S3ProvierManagedUploadOptions,
+		emitter: events.EventEmitter
+	) {
 		this.params = params;
 		this.opts = opts;
 		this.emitter = emitter;
+		this.body = this.validateAndSanitizeBody(this.params.Body);
 	}
 
 	public async upload() {
 		const { contentMd5 } = this.opts;
-		this.body = await this.validateAndSanitizeBody(this.params.Body);
 		this.totalBytesToUpload = this.byteLength(this.body);
 		if (this.totalBytesToUpload <= this.minPartSize) {
 			// Multipart upload is not required. Upload the sanitized body as is
@@ -83,7 +94,9 @@ export class AWSS3ProviderManagedUpload {
 			if (contentMd5) {
 				const content = this.params.Body;
 				if (content instanceof Blob) {
-					putObjectCommandInput.ContentMD5 = contentMd5(await readFileToArrayBuffer(content));
+					putObjectCommandInput.ContentMD5 = contentMd5(
+						await readFileToArrayBuffer(content)
+					);
 				} else {
 					putObjectCommandInput.ContentMD5 = contentMd5(content);
 				}
@@ -97,17 +110,26 @@ export class AWSS3ProviderManagedUpload {
 			const uploadId = await this.createMultiPartUpload();
 
 			// Step 2: Upload chunks in parallel as requested
-			const numberOfPartsToUpload = Math.ceil(this.totalBytesToUpload / this.minPartSize);
+			const numberOfPartsToUpload = Math.ceil(
+				this.totalBytesToUpload / this.minPartSize
+			);
 
 			const parts: Part[] = this.createParts();
-			for (let start = 0; start < numberOfPartsToUpload; start += this.queueSize) {
+			for (
+				let start = 0;
+				start < numberOfPartsToUpload;
+				start += this.queueSize
+			) {
 				/** This first block will try to cancel the upload if the cancel
 				 *	request came before any parts uploads have started.
 				 **/
 				await this.checkIfUploadCancelled(uploadId);
 
 				// Upload as many as `queueSize` parts simultaneously
-				await this.uploadParts(uploadId, parts.slice(start, start + this.queueSize));
+				await this.uploadParts(
+					uploadId,
+					parts.slice(start, start + this.queueSize)
+				);
 
 				/** Call cleanup a second time in case there were part upload requests
 				 *  in flight. This is to ensure that all parts are cleaned up.
@@ -127,7 +149,10 @@ export class AWSS3ProviderManagedUpload {
 	private createParts(): Part[] {
 		const parts: Part[] = [];
 		for (let bodyStart = 0; bodyStart < this.totalBytesToUpload; ) {
-			const bodyEnd = Math.min(bodyStart + this.minPartSize, this.totalBytesToUpload);
+			const bodyEnd = Math.min(
+				bodyStart + this.minPartSize,
+				this.totalBytesToUpload
+			);
 			parts.push({
 				bodyPart: this.body.slice(bodyStart, bodyEnd),
 				partNumber: parts.length + 1,
@@ -139,8 +164,10 @@ export class AWSS3ProviderManagedUpload {
 		return parts;
 	}
 
-	private async createMultiPartUpload() {
-		const createMultiPartUploadCommand = new CreateMultipartUploadCommand(this.params);
+	private async createMultiPartUpload(): Promise<string> {
+		const createMultiPartUploadCommand = new CreateMultipartUploadCommand(
+			this.params
+		);
 		const s3 = createNewS3Client(this.opts);
 		s3.middlewareStack.remove(SET_CONTENT_LENGTH_HEADER);
 
@@ -149,7 +176,12 @@ export class AWSS3ProviderManagedUpload {
 		// https://github.com/aws/aws-sdk-js-v3/issues/2000
 		s3.middlewareStack.add(
 			next => (args: any) => {
-				if (this.params.ContentType && args && args.request && args.request.headers) {
+				if (
+					this.params.ContentType &&
+					args &&
+					args.request &&
+					args.request.headers
+				) {
 					args.request.headers['Content-Type'] = this.params.ContentType;
 				}
 				return next(args);
@@ -161,6 +193,9 @@ export class AWSS3ProviderManagedUpload {
 
 		const response = await s3.send(createMultiPartUploadCommand);
 		logger.debug(response.UploadId);
+		if (!response.UploadId) {
+			throw new Error('Response without UploadId');
+		}
 		return response.UploadId;
 	}
 
@@ -174,7 +209,13 @@ export class AWSS3ProviderManagedUpload {
 			const allResults = await Promise.all(
 				parts.map(async part => {
 					this.setupEventListener(part);
-					const { Key, Bucket, SSECustomerAlgorithm, SSECustomerKey, SSECustomerKeyMD5 } = this.params;
+					const {
+						Key,
+						Bucket,
+						SSECustomerAlgorithm,
+						SSECustomerKey,
+						SSECustomerKeyMD5,
+					} = this.params;
 					const s3 = createNewS3Client(this.opts, part.emitter);
 					s3.middlewareStack.remove(SET_CONTENT_LENGTH_HEADER);
 					const uploadPartCommandInput: UploadPartCommandInput = {
@@ -203,7 +244,10 @@ export class AWSS3ProviderManagedUpload {
 				});
 			}
 		} catch (error) {
-			logger.error('error happened while uploading a part. Cancelling the multipart upload', error);
+			logger.error(
+				'error happened while uploading a part. Cancelling the multipart upload',
+				error
+			);
 			this.cancelUpload();
 			return;
 		}
@@ -223,7 +267,10 @@ export class AWSS3ProviderManagedUpload {
 			const data = await s3.send(completeUploadCommand);
 			return data.Key;
 		} catch (error) {
-			logger.error('error happened while finishing the upload. Cancelling the multipart upload', error);
+			logger.error(
+				'error happened while finishing the upload. Cancelling the multipart upload',
+				error
+			);
 			this.cancelUpload();
 			return;
 		}
@@ -277,7 +324,10 @@ export class AWSS3ProviderManagedUpload {
 
 	private setupEventListener(part: Part) {
 		part.emitter.on(SEND_UPLOAD_PROGRESS_EVENT, progress => {
-			this.progressChanged(part.partNumber, progress.loaded - part._lastUploadedBytes);
+			this.progressChanged(
+				part.partNumber,
+				progress.loaded - part._lastUploadedBytes
+			);
 			part._lastUploadedBytes = progress.loaded;
 		});
 	}
@@ -309,7 +359,7 @@ export class AWSS3ProviderManagedUpload {
 		}
 	}
 
-	private async validateAndSanitizeBody(body: any): Promise<any> {
+	private validateAndSanitizeBody(body: any): string | Blob {
 		if (this.isGenericObject(body)) {
 			// Any javascript object
 			return JSON.stringify(body);

--- a/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
+++ b/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
@@ -104,7 +104,6 @@ export class AWSS3ProviderManagedUpload {
 						await readFileToArrayBuffer(content)
 					);
 				} else {
-					const md5 = contentMd5(content);
 					putObjectCommandInput.ContentMD5 = contentMd5(content);
 				}
 			}

--- a/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
+++ b/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
@@ -14,7 +14,6 @@
 import {
 	ConsoleLogger as Logger,
 	Credentials,
-	getAmplifyUserAgent,
 	ICredentials,
 } from '@aws-amplify/core';
 import {
@@ -26,7 +25,6 @@ import {
 	ListPartsCommand,
 	PutObjectCommand,
 	PutObjectRequest,
-	S3Client,
 	UploadPartCommand,
 	UploadPartCommandInput,
 	PutObjectCommandInput,
@@ -36,14 +34,11 @@ import * as events from 'events';
 import { createNewS3Client } from '../common/StorageS3ClientUtils';
 import { readFileToArrayBuffer } from '../common/FileReaderUtils';
 import {
-	AxiosHttpHandler,
 	SEND_DOWNLOAD_PROGRESS_EVENT,
 	SEND_UPLOAD_PROGRESS_EVENT,
 } from './axios-http-handler';
 
 const logger = new Logger('AWSS3ProviderManagedUpload');
-
-const localTestingStorageEndpoint = 'http://localhost:20005';
 
 const SET_CONTENT_LENGTH_HEADER = 'contentLengthMiddleware';
 export declare interface Part {
@@ -384,39 +379,6 @@ export class AWSS3ProviderManagedUpload {
 			}
 		}
 		return false;
-	}
-
-	/**
-	 * @private
-	 * creates an S3 client with new V3 aws sdk
-	 */
-	protected async _createNewS3Client(config, emitter?: events.EventEmitter) {
-		const credentials = await this._getCredentials();
-		const {
-			region,
-			dangerouslyConnectToHttpEndpointForTesting,
-			cancelTokenSource,
-		} = config;
-		let localTestingConfig = {};
-
-		if (dangerouslyConnectToHttpEndpointForTesting) {
-			localTestingConfig = {
-				endpoint: localTestingStorageEndpoint,
-				tls: false,
-				bucketEndpoint: false,
-				forcePathStyle: true,
-			};
-		}
-
-		const client = new S3Client({
-			region,
-			credentials,
-			...localTestingConfig,
-			requestHandler: new AxiosHttpHandler({}, emitter, cancelTokenSource),
-			customUserAgent: getAmplifyUserAgent(),
-		});
-		client.middlewareStack.remove(SET_CONTENT_LENGTH_HEADER);
-		return client;
 	}
 
 	/**

--- a/packages/storage/src/types/AWSS3Provider.ts
+++ b/packages/storage/src/types/AWSS3Provider.ts
@@ -29,9 +29,7 @@ export interface S3ProviderGetConfig extends StorageOptions {
 	SSECustomerKeyMD5?: GetObjectRequest['SSECustomerKeyMD5'];
 }
 
-export type S3ProviderGetOuput<T> = T extends { download: true }
-	? GetObjectCommandOutput
-	: string;
+export type S3ProviderGetOuput<T> = T extends { download: true } ? GetObjectCommandOutput : string;
 
 export interface S3ProviderPutConfig extends StorageOptions {
 	progressCallback?: (progress: any) => any;

--- a/packages/storage/src/types/AWSS3Provider.ts
+++ b/packages/storage/src/types/AWSS3Provider.ts
@@ -1,13 +1,13 @@
 import {
-	GetObjectRequest,
-	GetObjectCommandOutput,
-	PutObjectRequest,
 	CopyObjectRequest,
-	_Object,
 	DeleteObjectCommandOutput,
+	GetObjectCommandOutput,
+	GetObjectRequest,
+	PutObjectRequest,
+	_Object,
 } from '@aws-sdk/client-s3';
-import { StorageOptions, StorageLevel } from './Storage';
 import { CancelTokenSource } from 'axios';
+import { StorageLevel, StorageOptions } from './Storage';
 
 type ListObjectsCommandOutputContent = _Object;
 
@@ -48,7 +48,7 @@ export interface S3ProviderPutConfig extends StorageOptions {
 	contentDisposition?: PutObjectRequest['ContentDisposition'];
 	contentEncoding?: PutObjectRequest['ContentEncoding'];
 	contentType?: PutObjectRequest['ContentType'];
-	contentMd5?: PutObjectRequest['ContentMD5'];
+	contentMd5?: (data: FileReader['result']) => string;
 	expires?: PutObjectRequest['Expires'];
 	metadata?: PutObjectRequest['Metadata'];
 	tagging?: PutObjectRequest['Tagging'];

--- a/packages/storage/src/types/AWSS3Provider.ts
+++ b/packages/storage/src/types/AWSS3Provider.ts
@@ -29,7 +29,9 @@ export interface S3ProviderGetConfig extends StorageOptions {
 	SSECustomerKeyMD5?: GetObjectRequest['SSECustomerKeyMD5'];
 }
 
-export type S3ProviderGetOuput<T> = T extends { download: true } ? GetObjectCommandOutput : string;
+export type S3ProviderGetOuput<T> = T extends { download: true }
+	? GetObjectCommandOutput
+	: string;
 
 export interface S3ProviderPutConfig extends StorageOptions {
 	progressCallback?: (progress: any) => any;
@@ -46,6 +48,7 @@ export interface S3ProviderPutConfig extends StorageOptions {
 	contentDisposition?: PutObjectRequest['ContentDisposition'];
 	contentEncoding?: PutObjectRequest['ContentEncoding'];
 	contentType?: PutObjectRequest['ContentType'];
+	contentMd5?: PutObjectRequest['ContentMD5'];
 	expires?: PutObjectRequest['Expires'];
 	metadata?: PutObjectRequest['Metadata'];
 	tagging?: PutObjectRequest['Tagging'];


### PR DESCRIPTION
#### Description of changes
Support `contentMd5` for `Storage.put`

Along with some minor changes:
- Moved `createS3Client` function to a separate file
- Added a fileReader util used for reading the file content (in order to run the `contentmd5` function
- More typings for `AWSS3ManagedUpload` constructor

#### Issue #, if available
#8675

#### Description of how you validated changes
- Unit tests
- Tested on sample app

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
