### PR TITLE
chore: Setup `tslib` & `importHelpers` to improve bundle size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1220,6 +1220,7 @@ releasable_branches: &releasable_branches
       - 1.0-stable
       - geo/main
       - next-major-version/5
+      - importHelpers-improvement
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
 		"publish:1.0-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-1.0 --message 'chore(release): Publish [ci skip]' --no-verify-access",
 		"publish:ui-components/main": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=ui-preview --preid=ui-preview --exact --no-verify-access",
 		"publish:verdaccio": "lerna publish --no-push --canary minor --dist-tag=unstable --preid=unstable --exact --force-publish --yes --no-verify-access",
-		"publish:geo/main": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=geo --preid=geo --exact --no-verify-access"
+		"publish:geo/main": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=geo --preid=geo --exact --no-verify-access",
+		"publish:importHelpers-improvement": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=importHelpers-improvement --preid=importHelpers-improvement --exact --no-verify-access"
 	},
 	"husky": {
 		"hooks": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -51,7 +51,8 @@
 		"@aws-sdk/client-pinpoint": "3.6.1",
 		"@aws-sdk/util-utf8-browser": "3.6.1",
 		"lodash": "^4.17.20",
-		"uuid": "^3.2.1"
+		"uuid": "^3.2.1",
+		"tslib": "^2.0.0"
 	},
 	"jest": {
 		"globals": {

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -51,7 +51,8 @@
     "@aws-amplify/pubsub": "4.5.5",
     "graphql": "15.8.0",
     "uuid": "^3.2.1",
-    "zen-observable-ts": "0.8.19"
+    "zen-observable-ts": "0.8.19",
+    "tslib": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -42,7 +42,8 @@
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
     "@aws-amplify/core": "4.7.6",
-    "axios": "0.26.0"
+    "axios": "0.26.0",
+    "tslib": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -52,7 +52,8 @@
 	},
 	"dependencies": {
 		"@aws-amplify/api-graphql": "2.3.19",
-		"@aws-amplify/api-rest": "2.0.55"
+		"@aws-amplify/api-rest": "2.0.55",
+		"tslib": "^2.0.0"
 	},
 	"jest": {
 		"globals": {

--- a/packages/auth/__tests__/hosted-ui.test.ts
+++ b/packages/auth/__tests__/hosted-ui.test.ts
@@ -160,6 +160,11 @@ jest.mock('amazon-cognito-identity-js/lib/CognitoUser', () => {
 import * as AmplifyCore from '@aws-amplify/core';
 const { Hub, Credentials, StorageHelper } = AmplifyCore;
 
+// Mock the module to ensure that setters are available for spying
+jest.mock('@aws-amplify/core', () => ({
+	...jest.requireActual('@aws-amplify/core'),
+}));
+
 const authOptionsWithOAuth: AuthOptions = {
 	userPoolId: 'awsUserPoolsId',
 	userPoolWebClientId: 'awsUserPoolsWebClientId',

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -44,7 +44,8 @@
     "@aws-amplify/cache": "4.0.57",
     "@aws-amplify/core": "4.7.6",
     "amazon-cognito-identity-js": "5.2.10",
-    "crypto-js": "^4.1.1"
+    "crypto-js": "^4.1.1",
+    "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@jest/test-sequencer": "^24.9.0"

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -46,7 +46,8 @@
     "@aws-amplify/pubsub": "4.5.5",
     "@aws-amplify/storage": "4.5.8",
     "@aws-amplify/ui": "2.0.5",
-    "@aws-amplify/xr": "3.0.55"
+    "@aws-amplify/xr": "3.0.55",
+    "tslib": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -44,7 +44,8 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/core": "4.7.6"
+    "@aws-amplify/core": "4.7.6",
+    "tslib": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,8 @@
 		"@aws-sdk/types": "3.6.1",
 		"@aws-sdk/util-hex-encoding": "3.6.1",
 		"universal-cookie": "^4.0.4",
-		"zen-observable-ts": "0.8.19"
+		"zen-observable-ts": "0.8.19",
+		"tslib": "^2.0.0"
 	},
 	"jest": {
 		"globals": {

--- a/packages/datastore-storage-adapter/package.json
+++ b/packages/datastore-storage-adapter/package.json
@@ -33,6 +33,9 @@
 		"url": "https://github.com/aws/aws-amplify/issues"
 	},
 	"homepage": "https://aws-amplify.github.io/",
+	"dependencies": {
+		"tslib": "^2.0.0"
+	},
 	"devDependencies": {
 		"@aws-amplify/core": "4.7.6",
 		"@aws-amplify/datastore": "3.12.12",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -58,7 +58,8 @@
 		"ulid": "2.3.0",
 		"uuid": "3.3.2",
 		"zen-observable-ts": "0.8.19",
-		"zen-push": "0.2.1"
+		"zen-push": "0.2.1",
+		"tslib": "^2.0.0"
 	},
 	"jest": {
 		"globals": {

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -44,7 +44,8 @@
 		"@aws-amplify/core": "4.7.6",
 		"@aws-sdk/client-location": "3.48.0",
 		"@turf/boolean-clockwise": "6.5.0",
-		"camelcase-keys": "6.2.2"
+		"camelcase-keys": "6.2.2",
+		"tslib": "^2.0.0"
 	},
 	"jest": {
 		"globals": {

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -46,7 +46,8 @@
 		"@aws-sdk/client-lex-runtime-v2": "3.171.0",
 		"base-64": "1.0.0",
 		"fflate": "0.7.3",
-		"pako": "2.0.4"
+		"pako": "2.0.4",
+		"tslib": "^2.0.0"
 	},
 	"jest": {
 		"globals": {

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -49,7 +49,8 @@
 		"@aws-sdk/client-translate": "3.6.1",
 		"@aws-sdk/eventstream-marshaller": "3.6.1",
 		"@aws-sdk/util-utf8-node": "3.6.1",
-		"uuid": "^3.2.1"
+		"uuid": "^3.2.1",
+		"tslib": "^2.0.0"
 	},
 	"jest": {
 		"globals": {

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -51,7 +51,8 @@
     "graphql": "15.8.0",
     "paho-mqtt": "^1.1.0",
     "uuid": "^3.2.1",
-    "zen-observable-ts": "0.8.19"
+    "zen-observable-ts": "0.8.19",
+    "tslib": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -47,7 +47,8 @@
     "@aws-sdk/util-create-request": "3.6.1",
     "@aws-sdk/util-format-url": "3.6.1",
     "axios": "0.26.0",
-    "events": "^3.1.0"
+    "events": "^3.1.0",
+    "tslib": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -41,7 +41,8 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/core": "4.7.6"
+    "@aws-amplify/core": "4.7.6",
+    "tslib": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -172,6 +172,7 @@ async function buildES5(typeScriptCompiler, watchMode) {
 		declaration: true,
 		noEmitOnError: true,
 		incremental: true,
+		importHelpers: true,
 		tsBuildInfoFile: es5TsBuildInfoFilePath,
 		typeRoots,
 		// temporary fix
@@ -229,6 +230,7 @@ function buildES6(typeScriptCompiler, watchMode) {
 		declaration: true,
 		noEmitOnError: true,
 		incremental: true,
+		importHelpers: true,
 		tsBuildInfoFile: es6TsBuildInfoFilePath,
 		typeRoots,
 		// temporary fix


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This change enables `importHelpers` in our shared build script (`build.js`) and adds `tslib` as a dependency to all packages that use the script to improve bundle size.

##### Note on methodology 
I collected the data below by looking at the minified WebPack bundle files that each of our modules produce. While this may not reflect all use-cases, it provides a readily available & consistent metric to evaluate the impact of the change. As far as dependency de-duping & flattening for more complex apps, the numbers below _should_ capture the worst-case where each package includes the minimum number of `tslib` dependencies that it requires without any additional de-duping that the importing app may perform.

| Package | Artifact | Before Change | After Change | Bundle Δ |
| --- | --- | --- | --- | --- |
| `aws-amplify` | aws-amplify.min.js | 1294 KiB | 1294 KiB | 0 KiB |
| `analytics` | aws-amplify-analytics.min.js | 296 KiB | 285 KiB | -11 KiB |
| `api` | aws-amplify-api.min.js | 146 KiB | 145 KiB | -1 KiB |
| `api-graphql` | aws-amplify-api-graphql.min.js | 144 KiB | 142 KiB | -2 KiB |
| `api-rest` | aws-amplify-api-rest.min.js | 43 KiB | 41 KiB | -2 KiB |
| `auth` | aws-amplify-auth.min.js | 157 KiB | 155 KiB | -2 KiB |
| `cache` | aws-amplify-cache.min.js  | 15.5 KiB | 15.7 KiB | +0.2 KiB |
| `core` | aws-amplify-core.min.js  | 290 KiB | 281 KiB | -9 KiB |
| `datastore` | aws-amplify-datastore.min.js  | 617 KiB | 590 KiB | -27 KiB |
| `datastore-storage-adapter` | aws-amplify-datastore-sqlite-adapter-expo.min.js, aws-amplify-datastore-storage-adapter.min.js  | 47.6 KiB | 44.9 KiB | -2.7 KiB |
| `geo` | aws-amplify-geo.min.js  | 218 KiB | 216 KiB | -2 KiB |
| `interactions` | aws-amplify-interactions.min.js  | 323 KiB | 315 KiB | -8 KiB |
| `predictions` | aws-amplify-predictions.min.js  | 556 KiB | 556 KiB | 0 KiB |
| `storage` | aws-amplify-storage.min.js | 328 KiB | 322 KiB | -6 KiB |
| `xr` | aws-amplify-xr.min.js | 14.7 KiB | 13.6 KiB | -1.1 KiB |

**Total Δ for entire project** -73.6 KiB

**Note** Soon-to-be deprecated UI packages, as well as the `pushnotification` package (which is not used for web & does not use the shared build script) were not included in this change.

##### Future improvements
- Refactor `build.js` so that each package can have its own `tsconfig.json`
  - This will allow us to disable `importHelpers` for packages where it doesn't provide any benefit such as `cache`
- Upgrade packages that depend on older (`< 2.0.0`) versions of `tslib` to improve dependency flattening, for example:
  - `@aws-crypto/sha256-js`
  - `@aws-sdk/credential-provider-cognito-identity`
  - `@aws-sdk/client-cognito-identity`

#### Issue #, if available
NA

#### Description of how you validated changes
- Local release build & unit test pass
- Manually evaluated WebPack'd bundle sizes

Integ test pass on `next-major-version/5`: https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/15155/workflows/3a454e6b-c4e8-47aa-9190-359b225d4ffd
  - Existing storage failures already present
 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
