### PR TITLE
Allow for complete messages to be captured in a subscription

### DIFF
--- a/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider/index.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider/index.ts
@@ -396,13 +396,21 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 			subscriptionFailedCallback,
 		} = this.subscriptionObserverMap.get(id) || {};
 
-		logger.debug({ id, observer, query, variables });
+		logger.debug({ id, observer, query, variables, type });
 
 		if (type === MESSAGE_TYPES.GQL_DATA && payload && payload.data) {
 			if (observer) {
 				observer.next(payload);
 			} else {
 				logger.debug(`observer not found for id: ${id}`);
+			}
+			return;
+		}
+
+		if (type === MESSAGE_TYPES.GQL_COMPLETE) {
+			logger.debug(`connection completed for id: ${id}`);
+			if (observer) {
+				observer.complete();
 			}
 			return;
 		}

--- a/packages/pubsub/src/PubSub.ts
+++ b/packages/pubsub/src/PubSub.ts
@@ -184,7 +184,7 @@ export class PubSubClass {
 					start: console.error,
 					next: value => observer.next({ provider, value }),
 					error: error => observer.error({ provider, error }),
-					// complete: observer.complete, // TODO: when all completed, complete the outer one
+					complete: observer.complete, // TODO: when all completed, complete the outer one
 				})
 			);
 


### PR DESCRIPTION

#### Description of changes
AppSync now supports [unsubscribing connections ](https://docs.aws.amazon.com/appsync/latest/devguide/aws-appsync-real-time-invalidation.html).  Previously this message is not available to uses of the amplify-js libraries.  This PR will allow a user to capture this completion message and take the appropriate action inside their application


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
```typescript
const subscription = API.graphql<Observable<{
      provider: any;
      value: GraphQLResult<any>;
    }>>(graphqlOperation(onCreateMessage))
    .subscribe({
      next: ({ provider, value }: {provider: any, value: GraphQLResult}) => {
        console.log({ provider, value });
      },
      complete: () => console.log('Complete'),
      error: ({ provider, error }: {provider: any, error: GraphQLResult}) => {
        error.errors?.forEach(e => {
          console.log(e);
        });
      }
    });
```


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
