### PR TITLE
chore(amplify-ui-vue): fixing tsconfig to recognize node

### DIFF
--- a/packages/amplify-ui-vue/tsconfig.json
+++ b/packages/amplify-ui-vue/tsconfig.json
@@ -18,7 +18,7 @@
 		"sourceMap": true,
 		"jsx": "react",
 		"target": "es2015",
-		"types": []
+		"types": ["node"]
 	},
 	"include": ["src/**/*.ts", "src/**/*.tsx"],
 	"exclude": ["**/__tests__/**"],


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

With the version regressions of @aws-sdk/client-cloudwatch-logs version in core #9189, running ```npm run build``` raised issues in the core package. Specifically: ``` ../../node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/node-config-provider/dist-types/ts3.4/fromEnv.d.ts(3,46): error TS2503: Cannot find namespace 'NodeJS'.```


#### Issue #, if available
#9189 #9119


#### Description of how you validated changes
I ran ```npm run build``` locally and everything built correctly after this change.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
