### PR TITLE
feat(auth): add bundle size analyzer plugin based on main

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -29,6 +29,7 @@
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint '{__tests__,src}/**/*.ts'"
+    
   },
   "repository": {
     "type": "git",

--- a/packages/auth/webpack.config.js
+++ b/packages/auth/webpack.config.js
@@ -1,11 +1,18 @@
+const BundleAnalyzerPlugin =
+	require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+
 module.exports = {
+	plugins: [new BundleAnalyzerPlugin()],
 	entry: {
 		'aws-amplify-auth.min': './lib-esm/index.js',
 	},
-	externals: ['react-native', {
-		'@aws-amplify/cache': 'aws_amplify_cache',
-		'@aws-amplify/core': 'aws_amplify_core'
-	}],
+	externals: [
+		'react-native',
+		{
+			'@aws-amplify/cache': 'aws_amplify_cache',
+			'@aws-amplify/core': 'aws_amplify_core',
+		},
+	],
 	output: {
 		filename: '[name].js',
 		path: __dirname + '/dist',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
it adds the webpack bundle size analyzer plugin



#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
