### PR TITLE
fix(amazon-cognito-identity-js): Missing cognito user challenge name …

### DIFF
--- a/packages/amazon-cognito-identity-js/index.d.ts
+++ b/packages/amazon-cognito-identity-js/index.d.ts
@@ -24,11 +24,20 @@ declare module 'amazon-cognito-identity-js' {
 			userAttributes: any,
 			requiredAttributes: any
 		) => void;
-		mfaRequired?: (challengeName: any, challengeParameters: any) => void;
-		totpRequired?: (challengeName: any, challengeParameters: any) => void;
+		mfaRequired?: (
+			challengeName: ChallengeName,
+			challengeParameters: any
+		) => void;
+		totpRequired?: (
+			challengeName: ChallengeName,
+			challengeParameters: any
+		) => void;
 		customChallenge?: (challengeParameters: any) => void;
-		mfaSetup?: (challengeName: any, challengeParameters: any) => void;
-		selectMFAType?: (challengeName: any, challengeParameters: any) => void;
+		mfaSetup?: (challengeName: ChallengeName, challengeParameters: any) => void;
+		selectMFAType?: (
+			challengeName: ChallengeName,
+			challengeParameters: any
+		) => void;
 	}
 
 	export interface IMfaSettings {
@@ -256,8 +265,14 @@ declare module 'amazon-cognito-identity-js' {
 			callbacks: {
 				onSuccess: (session: CognitoUserSession) => void;
 				onFailure: (err: any) => void;
-				mfaRequired?: (challengeName: any, challengeParameters: any) => void;
-				totpRequired?: (challengeName: any, challengeParameters: any) => void;
+				mfaRequired?: (
+					challengeName: ChallengeName,
+					challengeParameters: any
+				) => void;
+				totpRequired?: (
+					challengeName: ChallengeName,
+					challengeParameters: any
+				) => void;
 			}
 		): void;
 	}

--- a/packages/amazon-cognito-identity-js/index.d.ts
+++ b/packages/amazon-cognito-identity-js/index.d.ts
@@ -67,8 +67,18 @@ declare module 'amazon-cognito-identity-js' {
 		clientMetadata: Record<string, string>;
 	}
 
+	export type ChallengeName =
+		| 'CUSTOM_CHALLENGE'
+		| 'MFA_SETUP'
+		| 'NEW_PASSWORD_REQUIRED'
+		| 'SELECT_MFA_TYPE'
+		| 'SMS_MFA'
+		| 'SOFTWARE_TOKEN_MFA';
+
 	export class CognitoUser {
 		constructor(data: ICognitoUserData);
+
+		challengeName?: ChallengeName;
 
 		public setSignInUserSession(signInUserSession: CognitoUserSession): void;
 		public getSignInUserSession(): CognitoUserSession | null;

--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -1011,7 +1011,7 @@ describe('auth unit test', () => {
 			const spyon = jest
 				.spyOn(CognitoUser.prototype, 'authenticateUser')
 				.mockImplementationOnce((authenticationDetails, callback) => {
-					callback.mfaRequired('challengeName', 'challengeParam');
+					callback.mfaRequired('SELECT_MFA_TYPE', 'challengeParam');
 				});
 			const auth = new Auth(authOptions);
 			const user = new CognitoUser({
@@ -1019,7 +1019,7 @@ describe('auth unit test', () => {
 				Pool: userPool,
 			});
 			const userAfterSignedIn = Object.assign({}, user, {
-				challengeName: 'challengeName',
+				challengeName: 'SELECT_MFA_TYPE',
 				challengeParam: 'challengeParam',
 			});
 
@@ -1035,7 +1035,7 @@ describe('auth unit test', () => {
 			const spyon = jest
 				.spyOn(CognitoUser.prototype, 'authenticateUser')
 				.mockImplementationOnce((authenticationDetails, callback) => {
-					callback.mfaSetup('challengeName', 'challengeParam');
+					callback.mfaSetup('MFA_SETUP', 'challengeParam');
 				});
 			const auth = new Auth(authOptions);
 			const user = new CognitoUser({
@@ -1043,7 +1043,7 @@ describe('auth unit test', () => {
 				Pool: userPool,
 			});
 			const userAfterSignedIn = Object.assign({}, user, {
-				challengeName: 'challengeName',
+				challengeName: 'MFA_SETUP',
 				challengeParam: 'challengeParam',
 			});
 
@@ -1059,7 +1059,7 @@ describe('auth unit test', () => {
 			const spyon = jest
 				.spyOn(CognitoUser.prototype, 'authenticateUser')
 				.mockImplementationOnce((authenticationDetails, callback) => {
-					callback.totpRequired('challengeName', 'challengeParam');
+					callback.totpRequired('SOFTWARE_TOKEN_MFA', 'challengeParam');
 				});
 			const auth = new Auth(authOptions);
 			const user = new CognitoUser({
@@ -1067,7 +1067,7 @@ describe('auth unit test', () => {
 				Pool: userPool,
 			});
 			const userAfterSignedIn = Object.assign({}, user, {
-				challengeName: 'challengeName',
+				challengeName: 'SOFTWARE_TOKEN_MFA',
 				challengeParam: 'challengeParam',
 			});
 
@@ -1083,7 +1083,7 @@ describe('auth unit test', () => {
 			const spyon = jest
 				.spyOn(CognitoUser.prototype, 'authenticateUser')
 				.mockImplementationOnce((authenticationDetails, callback) => {
-					callback.selectMFAType('challengeName', 'challengeParam');
+					callback.selectMFAType('SELECT_MFA_TYPE', 'challengeParam');
 				});
 			const auth = new Auth(authOptions);
 			const user = new CognitoUser({
@@ -1091,7 +1091,7 @@ describe('auth unit test', () => {
 				Pool: userPool,
 			});
 			const userAfterSignedIn = Object.assign({}, user, {
-				challengeName: 'challengeName',
+				challengeName: 'SELECT_MFA_TYPE',
 				challengeParam: 'challengeParam',
 			});
 
@@ -1403,7 +1403,7 @@ describe('auth unit test', () => {
 			const spyon = jest
 				.spyOn(CognitoUser.prototype, 'completeNewPasswordChallenge')
 				.mockImplementationOnce((password, requiredAttributes, callback) => {
-					callback.mfaRequired('challengeName', 'challengeParam');
+					callback.mfaRequired('SMS_MFA', 'challengeParam');
 				});
 
 			const auth = new Auth(authOptions);
@@ -1422,7 +1422,7 @@ describe('auth unit test', () => {
 			const spyon = jest
 				.spyOn(CognitoUser.prototype, 'completeNewPasswordChallenge')
 				.mockImplementationOnce((password, requiredAttributes, callback) => {
-					callback.mfaSetup('challengeName', 'challengeParam');
+					callback.mfaSetup('MFA_SETUP', 'challengeParam');
 				});
 
 			const auth = new Auth(authOptions);


### PR DESCRIPTION
#### Description of changes
- Add `ChallengeName` type and `challengeName` property in `CognitoUser`


#### Issue #, if available
- https://github.com/aws-amplify/amplify-js/issues/3316
- https://github.com/aws-amplify/amplify-js/issues/3733
- https://github.com/aws-amplify/amplify-js/issues/6974

#### Description of how you validated changes
- `yarn link` and test on `auth` package
<img width="610" alt="Screen Shot 2565-07-01 at 01 08 18" src="https://user-images.githubusercontent.com/1315909/176748287-f945c213-af0a-479e-b215-20383755c374.png">


#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
