### PR TITLE
Added support for idp_identifier query parameter in cognito authorize…

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -73,6 +73,7 @@ import {
 	AuthErrorTypes,
 	AutoSignInOptions,
 	CognitoHostedUIIdentityProvider,
+	hasIdpIdentifier,
 	IAuthDevice,
 } from './types/Auth';
 
@@ -219,7 +220,6 @@ export class AuthClass {
 				? oauth
 				: (<any>oauth).awsCognito
 			: undefined;
-
 		if (cognitoHostedUIConfig) {
 			const cognitoAuthParams = Object.assign(
 				{
@@ -2339,6 +2339,7 @@ export class AuthClass {
 			isFederatedSignInOptions(providerOrOptions) ||
 			isFederatedSignInOptionsCustom(providerOrOptions) ||
 			hasCustomState(providerOrOptions) ||
+			hasIdpIdentifier(providerOrOptions) ||
 			typeof providerOrOptions === 'undefined'
 		) {
 			const options = providerOrOptions || {
@@ -2351,6 +2352,10 @@ export class AuthClass {
 			const customState = isFederatedSignInOptions(options)
 				? options.customState
 				: (options as FederatedSignInOptionsCustom).customState;
+
+			const idpIdentifier = isFederatedSignInOptions(options)
+				? options.idpIdentifier
+				: (options as FederatedSignInOptionsCustom).idpIdentifier;
 
 			if (this._config.userPoolId) {
 				const client_id = isCognitoHostedOpts(this._config.oauth)
@@ -2367,7 +2372,8 @@ export class AuthClass {
 					redirect_uri,
 					client_id,
 					provider,
-					customState
+					customState,
+					idpIdentifier
 				);
 			}
 		} else {

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -70,13 +70,15 @@ export type LegacyProvider =
 	| string;
 
 export type FederatedSignInOptions = {
-	provider: CognitoHostedUIIdentityProvider;
+	provider?: CognitoHostedUIIdentityProvider;
 	customState?: string;
+	idpIdentifier?: string;
 };
 
 export type FederatedSignInOptionsCustom = {
-	customProvider: string;
+	customProvider?: string;
 	customState?: string;
+	idpIdentifier?: string;
 };
 
 export function isFederatedSignInOptions(
@@ -98,6 +100,13 @@ export function hasCustomState(obj: any): boolean {
 		| FederatedSignInOptions
 		| FederatedSignInOptionsCustom
 	))[] = ['customState'];
+	return obj && !!keys.find(k => obj.hasOwnProperty(k));
+}
+export function hasIdpIdentifier(obj: any): boolean {
+	const keys: (keyof (
+		| FederatedSignInOptions
+		| FederatedSignInOptionsCustom
+	))[] = ['idpIdentifier'];
 	return obj && !!keys.find(k => obj.hasOwnProperty(k));
 }
 


### PR DESCRIPTION
… endpoint

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
##### Files changed
The following files had changes:
- `packages/auth/src/types/OAuth.ts`
- `packages/auth/src/Auth.ts`
- `packages/auth/src/OAuth/OAuth.ts`


##### Changes
The `packages/auth/src/types/OAuth.ts` file had the following changes:

An `idpIdentifier`filed was added as an optional field in the `FederatedSignInOptions` and `FederatedSignInOptionsCustom` types to enable the idp_identifier query parameter when sending the request URL to the Cognito authorize endpoint. Additionally, a `hasIdpIdentifier` function was added to evaluate if the provider options have an `idpIdentifier` key. Also, the provider field was made optional, as either an `idp_identifier` or a `provider` is used when requesting for an IdP, as described in the [Amazon Cognito documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html). 
 
The `packages/auth/src/Auth.ts` file had the following changes:

The `hasIdpIdentifier` function was used to check for the `idpIdentifier` key. In case it has it, the idpIdentifier value is extracted either from the `FederatedSignInOptions` type or the `FederatedSignInOptions` type. After that the `idpIdentifier` is passed to the `this._oAuthHandler.oauthSignIn` function.

Finally, the `packages/auth/src/OAuth/OAuth.ts` file had the following changes:

The function `oauthSignIn` was modified to make the `provider` argument optional and added an optional argument `idpIdentifier`. In case there is a `provider` present the request URL generated will send the `provider` as the `identity_provider` query parameter and ignore any `idpIdentifier` present, as either an `idp_identifier` or an `identity_provider` is used when requesting for an IdP. In case there is no provider, it will check for the idpIdentifier and send it as the `idp_identifier` query parameter in the Cognito authorize endpoint.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Closes #10226 


#### Description of how you validated changes

I created a sample React app with the following component:

```jsx
import { Auth } from "aws-amplify";
import { useEffect, useState } from "react";

export default function SignInPage() {
  const [user, setUser] = useState(null);

  const signIn = async () => {
    try {
      await Auth.federatedSignIn({
        idpIdentifier: "hotmail.com", // IdP identifier which was set up via amazon cognito
      });
    } catch (error) {
      console.log("error signing in", error);
    }
  };

  useEffect(() => {
    getUser().then((userData) => setUser(userData));
  }, []);

  function getUser() {
    return Auth.currentAuthenticatedUser()
      .then((userData) => userData)
      .catch(() => console.log("Not signed in"));
  }

  return (
    <div>
      <h1>
        Welcome{" "}
        {user ? JSON.stringify(user.attributes.email) : "Ups! Not signed in"}
      </h1>
      {user ? (
        <button onClick={() => Auth.signOut()}>Sign Out</button>
      ) : (
        <button onClick={signIn}>Federated Sign In</button>
      )}
    </div>
  );
}
```

The federate sign in identity was set up as described in the comment in #10226 and adding an IdPidentifier as shown below:
![image](https://user-images.githubusercontent.com/66692533/196775847-eda1d04f-b96d-4ff5-bbfe-cb5b43438282.png)

The app successfully logged in the user and added it to the cognito user pool created. 

Previous test cases when using default options or no arguments for the `federatedSignin` function where tested and they worked correctly.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes (It is not working for @aws-amplify/storage tests in the latest branch)
- [x] `yarn run test --scope @aws-amplify/auth` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
