### PR TITLE
fix(in-app-messaging): remove nesting of config in config

### DIFF
--- a/packages/notifications/src/inAppMessaging/InAppMessaging.ts
+++ b/packages/notifications/src/inAppMessaging/InAppMessaging.ts
@@ -56,7 +56,7 @@ export default class InAppMessaging {
 		onMessagesReceived,
 		...config
 	}: InAppMessagingConfig = {}): InAppMessagingConfig => {
-		this.config = { ...this.config, config };
+		this.config = { ...this.config, ...config };
 
 		logger.debug('configure InAppMessaging', this.config);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- prevent extra nesting of `config` within `this.config` in `InAppMessaging.configure`

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
NA


#### Description of how you validated changes
Manually tested with sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
