### PR TITLE
fix(pubsub): surface graphql connection failure error to observers

### DIFF
--- a/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider/index.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider/index.ts
@@ -593,6 +593,16 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider {
 					`${CONTROL_MSG.CONNECTION_FAILED}: ${JSON.stringify(payload)}`
 				);
 
+				observer.error({
+					errors: [
+						{
+							...new GraphQLError(
+								`${CONTROL_MSG.CONNECTION_FAILED}: ${JSON.stringify(payload)}`
+							),
+						},
+					],
+				});
+
 				if (startAckTimeoutId) clearTimeout(startAckTimeoutId);
 
 				if (typeof subscriptionFailedCallback === 'function') {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Follow up to https://github.com/aws-amplify/amplify-js/pull/10235.
In previous change, AppSyncRealTimeProvider blocks the GraphQL connection error to the subscribers. This breaks in the integration test [when subscription is disabled](https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/14982/workflows/93104c1c-ba16-432a-8d71-19831b335d37/jobs/155531). This fixes the unintended breaking change.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Validated the change in the Cypress integ test locally.



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
