### PR TITLE
feat(@aws-amplify/api-graphql) Add support for string 'authmode' values in TypeScript based apps 

### DIFF
--- a/packages/api-graphql/src/types/index.ts
+++ b/packages/api-graphql/src/types/index.ts
@@ -14,10 +14,12 @@
 import { GraphQLError } from 'graphql/error/GraphQLError';
 import { DocumentNode } from 'graphql/language/ast';
 
+type GRAPHQL_STR_MODE = 'API_KEY' | 'AWS_IAM' | 'OPENID_CONNECT' | 'AMAZON_COGNITO_USER_POOLS' | 'AWS_LAMBDA';
+
 export interface GraphQLOptions {
 	query: string | DocumentNode;
 	variables?: object;
-	authMode?: GRAPHQL_AUTH_MODE;
+	authMode?: GRAPHQL_AUTH_MODE | GRAPHQL_STR_MODE;
 	authToken?: string;
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
In TypeScript based projects, GraphQL operations that specify `authmode` does not accept string values (example: "API_KEY")and users have to import `GRAPHQL_AUTH_MODE` which is defined as an enum and use it to specify the value of `authmode`.

I added all valid authmode values (`'API_KEY'  'AWS_IAM'  'OPENID_CONNECT'  'AMAZON_COGNITO_USER_POOLS' 'AWS_LAMBDA'`) as accepted string values for type `authmode` 
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #7460 

<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
- Tested with local app (yarn linking)
- yarn test passed



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
