### PR TITLE
feat(api-rest): Add ability to configure RestAPI to auto retry

### DIFF
--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -42,7 +42,8 @@
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
     "@aws-amplify/core": "4.3.12",
-    "axios": "0.21.4"
+    "axios": "0.21.4",
+    "axios-retry": "3.2.4"
   },
   "jest": {
     "globals": {

--- a/packages/api-rest/src/types/index.ts
+++ b/packages/api-rest/src/types/index.ts
@@ -63,6 +63,10 @@ export interface apiOptions {
 	headers: object;
 	endpoints: object;
 	credentials?: object;
+	retry?: {
+		retries: number;
+		retryDelay?: (retryCount: number) => number;
+	};
 }
 
 export type ApiInfo = {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR adds retry ability to the RestAPI class. IMO, retry is crucial, as users' network connections are not always as stable as we'd like them to be, and sometimes API Gateway will timeout or return 5xx errors that are retryable.

This PR is a draft. My time is severely limited, so any help with writing tests would be appreciated!

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
