### PR TITLE
fix: Re-add notifications to aws-amplify deps

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -49,6 +49,7 @@
     "@aws-amplify/datastore": "3.14.2",
     "@aws-amplify/geo": "1.3.22",
     "@aws-amplify/interactions": "4.1.7",
+    "@aws-amplify/notifications": "1.0.0",
     "@aws-amplify/predictions": "4.0.59",
     "@aws-amplify/pubsub": "4.5.9",
     "@aws-amplify/storage": "4.5.12",


### PR DESCRIPTION
#### Description of changes
Previous change dropped `@aws-amplify/notifications` package dependency in `aws-amplify` causing integ test failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
