### PR TITLE
chore(storage): remove sinon as a dependency; convert sinon spies to mock functions

### DIFF
--- a/packages/storage/__tests__/providers/AWSS3ProviderManagedUpload-unit-test.ts
+++ b/packages/storage/__tests__/providers/AWSS3ProviderManagedUpload-unit-test.ts
@@ -22,7 +22,6 @@ import {
 } from '@aws-sdk/client-s3';
 import { Logger } from '@aws-amplify/core';
 import * as events from 'events';
-import * as sinon from 'sinon';
 
 jest.useRealTimers();
 
@@ -79,39 +78,64 @@ afterEach(() => {
 
 describe('single part upload tests', () => {
 	test('upload a string as body', async () => {
-		const putObjectSpyOn = jest.spyOn(S3Client.prototype, 'send').mockImplementation(command => {
-			if (command instanceof PutObjectCommand) return Promise.resolve(command.input.Key);
-		});
-		const uploader = new AWSS3ProviderManagedUpload(testParams, testOpts, new events.EventEmitter());
+		const putObjectSpyOn = jest
+			.spyOn(S3Client.prototype, 'send')
+			.mockImplementation(command => {
+				if (command instanceof PutObjectCommand)
+					return Promise.resolve(command.input.Key);
+			});
+		const uploader = new AWSS3ProviderManagedUpload(
+			testParams,
+			testOpts,
+			new events.EventEmitter()
+		);
 		const data = await uploader.upload();
 		expect(data).toBe(testParams.Key);
 		expect(putObjectSpyOn.mock.calls[0][0].input).toStrictEqual(testParams);
 	});
 
 	test('upload a javascript object as body', async () => {
-		const putObjectSpyOn = jest.spyOn(S3Client.prototype, 'send').mockImplementation(command => {
-			if (command instanceof PutObjectCommand) return Promise.resolve(command.input.Key);
-		});
+		const putObjectSpyOn = jest
+			.spyOn(S3Client.prototype, 'send')
+			.mockImplementation(command => {
+				if (command instanceof PutObjectCommand)
+					return Promise.resolve(command.input.Key);
+			});
 		const objectBody = { key1: 'value1', key2: 'value2' };
 		const testParamsWithObjectBody: any = Object.assign({}, testParams);
 		testParamsWithObjectBody.Body = objectBody;
-		const uploader = new AWSS3ProviderManagedUpload(testParamsWithObjectBody, testOpts, new events.EventEmitter());
+		const uploader = new AWSS3ProviderManagedUpload(
+			testParamsWithObjectBody,
+			testOpts,
+			new events.EventEmitter()
+		);
 		const data = await uploader.upload();
 		expect(data).toBe(testParamsWithObjectBody.Key);
-		expect(putObjectSpyOn.mock.calls[0][0].input).toStrictEqual(testParamsWithObjectBody);
+		expect(putObjectSpyOn.mock.calls[0][0].input).toStrictEqual(
+			testParamsWithObjectBody
+		);
 	});
 
 	test('upload a file as body', async () => {
-		const putObjectSpyOn = jest.spyOn(S3Client.prototype, 'send').mockImplementation(command => {
-			if (command instanceof PutObjectCommand) return Promise.resolve(command.input.Key);
-		});
+		const putObjectSpyOn = jest
+			.spyOn(S3Client.prototype, 'send')
+			.mockImplementation(command => {
+				if (command instanceof PutObjectCommand)
+					return Promise.resolve(command.input.Key);
+			});
 		const file = new File(['TestFileContent'], 'testFileName');
 		const testParamsWithFileBody: any = Object.assign({}, testParams);
 		testParamsWithFileBody.Body = file;
-		const uploader = new AWSS3ProviderManagedUpload(testParamsWithFileBody, testOpts, new events.EventEmitter());
+		const uploader = new AWSS3ProviderManagedUpload(
+			testParamsWithFileBody,
+			testOpts,
+			new events.EventEmitter()
+		);
 		const data = await uploader.upload();
 		expect(data).toBe(testParamsWithFileBody.Key);
-		expect(putObjectSpyOn.mock.calls[0][0].input).toStrictEqual(testParamsWithFileBody);
+		expect(putObjectSpyOn.mock.calls[0][0].input).toStrictEqual(
+			testParamsWithFileBody
+		);
 	});
 });
 
@@ -119,21 +143,23 @@ describe('multi part upload tests', () => {
 	test('happy case: upload a string as body that splits in two parts', async () => {
 		// setup event handling
 		const emitter = new events.EventEmitter();
-		const eventSpy = sinon.spy();
+		const eventSpy = jest.fn();
 		emitter.on('sendUploadProgress', eventSpy);
 
 		// Setup Spy for S3 service calls
-		const s3ServiceCallSpy = jest.spyOn(S3Client.prototype, 'send').mockImplementation(async command => {
-			if (command instanceof CreateMultipartUploadCommand) {
-				return Promise.resolve({ UploadId: testUploadId });
-			} else if (command instanceof UploadPartCommand) {
-				return Promise.resolve({
-					ETag: 'test_etag_' + command.input.PartNumber,
-				});
-			} else if (command instanceof CompleteMultipartUploadCommand) {
-				return Promise.resolve({ Key: testParams.Key });
-			}
-		});
+		const s3ServiceCallSpy = jest
+			.spyOn(S3Client.prototype, 'send')
+			.mockImplementation(async command => {
+				if (command instanceof CreateMultipartUploadCommand) {
+					return Promise.resolve({ UploadId: testUploadId });
+				} else if (command instanceof UploadPartCommand) {
+					return Promise.resolve({
+						ETag: 'test_etag_' + command.input.PartNumber,
+					});
+				} else if (command instanceof CompleteMultipartUploadCommand) {
+					return Promise.resolve({ Key: testParams.Key });
+				}
+			});
 
 		// Now make calls
 		const uploader = new TestClass(testParams, testOpts, emitter);
@@ -187,14 +213,14 @@ describe('multi part upload tests', () => {
 
 		// Progress report testing
 		// First progress is reported at the end, when first full part is uploaded
-		expect(eventSpy.getCall(0).args[0]).toStrictEqual({
+		expect(eventSpy).toHaveBeenNthCalledWith(1, {
 			key: testParams.Key,
 			loaded: testMinPartSize,
 			part: 1,
 			total: testParams.Body.length,
 		});
 		// Second progress is reported at the end of second and final part
-		expect(eventSpy.getCall(1).args[0]).toStrictEqual({
+		expect(eventSpy).toHaveBeenNthCalledWith(2, {
 			key: testParams.Key,
 			loaded: testParams.Body.length,
 			part: 2,
@@ -205,35 +231,37 @@ describe('multi part upload tests', () => {
 	test('error case: upload a string as body that splits in two parts but second part fails', async () => {
 		// setup event handling
 		const emitter = new events.EventEmitter();
-		const eventSpy = sinon.spy();
+		const eventSpy = jest.fn();
 		emitter.on('sendUploadProgress', eventSpy);
 
 		// Setup Spy for S3 service calls and introduce a service failure
-		const s3ServiceCallSpy = jest.spyOn(S3Client.prototype, 'send').mockImplementation(async command => {
-			if (command instanceof CreateMultipartUploadCommand) {
-				return Promise.resolve({ UploadId: testUploadId });
-			} else if (command instanceof UploadPartCommand) {
-				let promise = null;
-				if (command.input.PartNumber === 2) {
-					promise = new Promise((resolve, reject) => {
-						setTimeout(() => {
-							reject(new Error('Part 2 just going to fail in 100ms'));
-						}, 100);
-					});
-				} else {
-					promise = new Promise((resolve, reject) => {
-						setTimeout(() => {
-							resolve({
-								ETag: 'test_etag_' + command.input.PartNumber,
-							});
-						}, 200);
-					});
+		const s3ServiceCallSpy = jest
+			.spyOn(S3Client.prototype, 'send')
+			.mockImplementation(async command => {
+				if (command instanceof CreateMultipartUploadCommand) {
+					return Promise.resolve({ UploadId: testUploadId });
+				} else if (command instanceof UploadPartCommand) {
+					let promise = null;
+					if (command.input.PartNumber === 2) {
+						promise = new Promise((resolve, reject) => {
+							setTimeout(() => {
+								reject(new Error('Part 2 just going to fail in 100ms'));
+							}, 100);
+						});
+					} else {
+						promise = new Promise((resolve, reject) => {
+							setTimeout(() => {
+								resolve({
+									ETag: 'test_etag_' + command.input.PartNumber,
+								});
+							}, 200);
+						});
+					}
+					return promise;
+				} else if (command instanceof CompleteMultipartUploadCommand) {
+					return Promise.resolve({ Key: testParams.key });
 				}
-				return promise;
-			} else if (command instanceof CompleteMultipartUploadCommand) {
-				return Promise.resolve({ Key: testParams.key });
-			}
-		});
+			});
 
 		// Now make calls
 		const uploader = new TestClass(testParams, testOpts, emitter);
@@ -287,13 +315,13 @@ describe('multi part upload tests', () => {
 			UploadId: testUploadId,
 		});
 		// Progress reporting works as well
-		expect(eventSpy.getCall(0).args[0]).toStrictEqual({
+		expect(eventSpy).toHaveBeenNthCalledWith(1, {
 			key: testParams.Key,
 			loaded: testMinPartSize,
 			part: 1,
 			total: testParams.Body.length,
 		});
-		expect(eventSpy.getCall(1).args[0]).toStrictEqual({
+		expect(eventSpy).toHaveBeenNthCalledWith(2, {
 			key: testParams.Key,
 			loaded: testParams.Body.length,
 			part: 2,
@@ -319,8 +347,14 @@ describe('multi part upload tests', () => {
 				return Promise.resolve();
 			}
 		});
-		const uploader = new TestClass(testParams, testOpts, new events.EventEmitter());
-		await expect(uploader.upload()).rejects.toThrow('Upload was cancelled. Multi Part upload clean up failed');
+		const uploader = new TestClass(
+			testParams,
+			testOpts,
+			new events.EventEmitter()
+		);
+		await expect(uploader.upload()).rejects.toThrow(
+			'Upload was cancelled. Multi Part upload clean up failed'
+		);
 	});
 
 	test('error case: finish multipart upload failed', async () => {
@@ -336,7 +370,11 @@ describe('multi part upload tests', () => {
 			}
 		});
 		const loggerSpy = jest.spyOn(Logger.prototype, '_log');
-		const uploader = new TestClass(testParams, testOpts, new events.EventEmitter());
+		const uploader = new TestClass(
+			testParams,
+			testOpts,
+			new events.EventEmitter()
+		);
 		await uploader.upload();
 		expect(loggerSpy).toHaveBeenCalledWith(
 			'ERROR',

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -47,8 +47,7 @@
     "@aws-sdk/util-create-request": "3.6.1",
     "@aws-sdk/util-format-url": "3.6.1",
     "axios": "0.21.4",
-    "events": "^3.1.0",
-    "sinon": "^7.5.0"
+    "events": "^3.1.0"
   },
   "jest": {
     "globals": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Remove `sinon` as a dependency of `@aws-amplify/storage` by converting `sinon` spies to `jest` mock functions.

> There are some additional updates due to `prettier`, relevant changes are noted.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/9565



#### Description of how you validated changes

`yarn clean && yarn && yarn bootstrap && yarn build && yarn test`



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
