### PR TITLE
fix: An update to @types/lodash breaks the build - specify latest working version to unblock

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 	"devDependencies": {
 		"@babel/cli": "7.17.0",
 		"@babel/core": "7.17.2",
+		"@types/lodash": "4.14.182",
 		"@babel/preset-env": "^7.0.0",
 		"@babel/preset-react": "^7.0.0",
 		"@types/jest": "^24.0.18",

--- a/packages/aws-amplify-angular/package.json
+++ b/packages/aws-amplify-angular/package.json
@@ -34,7 +34,6 @@
 		"@angular/forms": "^6.0.3",
 		"@angular/platform-browser": "^5.2.9",
 		"@angular/platform-browser-dynamic": "^5.2.9",
-		"@types/lodash": "^4.14.106",
 		"@types/node": "^9.4.6",
 		"@types/paho-mqtt": "^1.0.3",
 		"@types/zen-observable": "^0.5.3",


### PR DESCRIPTION
#### Description of changes
Our build broke with the release of [@types/lodash 4.14.183](https://www.npmjs.com/package/@types/lodash). Fixing to `4.14.182` to keep the build unblocked.

#### Issue #, if available
NA

#### Description of how you validated changes
`yarn && yarn build` works

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
