### PR TITLE
chore: Revert "feat(@aws-amplify/analytics): Analytics Typescript updates (#9272)

### DIFF
--- a/packages/analytics/src/types/Analytics.ts
+++ b/packages/analytics/src/types/Analytics.ts
@@ -11,6 +11,7 @@
  * and limitations under the License.
  */
 import { ICredentials } from '@aws-amplify/core';
+
 /**
  * Analytics instance options
  */
@@ -57,17 +58,4 @@ export interface SessionTrackOpts {
 		| EventAttributes
 		| (() => EventAttributes | Promise<EventAttributes>);
 	provider?: string;
-}
-
-export interface AutoTrackOpts {
-	enable: boolean;
-	attributes?: EventAttributes;
-	provider?: string;
-}
-
-export interface AnalyticsEvent {
-	name: string;
-	attributes?: EventAttributes;
-	metrics?: EventMetrics;
-	immediate?: boolean;
 }


### PR DESCRIPTION
This reverts commit 9a52c2b6a59bf0d9622a2572f8752b7b419c0817.

#### Description of changes
Reverting the update since it's breaking autoTracking

#### Issue #, if available
N/A

#### Description of how you validated changes
Things went wrong during smoke testing


#### Checklist

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
