### PR TITLE
fix(datastore): correctly apply config values

### DIFF
--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -744,8 +744,6 @@ class DataStore {
 				userClasses,
 				this.storage,
 				modelInstanceCreator,
-				this.maxRecordsToSync,
-				this.syncPageSize,
 				this.conflictHandler,
 				this.errorHandler,
 				this.syncPredicates,
@@ -1329,12 +1327,13 @@ class DataStore {
 
 		this.syncExpressions =
 			(configDataStore && configDataStore.syncExpressions) ||
-			this.syncExpressions ||
-			configSyncExpressions;
+			configSyncExpressions ||
+			this.syncExpressions;
 
 		this.maxRecordsToSync =
 			(configDataStore && configDataStore.maxRecordsToSync) ||
 			configMaxRecordsToSync ||
+			this.maxRecordsToSync ||
 			10000;
 
 		// store on config object, so that Sync, Subscription, and Mutation processors can have access
@@ -1343,6 +1342,7 @@ class DataStore {
 		this.syncPageSize =
 			(configDataStore && configDataStore.syncPageSize) ||
 			configSyncPageSize ||
+			this.syncPageSize ||
 			1000;
 
 		// store on config object, so that Sync, Subscription, and Mutation processors can have access
@@ -1350,14 +1350,14 @@ class DataStore {
 
 		this.fullSyncInterval =
 			(configDataStore && configDataStore.fullSyncInterval) ||
-			this.fullSyncInterval ||
 			configFullSyncInterval ||
+			this.fullSyncInterval ||
 			24 * 60; // 1 day
 
 		this.storageAdapter =
 			(configDataStore && configDataStore.storageAdapter) ||
-			this.storageAdapter ||
 			configStorageAdapter ||
+			this.storageAdapter ||
 			undefined;
 
 		this.sessionId = this.retrieveSessionId();

--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -113,8 +113,6 @@ export class SyncEngine {
 		private readonly userModelClasses: TypeConstructorMap,
 		private readonly storage: Storage,
 		private readonly modelInstanceCreator: ModelInstanceCreator,
-		private readonly maxRecordsToSync: number,
-		private readonly syncPageSize: number,
 		conflictHandler: ConflictHandler,
 		errorHandler: ErrorHandler,
 		private readonly syncPredicates: WeakMap<SchemaModel, ModelPredicate<any>>,
@@ -189,11 +187,9 @@ export class SyncEngine {
 							});
 
 							let ctlSubsObservable: Observable<CONTROL_MSG>;
-							let dataSubsObservable: Observable<[
-								TransformerMutationType,
-								SchemaModel,
-								PersistentModel
-							]>;
+							let dataSubsObservable: Observable<
+								[TransformerMutationType, SchemaModel, PersistentModel]
+							>;
 
 							if (isNode) {
 								logger.warn(
@@ -244,8 +240,8 @@ export class SyncEngine {
 							//#region Base & Sync queries
 							try {
 								await new Promise((resolve, reject) => {
-									const syncQuerySubscription = this.syncQueriesObservable().subscribe(
-										{
+									const syncQuerySubscription =
+										this.syncQueriesObservable().subscribe({
 											next: message => {
 												const { type } = message;
 
@@ -263,8 +259,7 @@ export class SyncEngine {
 											error: error => {
 												reject(error);
 											},
-										}
-									);
+										});
 
 									if (syncQuerySubscription) {
 										subscriptions.push(syncQuerySubscription);
@@ -295,8 +290,7 @@ export class SyncEngine {
 										);
 
 										observer.next({
-											type:
-												ControlMessage.SYNC_ENGINE_OUTBOX_MUTATION_PROCESSED,
+											type: ControlMessage.SYNC_ENGINE_OUTBOX_MUTATION_PROCESSED,
 											data: {
 												model: modelConstructor,
 												element: model,
@@ -363,9 +357,8 @@ export class SyncEngine {
 					})
 					.subscribe({
 						next: async ({ opType, model, element, condition }) => {
-							const namespace = this.schema.namespaces[
-								this.namespaceResolver(model)
-							];
+							const namespace =
+								this.schema.namespaces[this.namespaceResolver(model)];
 							const MutationEventConstructor = this.modelClasses[
 								'MutationEvent'
 							] as PersistentModelConstructor<MutationEvent>;
@@ -603,16 +596,15 @@ export class SyncEngine {
 														isFullSync ? startedAt : lastFullSync
 												  );
 
-										modelMetadata = (this.modelClasses
-											.ModelMetadata as PersistentModelConstructor<any>).copyOf(
-											modelMetadata,
-											draft => {
-												draft.lastSync = startedAt;
-												draft.lastFullSync = isFullSync
-													? startedAt
-													: modelMetadata.lastFullSync;
-											}
-										);
+										modelMetadata = (
+											this.modelClasses
+												.ModelMetadata as PersistentModelConstructor<any>
+										).copyOf(modelMetadata, draft => {
+											draft.lastSync = startedAt;
+											draft.lastFullSync = isFullSync
+												? startedAt
+												: modelMetadata.lastFullSync;
+										});
 
 										await this.storage.save(
 											modelMetadata,
@@ -757,9 +749,9 @@ export class SyncEngine {
 				const syncPredicateUpdated = prevSyncPredicate !== lastSyncPredicate;
 
 				[[savedModel]] = await this.storage.save(
-					(this.modelClasses.ModelMetadata as PersistentModelConstructor<
-						any
-					>).copyOf(modelMetadata, draft => {
+					(
+						this.modelClasses.ModelMetadata as PersistentModelConstructor<any>
+					).copyOf(modelMetadata, draft => {
 						draft.fullSyncInterval = fullSyncInterval;
 						// perform a base sync if the syncPredicate changed in between calls to DataStore.start
 						// ensures that the local store contains all the data specified by the syncExpression
@@ -819,9 +811,8 @@ export class SyncEngine {
 	): SchemaModel {
 		const namespaceName = this.namespaceResolver(modelConstructor);
 
-		const modelDefinition = this.schema.namespaces[namespaceName].models[
-			modelConstructor.name
-		];
+		const modelDefinition =
+			this.schema.namespaces[namespaceName].models[modelConstructor.name];
 
 		return modelDefinition;
 	}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Some recent changes we made to DataStore introduced a regression causing certain config values (e.g. `syncPageSize` and `maxRecordsToSync`) to not be utilized correctly in the Sync Engine.

This PR restores the expected behavior.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/9534


#### Description of how you validated changes
Sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
