### PR TITLE
chore: stop generating unused dts in lib folder

### DIFF
--- a/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
+++ b/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
@@ -11,7 +11,7 @@ import {
 	initSchema as initSchemaType,
 } from '@aws-amplify/datastore';
 import { Model, Post, Comment, testSchema } from './helpers';
-import { SyncEngine } from '@aws-amplify/datastore/lib/sync';
+import { SyncEngine } from '@aws-amplify/datastore/lib-esm/sync';
 import Observable from 'zen-observable';
 import {
 	pause,

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -169,7 +169,7 @@ async function buildES5(typeScriptCompiler, watchMode) {
 		target: 'es5',
 		module: 'commonjs',
 		moduleResolution: 'node',
-		declaration: true,
+		declaration: false,
 		noEmitOnError: true,
 		incremental: true,
 		tsBuildInfoFile: es5TsBuildInfoFilePath,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
`*.d.ts` files are generated twice in `lib` and `lib-esm` folder. Only the ones in `lib-esm` are referred by customers. This change skip generating the `*.d.ts` file for the `lib` folder. This change improves library building speed by ~30%:

* before: 817.55s user 41.86s system 388% cpu 3:41.35 total
* after: 544.91s user 28.45s system 335% cpu 2:51.07 total

#### Description of how you validated changes
Unit test.
Manually tested importing types from `@aws-amplify/datastore/ssr`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
