### PR TITLE
chore: PubSub - Use prettier to rewrap to 120 characters consistently

### DIFF
--- a/packages/pubsub/src/Providers/AWSAppSyncProvider.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncProvider.ts
@@ -96,9 +96,9 @@ export class AWSAppSyncProvider extends MqttOverWSProvider {
 				const { mqttConnections = [], newSubscriptions } = options;
 
 				// creates a map of {"topic": "alias"}
-				const newAliases = Object.entries(
-					newSubscriptions
-				).map(([alias, v]: [string, { topic: string }]) => [v.topic, alias]);
+				const newAliases = Object.entries(newSubscriptions).map(
+					([alias, v]: [string, { topic: string }]) => [v.topic, alias]
+				);
 
 				// Merge new aliases with old ones
 				this._topicAlias = new Map([
@@ -107,31 +107,29 @@ export class AWSAppSyncProvider extends MqttOverWSProvider {
 				]);
 
 				// group by urls
-				const map: [
-					string,
-					{ url: string; topics: Set<string> }
-				][] = Object.entries(
-					targetTopics.reduce((acc, elem) => {
-						const connectionInfoForTopic = mqttConnections.find(
-							c => c.topics.indexOf(elem) > -1
-						);
+				const map: [string, { url: string; topics: Set<string> }][] =
+					Object.entries(
+						targetTopics.reduce((acc, elem) => {
+							const connectionInfoForTopic = mqttConnections.find(
+								c => c.topics.indexOf(elem) > -1
+							);
 
-						if (connectionInfoForTopic) {
-							const { client: clientId, url } = connectionInfoForTopic;
+							if (connectionInfoForTopic) {
+								const { client: clientId, url } = connectionInfoForTopic;
 
-							if (!acc[clientId]) {
-								acc[clientId] = {
-									url,
-									topics: new Set(),
-								};
+								if (!acc[clientId]) {
+									acc[clientId] = {
+										url,
+										topics: new Set(),
+									};
+								}
+
+								acc[clientId].topics.add(elem);
 							}
 
-							acc[clientId].topics.add(elem);
-						}
-
-						return acc;
-					}, {})
-				);
+							return acc;
+						}, {})
+					);
 
 				// reconnect everything we have in the map
 				await Promise.all(

--- a/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider.ts
@@ -33,10 +33,11 @@ import { CONTROL_MSG } from '../index';
 
 const logger = new Logger('AWSAppSyncRealTimeProvider');
 
-const AMPLIFY_SYMBOL = (typeof Symbol !== 'undefined' &&
-typeof Symbol.for === 'function'
-	? Symbol.for('amplify_default')
-	: '@@amplify_default') as Symbol;
+const AMPLIFY_SYMBOL = (
+	typeof Symbol !== 'undefined' && typeof Symbol.for === 'function'
+		? Symbol.for('amplify_default')
+		: '@@amplify_default'
+) as Symbol;
 
 const dispatchApiEvent = (event: string, data: any, message: string) => {
 	Hub.dispatch('api', { event, data, message }, 'PubSub', AMPLIFY_SYMBOL);
@@ -171,10 +172,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 		return url.match(standardDomainPattern) === null;
 	}
 
-	subscribe(
-		_topics: string[] | string,
-		options?: ProvidertOptions
-	): Observable<any> {
+	subscribe(_topics: string[] | string, options?: ProvidertOptions): Observable<any> {
 		const { appSyncGraphqlEndpoint } = options;
 
 		return new Observable(observer => {
@@ -182,9 +180,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 				observer.error({
 					errors: [
 						{
-							...new GraphQLError(
-								`Subscribe only available for AWS AppSync endpoint`
-							),
+							...new GraphQLError(`Subscribe only available for AWS AppSync endpoint`),
 						},
 					],
 				});
@@ -199,9 +195,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 					observer.error({
 						errors: [
 							{
-								...new GraphQLError(
-									`${CONTROL_MSG.REALTIME_SUBSCRIPTION_INIT_ERROR}: ${err}`
-								),
+								...new GraphQLError(`${CONTROL_MSG.REALTIME_SUBSCRIPTION_INIT_ERROR}: ${err}`),
 							},
 						],
 					});
@@ -214,8 +208,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 						// Waiting that subscription has been connected before trying to unsubscribe
 						await this._waitForSubscriptionToBeConnected(subscriptionId);
 
-						const { subscriptionState } =
-							this.subscriptionObserverMap.get(subscriptionId) || {};
+						const { subscriptionState } = this.subscriptionObserverMap.get(subscriptionId) || {};
 
 						if (!subscriptionState) {
 							// subscription already unsubscribed
@@ -238,14 +231,9 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 	}
 
 	protected get isSSLEnabled() {
-		return !this.options
-			.aws_appsync_dangerously_connect_to_http_endpoint_for_testing;
+		return !this.options.aws_appsync_dangerously_connect_to_http_endpoint_for_testing;
 	}
-	private async _startSubscriptionWithAWSAppSyncRealTime({
-		options,
-		observer,
-		subscriptionId,
-	}) {
+	private async _startSubscriptionWithAWSAppSyncRealTime({ options, observer, subscriptionId }) {
 		const {
 			appSyncGraphqlEndpoint,
 			authenticationType,
@@ -324,8 +312,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 			});
 			observer.complete();
 
-			const { subscriptionFailedCallback } =
-				this.subscriptionObserverMap.get(subscriptionId) || {};
+			const { subscriptionFailedCallback } = this.subscriptionObserverMap.get(subscriptionId) || {};
 
 			// Notify concurrent unsubscription
 			if (typeof subscriptionFailedCallback === 'function') {
@@ -338,10 +325,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 		// E.g.unsubscribe gets invoked prior to finishing WebSocket handshake or START_ACK.
 		// Both subscriptionFailedCallback and subscriptionReadyCallback are used to synchronized this.
 
-		const {
-			subscriptionFailedCallback,
-			subscriptionReadyCallback,
-		} = this.subscriptionObserverMap.get(subscriptionId);
+		const { subscriptionFailedCallback, subscriptionReadyCallback } = this.subscriptionObserverMap.get(subscriptionId);
 
 		// This must be done before sending the message in order to be listening immediately
 		this.subscriptionObserverMap.set(subscriptionId, {
@@ -362,18 +346,11 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 
 	// Waiting that subscription has been connected before trying to unsubscribe
 	private async _waitForSubscriptionToBeConnected(subscriptionId) {
-		const { subscriptionState } = this.subscriptionObserverMap.get(
-			subscriptionId
-		);
+		const { subscriptionState } = this.subscriptionObserverMap.get(subscriptionId);
 		// This in case unsubscribe is invoked before sending start subscription message
 		if (subscriptionState === SUBSCRIPTION_STATUS.PENDING) {
 			return new Promise((res, rej) => {
-				const {
-					observer,
-					subscriptionState,
-					variables,
-					query,
-				} = this.subscriptionObserverMap.get(subscriptionId);
+				const { observer, subscriptionState, variables, query } = this.subscriptionObserverMap.get(subscriptionId);
 				this.subscriptionObserverMap.set(subscriptionId, {
 					observer,
 					subscriptionState,
@@ -441,9 +418,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 	}
 
 	private _handleIncomingSubscriptionMessage(message: MessageEvent) {
-		logger.debug(
-			`subscription message from AWS AppSync RealTime: ${message.data}`
-		);
+		logger.debug(`subscription message from AWS AppSync RealTime: ${message.data}`);
 		const { id = '', payload, type } = JSON.parse(message.data);
 		const {
 			observer = null,
@@ -466,18 +441,12 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 		}
 
 		if (type === MESSAGE_TYPES.GQL_START_ACK) {
-			logger.debug(
-				`subscription ready for ${JSON.stringify({ query, variables })}`
-			);
+			logger.debug(`subscription ready for ${JSON.stringify({ query, variables })}`);
 			if (typeof subscriptionReadyCallback === 'function') {
 				subscriptionReadyCallback();
 			}
 			clearTimeout(startAckTimeoutId);
-			dispatchApiEvent(
-				CONTROL_MSG.SUBSCRIPTION_ACK,
-				{ query, variables },
-				'Connection established for subscription'
-			);
+			dispatchApiEvent(CONTROL_MSG.SUBSCRIPTION_ACK, { query, variables }, 'Connection established for subscription');
 			const subscriptionState = SUBSCRIPTION_STATUS.CONNECTED;
 			this.subscriptionObserverMap.set(id, {
 				observer,
@@ -517,9 +486,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 			observer.error({
 				errors: [
 					{
-						...new GraphQLError(
-							`${CONTROL_MSG.CONNECTION_FAILED}: ${JSON.stringify(payload)}`
-						),
+						...new GraphQLError(`${CONTROL_MSG.CONNECTION_FAILED}: ${JSON.stringify(payload)}`),
 					},
 				],
 			});
@@ -550,8 +517,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 	}
 
 	private _timeoutStartSubscriptionAck(subscriptionId) {
-		const { observer, query, variables } =
-			this.subscriptionObserverMap.get(subscriptionId) || {};
+		const { observer, query, variables } = this.subscriptionObserverMap.get(subscriptionId) || {};
 		if (!observer) {
 			return;
 		}
@@ -578,10 +544,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 			// Cleanup will be automatically executed
 			observer.complete();
 		}
-		logger.debug(
-			'timeoutStartSubscription',
-			JSON.stringify({ query, variables })
-		);
+		logger.debug('timeoutStartSubscription', JSON.stringify({ query, variables }));
 	}
 
 	private _initializeWebSocketConnection({
@@ -620,18 +583,16 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 					let discoverableEndpoint = appSyncGraphqlEndpoint;
 
 					if (this.isCustomDomain(discoverableEndpoint)) {
-						discoverableEndpoint = discoverableEndpoint.concat(
-							customDomainPath
-						);
+						discoverableEndpoint = discoverableEndpoint.concat(customDomainPath);
 					} else {
-						discoverableEndpoint = discoverableEndpoint.replace('appsync-api', 'appsync-realtime-api').replace('gogi-beta', 'grt-beta');
+						discoverableEndpoint = discoverableEndpoint
+							.replace('appsync-api', 'appsync-realtime-api')
+							.replace('gogi-beta', 'grt-beta');
 					}
 
-				    // Creating websocket url with required query strings
+					// Creating websocket url with required query strings
 					const protocol = this.isSSLEnabled ? 'wss://' : 'ws://';
-					discoverableEndpoint = discoverableEndpoint
-						.replace('https://', protocol)
-						.replace('http://', protocol);
+					discoverableEndpoint = discoverableEndpoint.replace('https://', protocol).replace('http://', protocol);
 
 					const awsRealTimeUrl = `${discoverableEndpoint}?header=${headerQs}&payload=${payloadQs}`;
 
@@ -646,10 +607,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 				} catch (err) {
 					this.promiseArray.forEach(({ rej }) => rej(err));
 					this.promiseArray = [];
-					if (
-						this.awsRealTimeSocket &&
-						this.awsRealTimeSocket.readyState === WebSocket.OPEN
-					) {
+					if (this.awsRealTimeSocket && this.awsRealTimeSocket.readyState === WebSocket.OPEN) {
 						this.awsRealTimeSocket.close(3001);
 					}
 					this.awsRealTimeSocket = null;
@@ -661,11 +619,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 
 	private async _initializeRetryableHandshake({ awsRealTimeUrl }) {
 		logger.debug(`Initializaling retryable Handshake`);
-		await jitteredExponentialRetry(
-			this._initializeHandshake.bind(this),
-			[{ awsRealTimeUrl }],
-			MAX_DELAY_MS
-		);
+		await jitteredExponentialRetry(this._initializeHandshake.bind(this), [{ awsRealTimeUrl }], MAX_DELAY_MS);
 	}
 
 	private async _initializeHandshake({ awsRealTimeUrl }) {
@@ -702,22 +656,13 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 					};
 
 					this.awsRealTimeSocket.onmessage = (message: MessageEvent) => {
-						logger.debug(
-							`subscription message from AWS AppSyncRealTime: ${message.data} `
-						);
+						logger.debug(`subscription message from AWS AppSyncRealTime: ${message.data} `);
 						const data = JSON.parse(message.data);
-						const {
-							type,
-							payload: {
-								connectionTimeoutMs = DEFAULT_KEEP_ALIVE_TIMEOUT,
-							} = {},
-						} = data;
+						const { type, payload: { connectionTimeoutMs = DEFAULT_KEEP_ALIVE_TIMEOUT } = {} } = data;
 						if (type === MESSAGE_TYPES.GQL_CONNECTION_ACK) {
 							ackOk = true;
 							this.keepAliveTimeout = connectionTimeoutMs;
-							this.awsRealTimeSocket.onmessage = this._handleIncomingSubscriptionMessage.bind(
-								this
-							);
+							this.awsRealTimeSocket.onmessage = this._handleIncomingSubscriptionMessage.bind(this);
 							this.awsRealTimeSocket.onerror = err => {
 								logger.debug(err);
 								this._errorDisconnect(CONTROL_MSG.CONNECTION_CLOSED);
@@ -731,11 +676,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 						}
 
 						if (type === MESSAGE_TYPES.GQL_CONNECTION_ERROR) {
-							const {
-								payload: {
-									errors: [{ errorType = '', errorCode = 0 } = {}] = [],
-								} = {},
-							} = data;
+							const { payload: { errors: [{ errorType = '', errorCode = 0 } = {}] = [] } = {} } = data;
 
 							rej({ errorType, errorCode });
 						}
@@ -749,9 +690,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 					function checkAckOk() {
 						if (!ackOk) {
 							rej(
-								new Error(
-									`Connection timeout: ack from AWSRealTime was not received on ${CONNECTION_INIT_TIMEOUT} ms`
-								)
+								new Error(`Connection timeout: ack from AWSRealTime was not received on ${CONNECTION_INIT_TIMEOUT} ms`)
 							);
 						}
 					}
@@ -851,12 +790,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 		};
 	}
 
-	private async _awsRealTimeIAMHeader({
-		payload,
-		canonicalUri,
-		appSyncGraphqlEndpoint,
-		region,
-	}) {
+	private async _awsRealTimeIAMHeader({ payload, canonicalUri, appSyncGraphqlEndpoint, region }) {
 		const endpointInfo = {
 			region,
 			service: 'appsync',

--- a/packages/pubsub/src/Providers/AWSIotProvider.ts
+++ b/packages/pubsub/src/Providers/AWSIotProvider.ts
@@ -38,11 +38,7 @@ export class AWSIoTProvider extends MqttOverWSProvider {
 				sessionToken: session_token,
 			} = await Credentials.get();
 
-			const result = Signer.signUrl(
-				endpoint,
-				{ access_key, secret_key, session_token },
-				serviceInfo
-			);
+			const result = Signer.signUrl(endpoint, { access_key, secret_key, session_token }, serviceInfo);
 
 			return result;
 		})();

--- a/packages/pubsub/src/Providers/MqttOverWSProvider.ts
+++ b/packages/pubsub/src/Providers/MqttOverWSProvider.ts
@@ -86,8 +86,7 @@ export class MqttOverWSProvider extends AbstractPubSubProvider {
 	}
 
 	protected get isSSLEnabled() {
-		return !this.options
-			.aws_appsync_dangerously_connect_to_http_endpoint_for_testing;
+		return !this.options.aws_appsync_dangerously_connect_to_http_endpoint_for_testing;
 	}
 
 	protected getTopicForValue(value) {
@@ -128,19 +127,13 @@ export class MqttOverWSProvider extends AbstractPubSubProvider {
 		}
 	}
 
-	public async newClient({
-		url,
-		clientId,
-	}: MqttProvidertOptions): Promise<any> {
+	public async newClient({ url, clientId }: MqttProvidertOptions): Promise<any> {
 		logger.debug('Creating new MQTT client', clientId);
 
 		// @ts-ignore
 		const client = new Paho.Client(url, clientId);
 		// client.trace = (args) => logger.debug(clientId, JSON.stringify(args, null, 2));
-		client.onMessageArrived = ({
-			destinationName: topic,
-			payloadString: msg,
-		}) => {
+		client.onMessageArrived = ({ destinationName: topic, payloadString: msg }) => {
 			this._onMessage(topic, msg);
 		};
 		client.onConnectionLost = ({ errorCode, ...args }) => {
@@ -159,13 +152,8 @@ export class MqttOverWSProvider extends AbstractPubSubProvider {
 		return client;
 	}
 
-	protected async connect(
-		clientId: string,
-		options: MqttProvidertOptions = {}
-	): Promise<any> {
-		return await this.clientsQueue.get(clientId, clientId =>
-			this.newClient({ ...options, clientId })
-		);
+	protected async connect(clientId: string, options: MqttProvidertOptions = {}): Promise<any> {
+		return await this.clientsQueue.get(clientId, clientId => this.newClient({ ...options, clientId }));
 	}
 
 	protected async disconnect(clientId: string): Promise<void> {
@@ -189,15 +177,9 @@ export class MqttOverWSProvider extends AbstractPubSubProvider {
 		targetTopics.forEach(topic => client.send(topic, message));
 	}
 
-	protected _topicObservers: Map<
-		string,
-		Set<SubscriptionObserver<any>>
-	> = new Map();
+	protected _topicObservers: Map<string, Set<SubscriptionObserver<any>>> = new Map();
 
-	protected _clientIdObservers: Map<
-		string,
-		Set<SubscriptionObserver<any>>
-	> = new Map();
+	protected _clientIdObservers: Map<string, Set<SubscriptionObserver<any>>> = new Map();
 
 	private _onMessage(topic: string, msg: any) {
 		try {
@@ -221,10 +203,7 @@ export class MqttOverWSProvider extends AbstractPubSubProvider {
 		}
 	}
 
-	subscribe(
-		topics: string[] | string,
-		options: MqttProvidertOptions = {}
-	): Observable<any> {
+	subscribe(topics: string[] | string, options: MqttProvidertOptions = {}): Observable<any> {
 		const targetTopics = ([] as string[]).concat(topics);
 		logger.debug('Subscribing to topic(s)', targetTopics.join(','));
 
@@ -279,9 +258,7 @@ export class MqttOverWSProvider extends AbstractPubSubProvider {
 					}
 
 					targetTopics.forEach(topic => {
-						const observersForTopic =
-							this._topicObservers.get(topic) ||
-							(new Set() as Set<SubscriptionObserver<any>>);
+						const observersForTopic = this._topicObservers.get(topic) || (new Set() as Set<SubscriptionObserver<any>>);
 
 						observersForTopic.delete(observer);
 

--- a/packages/pubsub/src/Providers/PubSubProvider.ts
+++ b/packages/pubsub/src/Providers/PubSubProvider.ts
@@ -43,14 +43,7 @@ export abstract class AbstractPubSubProvider implements PubSubProvider {
 
 	public abstract newClient(clientOptions: ProvidertOptions): Promise<any>;
 
-	public abstract publish(
-		topics: string[] | string,
-		msg: any,
-		options?: ProvidertOptions
-	): void;
+	public abstract publish(topics: string[] | string, msg: any, options?: ProvidertOptions): void;
 
-	public abstract subscribe(
-		topics: string[] | string,
-		options?: ProvidertOptions
-	): Observable<any>;
+	public abstract subscribe(topics: string[] | string, options?: ProvidertOptions): Observable<any>;
 }

--- a/packages/pubsub/src/PubSub.ts
+++ b/packages/pubsub/src/PubSub.ts
@@ -56,9 +56,7 @@ export class PubSubClass {
 	 */
 	private get awsAppSyncRealTimeProvider() {
 		if (!this._awsAppSyncRealTimeProvider) {
-			this._awsAppSyncRealTimeProvider = new AWSAppSyncRealTimeProvider(
-				this._options
-			);
+			this._awsAppSyncRealTimeProvider = new AWSAppSyncRealTimeProvider(this._options);
 		}
 		return this._awsAppSyncRealTimeProvider;
 	}
@@ -115,9 +113,7 @@ export class PubSubClass {
 	 * @param providerName - the name of the plugin
 	 */
 	removePluggable(providerName: string): void {
-		this._pluggables = this._pluggables.filter(
-			pluggable => pluggable.getProviderName() !== providerName
-		);
+		this._pluggables = this._pluggables.filter(pluggable => pluggable.getProviderName() !== providerName);
 	}
 
 	private getProviderByName(providerName) {
@@ -128,9 +124,7 @@ export class PubSubClass {
 			return this.awsAppSyncRealTimeProvider;
 		}
 
-		return this._pluggables.find(
-			pluggable => pluggable.getProviderName() === providerName
-		);
+		return this._pluggables.find(pluggable => pluggable.getProviderName() === providerName);
 	}
 
 	private getProviders(options: ProvidertOptions = {}) {
@@ -147,26 +141,13 @@ export class PubSubClass {
 		return [provider];
 	}
 
-	async publish(
-		topics: string[] | string,
-		msg: any,
-		options?: ProvidertOptions
-	) {
-		return Promise.all(
-			this.getProviders(options).map(provider =>
-				provider.publish(topics, msg, options)
-			)
-		);
+	async publish(topics: string[] | string, msg: any, options?: ProvidertOptions) {
+		return Promise.all(this.getProviders(options).map(provider => provider.publish(topics, msg, options)));
 	}
 
-	subscribe(
-		topics: string[] | string,
-		options?: ProvidertOptions
-	): Observable<any> {
+	subscribe(topics: string[] | string, options?: ProvidertOptions): Observable<any> {
 		if (isNode && this._options && this._options.ssr) {
-			throw new Error(
-				'Subscriptions are not supported for Server-Side Rendering (SSR)'
-			);
+			throw new Error('Subscriptions are not supported for Server-Side Rendering (SSR)');
 		}
 
 		logger.debug('subscribe options', options);
@@ -188,8 +169,7 @@ export class PubSubClass {
 				})
 			);
 
-			return () =>
-				subscriptions.forEach(subscription => subscription.unsubscribe());
+			return () => subscriptions.forEach(subscription => subscription.unsubscribe());
 		});
 	}
 }

--- a/packages/pubsub/src/types/Provider.ts
+++ b/packages/pubsub/src/types/Provider.ts
@@ -23,14 +23,7 @@ export interface PubSubProvider {
 	// return the name of you provider
 	getProviderName(): string;
 
-	publish(
-		topics: string[] | string,
-		msg: any,
-		options?: ProvidertOptions
-	): void;
+	publish(topics: string[] | string, msg: any, options?: ProvidertOptions): void;
 
-	subscribe(
-		topics: string[] | string,
-		options?: ProvidertOptions
-	): Observable<any>;
+	subscribe(topics: string[] | string, options?: ProvidertOptions): Observable<any>;
 }

--- a/packages/pubsub/tslint.json
+++ b/packages/pubsub/tslint.json
@@ -24,21 +24,9 @@
 		"triple-equals": [true, "allow-null-check"],
 		"comment-format": [true, "check-space"],
 		"indent": [false],
-		"whitespace": [
-			false,
-			"check-branch",
-			"check-decl",
-			"check-operator",
-			"check-preblock"
-		],
+		"whitespace": [false, "check-branch", "check-decl", "check-operator", "check-preblock"],
 		"eofline": true,
-		"variable-name": [
-			true,
-			"check-format",
-			"allow-pascal-case",
-			"allow-snake-case",
-			"allow-leading-underscore"
-		],
+		"variable-name": [true, "check-format", "allow-pascal-case", "allow-snake-case", "allow-leading-underscore"],
 		"semicolon": [true, "always", "ignore-interfaces"]
 	},
 	"rulesDirectory": []


### PR DESCRIPTION
#### Description of changes
Using prettier `printWidth: 120` to reflow existing pubsub category files programmatically. 

This package is substantially wrapped to 80 characters now, which passes tslint. I have vscode configured to use prettier to format files on save and it is defaulting to 80 characters given no configured `printWidth` value.  I would recommend we add this to the `.prettierrc.js` file, however since this could be disruptive to others I have not included that change in this PR.

All changes made by prettier automatically, I made no other edits.

#### Description of how you validated changes
- `yarn test`
- Running an AppSync integrated App and IoT integrated app to manually verify no behavior changes.
- `yarn lint` succeeds both before and after this change

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
