### PR TITLE
fix(pubsub): Remove browser param from reconnect integ tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1210,6 +1210,9 @@ jobs:
           browser: << parameters.browser >>
 
   integ_react_datastore_related_models:
+    parameters:
+      browser:
+        type: string
     executor: js-test-executor
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react/datastore/related-models
@@ -1239,9 +1242,6 @@ jobs:
           browser: chrome
 
   integ_react_api_reconnect:
-    parameters:
-      browser:
-        type: string
     executor: js-test-executor
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react/pubsub/reconnection-api
@@ -1757,18 +1757,12 @@ workflows:
             - build
           filters:
             <<: *releasable_branches
-          matrix:
-            parameters:
-              <<: *test_browsers
       - integ_react_api_reconnect:
           requires:
             - integ_setup
             - build
           filters:
             <<: *releasable_branches
-          matrix:
-            parameters:
-              <<: *test_browsers
 
       - deploy:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,9 +335,10 @@ jobs:
       - run:
           name: yarn install --non-interactive
           # temporarily rename .yarnrc before installing so that we can generate a yarn.lock artifact
+          # TODO: upgrade image with newer Node.js and remove --ignore-engines
           command: |
             mv .yarnrc ._yarnrc
-            yarn
+            yarn --ignore-engines
       - run: yarn bootstrap
       - run: yarn build
       # storing yarn.lock as an artifact, so that we can quickly get a dependency diff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1210,9 +1210,6 @@ jobs:
           browser: << parameters.browser >>
 
   integ_react_datastore_related_models:
-    parameters:
-      browser:
-        type: string
     executor: js-test-executor
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react/datastore/related-models
@@ -1227,9 +1224,6 @@ jobs:
           browser: << parameters.browser >>
 
   integ_react_iot_reconnect:
-    parameters:
-      browser:
-        type: string
     executor: js-test-executor
     <<: *test_env_vars
     working_directory: ~/amplify-js-samples-staging/samples/react/pubsub/reconnection-iot

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -6,11 +6,8 @@
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
 	"sideEffects": [
-		"./src/Analytics.ts",
 		"./lib/Analytics.js",
-		"./lib-esm/Analytics.js",
-		"./dist/aws-amplify-analytics.js",
-		"./dist/aws-amplify-analytics.min.js"
+		"./lib-esm/Analytics.js"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -9,11 +9,8 @@
     "./lib/index": "./lib-esm/index.js"
   },
   "sideEffects": [
-    "./src/GraphQLAPI.ts",
     "./lib/GraphQLAPI.js",
-    "./lib-esm/GraphQLAPI.js",
-    "./dist/aws-amplify-api-graphql.js",
-    "./dist/aws-amplify-api-graphql.min.js"
+    "./lib-esm/GraphQLAPI.js"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -9,11 +9,8 @@
     "./lib/index": "./lib-esm/index.js"
   },
   "sideEffects": [
-    "./src/RestAPI.ts",
     "./lib/RestAPI.js",
-    "./lib-esm/RestAPI.js",
-    "./dist/aws-amplify-api-rest.js",
-    "./dist/aws-amplify-api-rest.min.js"
+    "./lib-esm/RestAPI.js"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,11 +16,8 @@
 		"./lib/index": "./lib-esm/index.js"
 	},
 	"sideEffects": [
-		"./src/API.ts",
 		"./lib/API.js",
-		"./lib-esm/API.js",
-		"./dist/aws-amplify-api.js",
-		"./dist/aws-amplify-api.min.js"
+		"./lib-esm/API.js"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -9,11 +9,8 @@
     "./lib/index": "./lib-esm/index.js"
   },
   "sideEffects": [
-    "./src/Auth.ts",
     "./lib/Auth.js",
-    "./lib-esm/Auth.js",
-    "./dist/aws-amplify-auth.js",
-    "./dist/aws-amplify-auth.min.js"
+    "./lib-esm/Auth.js"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -9,11 +9,8 @@
     "./lib/index": "./lib-esm/index.js"
   },
   "sideEffects": [
-    "./src/amplifySingleton.ts",
     "./lib/amplifySingleton.js",
-    "./lib-esm/amplifySingleton.js",
-    "./dist/aws-amplify.min.js",
-    "./dist/aws-amplify.js"
+    "./lib-esm/amplifySingleton.js"
   ],
   "scripts": {
     "test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -9,14 +9,10 @@
     "./lib/index": "./lib-esm/reactnative.js"
   },
   "sideEffects": [
-    "./src/AsyncStorageCache.ts",
-    "./src/BrowserStorageCache.ts",
     "./lib/BrowserStorageCache.js",
     "./lib/AsyncStorageCache.js",
     "./lib-esm/BrowserStorageCache.js",
-    "./lib-esm/AsyncStorageCache.js",
-    "./dist/aws-amplify-cache.js",
-    "./dist/aws-amplify-cache.min.js"
+    "./lib-esm/AsyncStorageCache.js"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,14 +9,10 @@
 		"access": "public"
 	},
 	"sideEffects": [
-		"./src/I18n/index.ts",
-		"./src/Credentials.ts",
 		"./lib/I18n/index.js",
 		"./lib/Credentials.js",
 		"./lib-esm/I18n/index.js",
-		"./lib-esm/Credentials.js",
-		"./dist/aws-amplify-core.min.js",
-		"./dist/aws-amplify-core.js"
+		"./lib-esm/Credentials.js"
 	],
 	"scripts": {
 		"test": "tslint 'src/**/*.ts' && jest -w 1 --coverage",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -12,11 +12,8 @@
 		"access": "public"
 	},
 	"sideEffects": [
-		"./src/datastore/datastore.ts",
 		"./lib/datastore/datastore.js",
-		"./lib-esm/datastore/datastore.js",
-		"./dist/aws-amplify-datastore.min.js",
-		"./dist/aws-amplify-datastore.js"
+		"./lib-esm/datastore/datastore.js"
 	],
 	"scripts": {
 		"test": "npm run lint && jest -w 1 --coverage",

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -12,11 +12,8 @@
 		"access": "public"
 	},
 	"sideEffects": [
-		"./src/geo/geo.ts",
 		"./lib/geo/geo.js",
-		"./lib-esm/geo/geo.js",
-		"./dist/aws-amplify-geo.min.js",
-		"./dist/aws-amplify-geo.js"
+		"./lib-esm/geo/geo.js"
 	],
 	"scripts": {
 		"test": "yarn run lint && jest -w 1 --coverage",

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -9,11 +9,8 @@
 		"./lib/index": "./lib-esm/index.js"
 	},
 	"sideEffects": [
-		"./src/Interactions.ts",
 		"./lib/Interactions.js",
-		"./lib-esm/Interactions.js",
-		"./dist/aws-amplify-interactions.min.js",
-		"./dist/aws-amplify-interactions.js"
+		"./lib-esm/Interactions.js"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -6,11 +6,8 @@
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
 	"sideEffects": [
-		"./src/Notifications.ts",
 		"./lib/Notifications.js",
-		"./lib-esm/Notifications.js",
-		"./dist/aws-amplify-notifications.js",
-		"./dist/aws-amplify-notifications.min.js"
+		"./lib-esm/Notifications.js"
 	],
 	"publishConfig": {
 		"access": "public"

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -9,11 +9,8 @@
 		"./lib/index": "./lib-esm/index.js"
 	},
 	"sideEffects": [
-		"./src/Predictions.ts",
 		"./lib/Predictions.js",
-		"./lib-esm/Predictions.js",
-		"./dist/aws-amplify-predictions.min.js",
-		"./dist/aws-amplify-predictions.js"
+		"./lib-esm/Predictions.js"
 	],
 	"scripts": {
 		"test": "jest -w 1 --passWithNoTests --coverage --maxWorkers 2",

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -9,11 +9,8 @@
     "./lib/index": "./lib-esm/index.js"
   },
   "sideEffects": [
-    "./src/PubSub.ts",
     "./lib/PubSub.js",
-    "./lib-esm/PubSub.js",
-    "./dist/aws-amplify-pubsub.min.js",
-    "./dist/aws-amplify-pubsub.js"
+    "./lib-esm/PubSub.js"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/pubsub/src/types/Provider.ts
+++ b/packages/pubsub/src/types/Provider.ts
@@ -10,11 +10,6 @@ export interface ProviderOptions {
 	[key: string]: any;
 }
 
-/**
- * @deprecated Migrated to ProviderOptions
- */
-export type ProvidertOptions = ProviderOptions;
-
 export interface PubSubProvider {
 	// configure your provider
 	configure(config: object): object;

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -9,11 +9,8 @@
     "./lib/index": "./lib-esm/index.js"
   },
   "sideEffects": [
-    "./src/Storage.ts",
     "./lib/Storage.js",
-    "./lib-esm/Storage.js",
-    "./dist/aws-amplify-storage.min.js",
-    "./dist/aws-amplify-storage.js"
+    "./lib-esm/Storage.js"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -9,11 +9,8 @@
     "./lib/index": "./lib-esm/index.js"
   },
   "sideEffects": [
-    "./src/XR.ts",
     "./lib/XR.js",
-    "./lib-esm/XR.js",
-    "./dist/aws-amplify-xr.min.js",
-    "./dist/aws-amplify-xr.js"
+    "./lib-esm/XR.js"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
#### Description of changes
fix(pubsub): Remove browser param from reconnect integ tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
