### PR TITLE
test(geo): Add unit tests for validateGeofenceId

### DIFF
--- a/packages/geo/__tests__/util.test.ts
+++ b/packages/geo/__tests__/util.test.ts
@@ -15,6 +15,7 @@ import {
 	validateCoordinates,
 	validateLinearRing,
 	validatePolygon,
+	validateGeofenceId,
 	validateGeofencesInput,
 } from '../src/util';
 
@@ -124,6 +125,40 @@ describe('Geo utility functions', () => {
 			).toThrowError(
 				'polygonTooManyVertices: Polygon has more than the maximum 1000 vertices.'
 			);
+		});
+	});
+
+	describe('validateGeofenceId', () => {
+		test('should not throw an error for a geofence ID with letters and numbers', () => {
+			expect(() => validateGeofenceId('ExampleGeofence1')).not.toThrowError();
+		});
+
+		test('should not throw an error for a geofence ID with a dash', () => {
+			expect(() => validateGeofenceId('ExampleGeofence-1')).not.toThrowError();
+		});
+
+		test('should not throw an error for a geofence ID with a period', () => {
+			expect(() => validateGeofenceId('ExampleGeofence.1')).not.toThrowError();
+		});
+
+		test('should not throw an error for a geofence ID with an underscore', () => {
+			expect(() => validateGeofenceId('ExampleGeofence_1')).not.toThrowError();
+		});
+
+		test('should not throw an error for a geofence ID with non-basic Latin character', () => {
+			expect(() => validateGeofenceId('ExampleGeòfence-1')).not.toThrowError();
+		});
+
+		test('should not throw an error for a geofence ID with superscript and subscript numbers', () => {
+			expect(() => validateGeofenceId('ExampleGeofence-⁴₆')).not.toThrowError();
+		});
+
+		test('should throw an error for an empty string', () => {
+			expect(() => validateGeofenceId('')).toThrowError();
+		});
+
+		test('should throw an error for a geofence ID with an invalid character', () => {
+			expect(() => validateGeofenceId('ExampleGeofence-1&')).toThrowError();
 		});
 	});
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR adds additional unit tests for the `validateGeofenceId` function as part of the Geofences feature. These tests are useful to be able to identify regressions with changes to the function required to resolve #9951.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#9951 

#### Description of how you validated changes

1. `yarn && yarn build` to initialize the packages
2. `cd packages/geo && yarn test` to validate all tests pass.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced) - N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
