### PR TITLE
fix(cache): use named import when exporting from aws-amplify

### DIFF
--- a/packages/aws-amplify/src/index.ts
+++ b/packages/aws-amplify/src/index.ts
@@ -13,13 +13,13 @@
 
 import { Amplify, ServiceWorker } from '@aws-amplify/core';
 import { Auth } from '@aws-amplify/auth';
-import Cache from '@aws-amplify/cache';
+import { BrowserStorageCache } from '@aws-amplify/cache';
 
 /** Always importing Auth when users import Amplify such that
 	for unauthenticated access (no sign in and sign up),
 	users don't have to import Auth explicitly **/
 Amplify.Auth = Auth;
-Amplify.Cache = Cache;
+Amplify.Cache = BrowserStorageCache;
 Amplify.ServiceWorker = ServiceWorker;
 
 export {
@@ -42,7 +42,7 @@ export {
 	syncExpression,
 } from '@aws-amplify/datastore';
 export { PubSub } from '@aws-amplify/pubsub';
-export { default as Cache } from '@aws-amplify/cache';
+export { BrowserStorageCache as Cache } from '@aws-amplify/cache';
 export { Interactions } from '@aws-amplify/interactions';
 export * from '@aws-amplify/ui';
 export { XR } from '@aws-amplify/xr';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
We're currently exporting the default import of `Cache` from `aws-amplify`.
When customers use the Cache category:
```ts
import {Cache} from 'aws-amplify'
```
They get the following TS error
![image](https://user-images.githubusercontent.com/29709626/189397520-b07a627f-4ddf-44df-a674-21c4d4b79243.png)

This PR replaces the default import from the Cache module with a named import and lines up Cache with how we expose all other categories via the `aws-amplify` package.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://discord.com/channels/705853757799399426/707328986077855836/1017533084532486217


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
