### PR TITLE
fix(@aws-amplify/datastore-storage-adapter): remove extra, invalid sqlite mutations again

### DIFF
--- a/packages/amazon-cognito-identity-js/README.md
+++ b/packages/amazon-cognito-identity-js/README.md
@@ -478,7 +478,7 @@ cognitoUser.forgotPassword({
 	//Optional automatic callback
 	inputVerificationCode: function(data) {
 		console.log('Code sent to: ' + data);
-		var code = document.getElementById('code').value;
+		var verificationCode = document.getElementById('code').value;
 		var newPassword = document.getElementById('new_password').value;
 		cognitoUser.confirmPassword(verificationCode, newPassword, {
 			onSuccess() {

--- a/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
+++ b/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
@@ -315,7 +315,7 @@ describe('SQLiteAdapter', () => {
 		});
 	});
 
-	describe.only('at a high level', () => {
+	describe('at a high level', () => {
 		it('can manage a basic model', async () => {
 			const saved = await DataStore.save(
 				new Model({
@@ -332,7 +332,7 @@ describe('SQLiteAdapter', () => {
 			expect(retrieved).toEqual(saved);
 		});
 
-		it.only('can manage related models, where parent is saved first', async () => {
+		it('can manage related models, where parent is saved first', async () => {
 			const post = await DataStore.save(
 				new Post({
 					title: 'some post',
@@ -361,7 +361,7 @@ describe('SQLiteAdapter', () => {
 			});
 		});
 
-		it.only('should produce a mutation for a nested BELONGS_TO insert', async () => {
+		it('should produce a mutation for a nested BELONGS_TO insert', async () => {
 			await DataStore.save(
 				new Comment({
 					content: 'newly created comment',

--- a/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
+++ b/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
@@ -105,8 +105,6 @@ describe('SQLiteAdapter', () => {
 	let Comment: PersistentModelConstructor<Comment>;
 	let Model: PersistentModelConstructor<Model>;
 	let Post: PersistentModelConstructor<Post>;
-	let adapter: StorageAdapter;
-	let db: SQLiteDatabase;
 	let syncEngine: SyncEngine;
 	sqlog = [];
 
@@ -135,6 +133,8 @@ describe('SQLiteAdapter', () => {
 	 */
 	async function getMutations() {
 		await pause(250);
+		const adapter = (DataStore as any).storageAdapter;
+		const db = (adapter as any).db;
 		return await db.getAll('select * from MutationEvent', []);
 	}
 
@@ -147,6 +147,9 @@ describe('SQLiteAdapter', () => {
 	});
 
 	describe('something', () => {
+		let adapter: StorageAdapter;
+		let db: SQLiteDatabase;
+
 		beforeEach(async () => {
 			DataStore.configure({
 				storageAdapter: SQLiteAdapter,

--- a/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
+++ b/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
@@ -13,6 +13,10 @@ import {
 import { Model, Post, Comment, testSchema } from './helpers';
 import { SyncEngine } from '@aws-amplify/datastore/lib/sync';
 import Observable from 'zen-observable';
+import {
+	pause,
+	addCommonQueryTests,
+} from '../../datastore/__tests__/commonAdapterTests';
 
 jest.mock('@aws-amplify/datastore/src/sync/datastoreConnectivity', () => {
 	return {
@@ -37,85 +41,6 @@ jest.mock('react-native-sqlite-storage', () => {
 let initSchema: typeof initSchemaType;
 let DataStore: typeof DataStoreType;
 let sqlog: any[];
-
-/**
- * Convenience function to wait for a number of ms.
- *
- * Intended as a cheap way to wait for async operations to settle.
- *
- * @param ms number of ms to pause for
- */
-async function pause(ms) {
-	return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-const UUID_REGEX =
-	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-
-/**
- * Tests a mutation for expected values. If values are present on the mutation
- * that are not expected, throws an error. Expected values can be listed as a
- * literal value, a regular expression, or a function (v => bool).
- *
- * `id` is automatically tested and expected to be a UUID unless an alternative
- *  matcher is provided.
- *
- * @param mutation A mutation record to check
- * @param values An object for specific values to test. Format of key: value | regex | v => bool
- */
-function expectMutation(mutation, values) {
-	const data = JSON.parse(mutation.data);
-	const matchers = {
-		id: UUID_REGEX,
-		...values,
-	};
-	const errors = [
-		...errorsFrom(data, matchers),
-		...extraFieldsFrom(data, matchers).map(f => `Unexpected field: ${f}`),
-	];
-	if (errors.length > 0) {
-		throw new Error(
-			`Bad mutation: ${JSON.stringify(data, null, 2)}\n${errors.join('\n')}`
-		);
-	}
-}
-
-/**
- * Checks an object for adherence to expected values from a set of matchers.
- * Returns a list of erroneous key-value pairs.
- * @param data the object to validate.
- * @param matchers the matcher functions/values/regexes to test the object with
- */
-function errorsFrom(data, matchers) {
-	return Object.entries(matchers).reduce((errors, [property, matcher]) => {
-		const value = data[property];
-		if (
-			!(
-				(typeof matcher === 'function' && matcher(value)) ||
-				(matcher instanceof RegExp && matcher.test(value)) ||
-				value === matcher
-			)
-		) {
-			errors.push(
-				`Property '${property}' value "${value}" does not match "${matcher}"`
-			);
-		}
-		return errors;
-	}, []);
-}
-
-/**
- * Checks to see if a given object contains any extra, unexpected properties.
- * If any are present, it returns the list of unexpectd fields.
- *
- * @param data the object that MIGHT contain extra fields.
- * @param template the authorative template object.
- */
-function extraFieldsFrom(data, template) {
-	const fields = Object.keys(data);
-	const expectedFields = new Set(Object.keys(template));
-	return fields.filter(name => !expectedFields.has(name));
-}
 
 /**
  * A lower-level SQLite wrapper to test SQLiteAdapter against.
@@ -191,17 +116,17 @@ describe('SQLiteAdapter', () => {
 	 *
 	 * @param qty number of models to create. (default 3)
 	 */
-	async function addModels(qty = 3) {
-		for (let i = 0; i < qty; i++) {
-			await DataStore.save(
-				new Model({
-					field1: `field1 value ${i}`,
-					dateCreated: new Date().toISOString(),
-					emails: [],
-				})
-			);
-		}
-	}
+	// async function addModels(qty = 3) {
+	// 	for (let i = 0; i < qty; i++) {
+	// 		await DataStore.save(
+	// 			new Model({
+	// 				field1: `field1 value ${i}`,
+	// 				dateCreated: new Date().toISOString(),
+	// 				emails: [],
+	// 			})
+	// 		);
+	// 	}
+	// }
 
 	/**
 	 * Gets all mutations currently in the outbox. This should include ALL
@@ -213,52 +138,86 @@ describe('SQLiteAdapter', () => {
 		return await db.getAll('select * from MutationEvent', []);
 	}
 
-	beforeEach(async () => {
-		({ initSchema, DataStore } = require('@aws-amplify/datastore'));
-		DataStore.configure({
-			storageAdapter: SQLiteAdapter,
-		});
-		(DataStore as any).amplifyConfig.aws_appsync_graphqlEndpoint =
-			'https://0.0.0.0/does/not/exist/graphql';
-		const classes = initSchema(testSchema());
-		({ Comment, Model, Post } = classes as {
-			Comment: PersistentModelConstructor<Comment>;
-			Model: PersistentModelConstructor<Model>;
-			Post: PersistentModelConstructor<Post>;
-		});
-		await DataStore.clear();
-
-		// start() ensures storageAdapter is set
-		await DataStore.start();
-
-		adapter = (DataStore as any).storageAdapter;
-		db = (adapter as any).db;
-		syncEngine = (DataStore as any).sync;
-
-		// my jest spy-fu wasn't up to snuff here. but, this succesfully
-		// prevents the mutation process from clearing the mutation queue, which
-		// allows us to observe the state of mutations.
-		(syncEngine as any).mutationsProcessor.isReady = () => false;
-
-		sqlog = [];
+	({ initSchema, DataStore } = require('@aws-amplify/datastore'));
+	addCommonQueryTests({
+		initSchema,
+		DataStore,
+		storageAdapter: SQLiteAdapter,
+		getMutations,
 	});
 
-	describe('sanity checks', () => {
-		it('is set as the adapter SQLite tests', async () => {
-			expect(adapter.constructor.name).toEqual('CommonSQLiteAdapter');
+	describe('something', () => {
+		beforeEach(async () => {
+			DataStore.configure({
+				storageAdapter: SQLiteAdapter,
+			});
+			(DataStore as any).amplifyConfig.aws_appsync_graphqlEndpoint =
+				'https://0.0.0.0/does/not/exist/graphql';
+			const classes = initSchema(testSchema());
+			({ Comment, Model, Post } = classes as {
+				Comment: PersistentModelConstructor<Comment>;
+				Model: PersistentModelConstructor<Model>;
+				Post: PersistentModelConstructor<Post>;
+			});
+			await DataStore.clear();
+
+			// start() ensures storageAdapter is set
+			await DataStore.start();
+
+			adapter = (DataStore as any).storageAdapter;
+			db = (adapter as any).db;
+			syncEngine = (DataStore as any).sync;
+
+			// my jest spy-fu wasn't up to snuff here. but, this succesfully
+			// prevents the mutation process from clearing the mutation queue, which
+			// allows us to observe the state of mutations.
+			(syncEngine as any).mutationsProcessor.isReady = () => false;
+
+			sqlog = [];
 		});
 
-		it('is logging SQL statements during normal operation', async () => {
-			// `start()`, which is called during `beforeEach`, should perform
-			// a number of queries to create tables. the test adapter should
-			// log these all to `sqlog`.
-			expect(sqlog.length).toBeGreaterThan(0);
-		});
+		describe('sanity checks', () => {
+			it('is set as the adapter SQLite tests', async () => {
+				expect(adapter.constructor.name).toEqual('CommonSQLiteAdapter');
+			});
 
-		it('can batchSave', async () => {
-			const saves = new Set<ParameterizedStatement>();
-			saves.add([
-				`insert into "Model" (
+			it('is logging SQL statements during normal operation', async () => {
+				// `start()`, which is called during `beforeEach`, should perform
+				// a number of queries to create tables. the test adapter should
+				// log these all to `sqlog`.
+				expect(sqlog.length).toBeGreaterThan(0);
+			});
+
+			it('can batchSave', async () => {
+				const saves = new Set<ParameterizedStatement>();
+				saves.add([
+					`insert into "Model" (
+						"field1",
+						"dateCreated",
+						"emails",
+						"id",
+						"_version",
+						"_lastChangedAt",
+						"_deleted"
+					) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+					[
+						'field1 value 0',
+						'2022-04-18T19:29:46.316Z',
+						[],
+						'a1d63606-bd3b-4641-870a-ac97694577a8',
+						null,
+						null,
+						null,
+					],
+				]);
+				await db.batchSave(saves);
+				const result = await db.get('select * from "Model" limit 1', []);
+				expect(result.id).toEqual('a1d63606-bd3b-4641-870a-ac97694577a8');
+			});
+
+			it('can batchQuery', async () => {
+				await db.save(
+					`insert into "Model" (
 					"field1",
 					"dateCreated",
 					"emails",
@@ -267,277 +226,26 @@ describe('SQLiteAdapter', () => {
 					"_lastChangedAt",
 					"_deleted"
 				) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-				[
-					'field1 value 0',
-					'2022-04-18T19:29:46.316Z',
-					[],
-					'a1d63606-bd3b-4641-870a-ac97694577a8',
-					null,
-					null,
-					null,
-				],
-			]);
-			await db.batchSave(saves);
-			const result = await db.get('select * from "Model" limit 1', []);
-			expect(result.id).toEqual('a1d63606-bd3b-4641-870a-ac97694577a8');
-		});
+					[
+						'field1 value 0',
+						'2022-04-18T19:29:46.316Z',
+						'abcd@abcd.com',
+						'a1d63606-bd3b-4641-870a-ac97694577a8',
+						null,
+						null,
+						null,
+					]
+				);
 
-		it('can batchQuery', async () => {
-			await db.save(
-				`insert into "Model" (
-				"field1",
-				"dateCreated",
-				"emails",
-				"id",
-				"_version",
-				"_lastChangedAt",
-				"_deleted"
-			) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-				[
-					'field1 value 0',
-					'2022-04-18T19:29:46.316Z',
-					'abcd@abcd.com',
-					'a1d63606-bd3b-4641-870a-ac97694577a8',
-					null,
-					null,
-					null,
-				]
-			);
+				const queries = new Set<ParameterizedStatement>();
+				queries.add([
+					'select * from "Model" where id = ? limit 1',
+					['a1d63606-bd3b-4641-870a-ac97694577a8'],
+				]);
+				const result = await db.batchQuery(queries);
 
-			const queries = new Set<ParameterizedStatement>();
-			queries.add([
-				'select * from "Model" where id = ? limit 1',
-				['a1d63606-bd3b-4641-870a-ac97694577a8'],
-			]);
-			const result = await db.batchQuery(queries);
-
-			expect(result.length).toBe(1);
-		});
-	});
-
-	describe('at a high level', () => {
-		it('can manage a basic model', async () => {
-			const saved = await DataStore.save(
-				new Model({
-					field1: 'some value',
-					dateCreated: new Date().toISOString(),
-
-					// why is storage adapter seeing this as a required field?
-					emails: [],
-				})
-			);
-			const retrieved = await DataStore.query(Model, saved.id);
-
-			expect(saved.id).toBeTruthy();
-			expect(retrieved).toEqual(saved);
-		});
-
-		it('can manage related models, where parent is saved first', async () => {
-			const post = await DataStore.save(
-				new Post({
-					title: 'some post',
-				})
-			);
-
-			const comment = await DataStore.save(
-				new Comment({
-					content: 'some comment',
-					post,
-				})
-			);
-
-			await DataStore.save(
-				Comment.copyOf(comment, draft => {
-					draft.content = 'updated content';
-				})
-			);
-
-			const mutations = await getMutations();
-			expect(mutations.length).toEqual(2);
-			expectMutation(mutations[0], { title: 'some post' });
-			expectMutation(mutations[1], {
-				content: 'updated content',
-				postId: mutations[0].modelId,
+				expect(result.length).toBe(1);
 			});
-		});
-
-		it('should produce a mutation for a nested BELONGS_TO insert', async () => {
-			await DataStore.save(
-				new Comment({
-					content: 'newly created comment',
-					post: new Post({
-						title: 'newly created post',
-					}),
-				})
-			);
-
-			const mutations = await getMutations();
-
-			// two mutations are expected.
-			// 1st mutation should be for the inner object, the post.
-			// 2nd mutation should be for the outer object, the comment.
-			// reminder: mutation `data` is a JSON string containing the updated fields.
-
-			expect(mutations.length).toEqual(2);
-			expectMutation(mutations[0], { title: 'newly created post' });
-			expectMutation(mutations[1], {
-				content: 'newly created comment',
-				postId: mutations[0].modelId,
-			});
-		});
-	});
-
-	describe('query', () => {
-		it('should match fields of any non-empty value for `("ne", undefined)`', async () => {
-			const qty = 3;
-			await addModels(qty);
-
-			const results = await DataStore.query(Model, m =>
-				m.field1('ne', undefined)
-			);
-
-			expect(results.length).toEqual(qty);
-		});
-
-		it('should match fields of any non-empty value for `("ne", null)`', async () => {
-			const qty = 3;
-			await addModels(qty);
-
-			const results = await DataStore.query(Model, m => m.field1('ne', null));
-
-			expect(results.length).toEqual(qty);
-		});
-
-		it('should NOT match fields of any non-empty value for `("eq", undefined)`', async () => {
-			const qty = 3;
-			await addModels(qty);
-
-			const results = await DataStore.query(Model, m =>
-				m.field1('eq', undefined)
-			);
-
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("eq", null)`', async () => {
-			const qty = 3;
-			await addModels(qty);
-
-			const results = await DataStore.query(Model, m => m.field1('eq', null));
-
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("gt", null)`', async () => {
-			const qty = 3;
-			await addModels(qty);
-			const results = await DataStore.query(Model, m => m.field1('gt', null));
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("ge", null)`', async () => {
-			const qty = 3;
-			await addModels(qty);
-			const results = await DataStore.query(Model, m => m.field1('ge', null));
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("lt", null)`', async () => {
-			const qty = 3;
-			await addModels(qty);
-			const results = await DataStore.query(Model, m => m.field1('lt', null));
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("le", null)`', async () => {
-			const qty = 3;
-			await addModels(qty);
-			const results = await DataStore.query(Model, m => m.field1('le', null));
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("gt", undefined)`', async () => {
-			const qty = 3;
-			await addModels(qty);
-			const results = await DataStore.query(Model, m =>
-				m.field1('gt', undefined)
-			);
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("ge", undefined)`', async () => {
-			const qty = 3;
-			await addModels(qty);
-			const results = await DataStore.query(Model, m =>
-				m.field1('ge', undefined)
-			);
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("lt", undefined)`', async () => {
-			const qty = 3;
-			await addModels(qty);
-			const results = await DataStore.query(Model, m =>
-				m.field1('lt', undefined)
-			);
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("le", undefined)`', async () => {
-			const qty = 3;
-			await addModels(qty);
-			const results = await DataStore.query(Model, m =>
-				m.field1('le', undefined)
-			);
-			expect(results.length).toEqual(0);
-		});
-
-		it('should match gt', async () => {
-			await addModels(3);
-			const results = await DataStore.query(Model, m =>
-				m.field1('gt', 'field1 value 0')
-			);
-			expect(results.length).toEqual(2);
-		});
-
-		it('should match ge', async () => {
-			await addModels(3);
-			const results = await DataStore.query(Model, m =>
-				m.field1('ge', 'field1 value 1')
-			);
-			expect(results.length).toEqual(2);
-		});
-
-		it('should match lt', async () => {
-			await addModels(3);
-			const results = await DataStore.query(Model, m =>
-				m.field1('lt', 'field1 value 2')
-			);
-			expect(results.length).toEqual(2);
-		});
-
-		it('should match le', async () => {
-			await addModels(3);
-			const results = await DataStore.query(Model, m =>
-				m.field1('le', 'field1 value 1')
-			);
-			expect(results.length).toEqual(2);
-		});
-
-		it('should match eq', async () => {
-			await addModels(3);
-			const results = await DataStore.query(Model, m =>
-				m.field1('eq', 'field1 value 1')
-			);
-			expect(results.length).toEqual(1);
-		});
-
-		it('should match ne', async () => {
-			await addModels(3);
-			const results = await DataStore.query(Model, m =>
-				m.field1('ne', 'field1 value 1')
-			);
-			expect(results.length).toEqual(2);
 		});
 	});
 });

--- a/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
+++ b/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
@@ -109,24 +109,6 @@ describe('SQLiteAdapter', () => {
 	sqlog = [];
 
 	/**
-	 * Creates the given number of models, with `field1` populated to
-	 * `field1 value ${i}`.
-	 *
-	 * @param qty number of models to create. (default 3)
-	 */
-	// async function addModels(qty = 3) {
-	// 	for (let i = 0; i < qty; i++) {
-	// 		await DataStore.save(
-	// 			new Model({
-	// 				field1: `field1 value ${i}`,
-	// 				dateCreated: new Date().toISOString(),
-	// 				emails: [],
-	// 			})
-	// 		);
-	// 	}
-	// }
-
-	/**
 	 * Gets all mutations currently in the outbox. This should include ALL
 	 * mutations created/merged, because this test group starts the sync engine,
 	 * but prevents it from syncing/clearing the outbox.

--- a/packages/datastore-storage-adapter/__tests__/helpers.ts
+++ b/packages/datastore-storage-adapter/__tests__/helpers.ts
@@ -3,7 +3,6 @@ import {
 	MutableModel,
 	Schema,
 	InternalSchema,
-	SchemaModel,
 } from '@aws-amplify/datastore';
 
 export declare class Model {

--- a/packages/datastore-storage-adapter/package.json
+++ b/packages/datastore-storage-adapter/package.json
@@ -50,6 +50,7 @@
 					"lib": [
 						"es5",
 						"es2015",
+						"dom",
 						"esnext.asynciterable",
 						"es2019"
 					],
@@ -89,7 +90,8 @@
 			"/node_modules/",
 			"dist",
 			"lib",
-			"lib-esm"
+			"lib-esm",
+			"../datastore"
 		]
 	}
 }

--- a/packages/datastore-storage-adapter/package.json
+++ b/packages/datastore-storage-adapter/package.json
@@ -50,7 +50,6 @@
 					"lib": [
 						"es5",
 						"es2015",
-						"dom",
 						"esnext.asynciterable",
 						"es2019"
 					],

--- a/packages/datastore-storage-adapter/src/common/CommonSQLiteAdapter.ts
+++ b/packages/datastore-storage-adapter/src/common/CommonSQLiteAdapter.ts
@@ -147,9 +147,10 @@ export class CommonSQLiteAdapter implements StorageAdapter {
 				? modelUpdateStatement(instance, modelName)
 				: modelInsertStatement(instance, modelName);
 
-			saveStatements.add(saveStatement);
-
-			result.push([instance, opType]);
+			if (id === model.id || opType === OpType.INSERT) {
+				saveStatements.add(saveStatement);
+				result.push([instance, opType]);
+			}
 		}
 
 		await this.db.batchSave(saveStatements);

--- a/packages/datastore-storage-adapter/tslint.json
+++ b/packages/datastore-storage-adapter/tslint.json
@@ -13,7 +13,7 @@
 		"space-before-function-paren": [
 			true,
 			{
-				"anonymous": "always",
+				"anonymous": "never",
 				"named": "never"
 			}
 		],

--- a/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
+++ b/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
@@ -4,8 +4,9 @@ import {
 	initSchema as initSchemaType,
 } from '../src/datastore/datastore';
 import { PersistentModelConstructor, SortDirection } from '../src/types';
-import { Model, User, Profile, testSchema } from './helpers';
+import { pause, Model, User, Profile, testSchema } from './helpers';
 import { Predicates } from '../src/predicates';
+import { addCommonQueryTests } from './commonAdapterTests';
 
 let initSchema: typeof initSchemaType;
 let DataStore: typeof DataStoreType;
@@ -15,6 +16,19 @@ const ASAdapter = <any>AsyncStorageAdapter;
 describe('AsyncStorageAdapter tests', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+	});
+
+	async function getMutations(adapter) {
+		await pause(250);
+		return await adapter.getAll('sync_MutationEvent');
+	}
+
+	({ initSchema, DataStore } = require('../src/datastore/datastore'));
+	addCommonQueryTests({
+		initSchema,
+		DataStore,
+		storageAdapter: AsyncStorageAdapter,
+		getMutations,
 	});
 
 	describe('Query', () => {
@@ -65,6 +79,10 @@ describe('AsyncStorageAdapter tests', () => {
 					dateCreated: new Date(baseDate.getTime() + 2).toISOString(),
 				})
 			);
+		});
+
+		afterAll(async () => {
+			await DataStore.clear();
 		});
 
 		it('Should call getById for query by id', async () => {

--- a/packages/datastore/__tests__/IndexedDBAdapter.test.ts
+++ b/packages/datastore/__tests__/IndexedDBAdapter.test.ts
@@ -5,87 +5,38 @@ import {
 	initSchema as initSchemaType,
 } from '../src/datastore/datastore';
 import { PersistentModelConstructor, SortDirection } from '../src/types';
-import { Model, User, Profile, Post, Comment, testSchema } from './helpers';
+import {
+	pause,
+	expectMutation,
+	Model,
+	User,
+	Profile,
+	Post,
+	Comment,
+	testSchema,
+} from './helpers';
 import { Predicates } from '../src/predicates';
+import { addCommonQueryTests } from './commonAdapterTests';
 
 let initSchema: typeof initSchemaType;
 let DataStore: typeof DataStoreType;
 // using any to get access to private methods
 const IDBAdapter = <any>Adapter;
 
-async function pause(ms) {
-	return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-const UUID_REGEX =
-	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-
-/**
- * Tests a mutation for expected values. If values are present on the mutation
- * that are not expected, throws an error. Expected values can be listed as a
- * literal value, a regular expression, or a function (v => bool).
- *
- * `id` is automatically tested and expected to be a UUID unless an alternative
- *  matcher is provided.
- *
- * @param mutation A mutation record to check
- * @param values An object for specific values to test. Format of key: value | regex | v => bool
- */
-function expectMutation(mutation, values) {
-	const data = JSON.parse(mutation.data);
-	const matchers = {
-		id: UUID_REGEX,
-		...values,
-	};
-	const errors = [
-		...errorsFrom(data, matchers),
-		...extraFieldsFrom(data, matchers).map(f => `Unexpected field: ${f}`),
-	];
-	if (errors.length > 0) {
-		throw new Error(
-			`Bad mutation: ${JSON.stringify(data, null, 2)}\n${errors.join('\n')}`
-		);
-	}
-}
-
-/**
- * Checks an object for adherence to expected values from a set of matchers.
- * Returns a list of erroneous key-value pairs.
- * @param data the object to validate.
- * @param matchers the matcher functions/values/regexes to test the object with
- */
-function errorsFrom(data, matchers) {
-	return Object.entries(matchers).reduce((errors, [property, matcher]) => {
-		const value = data[property];
-		if (
-			!(
-				(typeof matcher === 'function' && matcher(value)) ||
-				(matcher instanceof RegExp && matcher.test(value)) ||
-				value === matcher
-			)
-		) {
-			errors.push(
-				`Property '${property}' value "${value}" does not match "${matcher}"`
-			);
-		}
-		return errors;
-	}, []);
-}
-
-/**
- * Checks to see if a given object contains any extra, unexpected properties.
- * If any are present, it returns the list of unexpectd fields.
- *
- * @param data the object that MIGHT contain extra fields.
- * @param template the authorative template object.
- */
-function extraFieldsFrom(data, template) {
-	const fields = Object.keys(data);
-	const expectedFields = new Set(Object.keys(template));
-	return fields.filter(name => !expectedFields.has(name));
-}
-
 describe('IndexedDBAdapter tests', () => {
+	async function getMutations(adapter) {
+		await pause(250);
+		return await adapter.getAll('sync_MutationEvent');
+	}
+
+	({ initSchema, DataStore } = require('../src/datastore/datastore'));
+	addCommonQueryTests({
+		initSchema,
+		DataStore,
+		storageAdapter: Adapter,
+		getMutations,
+	});
+
 	describe('Query', () => {
 		let Model: PersistentModelConstructor<Model>;
 		let model1Id: string;
@@ -97,6 +48,7 @@ describe('IndexedDBAdapter tests', () => {
 
 		beforeAll(async () => {
 			({ initSchema, DataStore } = require('../src/datastore/datastore'));
+			DataStore.configure({ storageAdapter: Adapter });
 
 			const classes = initSchema(testSchema());
 
@@ -110,6 +62,9 @@ describe('IndexedDBAdapter tests', () => {
 			// quickly enough that dates were colliding. (or so it seemed!)
 
 			const baseDate = new Date();
+
+			await DataStore.start();
+			await DataStore.clear();
 
 			({ id: model1Id } = await DataStore.save(
 				new Model({
@@ -187,120 +142,6 @@ describe('IndexedDBAdapter tests', () => {
 			expect(spyOnEngine).not.toHaveBeenCalled();
 			expect(spyOnMemory).not.toHaveBeenCalled();
 		});
-
-		it('should match fields of any non-empty value for `("ne", undefined)`', async () => {
-			const results = await DataStore.query(Model, m =>
-				m.field1('ne', undefined)
-			);
-			expect(results.length).toEqual(3);
-		});
-
-		it('should match fields of any non-empty value for `("ne", null)`', async () => {
-			const results = await DataStore.query(Model, m => m.field1('ne', null));
-			expect(results.length).toEqual(3);
-		});
-
-		it('should NOT match fields of any non-empty value for `("eq", undefined)`', async () => {
-			const results = await DataStore.query(Model, m =>
-				m.field1('eq', undefined)
-			);
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("eq", null)`', async () => {
-			const results = await DataStore.query(Model, m => m.field1('eq', null));
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("gt", null)`', async () => {
-			const results = await DataStore.query(Model, m => m.field1('gt', null));
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT  match fields of any non-empty value for `("ge", null)`', async () => {
-			const results = await DataStore.query(Model, m => m.field1('ge', null));
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("lt", null)`', async () => {
-			const results = await DataStore.query(Model, m => m.field1('lt', null));
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("le", null)`', async () => {
-			const results = await DataStore.query(Model, m => m.field1('le', null));
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("gt", undefined)`', async () => {
-			const results = await DataStore.query(Model, m =>
-				m.field1('gt', undefined)
-			);
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("ge", undefined)`', async () => {
-			const results = await DataStore.query(Model, m =>
-				m.field1('ge', undefined)
-			);
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("lt", undefined)`', async () => {
-			const results = await DataStore.query(Model, m =>
-				m.field1('lt', undefined)
-			);
-			expect(results.length).toEqual(0);
-		});
-
-		it('should NOT match fields of any non-empty value for `("le", undefined)`', async () => {
-			const results = await DataStore.query(Model, m =>
-				m.field1('le', undefined)
-			);
-			expect(results.length).toEqual(0);
-		});
-
-		it('should match gt', async () => {
-			const results = await DataStore.query(Model, m =>
-				m.field1('gt', 'field1 value 0')
-			);
-			expect(results.length).toEqual(2);
-		});
-
-		it('should match ge', async () => {
-			const results = await DataStore.query(Model, m =>
-				m.field1('ge', 'field1 value 1')
-			);
-			expect(results.length).toEqual(2);
-		});
-
-		it('should match lt', async () => {
-			const results = await DataStore.query(Model, m =>
-				m.field1('lt', 'field1 value 2')
-			);
-			expect(results.length).toEqual(2);
-		});
-
-		it('should match le', async () => {
-			const results = await DataStore.query(Model, m =>
-				m.field1('le', 'field1 value 1')
-			);
-			expect(results.length).toEqual(2);
-		});
-
-		it('should match eq', async () => {
-			const results = await DataStore.query(Model, m =>
-				m.field1('eq', 'field1 value 1')
-			);
-			expect(results.length).toEqual(1);
-		});
-
-		it('should match ne', async () => {
-			const results = await DataStore.query(Model, m =>
-				m.field1('ne', 'field1 value 1')
-			);
-			expect(results.length).toEqual(2);
-		});
 	});
 
 	describe('Delete', () => {
@@ -347,136 +188,6 @@ describe('IndexedDBAdapter tests', () => {
 			// both should be undefined, even though we only explicitly deleted the user
 			expect(user).toBeUndefined;
 			expect(profile).toBeUndefined;
-		});
-	});
-
-	describe('Save', () => {
-		let User: PersistentModelConstructor<User>;
-		let Profile: PersistentModelConstructor<Profile>;
-		let Comment: PersistentModelConstructor<Comment>;
-		let Post: PersistentModelConstructor<Post>;
-		let adapter: any;
-
-		async function getMutations() {
-			await pause(250);
-			return await adapter.getAll('sync_MutationEvent');
-		}
-
-		beforeEach(async () => {
-			({ initSchema, DataStore } = require('../src/datastore/datastore'));
-
-			DataStore.configure({
-				storageAdapter: Adapter,
-			});
-			(DataStore as any).amplifyConfig.aws_appsync_graphqlEndpoint =
-				'https://0.0.0.0/does/not/exist/graphql';
-
-			const classes = initSchema(testSchema());
-
-			({ User, Profile, Comment, Post } = classes as {
-				User: PersistentModelConstructor<User>;
-				Profile: PersistentModelConstructor<Profile>;
-				Comment: PersistentModelConstructor<Comment>;
-				Post: PersistentModelConstructor<Post>;
-			});
-
-			await DataStore.clear();
-
-			// ensure `.storageAdapter` is set.
-			await DataStore.start();
-
-			adapter = (DataStore as any).storageAdapter;
-			const syncEngine = (DataStore as any).sync;
-
-			// my jest spy-fu wasn't up to snuff here. but, this succesfully
-			// prevents the mutation process from clearing the mutation queue, which
-			// allows us to observe the state of mutations.
-			(syncEngine as any).mutationsProcessor.isReady = () => false;
-		});
-
-		it('should allow linking model via model field', async () => {
-			const profile = await DataStore.save(
-				new Profile({ firstName: 'Rick', lastName: 'Bob' })
-			);
-
-			const savedUser = await DataStore.save(
-				new User({ name: 'test', profile })
-			);
-			const user1Id = savedUser.id;
-
-			const user = await DataStore.query(User, user1Id);
-			expect(user.profileID).toEqual(profile.id);
-			expect(user.profile).toEqual(profile);
-		});
-
-		it('should allow linking model via FK', async () => {
-			const profile = await DataStore.save(
-				new Profile({ firstName: 'Rick', lastName: 'Bob' })
-			);
-
-			const savedUser = await DataStore.save(
-				new User({ name: 'test', profileID: profile.id })
-			);
-			const user1Id = savedUser.id;
-
-			const user = await DataStore.query(User, user1Id);
-			expect(user.profileID).toEqual(profile.id);
-			expect(user.profile).toEqual(profile);
-		});
-
-		it('should produce a single mutation for an updated model with a BelongTo (regression test)', async () => {
-			// SQLite adapter, for example, was producing an extra mutation
-			// in this scenario.
-
-			const post = await DataStore.save(
-				new Post({
-					title: 'some post',
-				})
-			);
-
-			const comment = await DataStore.save(
-				new Comment({
-					content: 'some comment',
-					post,
-				})
-			);
-
-			const updatedComment = await DataStore.save(
-				Comment.copyOf(comment, draft => {
-					draft.content = 'updated content';
-				})
-			);
-
-			const mutations = await getMutations();
-
-			// comment update should be smashed to together with post
-			expect(mutations.length).toBe(2);
-			expectMutation(mutations[0], { title: 'some post' });
-			expectMutation(mutations[1], {
-				content: 'updated content',
-				postId: mutations[0].modelId,
-			});
-		});
-
-		it('should produce a mutation for a nested BELONGS_TO insert', async () => {
-			const comment = await DataStore.save(
-				new Comment({
-					content: 'newly created comment',
-					post: new Post({
-						title: 'newly created post',
-					}),
-				})
-			);
-
-			const mutations = await getMutations();
-
-			// one for the new comment, one for the new post
-			expect(mutations.length).toBe(2);
-			expectMutation(mutations[0], { title: 'newly created post' });
-			expectMutation(mutations[1], {
-				content: 'newly created comment',
-				postId: mutations[0].modelId,
-			});
 		});
 	});
 });

--- a/packages/datastore/__tests__/commonAdapterTests.ts
+++ b/packages/datastore/__tests__/commonAdapterTests.ts
@@ -75,18 +75,21 @@ export function addCommonQueryTests({
 				new Model({
 					field1: 'field1 value 0',
 					dateCreated: baseDate.toISOString(),
+					emails: ['field1@exampl.com'],
 				})
 			);
 			await DataStore.save(
 				new Model({
 					field1: 'field1 value 1',
 					dateCreated: new Date(baseDate.getTime() + 1).toISOString(),
+					emails: ['field2@exampl.com'],
 				})
 			);
 			await DataStore.save(
 				new Model({
 					field1: 'field1 value 2',
 					dateCreated: new Date(baseDate.getTime() + 2).toISOString(),
+					emails: ['field3@exampl.com'],
 				})
 			);
 		});

--- a/packages/datastore/__tests__/commonAdapterTests.ts
+++ b/packages/datastore/__tests__/commonAdapterTests.ts
@@ -1,0 +1,347 @@
+import {
+	DataStore as DataStoreType,
+	PersistentModelConstructor,
+	initSchema as initSchemaType,
+} from '../src/';
+
+import {
+	pause,
+	expectMutation,
+	Model,
+	User,
+	Profile,
+	Post,
+	Comment,
+	testSchema,
+} from './helpers';
+
+export { pause };
+
+/**
+ * Adds common query test cases that all adapters should support.
+ *
+ * @param ctx A context object that provides a DataStore property, which returns
+ * a DataStore instance loaded with the storage adapter to test.
+ */
+export function addCommonQueryTests({
+	initSchema,
+	DataStore,
+	storageAdapter,
+	getMutations,
+}) {
+	describe('Common `query()` cases', () => {
+		let Model: PersistentModelConstructor<Model>;
+		let Comment: PersistentModelConstructor<Comment>;
+		let Post: PersistentModelConstructor<Post>;
+
+		beforeEach(async () => {
+			// ({ initSchema, DataStore } = require('../src/'));
+			DataStore.configure({ storageAdapter });
+
+			// establishing a fake appsync endpoint tricks DataStore into attempting
+			// sync operations, which we'll leverage to monitor how DataStore manages
+			// the outbox.
+			(DataStore as any).amplifyConfig.aws_appsync_graphqlEndpoint =
+				'https://0.0.0.0/does/not/exist/graphql';
+
+			const classes = initSchema(testSchema());
+			({ Comment, Model, Post } = classes as {
+				Comment: PersistentModelConstructor<Comment>;
+				Model: PersistentModelConstructor<Model>;
+				Post: PersistentModelConstructor<Post>;
+			});
+			await DataStore.clear();
+
+			// start() ensures storageAdapter is set
+			await DataStore.start();
+
+			const adapter = (DataStore as any).storageAdapter;
+			const db = (adapter as any).db;
+			const syncEngine = (DataStore as any).sync;
+
+			// my jest spy-fu wasn't up to snuff here. but, this succesfully
+			// prevents the mutation process from clearing the mutation queue, which
+			// allows us to observe the state of mutations.
+			(syncEngine as any).mutationsProcessor.isReady = () => false;
+
+			// NOTE: sort() test on these models can be flaky unless we
+			// strictly control the datestring of each! In a non-negligible percentage
+			// of test runs on a reasonably fast machine, DataStore.save() seemed to return
+			// quickly enough that dates were colliding. (or so it seemed!)
+
+			const baseDate = new Date();
+
+			await DataStore.save(
+				new Model({
+					field1: 'field1 value 0',
+					dateCreated: baseDate.toISOString(),
+				})
+			);
+			await DataStore.save(
+				new Model({
+					field1: 'field1 value 1',
+					dateCreated: new Date(baseDate.getTime() + 1).toISOString(),
+				})
+			);
+			await DataStore.save(
+				new Model({
+					field1: 'field1 value 2',
+					dateCreated: new Date(baseDate.getTime() + 2).toISOString(),
+				})
+			);
+		});
+
+		afterAll(async () => {
+			await DataStore.clear();
+
+			// prevent cross-contamination with other test suites that are not ~literally~
+			// expecting sync call counts to be ZERO.
+			(DataStore as any).amplifyConfig.aws_appsync_graphqlEndpoint = '';
+		});
+
+		it('should match fields of any non-empty value for `("ne", undefined)`', async () => {
+			const results = await DataStore.query(Model, m =>
+				m.field1('ne', undefined)
+			);
+			expect(results.length).toEqual(3);
+		});
+
+		it('should match fields of any non-empty value for `("ne", null)`', async () => {
+			const results = await DataStore.query(Model, m => m.field1('ne', null));
+			expect(results.length).toEqual(3);
+		});
+
+		it('should NOT match fields of any non-empty value for `("eq", undefined)`', async () => {
+			const results = await DataStore.query(Model, m =>
+				m.field1('eq', undefined)
+			);
+			expect(results.length).toEqual(0);
+		});
+
+		it('should NOT match fields of any non-empty value for `("eq", null)`', async () => {
+			const results = await DataStore.query(Model, m => m.field1('eq', null));
+			expect(results.length).toEqual(0);
+		});
+
+		it('should NOT match fields of any non-empty value for `("gt", null)`', async () => {
+			const results = await DataStore.query(Model, m => m.field1('gt', null));
+			expect(results.length).toEqual(0);
+		});
+
+		it('should NOT  match fields of any non-empty value for `("ge", null)`', async () => {
+			const results = await DataStore.query(Model, m => m.field1('ge', null));
+			expect(results.length).toEqual(0);
+		});
+
+		it('should NOT match fields of any non-empty value for `("lt", null)`', async () => {
+			const results = await DataStore.query(Model, m => m.field1('lt', null));
+			expect(results.length).toEqual(0);
+		});
+
+		it('should NOT match fields of any non-empty value for `("le", null)`', async () => {
+			const results = await DataStore.query(Model, m => m.field1('le', null));
+			expect(results.length).toEqual(0);
+		});
+
+		it('should NOT match fields of any non-empty value for `("gt", undefined)`', async () => {
+			const results = await DataStore.query(Model, m =>
+				m.field1('gt', undefined)
+			);
+			expect(results.length).toEqual(0);
+		});
+
+		it('should NOT match fields of any non-empty value for `("ge", undefined)`', async () => {
+			const results = await DataStore.query(Model, m =>
+				m.field1('ge', undefined)
+			);
+			expect(results.length).toEqual(0);
+		});
+
+		it('should NOT match fields of any non-empty value for `("lt", undefined)`', async () => {
+			const results = await DataStore.query(Model, m =>
+				m.field1('lt', undefined)
+			);
+			expect(results.length).toEqual(0);
+		});
+
+		it('should NOT match fields of any non-empty value for `("le", undefined)`', async () => {
+			const results = await DataStore.query(Model, m =>
+				m.field1('le', undefined)
+			);
+			expect(results.length).toEqual(0);
+		});
+
+		it('should match gt', async () => {
+			const results = await DataStore.query(Model, m =>
+				m.field1('gt', 'field1 value 0')
+			);
+			expect(results.length).toEqual(2);
+		});
+
+		it('should match ge', async () => {
+			const results = await DataStore.query(Model, m =>
+				m.field1('ge', 'field1 value 1')
+			);
+			expect(results.length).toEqual(2);
+		});
+
+		it('should match lt', async () => {
+			const results = await DataStore.query(Model, m =>
+				m.field1('lt', 'field1 value 2')
+			);
+			expect(results.length).toEqual(2);
+		});
+
+		it('should match le', async () => {
+			const results = await DataStore.query(Model, m =>
+				m.field1('le', 'field1 value 1')
+			);
+			expect(results.length).toEqual(2);
+		});
+
+		it('should match eq', async () => {
+			const results = await DataStore.query(Model, m =>
+				m.field1('eq', 'field1 value 1')
+			);
+			expect(results.length).toEqual(1);
+		});
+
+		it('should match ne', async () => {
+			const results = await DataStore.query(Model, m =>
+				m.field1('ne', 'field1 value 1')
+			);
+			expect(results.length).toEqual(2);
+		});
+	});
+
+	describe('Common `save()` cases', () => {
+		let Comment: PersistentModelConstructor<Comment>;
+		let Post: PersistentModelConstructor<Post>;
+		let Profile: PersistentModelConstructor<Profile>;
+		let User: PersistentModelConstructor<User>;
+		let adapter: any;
+
+		beforeEach(async () => {
+			// ({ initSchema, DataStore } = require('../src/'));
+			DataStore.configure({ storageAdapter });
+
+			// establishing a fake appsync endpoint tricks DataStore into attempting
+			// sync operations, which we'll leverage to monitor how DataStore manages
+			// the outbox.
+			(DataStore as any).amplifyConfig.aws_appsync_graphqlEndpoint =
+				'https://0.0.0.0/does/not/exist/graphql';
+
+			const classes = initSchema(testSchema());
+			({ User, Profile, Comment, Post } = classes as {
+				Comment: PersistentModelConstructor<Comment>;
+				Model: PersistentModelConstructor<Model>;
+				Post: PersistentModelConstructor<Post>;
+				Profile: PersistentModelConstructor<Profile>;
+				User: PersistentModelConstructor<User>;
+			});
+			await DataStore.clear();
+
+			// start() ensures storageAdapter is set
+			await DataStore.start();
+
+			adapter = (DataStore as any).storageAdapter;
+			const db = (adapter as any).db;
+			const syncEngine = (DataStore as any).sync;
+
+			// my jest spy-fu wasn't up to snuff here. but, this succesfully
+			// prevents the mutation process from clearing the mutation queue, which
+			// allows us to observe the state of mutations.
+			(syncEngine as any).mutationsProcessor.isReady = () => false;
+		});
+
+		afterAll(async () => {
+			await DataStore.clear();
+			(DataStore as any).amplifyConfig.aws_appsync_graphqlEndpoint = '';
+		});
+
+		it('should allow linking model via model field', async () => {
+			const profile = await DataStore.save(
+				new Profile({ firstName: 'Rick', lastName: 'Bob' })
+			);
+
+			const savedUser = await DataStore.save(
+				new User({ name: 'test', profile })
+			);
+			const user1Id = savedUser.id;
+
+			const user = await DataStore.query(User, user1Id);
+			expect(user.profileID).toEqual(profile.id);
+			expect(user.profile).toEqual(profile);
+		});
+
+		it('should allow linking model via FK', async () => {
+			const profile = await DataStore.save(
+				new Profile({ firstName: 'Rick', lastName: 'Bob' })
+			);
+
+			const savedUser = await DataStore.save(
+				new User({ name: 'test', profileID: profile.id })
+			);
+			const user1Id = savedUser.id;
+
+			const user = await DataStore.query(User, user1Id);
+			expect(user.profileID).toEqual(profile.id);
+			expect(user.profile).toEqual(profile);
+		});
+
+		it('should produce a single mutation for an updated model with a BelongTo (regression test)', async () => {
+			// SQLite adapter, for example, was producing an extra mutation
+			// in this scenario.
+
+			const post = await DataStore.save(
+				new Post({
+					title: 'some post',
+				})
+			);
+
+			const comment = await DataStore.save(
+				new Comment({
+					content: 'some comment',
+					post,
+				})
+			);
+
+			const updatedComment = await DataStore.save(
+				Comment.copyOf(comment, draft => {
+					draft.content = 'updated content';
+				})
+			);
+
+			const mutations = await getMutations(adapter);
+
+			// comment update should be smashed to together with post
+			expect(mutations.length).toBe(2);
+			expectMutation(mutations[0], { title: 'some post' });
+			expectMutation(mutations[1], {
+				content: 'updated content',
+				postId: mutations[0].modelId,
+			});
+		});
+
+		it('should produce a mutation for a nested BELONGS_TO insert', async () => {
+			const comment = await DataStore.save(
+				new Comment({
+					content: 'newly created comment',
+					post: new Post({
+						title: 'newly created post',
+					}),
+				})
+			);
+
+			const mutations = await getMutations(adapter);
+
+			// one for the new comment, one for the new post
+			expect(mutations.length).toBe(2);
+			expectMutation(mutations[0], { title: 'newly created post' });
+			expectMutation(mutations[1], {
+				content: 'newly created comment',
+				postId: mutations[0].modelId,
+			});
+		});
+	});
+}

--- a/packages/datastore/__tests__/commonAdapterTests.ts
+++ b/packages/datastore/__tests__/commonAdapterTests.ts
@@ -59,7 +59,6 @@ export function addCommonQueryTests({
 		}
 
 		beforeEach(async () => {
-			// ({ initSchema, DataStore } = require('../src/'));
 			DataStore.configure({ storageAdapter });
 
 			// establishing a fake appsync endpoint tricks DataStore into attempting
@@ -222,7 +221,6 @@ export function addCommonQueryTests({
 		let adapter: any;
 
 		beforeEach(async () => {
-			// ({ initSchema, DataStore } = require('../src/'));
 			DataStore.configure({ storageAdapter });
 
 			// establishing a fake appsync endpoint tricks DataStore into attempting

--- a/packages/datastore/__tests__/commonAdapterTests.ts
+++ b/packages/datastore/__tests__/commonAdapterTests.ts
@@ -34,6 +34,30 @@ export function addCommonQueryTests({
 		let Comment: PersistentModelConstructor<Comment>;
 		let Post: PersistentModelConstructor<Post>;
 
+		/**
+		 * Creates the given number of models, with `field1` populated to
+		 * `field1 value ${i}`.
+		 *
+		 * @param qty number of models to create. (default 3)
+		 */
+		async function addModels(qty = 3) {
+			// NOTE: sort() test on these models can be flaky unless we
+			// strictly control the datestring of each! In a non-negligible percentage
+			// of test runs on a reasonably fast machine, DataStore.save() seemed to return
+			// quickly enough that dates were colliding. (or so it seemed!)
+			const baseDate = new Date();
+
+			for (let i = 0; i < qty; i++) {
+				await DataStore.save(
+					new Model({
+						field1: `field1 value ${i}`,
+						dateCreated: new Date(baseDate.getTime() + i).toISOString(),
+						emails: [`field${i}@example.com`],
+					})
+				);
+			}
+		}
+
 		beforeEach(async () => {
 			// ({ initSchema, DataStore } = require('../src/'));
 			DataStore.configure({ storageAdapter });
@@ -64,34 +88,7 @@ export function addCommonQueryTests({
 			// allows us to observe the state of mutations.
 			(syncEngine as any).mutationsProcessor.isReady = () => false;
 
-			// NOTE: sort() test on these models can be flaky unless we
-			// strictly control the datestring of each! In a non-negligible percentage
-			// of test runs on a reasonably fast machine, DataStore.save() seemed to return
-			// quickly enough that dates were colliding. (or so it seemed!)
-
-			const baseDate = new Date();
-
-			await DataStore.save(
-				new Model({
-					field1: 'field1 value 0',
-					dateCreated: baseDate.toISOString(),
-					emails: ['field1@exampl.com'],
-				})
-			);
-			await DataStore.save(
-				new Model({
-					field1: 'field1 value 1',
-					dateCreated: new Date(baseDate.getTime() + 1).toISOString(),
-					emails: ['field2@exampl.com'],
-				})
-			);
-			await DataStore.save(
-				new Model({
-					field1: 'field1 value 2',
-					dateCreated: new Date(baseDate.getTime() + 2).toISOString(),
-					emails: ['field3@exampl.com'],
-				})
-			);
+			await addModels(3);
 		});
 
 		afterAll(async () => {

--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -6,6 +6,89 @@ import {
 	SchemaModel,
 } from '../src/types';
 
+/**
+ * Convenience function to wait for a number of ms.
+ *
+ * Intended as a cheap way to wait for async operations to settle.
+ *
+ * @param ms number of ms to pause for
+ */
+export async function pause(ms) {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Case insensitive regex that matches GUID's and UUID's.
+ * It does NOT permit whitespace on either end of the string. The caller must `trim()` first as-needed.
+ */
+export const UUID_REGEX =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Tests a mutation for expected values. If values are present on the mutation
+ * that are not expected, throws an error. Expected values can be listed as a
+ * literal value, a regular expression, or a function (v => bool).
+ *
+ * `id` is automatically tested and expected to be a UUID unless an alternative
+ *  matcher is provided.
+ *
+ * @param mutation A mutation record to check
+ * @param values An object for specific values to test. Format of key: value | regex | v => bool
+ */
+export function expectMutation(mutation, values) {
+	const data = JSON.parse(mutation.data);
+	const matchers = {
+		id: UUID_REGEX,
+		...values,
+	};
+	const errors = [
+		...errorsFrom(data, matchers),
+		...extraFieldsFrom(data, matchers).map(f => `Unexpected field: ${f}`),
+	];
+	if (errors.length > 0) {
+		throw new Error(
+			`Bad mutation: ${JSON.stringify(data, null, 2)}\n${errors.join('\n')}`
+		);
+	}
+}
+
+/**
+ * Checks an object for adherence to expected values from a set of matchers.
+ * Returns a list of erroneous key-value pairs.
+ * @param data the object to validate.
+ * @param matchers the matcher functions/values/regexes to test the object with
+ */
+export function errorsFrom(data, matchers) {
+	return Object.entries(matchers).reduce((errors, [property, matcher]) => {
+		const value = data[property];
+		if (
+			!(
+				(typeof matcher === 'function' && matcher(value)) ||
+				(matcher instanceof RegExp && matcher.test(value)) ||
+				value === matcher
+			)
+		) {
+			errors.push(
+				`Property '${property}' value "${value}" does not match "${matcher}"`
+			);
+		}
+		return errors;
+	}, []);
+}
+
+/**
+ * Checks to see if a given object contains any extra, unexpected properties.
+ * If any are present, it returns the list of unexpectd fields.
+ *
+ * @param data the object that MIGHT contain extra fields.
+ * @param template the authorative template object.
+ */
+export function extraFieldsFrom(data, template) {
+	const fields = Object.keys(data);
+	const expectedFields = new Set(Object.keys(template));
+	return fields.filter(name => !expectedFields.has(name));
+}
+
 export declare class Model {
 	public readonly id: string;
 	public readonly field1: string;

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -85,7 +85,8 @@
 		"testPathIgnorePatterns": [
 			"__tests__/model.ts",
 			"__tests__/schema.ts",
-			"__tests__/helpers.ts"
+			"__tests__/helpers.ts",
+			"__tests__/commonAdapterTests.ts"
 		],
 		"moduleFileExtensions": [
 			"ts",

--- a/packages/datastore/src/storage/adapter/InMemoryStore.ts
+++ b/packages/datastore/src/storage/adapter/InMemoryStore.ts
@@ -12,7 +12,7 @@ export class InMemoryStore {
 	multiRemove = async (keys: string[], callback?) => {
 		keys.forEach(k => this.db.delete(k));
 
-		callback();
+		typeof callback === 'function' && callback();
 	};
 
 	multiSet = async (entries: string[][], callback?) => {
@@ -20,7 +20,7 @@ export class InMemoryStore {
 			this.setItem(key, value);
 		});
 
-		callback();
+		typeof callback === 'function' && callback();
 	};
 
 	setItem = async (key: string, value: string) => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR fixes a regression in one of the fixes in #9813 and improves testing.

The original PR addressed several bugs. The fix for the bad mutation entries was red/green validated. However, the testing didn't go deep enough, and one of the related fixes would have produced the exact same red -> green test transition. Hence, either of two fixes satisfy the same test, meaning that a regression in either fix would go unnoticed.

A subsequent refactor of the SQLite adapter failed to carry the fix forward during merge conflict resolution.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Reported out of band.

#### Description of how you validated changes

This PR extends the adapter tests to validate mutations more deeply, and shares tests between adapters to better ensure the adapters share correct behavior.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
