### PR TITLE
Update Errors.ts

### DIFF
--- a/packages/auth/src/Errors.ts
+++ b/packages/auth/src/Errors.ts
@@ -28,7 +28,7 @@ export class AuthError extends Error {
 		this.constructor = AuthError;
 		Object.setPrototypeOf(this, AuthError.prototype);
 
-		this.name = 'AuthError';
+		this.name = type;
 		this.log = log || message;
 
 		logger.error(this.log);


### PR DESCRIPTION
Change 'AuthError' for type of error. Otherwise the error type is overwrited with 'AuthError' and this makes that becames imposible to translate error messages based on error code in the client.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
