### PR TITLE
fix(@aws-amplify/analytics): Analytics/types hotfix

### DIFF
--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -24,7 +24,6 @@ import {
 	EventAttributes,
 	EventMetrics,
 	AnalyticsEvent,
-	AutoTrackOpts,
 	AutoTrackSessionOpts,
 	AutoTrackPageViewOpts,
 	AutoTrackEventOpts,

--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -62,7 +62,7 @@ export class AnalyticsClass {
 	private _config;
 	private _pluggables: AnalyticsProvider[];
 	private _disabled: boolean;
-	private _trackers: Trackers;
+	private _trackers: Trackers | {};
 
 	/**
 	 * Initialize Analtyics
@@ -72,6 +72,7 @@ export class AnalyticsClass {
 		this._config = {};
 		this._pluggables = [];
 		this._disabled = false;
+		this._trackers = {};
 		_instance = this;
 
 		this.record = this.record.bind(this);

--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -25,6 +25,9 @@ import {
 	EventMetrics,
 	AnalyticsEvent,
 	AutoTrackOpts,
+	AutoTrackSessionOpts,
+	AutoTrackPageViewOpts,
+	AutoTrackEventOpts,
 } from './types';
 import { PageViewTracker, EventTracker, SessionTracker } from './trackers';
 
@@ -299,7 +302,15 @@ export class AnalyticsClass {
 	 * @param trackerType - The type of tracker to activate.
 	 * @param [opts] - Auto tracking options.
 	 */
-	public autoTrack(trackerType: TrackerTypes, opts: AutoTrackOpts) {
+	public autoTrack(trackerType: 'session', opts: AutoTrackSessionOpts);
+	public autoTrack(trackerType: 'pageView', opts: AutoTrackPageViewOpts);
+	public autoTrack(trackerType: 'event', opts: AutoTrackEventOpts);
+	// ensures backwards compatibility for non-pinpoint provider users
+	public autoTrack(
+		trackerType: TrackerTypes,
+		opts: { provider: string; [key: string]: any }
+	);
+	public autoTrack(trackerType: TrackerTypes, opts: { [key: string]: any }) {
 		if (!trackers[trackerType]) {
 			logger.debug('invalid tracker type');
 			return;

--- a/packages/analytics/src/types/Analytics.ts
+++ b/packages/analytics/src/types/Analytics.ts
@@ -63,6 +63,29 @@ export type AutoTrackAttributes =
 	| (() => EventAttributes | Promise<EventAttributes>)
 	| EventAttributes;
 
+export interface AutoTrackSessionOpts {
+	enable: boolean;
+	attributes?: AutoTrackAttributes;
+	provider?: string;
+}
+
+export interface AutoTrackPageViewOpts {
+	enable: boolean;
+	eventName?: string;
+	attributes?: AutoTrackAttributes;
+	type?: 'SPA' | 'multiPageApp';
+	provider?: string;
+	getUrl: () => string;
+}
+
+export interface AutoTrackEventOpts {
+	enable: true;
+	events?: string[];
+	selectorPrefix?: string;
+	provider?: string;
+	attributes?: AutoTrackAttributes;
+}
+
 export interface AutoTrackOpts {
 	enable: boolean;
 	events?: string[];

--- a/packages/analytics/src/types/Analytics.ts
+++ b/packages/analytics/src/types/Analytics.ts
@@ -59,10 +59,18 @@ export interface SessionTrackOpts {
 	provider?: string;
 }
 
+export type AutoTrackAttributes =
+	| (() => EventAttributes | Promise<EventAttributes>)
+	| EventAttributes;
+
 export interface AutoTrackOpts {
 	enable: boolean;
-	attributes?: EventAttributes;
+	events?: string[];
+	attributes?: AutoTrackAttributes;
 	provider?: string;
+	type?: string;
+	getUrl?: () => string;
+	selectorPrefix?: string;
 }
 
 export interface AnalyticsEvent {

--- a/packages/analytics/src/types/Analytics.ts
+++ b/packages/analytics/src/types/Analytics.ts
@@ -66,6 +66,7 @@ export type AutoTrackAttributes =
 export interface AutoTrackOpts {
 	enable: boolean;
 	events?: string[];
+	eventName?: string;
 	attributes?: AutoTrackAttributes;
 	provider?: string;
 	type?: string;

--- a/packages/analytics/src/types/Analytics.ts
+++ b/packages/analytics/src/types/Analytics.ts
@@ -86,17 +86,6 @@ export interface AutoTrackEventOpts {
 	attributes?: AutoTrackAttributes;
 }
 
-export interface AutoTrackOpts {
-	enable: boolean;
-	events?: string[];
-	eventName?: string;
-	attributes?: AutoTrackAttributes;
-	provider?: string;
-	type?: string;
-	getUrl?: () => string;
-	selectorPrefix?: string;
-}
-
 export interface AnalyticsEvent {
 	name: string;
 	attributes?: EventAttributes;

--- a/packages/analytics/src/types/Analytics.ts
+++ b/packages/analytics/src/types/Analytics.ts
@@ -79,7 +79,7 @@ export interface AutoTrackPageViewOpts {
 }
 
 export interface AutoTrackEventOpts {
-	enable: true;
+	enable: boolean;
 	events?: string[];
 	selectorPrefix?: string;
 	provider?: string;

--- a/packages/analytics/src/types/Analytics.ts
+++ b/packages/analytics/src/types/Analytics.ts
@@ -75,7 +75,7 @@ export interface AutoTrackPageViewOpts {
 	attributes?: AutoTrackAttributes;
 	type?: 'SPA' | 'multiPageApp';
 	provider?: string;
-	getUrl: () => string;
+	getUrl?: () => string;
 }
 
 export interface AutoTrackEventOpts {


### PR DESCRIPTION

#### Description of changes
- Add back the `_tracker={}` line in constructor
- Add some missing types back to autotrack


#### Issue #, if available

#### Description of how you validated changes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
