### PR TITLE
chore(fix axios version): patch security vuln for api-rest and storage

### DIFF
--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
     "@aws-amplify/core": "4.2.7",
-    "axios": "0.21.1"
+    "axios": "0.21.4"
   },
   "jest": {
     "globals": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -46,7 +46,7 @@
     "@aws-sdk/s3-request-presigner": "3.6.1",
     "@aws-sdk/util-create-request": "3.6.1",
     "@aws-sdk/util-format-url": "3.6.1",
-    "axios": "0.21.1",
+    "axios": "0.21.4",
     "events": "^3.1.0",
     "sinon": "^7.5.0"
   },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Axios had a security vulnerability on version 0.21.1 and they release a patch that would handle a denial of service attacked based on weak regular expression rules. This patch has been released by Axios yesterday.


#### Issue #, if available
[Axios pull request ](https://github.com/axios/axios/pull/3980), [issues from customers](https://github.com/aws-amplify/amplify-js/issues/8852)


#### Description of how you validated changes
I deleted all the node modules in the packages that were using the old version of axios and ran the unit tests with axios 0.21.4 and all the tests pass as before.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [n/a] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [n/a] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
