### PR TITLE
chore(amplify-js): consolidate react-native dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1149,7 +1149,6 @@ releasable_branches: &releasable_branches
       - ui-components/main
       - 1.0-stable
       - geo/main
-      - react-native-clean-up-deps
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1149,6 +1149,7 @@ releasable_branches: &releasable_branches
       - ui-components/main
       - 1.0-stable
       - geo/main
+      - react-native-clean-up-deps
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]

--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -93,7 +93,6 @@
     "genversion": "^2.2.0",
     "jsdoc": "3.4.0",
     "react": "^16.0.0",
-    "react-native": "^0.62.3",
     "rimraf": "^2.5.4",
     "webpack": "^3.5.5"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,7 @@
 		"find": "^0.2.7",
 		"genversion": "^2.2.0",
 		"prepend-file": "^1.3.1",
-		"react-native": "0.59.0"
+		"react-native": "^0.63.4"
 	},
 	"dependencies": {
 		"@aws-crypto/sha256-js": "1.0.0-alpha.0",

--- a/packages/pushnotification/package.json
+++ b/packages/pushnotification/package.json
@@ -49,9 +49,6 @@
     "@aws-amplify/core": "4.3.12",
     "@react-native-community/push-notification-ios": "1.0.3"
   },
-  "peerdependencies": {
-    "react-native": "^0.55.0"
-  },
   "jest": {
     "globals": {
       "ts-jest": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Consolidate `react-native` dependencies to a single dependency in `@aws-amplify/core`

> This is a duplicate of an earlier merged PR ([9451](https://github.com/aws-amplify/amplify-js/pull/9451)) that was preemptively reverted due to potential but ultimately unrelated integ test failures

**Why?**

Currently, Amplify JS has multiple versions of `react-native` listed as either `devDependencies` or `peerDependencies` in category level _package.json_ files, which leads to multiple `react-native` versions installed in the top-level `node_modules` during development. Usage of multiple versions is unnecessary as Amplify JS relies on very few React Native APIs, which are all available in version `63.4` and up.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
NA


#### Description of how you validated changes
- manually tested in sample app
- `yarn clean && yarn && yarn bootstrap && yarn build`
- `yarn test`
- ran integ tests against `react-native-clean-up-deps` branch ([tests passed, failed on deploy as expected](https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/10014/workflows/77e3e88b-a1f9-4c42-af55-284d2ee5c379))

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
