### PR TITLE
fix: Update AmazonPersonalizeProvider Analytics typings

### DIFF
--- a/packages/analytics/__tests__/Analytics.test.ts
+++ b/packages/analytics/__tests__/Analytics.test.ts
@@ -108,8 +108,12 @@ describe('Analytics test', () => {
 
 			await analytics.record({
 				name: 'event',
-				attributes: 'attributes',
-				metrics: 'metrics',
+				attributes: {
+					key: 'value',
+				},
+				metrics: {
+					metric: 123,
+				},
 			});
 			expect(record_spyon).toBeCalled();
 		});

--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -27,6 +27,7 @@ import {
 	AutoTrackSessionOpts,
 	AutoTrackPageViewOpts,
 	AutoTrackEventOpts,
+	PersonalizeAnalyticsEvent,
 } from './types';
 import { PageViewTracker, EventTracker, SessionTracker } from './trackers';
 
@@ -234,7 +235,10 @@ export class AnalyticsClass {
 	 * @param event - An object with the name of the event, attributes of the event and event metrics.
 	 * @param [provider] - name of the provider.
 	 */
-	public async record(event: AnalyticsEvent, provider?: string);
+	public async record(
+		event: AnalyticsEvent | PersonalizeAnalyticsEvent,
+		provider?: string
+	);
 	/**
 	 * Record one analytic event and send it to Pinpoint
 	 * @deprecated Use the new syntax and pass in the event as an object instead.
@@ -249,7 +253,7 @@ export class AnalyticsClass {
 		metrics?: EventMetrics
 	);
 	public async record(
-		event: string | AnalyticsEvent,
+		event: string | AnalyticsEvent | PersonalizeAnalyticsEvent,
 		providerOrAttributes?: string | EventAttributes,
 		metrics?: EventMetrics
 	) {

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -12,11 +12,11 @@
  */
 
 import { Analytics } from './Analytics';
-import { AnalyticsProvider } from './types';
+import { AnalyticsProvider, PersonalizeAnalyticsEventTypes } from './types';
 
 /**
  * @deprecated use named import
  */
 export default Analytics;
-export { AnalyticsProvider, Analytics };
+export { AnalyticsProvider, Analytics, PersonalizeAnalyticsEventTypes };
 export * from './Providers';

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -12,11 +12,11 @@
  */
 
 import { Analytics } from './Analytics';
-import { AnalyticsProvider, PersonalizeAnalyticsEventTypes } from './types';
+import { AnalyticsProvider } from './types';
 
 /**
  * @deprecated use named import
  */
 export default Analytics;
-export { AnalyticsProvider, Analytics, PersonalizeAnalyticsEventTypes };
+export { AnalyticsProvider, Analytics };
 export * from './Providers';

--- a/packages/analytics/src/types/Analytics.ts
+++ b/packages/analytics/src/types/Analytics.ts
@@ -93,13 +93,8 @@ export interface AnalyticsEvent {
 	immediate?: boolean;
 }
 
-export enum PersonalizeAnalyticsEventTypes {
-	IDENTIFY = 'Identify',
-	MEDIA_AUTOTRACK = 'MediaAutoTrack',
-}
-
 export interface PersonalizeAnalyticsEvent {
-	eventType?: 'Identify' | 'MediaAutoTrack' | PersonalizeAnalyticsEventTypes;
+	eventType?: 'Identify' | 'MediaAutoTrack';
 	userId?: string;
 	properties?: {
 		[key: string]: string;

--- a/packages/analytics/src/types/Analytics.ts
+++ b/packages/analytics/src/types/Analytics.ts
@@ -92,3 +92,11 @@ export interface AnalyticsEvent {
 	metrics?: EventMetrics;
 	immediate?: boolean;
 }
+
+export interface PersonalizeAnalyticsEvent {
+	eventType?: 'Identify' | 'MediaAutoTrack';
+	userId?: string;
+	properties?: {
+		[key: string]: string;
+	};
+}

--- a/packages/analytics/src/types/Analytics.ts
+++ b/packages/analytics/src/types/Analytics.ts
@@ -93,10 +93,4 @@ export interface AnalyticsEvent {
 	immediate?: boolean;
 }
 
-export interface PersonalizeAnalyticsEvent {
-	eventType?: 'Identify' | 'MediaAutoTrack';
-	userId?: string;
-	properties?: {
-		[key: string]: string;
-	};
-}
+export { PersonalizeAnalyticsEvent } from './Providers/AmazonPersonalizeProvider';

--- a/packages/analytics/src/types/Analytics.ts
+++ b/packages/analytics/src/types/Analytics.ts
@@ -93,8 +93,13 @@ export interface AnalyticsEvent {
 	immediate?: boolean;
 }
 
+export enum PersonalizeAnalyticsEventTypes {
+	IDENTIFY = 'Identify',
+	MEDIA_AUTOTRACK = 'MediaAutoTrack',
+}
+
 export interface PersonalizeAnalyticsEvent {
-	eventType?: 'Identify' | 'MediaAutoTrack';
+	eventType?: 'Identify' | 'MediaAutoTrack' | PersonalizeAnalyticsEventTypes;
 	userId?: string;
 	properties?: {
 		[key: string]: string;

--- a/packages/analytics/src/types/Providers/AmazonPersonalizeProvider.ts
+++ b/packages/analytics/src/types/Providers/AmazonPersonalizeProvider.ts
@@ -1,0 +1,7 @@
+export interface PersonalizeAnalyticsEvent {
+	eventType?: 'Identify' | 'MediaAutoTrack';
+	userId?: string;
+	properties?: {
+		[key: string]: string;
+	};
+}


### PR DESCRIPTION

#### Description of changes
Added types for `event` for 'AmazonPersonalize' provider


#### Issue #, if available
fixes #9943

#### Description of how you validated changes
`yarn build && yarn test`
Verified Typescript compiler doesn't complain about wrong type anymore with AmazonPersonalizeProvider specific event type


#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
