### PR TITLE
fix: Restore `tslib` dependencies for v5

### DIFF
--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -42,7 +42,8 @@
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
     "@aws-amplify/core": "4.7.8",
-    "axios": "0.26.0"
+    "axios": "0.26.0",
+    "tslib": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -52,7 +52,8 @@
 	},
 	"dependencies": {
 		"@aws-amplify/api-graphql": "2.3.21",
-		"@aws-amplify/api-rest": "2.0.57"
+		"@aws-amplify/api-rest": "2.0.57",
+		"tslib": "^2.0.0"
 	},
 	"jest": {
 		"globals": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -44,7 +44,8 @@
     "@aws-amplify/cache": "4.0.59",
     "@aws-amplify/core": "4.7.8",
     "amazon-cognito-identity-js": "5.2.11",
-    "crypto-js": "^4.1.1"
+    "crypto-js": "^4.1.1",
+    "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@jest/test-sequencer": "^24.9.0"

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -47,7 +47,8 @@
     "@aws-amplify/pubsub": "4.5.7",
     "@aws-amplify/storage": "4.5.10",
     "@aws-amplify/ui": "2.0.5",
-    "@aws-amplify/xr": "3.0.57"
+    "@aws-amplify/xr": "3.0.57",
+    "tslib": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -44,7 +44,8 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/core": "4.7.8"
+    "@aws-amplify/core": "4.7.8",
+    "tslib": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -46,7 +46,8 @@
 		"@aws-sdk/client-lex-runtime-v2": "3.186.0",
 		"base-64": "1.0.0",
 		"fflate": "0.7.3",
-		"pako": "2.0.4"
+		"pako": "2.0.4",
+		"tslib": "^2.0.0"
 	},
 	"jest": {
 		"globals": {

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -41,7 +41,8 @@
   },
   "homepage": "https://aws-amplify.github.io/",
   "dependencies": {
-    "@aws-amplify/core": "4.7.8"
+    "@aws-amplify/core": "4.7.8",
+    "tslib": "^2.0.0"
   },
   "jest": {
     "globals": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This change restores `tslib` dependencies that appear to have been dropped with a recent merge.

#### Issue #, if available
Original PR with testing details: https://github.com/aws-amplify/amplify-js/pull/10435

#### Description of how you validated changes
See original PR.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
