### PR TITLE
fix: remove dep on es2020.promise lib additions

### DIFF
--- a/packages/amplify-ui-components/tsconfig.json
+++ b/packages/amplify-ui-components/tsconfig.json
@@ -4,13 +4,7 @@
 		"allowUnreachableCode": false,
 		"declaration": false,
 		"experimentalDecorators": true,
-		"lib": [
-			"dom",
-			"es2017",
-			"ES2018.AsyncIterable",
-			"ES2018.AsyncGenerator",
-			"ES2020.Promise"
-		],
+		"lib": ["dom", "es2017", "ES2018.AsyncIterable", "ES2018.AsyncGenerator"],
 		"moduleResolution": "node",
 		"module": "esnext",
 		"target": "es2017",

--- a/packages/amplify-ui-vue/tsconfig.json
+++ b/packages/amplify-ui-vue/tsconfig.json
@@ -6,13 +6,7 @@
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"esModuleInterop": true,
-		"lib": [
-			"dom",
-			"es2015",
-			"es2018.asynciterable",
-			"es2018.asyncgenerator",
-			"es2020.promise"
-		],
+		"lib": ["dom", "es2015", "es2018.asynciterable", "es2018.asyncgenerator"],
 		"module": "es2015",
 		"moduleResolution": "node",
 		"noImplicitAny": true,

--- a/packages/amplify-ui/tsconfig.json
+++ b/packages/amplify-ui/tsconfig.json
@@ -4,14 +4,7 @@
 		"outDir": "./lib/",
 		"target": "es5",
 		"noImplicitAny": false,
-		"lib": [
-			"es5",
-			"es2015",
-			"dom",
-			"esnext.asynciterable",
-			"es2017.object",
-			"es2020.promise"
-		],
+		"lib": ["es5", "es2015", "dom", "esnext.asynciterable", "es2017.object"],
 		"sourceMap": true,
 		"module": "commonjs",
 		"moduleResolution": "node",

--- a/packages/core/src/Util/BackgroundProcessManager.ts
+++ b/packages/core/src/Util/BackgroundProcessManager.ts
@@ -369,7 +369,7 @@ export class BackgroundProcessManager {
 			this._state = BackgroundProcessManagerState.Closed;
 		}
 
-		return this._closingPromise;
+		return this._closingPromise as any;
 	}
 
 	/**

--- a/packages/pushnotification/tsconfig.json
+++ b/packages/pushnotification/tsconfig.json
@@ -11,8 +11,7 @@
 			"esnext.asynciterable",
 			"es2017.object",
 			"es2018.asynciterable",
-			"es2018.asyncgenerator",
-			"es2020.promise"
+			"es2018.asyncgenerator"
 		],
 		"sourceMap": true,
 		"module": "commonjs",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

The "settlement" guarantees PR inadvertently broke the customer-facing surface area by exposing es2020 promises. However, this is not intended to be a customer facing API: https://github.com/aws-amplify/amplify-js/pull/10450

This PR casts the return value in question to `any` so customers do not need to require `es2020.promise`.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

`es2020.promise` has also been from the adjacent internal package libs to help ensure this doesn't regress.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
