### PR TITLE
fix(ops): pin babel-core and babel-cli version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
 	},
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
-		"@babel/cli": "^7.0.0",
-		"@babel/core": "^7.0.0",
+		"@babel/cli": "7.17.0",
+		"@babel/core": "7.17.2",
 		"@babel/preset-env": "^7.0.0",
 		"@babel/preset-react": "^7.0.0",
 		"@types/jest": "^24.0.18",

--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -75,8 +75,8 @@
     "js-cookie": "^2.2.1"
   },
   "devDependencies": {
-    "@babel/cli": "^7.7.4",
-    "@babel/core": "^7.7.4",
+    "@babel/cli": "7.17.0",
+    "@babel/core": "7.17.2",
     "@babel/preset-env": "^7.7.4",
     "@babel/preset-react": "^7.0.0",
     "@react-native-async-storage/async-storage": "1.15.17",


### PR DESCRIPTION
#### Description of changes
`yarn build` was failing due to an issue in bable. Pinning the `@babel/core` and `@babel/cli` version.
See: https://github.com/babel/babel/issues/14273

#### Issue #, if available
N/A

#### Description of how you validated changes
ran `yarn setup-dev` from a fresh clone.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
