### PR TITLE
feat: add DataStore.clear abort callback

### DIFF
--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -1383,8 +1383,18 @@ class DataStore {
 		this.sessionId = this.retrieveSessionId();
 	};
 
-	clear = async function clear() {
+	clear = async function clear(
+		beforeClear?: (pending: MutationEvent[]) => boolean
+	) {
 		if (this.storage === undefined) {
+			return;
+		}
+
+		const continueClear = beforeClear
+			? beforeClear(await this.sync.outbox.getAll(this.storage))
+			: true;
+		if (!continueClear) {
+			logger.warn('Clear aborted.');
 			return;
 		}
 

--- a/packages/datastore/src/sync/outbox.ts
+++ b/packages/datastore/src/sync/outbox.ts
@@ -138,6 +138,17 @@ class MutationEventOutbox {
 		return mutationEvents;
 	}
 
+	public async getAll<T extends PersistentModel>(
+		storage: StorageFacade
+	): Promise<MutationEvent[]> {
+		const mutationEventModelDefinition =
+			this.schema.namespaces[SYNC].models.MutationEvent;
+
+		const mutationEvents = await storage.query(this.MutationEvent);
+
+		return mutationEvents;
+	}
+
 	public async getModelIds(storage: StorageFacade): Promise<Set<string>> {
 		const mutationEvents = await storage.query(this.MutationEvent);
 
@@ -250,7 +261,7 @@ class MutationEventOutbox {
 		});
 	}
 
-	/* 
+	/*
 	if a model is using custom timestamp fields
 	the custom field names will be stored in the model attributes
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->
To Do:
* add unit tests

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* DataStore.clear() does not check status of pending mutations before clearing.
* Given the following scenario a user would experience data loss without knowing:
    * The user authenticates with network connection
    * The user looses network connection
    * The user makes a mutation or creation
    * The user signs out (and app is configured to DataStore.clear() on sign out)
    * The user would not know about data loss

This change adds a callback (`beforeClear`) to `DataStore.clear()` that allows the customer to add custom abort/notification logic.

```typescript
await DataStore.clear((pending: MutationEvent[]) => {
  console.log('pending clear');
  if (pending.length > 0) {
    return false; // abort
  }
  return true; // continue
});
```

Implementation questions:
* Should `MutationEvent` be exposed?
    * We could just provide number of pending requests.
* Callback return value could be swapped where `false` indicates continue.
    * Would allow a callback with no return value to default to continue.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* Created a basic app with DataStore
* Add code snippet above to an onClick event for a button.
* Set network to offline in dev tools
* Add/modify a few records
* Click button to clear DataStore
* Check IDB still has all records

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced) https://github.com/aws-amplify/docs/pull/4200

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
