### PR TITLE
feat: add ts-coverage threshold to categories

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -16,7 +16,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
+		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
 		"test:watch": "tslint 'src/**/*.ts' && jest -w 1 --watch",
 		"build-with-test": "npm run clean && npm test && tsc && webpack",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -27,7 +27,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 69.26"
 	},
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -16,7 +16,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
+		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
 		"test:watch": "tslint 'src/**/*.ts' && jest -w 1 --watch",
 		"build-with-test": "npm run clean && npm test && tsc && webpack",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
@@ -26,7 +26,7 @@
 		"build": "npm run clean && npm run build:esm && npm run build:cjs",
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
-		"lint": "tslint 'src/**/*.ts'",
+		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
 		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
 	},
 	"react-native": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -27,7 +27,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint 'src/**/*.ts'",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 68"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
 	},
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js",

--- a/packages/analytics/tsconfig.build.json
+++ b/packages/analytics/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts'",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
   },
   "repository": {
     "type": "git",

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest --coverage",
+    "test": "tslint 'src/**/*.ts' && jest --coverage && npm run ts-coverage",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest --coverage && npm run ts-coverage",
+    "test": "tslint 'src/**/*.ts' && jest --coverage",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",
@@ -28,7 +28,7 @@
     "build": "npm run clean && npm run build:esm && npm run build:cjs",
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
-    "lint": "tslint 'src/**/*.ts'",
+    "lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
     "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
   },
   "repository": {

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 75.62"
   },
   "repository": {
     "type": "git",

--- a/packages/api-graphql/tsconfig.build.json
+++ b/packages/api-graphql/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts'",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 70"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
   },
   "repository": {
     "type": "git",

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 65.41"
   },
   "repository": {
     "type": "git",

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest --coverage ",
+    "test": "tslint 'src/**/*.ts' && jest --coverage",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest --coverage && npm run ts-coverage",
+    "test": "tslint 'src/**/*.ts' && jest --coverage ",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",
@@ -28,7 +28,7 @@
     "build": "npm run clean && npm run build:esm && npm run build:cjs",
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
-    "lint": "tslint 'src/**/*.ts'",
+    "lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
     "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
   },
   "repository": {

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest --coverage",
+    "test": "tslint 'src/**/*.ts' && jest --coverage && npm run ts-coverage",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",

--- a/packages/api-rest/tsconfig.build.json
+++ b/packages/api-rest/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,7 +26,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
+		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
 		"build-with-test": "npm test && npm run build",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,7 +26,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
+		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
 		"build-with-test": "npm test && npm run build",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",
@@ -35,7 +35,7 @@
 		"build": "npm run clean && npm run build:esm && npm run build:cjs",
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
-		"lint": "tslint 'src/**/*.ts'",
+		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
 		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
 	},
 	"repository": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,7 +36,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 91.93"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,7 +36,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint 'src/**/*.ts'",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/api/tsconfig.build.json
+++ b/packages/api/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint '{__tests__,src}/**/*.ts' && npm run ts-coverage",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 77.44"
   },
   "repository": {
     "type": "git",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "yarn lint --fix && jest -w 1 --coverage",
+    "test": "yarn lint --fix && jest -w 1 --coverage && npm run ts-coverage",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "yarn lint --fix && jest -w 1 --coverage && npm run ts-coverage",
+    "test": "yarn lint --fix && jest -w 1 --coverage ",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",
@@ -28,7 +28,7 @@
     "build": "npm run clean && npm run build:esm && npm run build:cjs",
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
-    "lint": "tslint '{__tests__,src}/**/*.ts'",
+    "lint": "tslint '{__tests__,src}/**/*.ts' && npm run ts-coverage",
     "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
   },
   "repository": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "yarn lint --fix && jest -w 1 --coverage ",
+    "test": "yarn lint --fix && jest -w 1 --coverage",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint '{__tests__,src}/**/*.ts'",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
   },
   "repository": {
     "type": "git",

--- a/packages/auth/tsconfig.build.json
+++ b/packages/auth/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -10,7 +10,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2 && npm run ts-coverage",
+    "test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2 ",
     "build-with-test": "npm run clean && npm test && tsc && webpack -p",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",
@@ -19,7 +19,7 @@
     "build": "npm run clean && npm run build:esm && npm run build:cjs",
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
-    "lint": "tslint 'src/**/*.ts'",
+    "lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
     "generate-docs-local": "typedoc --out docs src",
     "generate-docs-root": "typedoc --out ../../docs src",
     "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -22,7 +22,7 @@
     "lint": "tslint 'src/**/*.ts'",
     "generate-docs-local": "typedoc --out docs src",
     "generate-docs-root": "typedoc --out ../../docs src",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
   },
   "repository": {
     "type": "git",

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -10,7 +10,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2 ",
+    "test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2",
     "build-with-test": "npm run clean && npm test && tsc && webpack -p",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -22,7 +22,7 @@
     "lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
     "generate-docs-local": "typedoc --out docs src",
     "generate-docs-root": "typedoc --out ../../docs src",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 93.26"
   },
   "repository": {
     "type": "git",

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -10,7 +10,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2",
+    "test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2 && npm run ts-coverage",
     "build-with-test": "npm run clean && npm test && tsc && webpack -p",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",

--- a/packages/aws-amplify/tsconfig.build.json
+++ b/packages/aws-amplify/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
+    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",
@@ -31,7 +31,7 @@
     "build": "npm run clean && npm run build:esm && npm run build:cjs",
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
-    "lint": "tslint 'src/**/*.ts'",
+    "lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
     "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
   },
   "repository": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -32,7 +32,7 @@
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts'",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
   },
   "repository": {
     "type": "git",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -32,7 +32,7 @@
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 87.74"
   },
   "repository": {
     "type": "git",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
+    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",

--- a/packages/cache/tsconfig.build.json
+++ b/packages/cache/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
 		"./dist/aws-amplify-core.js"
 	],
 	"scripts": {
-		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
+		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
 		"build-with-test": "npm test && npm run build",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "rimraf lib-esm && node ./build es6",
@@ -29,7 +29,7 @@
 		"generate-version": "genversion src/Platform/version.ts --es6 --semi",
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
-		"lint": "tslint 'src/**/*.ts'",
+		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
 		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0 "
 	},
 	"react-native": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0 "
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 76.41 "
 	},
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
 		"./dist/aws-amplify-core.js"
 	],
 	"scripts": {
-		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
+		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
 		"build-with-test": "npm test && npm run build",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "rimraf lib-esm && node ./build es6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 76.41 "
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 76.41"
 	},
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint 'src/**/*.ts'",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 70 "
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0 "
 	},
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js",

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/datastore-storage-adapter/package.json
+++ b/packages/datastore-storage-adapter/package.json
@@ -22,7 +22,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint '{__tests__,src}/**/*.ts'  && npm run ts-coverage",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 94.16"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/datastore-storage-adapter/package.json
+++ b/packages/datastore-storage-adapter/package.json
@@ -12,7 +12,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"test": "npm run lint && jest -w 1 --coverage && npm run ts-coverage",
+		"test": "npm run lint && jest -w 1 --coverage",
 		"build-with-test": "npm test && npm run build",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",
@@ -21,7 +21,7 @@
 		"build": "yarn clean && yarn build:esm && npm run build:cjs",
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
-		"lint": "tslint '{__tests__,src}/**/*.ts'",
+		"lint": "tslint '{__tests__,src}/**/*.ts'  && npm run ts-coverage",
 		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
 	},
 	"repository": {

--- a/packages/datastore-storage-adapter/package.json
+++ b/packages/datastore-storage-adapter/package.json
@@ -22,7 +22,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint '{__tests__,src}/**/*.ts'",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/datastore-storage-adapter/package.json
+++ b/packages/datastore-storage-adapter/package.json
@@ -12,7 +12,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"test": "npm run lint && jest -w 1 --coverage",
+		"test": "npm run lint && jest -w 1 --coverage && npm run ts-coverage",
 		"build-with-test": "npm test && npm run build",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",

--- a/packages/datastore-storage-adapter/tsconfig.build.json
+++ b/packages/datastore-storage-adapter/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -19,7 +19,7 @@
 		"./dist/aws-amplify-datastore.js"
 	],
 	"scripts": {
-		"test": "npm run lint && jest -w 1 --coverage",
+		"test": "npm run lint && jest -w 1 --coverage && npm run ts-coverage",
 		"build-with-test": "npm test && npm run build",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -29,7 +29,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint '{__tests__,src}/**/*.ts'",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -19,7 +19,7 @@
 		"./dist/aws-amplify-datastore.js"
 	],
 	"scripts": {
-		"test": "npm run lint && jest -w 1 --coverage && npm run ts-coverage",
+		"test": "npm run lint && jest -w 1 --coverage",
 		"build-with-test": "npm test && npm run build",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",
@@ -27,7 +27,7 @@
 		"build:esm:watch": "rimraf lib-esm && node ./build es6 --watch",
 		"build": "yarn clean && yarn build:esm && npm run build:cjs",
 		"clean": "rimraf lib-esm lib dist",
-		"format": "echo \"Not implemented\"",
+		"format": "echo \"Not implemented\"  && npm run ts-coverage",
 		"lint": "tslint '{__tests__,src}/**/*.ts'",
 		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
 	},

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -29,7 +29,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"  && npm run ts-coverage",
 		"lint": "tslint '{__tests__,src}/**/*.ts'",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 92.05"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/datastore/tsconfig.build.json
+++ b/packages/datastore/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -29,7 +29,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint '{__tests__,src}/**/*.ts' && npm run ts-coverage",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 86.56"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -19,7 +19,7 @@
 		"./dist/aws-amplify-geo.js"
 	],
 	"scripts": {
-		"test": "yarn run lint && jest -w 1 --coverage && npm run ts-coverage",
+		"test": "yarn run lint && jest -w 1 --coverage",
 		"build-with-test": "yarn test && yarn run build",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",
@@ -28,7 +28,7 @@
 		"build": "yarn clean && yarn build:esm && yarn run build:cjs",
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
-		"lint": "tslint '{__tests__,src}/**/*.ts'",
+		"lint": "tslint '{__tests__,src}/**/*.ts' && npm run ts-coverage",
 		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
 	},
 	"repository": {

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -29,7 +29,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint '{__tests__,src}/**/*.ts'",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -19,7 +19,7 @@
 		"./dist/aws-amplify-geo.js"
 	],
 	"scripts": {
-		"test": "yarn run lint && jest -w 1 --coverage",
+		"test": "yarn run lint && jest -w 1 --coverage && npm run ts-coverage",
 		"build-with-test": "yarn test && yarn run build",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",

--- a/packages/geo/tsconfig.build.json
+++ b/packages/geo/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -29,7 +29,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 88.6"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -19,7 +19,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
+		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
 		"build-with-test": "npm run clean && npm test && tsc && webpack",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",
@@ -28,7 +28,7 @@
 		"build": "npm run clean && npm run build:esm && npm run build:cjs",
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
-		"lint": "tslint 'src/**/*.ts'",
+		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
 		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
 	},
 	"repository": {

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -29,7 +29,7 @@
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint 'src/**/*.ts'",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -19,7 +19,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
+		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
 		"build-with-test": "npm run clean && npm test && tsc && webpack",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",

--- a/packages/interactions/tsconfig.build.json
+++ b/packages/interactions/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -16,7 +16,7 @@
 		"./dist/aws-amplify-predictions.js"
 	],
 	"scripts": {
-		"test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2 ",
+		"test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2",
 		"build-with-test": "npm run clean && npm test && tsc && webpack -p",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -16,7 +16,7 @@
 		"./dist/aws-amplify-predictions.js"
 	],
 	"scripts": {
-		"test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2",
+		"test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2 && npm run ts-coverage",
 		"build-with-test": "npm run clean && npm test && tsc && webpack -p",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -28,7 +28,7 @@
 		"lint": "tslint 'src/**/*.ts'",
 		"generate-docs-local": "typedoc --out docs src",
 		"generate-docs-root": "typedoc --out ../../docs src",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -16,7 +16,7 @@
 		"./dist/aws-amplify-predictions.js"
 	],
 	"scripts": {
-		"test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2 && npm run ts-coverage",
+		"test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2 ",
 		"build-with-test": "npm run clean && npm test && tsc && webpack -p",
 		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
 		"build:esm": "node ./build es6",
@@ -25,7 +25,7 @@
 		"build": "npm run clean && npm run build:esm && npm run build:cjs",
 		"clean": "rimraf lib-esm lib dist",
 		"format": "echo \"Not implemented\"",
-		"lint": "tslint 'src/**/*.ts'",
+		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
 		"generate-docs-local": "typedoc --out docs src",
 		"generate-docs-root": "typedoc --out ../../docs src",
 		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -28,7 +28,7 @@
 		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
 		"generate-docs-local": "typedoc --out docs src",
 		"generate-docs-root": "typedoc --out ../../docs src",
-		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+		"ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 87.84"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/predictions/tsconfig.build.json
+++ b/packages/predictions/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts'",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
   },
   "repository": {
     "type": "git",

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
+    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
     "build-with-test": "npm run clean && npm test && tsc && webpack",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",
@@ -28,7 +28,7 @@
     "build": "npm run clean && npm run build:esm && npm run build:cjs",
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
-    "lint": "tslint 'src/**/*.ts'",
+    "lint": "tslint 'src/**/*.ts'  && npm run ts-coverage",
     "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
   },
   "repository": {

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts'  && npm run ts-coverage",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 87.63"
   },
   "repository": {
     "type": "git",

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
+    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
     "build-with-test": "npm run clean && npm test && tsc && webpack",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",

--- a/packages/pubsub/tsconfig.build.json
+++ b/packages/pubsub/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts'",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
   },
   "repository": {
     "type": "git",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
+    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",
@@ -28,7 +28,7 @@
     "build": "npm run clean && npm run build:esm && npm run build:cjs",
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
-    "lint": "tslint 'src/**/*.ts'",
+    "lint": "tslint 'src/**/*.ts'  && npm run ts-coverage",
     "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
   },
   "repository": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf lib-esm lib dist",
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts'  && npm run ts-coverage",
-    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 0"
+    "ts-coverage":  "typescript-coverage-report -p ./tsconfig.build.json -t 90.31"
   },
   "repository": {
     "type": "git",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",
+    "test": "tslint 'src/**/*.ts' && jest -w 1 --coverage && npm run ts-coverage",
     "build-with-test": "npm test && npm run build",
     "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
     "build:esm": "node ./build es6",

--- a/packages/storage/tsconfig.build.json
+++ b/packages/storage/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.settings.json",
 	"compilerOptions": {},
-	"include": ["lib*/**/*.ts"]
+	"include": ["lib*/**/*.ts", "src"]
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- Analyses internal typescript usage
- Adds a 0 threshold for ts-coverage per package
- Adds ts-coverage script to tests 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
