### PR TITLE
fix(@aws-amplify/datastore): fix mutations to retry indefinitely on network error

### DIFF
--- a/packages/core/src/Util/Retry.ts
+++ b/packages/core/src/Util/Retry.ts
@@ -57,7 +57,13 @@ export async function retry(
 
 const MAX_DELAY_MS = 5 * 60 * 1000;
 
-function jitteredBackoff(maxDelayMs: number): DelayFunction {
+/**
+ * @private
+ * Internal use of Amplify only
+ */
+export function jitteredBackoff(
+	maxDelayMs: number = MAX_DELAY_MS
+): DelayFunction {
 	const BASE_TIME_MS = 100;
 	const JITTER_FACTOR = 100;
 

--- a/packages/datastore/__tests__/mutation.test.ts
+++ b/packages/datastore/__tests__/mutation.test.ts
@@ -35,7 +35,7 @@ describe('Jittered retry', () => {
 			const lowerLimit = 2 ** attempt * 100;
 			const upperLimit = lowerLimit + 100;
 
-			if (lowerLimit < 205000) {
+			if (lowerLimit < 2 ** 12 * 100) {
 				console.log(
 					`attempt ${attempt} (${value}) should be between ${lowerLimit} and ${upperLimit} inclusively.`
 				);

--- a/packages/datastore/__tests__/mutation.test.ts
+++ b/packages/datastore/__tests__/mutation.test.ts
@@ -23,7 +23,7 @@ let Model: PersistentModelConstructor<ModelType>;
 let PostCustomPK: PersistentModelConstructor<PostCustomPKType>;
 let PostCustomPKSort: PersistentModelConstructor<PostCustomPKSortType>;
 
-describe.only('Jittered retry', () => {
+describe('Jittered retry', () => {
 	it('should progress exponentially until some limit', () => {
 		const COUNT = 13;
 
@@ -84,11 +84,11 @@ describe('MutationProcessor', () => {
 
 			await mutationProcessor.resume();
 
-			expect(mockJitteredExponentialRetry.mock.results).toHaveLength(1);
+			expect(mockRetry.mock.results).toHaveLength(1);
 
-			await expect(
-				mockJitteredExponentialRetry.mock.results[0].value
-			).rejects.toEqual(new Error('Network Error'));
+			await expect(mockRetry.mock.results[0].value).rejects.toEqual(
+				new Error('Network Error')
+			);
 
 			expect(mutationProcessorSpy).toHaveBeenCalled();
 
@@ -185,19 +185,17 @@ jest.mock('@aws-amplify/api', () => {
 	};
 });
 
-// mocking jitteredExponentialRetry to prevent it from retrying
+// mocking jitteredBackoff to prevent it from retrying
 // endlessly in the mutation processor and so that we can expect the thrown result in our test
 // should throw a Network Error
-let mockJitteredExponentialRetry;
+let mockRetry;
 jest.mock('@aws-amplify/core', () => {
-	mockJitteredExponentialRetry = jest
-		.fn()
-		.mockImplementation(async (fn, args) => {
-			await fn(...args);
-		});
+	mockRetry = jest.fn().mockImplementation(async (fn, args) => {
+		await fn(...args);
+	});
 	return {
 		...jest.requireActual('@aws-amplify/core'),
-		jitteredExponentialRetry: mockJitteredExponentialRetry,
+		retry: mockRetry,
 	};
 });
 

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -546,7 +546,7 @@ const originalJitteredBackoff = jitteredBackoff(MAX_RETRY_DELAY_MS);
  *
  * Wraps the jittered backoff calculation to retry Network Errors indefinitely.
  * Backs off according to original jittered retry logic until the original retry
- * logic hits its max. After this occurs, IFF the error is a Network Error, we
+ * logic hits its max. After this occurs, if the error is a Network Error, we
  * ignore the attempt count and return MAX_RETRY_DELAY_MS to retry forever (until
  * the request succeeds).
  *


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fixes a bug wherein mutation retries due to service reachability issues eventually end, resulting in data loss. Data can become isolated to a single client. This change causes failures due to network errors to retry indefinitely until connectivity is restored.

Provides an alternative to reachability testing from #9700.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#9699

#### Description of how you validated changes

Tested in app by overriding DataStore reachability test to always show online and disabling network in browser. Observed retries continue "indefinitely", whereas they did not previously.

Added unit test to show that retry delay scales on large attempt values for network errors.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
