### PR TITLE
Fix "EventEmitter.removeListener: Method has been deprecated" warning for modern react-native versions

### DIFF
--- a/packages/auth/__tests__/urlListener.native-test.ts
+++ b/packages/auth/__tests__/urlListener.native-test.ts
@@ -1,0 +1,96 @@
+import { Linking, AppState } from 'react-native';
+
+jest.mock('@aws-amplify/core', () => ({
+	ConsoleLogger: class MockConsoleLogger {
+		debug = jest.fn();
+	},
+}));
+
+jest.mock('react-native', () => ({
+	Linking: {
+		addEventListener: jest.fn(),
+		getInitialURL: jest.fn(),
+	},
+	AppState: {
+		addEventListener: jest.fn(),
+	},
+}));
+
+describe('urlListener react-native', () => {
+	const delay = (ms: number) => new Promise(ok => setTimeout(ok, ms));
+	const mockLinking = () => {
+		let linkingListener;
+		let appStateListener;
+
+		(AppState.addEventListener as jest.Mock).mockImplementation(
+			(event, callback) => {
+				appStateListener = callback;
+			}
+		);
+
+		(Linking.addEventListener as jest.Mock).mockImplementation(
+			(eventName, _listener) => {
+				linkingListener = _listener;
+			}
+		);
+
+		return {
+			emitAppStateChange: event => appStateListener(event),
+			emitLinkingChange: event => linkingListener(event),
+		};
+	};
+
+	it('should add event listeners once', cb => {
+		jest.isolateModules(async () => {
+			const urlListener = require('../src/urlListener.native').default;
+
+			await urlListener(jest.fn());
+			await urlListener(jest.fn());
+
+			expect(Linking.addEventListener).toHaveBeenCalledTimes(1);
+			expect(AppState.addEventListener).toHaveBeenCalledTimes(1);
+
+			cb();
+		});
+	});
+
+	it('should invoke passed callback with url when change', cb => {
+		jest.isolateModules(async () => {
+			const { emitLinkingChange } = mockLinking();
+			const url = 'https://aws.amazon.com/mock_url_1';
+			const callback = jest.fn();
+			const urlListener = require('../src/urlListener.native').default;
+
+			await urlListener(callback);
+
+			emitLinkingChange({ url });
+
+			expect(callback).toHaveBeenCalledWith({ url });
+
+			cb();
+		});
+	});
+
+	it('should invoke passed callback with url app when app was opened by link', cb => {
+		jest.isolateModules(async () => {
+			const { emitAppStateChange } = mockLinking();
+
+			const url = 'https://aws.amazon.com/mock_url_2';
+
+			(Linking.getInitialURL as jest.Mock).mockResolvedValueOnce(url);
+
+			const callback = jest.fn();
+			const urlListener = require('../src/urlListener.native').default;
+
+			await urlListener(callback);
+
+			emitAppStateChange('active');
+
+			await delay(0); // wait next tick, when `getInitialURL` will be resolved
+
+			expect(callback).toHaveBeenCalledWith({ url });
+
+			cb();
+		});
+	});
+});

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -66,7 +66,7 @@ import {
 
 import { parse } from 'url';
 import OAuth from './OAuth/OAuth';
-import { default as urlListener } from './urlListener';
+import urlListener from './urlListener';
 import { AuthError, NoUserPoolError } from './Errors';
 import {
 	AuthErrorTypes,
@@ -80,10 +80,11 @@ const USER_ADMIN_SCOPE = 'aws.cognito.signin.user.admin';
 // 10 sec, following this guide https://www.nngroup.com/articles/response-times-3-important-limits/
 const OAUTH_FLOW_MS_TIMEOUT = 10 * 1000;
 
-const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' &&
-typeof Symbol.for === 'function'
-	? Symbol.for('amplify_default')
-	: '@@amplify_default') as Symbol;
+const AMPLIFY_SYMBOL = (
+	typeof Symbol !== 'undefined' && typeof Symbol.for === 'function'
+		? Symbol.for('amplify_default')
+		: '@@amplify_default'
+) as Symbol;
 
 const dispatchAuthEvent = (event: string, data: any, message: string) => {
 	Hub.dispatch('auth', { event, data, message }, 'Auth', AMPLIFY_SYMBOL);
@@ -773,7 +774,7 @@ export class AuthClass {
 	 */
 	public async setPreferredMFA(
 		user: CognitoUser | any,
-		mfaMethod: 'TOTP' | 'SMS' | 'NOMFA' | 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA' 
+		mfaMethod: 'TOTP' | 'SMS' | 'NOMFA' | 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA'
 	): Promise<string> {
 		const clientMetadata = this._config.clientMetadata; // TODO: verify behavior if this is override during signIn
 
@@ -793,7 +794,7 @@ export class AuthClass {
 				};
 				break;
 			case 'SMS':
-			case 'SMS_MFA':	
+			case 'SMS_MFA':
 				smsMfaSettings = {
 					PreferredMfa: true,
 					Enabled: true,
@@ -1120,24 +1121,20 @@ export class AuthClass {
 	 **/
 	public deleteUserAttributes(
 		user: CognitoUser | any,
-		attributeNames: string[],
+		attributeNames: string[]
 	) {
 		const that = this;
 		return new Promise((resolve, reject) => {
 			that.userSession(user).then(session => {
-				user.deleteAttributes(
-					attributeNames,
-					(err, result) => {
-						if (err) {
-							return reject(err);
-						} else {
-							return resolve(result);
-						}
+				user.deleteAttributes(attributeNames, (err, result) => {
+					if (err) {
+						return reject(err);
+					} else {
+						return resolve(result);
 					}
-				);
+				});
 			});
 		});
-
 	}
 
 	/**
@@ -1841,7 +1838,7 @@ export class AuthClass {
 				code,
 				password,
 				{
-					onSuccess: (success) => {
+					onSuccess: success => {
 						dispatchAuthEvent(
 							'forgotPasswordSubmit',
 							user,
@@ -2053,12 +2050,8 @@ export class AuthClass {
 			if (hasCodeOrError || hasTokenOrError) {
 				this._storage.setItem('amplify-redirected-from-hosted-ui', 'true');
 				try {
-					const {
-						accessToken,
-						idToken,
-						refreshToken,
-						state,
-					} = await this._oAuthHandler.handleAuthResponse(currentUrl);
+					const { accessToken, idToken, refreshToken, state } =
+						await this._oAuthHandler.handleAuthResponse(currentUrl);
 					const session = new CognitoUserSession({
 						IdToken: new CognitoIdToken({ IdToken: idToken }),
 						RefreshToken: new CognitoRefreshToken({
@@ -2076,7 +2069,7 @@ export class AuthClass {
 						logger.debug('AWS credentials', credentials);
 					}
 
-					/* 
+					/*
 				Prior to the request we do sign the custom state along with the state we set. This check will verify
 				if there is a dash indicated when setting custom state from the request. If a dash is contained
 				then there is custom state present on the state string.
@@ -2115,10 +2108,7 @@ export class AuthClass {
 					);
 
 					if (isCustomStateIncluded) {
-						const customState = state
-							.split('-')
-							.splice(1)
-							.join('-');
+						const customState = state.split('-').splice(1).join('-');
 
 						dispatchAuthEvent(
 							'customOAuthState',
@@ -2352,4 +2342,3 @@ export class AuthClass {
 export const Auth = new AuthClass(null);
 
 Amplify.register(Auth);
-

--- a/packages/auth/src/urlListener.native.ts
+++ b/packages/auth/src/urlListener.native.ts
@@ -22,29 +22,19 @@ export default async callback => {
 
 	let Linking: any;
 	let AppState: any;
-	let subscription;
+
 	try {
 		({ Linking, AppState } = require('react-native'));
 	} catch (error) {
 		/* Keep webpack happy */
 	}
 
-	handler =
-		handler ||
-		(({ url, ...rest }: { url: string }) => {
-			logger.debug('urlListener', { url, ...rest });
-			callback({ url });
-		});
+	handler = ({ url, ...rest }: { url: string }) => {
+		logger.debug('urlListener', { url, ...rest });
+		callback({ url });
+	};
 
-	// Handles backward compatibility. removeEventListener is only available on RN versions before 0.65.
-	if (Linking.removeEventListener === typeof 'function') {
-		Linking.removeEventListener('url', handler);
-		Linking.addEventListener('url', handler);
-	} else {
-		// remove() method is only available on RN v0.65+.
-		subscription?.remove?.();
-		subscription = Linking.addEventListener('url', handler);
-	}
+	Linking.addEventListener('url', handler);
 	AppState.addEventListener('change', async newAppState => {
 		if (newAppState === 'active') {
 			const initialUrl = await Linking.getInitialURL();


### PR DESCRIPTION


#### Description of changes

I use

- `"react-native": "0.66.x",`
- `@aws-amplify/auth": "^3.4.34",`

And on every start a see this annoying warning 

```bash
 WARN  EventEmitter.removeListener('url', ...): Method has been deprecated. Please instead use `remove()` on the subscription returned by `EventEmitter.addListener`.
```


Then I check that implementation and find out that subscription impossible for function because
```ts
let handler;

export default async callback =>{
  	if (handler) { // this code make not possible to unsubscribe after first call
		return; 
	}
        // ....
        Linking.removeEventListener('url', handler);
        subscription?.remove?.();
}

So I decided to remove never reached unsubscription calls

#### Description of how you validated changes

covered with tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
