### PR TITLE
fix: correct no-op write detection

### DIFF
--- a/packages/datastore/__tests__/storage.test.ts
+++ b/packages/datastore/__tests__/storage.test.ts
@@ -15,8 +15,71 @@ import {
 	testSchema,
 } from './helpers';
 
-let initSchema: typeof initSchemaType;
-let DataStore: typeof DataStoreType;
+function getDataStore() {
+	const {
+		initSchema,
+		DataStore,
+	}: {
+		initSchema: typeof initSchemaType;
+		DataStore: typeof DataStoreType;
+	} = require('../src/datastore/datastore');
+
+	const classes = initSchema(testSchema());
+	const {
+		Model,
+		Post,
+		Comment,
+		PostComposite,
+		PostCustomPK,
+		PostCustomPKSort,
+		PostCustomPKComposite,
+	} = classes as {
+		Model: PersistentModelConstructor<Model>;
+		Post: PersistentModelConstructor<Post>;
+		Comment: PersistentModelConstructor<Comment>;
+		PostComposite: PersistentModelConstructor<PostComposite>;
+		PostCustomPK: PersistentModelConstructor<PostCustomPKType>;
+		PostCustomPKSort: PersistentModelConstructor<PostCustomPKSortType>;
+		PostCustomPKComposite: PersistentModelConstructor<PostCustomPKCompositeType>;
+	};
+
+	return {
+		DataStore,
+		Model,
+		Post,
+		Comment,
+		PostComposite,
+		PostCustomPK,
+		PostCustomPKSort,
+		PostCustomPKComposite,
+	};
+}
+
+/**
+ * Strip out schemaVersion save call that DS performs when starting.
+ * Allows us to run any of the tests in isolation (i.e., .only on any test will work)
+ *
+ * @returns A flattened array of mock function calls
+ */
+function processZenPushCalls(zenNext): Array<any> {
+	const {
+		mock: { calls },
+	} = zenNext;
+
+	if (!Array.isArray(calls)) {
+		return [];
+	}
+
+	if (calls.length) {
+		const [[first]] = calls;
+
+		if (first?.element?.key === 'schemaVersion') {
+			return calls.slice(1).flat();
+		}
+	}
+
+	return calls.flat();
+}
 
 describe('Storage tests', () => {
 	describe('Update', () => {
@@ -24,9 +87,6 @@ describe('Storage tests', () => {
 			let zenNext;
 
 			beforeEach(() => {
-				jest.resetModules();
-				jest.resetAllMocks();
-
 				zenNext = jest.fn();
 
 				jest.doMock('zen-push', () => {
@@ -37,17 +97,15 @@ describe('Storage tests', () => {
 
 					return zenPush;
 				});
+			});
 
-				({ initSchema, DataStore } = require('../src/datastore/datastore'));
+			afterEach(() => {
+				jest.resetModules();
+				jest.resetAllMocks();
 			});
 
 			test('scalar', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
-
+				const { DataStore, Model } = getDataStore();
 				const dateCreated = new Date().toISOString();
 
 				const model = await DataStore.save(
@@ -63,7 +121,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [_settingsSave, [modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [modelSave, modelUpdate] = processZenPushCalls(zenNext);
 
 				// Save should include
 				expect(modelSave.element.dateCreated).toEqual(dateCreated);
@@ -75,12 +133,7 @@ describe('Storage tests', () => {
 			});
 
 			test('scalar - unchanged', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
-
+				const { DataStore, Model } = getDataStore();
 				const dateCreated = new Date().toISOString();
 
 				const model = await DataStore.save(
@@ -96,20 +149,15 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[_modelSave], modelUpdate] = zenNext.mock.calls;
+				const [_modelSave, modelUpdate] = processZenPushCalls(zenNext);
 
-				expect(modelUpdate).toBeUndefined();
 				expect(modelUpdate).toBeUndefined();
 
 				expect(true).toBeTruthy();
 			});
 
 			test('update by nulling previous value', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
+				const { DataStore, Model } = getDataStore();
 
 				const model = await DataStore.save(
 					new Model({
@@ -125,18 +173,13 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [_modelSave, modelUpdate] = processZenPushCalls(zenNext);
 
 				expect(modelUpdate.element.optionalField1).toBeNull();
 			});
 
 			test('updating value with undefined gets saved as null', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
-
+				const { DataStore, Model } = getDataStore();
 				const model = await DataStore.save(
 					new Model({
 						field1: 'Some value',
@@ -151,17 +194,13 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [_modelSave, modelUpdate] = processZenPushCalls(zenNext);
 
 				expect(modelUpdate.element.optionalField1).toBeNull();
 			});
 
 			test('list (destructured)', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
+				const { DataStore, Model } = getDataStore();
 
 				const model = await DataStore.save(
 					new Model({
@@ -177,7 +216,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [_modelSave, modelUpdate] = processZenPushCalls(zenNext);
 
 				const expectedValueEmails = [
 					'john@doe.com',
@@ -191,11 +230,7 @@ describe('Storage tests', () => {
 			});
 
 			test('list (push)', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
+				const { DataStore, Model } = getDataStore();
 
 				const model = await DataStore.save(
 					new Model({
@@ -211,7 +246,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [_modelSave, modelUpdate] = processZenPushCalls(zenNext);
 
 				const expectedValueEmails = [
 					'john@doe.com',
@@ -225,11 +260,7 @@ describe('Storage tests', () => {
 			});
 
 			test('update with changed field and list unchanged', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
+				const { DataStore, Model } = getDataStore();
 
 				const model = await DataStore.save(
 					new Model({
@@ -247,24 +278,16 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [_modelSave, modelUpdate] = processZenPushCalls(zenNext);
 
 				expect(modelUpdate.element.dateCreated).toBeUndefined();
 				expect(modelUpdate.element.field1).toEqual('Updated value');
 				expect(modelUpdate.element.emails).toBeUndefined();
 			});
 
-			// this is failing on `main` as well, but it times out before it gets
-			// to the assertion (until I added expect.assertions)
-			// TODO:check with Dane on expected behavior, as it is likely affected by the
-			// mergePatches work
-			test.skip('update with list unchanged', async () => {
+			test('update with list unchanged', async () => {
 				expect.assertions(1);
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
+				const { DataStore, Model } = getDataStore();
 
 				const model = await DataStore.save(
 					new Model({
@@ -281,17 +304,13 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[_modelSave], modelUpdate] = zenNext.mock.calls;
+				const [_modelSave, modelUpdate] = processZenPushCalls(zenNext);
 
 				expect(modelUpdate).toBeUndefined();
 			});
 
 			test('update by nulling list', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
+				const { DataStore, Model } = getDataStore();
 
 				const model = await DataStore.save(
 					new Model({
@@ -307,17 +326,13 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [_modelSave, modelUpdate] = processZenPushCalls(zenNext);
 
 				expect(modelUpdate.element.emails).toBeNull();
 			});
 
 			test('custom type (destructured)', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
+				const { DataStore, Model } = getDataStore();
 
 				const model = await DataStore.save(
 					new Model({
@@ -340,7 +355,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [_modelSave, modelUpdate] = processZenPushCalls(zenNext);
 
 				const expectedValueMetadata = {
 					author: 'some author',
@@ -356,11 +371,7 @@ describe('Storage tests', () => {
 			});
 
 			test('custom type (accessor)', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
+				const { DataStore, Model } = getDataStore();
 
 				const model = await DataStore.save(
 					new Model({
@@ -380,7 +391,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [_modelSave, modelUpdate] = processZenPushCalls(zenNext);
 
 				const expectedValueMetadata = {
 					author: 'some author',
@@ -396,11 +407,7 @@ describe('Storage tests', () => {
 			});
 
 			test('custom type unchanged', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Model } = classes as {
-					Model: PersistentModelConstructor<Model>;
-				};
+				const { DataStore, Model } = getDataStore();
 
 				const model = await DataStore.save(
 					new Model({
@@ -425,7 +432,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [[_modelSave], [modelUpdate]] = zenNext.mock.calls;
+				const [_modelSave, modelUpdate] = processZenPushCalls(zenNext);
 
 				expect(modelUpdate.element.dateCreated).toBeUndefined();
 				expect(modelUpdate.element.field1).toEqual('Updated value');
@@ -433,12 +440,7 @@ describe('Storage tests', () => {
 			});
 
 			test('relation', async () => {
-				const classes = initSchema(testSchema());
-
-				const { Post, Comment } = classes as {
-					Post: PersistentModelConstructor<Post>;
-					Comment: PersistentModelConstructor<Comment>;
-				};
+				const { DataStore, Post, Comment } = getDataStore();
 
 				const post = await DataStore.save(
 					new Post({
@@ -465,14 +467,14 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [, [commentSave], , [commentUpdate]] = zenNext.mock.calls;
+				const [_postSave, commentSave, _anotherPostSave, commentUpdate] =
+					processZenPushCalls(zenNext);
 
 				expect(commentSave.element.postId).toEqual(post.id);
 				expect(commentUpdate.element.postId).toEqual(anotherPost.id);
 			});
 
 			test('composite key', async () => {
-				const classes = initSchema(testSchema());
 				// model has a GSI with a composite key defined:
 				// @key(name: "titleSort", fields: ["title", "created", "sort"])
 
@@ -481,9 +483,7 @@ describe('Storage tests', () => {
 
 				// updating the hash key [0] should NOT include the other fields in that key
 
-				const { PostComposite } = classes as {
-					PostComposite: PersistentModelConstructor<PostComposite>;
-				};
+				const { DataStore, PostComposite } = getDataStore();
 
 				const createdTimestamp = String(Date.now());
 
@@ -518,8 +518,8 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [, [postUpdate1], [postUpdate2], [postUpdate3]] =
-					zenNext.mock.calls;
+				const [_postSave, postUpdate1, postUpdate2, postUpdate3] =
+					processZenPushCalls(zenNext);
 
 				expect(postUpdate1.element.title).toBeUndefined();
 				expect(postUpdate1.element.created).toEqual(createdTimestamp);
@@ -538,13 +538,9 @@ describe('Storage tests', () => {
 			});
 
 			test('custom pk', async () => {
-				const classes = initSchema(testSchema());
-
 				// model has a custom pk defined via @key(fields: ["postId"])
 				// the PK should always be included in the mutation input
-				const { PostCustomPK } = classes as {
-					PostCustomPK: PersistentModelConstructor<PostCustomPKType>;
-				};
+				const { DataStore, PostCustomPK } = getDataStore();
 
 				const post = await DataStore.save(
 					new PostCustomPK({
@@ -561,7 +557,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [, [postUpdate]] = zenNext.mock.calls;
+				const [_postSave, postUpdate] = processZenPushCalls(zenNext);
 
 				expect(postUpdate.element.postId).toEqual('100');
 				expect(postUpdate.element.title).toEqual('Updated');
@@ -569,13 +565,9 @@ describe('Storage tests', () => {
 			});
 
 			test('custom pk - with sort', async () => {
-				const classes = initSchema(testSchema());
-
 				// model has a custom pk (hk + sort key) defined via @key(fields: ["id", "postId"])
 				// all of the fields in the PK should always be included in the mutation input
-				const { PostCustomPKSort } = classes as {
-					PostCustomPKSort: PersistentModelConstructor<PostCustomPKSortType>;
-				};
+				const { DataStore, PostCustomPKSort } = getDataStore();
 
 				const post = await DataStore.save(
 					new PostCustomPKSort({
@@ -591,7 +583,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [, [postUpdate]] = zenNext.mock.calls;
+				const [_postSave, postUpdate] = processZenPushCalls(zenNext);
 
 				expect(postUpdate.element.id).toEqual('abcdef');
 				expect(postUpdate.element.postId).toEqual('100');
@@ -600,13 +592,9 @@ describe('Storage tests', () => {
 			});
 
 			test('custom pk - with composite', async () => {
-				const classes = initSchema(testSchema());
-
 				// model has a custom pk (hk + composite key) defined via @key(fields: ["id", "postId", "sort"])
 				// all of the fields in the PK should always be included in the mutation input
-				const { PostCustomPKComposite } = classes as {
-					PostCustomPKComposite: PersistentModelConstructor<PostCustomPKCompositeType>;
-				};
+				const { DataStore, PostCustomPKComposite } = getDataStore();
 
 				const post = await DataStore.save(
 					new PostCustomPKComposite({
@@ -624,7 +612,7 @@ describe('Storage tests', () => {
 					})
 				);
 
-				const [, [postUpdate]] = zenNext.mock.calls;
+				const [_postSave, postUpdate] = processZenPushCalls(zenNext);
 
 				expect(postUpdate.element.id).toEqual('abcdef');
 				expect(postUpdate.element.postId).toEqual('100');

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -408,15 +408,15 @@ class StorageClass implements StorageFacade {
 			}
 		});
 
+		if (Object.keys(updatedElement).length === 0) {
+			return null;
+		}
+
 		// include field(s) from custom PK if one is specified for the model
 		if (primaryKey && primaryKey.length) {
 			for (const pkField of primaryKey) {
 				updatedElement[pkField] = originalElement[pkField];
 			}
-		}
-
-		if (Object.keys(updatedElement).length === 0) {
-			return null;
 		}
 
 		const { id, _version, _lastChangedAt, _deleted } = originalElement;

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -408,6 +408,7 @@ class StorageClass implements StorageFacade {
 			}
 		});
 
+        // Exit early when there are no changes introduced in the update mutation 
 		if (Object.keys(updatedElement).length === 0) {
 			return null;
 		}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The relevant change is in `packages/datastore/src/storage/storage.ts` - exit early when there are no changes introduced in the update mutation, instead of adding the PK to the mutation input when no other fields have been changed.

The changes to the `storage.test.ts` test file are there simply to allows us to run tests individually (via `.only`) without side-effects

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
