### PR TITLE
feat(auth): Pass more details to list of devices

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -2777,10 +2777,23 @@ export class AuthClass {
 							device.DeviceAttributes.find(
 								({ Name }) => Name === 'device_name'
 							) || {};
+						const deviceStatus =
+							device.DeviceAttributes.find(
+								({ Name }) => Name === 'device_status'
+							) || {};
+						const lastIpUsed =
+							device.DeviceAttributes.find(
+								({ Name }) => Name === 'last_ip_used'
+							) || {};
 
 						const deviceInfo: IAuthDevice = {
 							id: device.DeviceKey,
 							name: deviceName.Value,
+							status: deviceStatus.Value,
+							lastIpUsed: lastIpUsed.Value,
+							creationDate: device.DeviceCreateDate,
+							lastAuthenticatedDate: device.DeviceLastAuthenticatedDate,
+							lastModifiedDate: device.DeviceLastModifiedDate,
 						};
 						return deviceInfo;
 					});

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -219,6 +219,11 @@ export function isUsernamePasswordOpts(obj: any): obj is UsernamePasswordOpts {
 export interface IAuthDevice {
 	id: string;
 	name: string;
+	status: string;
+	lastIpUsed: string;
+	creationDate: number;
+	lastAuthenticatedDate: number;
+	lastModifiedDate: number;
 }
 
 export interface AutoSignInOptions {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This small change adds extra details to the list of devices. The following attributes have been added to AuthDevice:

- Status
- Last IP address used
- Creation timestamp
- Last modification timestamp
- Last Authentication timestamp

Typical use case would be to allow the user to see more details, like the last access and IP address, and assess if the device should be revoked. These are already sent in a response by the Cognito endpoint and are merely just passed through the SDK.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
- Ran yarn test
- Tested locally on a company project which already implements a list of devices


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
