### PR TITLE
Fixed Conflict handler doesn't run when a non-nullable @belongsTo fie…

### DIFF
--- a/packages/datastore/__tests__/graphql.ts
+++ b/packages/datastore/__tests__/graphql.ts
@@ -28,14 +28,8 @@ metadata {
 _version
 _lastChangedAt
 _deleted
-reference {
-	id
-	_deleted
-}
-blog {
-	id
-	_deleted
-}
+referencePostId
+postBlogId
 `;
 
 const ownerAuthPostSelectionSet = `id

--- a/packages/datastore/src/sync/utils.ts
+++ b/packages/datastore/src/sync/utils.ts
@@ -181,7 +181,7 @@ function getConnectionFields(
 							result.push(`${name} { ${keyFieldSelectionSet} _deleted }`);
 						} else {
 							// backwards-compatability for schema generated prior to custom primary key support
-							result.push(`${name} { id _deleted }`);
+							result.push(`${association.targetName}`);
 						}
 					}
 					break;


### PR DESCRIPTION
…ld exists and Optimistic Concurrency is used

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

`getConnectionFields` was changed replacing `result.push(${name} { id _deleted });` with `result.push(${association.targetName});` because the `jitteredRetry` function was getting an `error.data` of value `null` when `result.push(${name} { id _deleted });` was being used. This change solves the issue and the conflict handler gets executed normally. For more details on the issue see #10487 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#10487 


#### Description of how you validated changes

Tested in a sample app replicating what mentioned in #10487. Debugged to see if there were any braking changes with the change in the function as tests had to be changed. I validated both with subscriptions and non model fields to see if there were any breaking changes but there weren't. 

All tests in datastore pass after the change in `__tests__/graphql.ts`. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn run test --scope @aws-amplify/datastore ` passes (as tests in storage are not working)
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
