### PR TITLE
fix(datastore-storage-adapter): remove amplify deps

### DIFF
--- a/packages/datastore-storage-adapter/package.json
+++ b/packages/datastore-storage-adapter/package.json
@@ -33,12 +33,10 @@
 		"url": "https://github.com/aws/aws-amplify/issues"
 	},
 	"homepage": "https://aws-amplify.github.io/",
-	"dependencies": {
+	"devDependencies": {
+		"react-native-sqlite-storage": "5.0.0",
 		"@aws-amplify/core": "4.3.3",
 		"@aws-amplify/datastore": "3.5.0"
-	},
-	"devDependencies": {
-		"react-native-sqlite-storage": "5.0.0"
 	},
 	"jest": {
 		"globals": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Removing dependencies on core and datastore, as they were causing duplicates to get installed in node_modules

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/9110


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
