### PR TITLE
fix(storage): Fix storage api to have correct typing of .list response

### DIFF
--- a/packages/storage/__tests__/Storage-unit-test.ts
+++ b/packages/storage/__tests__/Storage-unit-test.ts
@@ -1,7 +1,7 @@
 import { AWSS3Provider as AWSStorageProvider } from '../src/providers/AWSS3Provider';
 import { Storage as StorageClass } from '../src/Storage';
 import {
-	S3ProviderListOutputWithToken,
+	S3ProviderListOutput,
 	Storage as StorageCategory,
 	StorageProvider,
 } from '../src';
@@ -806,7 +806,7 @@ describe('Storage', () => {
 			provider = new AWSStorageProvider();
 			storage.addPluggable(provider);
 			storage.configure(options);
-			const result: S3ProviderListOutputWithToken = {
+			const result: S3ProviderListOutput = {
 				results: [],
 				hasNextToken: false,
 				nextToken: undefined,

--- a/packages/storage/__tests__/Storage-unit-test.ts
+++ b/packages/storage/__tests__/Storage-unit-test.ts
@@ -809,7 +809,7 @@ describe('Storage', () => {
 			const result: S3ProviderListOutputWithToken = {
 				results: [],
 				hasNextToken: false,
-				nextToken: null,
+				nextToken: undefined,
 			};
 			listSpy = jest
 				.spyOn(AWSStorageProvider.prototype, 'list')
@@ -844,7 +844,8 @@ describe('Storage', () => {
 		test('list without provider', async () => {
 			const storage = new StorageClass();
 			try {
-				await storage.list('');
+				const result = await storage.list('');
+				expect(result.hasNextToken).toBeUndefined();
 			} catch (err) {
 				expect(err).toEqual('No plugin found in Storage for the provider');
 			}

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -47,7 +47,7 @@ import {
 	ResumableUploadConfig,
 	UploadTask,
 	S3ClientOptions,
-	S3ProviderListOutputWithToken,
+	S3ProviderListOutput,
 } from '../types';
 import { StorageErrorStrings } from '../common/StorageErrorStrings';
 import { dispatchStorageEvent } from '../common/StorageUtils';
@@ -674,8 +674,8 @@ export class AWSS3Provider implements StorageProvider {
 		params: ListObjectsV2Request,
 		opt: S3ClientOptions,
 		prefix: string
-	): Promise<S3ProviderListOutputWithToken> {
-		const list: S3ProviderListOutputWithToken = {
+	): Promise<S3ProviderListOutput> {
+		const list: S3ProviderListOutput = {
 			results: [],
 			hasNextToken: false,
 		};
@@ -701,13 +701,13 @@ export class AWSS3Provider implements StorageProvider {
 	 * List bucket objects relative to the level and prefix specified
 	 * @param {string} path - the path that contains objects
 	 * @param {S3ProviderListConfig} [config] - Optional configuration for the underlying S3 command
-	 * @return {Promise<S3ProviderListOutputWithToken>} - Promise resolves to list of keys, eTags, lastModified
+	 * @return {Promise<S3ProviderListOutput>} - Promise resolves to list of keys, eTags, lastModified
 	 * and file size for all objects in path
 	 */
 	public async list(
 		path: string,
 		config?: S3ProviderListConfig
-	): Promise<S3ProviderListOutputWithToken> {
+	): Promise<S3ProviderListOutput> {
 		const credentialsOK = await this._ensureCredentials();
 		if (!credentialsOK || !this._isWithCredentials(this._config)) {
 			throw new Error(StorageErrorStrings.NO_CREDENTIALS);
@@ -718,12 +718,12 @@ export class AWSS3Provider implements StorageProvider {
 		const final_path = prefix + path;
 		logger.debug('list ' + path + ' from ' + final_path);
 		try {
-			const list: S3ProviderListOutputWithToken = {
+			const list: S3ProviderListOutput = {
 				results: [],
 				hasNextToken: false,
 			};
 			const MAX_PAGE_SIZE = 1000;
-			let listResult: S3ProviderListOutputWithToken;
+			let listResult: S3ProviderListOutput;
 			const params: ListObjectsV2Request = {
 				Bucket: bucket,
 				Prefix: final_path,

--- a/packages/storage/src/types/AWSS3Provider.ts
+++ b/packages/storage/src/types/AWSS3Provider.ts
@@ -95,7 +95,7 @@ export type S3ProviderRemoveConfig = CommonStorageOptions & {
 	provider?: 'AWSS3';
 };
 
-export type S3ProviderListOutputWithToken = {
+export type S3ProviderListOutput = {
 	results: S3ProviderListOutputItem[];
 	nextToken?: string;
 	hasNextToken: boolean;
@@ -121,8 +121,6 @@ export interface S3ProviderListOutputItem {
 	lastModified: ListObjectsCommandOutputContent['LastModified'];
 	size: ListObjectsCommandOutputContent['Size'];
 }
-
-export type S3ProviderListOutput = S3ProviderListOutputWithToken;
 
 export interface S3CopyTarget {
 	key: string;

--- a/packages/storage/src/types/AWSS3Provider.ts
+++ b/packages/storage/src/types/AWSS3Provider.ts
@@ -122,7 +122,7 @@ export interface S3ProviderListOutputItem {
 	size: ListObjectsCommandOutputContent['Size'];
 }
 
-export type S3ProviderListOutput = S3ProviderListOutputItem[];
+export type S3ProviderListOutput = S3ProviderListOutputWithToken;
 
 export interface S3CopyTarget {
 	key: string;


### PR DESCRIPTION
#### Description of changes
fix(storage): Fix storage api to have correct typing of .list response

When using `Storage.list`, the response type did not have `nextToken` as expected.  Updating the types so that `Storage` has the correct response type and adding a test that would need to be fix to reflect the underlying typing problem.

#### Description of how you validated changes

Test updated and passing.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
