### PR TITLE
fix: Remove firefox from reconnect integ tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1241,7 +1241,8 @@ jobs:
           category: pubsub
           sample_name: reconnection-iot
           spec: reconnection
-          browser: << parameters.browser >>
+          # Firefox doesn't support network state management in cypress
+          browser: chrome
 
   integ_react_api_reconnect:
     parameters:
@@ -1258,7 +1259,8 @@ jobs:
           category: pubsub
           sample_name: reconnection-api
           spec: reconnection
-          browser: << parameters.browser >>
+          # Firefox doesn't support network state management in cypress
+          browser: chrome
 
   deploy:
     executor: macos-executor


### PR DESCRIPTION
#### Description of changes
Remove firefox from test runs. Adding to testing branch to test ahead of #10580

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
