### PR TITLE
fix(@aws-amplify/datastore): adds missing fields to items sent through observe/observeQuery

### DIFF
--- a/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
+++ b/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
@@ -120,12 +120,20 @@ describe('SQLiteAdapter', () => {
 		return await db.getAll('select * from MutationEvent', []);
 	}
 
+	async function clearOutbox() {
+		await pause(250);
+		const adapter = (DataStore as any).storageAdapter;
+		const db = (adapter as any).db;
+		return await db.executeStatements(['delete from MutationEvent']);
+	}
+
 	({ initSchema, DataStore } = require('@aws-amplify/datastore'));
 	addCommonQueryTests({
 		initSchema,
 		DataStore,
 		storageAdapter: SQLiteAdapter,
 		getMutations,
+		clearOutbox,
 	});
 
 	describe('something', () => {

--- a/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
+++ b/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
@@ -2,6 +2,7 @@ import AsyncStorageAdapter from '../src/storage/adapter/AsyncStorageAdapter';
 import {
 	DataStore as DataStoreType,
 	initSchema as initSchemaType,
+	syncClasses,
 } from '../src/datastore/datastore';
 import { PersistentModelConstructor, SortDirection } from '../src/types';
 import { pause, Model, User, Profile, testSchema } from './helpers';
@@ -23,12 +24,18 @@ describe('AsyncStorageAdapter tests', () => {
 		return await adapter.getAll('sync_MutationEvent');
 	}
 
+	async function clearOutbox(adapter) {
+		await pause(250);
+		return await adapter.delete(syncClasses['MutationEvent']);
+	}
+
 	({ initSchema, DataStore } = require('../src/datastore/datastore'));
 	addCommonQueryTests({
 		initSchema,
 		DataStore,
 		storageAdapter: AsyncStorageAdapter,
 		getMutations,
+		clearOutbox,
 	});
 
 	describe('Query', () => {

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -13,7 +13,16 @@ import {
 	PersistentModel,
 	PersistentModelConstructor,
 } from '../src/types';
-import { Comment, Model, Post, Metadata, testSchema, pause } from './helpers';
+import {
+	Comment,
+	Model,
+	Post,
+	Profile,
+	Metadata,
+	User,
+	testSchema,
+	pause,
+} from './helpers';
 
 let initSchema: typeof initSchemaType;
 let DataStore: typeof DataStoreType;
@@ -265,13 +274,17 @@ describe('DataStore observeQuery, with fake-indexeddb and fake sync', () => {
 
 	let Comment: PersistentModelConstructor<Comment>;
 	let Post: PersistentModelConstructor<Post>;
+	let User: PersistentModelConstructor<User>;
+	let Profile: PersistentModelConstructor<Profile>;
 
 	beforeEach(async () => {
 		({ initSchema, DataStore } = require('../src/datastore/datastore'));
 		const classes = initSchema(testSchema());
-		({ Comment, Post } = classes as {
+		({ Comment, Post, User, Profile } = classes as {
 			Comment: PersistentModelConstructor<Comment>;
 			Post: PersistentModelConstructor<Post>;
+			User: PersistentModelConstructor<User>;
+			Profile: PersistentModelConstructor<Profile>;
 		});
 
 		// This prevents pollution between tests. DataStore may have processes in
@@ -597,6 +610,249 @@ describe('DataStore observeQuery, with fake-indexeddb and fake sync', () => {
 				done(error);
 			}
 		})();
+	});
+
+	test('attaches related belongsTo properties consistently with query() on INSERT', async done => {
+		try {
+			const expecteds = [5, 15];
+
+			for (let i = 0; i < 5; i++) {
+				await DataStore.save(
+					new Comment({
+						content: `comment content ${i}`,
+						post: await DataStore.save(
+							new Post({
+								title: `new post ${i}`,
+							})
+						),
+					})
+				);
+			}
+
+			const sub = DataStore.observeQuery(Comment).subscribe(
+				({ items, isSynced }) => {
+					const expected = expecteds.shift() || 0;
+					expect(items.length).toBe(expected);
+
+					for (let i = 0; i < expected; i++) {
+						expect(items[i].content).toEqual(`comment content ${i}`);
+						expect(items[i].post.title).toEqual(`new post ${i}`);
+					}
+
+					if (expecteds.length === 0) {
+						sub.unsubscribe();
+						done();
+					}
+				}
+			);
+
+			setTimeout(async () => {
+				for (let i = 5; i < 15; i++) {
+					await DataStore.save(
+						new Comment({
+							content: `comment content ${i}`,
+							post: await DataStore.save(
+								new Post({
+									title: `new post ${i}`,
+								})
+							),
+						})
+					);
+				}
+			}, 1);
+		} catch (error) {
+			done(error);
+		}
+	});
+
+	test('attaches related hasOne properties consistently with query() on INSERT', async done => {
+		try {
+			const expecteds = [5, 15];
+
+			for (let i = 0; i < 5; i++) {
+				await DataStore.save(
+					new User({
+						name: `user ${i}`,
+						profile: await DataStore.save(
+							new Profile({
+								firstName: `firstName ${i}`,
+								lastName: `lastName ${i}`,
+							})
+						),
+					})
+				);
+			}
+
+			const sub = DataStore.observeQuery(User).subscribe(
+				({ items, isSynced }) => {
+					const expected = expecteds.shift() || 0;
+					expect(items.length).toBe(expected);
+
+					for (let i = 0; i < expected; i++) {
+						expect(items[i].name).toEqual(`user ${i}`);
+						expect(items[i].profile.firstName).toEqual(`firstName ${i}`);
+						expect(items[i].profile.lastName).toEqual(`lastName ${i}`);
+					}
+
+					if (expecteds.length === 0) {
+						sub.unsubscribe();
+						done();
+					}
+				}
+			);
+
+			setTimeout(async () => {
+				for (let i = 5; i < 15; i++) {
+					await DataStore.save(
+						new User({
+							name: `user ${i}`,
+							profile: await DataStore.save(
+								new Profile({
+									firstName: `firstName ${i}`,
+									lastName: `lastName ${i}`,
+								})
+							),
+						})
+					);
+				}
+			}, 1);
+		} catch (error) {
+			done(error);
+		}
+	});
+
+	test('attaches related belongsTo properties consistently with query() on UPDATE', async done => {
+		try {
+			const expecteds = [
+				['old post 0', 'old post 1', 'old post 2', 'old post 3', 'old post 4'],
+				['new post 0', 'new post 1', 'new post 2', 'new post 3', 'new post 4'],
+			];
+
+			for (let i = 0; i < 5; i++) {
+				await DataStore.save(
+					new Comment({
+						content: `comment content ${i}`,
+						post: await DataStore.save(
+							new Post({
+								title: `old post ${i}`,
+							})
+						),
+					})
+				);
+			}
+
+			const sub = DataStore.observeQuery(Comment).subscribe(
+				({ items, isSynced }) => {
+					const expected = expecteds.shift() || [];
+					expect(items.length).toBe(expected.length);
+
+					for (let i = 0; i < expected.length; i++) {
+						expect(items[i].content).toContain(`comment content ${i}`);
+						expect(items[i].post.title).toEqual(expected[i]);
+					}
+
+					if (expecteds.length === 0) {
+						sub.unsubscribe();
+						done();
+					}
+				}
+			);
+
+			setTimeout(async () => {
+				let postIndex = 0;
+				const comments = await DataStore.query(Comment);
+				for (const comment of comments) {
+					const newPost = await DataStore.save(
+						new Post({
+							title: `new post ${postIndex++}`,
+						})
+					);
+
+					await DataStore.save(
+						Comment.copyOf(comment, draft => {
+							draft.content = `updated: ${comment.content}`;
+							draft.post = newPost;
+						})
+					);
+				}
+			}, 1);
+		} catch (error) {
+			done(error);
+		}
+	});
+
+	test('attaches related hasOne properties consistently with query() on UPDATE', async done => {
+		try {
+			const expecteds = [
+				[
+					'first name 0',
+					'first name 1',
+					'first name 2',
+					'first name 3',
+					'first name 4',
+				],
+				[
+					'new first name 0',
+					'new first name 1',
+					'new first name 2',
+					'new first name 3',
+					'new first name 4',
+				],
+			];
+
+			for (let i = 0; i < 5; i++) {
+				await DataStore.save(
+					new User({
+						name: `user ${i}`,
+						profile: await DataStore.save(
+							new Profile({
+								firstName: `first name ${i}`,
+								lastName: `last name ${i}`,
+							})
+						),
+					})
+				);
+			}
+
+			const sub = DataStore.observeQuery(User).subscribe(
+				({ items, isSynced }) => {
+					const expected = expecteds.shift() || [];
+					expect(items.length).toBe(expected.length);
+
+					for (let i = 0; i < expected.length; i++) {
+						expect(items[i].name).toContain(`user ${i}`);
+						expect(items[i].profile.firstName).toEqual(expected[i]);
+					}
+
+					if (expecteds.length === 0) {
+						sub.unsubscribe();
+						done();
+					}
+				}
+			);
+
+			setTimeout(async () => {
+				let userIndex = 0;
+				const users = await DataStore.query(User);
+				for (const user of users) {
+					const newProfile = await DataStore.save(
+						new Profile({
+							firstName: `new first name ${userIndex++}`,
+							lastName: `new last name ${userIndex}`,
+						})
+					);
+
+					await DataStore.save(
+						User.copyOf(user, draft => {
+							draft.name = `updated: ${user.name}`;
+							draft.profile = newProfile;
+						})
+					);
+				}
+			}, 1);
+		} catch (error) {
+			done(error);
+		}
 	});
 });
 

--- a/packages/datastore/__tests__/IndexedDBAdapter.test.ts
+++ b/packages/datastore/__tests__/IndexedDBAdapter.test.ts
@@ -3,6 +3,7 @@ import 'fake-indexeddb/auto';
 import {
 	DataStore as DataStoreType,
 	initSchema as initSchemaType,
+	syncClasses,
 } from '../src/datastore/datastore';
 import { PersistentModelConstructor, SortDirection } from '../src/types';
 import {
@@ -29,12 +30,18 @@ describe('IndexedDBAdapter tests', () => {
 		return await adapter.getAll('sync_MutationEvent');
 	}
 
+	async function clearOutbox(adapter) {
+		await pause(250);
+		return await adapter.delete(syncClasses['MutationEvent']);
+	}
+
 	({ initSchema, DataStore } = require('../src/datastore/datastore'));
 	addCommonQueryTests({
 		initSchema,
 		DataStore,
 		storageAdapter: Adapter,
 		getMutations,
+		clearOutbox,
 	});
 
 	describe('Query', () => {

--- a/packages/datastore/__tests__/commonAdapterTests.ts
+++ b/packages/datastore/__tests__/commonAdapterTests.ts
@@ -361,7 +361,6 @@ export function addCommonQueryTests({
 			expect(mutations.length).toBe(1);
 			expectMutation(mutations[0], {
 				firstName: 'new first',
-				lastName: undefined,
 				_version: v => v === undefined || v === null,
 				_lastChangedAt: v => v === undefined || v === null,
 				_deleted: v => v === undefined || v === null,

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -43,7 +43,6 @@ import {
 	SchemaModel,
 	SchemaNamespace,
 	SchemaNonModel,
-	InternalSubscriptionMessage,
 	SubscriptionMessage,
 	DataStoreSnapshot,
 	SyncConflict,

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -1145,24 +1145,32 @@ class DataStore {
 				handle = this.storage
 					.observe(modelConstructor, predicate)
 					.filter(({ model }) => namespaceResolver(model) === USER)
-					.map(
-						(event: InternalSubscriptionMessage<T>): SubscriptionMessage<T> => {
-							// The `element` returned by storage only contains updated fields.
-							// Intercept the event to send the `savedElement` so that the first
-							// snapshot returned to the consumer contains all fields.
-							// In the event of a delete we return `element`, as `savedElement`
-							// here is undefined.
-							const { opType, model, condition, element, savedElement } = event;
+					.subscribe({
+						next: async item => {
+							// the `element` doesn't necessarily contain all item details or
+							// have related records attached consistently with that of a query()
+							// result item. for consistency, we attach them here.
 
-							return {
-								opType,
-								element: savedElement || element,
-								model,
-								condition,
-							};
-						}
-					)
-					.subscribe(observer);
+							let message = item;
+
+							// as lnog as we're not dealing with a DELETE, we need to fetch a fresh
+							// item from storage to ensure it's fully populated.
+							if (item.opType !== 'DELETE') {
+								const freshElement = await this.query(
+									item.model,
+									item.element.id
+								);
+								message = {
+									...message,
+									element: freshElement as T,
+								};
+							}
+
+							observer.next(message as SubscriptionMessage<T>);
+						},
+						error: err => observer.error(err),
+						complete: () => observer.complete(),
+					});
 			})();
 
 			return () => {

--- a/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
+++ b/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
@@ -399,6 +399,7 @@ export class AsyncStorageAdapter implements Adapter {
 			const nameSpace = this.namespaceResolver(modelConstructor);
 
 			const storeName = this.getStorenameForModel(modelConstructor);
+
 			if (condition) {
 				const fromDB = await this.db.get(model.id, storeName);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

`observe` and `observeQuery` were returning results that didn't contain all necessary fields and did not load related records the same way `query` does.

TODO:
- [x] Confirm that `observe` should *also* be updated along with `observeQuery` as this PR does
- [x] test with belongsTo
- [x] test with hasOne

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#9682


#### Description of how you validated changes

Added failing tests. Made the tests pass.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
