### PR TITLE
chore(deps): bump dexie from 3.2.0 to 3.2.2 in DataStore

### DIFF
--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -43,7 +43,7 @@
 	"devDependencies": {
 		"@react-native-community/netinfo": "4.7.0",
 		"@types/uuid": "3.4.5",
-		"dexie": "3.2.0",
+		"dexie": "3.2.2",
 		"dexie-export-import": "1.0.3",
 		"fake-indexeddb": "3.0.0"
 	},


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes Dependabot alert: https://github.com/aws-amplify/amplify-js/security/dependabot/14

Dependabot couldn't make an auto-PR because we don't have a `package-lock.json` checked in.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/security/dependabot/14


#### Description of how you validated changes
`yarn test`


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
