### PR TITLE
fix(in-app-messaging): Disable web session tracker when in non-browse…

### DIFF
--- a/packages/notifications/__tests__/InAppMessaging/InAppMessaging.test.ts
+++ b/packages/notifications/__tests__/InAppMessaging/InAppMessaging.test.ts
@@ -40,6 +40,14 @@ import { mockInAppMessagingProvider, mockStorage } from '../../__mocks__/mocks';
 
 jest.mock('@aws-amplify/core');
 jest.mock('../../src/InAppMessaging/eventListeners');
+jest.mock('../../src/InAppMessaging/Providers', () => ({
+	AWSPinpointProvider: () => ({
+		getCategory: jest.fn,
+		getSubCategory: jest.fn,
+		getProviderName: jest.fn,
+		configure: jest.fn,
+	}),
+}));
 
 const PROVIDER_NAME = 'InAppMessagingProvider';
 

--- a/packages/notifications/__tests__/Notifications.test.ts
+++ b/packages/notifications/__tests__/Notifications.test.ts
@@ -15,6 +15,9 @@ import Notifications from '../src/Notifications';
 import { adhocConfig, awsConfig, notificationsConfig } from '../__mocks__/data';
 
 jest.mock('@aws-amplify/core');
+jest.mock('../src/InAppMessaging', () =>
+	jest.fn(() => ({ configure: () => {} }))
+);
 
 describe('Notifications', () => {
 	test('registers with Amplify', () => {


### PR DESCRIPTION
…r environment

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR updates the web session tracker for notifications to check if it is operating within a browser environment. If not, attempting to even *check* for `document` being defined can crash an app.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
