### PR TITLE
Fix(storage): Remove unhandled promise rejection for _verifyFileSize()

### DIFF
--- a/packages/storage/src/providers/AWSS3UploadTask.ts
+++ b/packages/storage/src/providers/AWSS3UploadTask.ts
@@ -229,8 +229,9 @@ export class AWSS3UploadTask implements UploadTask {
 	private _validateParams() {
 		if (this.file.size / this.partSize > MAX_PARTS) {
 			throw new Error(
-				`Too many parts. Number of parts is ${this.file.size /
-					this.partSize}, maximum is ${MAX_PARTS}.`
+				`Too many parts. Number of parts is ${
+					this.file.size / this.partSize
+				}, maximum is ${MAX_PARTS}.`
 			);
 		}
 	}
@@ -302,7 +303,7 @@ export class AWSS3UploadTask implements UploadTask {
 					},
 				})
 			);
-			this._verifyFileSize();
+			await this._verifyFileSize();
 			this._emitEvent<UploadTaskCompleteEvent>(TaskEvents.UPLOAD_COMPLETE, {
 				key: `${this.params.Bucket}/${this.params.Key}`,
 			});
@@ -366,17 +367,29 @@ export class AWSS3UploadTask implements UploadTask {
 	 * @throws throws an error if the file size does not match between local copy of the file and the file on s3.
 	 */
 	private async _verifyFileSize() {
-		const obj = await this._listSingleFile({
-			key: this.params.Key,
-			bucket: this.params.Bucket,
-		});
+		let obj = null;
+		try {
+			obj = await this._listSingleFile({
+				key: this.params.Key,
+				bucket: this.params.Bucket,
+			});
+		} catch (e) {
+			logger.log('Could not get file on s3 for size matching: ', e);
+			// Allow to proceed to not break previous implementations.
+			// Could have authentication error caught since the `s3:getObject`
+			// action is not a listed as a prerequisite for Storage.put().
+			// Users can have this missing due to how one can use an
+			// existing S3 bucket.
+			// ? We can throw warning if DEV environments
+			return;
+		}
+
 		const valid = Boolean(obj && obj.Size === this.file.size);
 		if (!valid) {
 			throw new Error(
 				'File size does not match between local file and file on s3'
 			);
 		}
-		return valid;
 	}
 
 	private _isDone() {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The function `_verifyFileSize()` is not awaited in the `_completeUpload()` function located in `AWSS3UploadTask.ts`. This can cause unhandled promise rejections and the `_completeUpload()` to not behave as intended. This PR aims to solve this by awaiting the `_verifyFileSize()` while only rejecting if `ListObjectsV2Command`  fulfills and the remote and local file sizes are different. The change is due to Amplify allowing users to use pre-existing S3 instances and the permission `S3:ListBucket` is not listed as a prerequisite for uploading a file. Enforcing the `ListObjectsV2Command` can break some developers' app functionality if they did not have this action permitted.  

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Made a test that expects the error to be called with the message 'File size does not match between local file and file on s3' when remote and local file sizes do not match.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [X] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
