### PR TITLE
prevent redirect if callback is unregistered

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -2131,10 +2131,18 @@ export class AuthClass {
 					return credentials;
 				} catch (err) {
 					logger.debug('Error in cognito hosted auth response', err);
-
+					
+					const isUnregisteredCallback =
+						err && err.message === 'Unregistered OAuth Callback';
 					// Just like a successful handling of `?code`, replace the window history to "dispose" of the `code`.
 					// Otherwise, reloading the page will throw errors as the `code` has already been spent.
-					if (window && typeof window.history !== 'undefined') {
+					// Do not redirect if the callback is not registered in oauth config, as it can be used by the third party
+					// see https://github.com/aws-amplify/amplify-js/issues/9208
+					if (
+						window &&
+						typeof window.history !== 'undefined' &&
+						!isUnregisteredCallback
+					) {
 						window.history.replaceState(
 							{},
 							null,

--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -129,7 +129,12 @@ export default class OAuth {
 		const redirectSignInPathname =
 			parse(this._config.redirectSignIn).pathname || '/';
 
-		if (!code || currentUrlPathname !== redirectSignInPathname) {
+		if (currentUrlPathname !== redirectSignInPathname) {
+			// explicitly throw an error to notify caller about the invalid callback url
+			throw new Error('Unregistered OAuth callback');
+		}
+
+		if (!code) {
 			return;
 		}
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
https://github.com/aws-amplify/amplify-js/issues/9208 describes a situation when a third party `code` parameter is passed back to the web app, under a sub route different then the registered redirect URL in Cognito. In this case, we should not redirect back to root url blindly, and thus allow the customer to handle the third party code him/herself.

It should be noticed this issue was introduced after the change in https://github.com/aws-amplify/amplify-js/pull/8166, which will attempt to redirect to the route url, even error occurs (see below screenshot on why error occurs).

A careful look reveals that:
1. Instead of reverting it, we should detect the unregistered route, and only avoid redirecting in that case (thus keep the desired change in https://github.com/aws-amplify/amplify-js/pull/8166)
2. The current solution assuming such a "contract" of the `_handleCodeFlow` function.
   - As previous, if the input `code` is empty, return silently.
   - Yet if the input URL is not the registered, throw an explicit error.

Throwing an error at `_handleCodeFlow` function is essential, as it can help skip https://github.com/aws-amplify/amplify-js/blob/main/packages/auth/src/Auth.ts#L2062-L2078, which attempts to set a session with empty tokens, and makes a failure call to the identity pool to fetch credentials.

![Screen Shot 2021-12-16 at 5 05 26 PM](https://user-images.githubusercontent.com/9324418/146455932-ba10951f-a917-4cb4-8bff-9d6fc8dfe349.png)
![Screen Shot 2021-12-16 at 5 05 50 PM](https://user-images.githubusercontent.com/9324418/146455939-dd687db5-0d3e-4bd0-ae94-f32d6c5c70ad.png)

None of the above steps should happen if the `code` parameter is attached to an unregistered callback path (why use a parameter not for Cognito to call Cognito API?). Even eventually it will fail (with a network error), it is failing too late. The invalid url should be captured and thus prevent Auth from assuming an invalid session.

Note this PR is open for early opinions, and still pending for more testing. Specifically, I would like to test on React Native, due to a related issue
https://github.com/aws-amplify/amplify-js/issues/7468
https://github.com/aws-amplify/amplify-js/pull/8198



#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
9208


#### Description of how you validated changes
TBD


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
