### PR TITLE
feat(auth): initial state machine attempt

### DIFF
--- a/packages/auth/__tests__/state-machine-nested-test.ts
+++ b/packages/auth/__tests__/state-machine-nested-test.ts
@@ -1,17 +1,6 @@
-/*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
- * the License. A copy of the License is located at
- *
- *	 http://aws.amazon.com/apache2.0/
- *
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
- */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
-import { noop } from 'lodash';
 import { Machine } from '../src/stateMachine/machine';
 import { StateTransition } from '../src/stateMachine/types';
 import {
@@ -36,11 +25,11 @@ const badEvent = {
 	},
 };
 
-let parentMachine: Machine<DummyContext> | null;
+let parentMachine: Machine<DummyContext>;
 let parentStateOneTransitions: StateTransition<DummyContext, State1Payload>[];
 const parentTestSource = 'state-machine-nested-tests-parent';
 
-let childMachine: Machine<DummyContext> | null;
+let childMachine: Machine<DummyContext>;
 let childStateOneTransitions: StateTransition<DummyContext, State1Payload>[];
 const childTestSource = 'state-machine-parent-tests-child';
 
@@ -80,9 +69,7 @@ describe('Nested state machine persisted actor tests...', () => {
 
 	test('...the child SM can be instantiated on a parent machine context', () => {
 		expect(parentMachine?.context.actor).toBeTruthy();
-		expect(parentMachine?.context.actor?.initial).toEqual(
-			parentMachine?.context.actor?.current
-		);
+		expect(parentMachine?.context.actor?.current).toBeTruthy();
 	});
 
 	test('...parent can send an event to the child', () => {

--- a/packages/auth/__tests__/state-machine-nested-test.ts
+++ b/packages/auth/__tests__/state-machine-nested-test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *	 http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { noop } from 'lodash';
+import { Machine } from '../src/stateMachine/machine';
+import { StateTransition } from '../src/stateMachine/types';
+import {
+	DummyContext,
+	dummyMachine,
+	state1Name,
+	State1Payload,
+	state2Name,
+} from './utils/dummyMachine';
+
+const goodEvent = {
+	name: 'event1',
+	payload: {
+		p1: 'good',
+	},
+};
+
+const badEvent = {
+	name: 'event1',
+	payload: {
+		p1: 'bad',
+	},
+};
+
+let parentMachine: Machine<DummyContext> | null;
+let parentStateOneTransitions: StateTransition<DummyContext, State1Payload>[];
+const parentTestSource = 'state-machine-nested-tests-parent';
+
+let childMachine: Machine<DummyContext> | null;
+let childStateOneTransitions: StateTransition<DummyContext, State1Payload>[];
+const childTestSource = 'state-machine-parent-tests-child';
+
+describe('Nested state machine persisted actor tests...', () => {
+	beforeAll(() => {
+		parentStateOneTransitions = [
+			{
+				event: 'event1',
+				nextState: state2Name,
+				actions: [
+					async (ctx, _) => {
+						ctx.actor?.send<State1Payload>(goodEvent);
+					},
+				],
+			},
+		];
+		childStateOneTransitions = [
+			{
+				event: 'event1',
+				nextState: state2Name,
+			},
+		];
+		childMachine = dummyMachine(
+			{
+				testSource: childTestSource,
+			},
+			childStateOneTransitions
+		);
+		parentMachine = dummyMachine(
+			{
+				testSource: parentTestSource,
+				actor: childMachine,
+			},
+			parentStateOneTransitions
+		);
+	});
+
+	test('...the child SM can be instantiated on a parent machine context', () => {
+		expect(parentMachine?.context.actor).toBeTruthy();
+		expect(parentMachine?.context.actor?.initial).toEqual(
+			parentMachine?.context.actor?.current
+		);
+	});
+
+	test('...parent can send an event to the child', () => {
+		parentMachine?.send<State1Payload>(goodEvent);
+		expect(parentMachine?.context.actor?.current.name).toEqual(state2Name);
+	});
+});
+
+/// TODO: Invocation Tests

--- a/packages/auth/__tests__/state-machine-single-test.ts
+++ b/packages/auth/__tests__/state-machine-single-test.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *	 http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { noop } from 'lodash';
+import { Machine } from '../src/stateMachine/machine';
+import { StateTransition } from '../src/stateMachine/types';
+import {
+	badEvent,
+	DummyContext,
+	dummyMachine,
+	goodEvent,
+	state1Name,
+	State1Payload,
+	state2Name,
+} from './utils/dummyMachine';
+
+let machine: Machine<DummyContext> | null;
+let stateOneTransitions: StateTransition<DummyContext, State1Payload>[];
+const testSource = 'state-machine-single-tests';
+
+describe('State machine instantiation tests...', () => {
+	beforeAll(() => {
+		stateOneTransitions = [
+			{
+				event: 'event1',
+				nextState: state2Name,
+			},
+		];
+		machine = dummyMachine({ testSource }, stateOneTransitions);
+	});
+
+	test('...the SM can be instantiated', () => {
+		expect(machine).toBeTruthy();
+		expect(machine?.initial).toEqual(machine?.current);
+	});
+
+	test('...the SM state map has been created', () => {
+		const expectedState1 = machine?.states.get(state1Name);
+		const expectedState2 = machine?.states.get(state2Name);
+		expect(machine?.states.size).toEqual(2);
+		expect(expectedState1).toBeDefined();
+		expect(expectedState2).toBeDefined();
+	});
+
+	test("...the SM's initial context is set", () => {
+		expect(machine?.context.testSource).toEqual(testSource);
+	});
+
+	test("...the SM's initial state is set", () => {
+		expect(machine?.initial?.name).toEqual(state1Name);
+	});
+
+	test('...the SM performs a simple state transition', () => {
+		machine?.send<State1Payload>(goodEvent);
+		expect(machine?.current?.name).toEqual(state2Name);
+	});
+});
+
+describe('State machine guard tests...', () => {
+	beforeEach(() => {
+		stateOneTransitions = [
+			{
+				event: 'event1',
+				nextState: state2Name,
+				guards: [
+					(ctx, evt) => {
+						return evt.payload?.p1 == 'good';
+					},
+				],
+			},
+		];
+		machine = dummyMachine({ testSource }, stateOneTransitions);
+	});
+
+	test('...the state transitions if guard passes', () => {
+		machine?.send<State1Payload>(goodEvent);
+		expect(machine?.current?.name).toEqual(state2Name);
+	});
+
+	test('...the state transitions does not transition if guard fails', () => {
+		machine?.send<State1Payload>(badEvent);
+		expect(machine?.current?.name).toEqual(state1Name);
+	});
+});
+
+describe('State machine action tests...', () => {
+	beforeEach(() => {
+		const jestMock = jest.fn(() => {});
+		stateOneTransitions = [
+			{
+				event: 'event1',
+				nextState: state2Name,
+				guards: [
+					(_, evt) => {
+						return evt.payload?.p1 == 'good';
+					},
+				],
+				actions: [
+					async (ctx, _) => {
+						ctx.testFn ? ctx.testFn() : noop;
+					},
+				],
+			},
+		];
+		machine = dummyMachine(
+			{ testSource, testFn: jestMock },
+			stateOneTransitions
+		);
+	});
+
+	test('...the actions do not fire before transition', () => {
+		expect(machine?.context.testFn).toHaveBeenCalledTimes(0);
+	});
+
+	test('...the actions fire after transition', () => {
+		machine?.send<State1Payload>(goodEvent);
+		expect(machine?.context.testFn).toHaveBeenCalledTimes(1);
+	});
+
+	test('...the actions do not fire if guard fails', () => {
+		machine?.send<State1Payload>(badEvent);
+		expect(machine?.context.testFn).toHaveBeenCalledTimes(0);
+	});
+});
+
+describe('State machine reducer tests...', () => {
+	beforeEach(() => {
+		const jestMock = jest.fn(() => {});
+		stateOneTransitions = [
+			{
+				event: 'event1',
+				nextState: state2Name,
+				guards: [
+					(_, evt) => {
+						return evt.payload?.p1 == 'good';
+					},
+				],
+				reducers: [
+					(ctx, evt) => {
+						ctx.optional1 = evt.payload?.p1;
+					},
+				],
+			},
+		];
+		machine = dummyMachine(
+			{ testSource, testFn: jestMock },
+			stateOneTransitions
+		);
+	});
+
+	test('...the reducer is not invoked before transition ', () => {
+		expect(machine?.context.optional1).toBeFalsy();
+	});
+
+	test('...the reducers fire after transition', () => {
+		machine?.send<State1Payload>(goodEvent);
+		expect(machine?.context.optional1).toEqual('good');
+	});
+
+	test('...the reducers do not fire if guard fails', () => {
+		machine?.send<State1Payload>(badEvent);
+		expect(machine?.context.optional1).toBeFalsy();
+	});
+});

--- a/packages/auth/__tests__/state-machine-single-test.ts
+++ b/packages/auth/__tests__/state-machine-single-test.ts
@@ -1,15 +1,5 @@
-/*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
- * the License. A copy of the License is located at
- *
- *	 http://aws.amazon.com/apache2.0/
- *
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
- */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import { noop } from 'lodash';
 import { Machine } from '../src/stateMachine/machine';
@@ -24,7 +14,7 @@ import {
 	state2Name,
 } from './utils/dummyMachine';
 
-let machine: Machine<DummyContext> | null;
+let machine: Machine<DummyContext>;
 let stateOneTransitions: StateTransition<DummyContext, State1Payload>[];
 const testSource = 'state-machine-single-tests';
 
@@ -41,7 +31,6 @@ describe('State machine instantiation tests...', () => {
 
 	test('...the SM can be instantiated', () => {
 		expect(machine).toBeTruthy();
-		expect(machine?.initial).toEqual(machine?.current);
 	});
 
 	test('...the SM state map has been created', () => {
@@ -57,7 +46,7 @@ describe('State machine instantiation tests...', () => {
 	});
 
 	test("...the SM's initial state is set", () => {
-		expect(machine?.initial?.name).toEqual(state1Name);
+		expect(machine?.current?.name).toEqual(state1Name);
 	});
 
 	test('...the SM performs a simple state transition', () => {

--- a/packages/auth/__tests__/utils/dummyMachine.ts
+++ b/packages/auth/__tests__/utils/dummyMachine.ts
@@ -1,0 +1,78 @@
+import { Invocation } from '../../src/stateMachine/invocation';
+import { Machine } from '../../src/stateMachine/machine';
+import { MachineState } from '../../src/stateMachine/machineState';
+import {
+	MachineContext,
+	MachineEventPayload,
+	StateTransition,
+} from '../../src/stateMachine/types';
+
+const goodEvent = {
+	name: 'event1',
+	payload: {
+		p1: 'good',
+	},
+};
+
+const badEvent = {
+	name: 'event1',
+	payload: {
+		p1: 'bad',
+	},
+};
+
+type DummyContext = MachineContext & {
+	testSource: string;
+	testFn?: jest.Mock<any, any>;
+	optional1?: string;
+	optional2?: string;
+	actor?: Machine<DummyContext>;
+};
+
+type State1Payload = MachineEventPayload & {
+	p1?: string;
+};
+
+type State2Payload = MachineEventPayload & {
+	p2?: string;
+};
+
+const state1Name = 'State1';
+const state2Name = 'State2';
+
+function dummyMachine(
+	initialContext: DummyContext,
+	stateOneTransitions?: StateTransition<DummyContext, State1Payload>[],
+	stateOneInvocation?: Invocation<DummyContext, State1Payload>,
+	stateTwoTransitions?: StateTransition<DummyContext, State1Payload>[],
+	stateTwoInvocation?: Invocation<DummyContext, State1Payload>
+): Machine<DummyContext> {
+	return new Machine<DummyContext>({
+		name: 'DummyMachine',
+		context: initialContext,
+		initial: state1Name,
+		states: [
+			new MachineState<DummyContext, State1Payload>({
+				name: state1Name,
+				transitions: stateOneTransitions,
+				invocation: stateOneInvocation,
+			}),
+			new MachineState<DummyContext, State2Payload>({
+				name: state2Name,
+				transitions: stateTwoTransitions,
+				invocation: stateTwoInvocation,
+			}),
+		],
+	});
+}
+
+export {
+	DummyContext,
+	State1Payload,
+	State2Payload,
+	dummyMachine,
+	state1Name,
+	state2Name,
+	goodEvent,
+	badEvent,
+};

--- a/packages/auth/__tests__/utils/dummyMachine.ts
+++ b/packages/auth/__tests__/utils/dummyMachine.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Invocation } from '../../src/stateMachine/invocation';
 import { Machine } from '../../src/stateMachine/machine';
 import { MachineState } from '../../src/stateMachine/machineState';

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1,15 +1,5 @@
-/*
- * Copyright 2017-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
- * the License. A copy of the License is located at
- *
- *     http://aws.amazon.com/apache2.0/
- *
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
- */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import {
 	Amplify,

--- a/packages/auth/src/stateMachine/invocation.ts
+++ b/packages/auth/src/stateMachine/invocation.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *	 http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { MachineContext } from './types/MachineContext';
+import { MachineEvent } from './types/MachineEvent';
+import { MachineEventPayload } from './types/MachineEventPayload';
+import { StateMachine } from './StateMachine';
+
+export class Invocation<
+	ContextType extends MachineContext,
+	PayloadType extends MachineEventPayload
+> {
+	event: MachineEvent<PayloadType>;
+	machine: StateMachine<ContextType>;
+	constructor(
+		event: MachineEvent<PayloadType>,
+		machine: StateMachine<ContextType>
+	) {
+		this.event = event;
+		this.machine = machine;
+	}
+}

--- a/packages/auth/src/stateMachine/invocation.ts
+++ b/packages/auth/src/stateMachine/invocation.ts
@@ -1,31 +1,16 @@
-/*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
- * the License. A copy of the License is located at
- *
- *	 http://aws.amazon.com/apache2.0/
- *
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
- */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
-import { MachineContext } from './types/MachineContext';
-import { MachineEvent } from './types/MachineEvent';
-import { MachineEventPayload } from './types/MachineEventPayload';
-import { StateMachine } from './StateMachine';
+import { Machine } from './machine';
+import { MachineContext, MachineEventPayload, MachineEvent } from './types';
 
 export class Invocation<
 	ContextType extends MachineContext,
 	PayloadType extends MachineEventPayload
 > {
 	event: MachineEvent<PayloadType>;
-	machine: StateMachine<ContextType>;
-	constructor(
-		event: MachineEvent<PayloadType>,
-		machine: StateMachine<ContextType>
-	) {
+	machine: Machine<ContextType>;
+	constructor(event: MachineEvent<PayloadType>, machine: Machine<ContextType>) {
 		this.event = event;
 		this.machine = machine;
 	}

--- a/packages/auth/src/stateMachine/machine.ts
+++ b/packages/auth/src/stateMachine/machine.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *	 http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { MachineState } from './MachineState';
+import {
+	MachineContext,
+	MachineEventPayload,
+	MachineEvent,
+	StateMachineParams,
+	StateTransition,
+} from './types';
+
+// TODO: Queue
+// TODO: Listeners
+export class Machine<ContextType extends MachineContext> {
+	name: string;
+	states: Map<string, MachineState<ContextType, MachineEventPayload>>;
+	context: ContextType;
+	initial?: MachineState<ContextType, MachineEventPayload>;
+	current: MachineState<ContextType, MachineEventPayload>;
+	constructor(params: StateMachineParams<ContextType>) {
+		this.name = params.name;
+		this.states = this._createStateMap(params.states);
+		this.context = params.context;
+		this.initial = this.states.get(params.initial);
+		this.current = this.initial || params.states[0];
+	}
+
+	/**
+	 * Receives an event for processing
+	 *
+	 *
+	 * @typeParam PayloadType - The type of payload received in current state
+	 * @param event - The dispatched Event
+	 */
+	send<PayloadType extends MachineEventPayload>(
+		event: MachineEvent<PayloadType>
+	) {
+		const validTransition = this.current.findTransition(event);
+
+		///TODO: Communicate null transition
+		if (!validTransition) return;
+		const checkGuards = this._checkGuards(validTransition, event);
+		//TODO: Communicate guard failure
+		if (!checkGuards) return;
+
+		const nextState = this.states.get(validTransition.nextState);
+		//TODO: Handle error in state map
+		if (!nextState) return;
+
+		this.current = nextState;
+		this._enterState(validTransition, event);
+	}
+
+	private _enterState(
+		transition: StateTransition<ContextType, MachineEventPayload>,
+		event: MachineEvent<MachineEventPayload>
+	) {
+		this._invokeReducers(transition, event);
+		this._invokeActions(transition, event);
+		if (this.current?.invocation) {
+			this.current.invocation.machine.send(this.current.invocation.event);
+		}
+	}
+
+	private _checkGuards(
+		transition: StateTransition<ContextType, MachineEventPayload>,
+		event: MachineEvent<MachineEventPayload>
+	): boolean {
+		if (!transition.guards) return true;
+		for (let g = 0; g < transition.guards.length; g++) {
+			if (!transition.guards[g](this.context, event)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private _invokeReducers(
+		transition: StateTransition<ContextType, MachineEventPayload>,
+		event: MachineEvent<MachineEventPayload>
+	): void {
+		if (!transition.reducers) return;
+		for (let r = 0; r < transition.reducers.length; r++) {
+			transition.reducers[r](this.context, event);
+		}
+	}
+
+	private async _invokeActions(
+		transition: StateTransition<ContextType, MachineEventPayload>,
+		event: MachineEvent<MachineEventPayload>
+	): Promise<void> {
+		if (!transition.actions) return;
+		for (let r = 0; r < transition.actions.length; r++) {
+			transition.actions[r](this.context, event);
+		}
+	}
+
+	//TODO: validate states with uniqueness on name (otherwise a dupe will just be overridden in Map)
+	private _createStateMap(
+		states: MachineState<ContextType, MachineEventPayload>[]
+	): Map<string, MachineState<ContextType, MachineEventPayload>> {
+		return states.reduce(function (map, obj) {
+			map.set(obj.name, obj);
+			return map;
+		}, new Map<string, MachineState<ContextType, MachineEventPayload>>());
+	}
+}

--- a/packages/auth/src/stateMachine/machine.ts
+++ b/packages/auth/src/stateMachine/machine.ts
@@ -1,15 +1,5 @@
-/*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
- * the License. A copy of the License is located at
- *
- *	 http://aws.amazon.com/apache2.0/
- *
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
- */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import { MachineState } from './MachineState';
 import {
@@ -26,19 +16,16 @@ export class Machine<ContextType extends MachineContext> {
 	name: string;
 	states: Map<string, MachineState<ContextType, MachineEventPayload>>;
 	context: ContextType;
-	initial?: MachineState<ContextType, MachineEventPayload>;
 	current: MachineState<ContextType, MachineEventPayload>;
 	constructor(params: StateMachineParams<ContextType>) {
 		this.name = params.name;
 		this.states = this._createStateMap(params.states);
 		this.context = params.context;
-		this.initial = this.states.get(params.initial);
-		this.current = this.initial || params.states[0];
+		this.current = this.states.get(params.initial) || this.states[0];
 	}
 
 	/**
 	 * Receives an event for processing
-	 *
 	 *
 	 * @typeParam PayloadType - The type of payload received in current state
 	 * @param event - The dispatched Event

--- a/packages/auth/src/stateMachine/machineState.ts
+++ b/packages/auth/src/stateMachine/machineState.ts
@@ -1,15 +1,5 @@
-/*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
- * the License. A copy of the License is located at
- *
- *	 http://aws.amazon.com/apache2.0/
- *
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
- */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import { Invocation } from './invocation';
 import {

--- a/packages/auth/src/stateMachine/machineState.ts
+++ b/packages/auth/src/stateMachine/machineState.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *	 http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { Invocation } from './invocation';
+import {
+	MachineContext,
+	MachineEvent,
+	MachineEventPayload,
+	MachineStateParams,
+	StateTransition,
+} from './types';
+
+export class MachineState<
+	ContextType extends MachineContext,
+	PayloadType extends MachineEventPayload
+> {
+	name: string;
+	transitions?: StateTransition<ContextType, PayloadType>[];
+	invocation?: Invocation<MachineContext, MachineEventPayload>;
+	constructor(params: MachineStateParams<ContextType, PayloadType>) {
+		this.name = params.name;
+		//TODO: validate transitions with uniqueness on event
+		this.transitions = params.transitions;
+		this.invocation = params.invocation;
+	}
+
+	findTransition(
+		event: MachineEvent<PayloadType>
+	): StateTransition<ContextType, PayloadType> | undefined {
+		return this.transitions?.find(t => t.event === event.name);
+	}
+}

--- a/packages/auth/src/stateMachine/types.ts
+++ b/packages/auth/src/stateMachine/types.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ *	 http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { Invocation } from './invocation';
+import { MachineState } from './machineState';
+
+/**
+ * Base type for a Machine's context
+ */
+export type MachineContext = object;
+
+/**
+ * Base type for a MachineEvent's payload
+ */
+export type MachineEventPayload = object;
+
+/**
+ * Base type for a MachineEvent's payload
+ * @typeParam PayloadType - The type of the Event's payload
+ * @param name - The event name; used when matching a transition
+ * @param payload - The event payload
+ */
+export type MachineEvent<PayloadType extends MachineEventPayload> = {
+	name: string;
+	payload?: PayloadType;
+};
+
+/**
+ * The type accepted by the Machine constructor
+ * @typeParam PayloadType - The type of the Event's payload
+ * @param name - The Machine's name
+ * @param states - An array of MachineStates
+ * @param context - The Machine's extended state
+ * @param initial - The name of the Machine's initial State
+ */
+export type StateMachineParams<ContextType extends MachineContext> = object & {
+	name: string;
+	states: MachineState<ContextType, MachineEventPayload>[];
+	context: ContextType;
+	initial: string;
+};
+
+/**
+ * The type accepted by the MachineState constructor
+ * @typeParam ContextType - The type of the enclosing Machine's context
+ * @typeParam PayloadType - The type of the Event's payload
+ * @param name - The state name
+ * @param transitions - The array of available transitions
+ * @param invocation - An invocation to call when the State becomes the current state of enclosing Machine
+ */
+export type MachineStateParams<
+	ContextType extends MachineContext,
+	PayloadType extends MachineEventPayload
+> = object & {
+	name: string;
+	transitions?: StateTransition<ContextType, PayloadType>[];
+	invocation?: Invocation<any, MachineEventPayload>;
+};
+
+/**
+ * The type representing a state transition
+ * @typeParam ContextType - The type of the enclosing Machine's context
+ * @typeParam PayloadType - The type of the enclosing State's event payload
+ * @param event - The name of the event that can trigger the Transition
+ * @param nextState - The name of the State which will become the current State of the enclosing Machine, if the transition is triggered
+ * @param actions - An array of TransitionActions, to be invoked when transition is completed
+ * @param guards An array of TransitionGuards, to be invoked before the transition is completed
+ * @param reducers An array of TransitionReducers, to be invoked when the transition is completed
+ */
+export type StateTransition<
+	ContextType extends MachineContext,
+	PayloadType extends MachineEventPayload
+> = {
+	event: string;
+	nextState: string;
+	actions?: TransitionAction<ContextType, PayloadType>[];
+	guards?: TransitionGuard<ContextType, PayloadType>[];
+	reducers?: TransitionReducer<ContextType, PayloadType>[];
+};
+
+/**
+ * Type for a fire-and-forget action function
+ * @typeParam ContextType - The type of the enclosing Machine's context
+ * @typeParam PayloadType - The type of the Event's payload
+ */
+export type TransitionAction<
+	ContextType extends MachineContext,
+	PayloadType extends MachineEventPayload
+> = (context: ContextType, event: MachineEvent<PayloadType>) => Promise<void>;
+
+/**
+ * Type for a TransitionGuard, which can prevent the enclosing Transition from completing
+ * @typeParam ContextType - The type of the enclosing Machine's context
+ * @typeParam PayloadType - The type of the Event's payload
+ */
+export type TransitionGuard<
+	ContextType extends MachineContext,
+	PayloadType extends MachineEventPayload
+> = (context: ContextType, event: MachineEvent<PayloadType>) => boolean;
+
+/**
+ * Type for a TransitionReducer, which is used to modify the enclosing Machine's Context
+ * @typeParam ContextType - The type of the enclosing Machine's context
+ * @typeParam PayloadType - The type of the Event's payload
+ */
+export type TransitionReducer<
+	ContextType extends MachineContext,
+	PayloadType extends MachineEventPayload
+> = (context: ContextType, event: MachineEvent<PayloadType>) => void;

--- a/packages/auth/src/stateMachine/types.ts
+++ b/packages/auth/src/stateMachine/types.ts
@@ -1,15 +1,5 @@
-/*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
- * the License. A copy of the License is located at
- *
- *	 http://aws.amazon.com/apache2.0/
- *
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
- */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import { Invocation } from './invocation';
 import { MachineState } from './machineState';
@@ -17,12 +7,12 @@ import { MachineState } from './machineState';
 /**
  * Base type for a Machine's context
  */
-export type MachineContext = object;
+export type MachineContext = Record<string, unknown>;
 
 /**
  * Base type for a MachineEvent's payload
  */
-export type MachineEventPayload = object;
+export type MachineEventPayload = Record<string, unknown>;
 
 /**
  * Base type for a MachineEvent's payload
@@ -61,7 +51,7 @@ export type StateMachineParams<ContextType extends MachineContext> = object & {
 export type MachineStateParams<
 	ContextType extends MachineContext,
 	PayloadType extends MachineEventPayload
-> = object & {
+> = {
 	name: string;
 	transitions?: StateTransition<ContextType, PayloadType>[];
 	invocation?: Invocation<any, MachineEventPayload>;

--- a/packages/auth/src/types/AuthProvider.ts
+++ b/packages/auth/src/types/AuthProvider.ts
@@ -1,15 +1,5 @@
-/*
- * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
- * the License. A copy of the License is located at
- *
- *	 http://aws.amazon.com/apache2.0/
- *
- * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
- * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
- */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 export interface AuthProvider {
 	// configure your provider


### PR DESCRIPTION
#### Description of changes
This PR adds the initial implementation of our state machine utility classes and types, along with tests.

There are several Todos left here:

- "listener" and "notification" mechanism (including communicating null transitions or guard failure)
- event queuing
- error handling for state map creation
- validation of state and transition uniqueness
- tests for "invocations"... and honestly, invocations will probably be changed a fair amount anyway.

These todos  can be captured in a separate PR. Creating this state machine will likely require several iterations.

Also, please note that some of my type naming was influenced by a desire to avoid collisions with other pre-existing types in the JS ecosystem like "Event" or "State".

Also again, I know there is some fancy new syntax for annotating truly private class methods, but I don't think we can use them due to customers using older TS versions? Correct me if I'm wrong here.

#### Description of how you validated changes
Unit tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [ ] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
