### PR TITLE
fix(pubsub): Fix vite build issue

### DIFF
--- a/packages/pubsub/src/Providers/MqttOverWSProvider.ts
+++ b/packages/pubsub/src/Providers/MqttOverWSProvider.ts
@@ -21,8 +21,7 @@ import {
 	ConnectionStateMonitor,
 	CONNECTION_CHANGE,
 } from '../utils/ConnectionStateMonitor';
-import { AMPLIFY_SYMBOL } from './constants';
-import { CONNECTION_STATE_CHANGE } from '..';
+import { AMPLIFY_SYMBOL, CONNECTION_STATE_CHANGE } from './constants';
 
 const logger = new Logger('MqttOverWSProvider');
 

--- a/packages/pubsub/src/Providers/constants.ts
+++ b/packages/pubsub/src/Providers/constants.ts
@@ -2,6 +2,8 @@ export const MAX_DELAY_MS = 5000;
 
 export const NON_RETRYABLE_CODES = [400, 401, 403];
 
+export const CONNECTION_STATE_CHANGE = 'ConnectionStateChange';
+
 export enum MESSAGE_TYPES {
 	/**
 	 * Client -> Server message.

--- a/packages/pubsub/src/index.ts
+++ b/packages/pubsub/src/index.ts
@@ -22,7 +22,8 @@ enum CONTROL_MSG {
 	TIMEOUT_DISCONNECT = 'Timeout disconnect',
 }
 
-export const CONNECTION_STATE_CHANGE = 'ConnectionStateChange';
+export { CONNECTION_STATE_CHANGE } from './Providers/constants';
+
 export { ConnectionState } from './types';
 
 export { PubSub, CONTROL_MSG };


### PR DESCRIPTION
#### Description of changes
There is an issue related to the object load order that impacts the Vite build process (and maybe others). This [stack overflow](https://stackoverflow.com/questions/53122751/typeerror-object-prototype-may-only-be-an-object-or-null-undefined) question helped identify the nature of the problem.  In this case, the PubSub `index` files loads providers, which in turn load `CONNECTION_STATE_CHANGE` from further down `index` creating a cycle.

Moving this constant to a file so that the load order is acyclic fixes the issue.

#### Issue #, if available
#10295
#10287
#10260

#### Description of how you validated changes
I was able to reproduce the issue by following the Vue project instructions from #10287, however had trouble getting linking working to test a fix. The example React project from #10295 was very helpful in proving and testing that this fix works.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
