### PR TITLE
feat(@aws-amplify/datastore): lazy loading Many to Many implementation

### DIFF
--- a/packages/datastore/__tests__/model.ts
+++ b/packages/datastore/__tests__/model.ts
@@ -98,6 +98,45 @@ declare class PostAuthorJoinModel {
 	): PostAuthorJoinModel;
 }
 
+declare class ForumModel {
+	readonly id: string;
+	readonly title: string;
+	readonly editors?: AsyncCollection<ForumEditorJoinModel>;
+	constructor(init: ModelInit<ForumModel>);
+	static copyOf(
+		source: ForumModel,
+		mutator: (
+			draft: MutableModel<ForumModel>
+		) => MutableModel<ForumModel> | void
+	): ForumModel;
+}
+
+declare class ForumEditorJoinModel {
+	readonly id: string;
+	readonly editor?: Promise<EditorModel>;
+	readonly forum?: Promise<ForumModel>;
+	constructor(init: ModelInit<ForumEditorJoinModel>);
+	static copyOf(
+		source: ForumEditorJoinModel,
+		mutator: (
+			draft: MutableModel<ForumEditorJoinModel>
+		) => MutableModel<ForumEditorJoinModel> | void
+	): ForumEditorJoinModel;
+}
+
+declare class EditorModel {
+	readonly id: string;
+	readonly name: string;
+	readonly forums?: AsyncCollection<ForumEditorJoinModel>;
+	constructor(init: ModelInit<EditorModel>);
+	static copyOf(
+		source: EditorModel,
+		mutator: (
+			draft: MutableModel<EditorModel>
+		) => MutableModel<EditorModel> | void
+	): EditorModel;
+}
+
 declare class AuthorModel {
 	readonly id: string;
 	readonly name: string;
@@ -164,6 +203,9 @@ const {
 	Album,
 	Song,
 	Post,
+	Forum,
+	ForumEditorJoin,
+	Editor,
 	Comment,
 	Blog,
 	BlogOwner,
@@ -178,6 +220,9 @@ const {
 	Album: PersistentModelConstructor<AlbumModel>;
 	Song: PersistentModelConstructor<SongModel>;
 	Post: PersistentModelConstructor<PostModel>;
+	Forum: PersistentModelConstructor<ForumModel>;
+	ForumEditorJoin: PersistentModelConstructor<ForumEditorJoinModel>;
+	Editor: PersistentModelConstructor<EditorModel>;
 	Comment: PersistentModelConstructor<CommentModel>;
 	Blog: PersistentModelConstructor<BlogModel>;
 	BlogOwner: PersistentModelConstructor<BlogOwnerModel>;
@@ -195,6 +240,9 @@ export {
 	Album,
 	Song,
 	Post,
+	Forum,
+	ForumEditorJoin,
+	Editor,
 	Comment,
 	Blog,
 	BlogOwner,

--- a/packages/datastore/__tests__/schema.ts
+++ b/packages/datastore/__tests__/schema.ts
@@ -358,6 +358,146 @@ export const newSchema: Schema = {
 				},
 			},
 		},
+		Forum: {
+			syncable: true,
+			name: 'Forum',
+			pluralName: 'Forums',
+			attributes: [
+				{
+					type: 'model',
+					properties: {},
+				},
+			],
+			fields: {
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				title: {
+					name: 'title',
+					isArray: false,
+					type: 'String',
+					isRequired: true,
+					attributes: [],
+				},
+				editors: {
+					name: 'editors',
+					isArray: true,
+					type: {
+						model: 'ForumEditorJoin',
+					},
+					isRequired: false,
+					attributes: [],
+					association: {
+						connectionType: 'HAS_MANY',
+						associatedWith: 'forum',
+					},
+				},
+			},
+		},
+		Editor: {
+			syncable: true,
+			name: 'Editor',
+			pluralName: 'Editors',
+			attributes: [
+				{
+					type: 'model',
+					properties: {},
+				},
+			],
+			fields: {
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				name: {
+					name: 'name',
+					isArray: false,
+					type: 'String',
+					isRequired: true,
+					attributes: [],
+				},
+				forums: {
+					name: 'forums',
+					isArray: true,
+					type: {
+						model: 'ForumEditorJoin',
+					},
+					isRequired: false,
+					attributes: [],
+					association: {
+						connectionType: 'HAS_MANY',
+						associatedWith: 'editor',
+					},
+				},
+			},
+		},
+		ForumEditorJoin: {
+			syncable: true,
+			name: 'ForumEditorJoin',
+			pluralName: 'ForumEditorJoins',
+			attributes: [
+				{
+					type: 'model',
+					properties: {},
+				},
+				{
+					type: 'key',
+					properties: {
+						name: 'byEditor',
+						fields: ['editorID', 'forumID'],
+					},
+				},
+				{
+					type: 'key',
+					properties: {
+						name: 'byForum',
+						fields: ['forumID', 'editorID'],
+					},
+				},
+			],
+			fields: {
+				id: {
+					name: 'id',
+					isArray: false,
+					type: 'ID',
+					isRequired: true,
+					attributes: [],
+				},
+				editor: {
+					name: 'editor',
+					isArray: false,
+					type: {
+						model: 'Editor',
+					},
+					isRequired: false,
+					attributes: [],
+					association: {
+						connectionType: 'BELONGS_TO',
+						targetName: 'editorID',
+					},
+				},
+				forum: {
+					name: 'forum',
+					isArray: false,
+					type: {
+						model: 'Forum',
+					},
+					isRequired: false,
+					attributes: [],
+					association: {
+						connectionType: 'BELONGS_TO',
+						targetName: 'forumID',
+					},
+				},
+			},
+		},
 		BlogOwner: {
 			syncable: true,
 			name: 'BlogOwner',

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -602,6 +602,19 @@ const createModelClass = <T extends PersistentModel>(
 						const relatedModel: PersistentModelConstructor<
 							typeof relatedModelName
 						> = getModelConstructorByModelName(USER, relatedModelName);
+						const relatedModelDefinition = getModelDefinition(relatedModel);
+						if (
+							relatedModelDefinition.fields[associatedWith].type.hasOwnProperty(
+								'model'
+							)
+						) {
+							const result = await instance.query(relatedModel, (c) =>
+								c[associatedWith].id.eq(this.id)
+							);
+							const asyncResult = new AsyncCollection(result);
+							instanceMemos[field] = asyncResult;
+							return asyncResult;
+						}
 						const result = await instance.query(relatedModel, (c) =>
 							c[associatedWith].eq(this.id)
 						);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Many to Many LazyLoading implementation


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Unit tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
