### PR TITLE
fix: default to PUSH channel type for web analytics

### DIFF
--- a/packages/analytics/__tests__/Providers/AWSPinpointProvider-unit-test.ts
+++ b/packages/analytics/__tests__/Providers/AWSPinpointProvider-unit-test.ts
@@ -499,7 +499,7 @@ describe('AnalyticsProvider test', () => {
 					EndpointId: 'endpointId',
 					EndpointRequest: {
 						Attributes: {},
-						ChannelType: undefined,
+						ChannelType: 'PUSH',
 						Demographic: {
 							AppVersion: 'clientInfoAppVersion',
 							Make: 'clientInfoMake',
@@ -541,7 +541,7 @@ describe('AnalyticsProvider test', () => {
 					EndpointId: 'endpointId',
 					EndpointRequest: {
 						Attributes: {},
-						ChannelType: undefined,
+						ChannelType: 'PUSH',
 						Demographic: {
 							AppVersion: 'clientInfoAppVersion',
 							Locale: 'locale',

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -660,9 +660,9 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 				? 'GCM'
 				: 'APNS'
 			: 'PUSH';
-		// TODO: "PUSH" is a historical channel type, which is safe to be used for web analytics
+		// NOTE: "PUSH" is a historical channel type, which is safe to be used for web analytics
 		// PUSH channel type will not run into maximum endpoint limitation
-		// if pinpoint support specific web analytics channel type, we should update accordingly
+		// if pinpoint supports specific web analytics channel type, we should update accordingly
 		const tmp = {
 			channelType,
 			requestId: uuid(),

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -659,7 +659,10 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 			? clientInfo.platform === 'android'
 				? 'GCM'
 				: 'APNS'
-			: undefined;
+			: 'PUSH';
+		// TODO: "PUSH" is a historical channel type, which is safe to be used for web analytics
+		// PUSH channel type will not run into maximum endpoint limitation
+		// if pinpoint support specific web analytics channel type, we should update accordingly
 		const tmp = {
 			channelType,
 			requestId: uuid(),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Customers are still reporting the default endpoints Amplify created reaching the maximum limit, especially, during browser update.

The default endpoint we create does not have any channelType, and is used for collecting web analytics data. Currently, Pinpoint does not support a specific channel type for web analytics.

After discussion with service team, this change is to set the default channel type to "PUSH". This legacy channel type is not used for push notification, and will auto evict if reach maximum limits.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#7251
#6896


#### Description of how you validated changes
- localbrowser
- verify with service team


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] PR description included
- [x ] `yarn test` passes
- [ x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
