### PR TITLE
feat(in-app-messaging): Add web support for session cap

### DIFF
--- a/packages/notifications/src/InAppMessaging/SessionTracker/SessionTracker.ts
+++ b/packages/notifications/src/InAppMessaging/SessionTracker/SessionTracker.ts
@@ -10,12 +10,65 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-
+import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import noop from 'lodash/noop';
-import { SessionStateChangeHandler, SessionTrackerInterface } from './types';
+import {
+	SessionState,
+	SessionStateChangeHandler,
+	SessionTrackerInterface,
+} from './types';
+
+// Per https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
+let hidden: string;
+let visibilityChange: string;
+
+if (typeof document.hidden !== 'undefined') {
+	hidden = 'hidden';
+	visibilityChange = 'visibilitychange';
+} else if (typeof document['msHidden'] !== 'undefined') {
+	hidden = 'msHidden';
+	visibilityChange = 'msvisibilitychange';
+} else if (typeof document['webkitHidden'] !== 'undefined') {
+	hidden = 'webkitHidden';
+	visibilityChange = 'webkitvisibilitychange';
+}
+
+const logger = new Logger('InAppMessagingSessionTracker');
 
 export default class SessionTracker implements SessionTrackerInterface {
-	constructor(sessionStateChangeHandler: SessionStateChangeHandler = noop) {}
-	start = noop as SessionTrackerInterface['start'];
-	end = noop as SessionTrackerInterface['end'];
+	private sessionStateChangeHandler: SessionStateChangeHandler;
+
+	constructor(sessionStateChangeHandler: SessionStateChangeHandler = noop) {
+		this.sessionStateChangeHandler = sessionStateChangeHandler;
+	}
+
+	start = (): SessionState => {
+		document.addEventListener(visibilityChange, this.visibilityChangeHandler);
+		return this.getSessionState();
+	};
+
+	end = (): SessionState => {
+		document.removeEventListener(
+			visibilityChange,
+			this.visibilityChangeHandler
+		);
+		return this.getSessionState();
+	};
+
+	private getSessionState = (): SessionState => {
+		if (!document[hidden]) {
+			return 'started';
+		}
+		return 'ended';
+	};
+
+	private visibilityChangeHandler = () => {
+		if (document[hidden]) {
+			logger.debug('App is now hidden');
+			this.sessionStateChangeHandler('ended');
+		} else {
+			logger.debug('App is now visible');
+			this.sessionStateChangeHandler('started');
+		}
+	};
 }

--- a/packages/notifications/src/InAppMessaging/SessionTracker/SessionTracker.ts
+++ b/packages/notifications/src/InAppMessaging/SessionTracker/SessionTracker.ts
@@ -22,15 +22,17 @@ import {
 let hidden: string;
 let visibilityChange: string;
 
-if (typeof document.hidden !== 'undefined') {
-	hidden = 'hidden';
-	visibilityChange = 'visibilitychange';
-} else if (typeof document['msHidden'] !== 'undefined') {
-	hidden = 'msHidden';
-	visibilityChange = 'msvisibilitychange';
-} else if (typeof document['webkitHidden'] !== 'undefined') {
-	hidden = 'webkitHidden';
-	visibilityChange = 'webkitvisibilitychange';
+if (document) {
+	if (typeof document.hidden !== 'undefined') {
+		hidden = 'hidden';
+		visibilityChange = 'visibilitychange';
+	} else if (typeof document['msHidden'] !== 'undefined') {
+		hidden = 'msHidden';
+		visibilityChange = 'msvisibilitychange';
+	} else if (typeof document['webkitHidden'] !== 'undefined') {
+		hidden = 'webkitHidden';
+		visibilityChange = 'webkitvisibilitychange';
+	}
 }
 
 const logger = new Logger('InAppMessagingSessionTracker');
@@ -43,12 +45,12 @@ export default class SessionTracker implements SessionTrackerInterface {
 	}
 
 	start = (): SessionState => {
-		document.addEventListener(visibilityChange, this.visibilityChangeHandler);
+		document?.addEventListener(visibilityChange, this.visibilityChangeHandler);
 		return this.getSessionState();
 	};
 
 	end = (): SessionState => {
-		document.removeEventListener(
+		document?.removeEventListener(
 			visibilityChange,
 			this.visibilityChangeHandler
 		);
@@ -56,13 +58,17 @@ export default class SessionTracker implements SessionTrackerInterface {
 	};
 
 	private getSessionState = (): SessionState => {
-		if (!document[hidden]) {
+		if (document && !document[hidden]) {
 			return 'started';
 		}
+		// If, for any reason, document is undefined the session will never start
 		return 'ended';
 	};
 
 	private visibilityChangeHandler = () => {
+		if (!document) {
+			return;
+		}
 		if (document[hidden]) {
 			logger.debug('App is now hidden');
 			this.sessionStateChangeHandler('ended');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Previously, session tracking for the purposes of Pinpoint in-app messaging campaign session caps only worked with React Native. This PR implements the session tracker for web to extend that feature to the web.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
N/A

#### Description of how you validated changes
Created a web app and tested session cap mechanism to see that:
1. Session caps were enforced
2. Session caps were reset when browser visibility went from inactive to active

Tested with Chrome, Firefox, Safari and Edge

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
