### PR TITLE
fix(interactions): use pako instead of fflate in RN

### DIFF
--- a/packages/interactions/__tests__/providers/AWSLexProvider-unit-test.ts
+++ b/packages/interactions/__tests__/providers/AWSLexProvider-unit-test.ts
@@ -338,6 +338,28 @@ describe('Interactions', () => {
 			);
 			expect.assertions(1);
 		});
+
+		test('send obj text and obj voice messages in wrong format', async () => {
+			// obj text in wrong format
+			await expect(
+				provider.sendMessage('BookTrip', {
+					content: createBlob(),
+					options: {
+						messageType: 'text',
+					},
+				})
+			).rejects.toEqual('invalid content type');
+
+			// obj voice in wrong format
+			await expect(
+				provider.sendMessage('BookTrip', {
+					content: 'Hi',
+					options: {
+						messageType: 'voice',
+					},
+				})
+			).rejects.toEqual('invalid content type');
+		});
 	});
 
 	// attach 'onComplete' callback to bot

--- a/packages/interactions/__tests__/providers/AWSLexV2Provider-unit-test.ts
+++ b/packages/interactions/__tests__/providers/AWSLexV2Provider-unit-test.ts
@@ -442,6 +442,28 @@ describe('Interactions', () => {
 			);
 			expect.assertions(1);
 		});
+
+		test('send obj text and obj voice messages in wrong format', async () => {
+			// obj text in wrong format
+			await expect(
+				provider.sendMessage('BookTrip', {
+					content: createBlob(),
+					options: {
+						messageType: 'text',
+					},
+				})
+			).rejects.toEqual('invalid content type');
+
+			// obj voice in wrong format
+			await expect(
+				provider.sendMessage('BookTrip', {
+					content: 'Hi',
+					options: {
+						messageType: 'voice',
+					},
+				})
+			).rejects.toEqual('invalid content type');
+		});
 	});
 
 	// Test 'onComplete' API

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -45,7 +45,8 @@
 		"@aws-sdk/client-lex-runtime-service": "3.6.1",
 		"@aws-sdk/client-lex-runtime-v2": "3.31.0",
 		"base-64": "1.0.0",
-		"fflate": "0.7.3"
+		"fflate": "0.7.3",
+		"pako": "2.0.4"
 	},
 	"jest": {
 		"globals": {

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -163,7 +163,10 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 				content,
 				options: { messageType },
 			} = message;
-			if (messageType === 'voice' && typeof content === 'object') {
+			if (messageType === 'voice') {
+				if (typeof content !== 'object') {
+					return Promise.reject('invalid content type');
+				}
 				const inputStream =
 					content instanceof Uint8Array ? content : await convert(content);
 

--- a/packages/interactions/src/Providers/AWSLexProviderHelper/commonUtils.ts
+++ b/packages/interactions/src/Providers/AWSLexProviderHelper/commonUtils.ts
@@ -10,8 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import { strFromU8 } from 'fflate';
-import { base64ToArrayBuffer, gzipDecompress } from './convert';
+import { base64ToArrayBuffer, gzipDecompressToString } from './utils';
 
 export const unGzipBase64AsJson = async (gzipBase64: string | undefined) => {
 	if (typeof gzipBase64 === 'undefined') return undefined;
@@ -19,11 +18,7 @@ export const unGzipBase64AsJson = async (gzipBase64: string | undefined) => {
 	try {
 		const decodedArrayBuffer = base64ToArrayBuffer(gzipBase64);
 
-		const decompressedData: Uint8Array = await gzipDecompress(
-			decodedArrayBuffer
-		);
-
-		const objString = strFromU8(decompressedData, true);
+		const objString: string = await gzipDecompressToString(decodedArrayBuffer);
 
 		return JSON.parse(objString);
 	} catch (error) {

--- a/packages/interactions/src/Providers/AWSLexProviderHelper/convert.native.ts
+++ b/packages/interactions/src/Providers/AWSLexProviderHelper/convert.native.ts
@@ -12,7 +12,7 @@
  */
 
 import { decode } from 'base-64';
-import { gunzipSync } from 'fflate';
+import { ungzip } from 'pako';
 
 export const convert = async (stream: Blob): Promise<Uint8Array> => {
 	return new Promise(async (resolve, reject) => {
@@ -38,6 +38,15 @@ export const base64ToArrayBuffer = (base64: string): Uint8Array => {
 	return Uint8Array.from(binaryString, c => c.charCodeAt(0));
 };
 
-export const gzipDecompress = async (data: Uint8Array): Promise<Uint8Array> => {
-	return new Promise(resolve => resolve(gunzipSync(data)));
+export const gzipDecompressToString = async (
+	data: Uint8Array
+): Promise<string> => {
+	return new Promise((resolve, reject) => {
+		try {
+			const result: string = ungzip(data, { to: 'string' });
+			resolve(result);
+		} catch (error) {
+			reject('unable to decompress' + error);
+		}
+	});
 };

--- a/packages/interactions/src/Providers/AWSLexProviderHelper/convert.ts
+++ b/packages/interactions/src/Providers/AWSLexProviderHelper/convert.ts
@@ -11,8 +11,7 @@
  * and limitations under the License.
  */
 
-import { Readable } from 'stream';
-import { gunzip } from 'fflate';
+import { gunzip, strFromU8 } from 'fflate';
 
 export const convert = async (
 	stream: Blob | Readable | ReadableStream
@@ -30,11 +29,13 @@ export const base64ToArrayBuffer = (base64: string): Uint8Array => {
 	return Uint8Array.from(window.atob(base64), c => c.charCodeAt(0));
 };
 
-export const gzipDecompress = async (data: Uint8Array): Promise<Uint8Array> => {
+export const gzipDecompressToString = async (
+	data: Uint8Array
+): Promise<string> => {
 	return await new Promise((resolve, reject) => {
 		gunzip(data, (err, resp) => {
 			if (err) reject(err);
-			else resolve(resp);
+			else resolve(strFromU8(resp));
 		});
 	});
 };

--- a/packages/interactions/src/Providers/AWSLexV2Provider.ts
+++ b/packages/interactions/src/Providers/AWSLexV2Provider.ts
@@ -301,7 +301,11 @@ export class AWSLexV2Provider extends AbstractInteractionsProvider {
 		let params: RecognizeUtteranceCommandInput;
 
 		// prepare params
-		if (messageType === 'voice' && typeof content === 'object') {
+		if (messageType === 'voice') {
+			if (typeof content !== 'object') {
+				return Promise.reject('invalid content type');
+			}
+
 			const inputStream =
 				content instanceof Uint8Array ? content : await convert(content);
 


### PR DESCRIPTION
#### Description of changes
fflat lib is used in interactions to gzip data. 

This lib uses `.cjs` files which would throw an error during build in RN apps. RN apps would need to resolve this by adding the following in metro config file 
```
resolver: {
  sourceExts: [...sourceExts, "cjs"]
}
```

To avoid this, use an alternative lib pako instead of fflate in RN. For web continue using fflate since it's bundle size is much smaller than pako

#### Description of how you validated changes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
