### PR TITLE
feat(@aws-amplify/storage): pagination for storage list api using Token

### DIFF
--- a/packages/storage/__tests__/Storage-unit-test.ts
+++ b/packages/storage/__tests__/Storage-unit-test.ts
@@ -1,6 +1,10 @@
 import AWSStorageProvider from '../src/providers/AWSS3Provider';
 import { Storage as StorageClass } from '../src/Storage';
-import { Storage as StorageCategory, StorageProvider } from '../src';
+import {
+	S3ProviderListOutputWithToken,
+	Storage as StorageCategory,
+	StorageProvider,
+} from '../src';
 import axios, { CancelToken } from 'axios';
 import { AWSS3UploadTask } from '../src/providers/AWSS3UploadTask';
 import { S3Client } from '@aws-sdk/client-s3';
@@ -55,8 +59,10 @@ class TestCustomProvider implements StorageProvider {
 	}
 }
 
-class TestCustomProviderWithCopy extends TestCustomProvider
-	implements StorageProvider {
+class TestCustomProviderWithCopy
+	extends TestCustomProvider
+	implements StorageProvider
+{
 	copy(
 		src: { key: string },
 		dest: { key: string },
@@ -800,9 +806,14 @@ describe('Storage', () => {
 			provider = new AWSStorageProvider();
 			storage.addPluggable(provider);
 			storage.configure(options);
+			const result: S3ProviderListOutputWithToken = {
+				results: [],
+				hasNextPage: false,
+				nextPageToken: null,
+			};
 			listSpy = jest
 				.spyOn(AWSStorageProvider.prototype, 'list')
-				.mockImplementation(() => Promise.resolve([]));
+				.mockImplementation(() => Promise.resolve(result));
 		});
 
 		afterEach(() => {
@@ -819,7 +830,7 @@ describe('Storage', () => {
 			test('call list object with all available config', async () => {
 				storage.list('path', {
 					track: false,
-					maxKeys: 10,
+					pageSize: 10,
 					level: 'public',
 					customPrefix: {
 						public: 'public',
@@ -970,7 +981,7 @@ describe('Storage', () => {
 				.spyOn(axios.CancelToken, 'source')
 				.mockImplementation(() => {
 					return {
-						token: (tokenMock as unknown) as CancelToken,
+						token: tokenMock as unknown as CancelToken,
 						cancel: cancelMock,
 					};
 				});

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -751,17 +751,11 @@ export class AWSS3Provider implements StorageProvider {
 			} else {
 				if (pageSize < MAX_PAGE_SIZE && typeof pageSize === 'number')
 					params.MaxKeys = pageSize;
-				else {
-					throw new Error(
-						'Provided pageSize is not an integer or within 1-1000 range.'
-					);
-				}
+				else logger.warn(`pageSize should be from 0 - ${MAX_PAGE_SIZE}.`);
 				listResult = await this._list(params, opt, prefix);
 				list.results.push(...listResult.results);
 				list.hasNextPage = listResult.hasNextPage;
 				list.nextPageToken = null ?? listResult.nextPageToken;
-				if (pageSize > MAX_PAGE_SIZE)
-					logger.warn(`pageSize should be from 0 - ${MAX_PAGE_SIZE}.`);
 			}
 			dispatchStorageEvent(
 				track,

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -45,7 +45,6 @@ import {
 	S3ProviderGetOuput,
 	S3ProviderPutConfig,
 	S3ProviderRemoveConfig,
-	S3ProviderListOutput,
 	S3ProviderListConfig,
 	S3ProviderCopyConfig,
 	S3ProviderCopyOutput,
@@ -58,6 +57,7 @@ import {
 	ResumableUploadConfig,
 	UploadTask,
 	S3ClientOptions,
+	S3ProviderListOutputWithToken,
 } from '../types';
 import { StorageErrorStrings } from '../common/StorageErrorStrings';
 import { dispatchStorageEvent } from '../common/StorageUtils';
@@ -69,7 +69,6 @@ import {
 	autoAdjustClockskewMiddlewareOptions,
 	createS3Client,
 } from '../common/S3ClientUtils';
-import { S3ProviderListOutputWithToken } from '.././types/AWSS3Provider';
 import { AWSS3ProviderManagedUpload } from './AWSS3ProviderManagedUpload';
 import { AWSS3UploadTask, TaskEvents } from './AWSS3UploadTask';
 import { UPLOADS_STORAGE_KEY } from '../common/StorageConstants';
@@ -687,14 +686,14 @@ export class AWSS3Provider implements StorageProvider {
 		prefix: string
 	): Promise<S3ProviderListOutputWithToken> {
 		const result: S3ProviderListOutputWithToken = {
-			contents: [],
-			nextToken: '',
+			results: [],
+			hasNextPage: false,
 		};
 		const s3 = this._createNewS3Client(opt);
 		const listObjectsV2Command = new ListObjectsV2Command({ ...params });
 		const response = await s3.send(listObjectsV2Command);
 		if (response && response.Contents) {
-			result.contents = response.Contents.map(item => {
+			result.results = response.Contents.map(item => {
 				return {
 					key: item.Key.substr(prefix.length),
 					eTag: item.ETag,
@@ -702,7 +701,8 @@ export class AWSS3Provider implements StorageProvider {
 					size: item.Size,
 				};
 			});
-			result.nextToken = response.NextContinuationToken;
+			result.nextPageToken = response.NextContinuationToken;
+			result.hasNextPage = response.IsTruncated;
 		}
 		return result;
 	}
@@ -711,48 +711,54 @@ export class AWSS3Provider implements StorageProvider {
 	 * List bucket objects relative to the level and prefix specified
 	 * @param {string} path - the path that contains objects
 	 * @param {S3ProviderListConfig} [config] - Optional configuration for the underlying S3 command
-	 * @return {Promise<S3ProviderListOutput>} - Promise resolves to list of keys, eTags, lastModified and file size for
-	 * all objects in path
+	 * @return {Promise<S3ProviderListOutputWithToken>} - Promise resolves to list of keys, eTags, lastModified
+	 * and file size for all objects in path
 	 */
 	public async list(
 		path: string,
 		config?: S3ProviderListConfig
-	): Promise<S3ProviderListOutput> {
+	): Promise<S3ProviderListOutputWithToken> {
 		const credentialsOK = await this._ensureCredentials();
 		if (!credentialsOK || !this._isWithCredentials(this._config)) {
 			throw new Error(StorageErrorStrings.NO_CREDENTIALS);
 		}
 		const opt: S3ClientOptions = Object.assign({}, this._config, config);
-		const { bucket, track, maxKeys } = opt;
+		const { bucket, track, pageSize, pageToken } = opt;
 		const prefix = this._prefix(opt);
 		const final_path = prefix + path;
 		logger.debug('list ' + path + ' from ' + final_path);
 		try {
-			const list: S3ProviderListOutput = [];
-			let token: string;
+			const list: S3ProviderListOutputWithToken = {
+				results: [],
+				hasNextPage: false,
+			};
 			let listResult: S3ProviderListOutputWithToken;
 			const params: ListObjectsV2Request = {
 				Bucket: bucket,
 				Prefix: final_path,
 				MaxKeys: 1000,
+				ContinuationToken: pageToken,
 			};
-			if (maxKeys === 'ALL') {
+			params.ContinuationToken = pageToken;
+			if (pageSize === undefined) {
 				do {
-					params.ContinuationToken = token;
-					params.MaxKeys = 1000;
 					listResult = await this._list(params, opt, prefix);
-					list.push(...listResult.contents);
-					if (listResult.nextToken) token = listResult.nextToken;
-				} while (listResult.nextToken);
+					list.results.push(...listResult.results);
+					if (listResult.nextPageToken)
+						params.ContinuationToken = listResult.nextPageToken;
+				} while (listResult.nextPageToken);
 			} else {
-				maxKeys < 1000 || typeof maxKeys === 'string'
-					? (params.MaxKeys = maxKeys)
-					: (params.MaxKeys = 1000);
+				if (pageSize < 1000 || typeof pageSize === 'string')
+					params.MaxKeys = pageSize;
 				listResult = await this._list(params, opt, prefix);
-				list.push(...listResult.contents);
-				if (maxKeys > 1000)
+				list.results.push(...listResult.results);
+				list.hasNextPage = listResult.hasNextPage;
+				listResult.nextPageToken
+					? (list.nextPageToken = listResult.nextPageToken)
+					: (list.nextPageToken = null);
+				if (pageSize > 1000)
 					logger.warn(
-						"maxkeys can be from 0 - 1000 or 'ALL'. To list all files you can set maxKeys to 'ALL'."
+						'pageSize should be from 0 - 1000. The default pageSize is 1000.'
 					);
 			}
 			dispatchStorageEvent(
@@ -760,7 +766,7 @@ export class AWSS3Provider implements StorageProvider {
 				'list',
 				{ method: 'list', result: 'success' },
 				null,
-				`${list.length} items returned from list operation`
+				`${list.results.length} items returned from list operation`
 			);
 			logger.debug('list', list);
 			return list;

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -749,7 +749,7 @@ export class AWSS3Provider implements StorageProvider {
 						params.ContinuationToken = listResult.nextPageToken;
 				} while (listResult.nextPageToken);
 			} else {
-				if (pageSize < MAX_PAGE_SIZE && typeof pageSize === 'number')
+				if (pageSize <= MAX_PAGE_SIZE && typeof pageSize === 'number')
 					params.MaxKeys = pageSize;
 				else logger.warn(`pageSize should be from 0 - ${MAX_PAGE_SIZE}.`);
 				listResult = await this._list(params, opt, prefix);

--- a/packages/storage/src/types/AWSS3Provider.ts
+++ b/packages/storage/src/types/AWSS3Provider.ts
@@ -96,17 +96,19 @@ export type S3ProviderRemoveConfig = CommonStorageOptions & {
 };
 
 export type S3ProviderListOutputWithToken = {
-	contents: S3ProviderListOutputItem[];
-	nextToken: string;
+	results: S3ProviderListOutputItem[];
+	nextPageToken?: string;
+	hasNextPage: boolean;
 };
 
 export type S3ProviderRemoveOutput = DeleteObjectCommandOutput;
 
 export type S3ProviderListConfig = CommonStorageOptions & {
 	bucket?: string;
-	maxKeys?: number | 'ALL';
+	pageSize?: number;
 	provider?: 'AWSS3';
 	identityId?: string;
+	pageToken?: string;
 };
 
 export type S3ClientOptions = StorageOptions & {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
To enable users to paginate through storage using List api. Enabled users to pass a pageToken to the list Api so that they can get a next set of files.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#7133 
#6838 



#### Description of how you validated changes

- Unit test added for the change
- Tested change in the sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
