### PR TITLE
fix(interactions): fix configure default provider

### DIFF
--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -34,7 +34,7 @@
 		"@angular/forms": "^6.0.3",
 		"@angular/platform-browser": "^5.2.9",
 		"@angular/platform-browser-dynamic": "^5.2.9",
-		"@types/lodash": "^4.14.106",
+		"@types/lodash": "4.14.106",
 		"@types/node": "^9.4.6",
 		"@types/paho-mqtt": "^1.0.3",
 		"@types/zen-observable": "^0.5.3",

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -67,12 +67,17 @@ export class InteractionsClass {
 		Object.keys(bots_config).forEach(botKey => {
 			const bot = bots_config[botKey];
 			const providerName = bot.providerName || 'AWSLexProvider';
+
+			// add default provider if required
 			if (
 				!this._pluggables.AWSLexProvider &&
 				providerName === 'AWSLexProvider'
 			) {
 				this._pluggables.AWSLexProvider = new AWSLexProvider();
-			} else if (this._pluggables[providerName]) {
+			}
+
+			// configure bot with it's respective provider
+			if (this._pluggables[providerName]) {
 				this._pluggables[providerName].configure({ [bot.name]: bot });
 			} else {
 				logger.debug(


### PR DESCRIPTION
#### Description of changes
When configuring a bot using default V1 provider, we can configure it using manual configuration / aws-exports config.
When using aws-exports with default provider, configure bot on the category class and call the provider's configure method. Currently with default V1 provider, provider's configure isn't called sometimes

Steps to reproduce
1. Default V1 provider is used
2. bot is configured using aws-exports 
3. Interaction’s configure is called only once

Add following unit tests
- Configure bot with default provider (AWSLexProvider) using manual config
- Configure bot with default provider (AWSLexProvider) using aws-exports config

This fix should pass the current interactions integration tests

#### Description of how you validated changes
Unit test added for the change
Tested change in the sample app
Tested using integration tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
