### PR TITLE
fix(@aws-amplify/auth): RN Linking removeEventListener() deprecated #…

### DIFF
--- a/packages/auth/src/urlListener.native.ts
+++ b/packages/auth/src/urlListener.native.ts
@@ -22,6 +22,7 @@ export default async callback => {
 
 	let Linking: any;
 	let AppState: any;
+	let subscription;
 
 	try {
 		({ Linking, AppState } = require('react-native'));
@@ -36,8 +37,16 @@ export default async callback => {
 			callback({ url });
 		});
 
-	Linking.removeEventListener('url', handler);
-	Linking.addEventListener('url', handler);
+	// Handles backward compatibility. removeEventListener is only available on RN versions before 0.65.
+	if (subscription === null) {
+		Linking.removeEventListener('url', handler);
+		Linking.addEventListener('url', handler);
+	} else {
+		//remove() method is only available on RN v0.65+.
+		subscription?.remove?.();
+		subscription = Linking.addEventListener('url', handler);
+	}
+	
 	AppState.addEventListener('change', async newAppState => {
 		if (newAppState === 'active') {
 			const initialUrl = await Linking.getInitialURL();


### PR DESCRIPTION
…8902

Handles backward compatibility. removeEventListener is only available on RN versions < 0.65. remove() method is only available on RN v0.65+.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
