### PR TITLE
chore(in-app-messaging): update copyright years of in app messaging files

### DIFF
--- a/packages/aws-amplify-react-native/src/AmplifyTestIDs.js
+++ b/packages/aws-amplify-react-native/src/AmplifyTestIDs.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/BannerMessage/BannerMessage.tsx
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/BannerMessage/BannerMessage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/BannerMessage/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/BannerMessage/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/BannerMessage/styles.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/BannerMessage/styles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/BannerMessage/types.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/BannerMessage/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/CarouselMessage/CarouselMessage.tsx
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/CarouselMessage/CarouselMessage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/CarouselMessage/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/CarouselMessage/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/CarouselMessage/types.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/CarouselMessage/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/FullScreenMessage/FullScreenMessage.tsx
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/FullScreenMessage/FullScreenMessage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/FullScreenMessage/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/FullScreenMessage/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/FullScreenMessage/styles.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/FullScreenMessage/styles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/FullScreenMessage/types.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/FullScreenMessage/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/InAppMessageDisplay/InAppMessageDisplay.tsx
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/InAppMessageDisplay/InAppMessageDisplay.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/InAppMessageDisplay/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/InAppMessageDisplay/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/MessageWrapper/MessageWrapper.tsx
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/MessageWrapper/MessageWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/MessageWrapper/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/MessageWrapper/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/MessageWrapper/styles.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/MessageWrapper/styles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/MessageWrapper/types.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/MessageWrapper/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/ModalMessage/ModalMessage.tsx
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/ModalMessage/ModalMessage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/ModalMessage/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/ModalMessage/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/ModalMessage/types.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/ModalMessage/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/constants.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/__tests__/handleAction.spec.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/__tests__/handleAction.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/__tests__/useMessage.spec.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/__tests__/useMessage.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/__tests__/utils.spec.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/__tests__/utils.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/handleAction.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/handleAction.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/types.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/useMessage.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/useMessage.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/utils.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessage/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/__tests__/useMessageImage.spec.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/__tests__/useMessageImage.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/__tests__/utils.spec.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/__tests__/utils.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/constants.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/types.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/useMessageImage.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/useMessageImage.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/utils.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/__tests__/useMessageProps.spec.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/__tests__/useMessageProps.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/__tests__/utils.spec.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/__tests__/utils.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/types.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/useMessageProps.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/useMessageProps.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/utils.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageProps/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/types.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/utils.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/context/InAppMessagingContext.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/context/InAppMessagingContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/context/InAppMessagingProvider.tsx
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/context/InAppMessagingProvider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/context/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/context/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/context/types.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/context/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/hooks/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/hooks/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/hooks/useInAppMessaging.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/hooks/useInAppMessaging.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/ui/Button/Button.tsx
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/ui/Button/Button.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/ui/Button/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/ui/Button/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/ui/Button/styles.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/ui/Button/styles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/ui/Button/types.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/ui/Button/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/ui/IconButton/IconButton.tsx
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/ui/IconButton/IconButton.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/ui/IconButton/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/ui/IconButton/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/ui/IconButton/styles.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/ui/IconButton/styles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/ui/IconButton/types.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/ui/IconButton/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/InAppMessaging/ui/index.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/ui/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/__mocks__/@aws-amplify/core.ts
+++ b/packages/aws-amplify-react-native/src/__mocks__/@aws-amplify/core.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/aws-amplify-react-native/src/index.ts
+++ b/packages/aws-amplify-react-native/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/__mocks__/data.ts
+++ b/packages/notifications/__mocks__/data.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/__mocks__/mocks.ts
+++ b/packages/notifications/__mocks__/mocks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/__tests__/InAppMessaging/InAppMessaging.test.ts
+++ b/packages/notifications/__tests__/InAppMessaging/InAppMessaging.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/__tests__/InAppMessaging/Providers/AWSPinpointProvider/index.test.ts
+++ b/packages/notifications/__tests__/InAppMessaging/Providers/AWSPinpointProvider/index.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/__tests__/InAppMessaging/Providers/AWSPinpointProvider/utils.test.ts
+++ b/packages/notifications/__tests__/InAppMessaging/Providers/AWSPinpointProvider/utils.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/__tests__/InAppMessaging/eventListeners.test.ts
+++ b/packages/notifications/__tests__/InAppMessaging/eventListeners.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/__tests__/Notifications.test.ts
+++ b/packages/notifications/__tests__/Notifications.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/src/InAppMessaging/InAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/InAppMessaging.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
@@ -67,7 +67,7 @@ export default class InAppMessaging {
 
 		logger.debug('configure InAppMessaging', this.config);
 
-		this.pluggables.forEach((pluggable) => {
+		this.pluggables.forEach(pluggable => {
 			pluggable.configure(this.config[pluggable.getProviderName()]);
 		});
 
@@ -98,7 +98,7 @@ export default class InAppMessaging {
 	getPluggable = (providerName: string): InAppMessagingProvider => {
 		const pluggable =
 			this.pluggables.find(
-				(pluggable) => pluggable.getProviderName() === providerName
+				pluggable => pluggable.getProviderName() === providerName
 			) ?? null;
 
 		if (!pluggable) {
@@ -134,7 +134,7 @@ export default class InAppMessaging {
 	 */
 	removePluggable = (providerName: string): void => {
 		const index = this.pluggables.findIndex(
-			(pluggable) => pluggable.getProviderName() === providerName
+			pluggable => pluggable.getProviderName() === providerName
 		);
 		if (index === -1) {
 			logger.debug(`No plugin found with name ${providerName}`);
@@ -150,7 +150,7 @@ export default class InAppMessaging {
 	 */
 	syncMessages = (): Promise<void[]> =>
 		Promise.all<void>(
-			this.pluggables.map(async (pluggable) => {
+			this.pluggables.map(async pluggable => {
 				try {
 					const messages = await pluggable.getInAppMessages();
 					const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
@@ -164,7 +164,7 @@ export default class InAppMessaging {
 
 	clearMessages = (): Promise<void[]> =>
 		Promise.all<void>(
-			this.pluggables.map(async (pluggable) => {
+			this.pluggables.map(async pluggable => {
 				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
 				await this.removeMessages(key);
 			})
@@ -172,7 +172,7 @@ export default class InAppMessaging {
 
 	dispatchEvent = async (event: InAppMessagingEvent): Promise<void> => {
 		const messages: InAppMessage[][] = await Promise.all<InAppMessage[]>(
-			this.pluggables.map(async (pluggable) => {
+			this.pluggables.map(async pluggable => {
 				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
 				const messages = await this.getMessages(key);
 				return pluggable.processInAppMessages(messages, event);
@@ -191,7 +191,7 @@ export default class InAppMessaging {
 
 	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> =>
 		Promise.all<void>(
-			this.pluggables.map(async (pluggable) => {
+			this.pluggables.map(async pluggable => {
 				try {
 					await pluggable.identifyUser(userId, userInfo);
 				} catch (err) {

--- a/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/index.ts
+++ b/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
@@ -311,7 +311,7 @@ export default class AWSPinpointProvider implements InAppMessagingProvider {
 		const credentialsUpdated =
 			!credentials ||
 			Object.keys(currentCredentials).some(
-				(key) => currentCredentials[key] !== credentials[key]
+				key => currentCredentials[key] !== credentials[key]
 			);
 		// If endpoint is already initialized, and nothing else is changing, just early return
 		if (
@@ -506,7 +506,7 @@ export default class AWSPinpointProvider implements InAppMessagingProvider {
 	private normalizeMessages = (
 		messages: PinpointInAppMessage[]
 	): InAppMessage[] => {
-		return messages.map((message) => {
+		return messages.map(message => {
 			const { CampaignId, InAppMessage } = message;
 			return {
 				id: CampaignId,

--- a/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/types.ts
+++ b/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/utils.ts
+++ b/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
@@ -253,7 +253,7 @@ export const extractContent = ({
 	InAppMessage: message,
 }: PinpointInAppMessage): InAppMessageContent[] => {
 	return (
-		message?.Content?.map((content) => {
+		message?.Content?.map(content => {
 			const {
 				BackgroundColor,
 				BodyConfig,

--- a/packages/notifications/src/InAppMessaging/Providers/index.ts
+++ b/packages/notifications/src/InAppMessaging/Providers/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/src/InAppMessaging/SessionTracker/SessionTracker.native.ts
+++ b/packages/notifications/src/InAppMessaging/SessionTracker/SessionTracker.native.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
@@ -20,8 +20,8 @@ import {
 	SessionTrackerInterface,
 } from './types';
 
-const isActive = (appState) => appState === 'active';
-const isInactive = (appState) =>
+const isActive = appState => appState === 'active';
+const isInactive = appState =>
 	appState === 'inactive' || appState === 'background';
 
 const logger = new Logger('InAppMessagingSessionTracker');
@@ -53,7 +53,7 @@ export default class SessionTracker implements SessionTrackerInterface {
 		return 'ended';
 	};
 
-	private appStateChangeHandler = (nextAppState) => {
+	private appStateChangeHandler = nextAppState => {
 		// if going from active to inactive
 		if (isActive(this.currentAppState) && isInactive(nextAppState)) {
 			logger.debug('App has gone to the background');

--- a/packages/notifications/src/InAppMessaging/SessionTracker/SessionTracker.ts
+++ b/packages/notifications/src/InAppMessaging/SessionTracker/SessionTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/src/InAppMessaging/SessionTracker/index.ts
+++ b/packages/notifications/src/InAppMessaging/SessionTracker/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/src/InAppMessaging/SessionTracker/types.ts
+++ b/packages/notifications/src/InAppMessaging/SessionTracker/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/src/InAppMessaging/eventListeners.ts
+++ b/packages/notifications/src/InAppMessaging/eventListeners.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
@@ -32,7 +32,7 @@ export const notifyMessageInteractionEventListeners = (
 	message: InAppMessage,
 	event: InAppMessageInteractionEvent
 ): void => {
-	onMessageActionListeners[event].forEach((listener) => {
+	onMessageActionListeners[event].forEach(listener => {
 		listener.handleEvent(message);
 	});
 };

--- a/packages/notifications/src/InAppMessaging/index.ts
+++ b/packages/notifications/src/InAppMessaging/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/src/InAppMessaging/types.ts
+++ b/packages/notifications/src/InAppMessaging/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/src/Notifications.ts
+++ b/packages/notifications/src/Notifications.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- update range of copyright years of in app messaging files to include 2022


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
NA


#### Description of how you validated changes
NA


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
