### PR TITLE
fix(@aws-amplify/datastore): removed incorrect sync proc restart error

### DIFF
--- a/packages/datastore/__tests__/connectivityHandling.test.ts
+++ b/packages/datastore/__tests__/connectivityHandling.test.ts
@@ -1,0 +1,199 @@
+import { Observable } from 'zen-observable-ts';
+import { parse } from 'graphql';
+import { pause, getDataStore } from './helpers';
+
+describe('DataStore sync engine', () => {
+	let { DataStore, connectivityMonitor, Post, Comment, graphqlService } =
+		getDataStore({ online: true, isNode: false });
+
+	beforeEach(async () => {
+		console.log('BEFORE EACH');
+		({ DataStore, connectivityMonitor, Post, Comment, graphqlService } =
+			getDataStore({ online: true, isNode: false }));
+		await DataStore.start();
+	});
+
+	afterEach(async () => {
+		console.log('AFTER EACH');
+		// await DataStore.clear();
+	});
+
+	async function waitForEmptyOutbox() {
+		return new Promise(resolve => {
+			const { Hub } = require('@aws-amplify/core');
+			const hubCallback = message => {
+				console.log('hub event', message);
+				if (
+					message.payload.event === 'outboxStatus' &&
+					message.payload.data.isEmpty
+				) {
+					Hub.remove('datastore', hubCallback);
+					resolve();
+				}
+			};
+			Hub.listen('datastore', hubCallback);
+		});
+	}
+
+	describe('basic protocol', () => {
+		test('sends model create to the cloud', async () => {
+			const post = await DataStore.save(new Post({ title: 'post title' }));
+
+			// give thread control back to subscription event handlers.
+			await pause(1);
+
+			const table = graphqlService.tables.get('Post')!;
+			expect(table.size).toEqual(1);
+
+			const savedItem = table.get(JSON.stringify([post.id])) as any;
+			expect(savedItem.title).toEqual(post.title);
+		});
+
+		test('uses model create subscription event to populate metadata', async () => {
+			const post = await DataStore.save(new Post({ title: 'post title' }));
+			await waitForEmptyOutbox();
+
+			const retrieved = (await DataStore.query(Post, post.id)) as any;
+
+			expect(retrieved._version).toBe(1);
+			expect(retrieved._deleted).toBe(false);
+			expect(retrieved._lastChangedAt).toBeGreaterThan(0);
+		});
+
+		test('sends models update to the cloud', async () => {
+			const post = await DataStore.save(new Post({ title: 'post title' }));
+			await waitForEmptyOutbox();
+
+			const retrieved = await DataStore.query(Post, post.id);
+
+			const updated = await DataStore.save(
+				Post.copyOf(retrieved!, draft => {
+					draft.title = 'updated title';
+				})
+			);
+			await waitForEmptyOutbox();
+
+			const table = graphqlService.tables.get('Post')!;
+			expect(table.size).toEqual(1);
+
+			const savedItem = table.get(JSON.stringify([post.id])) as any;
+			expect(savedItem.title).toEqual(updated.title);
+		});
+	});
+
+	describe('connection state change handling', () => {
+		test('survives online -> offline -> online cycle', async () => {
+			const post = await DataStore.save(
+				new Post({
+					title: 'a title',
+				})
+			);
+
+			await waitForEmptyOutbox();
+			console.log('disconnecting');
+			connectivityMonitor.simulateDisconnect();
+			await pause(1);
+			console.log('reconnecting');
+			connectivityMonitor.simulateConnect();
+			await pause(1);
+
+			console.log('reconnected?');
+
+			const anotherPost = await DataStore.save(
+				new Post({
+					title: 'another title',
+				})
+			);
+			await waitForEmptyOutbox();
+
+			console.log('outbox empty');
+
+			const table = graphqlService.tables.get('Post')!;
+			expect(table.size).toEqual(2);
+
+			const cloudPost = table.get(JSON.stringify([post.id])) as any;
+			expect(cloudPost.title).toEqual('a title');
+
+			const cloudAnotherPost = table.get(
+				JSON.stringify([anotherPost.id])
+			) as any;
+			expect(cloudAnotherPost.title).toEqual('another title');
+		});
+
+		test('survives online -> offline -> save -> online cycle', async () => {
+			const post = await DataStore.save(
+				new Post({
+					title: 'a title',
+				})
+			);
+
+			await waitForEmptyOutbox();
+			connectivityMonitor.simulateDisconnect();
+			await pause(1);
+
+			const anotherPost = await DataStore.save(
+				new Post({
+					title: 'another title',
+				})
+			);
+			const outboxEmpty = waitForEmptyOutbox();
+
+			await pause(1);
+
+			connectivityMonitor.simulateConnect();
+
+			await outboxEmpty;
+
+			const table = graphqlService.tables.get('Post')!;
+			expect(table.size).toEqual(2);
+
+			const cloudPost = table.get(JSON.stringify([post.id])) as any;
+			expect(cloudPost.title).toEqual('a title');
+
+			const cloudAnotherPost = table.get(
+				JSON.stringify([anotherPost.id])
+			) as any;
+			expect(cloudAnotherPost.title).toEqual('another title');
+		});
+
+		test.only('survives online -> offline -> save/online race', async () => {
+			const post = await DataStore.save(
+				new Post({
+					title: 'a title',
+				})
+			);
+
+			await waitForEmptyOutbox();
+			console.log('disconnecting');
+			connectivityMonitor.simulateDisconnect();
+			await pause(1);
+
+			const outboxEmpty = waitForEmptyOutbox();
+
+			const anotherPost = await DataStore.save(
+				new Post({
+					title: 'another title',
+				})
+			);
+
+			// NO PAUSE: Simulate reconnect immediately, which causes a race
+			// between the save and the sync engine reconnection operations.
+
+			connectivityMonitor.simulateConnect();
+
+			await outboxEmpty;
+			console.log('outbox empty');
+
+			const table = graphqlService.tables.get('Post')!;
+			expect(table.size).toEqual(2);
+
+			const cloudPost = table.get(JSON.stringify([post.id])) as any;
+			expect(cloudPost.title).toEqual('a title');
+
+			const cloudAnotherPost = table.get(
+				JSON.stringify([anotherPost.id])
+			) as any;
+			expect(cloudAnotherPost.title).toEqual('another title');
+		});
+	});
+});

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -94,6 +94,7 @@ import {
 	mergePatches,
 } from '../util';
 import { getIdentifierValue } from '../sync/utils';
+import DataStoreConnectivity from '../sync/datastoreConnectivity';
 
 setAutoFreeze(true);
 enablePatches();
@@ -870,6 +871,7 @@ class DataStore {
 		API: this.API,
 		Cache: this.Cache,
 	};
+	private connectivityMonitor?: DataStoreConnectivity;
 
 	/**
 	 * **IMPORTANT!**
@@ -925,7 +927,6 @@ class DataStore {
 				});
 			} else {
 				await this.initialized;
-
 				return;
 			}
 
@@ -962,7 +963,8 @@ class DataStore {
 					this.syncPredicates,
 					this.amplifyConfig,
 					this.authModeStrategy,
-					this.amplifyContext
+					this.amplifyContext,
+					this.connectivityMonitor
 				);
 
 				const fullSyncIntervalInMilliseconds =
@@ -971,6 +973,8 @@ class DataStore {
 					.start({ fullSyncInterval: fullSyncIntervalInMilliseconds })
 					.subscribe({
 						next: ({ type, data }) => {
+							// console.log('sync sub message', { type, data });
+
 							// In Node, we need to wait for queries to be synced to prevent returning empty arrays.
 							// In the Browser, we can begin returning data once subscriptions are in place.
 							const readyType = isNode

--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -244,18 +244,8 @@ class SubscriptionProcessor {
 		Observable<CONTROL_MSG>,
 		Observable<[TransformerMutationType, SchemaModel, PersistentModel]>
 	] {
-		if (this.runningProcesses) {
-			throw new Error(
-				[
-					'Subscription processor is already started!',
-					'It must be stopped before it can be restarted.',
-					'Please report this error in a GitHub issue.',
-					'https://github.com/aws-amplify/amplify-js/issues',
-				].join('\n')
-			);
-		}
-
-		this.runningProcesses = new BackgroundProcessManager();
+		this.runningProcesses =
+			this.runningProcesses || new BackgroundProcessManager();
 
 		const ctlObservable = new Observable<CONTROL_MSG>(observer => {
 			const promises: Promise<void>[] = [];

--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -325,18 +325,8 @@ class SyncProcessor {
 	start(
 		typesLastSync: Map<SchemaModel, [string, number]>
 	): Observable<SyncModelPage> {
-		if (this.runningProcesses) {
-			throw new Error(
-				[
-					'The sync processor is already started!',
-					'Wait until it completes or `await stop()` it first!',
-					'(This is an Amplify bug; please open a Github Issue:',
-					'https://github.com/aws-amplify/amplify-js/issues)',
-				].join('\n')
-			);
-		}
-
-		this.runningProcesses = new BackgroundProcessManager();
+		this.runningProcesses =
+			this.runningProcesses || new BackgroundProcessManager();
 
 		const { maxRecordsToSync, syncPageSize } = this.amplifyConfig;
 		const parentPromises = new Map<string, Promise<void>>();

--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -118,6 +118,7 @@ class SyncProcessor {
 		let authModeAttempts = 0;
 		const authModeRetry = async () => {
 			if (!this.runningProcesses.isOpen) {
+				console.log(this.runningProcesses);
 				throw new Error(
 					'sync.retreievePage termination was requested. Exiting.'
 				);
@@ -325,8 +326,12 @@ class SyncProcessor {
 	start(
 		typesLastSync: Map<SchemaModel, [string, number]>
 	): Observable<SyncModelPage> {
+		console.log('attempting to start 1');
+
 		this.runningProcesses =
 			this.runningProcesses || new BackgroundProcessManager();
+
+		console.log('attempting to start 2', this.runningProcesses);
 
 		const { maxRecordsToSync, syncPageSize } = this.amplifyConfig;
 		const parentPromises = new Map<string, Promise<void>>();
@@ -346,84 +351,93 @@ class SyncProcessor {
 
 			const allModelsReady = Array.from(sortedTypesLastSyncs.entries())
 				.filter(([{ syncable }]) => syncable)
-				.map(([modelDefinition, [namespace, lastSync]]) =>
-					this.runningProcesses.add(async onTerminate => {
-						let done = false;
-						let nextToken: string = null;
-						let startedAt: number = null;
-						let items: ModelInstanceMetadata[] = null;
+				.map(
+					([modelDefinition, [namespace, lastSync]]) =>
+						this.runningProcesses.isOpen &&
+						this.runningProcesses.add(async onTerminate => {
+							let done = false;
+							let nextToken: string = null;
+							let startedAt: number = null;
+							let items: ModelInstanceMetadata[] = null;
 
-						let recordsReceived = 0;
-						const filter = this.graphqlFilterFromPredicate(modelDefinition);
+							let recordsReceived = 0;
+							const filter = this.graphqlFilterFromPredicate(modelDefinition);
 
-						const parents = this.schema.namespaces[
-							namespace
-						].modelTopologicalOrdering.get(modelDefinition.name);
-						const promises = parents.map(parent =>
-							parentPromises.get(`${namespace}_${parent}`)
-						);
+							const parents = this.schema.namespaces[
+								namespace
+							].modelTopologicalOrdering.get(modelDefinition.name);
+							const promises = parents.map(parent =>
+								parentPromises.get(`${namespace}_${parent}`)
+							);
 
-						const promise = new Promise<void>(async res => {
-							await Promise.all(promises);
+							const promise = new Promise<void>(async res => {
+								await Promise.all(promises);
 
-							do {
-								if (!this.runningProcesses) {
-									return;
-								}
+								do {
+									if (!this.runningProcesses) {
+										return;
+									}
 
-								const limit = Math.min(
-									maxRecordsToSync - recordsReceived,
-									syncPageSize
-								);
+									const limit = Math.min(
+										maxRecordsToSync - recordsReceived,
+										syncPageSize
+									);
 
-								({ items, nextToken, startedAt } = await this.retrievePage(
-									modelDefinition,
-									lastSync,
-									nextToken,
-									limit,
-									filter,
-									onTerminate
-								));
+									({ items, nextToken, startedAt } = await this.retrievePage(
+										modelDefinition,
+										lastSync,
+										nextToken,
+										limit,
+										filter,
+										onTerminate
+									));
 
-								recordsReceived += items.length;
+									recordsReceived += items.length;
 
-								done =
-									nextToken === null || recordsReceived >= maxRecordsToSync;
+									done =
+										nextToken === null || recordsReceived >= maxRecordsToSync;
 
-								observer.next({
-									namespace,
-									modelDefinition,
-									items,
-									done,
-									startedAt,
-									isFullSync: !lastSync,
-								});
-							} while (!done);
+									observer.next({
+										namespace,
+										modelDefinition,
+										items,
+										done,
+										startedAt,
+										isFullSync: !lastSync,
+									});
+								} while (!done);
 
-							res();
-						});
+								res();
+							});
 
-						parentPromises.set(`${namespace}_${modelDefinition.name}`, promise);
+							parentPromises.set(
+								`${namespace}_${modelDefinition.name}`,
+								promise
+							);
 
-						await promise;
-					})
+							await promise;
+						}, `adding model ${modelDefinition.name}`)
 				);
 
 			Promise.all(allModelsReady).then(() => {
 				observer.complete();
 			});
 
-			return this.runningProcesses.addCleaner(async () => {
-				this.runningProcesses = undefined;
-			});
+			// return this.runningProcesses.addCleaner(async () => {
+			// await this.runningProcesses.close();
+			// this.runningProcesses = undefined;
+			// });
 		});
 
 		return observable;
 	}
 
 	async stop() {
+		console.error(new Error("what's stopping the sync?"));
+		console.log('stopping sync');
 		logger.debug('stopping sync processor');
 		this.runningProcesses && (await this.runningProcesses.close());
+		this.runningProcesses = undefined;
 		logger.debug('sync processor stopped');
 	}
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

[PR 10055](https://github.com/aws-amplify/amplify-js/pull/10055) introduced an re-entry guard around sync and subscription processors, assuming that instances are never re-`start()`-ed. This is, however, an oversight. They *are* restarted by the connectivity monitor during the offline to online transition.

This PR removes those guards.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

`yarn link` into a sample app, observed the error, applied the fix, retested, observed no error.

Pending: Meaningful test coverage to stress this online -> start -> offline -> online transition.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
