### PR TITLE
chore: remove mobilehub config parser class

### DIFF
--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -15,7 +15,7 @@ import {
 	Amplify,
 	ConsoleLogger as Logger,
 	Hub,
-	Parser,
+	parseMobileHubConfig,
 } from '@aws-amplify/core';
 import { AWSPinpointProvider } from './Providers/AWSPinpointProvider';
 
@@ -95,7 +95,7 @@ export class AnalyticsClass {
 	public configure(config?) {
 		if (!config) return this._config;
 		logger.debug('configure Analytics', config);
-		const amplifyConfig = Parser.parseMobilehubConfig(config);
+		const amplifyConfig = parseMobileHubConfig(config);
 		this._config = Object.assign(
 			{},
 			this._config,

--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -1911,7 +1911,7 @@ describe('auth unit test', () => {
 			const spyon2 = jest
 				.spyOn(Credentials, 'refreshFederatedToken')
 				.mockImplementationOnce(() => {
-					return Promise.resolve('cred');
+					return Promise.resolve('cred' as any);
 				});
 
 			expect.assertions(1);

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -40,8 +40,8 @@ import {
 	Hub,
 	StorageHelper,
 	ICredentials,
-	Parser,
 	browserOrNode,
+	parseMobileHubConfig,
 	UniversalStorage,
 	urlSafeDecode,
 	HubCallback,
@@ -150,7 +150,7 @@ export class AuthClass {
 		const conf = Object.assign(
 			{},
 			this._config,
-			Parser.parseMobilehubConfig(config).Auth,
+			parseMobileHubConfig(config).Auth,
 			config
 		);
 		this._config = conf;

--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -80,15 +80,3 @@ export const parseMobileHubConfig = (config): AmplifyConfig => {
 	logger.debug('parse config', config, 'to amplifyconfig', amplifyConfig);
 	return amplifyConfig;
 };
-
-/**
- * @deprecated use per-function export
- */
-export class Parser {
-	static parseMobilehubConfig = parseMobileHubConfig;
-}
-
-/**
- * @deprecated use per-function export
- */
-export default Parser;

--- a/packages/storage/src/Storage.ts
+++ b/packages/storage/src/Storage.ts
@@ -11,7 +11,11 @@
  * and limitations under the License.
  */
 
-import { Amplify, ConsoleLogger as Logger, Parser } from '@aws-amplify/core';
+import {
+	Amplify,
+	ConsoleLogger as Logger,
+	parseMobileHubConfig,
+} from '@aws-amplify/core';
 import { AWSS3Provider } from './providers';
 import {
 	StorageCopySource,
@@ -130,11 +134,11 @@ export class Storage {
 		logger.debug('configure Storage');
 		if (!config) return this._config;
 
-		const amplifyConfig = Parser.parseMobilehubConfig(config);
+		const amplifyConfig = parseMobileHubConfig(config);
 
-		const storageKeysFromConfig = Object.keys(amplifyConfig.Storage);
+		const storageConfig = amplifyConfig.Storage ?? {};
 
-		const storageArrayKeys = [
+		const defaultProviderConfigKeys = [
 			'bucket',
 			'region',
 			'level',
@@ -147,32 +151,33 @@ export class Storage {
 			'SSEKMSKeyId',
 		];
 
-		const isInStorageArrayKeys = (k: string) =>
-			storageArrayKeys.some(x => x === k);
-		const checkConfigKeysFromArray = (k: string[]) =>
-			k.find(k => isInStorageArrayKeys(k));
+		const hasDefaultProviderConfigKeys = (config: object) =>
+			Object.keys(config).find(key => defaultProviderConfigKeys.includes(key));
 
 		if (
-			storageKeysFromConfig &&
-			checkConfigKeysFromArray(storageKeysFromConfig) &&
-			!amplifyConfig.Storage[DEFAULT_PROVIDER]
+			hasDefaultProviderConfigKeys(storageConfig) &&
+			!storageConfig[DEFAULT_PROVIDER]
 		) {
-			amplifyConfig.Storage[DEFAULT_PROVIDER] = {};
+			storageConfig[DEFAULT_PROVIDER] = {};
 		}
 
-		Object.entries(amplifyConfig.Storage).map(([key, value]) => {
-			if (key && isInStorageArrayKeys(key) && value !== undefined) {
-				amplifyConfig.Storage[DEFAULT_PROVIDER][key] = value;
-				delete amplifyConfig.Storage[key];
+		Object.entries(storageConfig).map(([key, value]) => {
+			if (
+				key &&
+				defaultProviderConfigKeys.includes(key) &&
+				value !== undefined
+			) {
+				storageConfig[DEFAULT_PROVIDER][key] = value;
+				delete storageConfig[key];
 			}
 		});
 
 		// only update new values for each provider
-		Object.keys(amplifyConfig.Storage).forEach(providerName => {
-			if (typeof amplifyConfig.Storage[providerName] !== 'string') {
+		Object.keys(storageConfig).forEach(providerName => {
+			if (typeof storageConfig[providerName] !== 'string') {
 				this._config[providerName] = {
 					...this._config[providerName],
-					...amplifyConfig.Storage[providerName],
+					...storageConfig[providerName],
 				};
 			}
 		});

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -13,10 +13,10 @@
 import {
 	ConsoleLogger as Logger,
 	Credentials,
-	Parser,
 	ICredentials,
 	StorageHelper,
 	Hub,
+	parseMobileHubConfig,
 } from '@aws-amplify/core';
 import {
 	S3Client,
@@ -137,7 +137,7 @@ export class AWSS3Provider implements StorageProvider {
 	public configure(config?): object {
 		logger.debug('configure Storage', config);
 		if (!config) return this._config;
-		const amplifyConfig = Parser.parseMobilehubConfig(config);
+		const amplifyConfig = parseMobileHubConfig(config);
 		this._config = Object.assign({}, this._config, amplifyConfig.Storage);
 		if (!this._config.bucket) {
 			logger.debug('Do not have bucket yet');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Remove deprecated MobileHub config parser class, but keep the function export


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
