### PR TITLE
fix(in-app-messaging): prevent extraneous setImageDimensions call

### DIFF
--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/useMessageImage.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/useMessageImage.ts
@@ -56,12 +56,12 @@ export default function useMessageImage(image: InAppMessageImage, layout: InAppM
 						(error) => {
 							logger.error(`Unable to retrieve size for image: ${error}`);
 
-							// set dimension values to 0 if size retrieval failure
+							// set failure dimension values on size retrieval failure
 							setImageDimensions(FAILURE_IMAGE_DIMENSIONS);
 						}
 					);
 				} else {
-					// set dimension values to 0 if prefetch failure
+					// set failure dimension values on prefetch failure
 					setImageDimensions(FAILURE_IMAGE_DIMENSIONS);
 				}
 			});

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/useMessageImage.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/useMessageImage.ts
@@ -19,7 +19,9 @@ import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import { InAppMessageImage, InAppMessageLayout } from '@aws-amplify/notifications';
 
 import { ImageDimensions, UseMessageImage } from './types';
-import { getImageDimensions, prefetchNetworkImage } from './utils';
+import { getLayoutImageDimensions, prefetchNetworkImage } from './utils';
+
+const FAILURE_IMAGE_DIMENSIONS: ImageDimensions = { height: 0, width: 0 };
 
 const logger = new Logger('Notifications.InAppMessaging');
 
@@ -44,24 +46,24 @@ export default function useMessageImage(image: InAppMessageImage, layout: InAppM
 	useEffect(() => {
 		if (hasImage) {
 			prefetchNetworkImage(src).then((loadingState) => {
-				// get image size once loaded
 				if (loadingState === 'loaded') {
+					// get image size once loaded
 					Image.getSize(
 						src,
 						(width, height) => {
-							setImageDimensions(getImageDimensions(height, width, layout));
+							setImageDimensions(getLayoutImageDimensions(height, width, layout));
 						},
 						(error) => {
 							logger.error(`Unable to retrieve size for image: ${error}`);
 
 							// set dimension values to 0 if size retrieval failure
-							setImageDimensions({ height: 0, width: 0 });
+							setImageDimensions(FAILURE_IMAGE_DIMENSIONS);
 						}
 					);
+				} else {
+					// set dimension values to 0 if prefetch failure
+					setImageDimensions(FAILURE_IMAGE_DIMENSIONS);
 				}
-
-				// set dimension values to 0 if prefetch failure
-				setImageDimensions({ height: 0, width: 0 });
 			});
 		}
 	}, [hasImage, layout, src]);

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/utils.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/utils.ts
@@ -43,7 +43,7 @@ export const prefetchNetworkImage = async (url: string): Promise<ImageLoadingSta
 	}
 };
 
-export const getImageDimensions = (
+export const getLayoutImageDimensions = (
 	imageHeight: number,
 	imageWidth: number,
 	layout: InAppMessageLayout


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->
- only call `setImageDimensions` on success or error of size retrieval/prefetching of image
- rename `getImageDimensions` to `getLayoutImageDimensions`

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
