### PR TITLE
fix(@aws-amplify/core): Fix guest credentials without Auth module

### DIFF
--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -73,6 +73,7 @@ export class AnalyticsClass {
 		Hub.listen('auth', listener);
 		Hub.listen('storage', listener);
 		Hub.listen('analytics', listener);
+		Hub.listen('core', listener);
 	}
 
 	public getModuleName() {
@@ -321,6 +322,8 @@ export class AnalyticsClass {
 let endpointUpdated = false;
 let authConfigured = false;
 let analyticsConfigured = false;
+let credentialsConfigured = false;
+
 const listener = capsule => {
 	const { channel, payload } = capsule;
 	logger.debug('on hub capsule ' + channel, payload);
@@ -334,6 +337,9 @@ const listener = capsule => {
 			break;
 		case 'analytics':
 			analyticsEvent(payload);
+			break;
+		case 'core':
+			coreEvent(payload);
 			break;
 		default:
 			break;
@@ -389,7 +395,7 @@ const authEvent = payload => {
 			return recordAuthEvent('auth_fail');
 		case 'configured':
 			authConfigured = true;
-			if (authConfigured && analyticsConfigured) {
+			if (analyticsConfigured) {
 				sendEvents();
 			}
 			break;
@@ -403,7 +409,21 @@ const analyticsEvent = payload => {
 	switch (event) {
 		case 'pinpointProvider_configured':
 			analyticsConfigured = true;
-			if (authConfigured && analyticsConfigured) {
+			if (authConfigured || credentialsConfigured) {
+				sendEvents();
+			}
+			break;
+	}
+};
+
+const coreEvent = payload => {
+	const { event } = payload;
+	if (!event) return;
+
+	switch (event) {
+		case 'credentials_configured':
+			credentialsConfigured = true;
+			if (analyticsConfigured) {
 				sendEvents();
 			}
 			break;

--- a/packages/core/__tests__/Credentials-test.ts
+++ b/packages/core/__tests__/Credentials-test.ts
@@ -52,7 +52,7 @@ describe('Credentials test', () => {
 			expect(credentials.Auth).toBeUndefined();
 
 			expect(credentials.get()).rejects.toMatchInlineSnapshot(
-				`"No Auth module registered in Amplify"`
+				`"No Cognito Identity pool provided for unauthenticated access"`
 			);
 		});
 

--- a/packages/core/__tests__/Credentials-test.ts
+++ b/packages/core/__tests__/Credentials-test.ts
@@ -1,6 +1,6 @@
 import { CredentialsClass as Credentials } from '../src/Credentials';
 import { Amplify } from '../src/Amplify';
-
+import { Hub } from '../src/Hub';
 const session = {};
 
 const user = {
@@ -70,10 +70,21 @@ describe('Credentials test', () => {
 	});
 
 	describe('configure test', () => {
-		test('happy case', () => {
+		test('happy case', done => {
+			expect.assertions(1);
 			const config = {
 				attr: 'attr',
 			};
+
+			Hub.listen('core', ({ channel, payload, source }) => {
+				if (
+					channel === 'core' &&
+					payload?.event === 'credentials_configured' &&
+					source === 'Credentials'
+				) {
+					done();
+				}
+			});
 
 			const credentials = new Credentials(null);
 			expect(credentials.configure(config)).toEqual({

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -118,7 +118,7 @@ export class CredentialsClass {
 		const { Auth = Amplify.Auth } = this;
 
 		if (!Auth || typeof Auth.currentUserCredentials !== 'function') {
-			// If Auth module is not import will do a best effort to get guest credentials
+			// If Auth module is not imported, do a best effort to get guest credentials
 			return this._setCredentialsForGuest();
 		}
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Removing dependency on Auth for getting guest credentials

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Sample app that will be included on samples staging repo in short, it was probe to be working with Analytics category on a react app.

```javascript
import { Amplify } from '@aws-amplify/core';
import { Analytics } from '@aws-amplify/analytics';
import awsconfig from './aws-exports';

Amplify.configure(awsconfig);

function App() {
  Analytics.record({
    name: 'working'
  })
// ....
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
