### PR TITLE
fix(@aws-amplify/geo): Update webpack config to mark core as external

### DIFF
--- a/packages/geo/webpack.config.js
+++ b/packages/geo/webpack.config.js
@@ -2,6 +2,7 @@ module.exports = {
 	entry: {
 		'aws-amplify-geo.min': './lib-esm/index.js',
 	},
+	externals: [{ '@aws-amplify/core': 'aws_amplify_core' }],
 	output: {
 		filename: '[name].js',
 		path: __dirname + '/dist',


### PR DESCRIPTION
#### Description of changes
Update webpack config to mark amplify core as external such that core doesn't get duplicated.

#### Description of how you validated changes
Built the bundles and tested in a barebone html website.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
