### PR TITLE
fix: pin async storage to 1.15.17

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -79,7 +79,7 @@
     "@babel/core": "^7.7.4",
     "@babel/preset-env": "^7.7.4",
     "@babel/preset-react": "^7.0.0",
-    "@react-native-async-storage/async-storage": "^1.13.0",
+    "@react-native-async-storage/async-storage": "1.15.17",
     "babel-loader": "^8.0.6",
     "cross-env": "^3.1.4",
     "eslint": "^3.19.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
 	},
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
-		"@react-native-async-storage/async-storage": "^1.13.0",
+		"@react-native-async-storage/async-storage": "1.15.17",
 		"find": "^0.2.7",
 		"genversion": "^2.2.0",
 		"prepend-file": "^1.3.1",


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Pinning `@react-native-async-storage/async-storage` in cognito and core package to `1.15.17`, `1.16` that was just published is causing build issues.

#### Issue #, if available


#### Description of how you validated changes
`yarn build`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
