### PR TITLE
fix(datastore): preserve ssr context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1139,6 +1139,24 @@ jobs:
           spec: search-outside-map
           # Temp fix:
           browser: chrome
+
+  integ_next_datastore_owner_auth:
+    parameters:
+      browser:
+        type: string
+    executor: js-test-executor
+    <<: *test_env_vars
+    working_directory: ~/amplify-js-samples-staging/samples/next/datastore/owner-based-default
+    steps:
+      - prepare_test_env
+      - integ_test_js:
+          test_name: 'next owner auth'
+          framework: next
+          category: datastore
+          sample_name: owner-based-default
+          spec: next-owner-based-default
+          browser: << parameters.browser >>
+
   deploy:
     executor: macos-executor
     working_directory: ~/amplify-js
@@ -1583,6 +1601,15 @@ workflows:
           matrix:
             parameters:
               <<: *test_browsers
+      - integ_next_datastore_owner_auth:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+          matrix:
+            parameters:
+              <<: *test_browsers
       - deploy:
           filters:
             <<: *releasable_branches
@@ -1630,6 +1657,7 @@ workflows:
             - integ_auth_test_cypress_no_ui
             - integ_react_graphql_api
             - integ_react_geo
+            - integ_next_datastore_owner_auth
       - post_release:
           filters:
             branches:

--- a/packages/aws-amplify/__tests__/withSSRContext-test.ts
+++ b/packages/aws-amplify/__tests__/withSSRContext-test.ts
@@ -1,4 +1,4 @@
-import { Amplify, CredentialsClass, UniversalStorage } from '@aws-amplify/core';
+import { Amplify, UniversalStorage } from '@aws-amplify/core';
 
 import { withSSRContext } from '../src/withSSRContext';
 
@@ -68,6 +68,16 @@ describe('withSSRContext', () => {
 	describe('DataStore', () => {
 		it('should be a different instance than Amplify.DataStore', () => {
 			expect(withSSRContext().DataStore).not.toBe(Amplify.DataStore);
+		});
+
+		it('should use Amplify components from the ssr context', () => {
+			const { Auth, API, DataStore } = withSSRContext();
+
+			expect(DataStore.Auth).toBe(Auth);
+			expect(DataStore.Auth).not.toBe(Amplify.Auth);
+
+			expect(DataStore.API).toBe(API);
+			expect(DataStore.API).not.toBe(Amplify.API);
 		});
 	});
 

--- a/packages/datastore/__tests__/authStrategies.test.ts
+++ b/packages/datastore/__tests__/authStrategies.test.ts
@@ -449,8 +449,10 @@ async function testMultiAuthStrategy({
 }) {
 	mockCurrentUser({ hasAuthenticatedUser });
 
-	const multiAuthStrategy =
+	const multiAuthStrategyWrapper =
 		require('../src/authModeStrategies/multiAuthStrategy').multiAuthStrategy;
+
+	const multiAuthStrategy = multiAuthStrategyWrapper({});
 
 	const schema = getAuthSchema(authRules);
 

--- a/packages/datastore/__tests__/mutation.test.ts
+++ b/packages/datastore/__tests__/mutation.test.ts
@@ -1,4 +1,3 @@
-import { RestClient } from '@aws-amplify/api-rest';
 import {
 	MutationProcessor,
 	safeJitteredBackoff,
@@ -350,7 +349,9 @@ async function instantiateMutationProcessor({
 			aws_appsync_apiKey: 'da2-xxxxxxxxxxxxxxxxxxxxxx',
 		},
 		() => null,
-		errorHandler
+		errorHandler,
+		() => null as any,
+		{} as any
 	);
 
 	(mutationProcessor as any).observer = true;

--- a/packages/datastore/__tests__/sync.test.ts
+++ b/packages/datastore/__tests__/sync.test.ts
@@ -442,7 +442,8 @@ function jitteredRetrySyncProcessorSetup({
 		null, // syncPredicates
 		{ aws_appsync_authenticationType: 'userPools' },
 		defaultAuthStrategy,
-		errorHandler
+		errorHandler,
+		{}
 	);
 
 	return SyncProcessor;

--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -21,6 +21,7 @@ import {
 	TypeConstructorMap,
 	ModelPredicate,
 	AuthModeStrategy,
+	AmplifyContext,
 } from '../types';
 import { exhaustiveCheck, getNow, SYNC, USER } from '../util';
 import DataStoreConnectivity from './datastoreConnectivity';
@@ -117,7 +118,8 @@ export class SyncEngine {
 		errorHandler: ErrorHandler,
 		private readonly syncPredicates: WeakMap<SchemaModel, ModelPredicate<any>>,
 		private readonly amplifyConfig: Record<string, any> = {},
-		private readonly authModeStrategy: AuthModeStrategy
+		private readonly authModeStrategy: AuthModeStrategy,
+		private readonly amplifyContext: AmplifyContext
 	) {
 		const MutationEvent = this.modelClasses[
 			'MutationEvent'
@@ -137,15 +139,19 @@ export class SyncEngine {
 			this.syncPredicates,
 			this.amplifyConfig,
 			this.authModeStrategy,
-			errorHandler
+			errorHandler,
+			this.amplifyContext
 		);
+
 		this.subscriptionsProcessor = new SubscriptionProcessor(
 			this.schema,
 			this.syncPredicates,
 			this.amplifyConfig,
 			this.authModeStrategy,
-			errorHandler
+			errorHandler,
+			this.amplifyContext
 		);
+
 		this.mutationsProcessor = new MutationProcessor(
 			this.schema,
 			this.storage,
@@ -156,8 +162,10 @@ export class SyncEngine {
 			this.amplifyConfig,
 			this.authModeStrategy,
 			errorHandler,
-			conflictHandler
+			conflictHandler,
+			this.amplifyContext
 		);
+
 		this.datastoreConnectivity = new DataStoreConnectivity();
 	}
 

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -25,6 +25,7 @@ import {
 	SchemaModel,
 	TypeConstructorMap,
 	ProcessName,
+	AmplifyContext,
 } from '../../types';
 import { exhaustiveCheck, USER } from '../../util';
 import { MutationEventOutbox } from '../outbox';
@@ -66,8 +67,10 @@ class MutationProcessor {
 		private readonly amplifyConfig: Record<string, any> = {},
 		private readonly authModeStrategy: AuthModeStrategy,
 		private readonly errorHandler: ErrorHandler,
-		private readonly conflictHandler?: ConflictHandler
+		private readonly conflictHandler: ConflictHandler,
+		private readonly amplifyContext: AmplifyContext
 	) {
+		this.amplifyContext.API = this.amplifyContext.API || API;
 		this.generateQueries();
 	}
 
@@ -276,7 +279,7 @@ class MutationProcessor {
 				do {
 					try {
 						const result = <GraphQLResult<Record<string, PersistentModel>>>(
-							await API.graphql(tryWith)
+							await this.amplifyContext.API.graphql(tryWith)
 						);
 						return [result, opName, modelDefinition];
 					} catch (err) {
@@ -343,7 +346,7 @@ class MutationProcessor {
 
 									const serverData = <
 										GraphQLResult<Record<string, PersistentModel>>
-									>await API.graphql({
+									>await this.amplifyContext.API.graphql({
 										query,
 										variables: { id: variables.input.id },
 										authMode,

--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -1,5 +1,5 @@
 import API, { GraphQLResult, GRAPHQL_AUTH_MODE } from '@aws-amplify/api';
-import Auth from '@aws-amplify/auth';
+import { Auth } from '@aws-amplify/auth';
 import Cache from '@aws-amplify/cache';
 import { ConsoleLogger as Logger, Hub, HubCapsule } from '@aws-amplify/core';
 import { CONTROL_MSG as PUBSUB_CONTROL_MSG } from '@aws-amplify/pubsub';
@@ -14,6 +14,7 @@ import {
 	AuthModeStrategy,
 	ErrorHandler,
 	ProcessName,
+	AmplifyContext,
 } from '../../types';
 import {
 	buildSubscriptionGraphQLOperation,
@@ -60,7 +61,8 @@ class SubscriptionProcessor {
 		private readonly syncPredicates: WeakMap<SchemaModel, ModelPredicate<any>>,
 		private readonly amplifyConfig: Record<string, any> = {},
 		private readonly authModeStrategy: AuthModeStrategy,
-		private readonly errorHandler: ErrorHandler
+		private readonly errorHandler: ErrorHandler,
+		private readonly amplifyContext: AmplifyContext = { Auth, API, Cache }
 	) {}
 
 	private buildSubscription(
@@ -253,8 +255,8 @@ class SubscriptionProcessor {
 			(async () => {
 				try {
 					// retrieving current AWS Credentials
-					// TODO Should this use `this.amplify.Auth` for SSR?
-					const credentials = await Auth.currentCredentials();
+					const credentials =
+						await this.amplifyContext.Auth.currentCredentials();
 					userCredentials = credentials.authenticated
 						? USER_CREDENTIALS.auth
 						: USER_CREDENTIALS.unauth;
@@ -264,8 +266,7 @@ class SubscriptionProcessor {
 
 				try {
 					// retrieving current token info from Cognito UserPools
-					// TODO Should this use `this.amplify.Auth` for SSR?
-					const session = await Auth.currentSession();
+					const session = await this.amplifyContext.Auth.currentSession();
 					cognitoTokenPayload = session.getIdToken().decodePayload();
 				} catch (err) {
 					// best effort to get jwt from Cognito
@@ -282,11 +283,14 @@ class SubscriptionProcessor {
 
 					let token;
 					// backwards compatibility
-					const federatedInfo = await Cache.getItem('federatedInfo');
+					const federatedInfo = await this.amplifyContext.Cache.getItem(
+						'federatedInfo'
+					);
 					if (federatedInfo) {
 						token = federatedInfo.token;
 					} else {
-						const currentUser = await Auth.currentAuthenticatedUser();
+						const currentUser =
+							await this.amplifyContext.Auth.currentAuthenticatedUser();
 						if (currentUser) {
 							token = currentUser.token;
 						}
@@ -387,7 +391,7 @@ class SubscriptionProcessor {
 									Observable<{
 										value: GraphQLResult<Record<string, PersistentModel>>;
 									}>
-								>(<unknown>API.graphql({ query, variables, ...{ authMode }, authToken }));
+								>(<unknown>this.amplifyContext.API.graphql({ query, variables, ...{ authMode }, authToken }));
 								let subscriptionReadyCallback: () => void;
 
 								subscriptions[modelDefinition.name][

--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -10,6 +10,7 @@ import {
 	AuthModeStrategy,
 	ErrorHandler,
 	ProcessName,
+	AmplifyContext,
 } from '../../types';
 import {
 	buildGraphQLOperation,
@@ -26,7 +27,6 @@ import {
 	NonRetryableError,
 } from '@aws-amplify/core';
 import { ModelPredicateCreator } from '../../predicates';
-import { ModelInstanceCreator } from '../../datastore/datastore';
 import { getSyncErrorType } from './errorMaps';
 const opResultDefaults = {
 	items: [],
@@ -45,8 +45,9 @@ class SyncProcessor {
 		private readonly amplifyConfig: Record<string, any> = {},
 		private readonly authModeStrategy: AuthModeStrategy,
 		private readonly errorHandler: ErrorHandler,
-		private readonly modelInstanceCreator?: ModelInstanceCreator
+		private readonly amplifyContext: AmplifyContext
 	) {
+		amplifyContext.API = amplifyContext.API || API;
 		this.generateQueries();
 	}
 
@@ -208,7 +209,7 @@ class SyncProcessor {
 						this.amplifyConfig
 					);
 
-					return await API.graphql({
+					return await this.amplifyContext.API.graphql({
 						query,
 						variables,
 						authMode,

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -13,6 +13,9 @@ import {
 } from './util';
 import { PredicateAll } from './predicates';
 import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api-graphql';
+import { Auth } from '@aws-amplify/auth';
+import { API } from '@aws-amplify/api';
+import Cache from '@aws-amplify/cache';
 import { Adapter } from './storage/adapter';
 
 //#region Schema types
@@ -823,3 +826,9 @@ export enum LimitTimerRaceResolvedValues {
 	TIMER = 'TIMER',
 }
 //#endregion
+
+export type AmplifyContext = {
+	Auth: typeof Auth;
+	API: typeof API;
+	Cache: typeof Cache;
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The Amplify library exports the `withSSRContext` function (https://docs.amplify.aws/lib/ssr/q/platform/js/#withssrcontext) that allows a Next.js application to use client-side credentials in an isolated context on the server. The function creates new instances of the Auth, API, Credentials, and DataStore classes and configures this instance of Auth with the client-side cookies injected into it from the client-side request.

Currently, a library bug is preventing DataStore from using these instances of Auth and API while running in an SSR Context. The reference to the instance does not get preserved in the DataStore implementation. Therefore, DataStore simply imports new default instances of these classes lacking the client-side auth configuration. This breaks all SSR flows that depend on client-side credentials, such as the ones in the linked issues.

This PR adds a context object that stores references to Auth and API categories in the top-level DataStore class (`datastore.ts`) and passes the context object by reference to the descendent classes that use these categories. This allows DataStore to perform authenticated requests while running in the SSR context, fixing the linked GH issues.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/8792
https://github.com/aws-amplify/amplify-js/issues/10027


#### Description of how you validated changes
1. Created new sample app and test script that validates DataStore with owner Auth with SSR Context: https://github.com/aws-amplify/amplify-js-samples-staging/pull/366 - **_must be merged before merging this PR_**
2. Ran all integ tests (including the new one, integ_next_datastore_owner_auth) against the changes in this branch: https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/12228/workflows/5e01d94a-0456-4448-bdff-f7bdb320b5da
3. Updated unit test for `ssrContext`
4. Tested locally with additional sample apps


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
