### PR TITLE
fix(@aws-amplify/core): use empty string as translation

### DIFF
--- a/packages/core/src/I18n/I18n.ts
+++ b/packages/core/src/I18n/I18n.ts
@@ -78,14 +78,14 @@ export class I18n {
 
 		const lang = this._lang;
 		let val = this.getByLanguage(key, lang);
-		if (val != null) {
+		if (val !== undefined) {
 			return val;
 		}
 
 		if (lang.indexOf('-') > 0) {
 			val = this.getByLanguage(key, lang.split('-')[0]);
 		}
-		if (val != null) {
+		if (val !== undefined) {
 			return val;
 		}
 

--- a/packages/core/src/I18n/I18n.ts
+++ b/packages/core/src/I18n/I18n.ts
@@ -78,14 +78,14 @@ export class I18n {
 
 		const lang = this._lang;
 		let val = this.getByLanguage(key, lang);
-		if (val) {
+		if (val != null) {
 			return val;
 		}
 
 		if (lang.indexOf('-') > 0) {
 			val = this.getByLanguage(key, lang.split('-')[0]);
 		}
-		if (val) {
+		if (val != null) {
 			return val;
 		}
 
@@ -105,7 +105,7 @@ export class I18n {
 		}
 
 		const lang_dict = this._dict[language];
-		if (!lang_dict) {
+		if (typeof lang_dict === 'undefined') {
 			return defVal;
 		}
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR fixes the I18n `get` function return an empty string, if provided vocabulary contains an empty string entry.
Only fallback to the default value if the vocabulary doesn't contain such a key at all.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-js/issues/8754

#### Description of how you validated changes
 * Local unit testing
 * Verified that get function return an empty string in my local app

test code
```
    I18n.setLanguage('fr');
    const dict = {
        'fr': {
            'empty string': "",
            'Sign Up': "S'inscrire"
        }
    };
    I18n.putVocabularies(dict);
    console.log(I18n.get('empty string'));// returnig empty string
    console.log(I18n.get('Sign Up'));// returnig provided vocabulary ( "S'inscrire" )
    console.log(I18n.get('Sign in'));//returnig key value('Sign in')
    console.log(I18n.get('Sign in','Se connecter'));//returnig default value ('Se connecter')
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
