### PR TITLE
fix(interactions): fix addPluggable API

### DIFF
--- a/packages/interactions/__tests__/Interactions-unit-test.ts
+++ b/packages/interactions/__tests__/Interactions-unit-test.ts
@@ -363,13 +363,6 @@ describe('Interactions', () => {
 			expect.assertions(4);
 		});
 
-		test('Add a invalid pluggable', () => {
-			expect(() => interactions.addPluggable(new WrongProvider())).toThrow(
-				'Invalid pluggable'
-			);
-			expect.assertions(1);
-		});
-
 		test('Add existing pluggable again', () => {
 			interactions.addPluggable(new DummyProvider());
 			expect(() => {

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -90,29 +90,27 @@ export class InteractionsClass {
 	}
 
 	public addPluggable(pluggable: InteractionsProvider) {
-		if (!(pluggable && pluggable.getCategory() === 'Interactions')) {
-			throw new Error('Invalid pluggable');
-		}
+		if (pluggable && pluggable.getCategory() === 'Interactions') {
+			if (!this._pluggables[pluggable.getProviderName()]) {
+				// configure bots for the new plugin
+				Object.keys(this._options.bots)
+					.filter(
+						botKey =>
+							this._options.bots[botKey].providerName ===
+							pluggable.getProviderName()
+					)
+					.forEach(botKey => {
+						const bot = this._options.bots[botKey];
+						pluggable.configure({ [bot.name]: bot });
+					});
 
-		if (!this._pluggables[pluggable.getProviderName()]) {
-			// configure bots for the new plugin
-			Object.keys(this._options.bots)
-				.filter(
-					botKey =>
-						this._options.bots[botKey].providerName ===
-						pluggable.getProviderName()
-				)
-				.forEach(botKey => {
-					const bot = this._options.bots[botKey];
-					pluggable.configure({ [bot.name]: bot });
-				});
-
-			this._pluggables[pluggable.getProviderName()] = pluggable;
-			return;
-		} else {
-			throw new Error(
-				'Pluggable ' + pluggable.getProviderName() + ' already plugged'
-			);
+				this._pluggables[pluggable.getProviderName()] = pluggable;
+				return;
+			} else {
+				throw new Error(
+					'Pluggable ' + pluggable.getProviderName() + ' already plugged'
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Description of changes
Plugins can be added using `Amplify.addPluggable()` or `<Category>.addPluggable()`

`Amplify.addPluggable()` calls addPluggable() of all category classes.
Update Interaction's addPluggable to not throw any error if the category doesn't match

#### Issue #, if available
#10249

#### Description of how you validated changes
- Unit test added for the change
- Tested change in the sample app

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.