### PR TITLE
feat: Selective TypeScript strict builds

### DIFF
--- a/packages/auth/build.js
+++ b/packages/auth/build.js
@@ -2,4 +2,4 @@
 
 const build = require('../../scripts/build');
 
-build(process.argv[2], process.argv[3], true);
+build(process.argv[2], process.argv[3]);

--- a/packages/auth/build.js
+++ b/packages/auth/build.js
@@ -2,4 +2,4 @@
 
 const build = require('../../scripts/build');
 
-build(process.argv[2], process.argv[3]);
+build(process.argv[2], process.argv[3], true);

--- a/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider/index.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider/index.ts
@@ -747,11 +747,15 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 			AWS_LAMBDA: this._customAuthHeader,
 		};
 
-		if (!authenticationType || !headerHandler[authenticationType]) {
-			logger.debug(`Authentication type ${authenticationType} not supported`);
+		const authenticationTypeString = String(authenticationType);
+
+		if (!authenticationTypeString || !headerHandler[authenticationTypeString]) {
+			logger.debug(
+				`Authentication type ${authenticationTypeString} not supported`
+			);
 			return '';
 		} else {
-			const handler = headerHandler[authenticationType];
+			const handler = headerHandler[authenticationTypeString];
 
 			const { host } = url.parse(appSyncGraphqlEndpoint ?? '');
 

--- a/packages/pubsub/tsconfig.json
+++ b/packages/pubsub/tsconfig.json
@@ -1,0 +1,14 @@
+//WARNING: The tsconfig used to build amplify is inline in ../../scripts/build.js, this file exists only to provide IDE feedback while modifying the library.
+//         This file intentionally sets ts to strict globally as an aspiration where not all packages have strict turned on in the actual build process.
+{
+	"compilerOptions": {
+		"rootDir": "./",
+		"target": "es5",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"strict": true,
+		"noImplicitAny": false,
+		"useUnknownInCatchVariables": false
+	},
+	"exclude": ["node_modules", ".vscode-test"]
+}

--- a/packages/pushnotification/build.js
+++ b/packages/pushnotification/build.js
@@ -2,4 +2,4 @@
 
 const build = require('../../scripts/build');
 
-build(process.argv[2], process.argv[3]);
+build(process.argv[2], process.argv[3], true);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -147,7 +147,7 @@ function reportWatchStatusChanged(diagnostic, newLine, options, errorCount) {
 	logger.info(ts.formatDiagnostic(diagnostic, formatHost));
 }
 
-async function buildES5(typeScriptCompiler, watchMode) {
+async function buildES5(typeScriptCompiler, watchMode, tsStrict) {
 	const jsx = ['@aws-amplify/ui-react', 'aws-amplify-react'].includes(
 		packageInfo.name
 	)
@@ -177,6 +177,7 @@ async function buildES5(typeScriptCompiler, watchMode) {
 		// temporary fix
 		types: ['node'],
 		outDir: pkgTscES5OutDir,
+		strict: tsStrict,
 	};
 
 	if (watchMode) {
@@ -204,7 +205,7 @@ async function buildES5(typeScriptCompiler, watchMode) {
 	});
 }
 
-function buildES6(typeScriptCompiler, watchMode) {
+function buildES6(typeScriptCompiler, watchMode, tsStrict) {
 	const jsx = ['@aws-amplify/ui-react', 'aws-amplify-react'].includes(
 		packageInfo.name
 	)
@@ -234,6 +235,7 @@ function buildES6(typeScriptCompiler, watchMode) {
 		// temporary fix
 		types: ['node'],
 		outDir: pkgTscES6OutDir,
+		strict: tsStrict,
 	};
 
 	if (watchMode) {
@@ -261,15 +263,15 @@ function buildES6(typeScriptCompiler, watchMode) {
 	});
 }
 
-function build(type, watchMode) {
+function build(type, watchMode, tsStrict) {
 	if (type === 'rollup') buildRollUp();
 
 	var typeScriptCompiler = watchMode
 		? runTypeScriptWithWatchMode
 		: runTypeScriptWithoutWatchMode;
 
-	if (type === 'es5') buildES5(typeScriptCompiler, watchMode);
-	if (type === 'es6') buildES6(typeScriptCompiler, watchMode);
+	if (type === 'es5') buildES5(typeScriptCompiler, watchMode, tsStrict);
+	if (type === 'es6') buildES6(typeScriptCompiler, watchMode, tsStrict);
 }
 
 module.exports = build;


### PR DESCRIPTION
#### Description of changes
As we adopt TS Strict for our packages, to maintain this high standard, our build process should compile with the expected TS strict configuration and IDE feedback should align with the.

- Since we compile for both ES5 and ES6, we need to have the option of turning TS Strict on for these builds
- The IDE will pay attention to a tsconfig.json file in the package or higher, so adding a minimal config to get IDE feedback
- Fixing two PubSub strict issues that complication caught


I headed down the path of consuming `tsconfig.json` files merged into the `build.js` script to keep these in parity, but the ts version used by vscode is not the same as the version used in build. While these are different, I am recommending we keep the build config separate from the config that will be referenced by vscode.

#### Issue #, if available
https://github.com/aws-amplify/amplify-js/issues/7188


#### Description of how you validated changes
`yarn build` succeeds - particularly for pubsub

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
