### PR TITLE
fix: update TTL of the cached endpoint id

### DIFF
--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -615,9 +615,13 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 		if (!endpointId) {
 			endpointId = uuid();
 			// set a longer TTL to avoid endpoint id being deleted after the default TTL (3 days)
-			const ttl = 1000 * 60 * 60 * 24 * 365 * 1000; // 1000 years
+			// also set its priority to the highest to reduce its chance of being deleted when cache is full
+			const ttl = 1000 * 60 * 60 * 24 * 365 * 100; // 100 years
 			const expiration = new Date().getTime() + ttl;
-			Cache.setItem(cacheKey, endpointId, { expires: expiration });
+			Cache.setItem(cacheKey, endpointId, {
+				expires: expiration,
+				priority: 1,
+			});
 		}
 		return endpointId;
 	}

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -614,7 +614,10 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 		);
 		if (!endpointId) {
 			endpointId = uuid();
-			Cache.setItem(cacheKey, endpointId);
+			// set a longer TTL to avoid endpoint id being deleted after the default TTL (3 days)
+			const ttl = 1000 * 60 * 60 * 24 * 365 * 1000; // 1000 years
+			const expiration = new Date().getTime() + ttl;
+			Cache.setItem(cacheKey, endpointId, { expires: expiration });
 		}
 		return endpointId;
 	}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->
We have customer complaining about the number of endpoints reaching maximum limits (https://github.com/aws-amplify/amplify-js/issues/6896, https://github.com/aws-amplify/amplify-js/issues/7251). After investigation, we notice this issue is due to the local cached endpoint id being deleted, thus amplify recreates a new one and assign it to the same user.

The cached endpoint id might be deleted manually by devTool during development, or might due to using a different browser (e.g. incognito mode), which we cannot prevent.

However, we notice customers report that the issue also happens in production. A deep dive reveals that the current endpoint id is cached with the default [3 days TTL](https://github.com/aws-amplify/amplify-js/blob/main/packages/cache/src/Utils/CacheUtils.ts#L23), meaning it will be expired and deleted automatically after 3 days.  ([getItem](https://github.com/aws-amplify/amplify-js/blob/main/packages/cache/src/BrowserStorageCache.ts#L357) will only refresh the visitedTime, not mutating the expires).

We should persist this value longer (now set to 100 years) since it does not have any value to create a new endpoint for the same device.

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- set endpoint id TTL to 100 years.
- set priority level to highest 1 (default to 5). Higher priority meaning it is less likely to be deleted when cache is full.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/7251
https://github.com/aws-amplify/amplify-js/issues/6896


#### Description of how you validated changes
1. check browser locally.
2. ensure the number is way below [safe integer in JS](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) so it won't overflow.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
