### PR TITLE
chore: mark ui packages as private

### DIFF
--- a/packages/amplify-ui-angular/package.json
+++ b/packages/amplify-ui-angular/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@aws-amplify/ui-angular",
+	"private": "true",
 	"version": "1.0.35",
 	"description": "Angular specific wrapper for @aws-amplify/ui-components",
 	"publishConfig": {

--- a/packages/amplify-ui-components/package.json
+++ b/packages/amplify-ui-components/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@aws-amplify/ui-components",
+	"private": "true",
 	"version": "1.9.6",
 	"description": "Core Amplify UI Component Library",
 	"module": "dist/index.mjs",

--- a/packages/amplify-ui-react/package.json
+++ b/packages/amplify-ui-react/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@aws-amplify/ui-react",
+	"private": "true",
 	"sideEffects": false,
 	"version": "1.2.26",
 	"description": "React specific wrapper for @aws-amplify/ui-components",

--- a/packages/amplify-ui-vue/package.json
+++ b/packages/amplify-ui-vue/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@aws-amplify/ui-vue",
+	"private": "true",
 	"sideEffects": true,
 	"version": "1.1.20",
 	"description": "Vue specific wrapper for @aws-amplify/ui-components",

--- a/packages/amplify-ui/package.json
+++ b/packages/amplify-ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@aws-amplify/ui",
+	"private": "true",
   "version": "2.0.3",
   "main": "dist/aws-amplify-ui.js",
   "types": "lib/index.d.ts",

--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "aws-amplify-angular",
+	"private": "true",
 	"version": "6.0.26",
 	"description": "AWS Amplify Angular Components",
 	"main": "bundles/aws-amplify-angular.umd.js",

--- a/packages/aws-amplify-react/package.json
+++ b/packages/aws-amplify-react/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "aws-amplify-react",
+	"private": "true",
 	"version": "5.1.9",
 	"description": "AWS Amplify is a JavaScript library for Frontend and mobile developers building cloud-enabled applications.",
 	"main": "./lib/index.js",

--- a/packages/aws-amplify-vue/package.json
+++ b/packages/aws-amplify-vue/package.json
@@ -1,8 +1,8 @@
 {
   "name": "aws-amplify-vue",
+	"private": "true",
   "version": "2.1.5",
   "license": "Apache-2.0",
-  "private": false,
   "author": "Amazon Web Services",
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
With [aws-amplify/amplify-ui](https://github.com/aws-amplify/amplify-ui) going GA and publishing to `latest`, we need to ensure that publish to `latest` only happens on the UI repo and not on the JS repo. 

For more context, Amplify UI publishes to `@aws-amplify/ui-react@2.x.x` and sets it as `latest`. But after a JS stable release, the `latest` dist-tag will be overwritten back to `@1.x.x`. To prevent this, we're putting `private` tags on the JS repo so that they are ignored from Lerna's versioning and publishing.

Migration will be the top priority as UI repo has reached GA. This PR is just to ensure `latest` dist-tags don't get overwritten by one another until we migrate completely.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
