### PR TITLE
ci: correctly utilize @next version when scaffolding for react-native

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1860,7 +1860,7 @@ orbs:
           - run-with-retry:
               label: Scaffold App
               pre-command: cd ../ && rm -rf amplify_getting_started_<< parameters.framework >>
-              command: npx react-native@<< parameters.tag >> init amplify_getting_started_<< parameters.framework >>
+              command: npx react-native@<< parameters.tag >> init amplify_getting_started_<< parameters.framework >> --version << parameters.tag >>
               no_output_timeout: 10m
           - run-with-retry:
               label: Install Amplify dependencies
@@ -1912,7 +1912,7 @@ orbs:
           - run-with-retry:
               label: Scaffold App
               pre-command: cd ../ && rm -rf amplify_getting_started_<< parameters.framework >>
-              command: npx react-native@<< parameters.tag >> init amplify_getting_started_<< parameters.framework >>
+              command: npx react-native@<< parameters.tag >> init amplify_getting_started_<< parameters.framework >> --version << parameters.tag >>
               no_output_timeout: 10m
           - run-with-retry:
               label: Install Amplify dependencies


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

The canaries currently test `@latest` and `@next` versions of our supported 3rd party frameworks. 

On React Native we're currently executing the following command to scaffold a new RN:
```sh
$ npx react-native@next init amplify_getting_started
```
This tells `npx` to get the `@next` version of the react-native cli and use it for initialization/scaffolding. However when the cli runs the `init` command, it will perform additional package installation, where it will default to the `latest` version of react-native unless another version is explicitly specified vio the `--version` command option. 

This PR passes the expected version to that option. I.e.:
```sh
$ npx react-native@next init amplify_getting_started --version next
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Validated locally to ensure the scaffolded project is created with the expected version of react-native


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
