### PR TITLE
fix: UsernameField when using password manager/autofill

### DIFF
--- a/packages/aws-amplify-vue/__tests__/UsernameField.test.js
+++ b/packages/aws-amplify-vue/__tests__/UsernameField.test.js
@@ -52,7 +52,7 @@ describe('UsernameField', () => {
 			wrapper
 				.findAll('input')
 				.at(0)
-				.trigger('keyup');
+				.trigger('input');
 			expect(mockEmailChanged).toBeCalled();
 		});
 	});
@@ -86,7 +86,7 @@ describe('UsernameField', () => {
 			wrapper
 				.findAll('input')
 				.at(0)
-				.trigger('keyup');
+				.trigger('input');
 			expect(mockUsernameChanged).toBeCalled();
 		});
 	});

--- a/packages/aws-amplify-vue/src/components/authenticator/UsernameField.vue
+++ b/packages/aws-amplify-vue/src/components/authenticator/UsernameField.vue
@@ -18,8 +18,7 @@ limitations under the License. */
 				v-model="username"
 				:placeholder="$Amplify.I18n.get(`Enter your ${getUsernameLabel()}`)"
 				autofocus
-				v-on:keyup="usernameChanged"
-				v-on:input="username = $event.target.value"
+				v-on:input="usernameChanged"
 				v-bind:data-test="auth.genericAttrs.usernameInput"
 			/>
 		</div>
@@ -32,8 +31,7 @@ limitations under the License. */
 				v-model="email"
 				:placeholder="$Amplify.I18n.get('Enter your email')"
 				autofocus
-				v-on:keyup="emailChanged"
-				v-on:input="email = $event.target.value"
+				v-on:input="emailChanged"
 				v-bind:data-test="auth.genericAttrs.emailInput"
 			/>
 		</div>
@@ -110,13 +108,15 @@ export default {
 				phoneNumber,
 			});
 		},
-		emailChanged() {
+		emailChanged(e) {
+			this.email = e.target.value;
 			this.$emit('username-field-changed', {
 				usernameField: 'email',
 				email: this.email,
 			});
 		},
-		usernameChanged() {
+		usernameChanged(e) {
+			this.username = e.target.value;
 			this.$emit('username-field-changed', {
 				usernameField: 'username',
 				username: this.username,


### PR DESCRIPTION
Use 'input' event instead of 'keyup' to detect input by password managers or
browser auto-fill to avoid bogus 'Username cannot be empty' errors

Reported in #3831 and #4374 but never actually fixed
