### PR TITLE
fix(amazon-cognito-identity-js): Fix UserPoolId validation ReDoS

### DIFF
--- a/packages/amazon-cognito-identity-js/src/CognitoUserPool.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUserPool.js
@@ -19,6 +19,8 @@ import Client from './Client';
 import CognitoUser from './CognitoUser';
 import StorageHelper from './StorageHelper';
 
+const USER_POOL_ID_MAX_LENGTH = 55;
+
 /** @class */
 export default class CognitoUserPool {
 	/**
@@ -46,7 +48,7 @@ export default class CognitoUserPool {
 		if (!UserPoolId || !ClientId) {
 			throw new Error('Both UserPoolId and ClientId are required.');
 		}
-		if (!/^[\w-]+_.+$/.test(UserPoolId)) {
+		if (UserPoolId.length > USER_POOL_ID_MAX_LENGTH || !/^[\w-]+_[0-9a-zA-Z]+$/.test(UserPoolId)) {
 			throw new Error('Invalid UserPoolId format.');
 		}
 		const region = UserPoolId.split('_')[0];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Check the User Pool ID for a max length of 55 (as per https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolType.html#CognitoUserPools-Type-UserPoolType-Id)
- Fix the regex used to validate the User Pool ID to remove the backtracking (see: https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
N/A


#### Description of how you validated changes
Ran tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
