### PR TITLE
fix(@aws-amplify/datastore): consecutive updates with timestamps

### DIFF
--- a/packages/datastore/__tests__/outbox.test.ts
+++ b/packages/datastore/__tests__/outbox.test.ts
@@ -142,6 +142,8 @@ describe('Outbox tests', () => {
 			_version: (updatedModel1 as any)._version + 1, // increment version like we would expect coming back from AppSync
 			_lastChangedAt: Date.now(),
 			_deleted: false,
+			createdAt: '2021-11-30T20:51:00.250Z',
+			updatedAt: '2021-11-30T20:52:00.250Z',
 		};
 
 		await Storage.runExclusive(async s => {
@@ -166,6 +168,8 @@ describe('Outbox tests', () => {
 				_version: inProgressData._version + 1, // increment version like we would expect coming back from AppSync
 				_lastChangedAt: Date.now(),
 				_deleted: false,
+				createdAt: '2021-11-30T20:51:00.250Z',
+				updatedAt: '2021-11-30T20:52:00.250Z',
 			};
 
 			await processMutationResponse(
@@ -320,9 +324,8 @@ async function instantiateOutbox(): Promise<void> {
 	Storage = <StorageType>DataStore.storage;
 	anyStorage = Storage;
 
-	const namespaceResolver = anyStorage.storage.namespaceResolver.bind(
-		anyStorage
-	);
+	const namespaceResolver =
+		anyStorage.storage.namespaceResolver.bind(anyStorage);
 
 	({ modelInstanceCreator } = anyStorage.storage);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
As of [this](https://docs.amplify.aws/cli/reference/feature-flags/#addTimestampFields) CLI feature flag timestamp fields get automatically added to the schema with a readOnly property and are added to the GraphQL selection set for queries and mutations. 

This PR adds logic to ignore the default (or custom - if configured) timestamp fields when comparing records as part of the [Consecutive Saves protocol](https://github.com/aws-amplify/amplify-js/pull/7354).


#### Description of how you validated changes
* unit tests updated
* sample app with default timestamps
* sample app with custom timestamp fields


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
