### PR TITLE
feat(@aws-amplify/geo): add searchForSuggestions API

### DIFF
--- a/packages/geo/__tests__/Geo.test.ts
+++ b/packages/geo/__tests__/Geo.test.ts
@@ -13,8 +13,9 @@
 import { Credentials } from '@aws-amplify/core';
 import {
 	LocationClient,
-	SearchPlaceIndexForPositionCommand,
 	SearchPlaceIndexForTextCommand,
+	SearchPlaceIndexForSuggestionsCommand,
+	SearchPlaceIndexForPositionCommand,
 } from '@aws-sdk/client-location';
 
 import { GeoClass } from '../src/Geo';
@@ -52,6 +53,18 @@ LocationClient.prototype.send = jest.fn(async command => {
 			Results: [
 				{
 					Place: TestPlacePascalCase,
+				},
+			],
+		};
+	}
+	if (command instanceof SearchPlaceIndexForSuggestionsCommand) {
+		return {
+			Results: [
+				{
+					Text: 'star',
+				},
+				{
+					Text: 'not star',
 				},
 			],
 		};
@@ -205,7 +218,7 @@ describe('Geo', () => {
 	});
 
 	describe('searchByText', () => {
-		const testString = 'starbucks';
+		const testString = 'star';
 
 		test('should search with just text input', async () => {
 			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
@@ -312,8 +325,124 @@ describe('Geo', () => {
 			geo.configure(awsConfig);
 			geo.removePluggable('AmazonLocationService');
 
-			const testString = 'starbucks';
 			await expect(geo.searchByText(testString)).rejects.toThrow(
+				'No plugin found in Geo for the provider'
+			);
+		});
+	});
+
+	describe('searchForSuggestions', () => {
+		const testString = 'star';
+		const testResults = ['star', 'not star'];
+
+		test('should search with just text input', async () => {
+			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+				return Promise.resolve(credentials);
+			});
+
+			const geo = new GeoClass();
+			geo.configure(awsConfig);
+
+			const results = await geo.searchForSuggestions(testString);
+			expect(results).toEqual(testResults);
+
+			const spyon = jest.spyOn(LocationClient.prototype, 'send');
+			const input = spyon.mock.calls[0][0].input;
+			expect(input).toEqual({
+				Text: testString,
+				IndexName: awsConfig.geo.amazon_location_service.search_indices.default,
+			});
+		});
+
+		test('should search using given options with biasPosition', async () => {
+			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+				return Promise.resolve(credentials);
+			});
+
+			const geo = new GeoClass();
+			geo.configure(awsConfig);
+
+			const searchOptions: SearchByTextOptions = {
+				biasPosition: [12345, 67890],
+				countries: ['USA'],
+				maxResults: 40,
+				searchIndexName: 'geoJSSearchCustomExample',
+			};
+			const results = await geo.searchForSuggestions(testString, searchOptions);
+			expect(results).toEqual(testResults);
+
+			const spyon = jest.spyOn(LocationClient.prototype, 'send');
+			const input = spyon.mock.calls[0][0].input;
+			expect(input).toEqual({
+				Text: testString,
+				IndexName: searchOptions.searchIndexName,
+				BiasPosition: searchOptions.biasPosition,
+				FilterCountries: searchOptions.countries,
+				MaxResults: searchOptions.maxResults,
+			});
+		});
+
+		test('should search using given options with searchAreaConstraints', async () => {
+			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+				return Promise.resolve(credentials);
+			});
+
+			const geo = new GeoClass();
+			geo.configure(awsConfig);
+
+			const searchOptions: SearchByTextOptions = {
+				searchAreaConstraints: [123, 456, 789, 321],
+				countries: ['USA'],
+				maxResults: 40,
+				searchIndexName: 'geoJSSearchCustomExample',
+			};
+			const results = await geo.searchForSuggestions(testString, searchOptions);
+			expect(results).toEqual(testResults);
+
+			const spyon = jest.spyOn(LocationClient.prototype, 'send');
+			const input = spyon.mock.calls[0][0].input;
+			expect(input).toEqual({
+				Text: testString,
+				IndexName: searchOptions.searchIndexName,
+				FilterBBox: searchOptions.searchAreaConstraints,
+				FilterCountries: searchOptions.countries,
+				MaxResults: searchOptions.maxResults,
+			});
+		});
+
+		test('should throw an error if both BiasPosition and SearchAreaConstraints are given in the options', async () => {
+			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+				return Promise.resolve(credentials);
+			});
+
+			const geo = new GeoClass();
+			geo.configure(awsConfig);
+
+			const searchOptions: SearchByTextOptions = {
+				countries: ['USA'],
+				maxResults: 40,
+				searchIndexName: 'geoJSSearchCustomExample',
+				biasPosition: [12345, 67890],
+				searchAreaConstraints: [123, 456, 789, 321],
+			};
+
+			await expect(
+				geo.searchForSuggestions(testString, searchOptions)
+			).rejects.toThrow(
+				'BiasPosition and SearchAreaConstraints are mutually exclusive, please remove one or the other from the options object'
+			);
+		});
+
+		test('should fail if there is no provider', async () => {
+			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+				return Promise.resolve(credentials);
+			});
+
+			const geo = new GeoClass();
+			geo.configure(awsConfig);
+			geo.removePluggable('AmazonLocationService');
+
+			await expect(geo.searchForSuggestions(testString)).rejects.toThrow(
 				'No plugin found in Geo for the provider'
 			);
 		});

--- a/packages/geo/__tests__/Providers/AmazonLocationServiceProvider.test.ts
+++ b/packages/geo/__tests__/Providers/AmazonLocationServiceProvider.test.ts
@@ -14,6 +14,7 @@ import { Credentials } from '@aws-amplify/core';
 import {
 	LocationClient,
 	SearchPlaceIndexForTextCommand,
+	SearchPlaceIndexForSuggestionsCommand,
 	SearchPlaceIndexForPositionCommand,
 } from '@aws-sdk/client-location';
 
@@ -51,6 +52,18 @@ LocationClient.prototype.send = jest.fn(async command => {
 			Results: [
 				{
 					Place: TestPlacePascalCase,
+				},
+			],
+		};
+	}
+	if (command instanceof SearchPlaceIndexForSuggestionsCommand) {
+		return {
+			Results: [
+				{
+					Text: 'star',
+				},
+				{
+					Text: 'not star',
 				},
 			],
 		};
@@ -159,7 +172,7 @@ describe('AmazonLocationServiceProvider', () => {
 	});
 
 	describe('searchByText', () => {
-		const testString = 'starbucks';
+		const testString = 'star';
 
 		test('should search with just text input', async () => {
 			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
@@ -301,6 +314,156 @@ describe('AmazonLocationServiceProvider', () => {
 			locationProvider.configure({});
 
 			expect(locationProvider.searchByText(testString)).rejects.toThrow(
+				'No Search Index found in amplify config, please run `amplify add geo` to create one and run `amplify push` after.'
+			);
+		});
+	});
+
+	describe('searchForSuggestions', () => {
+		const testString = 'star';
+		const testResults = ['star', 'not star'];
+
+		test('should search with just text input', async () => {
+			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+				return Promise.resolve(credentials);
+			});
+
+			const locationProvider = new AmazonLocationServiceProvider();
+			locationProvider.configure(awsConfig.geo.amazon_location_service);
+
+			const results = await locationProvider.searchForSuggestions(testString);
+
+			expect(results).toEqual(testResults);
+
+			const spyon = jest.spyOn(LocationClient.prototype, 'send');
+			const input = spyon.mock.calls[0][0].input;
+			expect(input).toEqual({
+				Text: testString,
+				IndexName: awsConfig.geo.amazon_location_service.search_indices.default,
+			});
+		});
+
+		test('should use biasPosition when given', async () => {
+			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+				return Promise.resolve(credentials);
+			});
+
+			const locationProvider = new AmazonLocationServiceProvider();
+			locationProvider.configure(awsConfig.geo.amazon_location_service);
+
+			const searchOptions: SearchByTextOptions = {
+				countries: ['USA'],
+				maxResults: 40,
+				searchIndexName: 'geoJSSearchCustomExample',
+				biasPosition: [12345, 67890],
+			};
+
+			const results = await locationProvider.searchForSuggestions(
+				testString,
+				searchOptions
+			);
+			expect(results).toEqual(testResults);
+
+			const spyon = jest.spyOn(LocationClient.prototype, 'send');
+			const input = spyon.mock.calls[0][0].input;
+
+			expect(input).toEqual({
+				Text: testString,
+				IndexName: searchOptions.searchIndexName,
+				BiasPosition: searchOptions.biasPosition,
+				FilterCountries: searchOptions.countries,
+				MaxResults: searchOptions.maxResults,
+			});
+		});
+
+		test('should use searchAreaConstraints when given', async () => {
+			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+				return Promise.resolve(credentials);
+			});
+
+			const locationProvider = new AmazonLocationServiceProvider();
+			locationProvider.configure(awsConfig.geo.amazon_location_service);
+
+			const searchOptions: SearchByTextOptions = {
+				countries: ['USA'],
+				maxResults: 40,
+				searchIndexName: 'geoJSSearchCustomExample',
+				searchAreaConstraints: [123, 456, 789, 321],
+			};
+
+			const resultsWithConstraints =
+				await locationProvider.searchForSuggestions(testString, searchOptions);
+			expect(resultsWithConstraints).toEqual(testResults);
+
+			const spyon = jest.spyOn(LocationClient.prototype, 'send');
+			const input = spyon.mock.calls[0][0].input;
+			expect(input).toEqual({
+				Text: testString,
+				IndexName: searchOptions.searchIndexName,
+				FilterBBox: searchOptions.searchAreaConstraints,
+				FilterCountries: searchOptions.countries,
+				MaxResults: searchOptions.maxResults,
+			});
+		});
+
+		test('should throw an error if both BiasPosition and SearchAreaConstraints are given in the options', async () => {
+			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+				return Promise.resolve(credentials);
+			});
+
+			const locationProvider = new AmazonLocationServiceProvider();
+			locationProvider.configure(awsConfig.geo.amazon_location_service);
+
+			const searchOptions: SearchByTextOptions = {
+				countries: ['USA'],
+				maxResults: 40,
+				searchIndexName: 'geoJSSearchCustomExample',
+				biasPosition: [12345, 67890],
+				searchAreaConstraints: [123, 456, 789, 321],
+			};
+
+			await expect(
+				locationProvider.searchForSuggestions(testString, searchOptions)
+			).rejects.toThrow(
+				'BiasPosition and SearchAreaConstraints are mutually exclusive, please remove one or the other from the options object'
+			);
+		});
+
+		test('should fail if credentials are invalid', async () => {
+			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+				return Promise.resolve();
+			});
+
+			const locationProvider = new AmazonLocationServiceProvider();
+
+			await expect(
+				locationProvider.searchForSuggestions(testString)
+			).rejects.toThrow('No credentials');
+		});
+
+		test('should fail if _getCredentials fails ', async () => {
+			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+				return Promise.reject();
+			});
+
+			const locationProvider = new AmazonLocationServiceProvider();
+
+			await expect(
+				locationProvider.searchForSuggestions(testString)
+			).rejects.toThrow('No credentials');
+		});
+
+		test('should fail if there are no search index resources', async () => {
+			jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
+				return Promise.resolve(credentials);
+			});
+
+			const locationProvider = new AmazonLocationServiceProvider();
+			locationProvider.configure({});
+
+			await expect(
+				locationProvider.searchForSuggestions(testString)
+			).rejects.toThrow(
 				'No Search Index found in amplify config, please run `amplify add geo` to create one and run `amplify push` after.'
 			);
 		});

--- a/packages/geo/src/Geo.ts
+++ b/packages/geo/src/Geo.ts
@@ -24,6 +24,7 @@ import {
 	GeoConfig,
 	Coordinates,
 	SearchByTextOptions,
+	SearchForSuggestionsResults,
 	SearchByCoordinatesOptions,
 	GeoProvider,
 	MapStyle,
@@ -162,6 +163,27 @@ export class GeoClass {
 
 		try {
 			return await prov.searchByText(text, options);
+		} catch (error) {
+			logger.debug(error);
+			throw error;
+		}
+	}
+
+	/**
+	 * Search for search term suggestions based on input text
+	 * @param  {string} text - The text string that is to be search for
+	 * @param  {SearchByTextOptions} options? - Optional parameters to the search
+	 * @returns {Promise<SearchForSuggestionsResults>} - Resolves to an array of search suggestion strings
+	 */
+	public async searchForSuggestions(
+		text: string,
+		options?: SearchByTextOptions
+	) {
+		const { providerName = DEFAULT_PROVIDER } = options || {};
+		const prov = this.getPluggable(providerName);
+
+		try {
+			return await prov.searchForSuggestions(text, options);
 		} catch (error) {
 			logger.debug(error);
 			throw error;

--- a/packages/geo/src/Providers/AmazonLocationServiceProvider.ts
+++ b/packages/geo/src/Providers/AmazonLocationServiceProvider.ts
@@ -19,9 +19,11 @@ import {
 } from '@aws-amplify/core';
 import {
 	Place as PlaceResult,
-	SearchPlaceIndexForTextCommandInput,
 	LocationClient,
 	SearchPlaceIndexForTextCommand,
+	SearchPlaceIndexForTextCommandInput,
+	SearchPlaceIndexForSuggestionsCommand,
+	SearchPlaceIndexForSuggestionsCommandInput,
 	SearchPlaceIndexForPositionCommand,
 	SearchPlaceIndexForPositionCommandInput,
 	BatchPutGeofenceCommand,
@@ -45,6 +47,7 @@ import {
 	GeoConfig,
 	SearchByTextOptions,
 	SearchByCoordinatesOptions,
+	SearchForSuggestionsResults,
 	GeoProvider,
 	Place,
 	AmazonLocationServiceMapStyle,
@@ -217,6 +220,82 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 		const results: Place[] = camelcaseKeys(PascalResults, {
 			deep: true,
 		}) as undefined as Place[];
+
+		return results;
+	}
+
+	/**
+	 * Search for suggestions based on the input text
+	 * @param  {string} text - The text string that is to be searched for
+	 * @param  {SearchByTextOptions} options? - Optional parameters to the search
+	 * @returns {Promise<SearchForSuggestionsResults>} - Resolves to an array of search suggestion strings
+	 */
+
+	public async searchForSuggestions(
+		text: string,
+		options?: SearchByTextOptions
+	): Promise<SearchForSuggestionsResults> {
+		const credentialsOK = await this._ensureCredentials();
+		if (!credentialsOK) {
+			throw new Error('No credentials');
+		}
+
+		this._verifySearchIndex(options?.searchIndexName);
+
+		/**
+		 * Setup the searchInput
+		 */
+		const locationServiceInput: SearchPlaceIndexForSuggestionsCommandInput = {
+			Text: text,
+			IndexName: this._config.search_indices.default,
+		};
+
+		/**
+		 * Map search options to Amazon Location Service input object
+		 */
+		if (options) {
+			locationServiceInput.FilterCountries = options.countries;
+			locationServiceInput.MaxResults = options.maxResults;
+
+			if (options.searchIndexName) {
+				locationServiceInput.IndexName = options.searchIndexName;
+			}
+
+			if (options['biasPosition'] && options['searchAreaConstraints']) {
+				throw new Error(
+					'BiasPosition and SearchAreaConstraints are mutually exclusive, please remove one or the other from the options object'
+				);
+			}
+			if (options['biasPosition']) {
+				locationServiceInput.BiasPosition = options['biasPosition'];
+			}
+			if (options['searchAreaConstraints']) {
+				locationServiceInput.FilterBBox = options['searchAreaConstraints'];
+			}
+		}
+
+		const client = new LocationClient({
+			credentials: this._config.credentials,
+			region: this._config.region,
+			customUserAgent: getAmplifyUserAgent(),
+		});
+		const command = new SearchPlaceIndexForSuggestionsCommand(
+			locationServiceInput
+		);
+
+		let response;
+		try {
+			response = await client.send(command);
+		} catch (error) {
+			logger.debug(error);
+			throw error;
+		}
+
+		/**
+		 * The response from Amazon Location Service is a "Results" array of objects with a single `Text` item.
+		 * Here we want to flatten that to an array of just the strings from those `Text` items.
+		 */
+		const results = response.Results.map(result => result.Text);
 
 		return results;
 	}

--- a/packages/geo/src/types/Geo.ts
+++ b/packages/geo/src/types/Geo.ts
@@ -84,6 +84,9 @@ export type SearchByCoordinatesOptions = {
 	providerName?: string;
 };
 
+// Return type for searchForSuggestions
+export type SearchForSuggestionsResults = string[];
+
 // Geometry object for Place points
 export type PlaceGeometry = {
 	point: Coordinates;

--- a/packages/geo/src/types/Provider.ts
+++ b/packages/geo/src/types/Provider.ts
@@ -13,6 +13,7 @@
 import {
 	SearchByTextOptions,
 	SearchByCoordinatesOptions,
+	SearchForSuggestionsResults,
 	Coordinates,
 	Place,
 	MapStyle,
@@ -50,6 +51,12 @@ export interface GeoProvider {
 		coordinates: Coordinates,
 		options?: SearchByCoordinatesOptions
 	): Promise<Place>;
+
+	// search for suggestions based on a text string
+	searchForSuggestions(
+		text: string,
+		options?: SearchByTextOptions
+	): Promise<SearchForSuggestionsResults>;
 
 	// create geofences
 	saveGeofences(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Adds `searchForSuggestions` API back into the `@geo` developer preview tag
This is essentially a revert of the revert that removed this API from `main` a few months ago due to needing an update on the underlying API. We are releasing again under developer preview as we wait for the next stage from Amazon Location Service on their API.

#### Description of how you validated changes
- Tests are included
- Ran through sample app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
