### PR TITLE
fix: docs for amazon-cognito-identity-js

### DIFF
--- a/packages/amazon-cognito-identity-js/README.md
+++ b/packages/amazon-cognito-identity-js/README.md
@@ -313,7 +313,7 @@ cognitoUser.authenticateUser(authenticationDetails, {
 			IdentityPoolId: '...', // your identity pool id here
 			Logins: {
 				// Change the key below according to the specific region your user pool is in.
-				'cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>': result
+				['cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>']: result
 					.getIdToken()
 					.getJwtToken(),
 			},


### PR DESCRIPTION
#### Description of changes

Use-case 4 '_[Authenticating a user and establishing a user session with the Amazon Cognito Identity service](https://github.com/svidgen/amplify-js/blob/ae9a634c2def68bf4f001560d8a2ca7b31e08c7f/packages/amazon-cognito-identity-js/README.md)_' had invalid JS syntax for defining a dynamic object key. 

This commit adds two simple square brackets in the appropriate places!

#### Description of how you validated changes

Using corrected demo code in a private environment.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
