### PR TITLE
fix(@aws-amplify/datastore): only stringify nested AWSJSON in mutation event

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -937,6 +937,7 @@ releasable_branches: &releasable_branches
       - main
       - ui-components/main
       - 1.0-stable
+      - ds-fix-mutation-event-replacer
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]
@@ -1206,43 +1207,43 @@ workflows:
           matrix:
             parameters:
               <<: *test_browsers
-      - deploy:
-          filters:
-            <<: *releasable_branches
-          requires:
-            - unit_test
-            - integ_react_predictions
-            - integ_react_datastore
-            - integ_react_datastore_multi_auth_one_rule
-            - integ_react_datastore_multi_auth_two_rules
-            - integ_react_datastore_multi_auth_three_plus_rules
-            - integ_react_datastore_subs_disabled
-            - integ_react_datastore_consecutive_saves
-            - integ_react_storage
-            - integ_react_storage_multipart_progress
-            - integ_react_storage_copy
-            - integ_react_storage_ui
-            - integ_react_interactions
-            - integ_angular_interactions
-            - integ_vue_interactions
-            - integ_react_amazon_cognito_identity_js_cookie_storage
-            - integ_react_amazon_cognito_identity_js
-            - integ_node_amazon_cognito_identity_js
-            - integ_react_auth
-            - integ_angular_auth
-            - integ_vue_auth
-            - integ_rn_ios_storage
-            - integ_rn_ios_storage_multipart_progress
-            # - integ_rn_android_storage_multipart_progress
-            - integ_rn_ios_push_notifications
-            - integ_rn_android_storage
-            - integ_datastore_auth
-            - integ_duplicate_packages
-            - integ_auth_test_cypress_no_ui
-      - post_release:
-          filters:
-            branches:
-              only:
-                - release
-          requires:
-            - deploy
+      # - deploy:
+      #     filters:
+      #       <<: *releasable_branches
+      #     requires:
+      #       - unit_test
+      #       - integ_react_predictions
+      #       - integ_react_datastore
+      #       - integ_react_datastore_multi_auth_one_rule
+      #       - integ_react_datastore_multi_auth_two_rules
+      #       - integ_react_datastore_multi_auth_three_plus_rules
+      #       - integ_react_datastore_subs_disabled
+      #       - integ_react_datastore_consecutive_saves
+      #       - integ_react_storage
+      #       - integ_react_storage_multipart_progress
+      #       - integ_react_storage_copy
+      #       - integ_react_storage_ui
+      #       - integ_react_interactions
+      #       - integ_angular_interactions
+      #       - integ_vue_interactions
+      #       - integ_react_amazon_cognito_identity_js_cookie_storage
+      #       - integ_react_amazon_cognito_identity_js
+      #       - integ_node_amazon_cognito_identity_js
+      #       - integ_react_auth
+      #       - integ_angular_auth
+      #       - integ_vue_auth
+      #       - integ_rn_ios_storage
+      #       - integ_rn_ios_storage_multipart_progress
+      #       # - integ_rn_android_storage_multipart_progress
+      #       - integ_rn_ios_push_notifications
+      #       - integ_rn_android_storage
+      #       - integ_datastore_auth
+      #       - integ_duplicate_packages
+      #       - integ_auth_test_cypress_no_ui
+      # - post_release:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #     requires:
+      #       - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -937,7 +937,6 @@ releasable_branches: &releasable_branches
       - main
       - ui-components/main
       - 1.0-stable
-      - ds-fix-mutation-event-replacer
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]
@@ -1207,43 +1206,43 @@ workflows:
           matrix:
             parameters:
               <<: *test_browsers
-      # - deploy:
-      #     filters:
-      #       <<: *releasable_branches
-      #     requires:
-      #       - unit_test
-      #       - integ_react_predictions
-      #       - integ_react_datastore
-      #       - integ_react_datastore_multi_auth_one_rule
-      #       - integ_react_datastore_multi_auth_two_rules
-      #       - integ_react_datastore_multi_auth_three_plus_rules
-      #       - integ_react_datastore_subs_disabled
-      #       - integ_react_datastore_consecutive_saves
-      #       - integ_react_storage
-      #       - integ_react_storage_multipart_progress
-      #       - integ_react_storage_copy
-      #       - integ_react_storage_ui
-      #       - integ_react_interactions
-      #       - integ_angular_interactions
-      #       - integ_vue_interactions
-      #       - integ_react_amazon_cognito_identity_js_cookie_storage
-      #       - integ_react_amazon_cognito_identity_js
-      #       - integ_node_amazon_cognito_identity_js
-      #       - integ_react_auth
-      #       - integ_angular_auth
-      #       - integ_vue_auth
-      #       - integ_rn_ios_storage
-      #       - integ_rn_ios_storage_multipart_progress
-      #       # - integ_rn_android_storage_multipart_progress
-      #       - integ_rn_ios_push_notifications
-      #       - integ_rn_android_storage
-      #       - integ_datastore_auth
-      #       - integ_duplicate_packages
-      #       - integ_auth_test_cypress_no_ui
-      # - post_release:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #     requires:
-      #       - deploy
+      - deploy:
+          filters:
+            <<: *releasable_branches
+          requires:
+            - unit_test
+            - integ_react_predictions
+            - integ_react_datastore
+            - integ_react_datastore_multi_auth_one_rule
+            - integ_react_datastore_multi_auth_two_rules
+            - integ_react_datastore_multi_auth_three_plus_rules
+            - integ_react_datastore_subs_disabled
+            - integ_react_datastore_consecutive_saves
+            - integ_react_storage
+            - integ_react_storage_multipart_progress
+            - integ_react_storage_copy
+            - integ_react_storage_ui
+            - integ_react_interactions
+            - integ_angular_interactions
+            - integ_vue_interactions
+            - integ_react_amazon_cognito_identity_js_cookie_storage
+            - integ_react_amazon_cognito_identity_js
+            - integ_node_amazon_cognito_identity_js
+            - integ_react_auth
+            - integ_angular_auth
+            - integ_vue_auth
+            - integ_rn_ios_storage
+            - integ_rn_ios_storage_multipart_progress
+            # - integ_rn_android_storage_multipart_progress
+            - integ_rn_ios_push_notifications
+            - integ_rn_android_storage
+            - integ_datastore_auth
+            - integ_duplicate_packages
+            - integ_auth_test_cypress_no_ui
+      - post_release:
+          filters:
+            branches:
+              only:
+                - release
+          requires:
+            - deploy

--- a/packages/datastore/src/sync/utils.ts
+++ b/packages/datastore/src/sync/utils.ts
@@ -395,11 +395,18 @@ export function createMutationInstanceFromModelOperation<
 			exhaustiveCheck(opType);
 	}
 
-	// stringify nested objects
+	// stringify nested objects of type AWSJSON
 	// this allows us to return parsed JSON to users (see `castInstanceType()` in datastore.ts),
-	// but still send the object correctly over-the-wire
+	// but still send the object correctly over the wire
 	const replacer = (k, v) => {
-		if (k && v !== null && typeof v === 'object' && !Array.isArray(v)) {
+		const isAWSJSON =
+			k &&
+			v !== null &&
+			typeof v === 'object' &&
+			modelDefinition.fields[k] &&
+			modelDefinition.fields[k].type === 'AWSJSON';
+
+		if (isAWSJSON) {
 			return JSON.stringify(v);
 		}
 		return v;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
We added automatic JSON parsing for AWSJSON fields in the latest version of DataStore (3.4.0). This change inadvertently affected non-model Types. 

This PR corrects that behavior, only stringifying fields of type AWSJSON.


#### Description of how you validated changes
* unit tests
* local sample app with non-model types and AWSJSON fields
* running e2e tests in CircleCI. Successful run: https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/8632/workflows/8c7e7f80-a713-4cc7-9707-ccd247c717fe

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
