### PR TITLE
fix(datastore-storage-adapter): don't enforce required model fields in sql

### DIFF
--- a/packages/datastore-storage-adapter/__tests__/SQLiteUtils.test.ts
+++ b/packages/datastore-storage-adapter/__tests__/SQLiteUtils.test.ts
@@ -35,6 +35,9 @@ const INTERNAL_TEST_SCHEMA_STATEMENTS = [
 const INTERNAL_TEST_SCHEMA_MANY_TO_MANY_STATEMENT =
 	'CREATE TABLE IF NOT EXISTS "PostEditor" ("id" PRIMARY KEY NOT NULL, "post" TEXT, "postID" TEXT NOT NULL, "editor" TEXT, "editorID" TEXT NOT NULL, "createdAt" TEXT, "updatedAt" TEXT, "_version" INTEGER, "_lastChangedAt" INTEGER, "_deleted" INTEGER);';
 
+const INTERNAL_TEST_SCHEMA_ONE_TO_MANY_STATEMENT =
+	'CREATE TABLE IF NOT EXISTS "Post" ("id" PRIMARY KEY NOT NULL, "title" TEXT NOT NULL, "comments" TEXT, "_version" INTEGER, "_lastChangedAt" INTEGER, "_deleted" INTEGER);';
+
 describe('SQLiteUtils tests', () => {
 	let Model: PersistentModelConstructor<Model>;
 
@@ -59,15 +62,21 @@ describe('SQLiteUtils tests', () => {
 	});
 
 	describe('modelCreateTableStatement', () => {
-		it('should generate valid CREATE TABLE statement from a M:N join table model with implicit FKs', () => {
+		it('should generate a valid CREATE TABLE statement from a M:N join table model with implicit FKs', () => {
 			expect(modelCreateTableStatement(postEditorImplicit, true)).toEqual(
 				INTERNAL_TEST_SCHEMA_MANY_TO_MANY_STATEMENT
 			);
 		});
 
-		it('should generate valid CREATE TABLE statement from a M:N join table model with explicit FKs', () => {
+		it('should generate a valid CREATE TABLE statement from a M:N join table model with explicit FKs', () => {
 			expect(modelCreateTableStatement(postEditorExplicit, true)).toEqual(
 				INTERNAL_TEST_SCHEMA_MANY_TO_MANY_STATEMENT
+			);
+		});
+
+		it('should generate a valid CREATE TABLE statement from a 1:M join table model', () => {
+			expect(modelCreateTableStatement(postWithRequiredComments, true)).toEqual(
+				INTERNAL_TEST_SCHEMA_ONE_TO_MANY_STATEMENT
 			);
 		});
 	});
@@ -653,6 +662,47 @@ const groupsAuthExplicit: SchemaModel = {
 					},
 				],
 			},
+		},
+	],
+};
+
+const postWithRequiredComments: SchemaModel = {
+	name: 'Post',
+	pluralName: 'Posts',
+	fields: {
+		id: {
+			name: 'id',
+			isArray: false,
+			type: 'ID',
+			isRequired: true,
+			attributes: [],
+		},
+		title: {
+			name: 'title',
+			isArray: false,
+			type: 'String',
+			isRequired: true,
+			attributes: [],
+		},
+		comments: {
+			name: 'comments',
+			isArray: true,
+			type: {
+				model: 'Comment',
+			},
+			isRequired: true,
+			attributes: [],
+			isArrayNullable: true,
+			association: {
+				connectionType: 'HAS_MANY',
+				associatedWith: 'post',
+			},
+		},
+	},
+	attributes: [
+		{
+			type: 'model',
+			properties: {},
 		},
 	],
 };

--- a/packages/datastore-storage-adapter/src/SQLiteAdapter/SQLiteUtils.ts
+++ b/packages/datastore-storage-adapter/src/SQLiteAdapter/SQLiteUtils.ts
@@ -133,23 +133,26 @@ export function modelCreateTableStatement(
 		}
 
 		if (isModelFieldType(field.type)) {
+			let columnParam = `"${field.name}" TEXT`;
+
 			// add targetName as well as field name for BELONGS_TO relations
 			if (isTargetNameAssociation(field.association)) {
-				const required = field.isRequired ? ' NOT NULL' : '';
-
-				let columnParam = `"${field.name}" TEXT`;
 				// check if this field has been explicitly defined in the model
 				const fkDefinedInModel = Object.values(model.fields).find(
 					(f: ModelField) => f.name === field.association.targetName
 				);
 
-				// only add auto-generate it if not
+				// if the field is not defined in the model, we have to add it in order to prevent
+				// "has no column named ${targetName}" error when inserting data
 				if (!fkDefinedInModel) {
+					const required = field.isRequired ? ' NOT NULL' : '';
 					columnParam += `, "${field.association.targetName}" TEXT${required}`;
 				}
-
-				return acc + `, ${columnParam}`;
 			}
+
+			// ignore isRequired param for model fields, since they will not contain
+			// the related data locally
+			return acc + `, ${columnParam}`;
 		}
 
 		// default to TEXT

--- a/packages/datastore-storage-adapter/src/SQLiteAdapter/SQLiteUtils.ts
+++ b/packages/datastore-storage-adapter/src/SQLiteAdapter/SQLiteUtils.ts
@@ -142,8 +142,7 @@ export function modelCreateTableStatement(
 					(f: ModelField) => f.name === field.association.targetName
 				);
 
-				// if the field is not defined in the model, we have to add it in order to prevent
-				// "has no column named ${targetName}" error when inserting data
+				// if the FK is not explicitly defined in the model, we have to add it here
 				if (!fkDefinedInModel) {
 					const required = field.isRequired ? ' NOT NULL' : '';
 					columnParam += `, "${field.association.targetName}" TEXT${required}`;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Don't attempt to enforce non-nullability of model fields in SQL, since relational data for those do not get saved in the fields themselves locally. 

For example:

```gql
type Post @model {
  comments: [Comment]! @connection
}
# OR
type Post @model {
  comments: [Comment!] @connection
}
```

Should **not** result in a `NOT NULL` constraint to be added to the `comments` column, as it will always be empty in the local store.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/9128


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
