### PR TITLE
fix(in-app-messaging): replace unused constant in test file

### DIFF
--- a/packages/aws-amplify-react-native/src/InAppMessaging/components/ModalMessage/__tests__/ModalMessage.spec.tsx
+++ b/packages/aws-amplify-react-native/src/InAppMessaging/components/ModalMessage/__tests__/ModalMessage.spec.tsx
@@ -16,7 +16,6 @@ import TestRenderer from 'react-test-renderer';
 
 import { IN_APP_MESSAGING } from '../../../../AmplifyTestIDs';
 import useMessageImage from '../../hooks/useMessageImage';
-import { INITIAL_IMAGE_DIMENSIONS } from '../../hooks/useMessageImage/constants';
 
 import ModalMessage from '../ModalMessage';
 
@@ -37,7 +36,7 @@ describe('ModalMessage', () => {
 	it('renders a message as expected without an image', () => {
 		mockUseMessageImage.mockReturnValueOnce({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: false,
 		});
 
@@ -67,7 +66,7 @@ describe('ModalMessage', () => {
 	it('returns null while an image is fetching', () => {
 		mockUseMessageImage.mockReturnValueOnce({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: true,
 		});
 
@@ -94,7 +93,7 @@ describe('ModalMessage', () => {
 	])('correctly handles a %s prop', (key, testID, testProps, expectedProps) => {
 		mockUseMessageImage.mockReturnValueOnce({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: false,
 		});
 
@@ -109,7 +108,7 @@ describe('ModalMessage', () => {
 	it('calls onClose when the close button is pressed', () => {
 		mockUseMessageImage.mockReturnValueOnce({
 			hasRenderableImage: false,
-			imageDimensions: INITIAL_IMAGE_DIMENSIONS,
+			imageDimensions: { height: null, width: null },
 			isImageFetching: false,
 		});
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Merging introduced an error where `INITIAL_IMAGE_DIMENSIONS ` was not found and so was not able to import it. Replaced it with default `{ height: null, width: null }`

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
yarn run test -u
yarn run lint


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
