### PR TITLE
fix(in-app-messaging): prevent reuse of image dimension object between multiple messages

### DIFF
--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/BannerMessage/__tests__/BannerMessage.spec.tsx
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/BannerMessage/__tests__/BannerMessage.spec.tsx
@@ -16,7 +16,6 @@ import TestRenderer from 'react-test-renderer';
 
 import { IN_APP_MESSAGING } from '../../../../AmplifyTestIDs';
 import useMessageImage from '../../hooks/useMessageImage';
-import { INITIAL_IMAGE_DIMENSIONS } from '../../hooks/useMessageImage/constants';
 
 import BannerMessage from '../BannerMessage';
 
@@ -37,7 +36,7 @@ describe('BannerMessage', () => {
 	it('renders a message as expected without an image', () => {
 		mockUseMessageImage.mockReturnValueOnce({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: false,
 		});
 
@@ -67,7 +66,7 @@ describe('BannerMessage', () => {
 	it('returns null while an image is fetching', () => {
 		mockUseMessageImage.mockReturnValueOnce({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: true,
 		});
 
@@ -94,7 +93,7 @@ describe('BannerMessage', () => {
 	])('correctly handles a %s prop', (key, testID, testProps, expectedProps) => {
 		mockUseMessageImage.mockReturnValueOnce({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: false,
 		});
 
@@ -109,7 +108,7 @@ describe('BannerMessage', () => {
 	it('calls onClose when the close button is pressed', () => {
 		mockUseMessageImage.mockReturnValueOnce({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: false,
 		});
 

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/FullScreenMessage/__tests__/FullScreenMessage.spec.tsx
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/FullScreenMessage/__tests__/FullScreenMessage.spec.tsx
@@ -15,7 +15,6 @@ import React from 'react';
 import TestRenderer from 'react-test-renderer';
 
 import useMessageImage from '../../hooks/useMessageImage';
-import { INITIAL_IMAGE_DIMENSIONS } from '../../hooks/useMessageImage/constants';
 
 import FullScreenMessage from '../FullScreenMessage';
 
@@ -35,7 +34,7 @@ describe('FullScreenMessage', () => {
 	it('renders as expected', () => {
 		mockUseMessageImage.mockReturnValueOnce({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: false,
 		});
 
@@ -47,7 +46,7 @@ describe('FullScreenMessage', () => {
 	it('returns null while an image is fetching', () => {
 		mockUseMessageImage.mockReturnValueOnce({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: true,
 		});
 

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/__tests__/useMessageImage.spec.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/__tests__/useMessageImage.spec.ts
@@ -16,7 +16,6 @@ import { renderHook } from '@testing-library/react-hooks';
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import { InAppMessageImage } from '@aws-amplify/notifications';
 
-import { INITIAL_IMAGE_DIMENSIONS } from '../constants';
 import { getLayoutImageDimensions, prefetchNetworkImage } from '../utils';
 import useMessageImage from '../useMessageImage';
 
@@ -50,7 +49,7 @@ describe('useMessageImage', () => {
 		// first render
 		expect(result.current).toStrictEqual({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: true,
 		});
 
@@ -76,7 +75,7 @@ describe('useMessageImage', () => {
 		// first render
 		expect(result.current).toStrictEqual({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: true,
 		});
 
@@ -87,7 +86,7 @@ describe('useMessageImage', () => {
 
 		expect(result.current).toStrictEqual({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: false,
 		});
 	});
@@ -100,7 +99,7 @@ describe('useMessageImage', () => {
 		// first render
 		expect(result.current).toStrictEqual({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: true,
 		});
 
@@ -110,7 +109,7 @@ describe('useMessageImage', () => {
 
 		expect(result.current).toStrictEqual({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: false,
 		});
 	});
@@ -120,7 +119,7 @@ describe('useMessageImage', () => {
 
 		expect(result.current).toStrictEqual({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: false,
 		});
 	});
@@ -130,7 +129,7 @@ describe('useMessageImage', () => {
 
 		expect(result.current).toStrictEqual({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: false,
 		});
 	});

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/constants.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/constants.ts
@@ -12,7 +12,6 @@
  */
 
 import { Dimensions } from 'react-native';
-import { ImageDimensions } from './types';
 
 // as images are not expected to be responsive to orientation changes get screen dimensions at app start
 const SCREEN_DIMENSIONS = Dimensions.get('screen');
@@ -33,5 +32,3 @@ export const BANNER_IMAGE_SCREEN_SIZE = BANNER_IMAGE_SCREEN_MULTIPLIER * BASE_SC
 export const CAROUSEL_IMAGE_SCREEN_SIZE = CAROUSEL_IMAGE_SCREEN_MULTIPLIER * BASE_SCREEN_DIMENSION;
 export const FULL_SCREEN_IMAGE_SCREEN_SIZE = FULL_SCREEN_IMAGE_SCREEN_MULTIPLIER * BASE_SCREEN_DIMENSION;
 export const MODAL_IMAGE_SCREEN_SIZE = MODAL_IMAGE_SCREEN_MULTIPLIER * BASE_SCREEN_DIMENSION;
-
-export const INITIAL_IMAGE_DIMENSIONS: ImageDimensions = { height: null, width: null };

--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/useMessageImage.ts
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/hooks/useMessageImage/useMessageImage.ts
@@ -17,7 +17,6 @@ import { Image } from 'react-native';
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import { InAppMessageImage, InAppMessageLayout } from '@aws-amplify/notifications';
 
-import { INITIAL_IMAGE_DIMENSIONS } from './constants';
 import { ImageDimensions, ImagePrefetchStatus, UseMessageImage } from './types';
 import { getLayoutImageDimensions, prefetchNetworkImage } from './utils';
 
@@ -39,7 +38,7 @@ export default function useMessageImage(image: InAppMessageImage, layout: InAppM
 	const [prefetchStatus, setPrefetchStatus] = useState<ImagePrefetchStatus>(
 		shouldPrefetch ? ImagePrefetchStatus.FETCHING : null
 	);
-	const imageDimensions = useRef<ImageDimensions>(INITIAL_IMAGE_DIMENSIONS).current;
+	const imageDimensions = useRef<ImageDimensions>({ height: null, width: null }).current;
 
 	const isImageFetching = prefetchStatus === ImagePrefetchStatus.FETCHING;
 	const hasRenderableImage = prefetchStatus === ImagePrefetchStatus.SUCCESS;

--- a/packages/aws-amplify-react-native/src/InAppMessaging/ui/Carousel/Carousel.tsx
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/ui/Carousel/Carousel.tsx
@@ -67,9 +67,9 @@ export default function Carousel<T>(props: CarouselProps<T>) {
 		};
 	}, [updateOrientation]);
 
-	const carouselRenderItem = (renderInfo: ListRenderItemInfo<T>) => {
-		return <View style={{ width }}>{renderItem(renderInfo)}</View>;
-	};
+	const carouselRenderItem = (renderInfo: ListRenderItemInfo<T>) => (
+		<View style={{ width }}>{renderItem(renderInfo)}</View>
+	);
 
 	if (!data?.length) {
 		return null;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Remove `INITIAL_IMAGE_DIMENSIONS` constant as it was being reused between `Carousel` messages leading to  incorrect image dimensions being used for rendering

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
NA


#### Description of how you validated changes
Manually tested


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
