### PR TITLE
feat(@aws-amplify/datastore): observeQuery API

### DIFF
--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -22,7 +22,7 @@ import {
 	ModelPredicate,
 	AuthModeStrategy,
 } from '../types';
-import { exhaustiveCheck, getNow, SYNC } from '../util';
+import { exhaustiveCheck, getNow, SYNC, USER } from '../util';
 import DataStoreConnectivity from './datastoreConnectivity';
 import { ModelMerger } from './merger';
 import { MutationEventOutbox } from './outbox';
@@ -95,6 +95,16 @@ export class SyncEngine {
 	private readonly modelMerger: ModelMerger;
 	private readonly outbox: MutationEventOutbox;
 	private readonly datastoreConnectivity: DataStoreConnectivity;
+	private readonly modelSyncedStatus: WeakMap<
+		PersistentModelConstructor<any>,
+		boolean
+	> = new WeakMap();
+
+	public getModelSyncedStatus(
+		modelConstructor: PersistentModelConstructor<any>
+	): boolean {
+		return this.modelSyncedStatus.get(modelConstructor);
+	}
 
 	constructor(
 		private readonly schema: InternalSchema,
@@ -615,6 +625,8 @@ export class SyncEngine {
 
 										const counts = count.get(modelConstructor);
 
+										this.modelSyncedStatus.set(modelConstructor, true);
+
 										observer.next({
 											type: ControlMessage.SYNC_ENGINE_MODEL_SYNCED,
 											data: {
@@ -708,6 +720,12 @@ export class SyncEngine {
 				.filter(({ syncable }) => syncable)
 				.forEach(model => {
 					models.push([namespace.name, model]);
+					if (namespace.name === USER) {
+						const modelConstructor = this.userModelClasses[
+							model.name
+						] as PersistentModelConstructor<any>;
+						this.modelSyncedStatus.set(modelConstructor, false);
+					}
 				});
 		});
 

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -367,6 +367,12 @@ export type SubscriptionMessage<T extends PersistentModel> = {
 	model: PersistentModelConstructor<T>;
 	condition: PredicatesGroup<T> | null;
 };
+
+export type DataStoreSnapshot<T extends PersistentModel> = {
+	items: T[];
+	isSynced: boolean;
+	itemsChanged: T[];
+};
 //#endregion
 
 //#region Predicates


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

## Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Exposes new functionality for customers to combine `DataStore.observe(...)` and `DataStore.query(...)` into one useful method
- Returns an observable with a `snapshot` (Type: `DataStoreSnapshot<T>`) which contains: `items` (an array of all the records synced so far), `isSynced` (a boolean which tells us if the local DB is full synced up with AppSync), and `itemsChanged` (an array of records which were synced since the last glimpse of `items` was provided).

### Usage
__How customers might use this:__
```js
DataStore.observeQuery(Post).subscribe(snapshot => {
  const { items, isSynced, itemsChanged } = snapshot;
  // check if `isSynced`, and do something with the items/itemsChanged, i.e. update the UI
});
```

This is particularly useful when there are many (thousands of) records to be synced from AppSync. Rather than having to wait for the `modelSynced` event (which could take many seconds), we will get batches of 1000 records as they get synced down, which provides a much smoother UX, and a quicker "perceived load time" to the end user.

For example, when querying a `Post` model with 4123 records in AppSync, it would work as follows:

#### FIRST time loading the app - i.e. there are no available records in the local DB

1. The `snapshot` returned from the observable in `observeQuery` provides:
`snapshot = { items: [], isSynced: false, itemsChanged: [] }`
2. Then the first page of results will return:
`snapshot: { items: Array(1000), isSynced: false, itemsChanged: Array(1000)}`
3. Second page:
`snapshot: { items: Array(2000), isSynced: false, itemsChanged: Array(1000)}`
4. Third page:
`snapshot: { items: Array(3000), isSynced: false, itemsChanged: Array(1000)}`
5. Fourth page:
`snapshot: { items: Array(4000), isSynced: false, itemsChanged: Array(1000)}`
6. Finally, the last page of results will return:
`snapshot: { items: Array(4123), isSynced: true, itemsChanged: Array(123)}`

#### After syncing is complete (i.e. refreshing the app without calling `DataStore.clear()`):
1. `snapshot = { items: [4123], isSynced: false, itemsChanged: [] }`
2. `snapshot = { items: [4123], isSynced: true, itemsChanged: [] }`
(the Observer.next() is called twice - once right away, and once when the `modelSynced` event via `Hub.listen` is triggered)

### Predicates/Query Options
Customers can still pass `predicates`, as well as options like `sort` order and `pagination` values. For example:
```js
DataStore.observeQuery(
  Post,
  p => p.status("eq", "PUBLISHED")
).subscribe(snapshot => {
  const { items, isSynced, itemsChanged } = snapshot;
  // update the UI
});
```
```js
DataStore.observeQuery(
  Post,
  Predicates.ALL,
  { sort: s => s.createdAt(SortDirection.DESCENDING) }
).subscribe(snapshot => {
  const { items, isSynced, itemsChanged } = snapshot;
  // update the UI
});
```
```js
DataStore.observeQuery(
  Post,
  p => p.status("eq", "PUBLISHED"),
  {
    sort: s => s.createdAt(SortDirection.DESCENDING),
    page: 0,
    limit: 100
  }
).subscribe(snapshot => {
  const { items, isSynced, itemsChanged } = snapshot;
  // update the UI
});
```

### Cancellation
Customers can cancel this subscription (and the query process itself while in-flight), by calling the `.unsubscribe()` method on the stored Observable. For example, in a React app:
```js
import { useState, useEffect } from "react";

// store the Observable in state, to unsubscribe later
const [postObserveQuery, setPostObserveQuery] = useState();


useEffect(() => {
  let postSub = DataStore.observeQuery(Post, Predicates.ALL).subscribe(snapshot => {
    const { items, isSynced, itemsChanged } = snapshot;
    // update the UI
  });
  setPostObserveQuery(postSub);

  // when the component is unmounted, unsubscribe from the observeQuery
  return () => {
    postObserveQuery.unsubscribe();
  }
}, []);

// ... or, somewhere in the UI maybe there is a "cancel" button, which could fire the unsubscribe method
const cancelObserveQuery = () => {
  postObserveQuery.unsubscribe();
};
```
This will immediately invoke the cleanup method within the Observable and unsubscribe from the established subscription.


## Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



## Description of how you validated changes



## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
