### PR TITLE
fix: merge patches for consecutive copyOf

### DIFF
--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -702,7 +702,7 @@ describe('DataStore tests', () => {
 			});
 			model = model3;
 
-			let result = await DataStore.save(model3);
+			await DataStore.save(model3);
 
 			const [settingsSave, saveOriginalModel, saveModel3] = <any>(
 				save.mock.calls
@@ -719,7 +719,7 @@ describe('DataStore tests', () => {
 				{
 					op: 'replace',
 					path: ['optionalField1'],
-					value: 'opitionalField1Change1',
+					value: 'optionalField1Change1',
 				},
 			];
 			expect(patches).toMatchObject(expectedPatches);
@@ -972,9 +972,9 @@ describe('DataStore tests', () => {
 
 			const expectedPatches2 = [
 				{
-					op: 'add',
-					path: ['emails', 3],
-					value: 'joe@doe.com',
+					op: 'replace',
+					path: ['emails'],
+					value: ['john@doe.com', 'jane@doe.com', 'joe@doe.com', 'joe@doe.com'],
 				},
 			];
 

--- a/packages/datastore/__tests__/util.test.ts
+++ b/packages/datastore/__tests__/util.test.ts
@@ -1,3 +1,4 @@
+import { enablePatches, produce, Patch } from 'immer';
 import {
 	isAWSDate,
 	isAWSDateTime,
@@ -11,6 +12,7 @@ import {
 	validatePredicateField,
 	valuesEqual,
 	processCompositeKeys,
+	mergePatches,
 } from '../src/util';
 
 describe('datastore util', () => {
@@ -590,6 +592,130 @@ describe('datastore util', () => {
 		});
 		invalid.forEach(test => {
 			expect(isAWSIPAddress(test)).toBe(false);
+		});
+	});
+
+	describe('mergePatches', () => {
+		enablePatches();
+		test('merge patches with no conflict', () => {
+			const modelA = {
+				foo: 'originalFoo',
+				bar: 'originalBar',
+			};
+			let patchesAB;
+			let patchesBC;
+			const modelB = produce(
+				modelA,
+				draft => {
+					draft.foo = 'newFoo';
+				},
+				patches => {
+					patchesAB = patches;
+				}
+			);
+			const modelC = produce(
+				modelB,
+				draft => {
+					draft.bar = 'newBar';
+				},
+				patches => {
+					patchesBC = patches;
+				}
+			);
+
+			const mergedPatches = mergePatches(modelA, patchesAB, patchesBC);
+			expect(mergedPatches).toEqual([
+				{
+					op: 'replace',
+					path: ['foo'],
+					value: 'newFoo',
+				},
+				{
+					op: 'replace',
+					path: ['bar'],
+					value: 'newBar',
+				},
+			]);
+		});
+		test('merge patches with conflict', () => {
+			const modelA = {
+				foo: 'originalFoo',
+				bar: 'originalBar',
+			};
+			let patchesAB;
+			let patchesBC;
+			const modelB = produce(
+				modelA,
+				draft => {
+					draft.foo = 'newFoo';
+					draft.bar = 'newBar';
+				},
+				patches => {
+					patchesAB = patches;
+				}
+			);
+			const modelC = produce(
+				modelB,
+				draft => {
+					draft.bar = 'newestBar';
+				},
+				patches => {
+					patchesBC = patches;
+				}
+			);
+
+			const mergedPatches = mergePatches(modelA, patchesAB, patchesBC);
+			expect(mergedPatches).toEqual([
+				{
+					op: 'replace',
+					path: ['foo'],
+					value: 'newFoo',
+				},
+				{
+					op: 'replace',
+					path: ['bar'],
+					value: 'newestBar',
+				},
+			]);
+		});
+		test('merge patches with conflict - list', () => {
+			const modelA = {
+				foo: [1, 2, 3],
+			};
+			let patchesAB;
+			let patchesBC;
+			const modelB = produce(
+				modelA,
+				draft => {
+					draft.foo.push(4);
+				},
+				patches => {
+					patchesAB = patches;
+				}
+			);
+			const modelC = produce(
+				modelB,
+				draft => {
+					draft.foo.push(5);
+				},
+				patches => {
+					patchesBC = patches;
+				}
+			);
+
+			const mergedPatches = mergePatches(modelA, patchesAB, patchesBC);
+			expect(mergedPatches).toEqual([
+				{
+					op: 'add',
+					path: ['foo', 3],
+					value: 4,
+				},
+				{
+					op: 'add',
+					path: ['foo', 4],
+					value: 5,
+				},
+			]);
 		});
 	});
 });

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer';
 import { monotonicFactory, ULID } from 'ulid';
 import { v4 as uuid } from 'uuid';
+import { produce, applyPatches, Patch } from 'immer';
 import { ModelInstanceCreator } from './datastore/datastore';
 import {
 	AllOperators,
@@ -146,7 +147,7 @@ export const isNonModelConstructor = (
 	return nonModelClasses.has(obj);
 };
 
-/* 
+/*
   When we have GSI(s) with composite sort keys defined on a model
 	There are some very particular rules regarding which fields must be included in the update mutation input
 	The field selection becomes more complex as the number of GSIs with composite sort keys grows
@@ -156,7 +157,7 @@ export const isNonModelConstructor = (
 	 2. all of the fields from any other composite sort key that intersect with the fields from 1.
 
 	 E.g.,
-	 Model @model 
+	 Model @model
 		@key(name: 'key1' fields: ['hk', 'a', 'b', 'c'])
 		@key(name: 'key2' fields: ['hk', 'a', 'b', 'd'])
 		@key(name: 'key3' fields: ['hk', 'x', 'y', 'z'])
@@ -192,7 +193,7 @@ export const processCompositeKeys = (
 		.filter(isModelAttributeCompositeKey)
 		.map(extractCompositeSortKey);
 
-	/* 
+	/*
 		if 2 sets of fields have any intersecting fields => combine them into 1 union set
 		e.g., ['a', 'b', 'c'] and ['a', 'b', 'd'] => ['a', 'b', 'c', 'd']
 	*/
@@ -772,4 +773,40 @@ export class DeferredCallbackResolver {
 	public resolve(): void {
 		this.limitPromise.resolve(LimitTimerRaceResolvedValues.LIMIT);
 	}
+}
+
+/**
+ * merge two sets of patches created by immer produce.
+ * newPatches take precedent over oldPatches for patches modifying the same path.
+ * In the case many consecutive pathces are merged the original model should
+ * always be the root model.
+ *
+ * Example:
+ * A -> B, patches1
+ * B -> C, patches2
+ *
+ * mergePatches(A, patches1, patches2) to get patches for A -> C
+ *
+ * @param originalSource the original Model the patches should be applied to
+ * @param oldPatches immer produce patch list
+ * @param newPatches immer produce patch list (will take precedence)
+ * @return merged patches
+ */
+export function mergePatches<T>(
+	originalSource: T,
+	oldPatches: Patch[],
+	newPatches: Patch[]
+): Patch[] {
+	const patchesToMerge = oldPatches.concat(newPatches);
+	let patches: Patch[];
+	produce(
+		originalSource,
+		draft => {
+			applyPatches(draft, patchesToMerge);
+		},
+		p => {
+			patches = p;
+		}
+	);
+	return patches;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Merge patches to be applied to a model on consecutive calls of `copyOf`. 

* Given model A
* make a copy from A -> B, creates patchesAB
* make a copy from B -> C, creates patchesBC
* DataStore.save(C)

Previously the save would only use patchesBC even though other changes exist in patchesAB. This change now combines patchesAB and patchesBC to patchesAC so that all patches are applied on the save.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Resolves #9891

#### Description of how you validated changes

* Unit tests

Created an app with the following:

```typescript
const obj = await DataStore.query(MyModel, 'id'); // { foo: 'original', bar: 'original' }
const newObject = MyModel.copyOf(obj, draft => {
  draft.foo = 'foo1';
  draft.bar = 'bar1';
});
const newObject2 = MyModel.copyOf(newObject, draft => {
  draft.foo = 'foo2';
});

await DataStore.save(newObject2);
```

Then I checked in local storage and Studio to see if the model was saved as `{ foo: 'foo2', bar: 'bar1' }`.

Before the fix it would be saved as `{ foo: 'foo2', bar: 'original' }`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
