### PR TITLE
Gh 7662/interactions/add lex v2 support

### DIFF
--- a/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.tsx
+++ b/packages/amplify-ui-components/src/components/amplify-chatbot/amplify-chatbot.tsx
@@ -16,7 +16,10 @@ import { AudioRecorder, visualize } from '../../common/audio-control';
 import { ChatResult } from '../../common/types/interactions-types';
 import { NO_INTERACTIONS_MODULE_FOUND } from '../../common/constants';
 import { Translations } from '../../common/Translations';
-import { InteractionsResponse } from '@aws-amplify/interactions';
+import {
+	InteractionsResponse,
+	InteractionsMessage,
+} from '@aws-amplify/interactions';
 
 // enum for possible bot states
 enum ChatState {
@@ -237,7 +240,7 @@ export class AmplifyChatbot {
 	}
 
 	private async sendVoiceMessage(audioInput: Blob) {
-		const interactionsMessage = {
+		const interactionsMessage: InteractionsMessage = {
 			content: audioInput,
 			options: {
 				messageType: 'voice',

--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -13,7 +13,7 @@
 		"transpile": "ngc",
 		"package": "rollup -c rollup.config.js",
 		"minify": "uglifyjs dist/bundles/aws-amplify-angular.umd.js --screw-ie8 --compress --mangle --comments --output dist/bundles/aws-amplify-angular.umd.min.js",
-		"build": "npm run transpile && npm run package && npm run minify && npm run declarations",
+		"build": "npm run transpile && npm run package && npm run declarations",
 		"build:esm:watch": "ngc --watch",
 		"build:cjs:watch": "echo \"CommonJS modules are not exported in angular. Use target build:esm:watch\"",
 		"format": "echo \"Not implemented\"",

--- a/packages/aws-amplify-react/src/Interactions/ChatBot.tsx
+++ b/packages/aws-amplify-react/src/Interactions/ChatBot.tsx
@@ -8,7 +8,7 @@ import {
 import { Input, Button } from '../AmplifyTheme';
 
 import { I18n } from '@aws-amplify/core';
-import { Interactions } from '@aws-amplify/interactions';
+import { Interactions, InteractionsMessage } from '@aws-amplify/interactions';
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import { chatBot } from '../Amplify-UI/data-test-attributes';
 const logger = new Logger('ChatBot');
@@ -30,6 +30,7 @@ const styles: { [pname: string]: React.CSSProperties } = {
 		height: '300px',
 		overflow: 'auto',
 	},
+	// @ts-ignore
 	textInput: Object.assign({}, Input, {
 		display: 'inline-block',
 		width: 'calc(100% - 90px - 15px)',
@@ -104,6 +105,7 @@ export class ChatBot extends React.Component<IChatBotProps, IChatBotState> {
 		}
 		if (!this.props.textEnabled && this.props.voiceEnabled) {
 			STATES.INITIAL.MESSAGE = 'Click the mic button';
+			// @ts-ignore
 			styles.textInput = Object.assign({}, Input, {
 				display: 'inline-block',
 				width: 'calc(100% - 40px - 15px)',
@@ -111,6 +113,7 @@ export class ChatBot extends React.Component<IChatBotProps, IChatBotState> {
 		}
 		if (this.props.textEnabled && !this.props.voiceEnabled) {
 			STATES.INITIAL.MESSAGE = 'Type a message';
+			// @ts-ignore
 			styles.textInput = Object.assign({}, Input, {
 				display: 'inline-block',
 				width: 'calc(100% - 60px - 15px)',
@@ -198,14 +201,14 @@ export class ChatBot extends React.Component<IChatBotProps, IChatBotState> {
 			return;
 		}
 
-		const interactionsMessage = {
+		const interactionsMessage: InteractionsMessage = {
 			content: this.state.audioInput,
 			options: {
 				messageType: 'voice',
 			},
 		};
 		const response = await Interactions.send(
-			this.props.botName,
+			this.props.botName as string,
 			interactionsMessage
 		);
 		this.setState(
@@ -227,7 +230,8 @@ export class ChatBot extends React.Component<IChatBotProps, IChatBotState> {
 				this.doneSpeakingHandler();
 			}
 		);
-		this.listItemsRef.current.scrollTop = this.listItemsRef.current.scrollHeight;
+		this.listItemsRef.current.scrollTop =
+			this.listItemsRef.current.scrollHeight;
 	}
 
 	doneSpeakingHandler() {
@@ -344,6 +348,7 @@ export class ChatBot extends React.Component<IChatBotProps, IChatBotState> {
 						{ message: this.state.inputText, from: 'me' },
 					],
 				},
+				// @ts-ignore
 				resolve
 			)
 		);
@@ -355,7 +360,7 @@ export class ChatBot extends React.Component<IChatBotProps, IChatBotState> {
 		}
 
 		const response = await Interactions.send(
-			this.props.botName,
+			this.props.botName as string,
 			this.state.inputText
 		);
 
@@ -368,7 +373,8 @@ export class ChatBot extends React.Component<IChatBotProps, IChatBotState> {
 			],
 			inputText: '',
 		});
-		this.listItemsRef.current.scrollTop = this.listItemsRef.current.scrollHeight;
+		this.listItemsRef.current.scrollTop =
+			this.listItemsRef.current.scrollHeight;
 	}
 
 	async changeInputText(event) {
@@ -388,7 +394,8 @@ export class ChatBot extends React.Component<IChatBotProps, IChatBotState> {
 					].filter(Boolean),
 				},
 				() => {
-					this.listItemsRef.current.scrollTop = this.listItemsRef.current.scrollHeight;
+					this.listItemsRef.current.scrollTop =
+						this.listItemsRef.current.scrollHeight;
 				}
 			);
 		};

--- a/packages/interactions/__tests__/providers/AWSLexProvider-unit-test.ts
+++ b/packages/interactions/__tests__/providers/AWSLexProvider-unit-test.ts
@@ -1,0 +1,497 @@
+/*
+ * Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+import { AWSLexProvider } from '../../src/Providers';
+import { Credentials } from '@aws-amplify/core';
+import {
+	LexRuntimeServiceClient,
+	PostContentCommand,
+	PostTextCommand,
+	PostTextCommandOutput,
+} from '@aws-sdk/client-lex-runtime-service';
+
+(global as any).Response = () => {};
+(global as any).Response.prototype.arrayBuffer = (blob: Blob) => {
+	return Promise.resolve(new ArrayBuffer(0));
+};
+
+// mock stream response
+const createBlob = () => {
+	return new Blob();
+};
+
+// bot config
+const botConfig = {
+	BookTrip: {
+		name: 'BookTrip', // default provider 'AWSLexProvider'
+		alias: '$LATEST',
+		region: 'us-west-2',
+	},
+	OrderFlowers: {
+		name: 'OrderFlowers',
+		alias: '$LATEST',
+		region: 'us-west-2',
+		providerName: 'AWSLexProvider',
+	},
+};
+
+LexRuntimeServiceClient.prototype.send = jest.fn((command, callback) => {
+	if (command instanceof PostTextCommand) {
+		if (command.input.inputText === 'done') {
+			const result = {
+				message: 'echo:' + command.input.inputText,
+				dialogState: 'ReadyForFulfillment',
+				slots: {
+					m1: 'hi',
+					m2: 'done',
+				},
+			};
+			return Promise.resolve(result);
+		} else if (command.input.inputText === 'error') {
+			const result = {
+				message: 'echo:' + command.input.inputText,
+				dialogState: 'Failed',
+			};
+			return Promise.resolve(result);
+		} else {
+			const result = {
+				message: 'echo:' + command.input.inputText,
+				dialogState: 'ElicitSlot',
+			};
+			return Promise.resolve(result);
+		}
+	} else if (command instanceof PostContentCommand) {
+		if (
+			command.input.contentType ===
+			'audio/x-l16; sample-rate=16000; channel-count=1'
+		) {
+			const bot = command.input.botName as string;
+			const [botName, status] = bot.split(':');
+
+			if (status === 'done') {
+				// we add the status to the botName
+				// because inputStream would just be a blob if type is voice
+				const result = {
+					message: 'voice:echo:' + command.input.botName,
+					dialogState: 'ReadyForFulfillment',
+					slots: {
+						m1: 'voice:hi',
+						m2: 'voice:done',
+					},
+					audioStream: createBlob(),
+				};
+				return Promise.resolve(result);
+			} else if (status === 'error') {
+				const result = {
+					message: 'voice:echo:' + command.input.botName,
+					dialogState: 'Failed',
+					audioStream: createBlob(),
+				};
+				return Promise.resolve(result);
+			} else {
+				const result = {
+					message: 'voice:echo:' + command.input.botName,
+					dialogState: 'ElicitSlot',
+					audioStream: createBlob(),
+				};
+				return Promise.resolve(result);
+			}
+		} else {
+			if (command.input.inputStream === 'done') {
+				const result = {
+					message: 'echo:' + command.input.inputStream,
+					dialogState: 'ReadyForFulfillment',
+					slots: {
+						m1: 'hi',
+						m2: 'done',
+					},
+					audioStream: createBlob(),
+				};
+				return Promise.resolve(result);
+			} else if (command.input.inputStream === 'error') {
+				const result = {
+					message: 'echo:' + command.input.inputStream,
+					dialogState: 'Failed',
+					audioStream: createBlob(),
+				};
+				return Promise.resolve(result);
+			} else {
+				const result = {
+					message: 'echo:' + command.input.inputStream,
+					dialogState: 'ElicitSlot',
+					audioStream: createBlob(),
+				};
+				return Promise.resolve(result);
+			}
+		}
+	}
+}) as any;
+
+afterEach(() => {
+	jest.restoreAllMocks();
+});
+
+describe('Interactions', () => {
+	describe('constructor test', () => {
+		test('happy case', () => {
+			const provider = new AWSLexProvider();
+		});
+	});
+
+	// Test 'getProviderName' API
+	describe('getProviderName API', () => {
+		test('happy case', () => {
+			const provider = new AWSLexProvider();
+			expect(provider.getProviderName()).toEqual('AWSLexProvider');
+		});
+	});
+
+	// Test 'getCategory' API
+	describe('getCategory API', () => {
+		test('happy case', () => {
+			const provider = new AWSLexProvider();
+			expect(provider.getCategory()).toEqual('Interactions');
+		});
+	});
+
+	// Test 'configure' API
+	describe('configure API', () => {
+		const provider = new AWSLexProvider();
+
+		test('happy case', () => {
+			expect(provider.configure(botConfig)).toEqual(botConfig);
+		});
+
+		test('configure multiple bots', () => {
+			// config 1st bot
+			expect(provider.configure(botConfig)).toEqual(botConfig);
+
+			const anotherBot = {
+				BookHotel: {
+					name: 'BookHotel',
+					alias: '$LATEST',
+					region: 'us-west-2',
+				},
+			};
+			// config 2nd bot
+			expect(provider.configure(anotherBot)).toEqual({
+				...botConfig,
+				...anotherBot,
+			});
+
+			const anotherBotUpdated = {
+				BookHotel: {
+					name: 'BookHotel',
+					alias: 'MyBookHotel',
+					region: 'us-west-1',
+				},
+			};
+			// re-configure updated 2nd bot
+			// 2nd bot is overridden
+			expect(provider.configure(anotherBotUpdated)).toEqual({
+				...botConfig,
+				...anotherBotUpdated,
+			});
+		});
+
+		test('FailureCase: invalid bot config', () => {
+			const invalidConfig = {
+				BookHotel: {
+					name: 'BookHotel',
+					region: 'us-west-2',
+					// alias: '$LATEST', this is required
+				},
+			};
+			// @ts-ignore
+			expect(() => provider.configure(invalidConfig)).toThrow(
+				'invalid bot configuration'
+			);
+		});
+	});
+
+	// Test 'send' API
+	describe('send API', () => {
+		let provider;
+
+		beforeEach(() => {
+			jest
+				.spyOn(Credentials, 'get')
+				.mockImplementation(() => Promise.resolve({ identityId: '1234' }));
+
+			provider = new AWSLexProvider();
+			provider.configure(botConfig);
+		});
+
+		test('send simple text message and fulfill', async () => {
+			let response = await provider.sendMessage('BookTrip', 'hi');
+			expect(response).toEqual({
+				dialogState: 'ElicitSlot',
+				message: 'echo:hi',
+			});
+
+			response = await provider.sendMessage('BookTrip', 'done');
+			expect(response).toEqual({
+				dialogState: 'ReadyForFulfillment',
+				message: 'echo:done',
+				slots: {
+					m1: 'hi',
+					m2: 'done',
+				},
+			});
+		});
+
+		test('send obj text message and fulfill', async () => {
+			let response = await provider.sendMessage('BookTrip', {
+				content: 'hi',
+				options: {
+					messageType: 'text',
+				},
+			});
+			expect(response).toEqual({
+				dialogState: 'ElicitSlot',
+				message: 'echo:hi',
+				audioStream: new Uint8Array(),
+			});
+
+			response = await provider.sendMessage('BookTrip', {
+				content: 'done',
+				options: {
+					messageType: 'text',
+				},
+			});
+			expect(response).toEqual({
+				dialogState: 'ReadyForFulfillment',
+				message: 'echo:done',
+				audioStream: new Uint8Array(),
+				slots: {
+					m1: 'hi',
+					m2: 'done',
+				},
+			});
+		});
+
+		test('send obj voice message and fulfill', async () => {
+			const botconfig = {
+				'BookTrip:hi': {
+					name: 'BookTrip:hi',
+					alias: '$LATEST',
+					region: 'us-west-2',
+				},
+				'BookTrip:done': {
+					name: 'BookTrip:done',
+					alias: '$LATEST',
+					region: 'us-west-2',
+				},
+			};
+			provider.configure(botconfig);
+
+			let response = await provider.sendMessage('BookTrip:hi', {
+				content: createBlob(),
+				options: {
+					messageType: 'voice',
+				},
+			});
+			expect(response).toEqual({
+				dialogState: 'ElicitSlot',
+				message: 'voice:echo:BookTrip:hi',
+				audioStream: new Uint8Array(),
+			});
+
+			response = await provider.sendMessage('BookTrip:done', {
+				content: createBlob(),
+				options: {
+					messageType: 'voice',
+				},
+			});
+			expect(response).toEqual({
+				dialogState: 'ReadyForFulfillment',
+				message: 'voice:echo:BookTrip:done',
+				audioStream: new Uint8Array(),
+				slots: {
+					m1: 'voice:hi',
+					m2: 'voice:done',
+				},
+			});
+		});
+
+		test('FailureCase: No credentials send', async () => {
+			jest
+				.spyOn(Credentials, 'get')
+				.mockImplementation(() => Promise.reject({ identityId: undefined }));
+
+			await expect(provider.sendMessage('BookTrip', 'hi')).rejects.toEqual(
+				'No credentials'
+			);
+		});
+
+		test('FailureCase: send to not existing bot', async () => {
+			await expect(provider.sendMessage('unknownBot', 'hi')).rejects.toEqual(
+				'Bot unknownBot does not exist'
+			);
+		});
+
+		test('FailureCase: send simple text, obj text and obj voice messages in wrong format', async () => {
+			// simple text in wrong format
+			await expect(provider.sendMessage('BookTrip', 3421)).rejects.toEqual(
+				`message type isn't supported`
+			);
+
+			// obj text in wrong format
+			await expect(
+				provider.sendMessage('BookTrip', {
+					content: createBlob(),
+					options: {
+						messageType: 'text',
+					},
+				})
+			).rejects.toEqual(`message type isn't supported`);
+
+			// obj text in wrong format
+			await expect(
+				provider.sendMessage('BookTrip', {
+					content: 'Hi',
+					options: {
+						messageType: 'voice',
+					},
+				})
+			).rejects.toEqual(`message type isn't supported`);
+		});
+	});
+
+	// Test 'onComplete' API
+	describe('onComplete API', () => {
+		const callback = (err, confirmation) => {};
+		let provider;
+
+		beforeEach(() => {
+			jest
+				.spyOn(Credentials, 'get')
+				.mockImplementation(() => Promise.resolve({ identityId: '1234' }));
+
+			provider = new AWSLexProvider();
+			provider.configure(botConfig);
+		});
+
+		test('happy case', () => {
+			provider.onComplete('BookTrip', callback);
+		});
+
+		test('FailureCase: onComplete to not existing bot', async () => {
+			expect(() => provider.onComplete('unknownBot', callback)).toThrow(
+				'Bot unknownBot does not exist'
+			);
+		});
+
+		test('FailureCase: onComplete with wrong input format', async () => {
+			// wrong callback
+			expect(() => provider.onComplete('BookTrip', 'hi')).toThrow(
+				`message type isn't supported`
+			);
+
+			// wrong botname
+			expect(() => provider.onComplete({}, 'Hi')).toThrow(
+				`message type isn't supported`
+			);
+		});
+	});
+
+	// Test 'reportBotStatus' API
+	describe('reportBotStatus API', () => {
+		// jest.useFakeTimers();
+		jest.useFakeTimers();
+		let provider;
+
+		let inProgressResp;
+		let completeSuccessResp;
+		let completeFailResp;
+
+		const inProgressCallback = (err, confirmation) =>
+			fail(`callback shouldn't be called`);
+
+		const completeSuccessCallback = (err, confirmation) => {
+			expect(err).toEqual(null);
+			expect(confirmation).toEqual({ slots: { m1: 'hi', m2: 'done' } });
+		};
+
+		const completeFailCallback = (err, confirmation) =>
+			expect(err).toEqual('Bot conversation failed');
+
+		beforeEach(async () => {
+			jest
+				.spyOn(Credentials, 'get')
+				.mockImplementation(() => Promise.resolve({ identityId: '1234' }));
+
+			provider = new AWSLexProvider();
+			provider.configure(botConfig);
+
+			inProgressResp = (await provider.sendMessage(
+				'BookTrip',
+				'hi'
+			)) as PostTextCommandOutput;
+
+			completeSuccessResp = (await provider.sendMessage(
+				'BookTrip',
+				'done'
+			)) as PostTextCommandOutput;
+
+			completeFailResp = (await provider.sendMessage(
+				'BookTrip',
+				'error'
+			)) as PostTextCommandOutput;
+		});
+
+		test('onComplete callback from `Interactions.onComplete`', async () => {
+			// 1. In progress, callback shouldn't be called
+			provider.onComplete('BookTrip', inProgressCallback);
+			provider.reportBotStatus('BookTrip', inProgressResp);
+			jest.runAllTimers();
+
+			// 2. task complete; success, callback be called with response
+			provider.onComplete('BookTrip', completeSuccessCallback);
+			provider.reportBotStatus('BookTrip', completeSuccessResp);
+			jest.runAllTimers();
+
+			// 3. task complete; error, callback be called with error
+			provider.onComplete('BookTrip', completeFailCallback);
+			provider.reportBotStatus('BookTrip', completeFailResp);
+			jest.runAllTimers();
+		});
+
+		test('onComplete callback from `Configure`', async () => {
+			const myBot: any = {
+				BookTrip: {
+					name: 'BookTrip',
+					alias: '$LATEST',
+					region: 'us-west-2',
+				},
+			};
+
+			// 1. In progress, callback shouldn't be called
+			myBot.BookTrip.onComplete = inProgressCallback;
+			provider.configure(myBot);
+			provider.reportBotStatus('BookTrip', inProgressResp);
+			jest.runAllTimers();
+
+			// 2. In progress, callback shouldn't be called
+			myBot.BookTrip.onComplete = completeSuccessCallback;
+			provider.configure(myBot);
+			provider.reportBotStatus('BookTrip', completeSuccessResp);
+			jest.runAllTimers();
+
+			// 3. In progress, callback shouldn't be called
+			myBot.BookTrip.onComplete = completeFailCallback;
+			provider.configure(myBot);
+			provider.reportBotStatus('BookTrip', completeFailResp);
+			jest.runAllTimers();
+		});
+	});
+});

--- a/packages/interactions/__tests__/providers/AWSLexProviderV2-unit-test.ts
+++ b/packages/interactions/__tests__/providers/AWSLexProviderV2-unit-test.ts
@@ -1,0 +1,551 @@
+/*
+ * Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+import { AWSLexProviderV2 } from '../../src/Providers';
+import { Credentials } from '@aws-amplify/core';
+import {
+	LexRuntimeV2Client,
+	RecognizeTextCommand,
+	RecognizeTextCommandOutput,
+	RecognizeUtteranceCommand,
+	RecognizeUtteranceCommandOutput,
+} from '@aws-sdk/client-lex-runtime-v2';
+
+import { unGzipBase64AsJson } from '../../src/Providers/AWSLexProviderHelper/convert';
+import { prototype } from 'stream';
+
+(global as any).Response = () => {};
+(global as any).Response.prototype.arrayBuffer = (blob: Blob) => {
+	return Promise.resolve(new ArrayBuffer(0));
+};
+
+// mock stream response
+const createBlob = () => {
+	return new Blob();
+};
+
+// bot config
+const botConfig = {
+	BookTrip: {
+		name: 'BookTrip',
+		botId: '0DNZS5QI8M',
+		aliasId: 'O1O8YV2JTG',
+		localeId: 'en_US',
+		region: 'us-west-2',
+		providerName: 'AWSLexProviderV2',
+	},
+	OrderFlowers: {
+		name: 'OrderFlowers',
+		botId: 'O1O8YV2JTG',
+		aliasId: '0DNZS5QI8M',
+		localeId: 'en_US',
+		region: 'us-west-2',
+		providerName: 'AWSLexProviderV2',
+	},
+};
+
+jest.mock('../../src/Providers/AWSLexProviderHelper/convert', () => ({
+	...jest.requireActual('../../src/Providers/AWSLexProviderHelper/convert'),
+	unGzipBase64AsJson: data => data,
+}));
+
+LexRuntimeV2Client.prototype.send = jest.fn((command, callback) => {
+	if (command instanceof RecognizeTextCommand) {
+		if (command.input.text === 'done') {
+			const result = {
+				sessionState: {
+					intent: {
+						slots: { m1: 'hi', m2: 'done' },
+						state: 'ReadyForFulfillment',
+					},
+				},
+				messages: [{ content: 'echo:' + command.input.text }],
+			};
+			return Promise.resolve(result);
+		} else if (command.input.text === 'error') {
+			const result = {
+				sessionState: {
+					intent: { state: 'Failed' },
+				},
+				messages: [{ content: 'echo:' + command.input.text }],
+			};
+			return Promise.resolve(result);
+		} else {
+			const result = {
+				sessionState: {
+					intent: { state: 'ElicitSlot' },
+				},
+				messages: [{ content: 'echo:' + command.input.text }],
+			};
+
+			return Promise.resolve(result);
+		}
+	} else if (command instanceof RecognizeUtteranceCommand) {
+		if (
+			command.input.requestContentType ===
+			'audio/x-l16; sample-rate=16000; channel-count=1'
+		) {
+			const bot = command.input.botId as string;
+			const [botName, status] = bot.split(':');
+
+			if (status === 'done') {
+				// we add the status to the botName
+				// because inputStream would just be a blob if type is voice
+				const result = {
+					sessionState: {
+						intent: {
+							slots: { m1: 'voice:hi', m2: 'voice:done' },
+							state: 'ReadyForFulfillment',
+						},
+					},
+					messages: [{ content: 'voice:echo:' + command.input.botId }],
+					audioStream: createBlob(),
+				};
+				return Promise.resolve(result);
+			} else if (status === 'error') {
+				const result = {
+					sessionState: {
+						intent: { state: 'Failed' },
+					},
+					messages: [{ content: 'voice:echo:' + command.input.botId }],
+					audioStream: createBlob(),
+				};
+				return Promise.resolve(result);
+			} else {
+				const result = {
+					sessionState: {
+						intent: { state: 'ElicitSlot' },
+					},
+					messages: [{ content: 'voice:echo:' + command.input.botId }],
+					audioStream: createBlob(),
+				};
+				return Promise.resolve(result);
+			}
+		} else {
+			if (command.input.inputStream === 'done') {
+				const result = {
+					sessionState: {
+						intent: {
+							slots: { m1: 'hi', m2: 'done' },
+							state: 'ReadyForFulfillment',
+						},
+					},
+					messages: [{ content: 'echo:' + command.input.inputStream }],
+					audioStream: createBlob(),
+				};
+				return Promise.resolve(result);
+			} else if (command.input.inputStream === 'error') {
+				const result = {
+					sessionState: {
+						intent: { state: 'Failed' },
+					},
+					messages: [{ content: 'echo:' + command.input.inputStream }],
+					audioStream: createBlob(),
+				};
+				return Promise.resolve(result);
+			} else {
+				const result = {
+					sessionState: {
+						intent: { state: 'ElicitSlot' },
+					},
+					messages: [{ content: 'echo:' + command.input.inputStream }],
+					audioStream: createBlob(),
+				};
+				return Promise.resolve(result);
+			}
+		}
+	}
+}) as any;
+
+afterEach(() => {
+	jest.restoreAllMocks();
+});
+
+describe('Interactions', () => {
+	describe('constructor test', () => {
+		test('happy case', () => {
+			const provider = new AWSLexProviderV2();
+		});
+	});
+
+	// Test 'getProviderName' API
+	describe('getProviderName API', () => {
+		test('happy case', () => {
+			const provider = new AWSLexProviderV2();
+			expect(provider.getProviderName()).toEqual('AWSLexProviderV2');
+		});
+	});
+
+	// Test 'getCategory' API
+	describe('getCategory API', () => {
+		test('happy case', () => {
+			const provider = new AWSLexProviderV2();
+			expect(provider.getCategory()).toEqual('Interactions');
+		});
+	});
+
+	// Test 'configure' API
+	describe('configure API', () => {
+		const provider = new AWSLexProviderV2();
+
+		test('happy case', () => {
+			expect(provider.configure(botConfig)).toEqual(botConfig);
+		});
+
+		test('configure multiple bots', () => {
+			// config 1st bot
+			expect(provider.configure(botConfig)).toEqual(botConfig);
+
+			const anotherBot = {
+				BookTrip: {
+					name: 'BookHotel',
+					botId: '0DNZS5QI8M',
+					aliasId: 'O1O8YV2JTG',
+					localeId: 'en_US',
+					region: 'us-west-2',
+					providerName: 'AWSLexProviderV2',
+				},
+			};
+			// config 2nd bot
+			expect(provider.configure(anotherBot)).toEqual({
+				...botConfig,
+				...anotherBot,
+			});
+
+			const anotherBotUpdated = {
+				BookTrip: {
+					name: 'BookHotel',
+					botId: '0DNZS5QI8M',
+					aliasId: '7542RC2HTD',
+					localeId: 'en_IN',
+					region: 'us-west-2',
+					providerName: 'AWSLexProviderV2',
+				},
+			};
+			// re-configure updated 2nd bot
+			// 2nd bot is overridden
+			expect(provider.configure(anotherBotUpdated)).toEqual({
+				...botConfig,
+				...anotherBotUpdated,
+			});
+		});
+
+		test('FailureCase: invalid bot config', () => {
+			const v1Bot = {
+				BookHotel: {
+					name: 'BookHotel',
+					alias: '$LATEST',
+					region: 'us-west-2',
+				},
+			};
+			// @ts-ignore
+			expect(() => provider.configure(v1Bot)).toThrow(
+				'invalid bot configuration'
+			);
+		});
+	});
+
+	// Test 'send' API
+	describe('send API', () => {
+		let provider;
+
+		beforeEach(() => {
+			jest
+				.spyOn(Credentials, 'get')
+				.mockImplementation(() => Promise.resolve({ identityId: '1234' }));
+
+			provider = new AWSLexProviderV2();
+			provider.configure(botConfig);
+		});
+
+		test('send simple text message and fulfill', async () => {
+			let response = await provider.sendMessage('BookTrip', 'hi');
+			expect(response).toEqual({
+				sessionState: {
+					intent: {
+						state: 'ElicitSlot',
+					},
+				},
+				messages: [{ content: 'echo:hi' }],
+			});
+
+			response = await provider.sendMessage('BookTrip', 'done');
+			expect(response).toEqual({
+				sessionState: {
+					intent: {
+						slots: { m1: 'hi', m2: 'done' },
+						state: 'ReadyForFulfillment',
+					},
+				},
+				messages: [{ content: 'echo:done' }],
+			});
+		});
+
+		test('send obj text message and fulfill', async () => {
+			let response = await provider.sendMessage('BookTrip', {
+				content: 'hi',
+				options: {
+					messageType: 'text',
+				},
+			});
+			expect(response).toEqual({
+				sessionState: {
+					intent: {
+						state: 'ElicitSlot',
+					},
+				},
+				messages: [{ content: 'echo:hi' }],
+				audioStream: new Uint8Array(),
+			});
+
+			response = await provider.sendMessage('BookTrip', {
+				content: 'done',
+				options: {
+					messageType: 'text',
+				},
+			});
+			expect(response).toEqual({
+				sessionState: {
+					intent: {
+						slots: { m1: 'hi', m2: 'done' },
+						state: 'ReadyForFulfillment',
+					},
+				},
+				messages: [{ content: 'echo:done' }],
+				audioStream: new Uint8Array(),
+			});
+		});
+
+		test('send obj voice message and fulfill', async () => {
+			const botconfig = {
+				BookTrip: {
+					name: 'BookTrip',
+					botId: '0DNZS5QI8M:hi',
+					aliasId: 'O1O8YV2JTG',
+					localeId: 'en_US',
+					providerName: 'AWSLexProviderV2',
+					region: 'us-west-2',
+				},
+			};
+			provider.configure(botconfig);
+
+			let response = await provider.sendMessage('BookTrip', {
+				content: createBlob(),
+				options: {
+					messageType: 'voice',
+				},
+			});
+			expect(response).toEqual({
+				sessionState: {
+					intent: {
+						state: 'ElicitSlot',
+					},
+				},
+				messages: [{ content: 'voice:echo:0DNZS5QI8M:hi' }],
+				audioStream: new Uint8Array(),
+			});
+
+			botconfig.BookTrip.botId = '0DNZS5QI8M:done';
+			provider.configure(botconfig);
+			response = await provider.sendMessage('BookTrip', {
+				content: createBlob(),
+				options: {
+					messageType: 'voice',
+				},
+			});
+			expect(response).toEqual({
+				sessionState: {
+					intent: {
+						slots: { m1: 'voice:hi', m2: 'voice:done' },
+						state: 'ReadyForFulfillment',
+					},
+				},
+				messages: [{ content: 'voice:echo:0DNZS5QI8M:done' }],
+				audioStream: new Uint8Array(),
+			});
+		});
+
+		test('FailureCase: No credentials send', async () => {
+			jest
+				.spyOn(Credentials, 'get')
+				.mockImplementation(() => Promise.reject({ identityId: '1234' }));
+
+			await expect(provider.sendMessage('BookTrip', 'hi')).rejects.toEqual(
+				'No credentials'
+			);
+		});
+
+		test('FailureCase: send to not existing bot', async () => {
+			await expect(provider.sendMessage('unknownBot', 'hi')).rejects.toEqual(
+				'Bot unknownBot does not exist'
+			);
+		});
+
+		test('FailureCase: send simple text, obj text and obj voice messages in wrong format', async () => {
+			await expect(provider.sendMessage('BookTrip', 3421)).rejects.toEqual(
+				`message type isn't supported`
+			);
+
+			// obj text in wrong format
+			await expect(
+				provider.sendMessage('BookTrip', {
+					content: createBlob(),
+					options: {
+						messageType: 'text',
+					},
+				})
+			).rejects.toEqual(`message type isn't supported`);
+
+			// obj voice in wrong format
+			await expect(
+				provider.sendMessage('BookTrip', {
+					content: 'Hi',
+					options: {
+						messageType: 'voice',
+					},
+				})
+			).rejects.toEqual(`message type isn't supported`);
+		});
+	});
+
+	// Test 'onComplete' API
+	describe('onComplete API', () => {
+		const callback = (err, confirmation) => {};
+		let provider;
+
+		beforeEach(() => {
+			jest
+				.spyOn(Credentials, 'get')
+				.mockImplementation(() => Promise.resolve({ identityId: '1234' }));
+
+			provider = new AWSLexProviderV2();
+			provider.configure(botConfig);
+		});
+
+		test('happy case', () => {
+			provider.onComplete('BookTrip', callback);
+		});
+
+		test('FailureCase: onComplete to not existing bot', async () => {
+			expect(() => provider.onComplete('unknownBot', callback)).toThrow(
+				'Bot unknownBot does not exist'
+			);
+		});
+
+		test('FailureCase: onComplete with wrong input format', async () => {
+			// wrong callback
+			expect(() => provider.onComplete('BookTrip', 'hi')).toThrow(
+				`message type isn't supported`
+			);
+
+			// wrong botname
+			expect(() => provider.onComplete({}, 'Hi')).toThrow(
+				`message type isn't supported`
+			);
+		});
+	});
+
+	// Test 'reportBotStatus' API
+	describe('reportBotStatus API', () => {
+		jest.useFakeTimers();
+		let provider;
+
+		let inProgressResp;
+		let completeSuccessResp;
+		let completeFailResp;
+
+		const inProgressCallback = (err, confirmation) => {
+			fail(`callback shouldn't be called`);
+		};
+
+		const completeSuccessCallback = (err, confirmation) => {
+			expect(err).toEqual(null);
+			expect(confirmation).toEqual({ slots: { m1: 'hi', m2: 'done' } });
+		};
+
+		const completeFailCallback = (err, confirmation) => {
+			expect(err).toEqual('Bot conversation failed');
+		};
+
+		beforeEach(async () => {
+			jest
+				.spyOn(Credentials, 'get')
+				.mockImplementation(() => Promise.resolve({ identityId: '1234' }));
+
+			provider = new AWSLexProviderV2();
+			provider.configure(botConfig);
+
+			inProgressResp = (await provider.sendMessage(
+				'BookTrip',
+				'hi'
+			)) as RecognizeTextCommandOutput;
+
+			completeSuccessResp = (await provider.sendMessage(
+				'BookTrip',
+				'done'
+			)) as RecognizeTextCommandOutput;
+
+			completeFailResp = (await provider.sendMessage(
+				'BookTrip',
+				'error'
+			)) as RecognizeTextCommandOutput;
+		});
+
+		test('onComplete callback from `Interactions.onComplete`', async () => {
+			// 1. In progress, callback shouldn't be called
+			provider.onComplete('BookTrip', inProgressCallback);
+			provider.reportBotStatus('BookTrip', inProgressResp.sessionState);
+			jest.runAllTimers();
+
+			// 2. task complete; success, callback be called with response
+			provider.onComplete('BookTrip', completeSuccessCallback);
+			provider.reportBotStatus('BookTrip', completeSuccessResp.sessionState);
+			jest.runAllTimers();
+
+			// 3. task complete; error, callback be called with error
+			provider.onComplete('BookTrip', completeFailCallback);
+			provider.reportBotStatus('BookTrip', completeFailResp.sessionState);
+			jest.runAllTimers();
+		});
+
+		test('onComplete callback from `Configure`', async () => {
+			const myBot: any = {
+				BookTrip: {
+					name: 'BookTrip',
+					botId: '0DNZS5QI8M',
+					aliasId: 'O1O8YV2JTG',
+					localeId: 'en_US',
+					region: 'us-west-2',
+					providerName: 'AWSLexProviderV2',
+				},
+			};
+
+			// 1. In progress, callback shouldn't be called
+			myBot.BookTrip.onComplete = inProgressCallback;
+			provider.configure(myBot);
+			provider.reportBotStatus('BookTrip', inProgressResp.sessionState);
+			jest.runAllTimers();
+
+			// 2. In progress, callback shouldn't be called
+			myBot.BookTrip.onComplete = completeSuccessCallback;
+			provider.configure(myBot);
+			provider.reportBotStatus('BookTrip', completeSuccessResp.sessionState);
+			jest.runAllTimers();
+
+			// 3. In progress, callback shouldn't be called
+			myBot.BookTrip.onComplete = completeFailCallback;
+			provider.configure(myBot);
+			provider.reportBotStatus('BookTrip', completeFailResp.sessionState);
+			jest.runAllTimers();
+		});
+	});
+});

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -42,7 +42,9 @@
 	"homepage": "https://aws-amplify.github.io/",
 	"dependencies": {
 		"@aws-amplify/core": "4.6.1",
-		"@aws-sdk/client-lex-runtime-service": "3.6.1"
+		"@aws-sdk/client-lex-runtime-service": "3.6.1",
+		"@aws-sdk/client-lex-runtime-v2": "3.31.0",
+		"fflate": "^0.7.3"
 	},
 	"jest": {
 		"globals": {

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -116,19 +116,7 @@ export class InteractionsClass {
 
 	public async send(
 		botname: string,
-		message: string
-	): Promise<InteractionsResponse>;
-	public async send(
-		botname: string,
-		message: InteractionsMessage
-	): Promise<InteractionsResponse>;
-	public async send(
-		botname: string,
-		message: object
-	): Promise<InteractionsResponse>;
-	public async send(
-		botname: string,
-		message: string | object
+		message: string | InteractionsMessage
 	): Promise<InteractionsResponse> {
 		if (
 			!(

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -31,13 +31,13 @@ export class InteractionsClass {
 	 *
 	 * @param {InteractionsOptions} options - Configuration object for Interactions
 	 */
-	constructor(options: InteractionsOptions) {
+	constructor(options: InteractionsOptions = {}) {
 		this._options = options;
 		logger.debug('Interactions Options', this._options);
 		this._pluggables = {};
 	}
 
-	public getModuleName() {
+	public getModuleName(): string {
 		return 'Interactions';
 	}
 
@@ -46,7 +46,7 @@ export class InteractionsClass {
 	 * @param {InteractionsOptions} options - Configuration object for Interactions
 	 * @return {Object} - The current configuration
 	 */
-	configure(options: InteractionsOptions) {
+	public configure(options: InteractionsOptions): InteractionsOptions {
 		const opt = options ? options.Interactions || options : {};
 		logger.debug('configure Interactions', { opt });
 		this._options = { bots: {}, ...opt, ...opt.Interactions };
@@ -63,33 +63,52 @@ export class InteractionsClass {
 			}
 		}
 
-		// Check if AWSLex provider is already on pluggables
-		if (
-			!this._pluggables.AWSLexProvider &&
-			bots_config &&
-			Object.keys(bots_config)
-				.map(key => bots_config[key])
-				.find(bot => !bot.providerName || bot.providerName === 'AWSLexProvider')
-		) {
-			this._pluggables.AWSLexProvider = new AWSLexProvider();
-		}
-
-		Object.keys(this._pluggables).map(key => {
-			this._pluggables[key].configure(this._options.bots);
+		// configure bots to their specific providers
+		Object.keys(bots_config).map(botKey => {
+			const bot = bots_config[botKey];
+			const providerName = bot.providerName || 'AWSLexProvider';
+			if (
+				!this._pluggables.AWSLexProvider &&
+				providerName === 'AWSLexProvider'
+			) {
+				this._pluggables.AWSLexProvider = new AWSLexProvider();
+			} else if (!this._pluggables[providerName]) {
+				throw new Error(
+					'providerName ' +
+						providerName +
+						' does not exist, did you try addPluggable first?'
+				);
+			}
+			this._pluggables[providerName].configure({ [bot.name]: bot });
 		});
 
 		return this._options;
 	}
 
 	public addPluggable(pluggable: InteractionsProvider) {
+		if (!(pluggable && pluggable.getCategory() === 'Interactions')) {
+			throw new Error('Invalid pluggable');
+		}
+
 		if (pluggable && pluggable.getCategory() === 'Interactions') {
 			if (!this._pluggables[pluggable.getProviderName()]) {
-				pluggable.configure(this._options.bots);
+				// configure bots for the new plugin
+				Object.keys(this._options.bots)
+					.filter(
+						botKey =>
+							this._options.bots[botKey].providerName ===
+							pluggable.getProviderName()
+					)
+					.map(botKey => {
+						const bot = this._options.bots[botKey];
+						pluggable.configure({ [bot.name]: bot });
+					});
+
 				this._pluggables[pluggable.getProviderName()] = pluggable;
 				return;
 			} else {
 				throw new Error(
-					'Bot ' + pluggable.getProviderName() + ' already plugged'
+					'Pluggable ' + pluggable.getProviderName() + ' already plugged'
 				);
 			}
 		}
@@ -111,15 +130,24 @@ export class InteractionsClass {
 		botname: string,
 		message: string | object
 	): Promise<InteractionsResponse> {
+		if (
+			!(
+				typeof botname === 'string' &&
+				(typeof message === 'string' || typeof message === 'object')
+			)
+		) {
+			return Promise.reject(`message type isn't supported`);
+		}
+
 		if (!this._options.bots || !this._options.bots[botname]) {
-			throw new Error('Bot ' + botname + ' does not exist');
+			return Promise.reject('Bot ' + botname + ' does not exist');
 		}
 
 		const botProvider =
 			this._options.bots[botname].providerName || 'AWSLexProvider';
 
 		if (!this._pluggables[botProvider]) {
-			throw new Error(
+			return Promise.reject(
 				'Bot ' +
 					botProvider +
 					' does not have valid pluggin did you try addPluggable first?'
@@ -128,7 +156,14 @@ export class InteractionsClass {
 		return await this._pluggables[botProvider].sendMessage(botname, message);
 	}
 
-	public onComplete(botname: string, callback: (err, confirmation) => void) {
+	public onComplete(
+		botname: string,
+		callback: (err, confirmation) => void
+	): void {
+		if (!(typeof botname === 'string' && typeof callback === 'function')) {
+			throw new Error(`message type isn't supported`);
+		}
+
 		if (!this._options.bots || !this._options.bots[botname]) {
 			throw new Error('Bot ' + botname + ' does not exist');
 		}
@@ -146,5 +181,5 @@ export class InteractionsClass {
 	}
 }
 
-export const Interactions = new InteractionsClass(null);
+export const Interactions = new InteractionsClass();
 Amplify.register(Interactions);

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -48,7 +48,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 		return 'AWSLexProvider';
 	}
 
-	configure(config: AWSLexProviderOptions = {}): InteractionsOptions {
+	configure(config: AWSLexProviderOptions = {}): AWSLexProviderOptions {
 		const propertiesToTest = ['name', 'alias', 'region'];
 
 		Object.keys(config).map(botKey => {

--- a/packages/interactions/src/Providers/AWSLexProviderHelper/convert.ts
+++ b/packages/interactions/src/Providers/AWSLexProviderHelper/convert.ts
@@ -1,4 +1,6 @@
+import { gunzipSync, strFromU8 } from 'fflate';
 import { Readable } from 'stream';
+
 export const convert = (
 	stream: Blob | Readable | ReadableStream
 ): Promise<Uint8Array> => {
@@ -9,4 +11,23 @@ export const convert = (
 	} else {
 		throw new Error('Readable is not supported.');
 	}
+};
+
+export const base64ToArrayBuffer = (base64: string): Uint8Array => {
+	const binary_string = window.atob(base64);
+	const len = binary_string.length;
+	const bytes = new Uint8Array(len);
+	for (let i = 0; i < len; i++) {
+		bytes[i] = binary_string.charCodeAt(i);
+	}
+	return bytes;
+};
+
+export const unGzipBase64AsJson = <T>(gzipBase64: string): T => {
+	// base64 decode
+	// gzip decompress and convert to string
+	// string to obj
+	return JSON.parse(
+		strFromU8(gunzipSync(base64ToArrayBuffer(gzipBase64)))
+	) as T;
 };

--- a/packages/interactions/src/Providers/AWSLexProviderV2.ts
+++ b/packages/interactions/src/Providers/AWSLexProviderV2.ts
@@ -50,7 +50,7 @@ export class AWSLexProviderV2 extends AbstractInteractionsProvider {
 		return 'AWSLexProviderV2';
 	}
 
-	configure(config: AWSLexProviderV2Options = {}): InteractionsOptions {
+	configure(config: AWSLexProviderV2Options = {}): AWSLexProviderV2Options {
 		const propertiesToTest = [
 			'name',
 			'botId',

--- a/packages/interactions/src/Providers/AWSLexProviderV2.ts
+++ b/packages/interactions/src/Providers/AWSLexProviderV2.ts
@@ -1,15 +1,3 @@
-/*
- * Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
- * the License. A copy of the License is located at
- *
- *     http://aws.amazon.com/apache2.0/
- *
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
- */
 import { AbstractInteractionsProvider } from './InteractionsProvider';
 import {
 	InteractionsOptions,

--- a/packages/interactions/src/Providers/InteractionsProvider.ts
+++ b/packages/interactions/src/Providers/InteractionsProvider.ts
@@ -22,7 +22,8 @@ import { ConsoleLogger as Logger } from '@aws-amplify/core';
 const logger = new Logger('AbstractInteractionsProvider');
 
 export abstract class AbstractInteractionsProvider
-	implements InteractionsProvider {
+	implements InteractionsProvider
+{
 	protected _config: InteractionsOptions;
 
 	constructor(options: InteractionsOptions = {}) {

--- a/packages/interactions/src/Providers/index.ts
+++ b/packages/interactions/src/Providers/index.ts
@@ -11,4 +11,5 @@
  * and limitations under the License.
  */
 export * from './AWSLexProvider';
+export * from './AWSLexProviderV2';
 export * from './InteractionsProvider';

--- a/packages/interactions/src/index.ts
+++ b/packages/interactions/src/index.ts
@@ -19,5 +19,6 @@ export default Interactions;
 
 export * from './types';
 export * from './Providers/AWSLexProvider';
+export * from './Providers/AWSLexProviderV2';
 
 export { Interactions };

--- a/packages/interactions/src/index.ts
+++ b/packages/interactions/src/index.ts
@@ -18,6 +18,7 @@ import { Interactions } from './Interactions';
 export default Interactions;
 
 export * from './types';
+export * from './Providers/InteractionsProvider';
 export * from './Providers/AWSLexProvider';
 export * from './Providers/AWSLexProviderV2';
 

--- a/packages/interactions/src/types/Provider.ts
+++ b/packages/interactions/src/types/Provider.ts
@@ -15,9 +15,7 @@ import { InteractionsResponse } from './Response';
 
 export interface InteractionsProvider {
 	// configure your provider
-	configure(
-		config: AWSLexProviderOptions | AWSLexProviderV2Options | undefined
-	): object;
+	configure(config: InteractionsOptions): InteractionsOptions;
 
 	// return 'Interactions'
 	getCategory(): string;
@@ -31,6 +29,10 @@ export interface InteractionsProvider {
 		botname: string,
 		callback: (err: any, confirmation: InteractionsResponse) => void
 	);
+}
+
+export interface generic {
+	[key: string]: any;
 }
 
 export interface InteractionsProviders {

--- a/packages/interactions/src/types/Provider.ts
+++ b/packages/interactions/src/types/Provider.ts
@@ -15,7 +15,9 @@ import { InteractionsResponse } from './Response';
 
 export interface InteractionsProvider {
 	// configure your provider
-	configure(config: object): object;
+	configure(
+		config: AWSLexProviderOptions | AWSLexProviderV2Options | undefined
+	): object;
 
 	// return 'Interactions'
 	getCategory(): string;
@@ -33,4 +35,34 @@ export interface InteractionsProvider {
 
 export interface InteractionsProviders {
 	[key: string]: InteractionsProvider;
+}
+
+export interface InteractionsProviderOptions {
+	[key: string]: AWSLexProviderOptions | AWSLexProviderV2Options;
+}
+
+export interface AWSLexProviderOption {
+	name: string;
+	alias: string;
+	region: string;
+	providerName?: string;
+	onComplete?(botname: string, callback: (err, confirmation) => void): void;
+}
+
+export interface AWSLexProviderOptions {
+	[key: string]: AWSLexProviderOption;
+}
+
+export interface AWSLexProviderV2Option {
+	name: string;
+	botId: string;
+	aliasId: string;
+	localeId: string;
+	region: string;
+	providerName: string;
+	onComplete?(botname: string, callback: (err, confirmation) => void): void;
+}
+
+export interface AWSLexProviderV2Options {
+	[key: string]: AWSLexProviderV2Option;
 }


### PR DESCRIPTION
#### Description of changes
In Interactions, add support for LexV2. 

Interactions would support LexV1 bots by default.
To add LexV2 bots import the `AWSLexProviderV2` provider and use the ` addPluggable` method to add the provider. Manually configure the V2 bot.
 
```js
import { Amplify, Interactions } from 'aws-amplify';
import { AWSLexProviderV2 } from '@aws-amplify/interactions';

Interactions.addPluggable(new AWSLexProviderV2());

const interactionsConfig = {
    Auth: {
        identityPoolId: "<identityPoolId>",
        region: "<region>"
    },
    Interactions: {
        bots: {
            my_v1_bot: { // default provider "AWSLexProvider"
                name: "my_v1_bot",
                alias: "$LATEST",
                region: "<region>",
            },
            my_v2_bot: {
                name: "my_v2_bot",
                aliasId: "<aliasId>",
                botId: "<botId>",
                localeId: "<localeId>",
                region: "<region>",
                providerName: "AWSLexProviderV2",
            },
        }
    }
}

Amplify.configure(interactionsConfig);
```

#### Issue #, if available
#7662 
#4690

#### Description of how you validated changes
- Unit test added for the change
- Tested change in the sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
