### PR TITLE
refactor: enforce "strict" type checking on aws-amplify-react-native

### DIFF
--- a/packages/aws-amplify-react-native/src/AmplifyUI.tsx
+++ b/packages/aws-amplify-react-native/src/AmplifyUI.tsx
@@ -81,8 +81,6 @@ interface IPhoneState {
 	phone: string;
 }
 
-const minWidth = { minWidth: Platform.OS === 'android' ? 16 : 0 };
-
 export class PhoneField extends Component<IPhoneProps, IPhoneState> {
 	constructor(props: IPhoneProps) {
 		super(props);
@@ -161,7 +159,7 @@ export const LinkCell: FC<ILinkCellProps> = (props) => {
 			<TouchableHighlight
 				onPress={props.onPress}
 				underlayColor={theme.linkUnderlay.color}
-				{...setTestId(props.testID)}
+				{...setTestId(props.testID!)}
 				disabled={disabled}
 			>
 				<Text style={disabled ? theme.sectionFooterLinkDisabled : theme.sectionFooterLink}>{props.children}</Text>
@@ -179,7 +177,7 @@ export const Header: FC<IHeaderProps> = (props) => {
 	const theme = props.theme || AmplifyTheme;
 	return (
 		<View style={theme.sectionHeader}>
-			<Text style={theme.sectionHeaderText} {...setTestId(props.testID)}>
+			<Text style={theme.sectionHeaderText} {...setTestId(props.testID!)}>
 				{props.children}
 			</Text>
 		</View>

--- a/packages/aws-amplify-react-native/src/Auth/AuthPiece.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/AuthPiece.tsx
@@ -20,7 +20,7 @@ import AmplifyMessageMap from '../AmplifyMessageMap';
 import { FormField, PhoneField } from '../AmplifyUI';
 import TEST_ID from '../AmplifyTestIDs';
 import { OnStateChangeType, UsernameAttributesType } from '../../types';
-import { setTestId } from '../Utils'
+import { setTestId } from '../Utils';
 
 const logger = new Logger('AuthPiece');
 
@@ -48,10 +48,10 @@ export interface IAuthPieceState {
 	username?: string;
 }
 
-export default class AuthPiece<
-	Props extends IAuthPieceProps,
-	State extends IAuthPieceState
-> extends React.Component<Props, State> {
+export default class AuthPiece<Props extends IAuthPieceProps, State extends IAuthPieceState> extends React.Component<
+	Props,
+	State
+> {
 	_isHidden: boolean;
 	_validAuthStates: String[];
 
@@ -86,7 +86,7 @@ export default class AuthPiece<
 			return (
 				<FormField
 					theme={theme}
-					onChangeText={text => this.setState({ email: text })}
+					onChangeText={(text) => this.setState({ email: text })}
 					label={I18n.get('Email')}
 					placeholder={I18n.get('Enter your email')}
 					required={true}
@@ -99,7 +99,7 @@ export default class AuthPiece<
 				<PhoneField
 					theme={theme}
 					key={'phone_number'}
-					onChangeText={text => this.setState({ phone_number: text })}
+					onChangeText={(text) => this.setState({ phone_number: text })}
 					label={I18n.get('Phone Number')}
 					placeholder={I18n.get('Enter your phone number')}
 					keyboardType="phone-pad"
@@ -112,7 +112,7 @@ export default class AuthPiece<
 			return (
 				<FormField
 					theme={theme}
-					onChangeText={text => this.setState({ username: text })}
+					onChangeText={(text) => this.setState({ username: text })}
 					label={I18n.get(this.getUsernameLabel())}
 					placeholder={I18n.get('Enter your username')}
 					required={true}
@@ -135,7 +135,7 @@ export default class AuthPiece<
 	}
 
 	checkContact(user: any) {
-		Auth.verifiedContact(user).then(data => {
+		Auth.verifiedContact(user).then((data) => {
 			logger.debug('verified user attributes', data);
 			if (!JS.isEmpty(data.verified)) {
 				this.changeState('signedIn', user);
@@ -158,15 +158,14 @@ export default class AuthPiece<
 			msg = JSON.stringify(err);
 		}
 
-		const map =
-			this.props.errorMessage || this.props.messageMap || AmplifyMessageMap;
+		const map = this.props.errorMessage || this.props.messageMap || AmplifyMessageMap;
 		msg = typeof map === 'string' ? map : map(msg);
 		this.setState({ error: msg });
 		Keyboard.dismiss();
 	}
 
 	render() {
-		if (!this._validAuthStates.includes(this.props.authState)) {
+		if (!this._validAuthStates.includes(this.props.authState as string)) {
 			this._isHidden = true;
 			return null;
 		}

--- a/packages/aws-amplify-react-native/src/Auth/Authenticator.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/Authenticator.tsx
@@ -74,7 +74,7 @@ interface IAuthenticatorState {
 
 export default class Authenticator extends React.Component<IAuthenticatorProps, IAuthenticatorState> {
 	_initialAuthState: string;
-	_isMounted: boolean;
+	_isMounted!: boolean;
 
 	constructor(props: IAuthenticatorProps) {
 		super(props);
@@ -130,7 +130,7 @@ export default class Authenticator extends React.Component<IAuthenticatorProps, 
 			this.setState({
 				authState: nextAuthState,
 				authData: nextAuthData,
-				error: null,
+				error: null as never,
 			});
 			logger.log('Auth Data was set:', nextAuthData);
 			logger.info(`authState has been updated to ${nextAuthState}`);

--- a/packages/aws-amplify-react-native/src/Auth/ConfirmSignIn.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/ConfirmSignIn.tsx
@@ -13,20 +13,12 @@
 
 import React from 'react';
 import { View } from 'react-native';
-import { Auth, I18n, Logger, JS } from 'aws-amplify';
-import {
-	AmplifyButton,
-	FormField,
-	LinkCell,
-	Header,
-	ErrorRow,
-	SignedOutMessage,
-	Wrapper,
-} from '../AmplifyUI';
+import { Auth, I18n, Logger } from 'aws-amplify';
+import { AmplifyButton, FormField, LinkCell, Header, ErrorRow, SignedOutMessage, Wrapper } from '../AmplifyUI';
 import AuthPiece, { IAuthPieceProps, IAuthPieceState } from './AuthPiece';
 import { AmplifyThemeType } from '../AmplifyTheme';
 import TEST_ID from '../AmplifyTestIDs';
-import { setTestId } from '../Utils'
+import { setTestId } from '../Utils';
 
 const logger = new Logger('ConfirmSignIn');
 
@@ -36,16 +28,13 @@ interface IConfirmSignInState extends IAuthPieceState {
 	code?: string;
 }
 
-export default class ConfirmSignIn extends AuthPiece<
-	IConfirmSignInProps,
-	IConfirmSignInState
-> {
+export default class ConfirmSignIn extends AuthPiece<IConfirmSignInProps, IConfirmSignInState> {
 	constructor(props: IConfirmSignInProps) {
 		super(props);
 
 		this._validAuthStates = ['confirmSignIn'];
 		this.state = {
-			code: null,
+			code: null as never,
 			error: null,
 		};
 
@@ -57,9 +46,9 @@ export default class ConfirmSignIn extends AuthPiece<
 		const user = this.props.authData;
 		const { code } = this.state;
 		logger.debug('Confirm Sign In for ' + user.username);
-		Auth.confirmSignIn(user, code)
-			.then(data => this.checkContact(user))
-			.catch(err => this.error(err));
+		Auth.confirmSignIn(user, code!)
+			.then((data) => this.checkContact(user))
+			.catch((err) => this.error(err));
 	}
 
 	showComponent(theme: AmplifyThemeType) {
@@ -73,7 +62,7 @@ export default class ConfirmSignIn extends AuthPiece<
 						<View style={theme.sectionBody}>
 							<FormField
 								theme={theme}
-								onChangeText={text => this.setState({ code: text })}
+								onChangeText={(text) => this.setState({ code: text })}
 								label={I18n.get('Confirmation Code')}
 								placeholder={I18n.get('Enter your confirmation code')}
 								required={true}

--- a/packages/aws-amplify-react-native/src/Auth/ConfirmSignUp.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/ConfirmSignUp.tsx
@@ -33,7 +33,7 @@ export default class ConfirmSignUp extends AuthPiece<IConfirmSignUpProps, IConfi
 
 		this._validAuthStates = ['confirmSignUp'];
 		this.state = {
-			username: null,
+			username: null as never,
 			code: null,
 			error: null,
 		};
@@ -46,7 +46,7 @@ export default class ConfirmSignUp extends AuthPiece<IConfirmSignUpProps, IConfi
 		const { code } = this.state;
 		const username = this.getUsernameFromInput();
 		logger.debug('Confirm Sign Up for ' + username);
-		Auth.confirmSignUp(username, code)
+		Auth.confirmSignUp(username!, code!)
 			.then((data) => this.changeState('signedUp'))
 			.catch((err) => this.error(err));
 	}
@@ -54,7 +54,7 @@ export default class ConfirmSignUp extends AuthPiece<IConfirmSignUpProps, IConfi
 	resend() {
 		const username = this.getUsernameFromInput();
 		logger.debug('Resend Sign Up for ' + username);
-		Auth.resendSignUp(username)
+		Auth.resendSignUp(username!)
 			.then(() => logger.debug('code sent'))
 			.catch((err) => this.error(err));
 	}

--- a/packages/aws-amplify-react-native/src/Auth/ForgotPassword.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/ForgotPassword.tsx
@@ -14,19 +14,11 @@
 import React from 'react';
 import { View } from 'react-native';
 import { Auth, I18n, Logger } from 'aws-amplify';
-import {
-	FormField,
-	AmplifyButton,
-	LinkCell,
-	Header,
-	ErrorRow,
-	SignedOutMessage,
-	Wrapper,
-} from '../AmplifyUI';
+import { FormField, AmplifyButton, LinkCell, Header, ErrorRow, SignedOutMessage, Wrapper } from '../AmplifyUI';
 import AuthPiece, { IAuthPieceProps, IAuthPieceState } from './AuthPiece';
 import { AmplifyThemeType } from '../AmplifyTheme';
 import TEST_ID from '../AmplifyTestIDs';
-import { setTestId } from '../Utils'
+import { setTestId } from '../Utils';
 
 const logger = new Logger('ForgotPassword');
 
@@ -38,10 +30,7 @@ interface IForgotPasswordState extends IAuthPieceState {
 	password?: string;
 }
 
-export default class ForgotPassword extends AuthPiece<
-	IForgotPasswordProps,
-	IForgotPasswordState
-> {
+export default class ForgotPassword extends AuthPiece<IForgotPasswordProps, IForgotPasswordState> {
 	constructor(props: IForgotPasswordProps) {
 		super(props);
 
@@ -69,22 +58,22 @@ export default class ForgotPassword extends AuthPiece<
 			return;
 		}
 		Auth.forgotPassword(username)
-			.then(data => {
+			.then((data) => {
 				logger.debug(data);
 				this.setState({ delivery: data.CodeDeliveryDetails });
 			})
-			.catch(err => this.error(err));
+			.catch((err) => this.error(err));
 	}
 
 	submit() {
 		const { code, password } = this.state;
 		const username = this.getUsernameFromInput();
-		Auth.forgotPasswordSubmit(username, code, password)
-			.then(data => {
+		Auth.forgotPasswordSubmit(username!, code!, password!)
+			.then((data) => {
 				logger.debug(data);
 				this.changeState('signIn');
 			})
-			.catch(err => this.error(err));
+			.catch((err) => this.error(err));
 	}
 
 	forgotBody(theme: AmplifyThemeType) {
@@ -107,7 +96,7 @@ export default class ForgotPassword extends AuthPiece<
 			<View style={theme.sectionBody}>
 				<FormField
 					theme={theme}
-					onChangeText={text => this.setState({ code: text })}
+					onChangeText={(text) => this.setState({ code: text })}
 					label={I18n.get('Confirmation Code')}
 					placeholder={I18n.get('Enter your confirmation code')}
 					required={true}
@@ -115,7 +104,7 @@ export default class ForgotPassword extends AuthPiece<
 				/>
 				<FormField
 					theme={theme}
-					onChangeText={text => this.setState({ password: text })}
+					onChangeText={(text) => this.setState({ password: text })}
 					label={I18n.get('Password')}
 					placeholder={I18n.get('Enter your new password')}
 					secureTextEntry={true}

--- a/packages/aws-amplify-react-native/src/Auth/RequireNewPassword.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/RequireNewPassword.tsx
@@ -14,19 +14,11 @@
 import React from 'react';
 import { View, ScrollView } from 'react-native';
 import { Auth, I18n, Logger } from 'aws-amplify';
-import {
-	FormField,
-	AmplifyButton,
-	LinkCell,
-	Header,
-	ErrorRow,
-	SignedOutMessage,
-	Wrapper,
-} from '../AmplifyUI';
+import { FormField, AmplifyButton, LinkCell, Header, ErrorRow, SignedOutMessage, Wrapper } from '../AmplifyUI';
 import AuthPiece, { IAuthPieceProps, IAuthPieceState } from './AuthPiece';
 import { AmplifyThemeType } from '../AmplifyTheme';
 import TEST_ID from '../AmplifyTestIDs';
-import { setTestId } from '../Utils'
+import { setTestId } from '../Utils';
 
 const logger = new Logger('RequireNewPassword');
 
@@ -38,16 +30,13 @@ interface IRequireNewPasswordState extends IAuthPieceState {
 	requiredAttributes: Record<string, any>;
 }
 
-export default class RequireNewPassword extends AuthPiece<
-	IRequireNewPasswordProps,
-	IRequireNewPasswordState
-> {
+export default class RequireNewPassword extends AuthPiece<IRequireNewPasswordProps, IRequireNewPasswordState> {
 	constructor(props: IRequireNewPasswordProps) {
 		super(props);
 
 		this._validAuthStates = ['requireNewPassword'];
 		this.state = {
-			password: null,
+			password: null as never,
 			error: null,
 			requiredAttributes: {},
 		};
@@ -59,22 +48,22 @@ export default class RequireNewPassword extends AuthPiece<
 		const user = this.props.authData;
 		const { password, requiredAttributes } = this.state;
 		logger.debug('Require new password for ' + user.username);
-		Auth.completeNewPassword(user, password, requiredAttributes)
-			.then(user => {
+		Auth.completeNewPassword(user, password!, requiredAttributes)
+			.then((user) => {
 				if (user.challengeName === 'SMS_MFA') {
 					this.changeState('confirmSignIn', user);
 				} else {
 					this.checkContact(user);
 				}
 			})
-			.catch(err => this.error(err));
+			.catch((err) => this.error(err));
 	}
 
 	generateForm(attribute: string, theme: AmplifyThemeType) {
 		return (
 			<FormField
 				theme={theme}
-				onChangeText={text => {
+				onChangeText={(text) => {
 					const attributes = this.state.requiredAttributes;
 					if (text !== '') attributes[attribute] = text;
 					else delete attributes[attribute];
@@ -100,14 +89,14 @@ export default class RequireNewPassword extends AuthPiece<
 					<View style={theme.sectionBody}>
 						<FormField
 							theme={theme}
-							onChangeText={text => this.setState({ password: text })}
+							onChangeText={(text) => this.setState({ password: text })}
 							label={I18n.get('Password')}
 							placeholder={I18n.get('Enter your password')}
 							secureTextEntry={true}
 							required={true}
 							{...setTestId(TEST_ID.AUTH.PASSWORD_INPUT)}
 						/>
-						{requiredAttributes.map(attribute => {
+						{requiredAttributes.map((attribute) => {
 							logger.debug('attributes', attribute);
 							return this.generateForm(attribute, theme);
 						})}
@@ -118,8 +107,7 @@ export default class RequireNewPassword extends AuthPiece<
 							disabled={
 								!(
 									this.state.password &&
-									Object.keys(this.state.requiredAttributes).length ===
-										Object.keys(requiredAttributes).length
+									Object.keys(this.state.requiredAttributes).length === Object.keys(requiredAttributes).length
 								)
 							}
 							{...setTestId(TEST_ID.AUTH.CHANGE_PASSWORD_BUTTON)}
@@ -145,6 +133,6 @@ export default class RequireNewPassword extends AuthPiece<
 function convertToPlaceholder(str: string) {
 	return str
 		.split('_')
-		.map(part => part.charAt(0).toUpperCase() + part.substr(1).toLowerCase())
+		.map((part) => part.charAt(0).toUpperCase() + part.substr(1).toLowerCase())
 		.join(' ');
 }

--- a/packages/aws-amplify-react-native/src/Auth/SignIn.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/SignIn.tsx
@@ -15,15 +15,7 @@ import React from 'react';
 import { View } from 'react-native';
 import { Auth, I18n, Logger } from 'aws-amplify';
 import AuthPiece, { IAuthPieceProps, IAuthPieceState } from './AuthPiece';
-import {
-	AmplifyButton,
-	FormField,
-	LinkCell,
-	Header,
-	ErrorRow,
-	SignedOutMessage,
-	Wrapper,
-} from '../AmplifyUI';
+import { AmplifyButton, FormField, LinkCell, Header, ErrorRow, SignedOutMessage, Wrapper } from '../AmplifyUI';
 import { AmplifyThemeType } from '../AmplifyTheme';
 import TEST_ID from '../AmplifyTestIDs';
 import { setTestId } from '../Utils';
@@ -43,8 +35,8 @@ export default class SignIn extends AuthPiece<ISignInProps, ISignInState> {
 
 		this._validAuthStates = ['signIn', 'signedOut', 'signedUp'];
 		this.state = {
-			username: null,
-			password: null,
+			username: null as never,
+			password: null as never,
 			error: null,
 			hasPendingSignIn: false,
 		};
@@ -65,7 +57,7 @@ export default class SignIn extends AuthPiece<ISignInProps, ISignInState> {
 		const username = this.getUsernameFromInput() || '';
 		logger.debug('Sign In for ' + username);
 		await Auth.signIn(username, password)
-			.then(user => {
+			.then((user) => {
 				logger.debug(user);
 				if (user.challengeName === 'SMS_MFA') {
 					this.changeState('confirmSignIn', user);
@@ -76,7 +68,7 @@ export default class SignIn extends AuthPiece<ISignInProps, ISignInState> {
 					this.checkContact(user);
 				}
 			})
-			.catch(err => {
+			.catch((err) => {
 				if (err.code === 'PasswordResetRequiredException') {
 					logger.debug('the user requires a new password');
 					this.changeState('forgotPassword', username);
@@ -93,17 +85,14 @@ export default class SignIn extends AuthPiece<ISignInProps, ISignInState> {
 			<Wrapper>
 				<View style={theme.section}>
 					<View>
-						<Header
-							theme={theme}
-							testID={TEST_ID.AUTH.SIGN_IN_TO_YOUR_ACCOUNT_TEXT}
-						>
+						<Header theme={theme} testID={TEST_ID.AUTH.SIGN_IN_TO_YOUR_ACCOUNT_TEXT}>
 							{I18n.get('Sign in to your account')}
 						</Header>
 						<View style={theme.sectionBody}>
 							{this.renderUsernameField(theme)}
 							<FormField
 								theme={theme}
-								onChangeText={text => this.setState({ password: text })}
+								onChangeText={(text) => this.setState({ password: text })}
 								label={I18n.get('Password')}
 								placeholder={I18n.get('Enter your password')}
 								secureTextEntry={true}
@@ -114,10 +103,7 @@ export default class SignIn extends AuthPiece<ISignInProps, ISignInState> {
 								text={I18n.get('Sign In').toUpperCase()}
 								theme={theme}
 								onPress={this.signIn}
-								disabled={
-									!!(!this.getUsernameFromInput() && password) ||
-									hasPendingSignIn
-								}
+								disabled={!!(!this.getUsernameFromInput() && password) || hasPendingSignIn}
 								{...setTestId(TEST_ID.AUTH.SIGN_IN_BUTTON)}
 							/>
 						</View>
@@ -129,11 +115,7 @@ export default class SignIn extends AuthPiece<ISignInProps, ISignInState> {
 							>
 								{I18n.get('Forgot Password')}
 							</LinkCell>
-							<LinkCell
-								theme={theme}
-								onPress={() => this.changeState('signUp')}
-								testID={TEST_ID.AUTH.SIGN_UP_BUTTON}
-							>
+							<LinkCell theme={theme} onPress={() => this.changeState('signUp')} testID={TEST_ID.AUTH.SIGN_UP_BUTTON}>
 								{I18n.get('Sign Up')}
 							</LinkCell>
 						</View>

--- a/packages/aws-amplify-react-native/src/Auth/SignUp.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/SignUp.tsx
@@ -32,7 +32,7 @@ import signUpWithUsernameFields, {
 } from './common/default-sign-up-fields';
 import TEST_ID from '../AmplifyTestIDs';
 import { ISignUpField } from '../../types';
-import { setTestId } from '../Utils'
+import { setTestId } from '../Utils';
 
 const logger = new Logger('SignUp');
 
@@ -55,7 +55,7 @@ interface ISignUpState extends IAuthPieceState {
 export default class SignUp extends AuthPiece<ISignUpProps, ISignUpState> {
 	header: string;
 	defaultSignUpFields: ISignUpField[];
-	signUpFields: ISignUpField[];
+	signUpFields!: ISignUpField[];
 
 	constructor(props: ISignUpProps) {
 		super(props);
@@ -95,19 +95,16 @@ export default class SignUp extends AuthPiece<ISignUpProps, ISignUpState> {
 			this.props.signUpConfig.hiddenDefaults &&
 			this.props.signUpConfig.hiddenDefaults.length > 0
 		) {
-			this.defaultSignUpFields = this.defaultSignUpFields.filter(d => {
-				return !this.props.signUpConfig.hiddenDefaults.includes(d.key);
+			this.defaultSignUpFields = this.defaultSignUpFields.filter((d) => {
+				return !this.props.signUpConfig!.hiddenDefaults!.includes(d.key);
 			});
 		}
 
 		if (this.checkCustomSignUpFields()) {
-			if (
-				!this.props.signUpConfig ||
-				!this.props.signUpConfig.hideAllDefaults
-			) {
+			if (!this.props.signUpConfig || !this.props.signUpConfig.hideAllDefaults) {
 				// see if fields passed to component should override defaults
 				this.defaultSignUpFields.forEach((f, i) => {
-					const matchKey = this.signUpFields.findIndex(d => {
+					const matchKey = this.signUpFields.findIndex((d) => {
 						return d.key === f.key;
 					});
 					if (matchKey === -1) {
@@ -116,7 +113,7 @@ export default class SignUp extends AuthPiece<ISignUpProps, ISignUpState> {
 				});
 			}
 
-			/* 
+			/*
             sort fields based on following rules:
             1. Fields with displayOrder are sorted before those without displayOrder
             2. Fields with conflicting displayOrder are sorted alphabetically by key
@@ -146,6 +143,7 @@ export default class SignUp extends AuthPiece<ISignUpProps, ISignUpState> {
 						return 1;
 					}
 				}
+				return undefined as never;
 			});
 		} else {
 			this.signUpFields = this.defaultSignUpFields;
@@ -153,13 +151,11 @@ export default class SignUp extends AuthPiece<ISignUpProps, ISignUpState> {
 	}
 
 	needPrefix(key) {
-		const field = this.signUpFields.find(e => e.key === key);
+		const field = this.signUpFields.find((e) => e.key === key);
 		if (key.indexOf('custom:') !== 0) {
-			return field.custom;
-		} else if (key.indexOf('custom:') === 0 && field.custom === false) {
-			logger.warn(
-				'Custom prefix prepended to key but custom field flag is set to false'
-			);
+			return field!.custom;
+		} else if (key.indexOf('custom:') === 0 && field!.custom === false) {
+			logger.warn('Custom prefix prepended to key but custom field flag is set to false');
 		}
 		return null;
 	}
@@ -167,26 +163,20 @@ export default class SignUp extends AuthPiece<ISignUpProps, ISignUpState> {
 	getDefaultDialCode() {
 		return this.props.signUpConfig &&
 			this.props.signUpConfig.defaultCountryCode &&
-			countryDialCodes.indexOf(
-				`+${this.props.signUpConfig.defaultCountryCode}`
-			) !== -1
+			countryDialCodes.indexOf(`+${this.props.signUpConfig.defaultCountryCode}`) !== -1
 			? `+${this.props.signUpConfig.defaultCountryCode}`
 			: '+1';
 	}
 
 	checkCustomSignUpFields() {
 		return (
-			this.props.signUpConfig &&
-			this.props.signUpConfig.signUpFields &&
-			this.props.signUpConfig.signUpFields.length > 0
+			this.props.signUpConfig && this.props.signUpConfig.signUpFields && this.props.signUpConfig.signUpFields.length > 0
 		);
 	}
 
 	signUp() {
 		if (!Auth || typeof Auth.signUp !== 'function') {
-			throw new Error(
-				'No Auth module found, please ensure @aws-amplify/auth is imported'
-			);
+			throw new Error('No Auth module found, please ensure @aws-amplify/auth is imported');
 		}
 
 		const signup_info = {
@@ -200,11 +190,7 @@ export default class SignUp extends AuthPiece<ISignUpProps, ISignUpState> {
 
 		inputKeys.forEach((key, index) => {
 			if (!['username', 'password', 'checkedValue'].includes(key)) {
-				if (
-					key !== 'phone_line_number' &&
-					key !== 'dial_code' &&
-					key !== 'error'
-				) {
+				if (key !== 'phone_line_number' && key !== 'dial_code' && key !== 'error') {
 					const newKey = `${this.needPrefix(key) ? 'custom:' : ''}${key}`;
 					signup_info.attributes[newKey] = inputVals[index];
 				}
@@ -212,11 +198,10 @@ export default class SignUp extends AuthPiece<ISignUpProps, ISignUpState> {
 		});
 
 		let labelCheck = false;
-		this.signUpFields.forEach(field => {
+		this.signUpFields.forEach((field) => {
 			if (field.label === this.getUsernameLabel()) {
 				logger.debug(`Changing the username to the value of ${field.label}`);
-				signup_info.username =
-					signup_info.attributes[field.key] || signup_info.username;
+				signup_info.username = signup_info.attributes[field.key] || signup_info.username;
 				labelCheck = true;
 			}
 		});
@@ -230,30 +215,27 @@ export default class SignUp extends AuthPiece<ISignUpProps, ISignUpState> {
 		}
 
 		logger.debug('Signing up with', signup_info);
-		Auth.signUp(signup_info)
-			.then(data => {
+		Auth.signUp(signup_info as never)
+			.then((data) => {
 				// @ts-ignore
 				this.changeState('confirmSignUp', data.user.username);
 			})
-			.catch(err => this.error(err));
+			.catch((err) => this.error(err));
 	}
 
 	showComponent(theme) {
 		if (this.checkCustomSignUpFields()) {
-			this.signUpFields = this.props.signUpConfig.signUpFields;
+			this.signUpFields = this.props.signUpConfig!.signUpFields!;
 		}
 		this.sortFields();
 		return (
 			<Wrapper>
-				<ScrollView 
-					style={theme.sectionScroll}
-					keyboardShouldPersistTaps='handled'
-					>
+				<ScrollView style={theme.sectionScroll} keyboardShouldPersistTaps="handled">
 					<Header theme={theme} testID={TEST_ID.AUTH.SIGN_UP_TEXT}>
 						{I18n.get(this.header)}
 					</Header>
 					<View style={theme.sectionBody}>
-						{this.signUpFields.map(field => {
+						{this.signUpFields.map((field) => {
 							return field.key !== 'phone_number' ? (
 								<FormField
 									key={field.key}
@@ -261,7 +243,7 @@ export default class SignUp extends AuthPiece<ISignUpProps, ISignUpState> {
 									// @ts-ignore
 									type={field.type}
 									secureTextEntry={field.type === 'password'}
-									onChangeText={text => {
+									onChangeText={(text) => {
 										const stateObj = this.state;
 										stateObj[field.key] = text;
 										this.setState(stateObj);
@@ -269,19 +251,19 @@ export default class SignUp extends AuthPiece<ISignUpProps, ISignUpState> {
 									label={I18n.get(field.label)}
 									placeholder={I18n.get(field.placeholder)}
 									required={field.required}
-									{...setTestId(field.testID)}
+									{...setTestId(field.testID!)}
 								/>
 							) : (
 								<PhoneField
 									theme={theme}
 									key={field.key}
-									onChangeText={text => this.setState({ phone_number: text })}
+									onChangeText={(text) => this.setState({ phone_number: text })}
 									label={I18n.get(field.label)}
 									placeholder={I18n.get(field.placeholder)}
 									keyboardType="phone-pad"
 									required={field.required}
 									defaultDialCode={this.getDefaultDialCode()}
-									{...setTestId(field.testID)}
+									{...setTestId(field.testID!)}
 								/>
 							);
 						})}
@@ -301,11 +283,7 @@ export default class SignUp extends AuthPiece<ISignUpProps, ISignUpState> {
 						>
 							{I18n.get('Confirm a Code')}
 						</LinkCell>
-						<LinkCell
-							theme={theme}
-							onPress={() => this.changeState('signIn')}
-							testID={TEST_ID.AUTH.SIGN_IN_BUTTON}
-						>
+						<LinkCell theme={theme} onPress={() => this.changeState('signIn')} testID={TEST_ID.AUTH.SIGN_IN_BUTTON}>
 							{I18n.get('Sign In')}
 						</LinkCell>
 					</View>

--- a/packages/aws-amplify-react-native/src/Auth/VerifyContact.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/VerifyContact.tsx
@@ -37,7 +37,7 @@ export default class VerifyContact extends AuthPiece<IVerifyContactProps, IVerif
 
 		this._validAuthStates = ['verifyContact'];
 		this.state = {
-			verifyAttr: null,
+			verifyAttr: null as never,
 			error: null,
 		};
 
@@ -71,7 +71,6 @@ export default class VerifyContact extends AuthPiece<IVerifyContactProps, IVerif
 	}
 
 	verify() {
-		const user = this.props.authData;
 		const attr = this.state.pickAttr;
 		if (!attr) {
 			this.error('Neither Email nor Phone Number selected');
@@ -90,7 +89,7 @@ export default class VerifyContact extends AuthPiece<IVerifyContactProps, IVerif
 	submit() {
 		const attr = this.state.verifyAttr;
 		const { code } = this.state;
-		Auth.verifyCurrentUserAttributeSubmit(attr, code)
+		Auth.verifyCurrentUserAttributeSubmit(attr!, code!)
 			.then((data) => {
 				logger.debug(data);
 				this.changeState('signedIn', this.props.authData);
@@ -148,7 +147,6 @@ export default class VerifyContact extends AuthPiece<IVerifyContactProps, IVerif
 			return null;
 		}
 
-		const { email, phone_number } = unverified;
 		return (
 			<View style={theme.sectionBody}>
 				{this.createPicker(unverified)}

--- a/packages/aws-amplify-react-native/src/Auth/index.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/index.tsx
@@ -61,7 +61,7 @@ export function withAuthenticator<Props extends object>(
 	includeGreetings: boolean | { [index: string]: any } = false,
 	authenticatorComponents = [],
 	federated = null,
-	theme: AmplifyThemeType = null,
+	theme: AmplifyThemeType = null as never,
 	signUpConfig: ISignUpConfig = {}
 ) {
 	class Wrapper extends React.Component<Props & IWithAuthenticatorProps, IWithAuthenticatorState> {
@@ -72,7 +72,7 @@ export function withAuthenticator<Props extends object>(
 
 			this.handleAuthStateChange = this.handleAuthStateChange.bind(this);
 
-			this.state = { authState: props.authState };
+			this.state = { authState: props.authState! };
 
 			this.authConfig = {};
 

--- a/packages/aws-amplify-react-native/src/Auth/withOAuth.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/withOAuth.tsx
@@ -14,10 +14,7 @@ import * as React from 'react';
 import { Linking } from 'react-native';
 
 import { Logger, Hub } from '@aws-amplify/core';
-import {
-	default as Auth,
-	CognitoHostedUIIdentityProvider,
-} from '@aws-amplify/auth';
+import { default as Auth, CognitoHostedUIIdentityProvider } from '@aws-amplify/auth';
 
 const logger = new Logger('withOAuth');
 
@@ -44,15 +41,10 @@ interface IWithOAuthState {
 	user?: any;
 }
 
-export default function withOAuth<Props extends object>(
-	Comp: React.ComponentType<IWithOAuthProps & IOAuthProps>
-) {
-	let listeners = [];
+export default function withOAuth<Props extends object>(Comp: React.ComponentType<IWithOAuthProps & IOAuthProps>) {
+	let listeners = [] as unknown[];
 
-	return class WithOAuth extends React.Component<
-		Props & IWithOAuthProps,
-		IWithOAuthState
-	> {
+	return class WithOAuth extends React.Component<Props & IWithOAuthProps, IWithOAuthState> {
 		_isMounted: boolean;
 		urlOpener: any;
 
@@ -71,11 +63,11 @@ export default function withOAuth<Props extends object>(
 
 			this.state = {
 				user: null,
-				error: null,
+				error: null as never,
 				loading: false,
 			};
 
-			listeners.forEach(listener => Hub.remove('auth', listener));
+			listeners.forEach((listener) => Hub.remove('auth', listener as never));
 			listeners = [this];
 			this.onHubCapsule = this.onHubCapsule.bind(this);
 			Hub.listen('auth', this.onHubCapsule);
@@ -85,10 +77,10 @@ export default function withOAuth<Props extends object>(
 			this._isMounted = true;
 			this.setState({ loading: true }, () => {
 				Auth.currentAuthenticatedUser()
-					.then(user => {
+					.then((user) => {
 						this.setState({ user, loading: false });
 					})
-					.catch(error => {
+					.catch((error) => {
 						logger.debug(error);
 						this.setState({ user: null, loading: false });
 					});
@@ -107,11 +99,11 @@ export default function withOAuth<Props extends object>(
 				switch (payload.event) {
 					case 'signIn':
 					case 'cognitoHostedUI': {
-						Auth.currentAuthenticatedUser().then(user => {
+						Auth.currentAuthenticatedUser().then((user) => {
 							logger.debug('signed in');
 							this.setState({
 								user,
-								error: null,
+								error: null as never,
 								loading: false,
 							});
 						});
@@ -121,7 +113,7 @@ export default function withOAuth<Props extends object>(
 						logger.debug('signed out');
 						this.setState({
 							user: null,
-							error: null,
+							error: null as never,
 							loading: false,
 						});
 						break;
@@ -144,9 +136,7 @@ export default function withOAuth<Props extends object>(
 
 		_getOAuthConfig() {
 			if (!Auth || typeof Auth.configure !== 'function') {
-				throw new Error(
-					'No Auth module found, please ensure @aws-amplify/auth is imported'
-				);
+				throw new Error('No Auth module found, please ensure @aws-amplify/auth is imported');
 			}
 
 			// @ts-ignore
@@ -162,13 +152,11 @@ export default function withOAuth<Props extends object>(
 		}
 
 		hostedUISignIn(provider) {
-			this.setState({ loading: true }, () =>
-				Auth.federatedSignIn({ provider })
-			);
+			this.setState({ loading: true }, () => Auth.federatedSignIn({ provider }));
 		}
 
 		signOut() {
-			return Auth.signOut().catch(error => logger.warn(error));
+			return Auth.signOut().catch((error) => logger.warn(error));
 		}
 
 		render() {
@@ -179,23 +167,11 @@ export default function withOAuth<Props extends object>(
 				loading,
 				oAuthUser,
 				oAuthError,
-				hostedUISignIn: this.hostedUISignIn.bind(
-					this,
-					CognitoHostedUIIdentityProvider.Cognito
-				),
-				facebookSignIn: this.hostedUISignIn.bind(
-					this,
-					CognitoHostedUIIdentityProvider.Facebook
-				),
-				amazonSignIn: this.hostedUISignIn.bind(
-					this,
-					CognitoHostedUIIdentityProvider.Amazon
-				),
-				googleSignIn: this.hostedUISignIn.bind(
-					this,
-					CognitoHostedUIIdentityProvider.Google
-				),
-				customProviderSignIn: provider => this.hostedUISignIn(provider),
+				hostedUISignIn: this.hostedUISignIn.bind(this, CognitoHostedUIIdentityProvider.Cognito),
+				facebookSignIn: this.hostedUISignIn.bind(this, CognitoHostedUIIdentityProvider.Facebook),
+				amazonSignIn: this.hostedUISignIn.bind(this, CognitoHostedUIIdentityProvider.Amazon),
+				googleSignIn: this.hostedUISignIn.bind(this, CognitoHostedUIIdentityProvider.Google),
+				customProviderSignIn: (provider) => this.hostedUISignIn(provider),
 				signOut: this.signOut,
 			};
 

--- a/packages/aws-amplify-react-native/src/Interactions/ChatBot.tsx
+++ b/packages/aws-amplify-react-native/src/Interactions/ChatBot.tsx
@@ -1,11 +1,5 @@
 import React, { Component } from 'react';
-import {
-	View,
-	TextInput,
-	Text,
-	KeyboardAvoidingView,
-	ScrollView,
-} from 'react-native';
+import { View, TextInput, Text, KeyboardAvoidingView, ScrollView } from 'react-native';
 import Interactions from '@aws-amplify/interactions';
 import { I18n } from 'aws-amplify';
 import { AmplifyButton } from '../AmplifyUI';
@@ -194,13 +188,10 @@ export class ChatBot extends Component<IChatBotProps, IChatBotState> {
 			return;
 		}
 
-		await new Promise(resolve =>
+		await new Promise((resolve) =>
 			this.setState(
 				{
-					dialog: [
-						...this.state.dialog,
-						{ message: this.state.inputText, from: 'me' },
-					],
+					dialog: [...this.state.dialog, { message: this.state.inputText, from: 'me' }],
 				},
 				resolve
 			)
@@ -214,15 +205,9 @@ export class ChatBot extends Component<IChatBotProps, IChatBotState> {
 					messageType: 'text',
 				},
 			};
-			response = await Interactions.send(
-				this.props.botName,
-				interactionsMessage
-			);
+			response = await Interactions.send(this.props.botName!, interactionsMessage);
 		} else {
-			response = await Interactions.send(
-				this.props.botName,
-				this.state.inputText
-			);
+			response = await Interactions.send(this.props.botName!, this.state.inputText);
 		}
 
 		this.setState(
@@ -254,19 +239,16 @@ export class ChatBot extends Component<IChatBotProps, IChatBotState> {
 			const path = `${RNFS.DocumentDirectoryPath}/responseAudio.mp3`;
 			const data = Buffer.from(response.audioStream).toString('base64');
 			await RNFS.writeFile(path, data, 'base64');
-			const speech = new Sound(path, '', async err => {
+			const speech = new Sound(path, '', async (err) => {
 				if (!err) {
 					speech.play(async () => {
 						speech.release();
-						RNFS.exists(path).then(res => {
+						RNFS.exists(path).then((res) => {
 							if (res) {
 								RNFS.unlink(path);
 							}
 						});
-						if (
-							response.dialogState === 'ElicitSlot' &&
-							this.props.conversationModeOn
-						) {
+						if (response.dialogState === 'ElicitSlot' && this.props.conversationModeOn) {
 							await this.startRecognizing();
 						}
 					});
@@ -284,10 +266,9 @@ export class ChatBot extends Component<IChatBotProps, IChatBotState> {
 
 			this.setState(
 				{
-					dialog: [
-						...(!clearOnComplete && this.state.dialog),
-						message && { from: 'bot', message },
-					].filter(Boolean),
+					dialog: [...((!clearOnComplete && this.state.dialog) as []), message && { from: 'bot', message }].filter(
+						Boolean
+					),
 				},
 				() => {
 					setTimeout(() => {
@@ -343,11 +324,11 @@ export class ChatBot extends Component<IChatBotProps, IChatBotState> {
 			inputText: e.value.join(' '),
 		});
 		if (timer !== null) {
-			clearTimeout(timer);
+			clearTimeout(timer!);
 		}
 		timer = setTimeout(async () => {
 			await Voice.stop();
-		}, this.state.silenceDelay);
+		}, this.state.silenceDelay) as never;
 	}
 
 	async startRecognizing() {
@@ -394,11 +375,7 @@ export class ChatBot extends Component<IChatBotProps, IChatBotState> {
 		const { styles: overrideStyles } = this.props;
 
 		return (
-			<KeyboardAvoidingView
-				style={[styles.container, overrideStyles.container]}
-				behavior="padding"
-				enabled
-			>
+			<KeyboardAvoidingView style={[styles.container, overrideStyles.container]} behavior="padding" enabled>
 				<ScrollView
 					ref={this.listItemsRef}
 					style={[styles.list, overrideStyles.list]}
@@ -412,7 +389,7 @@ export class ChatBot extends Component<IChatBotProps, IChatBotState> {
 					textEnabled={this.props.textEnabled}
 					styles={styles}
 					overrideStyles={overrideStyles}
-					onChangeText={inputText => this.setState({ inputText })}
+					onChangeText={(inputText) => this.setState({ inputText })}
 					inputText={this.state.inputText}
 					onSubmitEditing={this.submit}
 					editable={this.state.inputEditable}
@@ -455,12 +432,7 @@ function ChatBotInputs(props) {
 	}
 
 	if (!voiceEnabled && !textEnabled) {
-		return (
-			<Text>
-				No Chatbot inputs enabled. Set at least one of voiceEnabled or
-				textEnabled in the props.{' '}
-			</Text>
-		);
+		return <Text>No Chatbot inputs enabled. Set at least one of voiceEnabled or textEnabled in the props. </Text>;
 	}
 
 	return (
@@ -552,11 +524,7 @@ function ChatBotMicButton(props) {
 	}
 
 	return (
-		<AmplifyButton
-			onPress={handleMicButton}
-			style={[styles.buttonMic, overrideStyles.buttonMic]}
-			text={micText}
-		/>
+		<AmplifyButton onPress={handleMicButton} style={[styles.buttonMic, overrideStyles.buttonMic]} text={micText} />
 	);
 }
 

--- a/packages/aws-amplify-react-native/src/Storage/S3Album.tsx
+++ b/packages/aws-amplify-react-native/src/Storage/S3Album.tsx
@@ -40,15 +40,15 @@ export default class S3Album extends Component<IS3AlbumProps, IS3AlbumState> {
 	componentDidMount() {
 		const { path, level, filter } = this.props;
 		logger.debug(path);
-		Storage.list(path, { level: level ? level : 'public' })
-			.then(data => {
+		Storage.list(path!, { level: level ? (level as never) : 'public' })
+			.then((data) => {
 				logger.debug(data);
 				if (filter) {
 					data = filter(data);
 				}
 				this.setState({ images: data });
 			})
-			.catch(err => logger.warn(err));
+			.catch((err) => logger.warn(err));
 	}
 
 	render() {
@@ -63,7 +63,7 @@ export default class S3Album extends Component<IS3AlbumProps, IS3AlbumState> {
 			width: '100%',
 			height: height,
 		});
-		const list = this.state.images.map(image => {
+		const list = this.state.images.map((image) => {
 			return (
 				<S3Image
 					key={image.key}

--- a/packages/aws-amplify-react-native/src/Storage/S3Image.tsx
+++ b/packages/aws-amplify-react-native/src/Storage/S3Image.tsx
@@ -41,14 +41,14 @@ export default class S3Image extends Component<IS3ImageProps, IS3ImageState> {
 
 	getImageSource() {
 		const { imgKey, level } = this.props;
-		Storage.get(imgKey, { level: level ? level : 'public' })
-			.then(url => {
+		Storage.get(imgKey!, { level: level ? (level as never) : 'public' })
+			.then((url) => {
 				logger.debug(url);
 				this.setState({
 					src: { uri: url },
 				});
 			})
-			.catch(err => logger.warn(err));
+			.catch((err) => logger.warn(err));
 	}
 
 	load() {
@@ -66,13 +66,13 @@ export default class S3Image extends Component<IS3ImageProps, IS3ImageState> {
 				contentType: type,
 				level: level ? level : 'public',
 			};
-			const ret = Storage.put(imgKey, body, opt);
+			const ret = Storage.put(imgKey, body, opt as never) as Promise<unknown>;
 			ret
-				.then(data => {
+				.then((data) => {
 					logger.debug(data);
 					that.getImageSource();
 				})
-				.catch(err => logger.warn(err));
+				.catch((err) => logger.warn(err));
 		} else {
 			that.getImageSource();
 		}
@@ -83,10 +83,7 @@ export default class S3Image extends Component<IS3ImageProps, IS3ImageState> {
 	}
 
 	componentDidUpdate(prevProps: IS3ImageProps) {
-		if (
-			prevProps.imgKey !== this.props.imgKey ||
-			prevProps.body !== this.props.body
-		) {
+		if (prevProps.imgKey !== this.props.imgKey || prevProps.body !== this.props.body) {
 			this.load();
 		}
 	}
@@ -99,11 +96,7 @@ export default class S3Image extends Component<IS3ImageProps, IS3ImageState> {
 
 		const { style, resizeMode } = this.props;
 		const theme = this.props.theme || AmplifyTheme;
-		const photoStyle = Object.assign(
-			{},
-			StyleSheet.flatten(theme.photo),
-			style
-		);
+		const photoStyle = Object.assign({}, StyleSheet.flatten(theme.photo), style);
 
 		return <Image source={src} resizeMode={resizeMode} style={photoStyle} />;
 	}

--- a/packages/aws-amplify-react-native/tsconfig.json
+++ b/packages/aws-amplify-react-native/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"strict": false,
+		"strict": true,
+		"skipLibCheck": true,
 		"outDir": "./dist/",
 		"sourceMap": true,
 		"noImplicitAny": false,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR changes `aws-amplify-react-native` to use TypeScript's `strict` mode for type checking. This PR changes no runtime behavior but fixes various type-checking issues.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

I did not raise an issue since this is an internal-only change and should not impact external users.

#### Description of how you validated changes

I ran `tsc --noEmit` and verified the build works in my app as expected.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
