### PR TITLE
fix(@aws-amplify/storage): add useAccelerateEndpoint to create s3client

### DIFF
--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -827,6 +827,7 @@ export class AWSS3Provider implements StorageProvider {
 			region?: string;
 			cancelTokenSource?: CancelTokenSource;
 			dangerouslyConnectToHttpEndpointForTesting?: boolean;
+			useAccelerateEndpoint?: boolean;
 		},
 		emitter?: events.EventEmitter
 	): S3Client {
@@ -834,6 +835,7 @@ export class AWSS3Provider implements StorageProvider {
 			region,
 			cancelTokenSource,
 			dangerouslyConnectToHttpEndpointForTesting,
+			useAccelerateEndpoint = false,
 		} = config;
 		let localTestingConfig = {};
 
@@ -854,6 +856,7 @@ export class AWSS3Provider implements StorageProvider {
 			customUserAgent: getAmplifyUserAgent(),
 			...localTestingConfig,
 			requestHandler: new AxiosHttpHandler({}, emitter, cancelTokenSource),
+			useAccelerateEndpoint,
 		});
 		return s3client;
 	}


### PR DESCRIPTION
#### Description of changes
Add `useAccelerateEndpoint` to the other `createNewS3Client` function (it was only enabled in `AWSS3ManagedUpload`).

#### Issue #, if available
fixes #9143

#### Description of how you validated changes
`yarn test`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
