### PR TITLE
Updated CircleCI config to use `next-major-version/5` branch of `amplify-js-samples-staging`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,6 +386,7 @@ jobs:
             echo $SSH_HOST_PUBLIC_KEY >> ~/.ssh/known_hosts
             git clone $AMPLIFY_JS_SAMPLES_STAGING_URL
             cd amplify-js-samples-staging
+            git checkout next-major-version/5
             yarn
       - save_cache:
           key: amplify-js-{{ .Branch }}-{{ checksum "amplify-js-samples-staging/yarn.lock" }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This change updates our CircleCI configuration to use the `next-major-version/5` branch of `amplify-js-samples-staging` to allow us to make breaking integ test changes ahead of our v5 release without breaking `main` tests.

https://github.com/aws-amplify/amplify-js-samples-staging/tree/next-major-version/5

#### Issue #, if available
NA

#### Description of how you validated changes
Need to merge to test CircleCI config.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
