### PR TITLE
feat(predictions):adds ssml support to polly integration

### DIFF
--- a/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
@@ -124,7 +124,7 @@ export class AmazonAIConvertPredictionsProvider extends AbstractConvertPredictio
 			OutputFormat: 'mp3',
 			Text: input.textToSpeech.source.text,
 			VoiceId: voiceId,
-			TextType: 'text',
+			TextType: input.textToSpeech.source.textType || 'text',
 			SampleRate: '24000',
 			// tslint:disable-next-line: align
 		});
@@ -254,9 +254,10 @@ export class AmazonAIConvertPredictionsProvider extends AbstractConvertPredictio
 			let fullText = '';
 			connection.onmessage = message => {
 				try {
-					const decodedMessage = AmazonAIConvertPredictionsProvider.serializeDataFromTranscribe(
-						message
-					);
+					const decodedMessage =
+						AmazonAIConvertPredictionsProvider.serializeDataFromTranscribe(
+							message
+						);
 					if (decodedMessage) {
 						fullText += decodedMessage + ' ';
 					}

--- a/packages/predictions/src/types/Predictions.ts
+++ b/packages/predictions/src/types/Predictions.ts
@@ -103,6 +103,7 @@ export interface TextToSpeechInput {
 	textToSpeech: {
 		source: {
 			text: string;
+			textType?: 'text' | 'ssml';
 		};
 		terminology?: string;
 		voiceId?: string;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- Adds optional `textType` property to `TextToSpeechInput` interface that can be set to either 'text' or 'ssml'.
- Updated the SynthesizeSpeech call so the TextType can be set by the `textType` property. TextType defaults to 'text' if `textType` property is undefined maintaining current functionality.

#### Issue #, if available

- [6075](https://github.com/aws-amplify/amplify-js/issues/6075)

<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

- Ran change through a sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
