### PR TITLE
ci: update cypress docker image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ executors:
 
   js-test-executor:
     docker:
-      - image: cypress/included:8.7.0
+      - image: cypress/included:9.4.1
       - image: verdaccio/verdaccio
         auth:
           username: $DOCKERHUB_USERNAME
@@ -1537,7 +1537,9 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
-          browser: chrome
+          matrix:
+            parameters:
+              <<: *test_browsers
       - deploy:
           filters:
             <<: *releasable_branches


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The current version of the Cypress Docker image (cypress/included:8.7.0) uses Firefox v89, which has a WebGL issue when running on Linux containers and prevents us from being able to test `@aws-amplify/geo` with Firefox in CI.

The latest version (cypress/included:9.5.1) uses Firefox v96, which fails our `amazon-cognito-identity-js-cookie-storage` tests due to an issue with cookies using the `lax` property for `cookie.sameSite`. This also happens when I run Cypress locally with Firefox v96 installed on my dev machine.

Using Firefox v97 fixes this issue locally, but there isn't a Cypress Docker image with that version out yet (well, technically, there _is_, but it's a `slim` version and doesn't even have `git` installed and thus breaks nearly all of our tests 😅).

Thus, this PR moves us to `cypress/included:9.4.1` which uses Firefox v93 and passes all tests, including `geo` tests!

- Update Cypress Docker image: cypress/included:8.7.0 => cypress/included:9.4.1
- Run `geo` tests in Firefox

#### Description of how you validated changes
Modified the config to run on this branch with new versions, confirmed all tests pass in CircleCI, then reverted that part of the change.
You can see this successful test run on CircleCI here: https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/10300/workflows/bba622c6-1646-4879-92b6-35e8c48c4ea7

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
