### PR TITLE
chore: fix build on next, resolve babel deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,9 @@
 		"wml": "0.0.83"
 	},
 	"resolutions": {
+		"@babel/generator": "7.19.6",
+		"@babel/helpers": "7.19.4",
+		"@babel/helper-skip-transparent-expression-wrappers": "7.18.9",
 		"@babel/types": "7.12.10",
 		"@types/babel__traverse": "7.0.8",
 		"@babel/traverse": "7.17.9",


### PR DESCRIPTION
#### Description of changes
Merge [build fix](https://github.com/aws-amplify/amplify-js/pull/10548) across from `main`.

The build started failing on numerous babel deps, each looking for a isTSSatisfiesExpression function that doesn't exist.

Added three bad deps (each updated within the last few hours of this PR) to resolutions.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
