### PR TITLE
feat(@aws-amplify/datastore): hasOne CRUD improvements

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,4 +2,5 @@ module.exports = {
 	trailingComma: 'es5',
 	singleQuote: true,
 	useTabs: true,
+	arrowParens: 'avoid',
 };

--- a/packages/datastore-storage-adapter/src/SQLiteAdapter/SQLiteAdapter.ts
+++ b/packages/datastore-storage-adapter/src/SQLiteAdapter/SQLiteAdapter.ts
@@ -194,21 +194,19 @@ export class SQLiteAdapter implements StorageAdapter {
 			switch (relationType) {
 				case 'HAS_ONE':
 					for await (const recordItem of records) {
-						if (recordItem[fieldName]) {
-							const [queryStatement, params] = queryByIdStatement(
-								recordItem[fieldName],
-								tableName
-							);
+						const getByfield = recordItem[targetName] ? targetName : fieldName;
+						if (!recordItem[getByfield]) break;
 
-							const connectionRecord = await this.db.get(
-								queryStatement,
-								params
-							);
+						const [queryStatement, params] = queryByIdStatement(
+							recordItem[getByfield],
+							tableName
+						);
 
-							recordItem[fieldName] =
-								connectionRecord &&
-								this.modelInstanceCreator(modelConstructor, connectionRecord);
-						}
+						const connectionRecord = await this.db.get(queryStatement, params);
+
+						recordItem[fieldName] =
+							connectionRecord &&
+							this.modelInstanceCreator(modelConstructor, connectionRecord);
 					}
 
 					break;
@@ -236,7 +234,7 @@ export class SQLiteAdapter implements StorageAdapter {
 					// TODO: Lazy loading
 					break;
 				default:
-					const _: never = relationType;
+					const _: never = relationType as never;
 					throw new Error(`invalid relation type ${relationType}`);
 					break;
 			}

--- a/packages/datastore-storage-adapter/src/SQLiteAdapter/SQLiteUtils.ts
+++ b/packages/datastore-storage-adapter/src/SQLiteAdapter/SQLiteUtils.ts
@@ -90,9 +90,8 @@ export const implicitAuthFieldsForModel: (model: SchemaModel) => string[] = (
 		return [];
 	}
 
-	const authRules: ModelAttributeAuth = model.attributes.find(
-		isModelAttributeAuth
-	);
+	const authRules: ModelAttributeAuth =
+		model.attributes.find(isModelAttributeAuth);
 
 	if (!authRules) {
 		return [];
@@ -307,7 +306,7 @@ export function whereClauseFromPredicate<T extends PersistentModel>(
 					filterType = 'OR';
 					break;
 				default:
-					const _: never = groupType;
+					const _: never = groupType as never;
 					throw new Error(`Invalid ${groupType}`);
 			}
 
@@ -319,9 +318,8 @@ export function whereClauseFromPredicate<T extends PersistentModel>(
 				`${isNegation ? 'NOT' : ''}(${groupResult.join(` ${filterType} `)})`
 			);
 		} else if (isPredicateObj(predicate)) {
-			const [condition, conditionParams] = whereConditionFromPredicateObject(
-				predicate
-			);
+			const [condition, conditionParams] =
+				whereConditionFromPredicateObject(predicate);
 
 			result.push(condition);
 			params.push(...conditionParams);

--- a/packages/datastore-storage-adapter/src/SQLiteAdapter/types.ts
+++ b/packages/datastore-storage-adapter/src/SQLiteAdapter/types.ts
@@ -25,7 +25,7 @@ export function getSQLiteType(
 		case 'Float':
 			return 'REAL';
 		default:
-			const _: never = scalar;
-			throw new Error(`unknown type ${scalar}`);
+			const _: never = scalar as never;
+			throw new Error(`unknown type ${scalar as string}`);
 	}
 }

--- a/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
+++ b/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
@@ -13,6 +13,10 @@ let DataStore: typeof DataStoreType;
 const ASAdapter = <any>AsyncStorageAdapter;
 
 describe('AsyncStorageAdapter tests', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
 	describe('Query', () => {
 		let Model: PersistentModelConstructor<Model>;
 		let model1Id: string;
@@ -54,10 +58,6 @@ describe('AsyncStorageAdapter tests', () => {
 					dateCreated: new Date().toISOString(),
 				})
 			);
-		});
-
-		beforeEach(() => {
-			jest.clearAllMocks();
 		});
 
 		it('Should call getById for query by id', async () => {
@@ -167,6 +167,54 @@ describe('AsyncStorageAdapter tests', () => {
 			// both should be undefined, even though we only explicitly deleted the user
 			expect(user).toBeUndefined;
 			expect(profile).toBeUndefined;
+		});
+	});
+
+	describe('Save', () => {
+		let User: PersistentModelConstructor<User>;
+		let Profile: PersistentModelConstructor<Profile>;
+		let profile1Id: string;
+		let profile: Profile;
+		let user1Id: string;
+
+		beforeAll(async () => {
+			({ initSchema, DataStore } = require('../src/datastore/datastore'));
+
+			const classes = initSchema(testSchema());
+
+			({ User } = classes as {
+				User: PersistentModelConstructor<User>;
+			});
+
+			({ Profile } = classes as {
+				Profile: PersistentModelConstructor<Profile>;
+			});
+
+			profile = await DataStore.save(
+				new Profile({ firstName: 'Rick', lastName: 'Bob' })
+			);
+			({ id: profile1Id } = profile);
+		});
+
+		it('should allow linking model via model field', async () => {
+			const savedUser = await DataStore.save(
+				new User({ name: 'test', profile })
+			);
+			({ id: user1Id } = savedUser);
+
+			const user = await DataStore.query(User, user1Id);
+			expect(user.profileID).toEqual(profile1Id);
+			expect(user.profile).toEqual(profile);
+		});
+
+		it('should allow linking model via FK', async () => {
+			({ id: user1Id } = await DataStore.save(
+				new User({ name: 'test', profileID: profile1Id })
+			));
+
+			const user = await DataStore.query(User, user1Id);
+			expect(user.profileID).toEqual(profile1Id);
+			expect(user.profile).toEqual(profile);
 		});
 	});
 });

--- a/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
+++ b/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
@@ -173,9 +173,7 @@ describe('AsyncStorageAdapter tests', () => {
 	describe('Save', () => {
 		let User: PersistentModelConstructor<User>;
 		let Profile: PersistentModelConstructor<Profile>;
-		let profile1Id: string;
 		let profile: Profile;
-		let user1Id: string;
 
 		beforeAll(async () => {
 			({ initSchema, DataStore } = require('../src/datastore/datastore'));
@@ -193,27 +191,27 @@ describe('AsyncStorageAdapter tests', () => {
 			profile = await DataStore.save(
 				new Profile({ firstName: 'Rick', lastName: 'Bob' })
 			);
-			({ id: profile1Id } = profile);
 		});
 
 		it('should allow linking model via model field', async () => {
 			const savedUser = await DataStore.save(
 				new User({ name: 'test', profile })
 			);
-			({ id: user1Id } = savedUser);
+			const user1Id = savedUser.id;
 
 			const user = await DataStore.query(User, user1Id);
-			expect(user.profileID).toEqual(profile1Id);
+			expect(user.profileID).toEqual(profile.id);
 			expect(user.profile).toEqual(profile);
 		});
 
 		it('should allow linking model via FK', async () => {
-			({ id: user1Id } = await DataStore.save(
-				new User({ name: 'test', profileID: profile1Id })
-			));
+			const savedUser = await DataStore.save(
+				new User({ name: 'test', profileID: profile.id })
+			);
+			const user1Id = savedUser.id;
 
 			const user = await DataStore.query(User, user1Id);
-			expect(user.profileID).toEqual(profile1Id);
+			expect(user.profileID).toEqual(profile.id);
 			expect(user.profile).toEqual(profile);
 		});
 	});

--- a/packages/datastore/__tests__/IndexedDBAdapter.test.ts
+++ b/packages/datastore/__tests__/IndexedDBAdapter.test.ts
@@ -159,9 +159,7 @@ describe('IndexedDBAdapter tests', () => {
 	describe('Save', () => {
 		let User: PersistentModelConstructor<User>;
 		let Profile: PersistentModelConstructor<Profile>;
-		let profile1Id: string;
 		let profile: Profile;
-		let user1Id: string;
 
 		beforeAll(async () => {
 			({ initSchema, DataStore } = require('../src/datastore/datastore'));
@@ -179,27 +177,27 @@ describe('IndexedDBAdapter tests', () => {
 			profile = await DataStore.save(
 				new Profile({ firstName: 'Rick', lastName: 'Bob' })
 			);
-			({ id: profile1Id } = profile);
 		});
 
 		it('should allow linking model via model field', async () => {
 			const savedUser = await DataStore.save(
 				new User({ name: 'test', profile })
 			);
-			({ id: user1Id } = savedUser);
+			const user1Id = savedUser.id;
 
 			const user = await DataStore.query(User, user1Id);
-			expect(user.profileID).toEqual(profile1Id);
+			expect(user.profileID).toEqual(profile.id);
 			expect(user.profile).toEqual(profile);
 		});
 
 		it('should allow linking model via FK', async () => {
-			({ id: user1Id } = await DataStore.save(
-				new User({ name: 'test', profileID: profile1Id })
-			));
+			const savedUser = await DataStore.save(
+				new User({ name: 'test', profileID: profile.id })
+			);
+			const user1Id = savedUser.id;
 
 			const user = await DataStore.query(User, user1Id);
-			expect(user.profileID).toEqual(profile1Id);
+			expect(user.profileID).toEqual(profile.id);
 			expect(user.profile).toEqual(profile);
 		});
 	});

--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -48,7 +48,8 @@ export declare class Comment {
 export declare class User {
 	public readonly id: string;
 	public readonly name: string;
-	public readonly profileID: string;
+	public readonly profile?: Profile;
+	public readonly profileID?: string;
 }
 export declare class Profile {
 	public readonly id: string;

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -337,6 +337,7 @@ export const traverseModel = <T extends PersistentModel>(
 							);
 						} catch (error) {
 							// Do nothing
+							console.log(error);
 						}
 
 						result.push({
@@ -345,9 +346,20 @@ export const traverseModel = <T extends PersistentModel>(
 							instance: modelInstance,
 						});
 
-						(<any>draftInstance)[rItem.fieldName] = (<PersistentModel>(
-							draftInstance[rItem.fieldName]
-						)).id;
+						// targetName will be defined for Has One if feature flag
+						// https://docs.amplify.aws/cli/reference/feature-flags/#useAppsyncModelgenPlugin
+						// is true (default as of 5/7/21)
+						// Making this conditional for backward-compatibility
+						if (rItem.targetName) {
+							(<any>draftInstance)[rItem.targetName] = (<PersistentModel>(
+								draftInstance[rItem.fieldName]
+							)).id;
+							delete draftInstance[rItem.fieldName];
+						} else {
+							(<any>draftInstance)[rItem.fieldName] = (<PersistentModel>(
+								draftInstance[rItem.fieldName]
+							)).id;
+						}
 					}
 
 					break;
@@ -491,7 +503,7 @@ export const isPrivateMode = () => {
 	});
 };
 
-const randomBytes = function(nBytes: number): Buffer {
+const randomBytes = (nBytes: number): Buffer => {
 	return Buffer.from(new WordArray().random(nBytes).toString(), 'hex');
 };
 const prng = () => randomBytes(1).readUInt8(0) / 0xff;


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Some minor improvements for HasOne relationships. Non-breaking. 

1. Allow saving hasOne by model field. 
```gql
type User @model @auth(rules: [{ allow: public }]) {
  id: ID!
  profileID: ID
  profile: Profile @connection(fields: ["profileID"])
}

type Profile @model @auth(rules: [{ allow: public }]) {
  id: ID!
  name: String
}
```
```ts
const profileBob = await DataStore.save(new Profile({
  name: 'Bob'
}));

await DataStore.save(new User({
  profile: profileBob
}));

// can still save by FK if desired:
await DataStore.save(new User({
  profileID: profileBob.id
}));
```
2. Resolve hasOne connected model, just like belongsTo
```ts
const user = await DataStore.query(User, 'id');
// user.profile will correctly resolve to the linked profile
```
3. Fix bug where deletes were erroring out for optional hasOne relations
4. Fix minor TS errors in datastore-storage-adapter package (needed after TS version upgrade)


#### Description of how you validated changes
* unit tests
* sample apps

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
