### PR TITLE
Change maven repository order to use google first

### DIFF
--- a/packages/pushnotification/android/build.gradle
+++ b/packages/pushnotification/android/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
     repositories {
-        jcenter()
-				google()
+        google()
+        jcenter()		
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.1'
@@ -13,10 +13,8 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
-        maven {
-            url 'https://maven.google.com'
-        }
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

In the past day, jCenter had troubles in their Maven repository. That makes the android ```amplify-js:pushnotification``` package impossible to build, because there is a google-services dependency from jCenter which causes a timeout during builds that use the ```amplify-js:pushnotification``` package in the react native app.

![image](https://user-images.githubusercontent.com/26905837/199039513-0354063c-481b-4db6-b50b-1b9d3a073dc5.png)

In this PR I change the order of the maven repository to make google maven repository first, and solve the issue.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
I run a build for the pushnotification package, which succeded. 
Also I make this change inside my react-native app and it worked.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
