### PR TITLE
fix: Linking.removeListener deprecated in RN 0.65+

### DIFF
--- a/packages/auth/src/urlListener.native.ts
+++ b/packages/auth/src/urlListener.native.ts
@@ -14,6 +14,7 @@ import { ConsoleLogger as Logger } from '@aws-amplify/core';
 const logger = new Logger('urlListener');
 
 let handler;
+let subscription;
 
 export default async callback => {
 	if (handler) {
@@ -36,8 +37,8 @@ export default async callback => {
 			callback({ url });
 		});
 
-	Linking.removeEventListener('url', handler);
-	Linking.addEventListener('url', handler);
+	subscription?.remove?.();
+	subscription = Linking.addEventListener('url', handler);
 	AppState.addEventListener('change', async newAppState => {
 		if (newAppState === 'active') {
 			const initialUrl = await Linking.getInitialURL();


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The library aws-amplify was throwing error `Attempted to remove more RCTLinkingManager listeners than added`and warnging `WARN  EventEmitter.removeListener('url', ...): Method has been deprecated. Please instead use 'remove()' on the subscription returned by 'EventEmitter.addListener'.` in React Native v0.65 only on iOS. 

To fix it, I've changed `removeListener` to conditional remove, so now it throws neither an error nor a warning.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/8902


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
