### PR TITLE
A node script to improve React-Native local development 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ packages/**/cjs/
 packages/**/cypress/videos/
 yarn.lock
 package-lock.json
+packages/*/.watchmanconfig

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,37 @@ yarn link @aws-amplify/auth
 
 These tests are only necessary if you’re looking to contribute a Pull Request. If you’re just playing locally you don’t need them. However if you’re contributing a Pull Request for anything other than bug fixes it would be best to validate that first because depending on the scope of the change.
 
+**Using the set-dev:reactnative script to work with React-Native apps**
+
+To develop locally alongside a React-Native app, make sure to finish the build steps mentioned in the section: `Setting up for local development`
+
+Then, run the below command in the root of the amplify-js local repository (auth for example):
+
+```
+npm run setup-dev:reactnative -- -p @aws-amplify/auth -t ~/path/to/your/rn/app/root
+```
+
+The options -p is used to specify single or multiple package names and the -t option is used to specify the path to your sample React-Native app.
+
+To devlop multiple/all packages, provide the package names separated by a comma or use the keyword all:
+
+```
+npm run setup-dev:reactnative -- -p @aws-amplify/auth,aws-amplify-react-native -t ~/path/to/your/rn/app/root
+npm run setup-dev:reactnative -- -p all -t ~/path/to/your/rn/app/root
+```
+
+Note: `--` is important to provide arguments as shown above.
+
+**Debugging problems with the script**
+
+- If the WML command does not do anything after adding the links, watch it's src file using watchman. run the below from the root of this repository:
+
+  ```
+  watchman watch node_modules/wml/src
+  ```
+
+- When using VScode, for the script to open a new terminal and tabs you will need to provide the editor accessiblity permissions.
+
 #### Verdaccio
 
 Verdaccio is a lightweight private npm proxy registry built in Node.js. Install [Verdaccio](https://verdaccio.org/docs/en/installation). You can setup Verdaccio to publish packages locally to test the changes.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"description": "",
 	"scripts": {
 		"setup-dev": "yarn && yarn bootstrap && yarn link-all && yarn build",
+		"setup-dev:reactnative": "node ./scripts/setup-dev-rn",
 		"bootstrap": "lerna bootstrap",
 		"test": "lerna run test --stream",
 		"cypress": "lerna run cypress",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
 		"webpack": "^4.32.0",
 		"webpack-bundle-analyzer": "^3.3.2",
 		"webpack-cli": "^3.1.0",
-		"winston": "^3.2.1"
+		"winston": "^3.2.1",
+		"wml": "0.0.83"
 	},
 	"resolutions": {
 		"@babel/types": "7.12.10",

--- a/packages/amplify-ui/build.js
+++ b/packages/amplify-ui/build.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const build = require('../../scripts/build');
+
+build(process.argv[2], process.argv[3]);

--- a/packages/amplify-ui/package.json
+++ b/packages/amplify-ui/package.json
@@ -11,7 +11,9 @@
     "test": "webpack",
     "start": "webpack-dev-server",
     "clean": "rimraf dist lib",
-    "build": "npm run clean && webpack && copyfiles -u 1 ./src/*.css.d.ts ./lib"
+    "build": "npm run clean && webpack && copyfiles -u 1 ./src/*.css.d.ts ./lib",
+    "build:cjs:watch": "node ./build es5 --watch",
+    "build:esm:watch": "echo \"ES Modules are not exported in react-native. Use target build:cjs:watch\""
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/pushnotification/build.js
+++ b/packages/pushnotification/build.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const build = require('../../scripts/build');
+
+build(process.argv[2], process.argv[3]);

--- a/packages/pushnotification/package.json
+++ b/packages/pushnotification/package.json
@@ -12,6 +12,8 @@
     "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
     "build-with-test": "npm test && npm run build",
     "build": "npm run clean && tsc",
+    "build:cjs:watch": "node ./build es5 --watch",
+    "build:esm:watch": "echo \"ES Modules are not exported in react-native. Use target build:cjs:watch\"",
     "clean": "rimraf lib lib-esm dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts'"

--- a/scripts/setup-dev-rn.js
+++ b/scripts/setup-dev-rn.js
@@ -1,0 +1,223 @@
+'use strict';
+
+const path = require('path');
+const yargs = require('yargs');
+var { exec } = require('child_process');
+const { readdirSync, existsSync } = require('fs');
+var exec = require('child_process').exec;
+var os = require('os');
+const winston = require('winston');
+const logger = winston.createLogger({
+	level: process.env.LOG_LEVEL ? process.env.LOG_LEVEL.toLowerCase() : 'info',
+	transports: [
+		new winston.transports.Console({
+			format: winston.format.combine(
+				winston.format.prettyPrint(2),
+				winston.format.colorize({ all: true })
+			),
+		}),
+	],
+});
+
+async function setupDevRn() {
+	const args = yargs.argv;
+	const dependentAppPath = args.t;
+	var packages = args.p;
+	const pkgRootPath = process.cwd();
+
+	// Exit if package option is not given
+	if (packages === undefined || packages === true) {
+		logger.error('Package option cannot be empty.');
+		return;
+	}
+
+	// Exit if dependent app option is not given
+	if (dependentAppPath === undefined || dependentAppPath === true) {
+		logger.error('Target App path cannot be empty.');
+		return;
+	}
+
+	// Exit if dependent app path is given but does not exist
+	if (!existsSync(dependentAppPath)) {
+		logger.error(
+			'Dependent app path given does not exist. Please provide a valid path'
+		);
+		return;
+	}
+
+	// Exit for unsupported OS
+	if (os.platform() !== 'darwin') {
+		logger.error(
+			'No support for this operating system. Currenlty only supports OSX.'
+		);
+		return;
+	}
+
+	// Remove packages that do not have build:watch script
+	const excludedPacks = [
+		'aws-amplify-vue',
+		'@aws-amplify/ui-vue',
+		'@aws-amplify/ui-angular',
+		'@aws-amplify/ui-components',
+		'@aws-amplify/ui-storybook',
+		'aws-amplify-angular',
+	];
+
+	// Exclude unrelated pacakges
+	const allPacks = getPackageNames('./packages/').filter(
+		el => !excludedPacks.includes(el)
+	);
+
+	// ALL Packages list formation
+	if (packages === 'all') {
+		packages = allPacks.join(',');
+	}
+
+	const packagesArr = packages.split(',');
+
+	const cjsPacksPreset = [
+		'aws-amplify-react-native',
+		'@aws-amplify/pushnotification',
+		'@aws-amplify/ui',
+	];
+	const esmPackages = [];
+	const cjsPackages = [];
+
+	packagesArr.forEach(element => {
+		if (!allPacks.includes(element)) {
+			logger.error(
+				`Package ${element} is not supported by this script or does not exist. Here is list of supported packages: ${allPacks}`
+			);
+			process.exit(0);
+		}
+
+		// Divide the packagesArr into cjs and esm packages
+		if (!cjsPacksPreset.includes(element)) {
+			esmPackages.push(element);
+		} else {
+			cjsPackages.push(element);
+		}
+	});
+
+	const finalCmds = [];
+
+	// LERNA build:ESM:watch command with scopes for multiple or all packages
+	if (esmPackages.length > 0) {
+		const scopes = `{${esmPackages.join(',')},}`;
+		const watchCmd = `npx lerna exec --scope=${scopes} npm run build:esm:watch --parallel`;
+		const lernaBuildWatchCmd = `cd ${pkgRootPath} && ${watchCmd}`;
+		finalCmds.push(lernaBuildWatchCmd);
+	}
+
+	// WML add command formation
+	const directoryPackNames = scopeToDirectoryName(packagesArr);
+	const wmlAddStrings = buildWmlAddStrings(
+		directoryPackNames,
+		dependentAppPath,
+		pkgRootPath
+	);
+	const wmlClearCmd = 'npm-exec wml rm all && ';
+	const wmlAddCmd = wmlAddStrings.join(' ');
+	const wmlStart = 'npm-exec wml start';
+	const navToDirAndAlias = `cd ${pkgRootPath} && alias npm-exec='PATH=$(npm bin):$PATH'`;
+	const finalWmlCmd =
+		navToDirAndAlias + ' & ' + wmlClearCmd + wmlAddCmd + wmlStart;
+
+	finalCmds.push(finalWmlCmd);
+
+	// LERNA build:CJS:watch package command to be run in a new tab
+	if (cjsPackages.length > 0) {
+		var rnPackageBuildWatch = `cd ${pkgRootPath}`;
+		const cjsScopes = `{${cjsPackages.join(',')},}`;
+		rnPackageBuildWatch = `${rnPackageBuildWatch} && npx lerna exec --scope=${cjsPackages} npm run build:cjs:watch --parallel`;
+		finalCmds.push(rnPackageBuildWatch);
+	}
+
+	// Open each command in a new tab in a new terminal
+	openTab(finalCmds);
+}
+
+// Convert scoped packagenames to directory names used for path formation for wml commands
+const scopeToDirectoryName = scopedPackages => {
+	scopedPackages = scopedPackages.map(
+		scoPackage => scoPackage.split('/')[1] ?? scoPackage
+	);
+	console.log(scopedPackages);
+	return scopedPackages.map(packageName =>
+		packageName.includes('ui') ? `amplify-${packageName}` : packageName
+	);
+};
+
+// Get all package names from under the packages directory
+const getPackageNames = source =>
+	readdirSync(source, { withFileTypes: true })
+		.filter(dirent => dirent.isDirectory())
+		.map(dirent => require(`../packages/${dirent.name}/package.json`).name);
+
+// Form all the wml add commands needed
+function buildWmlAddStrings(packages, dependentAppPath, pkgRootPath) {
+	var wmlAddCmds = [];
+	const packagesDir = path.resolve(pkgRootPath, 'packages');
+	const sampleAppNodeModulesDir = path.join(dependentAppPath, 'node_modules');
+
+	packages.forEach(element => {
+		// Remove scoped package name for the source
+		// but keep it for target
+		var srcPackage = '';
+		if (element.includes('@aws-amplify/')) {
+			srcPackage = element.split('/')[1];
+			if (srcPackage === 'ui-react') {
+				srcPackage = `amplify-${srcPackage}`;
+			}
+		} else {
+			srcPackage = element;
+		}
+		const source = path.resolve(packagesDir, srcPackage);
+		const target = path.resolve(sampleAppNodeModulesDir, element);
+		wmlAddCmds.push(` npm-exec wml add ${source} ${target} && `);
+	});
+	return wmlAddCmds;
+}
+
+// OSA script to open a new terminal and tabs for each command execution
+function openTab(cmdArr, cb) {
+	var open = ['osascript -e \'tell application "Terminal" to activate\' '];
+	cmdArr.forEach(element => {
+		const splitCmds = element.split(' & ');
+		if (splitCmds.length == 2) {
+			open.push(
+				'-e \'tell application "System Events" to tell process "Terminal" to keystroke "t"',
+				"using command down' ",
+				'-e \'tell application "Terminal" to do script',
+				'"',
+				splitCmds[0],
+				'"',
+				"in front window' ",
+				"-e 'delay 0.2' ",
+				'-e \'tell application "Terminal" to do script',
+				'"',
+				splitCmds[1],
+				'"',
+				"in front window' "
+			);
+		} else {
+			open.push(
+				'-e \'tell application "System Events" to tell process "Terminal" to keystroke "t"',
+				"using command down' ",
+				'-e \'tell application "Terminal" to do script',
+				'"',
+				element,
+				'"',
+				"in front window' ",
+				"-e 'delay 0.2' "
+			);
+		}
+	});
+
+	open = open.join(' ');
+	exec(open);
+}
+
+setupDevRn();
+
+module.exports = setupDevRn;

--- a/scripts/setup-dev-rn.js
+++ b/scripts/setup-dev-rn.js
@@ -142,7 +142,6 @@ const scopeToDirectoryName = scopedPackages => {
 	scopedPackages = scopedPackages.map(
 		scoPackage => scoPackage.split('/')[1] ?? scoPackage
 	);
-	console.log(scopedPackages);
 	return scopedPackages.map(packageName =>
 		packageName.includes('ui') ? `amplify-${packageName}` : packageName
 	);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This introduces a script that internally makes use of the existing lerna build:watch and wml commands to setup the required dev env to develop amplify-js library and it's packages using a sample React-Native app. 

Currently only supports running on MacOS. Documentation on how to use is added to the Contribution guide included in this PR. 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->


#### Description of how you validated changes
Manual validation by running it against different use cases. 


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Demo:

https://user-images.githubusercontent.com/10944487/133674488-75285506-4fdb-4e25-a408-d7135e0f9b4f.mov


