### PR TITLE
fix-10275 - handle electron/app redirects for hosted-ui

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -133,6 +133,9 @@ export class AuthClass {
 				case 'signOut':
 					this._storage.removeItem('amplify-signin-with-hostedUI');
 					break;
+				case 'oAuthSignOut':
+					this._storage.removeItem('amplify-signin-with-hostedUI');
+					break;
 				case 'cognitoHostedUI':
 					this._storage.setItem('amplify-signin-with-hostedUI', 'true');
 					break;
@@ -2480,11 +2483,17 @@ export class AuthClass {
 					currentUser.setSignInUserSession(session);
 
 					if (window && typeof window.history !== 'undefined') {
-						window.history.replaceState(
-							{},
-							null,
-							(this._config.oauth as AwsCognitoOAuthOpts).redirectSignIn
-						);
+						if (
+							(
+								this._config.oauth as AwsCognitoOAuthOpts
+							).redirectSignIn.startsWith('http')
+						) {
+							window.history.replaceState(
+								{},
+								null,
+								(this._config.oauth as AwsCognitoOAuthOpts).redirectSignIn
+							);
+						}
 					}
 
 					dispatchAuthEvent(
@@ -2516,11 +2525,17 @@ export class AuthClass {
 					// Just like a successful handling of `?code`, replace the window history to "dispose" of the `code`.
 					// Otherwise, reloading the page will throw errors as the `code` has already been spent.
 					if (window && typeof window.history !== 'undefined') {
-						window.history.replaceState(
-							{},
-							null,
-							(this._config.oauth as AwsCognitoOAuthOpts).redirectSignIn
-						);
+						if (
+							(
+								this._config.oauth as AwsCognitoOAuthOpts
+							).redirectSignIn.startsWith('http')
+						) {
+							window.history.replaceState(
+								{},
+								null,
+								(this._config.oauth as AwsCognitoOAuthOpts).redirectSignIn
+							);
+						}
 					}
 
 					dispatchAuthEvent(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
There is in issue when using Hosted-UI with electron. It appears the library is trying to push the redirect url on the history. However, the history of the app is http:localhost but the redirect is an app name and path when using in electron. This errors and prevents some final logic to execute including setting the "amplify-signin-with-hostedUI" key. This then prevents the app from fully signing out via the hostedUI. The library is also not removing the "amplify-signin-with-hostedUI" key after signout.

This fix checks for http/https url and otherwise skips the adding to the history.  It also added the appropriate hook to remove "amplify-signin-with-hostedUI" on oauth signout. 


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
[10275](https://github.com/aws-amplify/amplify-js/issues/10275)


#### Description of how you validated changes
Built our own app and linked int the changes. Ran inside electron and outside.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
