### PR TITLE
chore: bump up @aws-sdk packages to 3.175.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1218,6 +1218,7 @@ releasable_branches: &releasable_branches
       - ui-components/main
       - 1.0-stable
       - geo/main
+      - bump-aws-sdk-3.175.0
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]

--- a/packages/amplify-ui-vue/tsconfig.json
+++ b/packages/amplify-ui-vue/tsconfig.json
@@ -18,7 +18,7 @@
 		"sourceMap": true,
 		"jsx": "react",
 		"target": "es2015",
-		"types": []
+		"types": ["node"]
 	},
 	"include": ["src/**/*.ts", "src/**/*.tsx"],
 	"exclude": ["**/__tests__/**"],

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -45,11 +45,11 @@
 	"dependencies": {
 		"@aws-amplify/cache": "4.0.56",
 		"@aws-amplify/core": "4.7.5",
-		"@aws-sdk/client-firehose": "3.6.1",
-		"@aws-sdk/client-kinesis": "3.6.1",
-		"@aws-sdk/client-personalize-events": "3.6.1",
-		"@aws-sdk/client-pinpoint": "3.6.1",
-		"@aws-sdk/util-utf8-browser": "3.6.1",
+		"@aws-sdk/client-firehose": "3.171.0",
+		"@aws-sdk/client-kinesis": "3.171.0",
+		"@aws-sdk/client-personalize-events": "3.171.0",
+		"@aws-sdk/client-pinpoint": "3.171.0",
+		"@aws-sdk/util-utf8-browser": "3.170.0",
 		"lodash": "^4.17.20",
 		"uuid": "^3.2.1"
 	},

--- a/packages/aws-amplify-angular/rollup.config.js
+++ b/packages/aws-amplify-angular/rollup.config.js
@@ -36,7 +36,7 @@ export default {
 		'@aws-amplify/core',
 	],
 	plugins: [
-		nodeResolve({ preferBuiltins: false, modulesOnly: true }),
+		nodeResolve({ preferBuiltins: false, modulesOnly: true, browser: true }),
 		commonjs({ include: 'node_modules/**' }),
 		globals(),
 		json(),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,11 +56,11 @@
 	},
 	"dependencies": {
 		"@aws-crypto/sha256-js": "1.0.0-alpha.0",
-		"@aws-sdk/client-cloudwatch-logs": "3.6.1",
-		"@aws-sdk/client-cognito-identity": "3.6.1",
-		"@aws-sdk/credential-provider-cognito-identity": "3.6.1",
-		"@aws-sdk/types": "3.6.1",
-		"@aws-sdk/util-hex-encoding": "3.6.1",
+		"@aws-sdk/client-cloudwatch-logs": "3.171.0",
+		"@aws-sdk/client-cognito-identity": "3.171.0",
+		"@aws-sdk/credential-provider-cognito-identity": "3.171.0",
+		"@aws-sdk/types": "3.171.0",
+		"@aws-sdk/util-hex-encoding": "3.170.0",
 		"universal-cookie": "^4.0.4",
 		"zen-observable-ts": "0.8.19"
 	},

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -42,7 +42,7 @@
 	"homepage": "https://aws-amplify.github.io/",
 	"dependencies": {
 		"@aws-amplify/core": "4.7.5",
-		"@aws-sdk/client-location": "3.48.0",
+		"@aws-sdk/client-location": "3.171.0",
 		"@turf/boolean-clockwise": "6.5.0",
 		"camelcase-keys": "6.2.2"
 	},

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -42,7 +42,7 @@
 	"homepage": "https://aws-amplify.github.io/",
 	"dependencies": {
 		"@aws-amplify/core": "4.7.5",
-		"@aws-sdk/client-lex-runtime-service": "3.6.1",
+		"@aws-sdk/client-lex-runtime-service": "3.171.0",
 		"@aws-sdk/client-lex-runtime-v2": "3.171.0",
 		"base-64": "1.0.0",
 		"fflate": "0.7.3",

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -42,13 +42,13 @@
 	"dependencies": {
 		"@aws-amplify/core": "4.7.5",
 		"@aws-amplify/storage": "4.5.7",
-		"@aws-sdk/client-comprehend": "3.6.1",
-		"@aws-sdk/client-polly": "3.6.1",
-		"@aws-sdk/client-rekognition": "3.6.1",
-		"@aws-sdk/client-textract": "3.6.1",
-		"@aws-sdk/client-translate": "3.6.1",
-		"@aws-sdk/eventstream-marshaller": "3.6.1",
-		"@aws-sdk/util-utf8-node": "3.6.1",
+		"@aws-sdk/client-comprehend": "3.171.0",
+		"@aws-sdk/client-polly": "3.171.0",
+		"@aws-sdk/client-rekognition": "3.171.0",
+		"@aws-sdk/client-textract": "3.171.0",
+		"@aws-sdk/client-translate": "3.171.0",
+		"@aws-sdk/eventstream-codec": "3.171.0",
+		"@aws-sdk/util-utf8-node": "3.170.0",
 		"uuid": "^3.2.1"
 	},
 	"jest": {

--- a/packages/storage/__tests__/common/S3ClientUtils-unit-test.ts
+++ b/packages/storage/__tests__/common/S3ClientUtils-unit-test.ts
@@ -10,7 +10,7 @@ import {
 	Credentials,
 	getAmplifyUserAgent,
 } from '@aws-amplify/core';
-import { S3ClientConfig } from '@aws-sdk/client-s3';
+import { S3ClientResolvedConfig } from '@aws-sdk/client-s3';
 
 const credentials: ICredentials = {
 	accessKeyId: 'accessKeyId',
@@ -174,7 +174,7 @@ describe('S3ClientUtils tests', () => {
 		const dateNow = Date.now();
 		// keep the Date.now() call inside the middleware consistent
 		jest.spyOn(Date, 'now').mockImplementation(() => dateNow);
-		const s3ClientConfig = { systemClockOffset: 0 } as S3ClientConfig;
+		const s3ClientConfig = { systemClockOffset: 0 } as S3ClientResolvedConfig;
 		const middleware = autoAdjustClockskewMiddleware(s3ClientConfig);
 		const oneHourInMs = 1000 * 60 * 60;
 		try {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -42,10 +42,10 @@
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
     "@aws-amplify/core": "4.7.5",
-    "@aws-sdk/client-s3": "3.6.1",
-    "@aws-sdk/s3-request-presigner": "3.6.1",
-    "@aws-sdk/util-create-request": "3.6.1",
-    "@aws-sdk/util-format-url": "3.6.1",
+    "@aws-sdk/client-s3": "3.171.0",
+    "@aws-sdk/s3-request-presigner": "3.173.0",
+    "@aws-sdk/util-create-request": "3.171.0",
+    "@aws-sdk/util-format-url": "3.171.0",
     "axios": "0.26.0",
     "events": "^3.1.0"
   },

--- a/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
+++ b/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
@@ -14,7 +14,7 @@
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import {
 	PutObjectCommand,
-	PutObjectRequest,
+	PutObjectCommandInput,
 	CreateMultipartUploadCommand,
 	UploadPartCommand,
 	CompleteMultipartUploadCommand,
@@ -55,7 +55,7 @@ export class AWSS3ProviderManagedUpload {
 
 	// Data for current upload
 	private body = null;
-	private params: PutObjectRequest = null;
+	private params: PutObjectCommandInput = null;
 	private opts = null;
 	private completedParts: CompletedPart[] = [];
 	private s3client: S3Client;
@@ -66,7 +66,11 @@ export class AWSS3ProviderManagedUpload {
 	private totalBytesToUpload = 0;
 	private emitter: events.EventEmitter = null;
 
-	constructor(params: PutObjectRequest, opts, emitter: events.EventEmitter) {
+	constructor(
+		params: PutObjectCommandInput,
+		opts,
+		emitter: events.EventEmitter
+	) {
 		this.params = params;
 		this.opts = opts;
 		this.emitter = emitter;
@@ -97,7 +101,6 @@ export class AWSS3ProviderManagedUpload {
 					start < numberOfPartsToUpload;
 					start += this.queueSize
 				) {
-
 					// Upload as many as `queueSize` parts simultaneously
 					await this.uploadParts(
 						this.uploadId,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Follow up to https://github.com/aws-amplify/amplify-js/pull/7822, update `@aws-sdk` packages after over 1.5 years. Targeting the package set in the [3.175.0 release of `@aws-sdk`](https://github.com/aws/aws-sdk-js-v3/tree/v3.175.0)

Pending:
* Integration test
* Bundle size report

Resolves: https://github.com/aws-amplify/amplify-js/issues/9639

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
TBD


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
