### PR TITLE
feat(@aws-amplify/auth): Auto sign in after sign up

### DIFF
--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -600,7 +600,7 @@ describe('auth unit test', () => {
 					phone_number: 'phone_number',
 					otherAttrs: 'otherAttrs',
 				},
-				autoSignIn: true,
+				autoSignIn: { enabled: true },
 			};
 			expect(await auth.signUp(attrs)).toBe(signUpResult);
 			expect(signInSpyon).toHaveBeenCalledTimes(1);
@@ -624,7 +624,7 @@ describe('auth unit test', () => {
 					phone_number: 'phone_number',
 					otherAttrs: 'otherAttrs',
 				},
-				autoSignIn: true,
+				autoSignIn: { enabled: true },
 			};
 			expect(await auth.signUp(attrs)).toBe('signUpResult');
 			expect(await auth.confirmSignUp('username', 'code')).toBe('Success');
@@ -647,7 +647,7 @@ describe('auth unit test', () => {
 					phone_number: 'phone_number',
 					otherAttrs: 'otherAttrs',
 				},
-				autoSignIn: true,
+				autoSignIn: { enabled: true },
 			};
 			expect(await auth.signUp(attrs)).toBe('signUpResult');
 			jest.advanceTimersByTime(11000);
@@ -675,7 +675,7 @@ describe('auth unit test', () => {
 					phone_number: 'phone_number',
 					otherAttrs: 'otherAttrs',
 				},
-				autoSignIn: true,
+				autoSignIn: { enabled: true },
 			};
 			expect(await auth.signUp(attrs)).toBe('signUpResult');
 			try {

--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -326,7 +326,7 @@ const authOptionConfirmationLink: AuthOptions = {
 	region: 'region',
 	identityPoolId: 'awsCognitoIdentityPoolId',
 	mandatorySignIn: false,
-	verificationMethod: 'link',
+	signUpVerificationMethod: 'link',
 };
 
 const authOptionsWithClientMetadata: AuthOptions = {

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -275,6 +275,7 @@ export class AuthClass {
 					AuthErrorTypes.AutoSignInError
 				);
 			}
+			this._storage.removeItem('pollingStarted');
 		}
 		return this._config;
 	}

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -266,8 +266,10 @@ export class AuthClass {
 			!this.autoSignInInitiated &&
 			typeof this._storage['getItem'] === 'function'
 		) {
-			const pollingInitiated = this._storage.getItem('pollingStarted') || false;
-			if (pollingInitiated === 'true') {
+			const pollingInitiated = this.isTrueStorageValue(
+				this._storage.getItem('pollingStarted')
+			);
+			if (pollingInitiated) {
 				dispatchAuthEvent(
 					'AutoSignInFail',
 					null,
@@ -489,7 +491,7 @@ export class AuthClass {
 						}
 						if (autoSignInPolling) {
 							clearInterval(autoSignInPolling);
-							this._storage.setItem('pollingStarted', false);
+							this._storage.removeItem('pollingStarted');
 						}
 					},
 					error => {
@@ -549,8 +551,10 @@ export class AuthClass {
 							data,
 							`${username} has been confirmed successfully`
 						);
-						const autoSignIn = this._storage.getItem('autoSignIn') || false;
-						if (autoSignIn === 'true' && !this.autoSignInInitiated) {
+						const autoSignIn = this.isTrueStorageValue(
+							this._storage.getItem('autoSignIn')
+						);
+						if (autoSignIn && !this.autoSignInInitiated) {
 							dispatchAuthEvent(
 								'AutoSignInFail',
 								null,
@@ -563,6 +567,10 @@ export class AuthClass {
 				clientMetadata
 			);
 		});
+	}
+
+	private isTrueStorageValue(value: any) {
+		return value ? value === 'true' : false;
 	}
 
 	/**

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -256,20 +256,25 @@ export class AuthClass {
 			});
 		}
 
-		const pollingInitiated = this._storage.getItem('pollingStarted') || false;
-		if (!this.autoSignInInitiated && pollingInitiated) {
-			dispatchAuthEvent(
-				'AutoSignInFail',
-				null,
-				'Error trying to auto sign in user'
-			);
-		}
-
 		dispatchAuthEvent(
 			'configured',
 			null,
 			`The Auth category has been configured successfully`
 		);
+
+		if (
+			!this.autoSignInInitiated &&
+			typeof this._storage['getItem'] === 'function'
+		) {
+			const pollingInitiated = this._storage.getItem('pollingStarted') || false;
+			if (pollingInitiated) {
+				dispatchAuthEvent(
+					'AutoSignInFail',
+					null,
+					'Error trying to auto sign in user'
+				);
+			}
+		}
 		return this._config;
 	}
 

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -267,7 +267,7 @@ export class AuthClass {
 			typeof this._storage['getItem'] === 'function'
 		) {
 			const pollingInitiated = this._storage.getItem('pollingStarted') || false;
-			if (pollingInitiated) {
+			if (pollingInitiated === 'true') {
 				dispatchAuthEvent(
 					'AutoSignInFail',
 					null,
@@ -446,7 +446,7 @@ export class AuthClass {
 	private async onConfirmSignUp(
 		authDetails: AuthenticationDetails,
 		listenEvent?: HubCallback,
-		autoSignInPolling?: NodeJS.Timer
+		autoSignInPolling?: ReturnType<typeof setInterval>
 	) {
 		const user = this.createCognitoUser(authDetails.getUsername());
 		try {
@@ -525,8 +525,8 @@ export class AuthClass {
 							data,
 							`${username} has been confirmed successfully`
 						);
-						const autoSignIn = this._storage.getItem('autoSignIn');
-						if (autoSignIn && !this.autoSignInInitiated) {
+						const autoSignIn = this._storage.getItem('autoSignIn') || false;
+						if (autoSignIn === 'true' && !this.autoSignInInitiated) {
 							dispatchAuthEvent(
 								'AutoSignInFail',
 								null,

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -272,7 +272,7 @@ export class AuthClass {
 				dispatchAuthEvent(
 					'autoSignIn_failure',
 					null,
-					'Please use your credentials to sign in.'
+					AuthErrorTypes.AutoSignInError
 				);
 			}
 		}
@@ -315,7 +315,7 @@ export class AuthClass {
 		let validationData: CognitoUserAttribute[] = null;
 		let clientMetadata;
 		let autoSignIn: AutoSignInOptions = { enabled: false };
-		const autoSignInValidationData: CognitoUserAttribute[] = null;
+		let autoSignInValidationData = {};
 		let autoSignInClientMetaData: ClientMetaData = {};
 
 		if (params && typeof params === 'string') {
@@ -371,16 +371,7 @@ export class AuthClass {
 			autoSignIn = params.autoSignIn ?? { enabled: false };
 			if (autoSignIn.enabled) {
 				this._storage.setItem('autoSignIn', true);
-				if (autoSignIn.validationData) {
-					Object.keys(autoSignIn.validationData).map(key => {
-						autoSignInValidationData.push(
-							new CognitoUserAttribute({
-								Name: key,
-								Value: autoSignIn.validationData[key],
-							})
-						);
-					});
-				}
+				autoSignInValidationData = autoSignIn.validationData ?? {};
 				autoSignInClientMetaData = autoSignIn.clientMetaData ?? {};
 			}
 		} else {
@@ -437,7 +428,7 @@ export class AuthClass {
 	private handleAutoSignIn(
 		username: string,
 		password: string,
-		validationData: CognitoUserAttribute[],
+		validationData: {},
 		clientMetadata: any,
 		data: any
 	) {
@@ -506,6 +497,7 @@ export class AuthClass {
 							clearInterval(autoSignInPollingIntervalId);
 							this._storage.removeItem('pollingStarted');
 						}
+						this._storage.removeItem('autoSignIn');
 					},
 					error => {
 						logger.error(error);
@@ -569,7 +561,7 @@ export class AuthClass {
 							dispatchAuthEvent(
 								'autoSignIn_failure',
 								null,
-								'Please use your credentials to sign in.'
+								AuthErrorTypes.AutoSignInError
 							);
 						}
 						resolve(data);

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -450,7 +450,7 @@ export class AuthClass {
 		});
 		if (data.userConfirmed) {
 			this.onConfirmSignUp(authDetails);
-		} else if (this._config.verificationMethod === 'link') {
+		} else if (this._config.signUpVerificationMethod === 'link') {
 			this.handleLinkAutoSignIn(authDetails);
 		} else {
 			this.handleCodeAutoSignIn(authDetails);

--- a/packages/auth/src/Errors.ts
+++ b/packages/auth/src/Errors.ts
@@ -110,6 +110,9 @@ export const authErrorMessages: AuthErrorMessages = {
 	networkError: {
 		message: AuthErrorStrings.NETWORK_ERROR,
 	},
+	autoSignInError: {
+		message: AuthErrorStrings.AUTOSIGNIN_ERROR,
+	},
 	default: {
 		message: AuthErrorStrings.DEFAULT_MSG,
 	},

--- a/packages/auth/src/common/AuthErrorStrings.ts
+++ b/packages/auth/src/common/AuthErrorStrings.ts
@@ -13,4 +13,5 @@ export enum AuthErrorStrings {
 	NO_USER_SESSION = 'Failed to get the session because the user is empty',
 	NETWORK_ERROR = 'Network Error',
 	DEVICE_CONFIG = 'Device tracking has not been configured in this User Pool',
+	AUTOSIGNIN_ERROR = 'Please use your credentials to sign in',
 }

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -203,6 +203,7 @@ export enum AuthErrorTypes {
 	Default = 'default',
 	DeviceConfig = 'deviceConfig',
 	NetworkError = 'networkError',
+	AutoSignInError = 'autoSignInError',
 }
 
 export type AuthErrorMessages = { [key in AuthErrorTypes]: AuthErrorMessage };

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -25,7 +25,7 @@ export interface SignUpParams {
 	attributes?: object;
 	validationData?: { [key: string]: any };
 	clientMetadata?: { [key: string]: string };
-	autoSignIn?: boolean;
+	autoSignIn?: AutoSignInOptions;
 }
 
 export interface AuthCache {
@@ -228,6 +228,12 @@ export function isUsernamePasswordOpts(obj: any): obj is UsernamePasswordOpts {
 export interface IAuthDevice {
 	id: string;
 	name: string;
+}
+
+export interface AutoSignInOptions {
+	enabled: boolean;
+	clientMetaData?: ClientMetaData;
+	validationData?: { [key: string]: any };
 }
 
 export enum GRAPHQL_AUTH_MODE {

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -51,7 +51,7 @@ export interface AuthOptions {
 	identityPoolRegion?: string;
 	clientMetadata?: any;
 	endpoint?: string;
-	verificationMethod?: string;
+	verificationMethod?: 'code' | 'link';
 }
 
 export enum CognitoHostedUIIdentityProvider {

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -51,7 +51,7 @@ export interface AuthOptions {
 	identityPoolRegion?: string;
 	clientMetadata?: any;
 	endpoint?: string;
-	verificationMethod?: 'code' | 'link';
+	signUpVerificationMethod?: 'code' | 'link';
 }
 
 export enum CognitoHostedUIIdentityProvider {

--- a/packages/core/__tests__/parseMobileHubConfig-test.ts
+++ b/packages/core/__tests__/parseMobileHubConfig-test.ts
@@ -46,7 +46,7 @@ describe('Parser', () => {
 				region: '',
 				userPoolId: 'b',
 				userPoolWebClientId: '',
-				verificationMethod: 'code',
+				signUpVerificationMethod: 'code',
 			},
 			Geo: {
 				AmazonLocationService: {

--- a/packages/core/__tests__/parseMobileHubConfig-test.ts
+++ b/packages/core/__tests__/parseMobileHubConfig-test.ts
@@ -46,6 +46,7 @@ describe('Parser', () => {
 				region: '',
 				userPoolId: 'b',
 				userPoolWebClientId: '',
+				verificationMethod: 'code',
 			},
 			Geo: {
 				AmazonLocationService: {

--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -25,7 +25,8 @@ export const parseMobileHubConfig = (config): AmplifyConfig => {
 			identityPoolId: config['aws_cognito_identity_pool_id'],
 			identityPoolRegion: config['aws_cognito_region'],
 			mandatorySignIn: config['aws_mandatory_sign_in'] === 'enable',
-			verificationMethod: config['aws_cognito_verification_method'] || 'code',
+			signUpVerificationMethod:
+				config['aws_cognito_sign_up_verification_method'] || 'code',
 		};
 	}
 


### PR DESCRIPTION
#### Description of changes
Changes add confirm sign up listener to initiate auto sign in once account is confirmed. It happens if autoSignIn is set to true in params for SignUp function.
Since customers can choose either code, link, or autoConfirm, the solution use three different ways to auto sign in. autoConfirm implementation immediately calls on confirmSignUp function. Link implementation uses polling to sign user in since there is no explicit way to know if user clicked the link. Polling is done within 3 minutes (time verification link is valid) every 5 seconds. Code implementation is using hub listening event. Once user confirms account with code, it dispatches listening event. SignUp function is listening for this event to initiate SignIn process.


#### Issue #, if available
https://github.com/aws-amplify/amplify-js/issues/6320
https://github.com/aws-amplify/amplify-js/issues/3882
https://github.com/aws-amplify/amplify-js/issues/3631
https://github.com/aws-amplify/amplify-js/issues/6018


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
