### PR TITLE
build(release): automate github release with lerna

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"unlink-all": "lerna exec --no-bail --parallel -- yarn unlink; exit 0",
 		"publish:main": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=unstable --preid=unstable --exact --no-verify-access",
 		"publish:beta": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=beta --preid=beta --exact --no-verify-access",
-		"publish:release": "lerna publish --conventional-commits --yes --message 'chore(release): Publish [ci skip]' --no-verify-access",
+		"publish:release": "lerna publish --conventional-commits --create-release github --yes --message 'chore(release): Publish [ci skip]' --no-verify-access",
 		"publish:1.0-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-1.0 --message 'chore(release): Publish [ci skip]' --no-verify-access",
 		"publish:ui-components/main": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=ui-preview --preid=ui-preview --exact --no-verify-access",
 		"publish:verdaccio": "lerna publish --no-push --canary minor --dist-tag=unstable --preid=unstable --exact --force-publish --yes --no-verify-access",


### PR DESCRIPTION
#### Description of changes
Currently when we publish the package we automatically create the release tag on github but need to [manually create a release](https://github.com/aws-amplify/amplify-js/releases/tag/aws-amplify%404.3.30).
Update package.json to include the `--create-release github` flag to automatically create a release ([reference lerna docs](https://github.com/lerna/lerna/blob/main/commands/version/README.md#--create-release-type)) 


#### Description of how you validated changes
- Created a [sample repo](https://github.com/ashwinkumar6/lerna-poc) to test this. It's a monorepo with multiple packages  which are managed by lerna, like amplify-js's project structure
- When creating a release/publish, lerna only updates the package versions of the packages which are changed, creates a tag and a release on github
- The sample repo also uses the [same lerna version](https://github.com/ashwinkumar6/lerna-poc/blob/main/package.json#L18) thats currently being used on amplify-js 


- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
