### PR TITLE
chore: Update message received API to return a single message instead…

### DIFF
--- a/packages/notifications/src/inAppMessaging/eventListeners.ts
+++ b/packages/notifications/src/inAppMessaging/eventListeners.ts
@@ -3,43 +3,37 @@ import {
 	InAppMessageInteractionEvent,
 	OnMessageInteractionEventHandler,
 	OnMessageInteractionEventListener,
-	OnMessagesReceivedHandler,
-	OnMessagesReceivedListener,
 } from './types';
 
 const onMessageActionListeners: Record<
 	InAppMessageInteractionEvent,
-	Set<OnMessageInteractionEventListener | OnMessagesReceivedListener>
+	Set<OnMessageInteractionEventListener>
 > = {
-	[InAppMessageInteractionEvent.MESSAGES_RECEIVED]: new Set(),
+	[InAppMessageInteractionEvent.MESSAGE_RECEIVED]: new Set(),
 	[InAppMessageInteractionEvent.MESSAGE_DISPLAYED]: new Set(),
 	[InAppMessageInteractionEvent.MESSAGE_DISMISSED]: new Set(),
 	[InAppMessageInteractionEvent.MESSAGE_ACTION_TAKEN]: new Set(),
 };
 
 export const notifyMessageInteractionEventListeners = (
-	message: InAppMessage | InAppMessage[],
+	message: InAppMessage,
 	event: InAppMessageInteractionEvent
 ): void => {
 	onMessageActionListeners[event].forEach(listener => {
-		listener.handleEvent(message as any);
+		listener.handleEvent(message);
 	});
 };
 
-export const addMessageInteractionEventListener = <
-	Handler extends OnMessageInteractionEventHandler | OnMessagesReceivedHandler
->(
-	handler: Handler,
+export const addMessageInteractionEventListener = (
+	handler: OnMessageInteractionEventHandler,
 	event: InAppMessageInteractionEvent
-): Handler extends OnMessageInteractionEventHandler
-	? OnMessageInteractionEventListener
-	: OnMessagesReceivedListener => {
+): OnMessageInteractionEventListener => {
 	const listener = {
 		handleEvent: handler,
 		remove: () => {
-			onMessageActionListeners[event].delete(listener as any);
+			onMessageActionListeners[event].delete(listener);
 		},
 	};
-	onMessageActionListeners[event].add(listener as any);
-	return listener as any;
+	onMessageActionListeners[event].add(listener);
+	return listener;
 };

--- a/packages/notifications/src/inAppMessaging/types.ts
+++ b/packages/notifications/src/inAppMessaging/types.ts
@@ -101,25 +101,20 @@ export interface InAppMessage {
 	metadata?: any;
 }
 
-export type OnMessagesReceivedHandler = (messages: InAppMessage[]) => any;
-
 export type OnMessageInteractionEventHandler = (message: InAppMessage) => any;
 
-interface Listener {
+export interface OnMessageInteractionEventListener {
+	handleEvent: OnMessageInteractionEventHandler;
 	remove: () => void;
 }
 
-export interface OnMessagesReceivedListener extends Listener {
-	handleEvent: OnMessagesReceivedHandler;
-}
-
-export interface OnMessageInteractionEventListener extends Listener {
-	handleEvent: OnMessageInteractionEventHandler;
-}
-
 export enum InAppMessageInteractionEvent {
-	MESSAGES_RECEIVED,
+	MESSAGE_RECEIVED,
 	MESSAGE_DISPLAYED,
 	MESSAGE_DISMISSED,
 	MESSAGE_ACTION_TAKEN,
 }
+
+export type InAppMessageConflictHandler = (
+	messages: InAppMessage[]
+) => InAppMessage;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR updates the InAppMessaging `onMessagesReceived` function to work with a single message instead of an array of messages. Rather than delegating prioritization responsibilities to the UI, the logic for prioritization is also now encapsulated in the provider. Additional conflict resolution is handled with a `conflictHandler` which can be set via a `setConflictHandler` API on the InAppMessaging subcategory.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Tested manually with a React Native app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
