### PR TITLE
test(integ): remove vue 2 test on legacy Auth UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1274,7 +1274,6 @@ releasable_branches: &releasable_branches
       - geo/main
       - in-app-messaging/main
       - next-major-version/5
-      - remove-vue2-auth-integ
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,13 +489,6 @@ jobs:
           spec: authenticator
           browser: << parameters.browser >>
       - integ_test_js:
-          test_name: 'Vue 2 Authenticator'
-          framework: vue
-          category: auth
-          sample_name: amplify-authenticator
-          spec: ui-amplify-authenticator
-          browser: << parameters.browser >>
-      - integ_test_js:
           test_name: 'Vue 3 Authenticator'
           framework: vue
           category: auth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1274,6 +1274,7 @@ releasable_branches: &releasable_branches
       - geo/main
       - in-app-messaging/main
       - next-major-version/5
+      - remove-vue2-auth-integ
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Remove vue 2 integration test with legacy UI. This change is to unblock the integration test.
The legacy auth UI test is intact in Angular and React. We plan to remove them later. The new auth UI doesn't support Vue 2. So we don't expect to add new integ test to cover this exact use case.

The signIn/signUp/signOut test on new UI test case is already covered.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Next major version integ pipeline blocked:
https://app.circleci.com/pipelines/github/aws-amplify/amplify-js?branch=next-major-version%2F5


#### Description of how you validated changes
[Integ test](https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/16274/workflows/7cecf210-cf0d-4758-a32c-e81e6338dc68)


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
