### PR TITLE
chore(amplify-js): revert 9451 - consolidate react-native dependencies

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -93,6 +93,7 @@
     "genversion": "^2.2.0",
     "jsdoc": "^3.4.0",
     "react": "^16.0.0",
+    "react-native": "^0.62.3",
     "rimraf": "^2.5.4",
     "webpack": "^3.5.5"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,7 @@
 		"find": "^0.2.7",
 		"genversion": "^2.2.0",
 		"prepend-file": "^1.3.1",
-		"react-native": "^0.63.4"
+		"react-native": "0.59.0"
 	},
 	"dependencies": {
 		"@aws-crypto/sha256-js": "1.0.0-alpha.0",

--- a/packages/pushnotification/package.json
+++ b/packages/pushnotification/package.json
@@ -49,6 +49,9 @@
     "@aws-amplify/core": "4.3.12",
     "@react-native-community/push-notification-ios": "1.0.3"
   },
+  "peerdependencies": {
+    "react-native": "^0.55.0"
+  },
   "jest": {
     "globals": {
       "ts-jest": {


### PR DESCRIPTION
Reverts aws-amplify/amplify-js#9451

Potentially causes failures in the `integ_rn_ios_push_notifications` and `integ_rn_android` integration tests, will re-open once the tests are passing with the changes