### PR TITLE
feat(geo): add region to Amazon Location Service MapStyle

### DIFF
--- a/packages/geo/__tests__/Geo.test.ts
+++ b/packages/geo/__tests__/Geo.test.ts
@@ -140,9 +140,11 @@ describe('Geo', () => {
 
 			const maps = [];
 			const availableMaps = awsConfig.geo.amazon_location_services.maps.items;
+			const region = awsConfig.geo.amazon_location_services.region;
+
 			for (const mapName in availableMaps) {
 				const style = availableMaps[mapName].style;
-				maps.push({ mapName, style });
+				maps.push({ mapName, style, region });
 			}
 
 			expect(geo.getAvailableMaps()).toEqual(maps);
@@ -179,7 +181,8 @@ describe('Geo', () => {
 			const mapName = awsConfig.geo.amazon_location_services.maps.default;
 			const style =
 				awsConfig.geo.amazon_location_services.maps.items[mapName].style;
-			const testMap = { mapName, style };
+			const region = awsConfig.geo.amazon_location_services.region;
+			const testMap = { mapName, style, region };
 
 			const defaultMapsResource = geo.getDefaultMap();
 			expect(defaultMapsResource).toEqual(testMap);

--- a/packages/geo/__tests__/Providers/AmazonLocationServicesProvider.test.ts
+++ b/packages/geo/__tests__/Providers/AmazonLocationServicesProvider.test.ts
@@ -101,9 +101,10 @@ describe('AmazonLocationServicesProvider', () => {
 
 			const maps = [];
 			const availableMaps = awsConfig.geo.amazon_location_services.maps.items;
+			const region = awsConfig.geo.amazon_location_services.region;
 			for (const mapName in availableMaps) {
 				const style = availableMaps[mapName].style;
-				maps.push({ mapName, style });
+				maps.push({ mapName, style, region });
 			}
 
 			expect(provider.getAvailableMaps()).toEqual(maps);
@@ -136,7 +137,9 @@ describe('AmazonLocationServicesProvider', () => {
 			const mapName = awsConfig.geo.amazon_location_services.maps.default;
 			const style =
 				awsConfig.geo.amazon_location_services.maps.items[mapName].style;
-			const testMap = { mapName, style };
+			const region = awsConfig.geo.amazon_location_services.region;
+
+			const testMap = { mapName, style, region };
 
 			const defaultMapsResource = provider.getDefaultMap();
 			expect(defaultMapsResource).toEqual(testMap);

--- a/packages/geo/src/Providers/AmazonLocationServicesProvider.ts
+++ b/packages/geo/src/Providers/AmazonLocationServicesProvider.ts
@@ -11,7 +11,11 @@
  * and limitations under the License.
  */
 import camelcaseKeys from 'camelcase-keys';
-import { ConsoleLogger as Logger, Credentials, getAmplifyUserAgent } from '@aws-amplify/core';
+import {
+	ConsoleLogger as Logger,
+	Credentials,
+	getAmplifyUserAgent,
+} from '@aws-amplify/core';
 import {
 	Place as PlaceResult,
 	SearchPlaceIndexForTextCommandInput,
@@ -27,7 +31,7 @@ import {
 	SearchByCoordinatesOptions,
 	GeoProvider,
 	Place,
-	MapStyle,
+	AmazonLocationServiceMapStyle,
 	Coordinates,
 } from '../types';
 
@@ -81,21 +85,22 @@ export class AmazonLocationServicesProvider implements GeoProvider {
 
 	/**
 	 * Get the map resources that are currently available through the provider
-	 * @returns {MapStyle[]}- Array of available map resources
+	 * @returns {AmazonLocationServiceMapStyle[]}- Array of available map resources
 	 */
-	public getAvailableMaps(): MapStyle[] {
+	public getAvailableMaps(): AmazonLocationServiceMapStyle[] {
 		if (!this._config.maps) {
 			throw new Error(
 				"No map resources found in amplify config, run 'amplify add geo' to create them and ensure to run `amplify push` after"
 			);
 		}
 
-		const mapStyles: MapStyle[] = [];
+		const mapStyles: AmazonLocationServiceMapStyle[] = [];
 		const availableMaps = this._config.maps.items;
+		const region = this._config.region;
 
 		for (const mapName in availableMaps) {
 			const style = availableMaps[mapName].style;
-			mapStyles.push({ mapName, style });
+			mapStyles.push({ mapName, style, region });
 		}
 
 		return mapStyles;
@@ -103,9 +108,9 @@ export class AmazonLocationServicesProvider implements GeoProvider {
 
 	/**
 	 * Get the map resource set as default in amplify config
-	 * @returns {MapStyle} - Map resource set as the default in amplify config
+	 * @returns {AmazonLocationServiceMapStyle} - Map resource set as the default in amplify config
 	 */
-	public getDefaultMap(): MapStyle {
+	public getDefaultMap(): AmazonLocationServiceMapStyle {
 		if (!this._config.maps) {
 			throw new Error(
 				"No map resources found in amplify config, run 'amplify add geo' to create them and ensure to run `amplify push` after"
@@ -119,8 +124,9 @@ export class AmazonLocationServicesProvider implements GeoProvider {
 
 		const mapName = this._config.maps.default;
 		const style = this._config.maps.items[mapName].style;
+		const region = this._config.region;
 
-		return { mapName, style };
+		return { mapName, style, region };
 	}
 
 	/**

--- a/packages/geo/src/types/AmazonLocationServicesProvider.ts
+++ b/packages/geo/src/types/AmazonLocationServicesProvider.ts
@@ -1,0 +1,5 @@
+import { MapStyle } from './Geo';
+
+export interface AmazonLocationServiceMapStyle extends MapStyle {
+	region: string;
+}

--- a/packages/geo/src/types/index.ts
+++ b/packages/geo/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './Geo';
 export * from './Provider';
+export * from './AmazonLocationServicesProvider';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Add new `AmazonLocationServiceMapStyle` type
- Add `region` to this type and return in the `MapStyle` objects from the `AmazonLocationServicesProvider`

#### Description of how you validated changes
Published to Verdaccio locally and used it through `maplibre-gl-js-amplify` with a Demo application:
![image](https://user-images.githubusercontent.com/16496746/128940594-c515d380-b401-4630-917e-d4ad5199a9fc.png)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
