### PR TITLE
test(datastore): move test utils to directory

### DIFF
--- a/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
+++ b/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
@@ -16,7 +16,7 @@ import Observable from 'zen-observable';
 import {
 	pause,
 	addCommonQueryTests,
-} from '../../datastore/__tests__/commonAdapterTests';
+} from '../../datastore/__tests__/__utils__/commonAdapterTests';
 
 jest.mock('@aws-amplify/datastore/src/sync/datastoreConnectivity', () => {
 	return {

--- a/packages/datastore/__tests__/AsyncStorage.ts
+++ b/packages/datastore/__tests__/AsyncStorage.ts
@@ -15,8 +15,8 @@ import {
 	PostAuthorJoin as PostAuthorJoinType,
 	PostMetadata as PostMetadataType,
 	Person as PersonType,
-} from './model';
-import { newSchema } from './schema';
+} from './__utils__/model';
+import { newSchema } from './__utils__/schema';
 import { SortDirection } from '../src/types';
 
 let AsyncStorageAdapter: typeof AsyncStorageAdapterType;

--- a/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
+++ b/packages/datastore/__tests__/AsyncStorageAdapter.test.ts
@@ -5,9 +5,9 @@ import {
 	syncClasses,
 } from '../src/datastore/datastore';
 import { PersistentModelConstructor, SortDirection } from '../src/types';
-import { pause, Model, User, Profile, testSchema } from './helpers';
+import { pause, Model, User, Profile, testSchema } from './__utils__/helpers';
 import { Predicates } from '../src/predicates';
-import { addCommonQueryTests } from './commonAdapterTests';
+import { addCommonQueryTests } from './__utils__/commonAdapterTests';
 
 let initSchema: typeof initSchemaType;
 let DataStore: typeof DataStoreType;

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -22,7 +22,7 @@ import {
 	User,
 	testSchema,
 	pause,
-} from './helpers';
+} from './__utils__/helpers';
 
 let initSchema: typeof initSchemaType;
 let DataStore: typeof DataStoreType;

--- a/packages/datastore/__tests__/IndexedDBAdapter.test.ts
+++ b/packages/datastore/__tests__/IndexedDBAdapter.test.ts
@@ -15,9 +15,9 @@ import {
 	Post,
 	Comment,
 	testSchema,
-} from './helpers';
+} from './__utils__/helpers';
 import { Predicates } from '../src/predicates';
-import { addCommonQueryTests } from './commonAdapterTests';
+import { addCommonQueryTests } from './__utils__/commonAdapterTests';
 
 let initSchema: typeof initSchemaType;
 let DataStore: typeof DataStoreType;

--- a/packages/datastore/__tests__/Merger.test.ts
+++ b/packages/datastore/__tests__/Merger.test.ts
@@ -4,7 +4,7 @@ import {
 	DataStore as DataStoreType,
 	initSchema as initSchemaType,
 } from '../src/datastore/datastore';
-import { Model as ModelType, testSchema } from './helpers';
+import { Model as ModelType, testSchema } from './__utils__/helpers';
 
 let initSchema: typeof initSchemaType;
 let DataStore: typeof DataStoreType;

--- a/packages/datastore/__tests__/__utils__/commonAdapterTests.ts
+++ b/packages/datastore/__tests__/__utils__/commonAdapterTests.ts
@@ -2,7 +2,7 @@ import {
 	DataStore as DataStoreType,
 	PersistentModelConstructor,
 	initSchema as initSchemaType,
-} from '../src/';
+} from '../../src/';
 
 import {
 	pause,

--- a/packages/datastore/__tests__/__utils__/helpers.ts
+++ b/packages/datastore/__tests__/__utils__/helpers.ts
@@ -4,7 +4,7 @@ import {
 	Schema,
 	InternalSchema,
 	SchemaModel,
-} from '../src/types';
+} from '../../src/types';
 
 /**
  * Convenience function to wait for a number of ms.

--- a/packages/datastore/__tests__/__utils__/model.ts
+++ b/packages/datastore/__tests__/__utils__/model.ts
@@ -4,7 +4,7 @@ import {
 	PersistentModelConstructor,
 } from '@aws-amplify/datastore';
 
-import { initSchema, NonModelTypeConstructor } from '../src/index';
+import { initSchema, NonModelTypeConstructor } from '../../src/index';
 import { newSchema } from './schema';
 
 declare class BlogModel {

--- a/packages/datastore/__tests__/__utils__/schema.ts
+++ b/packages/datastore/__tests__/__utils__/schema.ts
@@ -1,4 +1,4 @@
-import { Schema } from '../src/types';
+import { Schema } from '../../src/types';
 
 export const newSchema: Schema = {
 	models: {

--- a/packages/datastore/__tests__/graphql.ts
+++ b/packages/datastore/__tests__/graphql.ts
@@ -13,7 +13,7 @@ import {
 	groupSchema,
 	implicitOwnerSchema,
 	newSchema,
-} from './schema';
+} from './__utils__/schema';
 
 const postSelectionSet = `
 id

--- a/packages/datastore/__tests__/indexeddb.test.ts
+++ b/packages/datastore/__tests__/indexeddb.test.ts
@@ -14,7 +14,7 @@ import {
 	PostAuthorJoin,
 	PostMetadata,
 	Person,
-} from './model';
+} from './__utils__/model';
 let db: idb.IDBPDatabase;
 
 const indexedDB = require('fake-indexeddb');

--- a/packages/datastore/__tests__/mutation.test.ts
+++ b/packages/datastore/__tests__/mutation.test.ts
@@ -9,7 +9,7 @@ import {
 	PostCustomPKSort as PostCustomPKSortType,
 	testSchema,
 	internalTestSchema,
-} from './helpers';
+} from './__utils__/helpers';
 import {
 	PersistentModelConstructor,
 	InternalSchema,

--- a/packages/datastore/__tests__/outbox.test.ts
+++ b/packages/datastore/__tests__/outbox.test.ts
@@ -7,7 +7,11 @@ import {
 import { ExclusiveStorage as StorageType } from '../src/storage/storage';
 import { MutationEventOutbox } from '../src/sync/outbox';
 import { ModelMerger } from '../src/sync/merger';
-import { Model as ModelType, testSchema, internalTestSchema } from './helpers';
+import {
+	Model as ModelType,
+	testSchema,
+	internalTestSchema,
+} from './__utils__/helpers';
 import {
 	TransformerMutationType,
 	createMutationInstanceFromModelOperation,

--- a/packages/datastore/__tests__/storage.test.ts
+++ b/packages/datastore/__tests__/storage.test.ts
@@ -13,7 +13,7 @@ import {
 	PostCustomPKSort,
 	PostCustomPKComposite,
 	testSchema,
-} from './helpers';
+} from './__utils__/helpers';
 
 let initSchema: typeof initSchemaType;
 let DataStore: typeof DataStoreType;

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -83,10 +83,7 @@
 		},
 		"testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
 		"testPathIgnorePatterns": [
-			"__tests__/model.ts",
-			"__tests__/schema.ts",
-			"__tests__/helpers.ts",
-			"__tests__/commonAdapterTests.ts"
+			"__tests__/__utils__"
 		],
 		"moduleFileExtensions": [
 			"ts",
@@ -109,7 +106,8 @@
 			"/node_modules/",
 			"dist",
 			"lib",
-			"lib-esm"
+			"lib-esm",
+			"__tests__/__utils__"
 		]
 	}
 }


### PR DESCRIPTION
Remove test utils from coverage path

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Move all datastore test utils to `__tests__/__utils__` and remove from test coverage path.

* Avoids confusion of what is a test suite and what are helper functions.
* Makes it easy to set ignore test coverage path.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

Unit testing. See that util files are no longer in the coverage output.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
