### PR TITLE
refactor: Prevent show "EventEmitter.removeListener: Method has been deprecated" warning for modern react-native versions

### DIFF
--- a/packages/auth/__tests__/urlListener.native-test.ts
+++ b/packages/auth/__tests__/urlListener.native-test.ts
@@ -1,0 +1,96 @@
+import { Linking, AppState } from 'react-native';
+
+jest.mock('@aws-amplify/core', () => ({
+	ConsoleLogger: class MockConsoleLogger {
+		debug = jest.fn();
+	},
+}));
+
+jest.mock('react-native', () => ({
+	Linking: {
+		addEventListener: jest.fn(),
+		getInitialURL: jest.fn(),
+	},
+	AppState: {
+		addEventListener: jest.fn(),
+	},
+}));
+
+describe('urlListener', () => {
+	const delay = (ms: number) => new Promise(ok => setTimeout(ok, ms));
+	const mockLinking = () => {
+		let linkingListener;
+		let appStateListener;
+
+		(AppState.addEventListener as jest.Mock).mockImplementation(
+			(event, callback) => {
+				appStateListener = callback;
+			}
+		);
+
+		(Linking.addEventListener as jest.Mock).mockImplementation(
+			(eventName, _listener) => {
+				linkingListener = _listener;
+			}
+		);
+
+		return {
+			emitAppStateChange: event => appStateListener(event),
+			emitLinkingChange: event => linkingListener(event),
+		};
+	};
+
+	it('should add event listeners once', done => {
+		jest.isolateModules(async () => {
+			const urlListener = require('../src/urlListener.native').default;
+
+			await urlListener(jest.fn());
+			await urlListener(jest.fn());
+
+			expect(Linking.addEventListener).toHaveBeenCalledTimes(1);
+			expect(AppState.addEventListener).toHaveBeenCalledTimes(1);
+
+			done();
+		});
+	});
+
+	it('should invoke passed callback with url when change', done => {
+		jest.isolateModules(async () => {
+			const { emitLinkingChange } = mockLinking();
+			const url = 'https://aws.amazon.com/mock_url_1';
+			const callback = jest.fn();
+			const urlListener = require('../src/urlListener.native').default;
+
+			await urlListener(callback);
+
+			emitLinkingChange({ url });
+
+			expect(callback).toHaveBeenCalledWith({ url });
+
+			done();
+		});
+	});
+
+	it('should invoke passed callback with url app when app was opened by link', done => {
+		jest.isolateModules(async () => {
+			const { emitAppStateChange } = mockLinking();
+
+			const url = 'https://aws.amazon.com/mock_url_2';
+
+			(Linking.getInitialURL as jest.Mock).mockResolvedValueOnce(url);
+
+			const callback = jest.fn();
+			const urlListener = require('../src/urlListener.native').default;
+
+			await urlListener(callback);
+
+			emitAppStateChange('active');
+
+			await delay(0); // wait next tick, when `getInitialURL` will be resolved
+
+			expect(callback).toHaveBeenCalledWith({ url });
+
+			done();
+		});
+	});
+});

--- a/packages/auth/src/urlListener.native.ts
+++ b/packages/auth/src/urlListener.native.ts
@@ -22,29 +22,19 @@ export default async callback => {
 
 	let Linking: any;
 	let AppState: any;
-	let subscription;
+
 	try {
 		({ Linking, AppState } = require('react-native'));
 	} catch (error) {
 		/* Keep webpack happy */
 	}
 
-	handler =
-		handler ||
-		(({ url, ...rest }: { url: string }) => {
-			logger.debug('urlListener', { url, ...rest });
-			callback({ url });
-		});
+	handler = ({ url, ...rest }: { url: string }) => {
+		logger.debug('urlListener', { url, ...rest });
+		callback({ url });
+	};
 
-	// Handles backward compatibility. removeEventListener is only available on RN versions before 0.65.
-	if (Linking.removeEventListener === typeof 'function') {
-		Linking.removeEventListener('url', handler);
-		Linking.addEventListener('url', handler);
-	} else {
-		// remove() method is only available on RN v0.65+.
-		subscription?.remove?.();
-		subscription = Linking.addEventListener('url', handler);
-	}
+	Linking.addEventListener('url', handler);
 	AppState.addEventListener('change', async newAppState => {
 		if (newAppState === 'active') {
 			const initialUrl = await Linking.getInitialURL();


### PR DESCRIPTION
#### Description of changes

Fix: https://github.com/aws-amplify/amplify-js/issues/9492

I use

- `"react-native": "0.66.x",`
- `@aws-amplify/auth": "^3.4.34",`

And on every start a see this annoying warning 

```bash
 WARN  EventEmitter.removeListener('url', ...): Method has been deprecated. Please instead use `remove()` on the subscription returned by `EventEmitter.addListener`.
```


Then I check that implementation and find out that subscription impossible for function because

```ts
let handler;

export default async callback =>{
  	if (handler) { // this code make not possible to unsubscribe after first call
		return; 
	}
        // ....
        Linking.removeEventListener('url', handler);
        subscription?.remove?.();
}
```

So I decided to remove never reached unsubscription calls

#### Description of how you validated changes

covered with tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
