### PR TITLE
chore(CODEOWNERS): update geo category codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 /packages/core @elorzafe @manueliglesias @iartemiev
 /packages/datastore @svidgen @david-mcafee @manueliglesias
 /packages/datastore-storage-adapter @svidgen @david-mcafee @manueliglesias
-/packages/geo @TreTuna @thaddmt
+/packages/geo @thaddmt
 /packages/interactions @katiegoines
 /packages/predictions @elorzafe @stocaaro
 /packages/pubsub @stocaaro @elorzafe @ashika01


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Was looking up some info in the _CODEOWNERS_ file and saw this warning due to the inclusion of a code owner who is no longer part of Amplify:
<img width="766" alt="image" src="https://user-images.githubusercontent.com/15002885/176777347-239c24f9-cfd2-49c0-9374-30c3558e6666.png">

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
NA


#### Description of how you validated changes
NA


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
