### PR TITLE
fix: Datastore/fix offline polling retry

### DIFF
--- a/packages/datastore/__tests__/mutation.test.ts
+++ b/packages/datastore/__tests__/mutation.test.ts
@@ -38,7 +38,7 @@ describe('MutationProcessor', () => {
 
 			await expect(
 				mockJitteredExponentialRetry.mock.results[0].value
-			).rejects.toEqual(new Error('Network Error'));
+			).rejects.toEqual(new Error('Offline'));
 
 			expect(mutationProcessorSpy).toHaveBeenCalled();
 
@@ -221,7 +221,7 @@ async function instantiateMutationProcessor() {
 		() => null
 	);
 
-	(mutationProcessor as any).observer = true;
+	(mutationProcessor as any).observer = { next: () => {}, error: () => {} };
 
 	return mutationProcessor;
 }
@@ -254,11 +254,9 @@ const axiosError = {
 	stack:
 		'Error: timeout of 0ms exceeded\n    at createError (http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false:265622:17)\n    at EventTarget.handleTimeout (http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false:265537:16)\n    at EventTarget.dispatchEvent (http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false:32460:27)\n    at EventTarget.setReadyState (http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false:31623:20)\n    at EventTarget.__didCompleteResponse (http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false:31443:16)\n    at http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false:31553:47\n    at RCTDeviceEventEmitter.emit (http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false:7202:37)\n    at MessageQueue.__callFunction (http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false:2813:31)\n    at http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false:2545:17\n    at MessageQueue.__guard (http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false:2767:13)',
 	config: {
-		url:
-			'https://xxxxxxxxxxxxxxxxxxxxxx.appsync-api.us-west-2.amazonaws.com/graphql',
+		url: 'https://xxxxxxxxxxxxxxxxxxxxxx.appsync-api.us-west-2.amazonaws.com/graphql',
 		method: 'post',
-		data:
-			'{"query":"mutation operation($input: UpdatePostInput!, $condition: ModelPostConditionInput) {  updatePost(input: $input, condition: $condition) {    id    title    rating    status    _version    _lastChangedAt    _deleted    blog {      id      _deleted    }  }}","variables":{"input":{"id":"86e8f2c1-b002-4ff2-92a2-3dad37933477","status":"INACTIVE","_version":1},"condition":null}}',
+		data: '{"query":"mutation operation($input: UpdatePostInput!, $condition: ModelPostConditionInput) {  updatePost(input: $input, condition: $condition) {    id    title    rating    status    _version    _lastChangedAt    _deleted    blog {      id      _deleted    }  }}","variables":{"input":{"id":"86e8f2c1-b002-4ff2-92a2-3dad37933477","status":"INACTIVE","_version":1},"condition":null}}',
 		headers: {
 			Accept: 'application/json, text/plain, */*',
 			'Content-Type': 'application/json; charset=UTF-8',

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -54,6 +54,7 @@ import {
 	isNonModelFieldType,
 	isModelFieldType,
 	ObserveQueryOptions,
+	PollOfflineType,
 } from '../types';
 import {
 	DATASTORE,
@@ -687,6 +688,7 @@ class DataStore {
 	private conflictHandler: ConflictHandler;
 	private errorHandler: (error: SyncError) => void;
 	private fullSyncInterval: number;
+	private pollOffline: PollOfflineType;
 	private initialized: Promise<void>;
 	private initReject: Function;
 	private initResolve: Function;
@@ -754,7 +756,10 @@ class DataStore {
 			// tslint:disable-next-line:max-line-length
 			const fullSyncIntervalInMilliseconds = this.fullSyncInterval * 1000 * 60; // fullSyncInterval from param is in minutes
 			syncSubscription = this.sync
-				.start({ fullSyncInterval: fullSyncIntervalInMilliseconds })
+				.start({
+					fullSyncInterval: fullSyncIntervalInMilliseconds,
+					pollOffline: this.pollOffline,
+				})
 				.subscribe({
 					next: ({ type, data }) => {
 						// In Node, we need to wait for queries to be synced to prevent returning empty arrays.
@@ -1293,6 +1298,7 @@ class DataStore {
 			syncExpressions: configSyncExpressions,
 			authProviders: configAuthProviders,
 			storageAdapter: configStorageAdapter,
+			pollOffline: configPollOffline,
 			...configFromAmplify
 		} = config;
 
@@ -1324,6 +1330,9 @@ class DataStore {
 		// store on config object, so that Sync, Subscription, and Mutation processors can have access
 		this.amplifyConfig.authProviders =
 			(configDataStore && configDataStore.authProviders) || configAuthProviders;
+
+		this.pollOffline =
+			(configDataStore && configDataStore.pollOffline) || configPollOffline;
 
 		this.syncExpressions =
 			(configDataStore && configDataStore.syncExpressions) ||

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -407,15 +407,14 @@ export type DataStoreSnapshot<T extends PersistentModel> = {
 
 //#region Predicates
 
-export type PredicateExpression<M extends PersistentModel, FT> = TypeName<
+export type PredicateExpression<
+	M extends PersistentModel,
 	FT
-> extends keyof MapTypeToOperands<FT>
+> = TypeName<FT> extends keyof MapTypeToOperands<FT>
 	? (
 			operator: keyof MapTypeToOperands<FT>[TypeName<FT>],
 			// make the operand type match the type they're trying to filter on
-			operand: MapTypeToOperands<FT>[TypeName<FT>][keyof MapTypeToOperands<
-				FT
-			>[TypeName<FT>]]
+			operand: MapTypeToOperands<FT>[TypeName<FT>][keyof MapTypeToOperands<FT>[TypeName<FT>]]
 	  ) => ModelPredicate<M>
 	: never;
 
@@ -483,8 +482,7 @@ export type PredicateGroups<T extends PersistentModel> = {
 
 export type ModelPredicate<M extends PersistentModel> = {
 	[K in keyof M]-?: PredicateExpression<M, NonNullable<M[K]>>;
-} &
-	PredicateGroups<M>;
+} & PredicateGroups<M>;
 
 export type ProducerModelPredicate<M extends PersistentModel> = (
 	condition: ModelPredicate<M>
@@ -574,9 +572,10 @@ export type SortPredicate<T extends PersistentModel> = {
 	[K in keyof T]-?: SortPredicateExpression<T, NonNullable<T[K]>>;
 };
 
-export type SortPredicateExpression<M extends PersistentModel, FT> = TypeName<
+export type SortPredicateExpression<
+	M extends PersistentModel,
 	FT
-> extends keyof MapTypeToOperands<FT>
+> = TypeName<FT> extends keyof MapTypeToOperands<FT>
 	? (sortDirection: keyof typeof SortDirection) => SortPredicate<M>
 	: never;
 
@@ -585,9 +584,8 @@ export enum SortDirection {
 	DESCENDING = 'DESCENDING',
 }
 
-export type SortPredicatesGroup<
-	T extends PersistentModel
-> = SortPredicateObject<T>[];
+export type SortPredicatesGroup<T extends PersistentModel> =
+	SortPredicateObject<T>[];
 
 export type SortPredicateObject<T extends PersistentModel> = {
 	field: keyof T;
@@ -661,6 +659,7 @@ export type DataStoreConfig = {
 		syncExpressions?: SyncExpression[];
 		authProviders?: AuthProviders;
 		storageAdapter?: Adapter;
+		pollOffline?: PollOfflineType;
 	};
 	authModeStrategyType?: AuthModeStrategyType;
 	conflictHandler?: ConflictHandler; // default : retry until client wins up to x times
@@ -671,6 +670,7 @@ export type DataStoreConfig = {
 	syncExpressions?: SyncExpression[];
 	authProviders?: AuthProviders;
 	storageAdapter?: Adapter;
+	pollOffline?: PollOfflineType;
 };
 
 export type AuthProviders = {
@@ -681,6 +681,11 @@ export enum AuthModeStrategyType {
 	DEFAULT = 'DEFAULT',
 	MULTI_AUTH = 'MULTI_AUTH',
 }
+
+export type PollOfflineType = {
+	enabled: boolean;
+	interval: number;
+};
 
 export type AuthModeStrategyReturn =
 	| GRAPHQL_AUTH_MODE


### PR DESCRIPTION
#### Description of changes
I believe there should be three circumstances where offline should be monitored:

1. navigator.onLine (existing reachability)
2. Polling/websocket monitoring (in this PR i used polling but happy to use websockets with some pointers about how to implement)
3. Responsive to mutations e.g. if a mutation fails with a network error we float this up and set status to offline and pause mutation processing

Within this PR I am implementing point 2 & 3 above. 

As well as this we want to monitor what and if anything has been kicked from the outbox queue.  I've added a parameter on event outboxMutationProcessed called isDeadLetter which responds if an error causes a dequeue.

I also understand polling isn't what everyone would want so added an offline poll config option containing the poll interval if someone wants improved offline reachability turned on.


#### Issue #, if available
(https://github.com/aws-amplify/amplify-js/issues/9699)


#### Description of how you validated changes
Using local sample app


#### Checklist

- [ X] PR description included
- [ X] `yarn test` passes
- [ X] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
