### PR TITLE
feat(@aws-amplify/auth): Add a 'SUCCESS' response on successful call to forgotPasswordSubmit

### DIFF
--- a/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
@@ -1120,7 +1120,7 @@ describe('verifyAttribute(), getAttributeVerificationCode', () => {
 		netRequestMockSuccess(true);
 		cognitoUser.getAttributeVerificationCode(...getAttrsVerifCodeDefaults);
 		callback.inputVerificationCode = jest.fn();
-		expect(callback.onSuccess.mock.calls.length).toEqual(1);
+		expect(callback.onSuccess).toHaveBeenCalledWith('SUCCESS');
 	});
 
 	test('when inputVerificationCode exists in the callback, call inputVerifier with the data', () => {

--- a/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
@@ -1169,7 +1169,7 @@ describe('confirmPassword() and forgotPassword()', () => {
 	test('happy path should callback onSuccess', () => {
 		netRequestMockSuccess(true);
 		cognitoUser.confirmPassword(...confirmPasswordDefaults);
-		expect(callback.onSuccess.mock.calls.length).toEqual(1);
+		expect(callback.onSuccess).toHaveBeenCalledWith('SUCCESS')
 	});
 
 	test('client request throws an error', () => {

--- a/packages/amazon-cognito-identity-js/index.d.ts
+++ b/packages/amazon-cognito-identity-js/index.d.ts
@@ -216,7 +216,7 @@ declare module 'amazon-cognito-identity-js' {
 		public getAttributeVerificationCode(
 			name: string,
 			callback: {
-				onSuccess: () => void;
+				onSuccess: (success: string) => void;
 				onFailure: (err: Error) => void;
 				inputVerificationCode?: (data: string) => void | null;
 			}

--- a/packages/amazon-cognito-identity-js/index.d.ts
+++ b/packages/amazon-cognito-identity-js/index.d.ts
@@ -129,7 +129,7 @@ declare module 'amazon-cognito-identity-js' {
 			verificationCode: string,
 			newPassword: string,
 			callbacks: {
-				onSuccess: () => void;
+				onSuccess: (success: string) => void;
 				onFailure: (err: Error) => void;
 			},
 			clientMetaData?: ClientMetadata

--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -1700,7 +1700,7 @@ export default class CognitoUser {
 			if (err) {
 				return callback.onFailure(err);
 			}
-			return callback.onSuccess();
+			return callback.onSuccess('SUCCESS');
 		});
 	}
 

--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -1732,7 +1732,7 @@ export default class CognitoUser {
 				if (typeof callback.inputVerificationCode === 'function') {
 					return callback.inputVerificationCode(data);
 				}
-				return callback.onSuccess();
+				return callback.onSuccess('SUCCESS');
 			}
 		);
 		return undefined;

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1540,8 +1540,8 @@ export class AuthClass {
 			user.getAttributeVerificationCode(
 				attr,
 				{
-					onSuccess() {
-						return resolve();
+					onSuccess(success) {
+						return resolve(success);
 					},
 					onFailure(err) {
 						return reject(err);

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1819,7 +1819,7 @@ export class AuthClass {
 		code: string,
 		password: string,
 		clientMetadata: ClientMetaData = this._config.clientMetadata
-	): Promise<void> {
+	): Promise<string> {
 		if (!this.userPool) {
 			return this.rejectNoUserPool();
 		}
@@ -1839,13 +1839,13 @@ export class AuthClass {
 				code,
 				password,
 				{
-					onSuccess: () => {
+					onSuccess: (success) => {
 						dispatchAuthEvent(
 							'forgotPasswordSubmit',
 							user,
 							`${username} forgotPasswordSubmit successful`
 						);
-						resolve();
+						resolve(success);
 						return;
 					},
 					onFailure: err => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The function `forgotPasswordSubmit` does not return anything on successful password reset. This PR adds a 'SUCCESS' response when the password reset is successful. 
The `forgotPasswordSubmit` function is a part of the forgot password flow where users get a verification code (email or SMS ..) and provide that code along with the new password to the forgotPasswordSubmit function to reset the password.   


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#8453 


#### Description of how you validated changes
- linked a test app with my local AmplifyJS project with yarn linking and verified that we get 'SUCCESS' response when successfully submitting the verification code and the new password.
- `yarn test` passes


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
