### PR TITLE
feat(geo): Added mapstyle region type

### DIFF
--- a/packages/geo/src/types/Geo.ts
+++ b/packages/geo/src/types/Geo.ts
@@ -33,6 +33,7 @@ export interface GeoConfig {
 export interface MapStyle {
 	mapName: string;
 	style: string;
+	region: string;
 }
 
 export type Longitude = number;


### PR DESCRIPTION
#### Description of changes
I added the "MapStyle" "region" type because of a type error during TypeScript development.

#### Issue #, if available
https://github.com/aws-amplify/amplify-js/issues/9173

#### Description of how you validated changes
```typescript
import { Amplify } from 'aws-amplify';
import { Auth } from 'aws-amplify';
import { Geo } from '@aws-amplify/geo';
import awsconfig from './aws-exports';
import { AmplifyMapLibreRequest } from 'maplibre-gl-js-amplify';

Amplify.configure(awsconfig);
const credentials = await Auth.currentCredentials();
const { transformRequest } = new AmplifyMapLibreRequest(
    credentials,
    Geo.getDefaultMap().region
);
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
