### PR TITLE
fix: update geo integ tests to use chrome due to issue with CRA Jest …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ executors:
 
   js-test-executor:
     docker:
-      - image: cypress/included:9.4.1
+      - image: cypress/included:8.7.0
       - image: verdaccio/verdaccio
         auth:
           username: $DOCKERHUB_USERNAME
@@ -1112,14 +1112,16 @@ jobs:
           category: geo
           sample_name: display-map
           spec: display-map
-          browser: << parameters.browser >>
+          # Temp fix:
+          browser: chrome
       - integ_test_js:
           test_name: 'Search Outside Map'
           framework: react
           category: geo
           sample_name: search-outside-map
           spec: search-outside-map
-          browser: << parameters.browser >>
+          # Temp fix:
+          browser: chrome
   deploy:
     executor: macos-executor
     working_directory: ~/amplify-js


### PR DESCRIPTION
…dependency when using Node 16.5.x

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Today we ran into an issue with the integ tests failing. We discovered that create react app, using yarn, fails, due to a recent update of a Jest dependency when using Node 16.5.x.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
