### PR TITLE
feat(@aws-amplify/auth): auto sign in after sign up or confirm sign u…

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -45,7 +45,6 @@ import {
 	UniversalStorage,
 	urlSafeDecode,
 	HubCallback,
-	HubPayload,
 } from '@aws-amplify/core';
 import {
 	CookieStorage,

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -31,6 +31,7 @@ import {
 	FederatedSignInOptions,
 	AwsCognitoOAuthOpts,
 	ClientMetaData,
+	AutoSignInResponse,
 } from './types';
 
 import {
@@ -285,22 +286,36 @@ export class AuthClass {
 	public signUp(
 		params: string | SignUpParams,
 		...restOfAttrs: string[]
-	): Promise<ISignUpResult> {
+	): Promise<ISignUpResult | AutoSignInResponse> {
 		if (!this.userPool) {
 			return this.rejectNoUserPool();
 		}
-
 		let username: string = null;
 		let password: string = null;
 		const attributes: CognitoUserAttribute[] = [];
 		let validationData: CognitoUserAttribute[] = null;
 		let clientMetadata;
+		let autoSignIn = false;
+		let confirmSignUp = true;
+		let confirmSignUpOption = 'code';
 
 		if (params && typeof params === 'string') {
 			username = params;
 			password = restOfAttrs ? restOfAttrs[0] : null;
 			const email: string = restOfAttrs ? restOfAttrs[1] : null;
 			const phone_number: string = restOfAttrs ? restOfAttrs[2] : null;
+
+			if (restOfAttrs && restOfAttrs[3] && restOfAttrs[3] === 'true') {
+				autoSignIn = true;
+			}
+
+			if (restOfAttrs && restOfAttrs[4] && restOfAttrs[4] === 'false') {
+				confirmSignUp = false;
+			}
+
+			if (restOfAttrs && restOfAttrs[5]) {
+				confirmSignUpOption = restOfAttrs[5];
+			}
 
 			if (email)
 				attributes.push(
@@ -345,6 +360,15 @@ export class AuthClass {
 					);
 				});
 			}
+			if (params['autoSignIn']) {
+				autoSignIn = params['autoSignIn'];
+			}
+			if (params['confirmSignUp']) {
+				confirmSignUp = params['confirmSignUp'];
+			}
+			if (params['confirmSignUpOption']) {
+				confirmSignUpOption = params['confirmSignUpOption'];
+			}
 		} else {
 			return this.rejectAuthError(AuthErrorTypes.SignUpError);
 		}
@@ -354,6 +378,9 @@ export class AuthClass {
 		}
 		if (!password) {
 			return this.rejectAuthError(AuthErrorTypes.EmptyPassword);
+		}
+		if (autoSignIn && confirmSignUpOption === 'code') {
+			this._storage.setItem('user_password', password);
 		}
 
 		logger.debug('signUp attrs:', attributes);
@@ -379,7 +406,60 @@ export class AuthClass {
 							data,
 							`${username} has signed up successfully`
 						);
-						resolve(data);
+						if (
+							autoSignIn &&
+							(!confirmSignUp || confirmSignUpOption === 'link')
+						) {
+							let times = 0;
+							const user = this.createCognitoUser(username);
+							const authDetails = new AuthenticationDetails({
+								Username: username,
+								Password: password,
+								ValidationData: validationData,
+								ClientMetadata: clientMetadata,
+							});
+							let result = null;
+							const interval = setInterval(async () => {
+								await user.authenticateUser(
+									authDetails,
+									this.authCallbacks(
+										user,
+										value => {
+											dispatchAuthEvent(
+												'signIn',
+												data,
+												`${username} has signed in successfully`
+											);
+											result = value;
+										},
+										error => {
+											dispatchAuthEvent(
+												'signIn',
+												error,
+												`${username} failed to sign in`
+											);
+										}
+									)
+								);
+								times += 1;
+								if (times >= 120 || result) {
+									clearInterval(interval);
+									result
+										? resolve({
+												operationResult: 'success',
+												user: result,
+												userConfirmed: true,
+										  })
+										: resolve({
+												operationResult: 'success',
+												user: null,
+												userConfirmed: false,
+										  });
+								}
+							}, 5000);
+						} else {
+							resolve(data);
+						}
 					}
 				},
 				clientMetadata
@@ -398,7 +478,7 @@ export class AuthClass {
 		username: string,
 		code: string,
 		options?: ConfirmSignUpOptions
-	): Promise<any> {
+	): Promise<AutoSignInResponse | any> {
 		if (!this.userPool) {
 			return this.rejectNoUserPool();
 		}
@@ -428,6 +508,46 @@ export class AuthClass {
 				(err, data) => {
 					if (err) {
 						reject(err);
+					} else if (options && options.autoSignIn) {
+						dispatchAuthEvent(
+							'confirmSignUp',
+							data,
+							`${username} has been confirmed successfully`
+						);
+						let password = null;
+						password = this._storage.getItem('user_password');
+						if (password) {
+							const validationData = {};
+							const authDetails = new AuthenticationDetails({
+								Username: username,
+								Password: password,
+								ValidationData: validationData,
+								ClientMetadata: clientMetadata,
+							});
+							user.authenticateUser(
+								authDetails,
+								this.authCallbacks(
+									user,
+									value => {
+										this._storage.removeItem('user_password');
+										resolve({
+											operationResult: 'success',
+											user: value,
+											userConfirmed: true,
+										});
+									},
+									error => {
+										reject(error);
+									}
+								)
+							);
+						} else {
+							resolve({
+								operationResult: 'success',
+								user: null,
+								userConfirmed: true,
+							});
+						}
 					} else {
 						resolve(data);
 					}

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -14,6 +14,7 @@
 import {
 	ICookieStorageData,
 	ICognitoStorage,
+	CognitoUser,
 } from 'amazon-cognito-identity-js';
 
 /**
@@ -25,6 +26,9 @@ export interface SignUpParams {
 	attributes?: object;
 	validationData?: { [key: string]: any };
 	clientMetadata?: { [key: string]: string };
+	autoSignIn?: boolean;
+	confirmSignUp?: boolean;
+	confirmSignUpOption?: string;
 }
 
 export interface AuthCache {
@@ -50,6 +54,9 @@ export interface AuthOptions {
 	identityPoolRegion?: string;
 	clientMetadata?: any;
 	endpoint?: string;
+	autoSignIn?: boolean;
+	confirmSignUp?: boolean;
+	confirmSignUpOption?: string;
 }
 
 export enum CognitoHostedUIIdentityProvider {
@@ -166,6 +173,7 @@ export type OAuthOpts = AwsCognitoOAuthOpts | Auth0OAuthOpts;
 export interface ConfirmSignUpOptions {
 	forceAliasCreation?: boolean;
 	clientMetadata?: ClientMetaData;
+	autoSignIn?: boolean;
 }
 
 export interface SignOutOpts {
@@ -234,4 +242,14 @@ export enum GRAPHQL_AUTH_MODE {
 	OPENID_CONNECT = 'OPENID_CONNECT',
 	AMAZON_COGNITO_USER_POOLS = 'AMAZON_COGNITO_USER_POOLS',
 	AWS_LAMBDA = 'AWS_LAMBDA',
+}
+
+/**
+ * interface for signUpResponse
+ */
+
+export interface AutoSignInResponse {
+	operationResult: string;
+	user?: CognitoUser;
+	userConfirmed: boolean;
 }

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -51,7 +51,7 @@ export interface AuthOptions {
 	identityPoolRegion?: string;
 	clientMetadata?: any;
 	endpoint?: string;
-	autoSignIn?: boolean;
+	verificationMethod?: string;
 }
 
 export enum CognitoHostedUIIdentityProvider {

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -14,7 +14,6 @@
 import {
 	ICookieStorageData,
 	ICognitoStorage,
-	CognitoUser,
 } from 'amazon-cognito-identity-js';
 
 /**

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -27,8 +27,6 @@ export interface SignUpParams {
 	validationData?: { [key: string]: any };
 	clientMetadata?: { [key: string]: string };
 	autoSignIn?: boolean;
-	confirmSignUp?: boolean;
-	confirmSignUpOption?: string;
 }
 
 export interface AuthCache {
@@ -55,8 +53,6 @@ export interface AuthOptions {
 	clientMetadata?: any;
 	endpoint?: string;
 	autoSignIn?: boolean;
-	confirmSignUp?: boolean;
-	confirmSignUpOption?: string;
 }
 
 export enum CognitoHostedUIIdentityProvider {
@@ -173,7 +169,6 @@ export type OAuthOpts = AwsCognitoOAuthOpts | Auth0OAuthOpts;
 export interface ConfirmSignUpOptions {
 	forceAliasCreation?: boolean;
 	clientMetadata?: ClientMetaData;
-	autoSignIn?: boolean;
 }
 
 export interface SignOutOpts {
@@ -242,14 +237,4 @@ export enum GRAPHQL_AUTH_MODE {
 	OPENID_CONNECT = 'OPENID_CONNECT',
 	AMAZON_COGNITO_USER_POOLS = 'AMAZON_COGNITO_USER_POOLS',
 	AWS_LAMBDA = 'AWS_LAMBDA',
-}
-
-/**
- * interface for signUpResponse
- */
-
-export interface AutoSignInResponse {
-	operationResult: string;
-	user?: CognitoUser;
-	userConfirmed: boolean;
 }

--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -25,6 +25,7 @@ export const parseMobileHubConfig = (config): AmplifyConfig => {
 			identityPoolId: config['aws_cognito_identity_pool_id'],
 			identityPoolRegion: config['aws_cognito_region'],
 			mandatorySignIn: config['aws_mandatory_sign_in'] === 'enable',
+			verificationMethod: config['aws_cognito_verification_method'] || 'code',
 		};
 	}
 


### PR DESCRIPTION
…p implementation

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Changes add confirm sign up listener to initiate auto sign in once account is confirmed. It happens if autoSignIn is set to true in params for SignUp function. 
Since customers can choose either code, link, or autoConfirm, the solution use three different ways to auto sign in. autoConfirm implementation immediately calls on confirmSignUp function. Link implementation uses polling to sign user in since there is no explicit way to know if user clicked the link. Polling is done within 3 minutes (time verification link is valid) every 5 seconds. Code implementation is using hub listening event. Once user confirms account with code, it dispatches listening event. SignUp function is listening for this event to initiate SignIn process.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
