### PR TITLE
fix: pin jsdoc version

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -91,7 +91,7 @@
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
     "genversion": "^2.2.0",
-    "jsdoc": "^3.4.0",
+    "jsdoc": "3.4.0",
     "react": "^16.0.0",
     "react-native": "^0.62.3",
     "rimraf": "^2.5.4",


### PR DESCRIPTION
#### Description of changes
The latest jsdoc requires node >= 14. Pinning it to an older version to avoid upgrading our docker images' node version.

#### Issue #, if available

#### Description of how you validated changes
CircleCI 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
