### PR TITLE
feat(in-app-messaging): add default and support for custom feedback on button press events

### DIFF
--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/constants.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/constants.ts
@@ -47,6 +47,11 @@ export const ICON_BUTTON_HIT_SLOP = 10;
 
 // component specific constants
 
+// Message UI Buttons
+
+// default value applied in React Native TouchableOpacity
+export const BUTTON_PRESSED_OPACITY = 0.2;
+
 // BannerMessage
 // iOS shadow values
 export const BANNER_SHADOW_HEIGHT = 2;

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/utils.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/utils.ts
@@ -45,7 +45,7 @@ export const getButtonComponentStyle = (
 		// the style prop of the React Native Pressable component used in the message UI accepts either a ViewStyle array
 		// or a function receiving a boolean reflecting whether the component is currently pressed, returning a ViewStyle
 		// array. Utilizing the latter, we add an opacity value to the UI message button style during press events
-		container: ({ pressed }) => {
+		container: ({ pressed } = { pressed: false }) => {
 			// default button press interaction opacity
 			const opacity = pressed ? BUTTON_PRESSED_OPACITY : null;
 

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/utils.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/utils.ts
@@ -14,6 +14,7 @@
 import { StyleProp, StyleSheet, TextStyle, ViewStyle } from 'react-native';
 import { InAppMessageStyle } from '@aws-amplify/notifications';
 
+import { BUTTON_PRESSED_OPACITY } from '../../constants';
 import { InAppMessageComponentBaseProps, InAppMessageComponentButtonStyle } from '../../types';
 import { MessageStylePropParams, MessageStyleProps } from './types';
 
@@ -41,7 +42,18 @@ export const getButtonComponentStyle = (
 	const { container, text } = overrideStyle ?? {};
 
 	return {
-		container: [buttonContainer, { backgroundColor, borderRadius }, container],
+		// the style prop of the React Native Pressable component used in the message UI accepts either a ViewStyle array
+		// or a function receiving a boolean reflecting whether the component is currently pressed, returning a ViewStyle
+		// array. Utilizing the latter, we add an opacity value to the UI message button style during press events
+		container: ({ pressed }) => {
+			// default button press interaction opacity
+			const opacity = pressed ? BUTTON_PRESSED_OPACITY : null;
+
+			// pass `pressed` to container and evaluate if the consumer passed a function for custom button style
+			const finalOverrideContainerStyle = typeof container === 'function' ? container({ pressed }) : container;
+
+			return [{ opacity }, buttonContainer, { backgroundColor, borderRadius }, finalOverrideContainerStyle];
+		},
 		text: [buttonText, { color }, text],
 	};
 };

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/types.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/types.ts
@@ -12,12 +12,13 @@
  */
 
 import { ColorValue, ImageStyle, StyleProp, TextStyle, ViewStyle } from 'react-native';
-
 import { InAppMessageButton, InAppMessageContent, InAppMessageLayout } from '@aws-amplify/notifications';
 
+import { ButtonProps } from '../ui';
+
 export type InAppMessageComponentButtonStyle = {
-	container?: StyleProp<ViewStyle>;
-	text?: StyleProp<TextStyle>;
+	container?: ButtonProps['style'];
+	text?: ButtonProps['textStyle'];
 };
 
 export type InAppMessageComponentStyle = {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- apply a default `opacity` on press events for in-app UI buttons
- add support for custom press event style

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
NA


#### Description of how you validated changes
Manually tested in sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
