### PR TITLE
fix: Reject promises with Errors instead of strings

### DIFF
--- a/packages/auth/__tests__/hosted-ui.test.ts
+++ b/packages/auth/__tests__/hosted-ui.test.ts
@@ -298,12 +298,13 @@ describe('Hosted UI tests', () => {
 			},
 		};
 
-		expect.assertions(2);
+		expect.assertions(3);
 
 		try {
 			await auth.signOut({ global: true });
 		} catch (err) {
-			expect(err).toEqual('Signout timeout fail');
+			expect(err).toBeInstanceOf(Error);
+			expect(err.message).toEqual('Signout timeout fail');
 		}
 
 		expect(spyGlobalSignOut).toBeCalled();
@@ -448,12 +449,13 @@ describe('Hosted UI tests', () => {
 			},
 		};
 
-		expect.assertions(1);
+		expect.assertions(2);
 
 		try {
 			await auth.signOut({ global: false });
 		} catch (err) {
-			expect(err).toEqual('Signout timeout fail');
+			expect(err).toBeInstanceOf(Error);
+			expect(err.message).toEqual('Signout timeout fail');
 		}
 	});
 
@@ -519,17 +521,15 @@ describe('Hosted UI tests', () => {
 			};
 		});
 
-		const urlOpener = jest.fn(
-			(url: string): Promise<any> => {
-				return new Promise(() => {
-					expect(url).toEqual(
-						'https://xxxxxxxxxxxx-xxxxxx-xxx.auth.us-west-2.amazoncognito.com/logout?client_id=awsUserPoolsWebClientId&logout_uri=http%3A%2F%2Flocalhost%3A4200%2F'
-					);
+		const urlOpener = jest.fn((url: string): Promise<any> => {
+			return new Promise(() => {
+				expect(url).toEqual(
+					'https://xxxxxxxxxxxx-xxxxxx-xxx.auth.us-west-2.amazoncognito.com/logout?client_id=awsUserPoolsWebClientId&logout_uri=http%3A%2F%2Flocalhost%3A4200%2F'
+				);
 
-					done();
-				});
-			}
-		);
+				done();
+			});
+		});
 		const options = {
 			...authOptionsWithOAuth,
 		};

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1405,7 +1405,7 @@ export class AuthClass {
 					);
 				}
 				logger.debug('The user is not authenticated by the error', e);
-				return Promise.reject('The user is not authenticated');
+				return Promise.reject(Error('The user is not authenticated'));
 			}
 			this.user = user;
 			return this.user;
@@ -1684,7 +1684,7 @@ export class AuthClass {
 		this._oAuthHandler.signOut(); // this method redirects url
 
 		// App should be redirected to another url otherwise it will reject
-		setTimeout(() => reject('Signout timeout fail'), 3000);
+		setTimeout(() => reject(Error('Signout timeout fail')), 3000);
 	}
 
 	/**
@@ -2245,7 +2245,7 @@ export class AuthClass {
 			currUser = await this.currentUserPoolUser();
 		} catch (error) {
 			logger.debug('The user is not authenticated by the error', error);
-			return Promise.reject('The user is not authenticated');
+			return Promise.reject(Error('The user is not authenticated'));
 		}
 
 		currUser.getCachedDeviceKeyAndPassword();

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -80,10 +80,11 @@ const USER_ADMIN_SCOPE = 'aws.cognito.signin.user.admin';
 // 10 sec, following this guide https://www.nngroup.com/articles/response-times-3-important-limits/
 const OAUTH_FLOW_MS_TIMEOUT = 10 * 1000;
 
-const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' &&
-typeof Symbol.for === 'function'
-	? Symbol.for('amplify_default')
-	: '@@amplify_default') as Symbol;
+const AMPLIFY_SYMBOL = (
+	typeof Symbol !== 'undefined' && typeof Symbol.for === 'function'
+		? Symbol.for('amplify_default')
+		: '@@amplify_default'
+) as Symbol;
 
 const dispatchAuthEvent = (event: string, data: any, message: string) => {
 	Hub.dispatch('auth', { event, data, message }, 'Auth', AMPLIFY_SYMBOL);
@@ -773,7 +774,7 @@ export class AuthClass {
 	 */
 	public async setPreferredMFA(
 		user: CognitoUser | any,
-		mfaMethod: 'TOTP' | 'SMS' | 'NOMFA' | 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA' 
+		mfaMethod: 'TOTP' | 'SMS' | 'NOMFA' | 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA'
 	): Promise<string> {
 		const clientMetadata = this._config.clientMetadata; // TODO: verify behavior if this is override during signIn
 
@@ -793,7 +794,7 @@ export class AuthClass {
 				};
 				break;
 			case 'SMS':
-			case 'SMS_MFA':	
+			case 'SMS_MFA':
 				smsMfaSettings = {
 					PreferredMfa: true,
 					Enabled: true,
@@ -1120,24 +1121,20 @@ export class AuthClass {
 	 **/
 	public deleteUserAttributes(
 		user: CognitoUser | any,
-		attributeNames: string[],
+		attributeNames: string[]
 	) {
 		const that = this;
 		return new Promise((resolve, reject) => {
 			that.userSession(user).then(session => {
-				user.deleteAttributes(
-					attributeNames,
-					(err, result) => {
-						if (err) {
-							return reject(err);
-						} else {
-							return resolve(result);
-						}
+				user.deleteAttributes(attributeNames, (err, result) => {
+					if (err) {
+						return reject(err);
+					} else {
+						return resolve(result);
 					}
-				);
+				});
 			});
 		});
-
 	}
 
 	/**
@@ -1841,7 +1838,7 @@ export class AuthClass {
 				code,
 				password,
 				{
-					onSuccess: (success) => {
+					onSuccess: success => {
 						dispatchAuthEvent(
 							'forgotPasswordSubmit',
 							user,
@@ -2053,12 +2050,8 @@ export class AuthClass {
 			if (hasCodeOrError || hasTokenOrError) {
 				this._storage.setItem('amplify-redirected-from-hosted-ui', 'true');
 				try {
-					const {
-						accessToken,
-						idToken,
-						refreshToken,
-						state,
-					} = await this._oAuthHandler.handleAuthResponse(currentUrl);
+					const { accessToken, idToken, refreshToken, state } =
+						await this._oAuthHandler.handleAuthResponse(currentUrl);
 					const session = new CognitoUserSession({
 						IdToken: new CognitoIdToken({ IdToken: idToken }),
 						RefreshToken: new CognitoRefreshToken({
@@ -2115,10 +2108,7 @@ export class AuthClass {
 					);
 
 					if (isCustomStateIncluded) {
-						const customState = state
-							.split('-')
-							.splice(1)
-							.join('-');
+						const customState = state.split('-').splice(1).join('-');
 
 						dispatchAuthEvent(
 							'customOAuthState',
@@ -2352,4 +2342,3 @@ export class AuthClass {
 export const Auth = new AuthClass(null);
 
 Amplify.register(Auth);
-


### PR DESCRIPTION
#### Description of changes
This makes things easier to debug since an error comes with a stack trace and a string does not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
