### PR TITLE
fix(aws-amplify-react-native): Add linkUnderlay to theme object

### DIFF
--- a/packages/aws-amplify-react-native/src/AmplifyTheme.ts
+++ b/packages/aws-amplify-react-native/src/AmplifyTheme.ts
@@ -137,6 +137,9 @@ export default StyleSheet.create({
 	inputLabel: {
 		marginBottom: 8,
 	},
+	linkUnderlay: {
+		color: linkUnderlayColor,
+	},
 	phoneContainer: {
 		display: 'flex',
 		flexDirection: 'row',

--- a/packages/aws-amplify-react-native/src/AmplifyUI.tsx
+++ b/packages/aws-amplify-react-native/src/AmplifyUI.tsx
@@ -28,7 +28,7 @@ import {
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import { I18n } from 'aws-amplify';
-import AmplifyTheme, { AmplifyThemeType, linkUnderlayColor, placeholderColor } from './AmplifyTheme';
+import AmplifyTheme, { AmplifyThemeType, placeholderColor } from './AmplifyTheme';
 import countryDialCodes from './CountryDialCodes';
 import TEST_ID from './AmplifyTestIDs';
 import icons from './icons';
@@ -160,7 +160,7 @@ export const LinkCell: FC<ILinkCellProps> = (props) => {
 		<View style={theme.cell}>
 			<TouchableHighlight
 				onPress={props.onPress}
-				underlayColor={linkUnderlayColor}
+				underlayColor={theme.linkUnderlay.color}
 				{...setTestId(props.testID)}
 				disabled={disabled}
 			>


### PR DESCRIPTION
Add linkUnderlay to theme object can be overridden

#### Description of changes
This PR adds a `linkUnderlay` property to the `AmplifyTheme` object and updates references to the original constant to use the theme instead. This allows the underlay color to be configurable.

Previously:
```js
const AuthTheme = Object.assign({}, AmplifyTheme, {
  container: {
    backgroundColor: '#000',
  },
  // no way to override link underlay color - underlay would always show up white on dark background
});
```

After this PR:
```js
const AuthTheme = Object.assign({}, AmplifyTheme, {
  container: {
    backgroundColor: '#000',
  },
  linkUnderlay: {
    color: '#000',
  },
});
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#9446 


#### Description of how you validated changes
Manually tested the ability to override this property with a test app using the authenticator HOC.
Manually tested the authenticator HOC works as before (white underlay) if not overridden.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
