### PR TITLE
fix: resolve error-stack-parser, new bug blocking builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
 		"@babel/traverse": "7.17.9",
 		"@types/react": "16.9.10",
 		"terser": "4.6.7",
-		"npm-packlist": "1.1.12"
+		"npm-packlist": "1.1.12",
+		"error-stack-parser": "2.0.6"
 	},
 	"bundlewatch": {
 		"files": [


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

A new release of error-stack-parser introduced a build-blocking error. There is already [an issue in that repo](https://github.com/stacktracejs/error-stack-parser/issues/80) for the bug.  This PR resolves the dep to a known working version, 2.0.6.

Mirrors [`amplify-ui` PR](https://github.com/aws-amplify/amplify-ui/pull/2039/files) for the same breakage.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

`yarn setup-dev` was failing on a fresh clone and is **now succeeding**.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
