### PR TITLE
fix(@aws-amplify/datastore): fix join conditions on predicate not groups

### DIFF
--- a/packages/datastore/__tests__/Predicate.ts
+++ b/packages/datastore/__tests__/Predicate.ts
@@ -376,27 +376,6 @@ describe('Predicates', () => {
 					]);
 				});
 
-				describe('predicate typings', () => {
-					test('not group must return single', async () => {
-						expect(() =>
-							recursivePredicateFor(AuthorMeta).not(a => [
-								a.name.contains('Bob'),
-							])
-						).toThrow();
-					});
-
-					test('and group must return array', async () => {
-						expect(() =>
-							recursivePredicateFor(AuthorMeta).and(a => a.name.contains('Bob'))
-						).toThrow();
-					});
-
-					test('or group must return array', async () => {
-						expect(() =>
-							recursivePredicateFor(AuthorMeta).or(a => a.name.contains('Bob'))
-						).toThrow();
-					});
-				});
 
 				describe('with a logical grouping', () => {
 					test('can perform and() logic, matching an item', async () => {

--- a/packages/datastore/__tests__/Predicate.ts
+++ b/packages/datastore/__tests__/Predicate.ts
@@ -379,7 +379,6 @@ describe('Predicates', () => {
 				describe('predicate typings', () => {
 					test('not group must return single', async () => {
 						expect(() =>
-							// @ts-expect-error
 							recursivePredicateFor(AuthorMeta).not(a => [
 								a.name.contains('Bob'),
 							])
@@ -388,14 +387,12 @@ describe('Predicates', () => {
 
 					test('and group must return array', async () => {
 						expect(() =>
-							// @ts-expect-error
 							recursivePredicateFor(AuthorMeta).and(a => a.name.contains('Bob'))
 						).toThrow();
 					});
 
 					test('or group must return array', async () => {
 						expect(() =>
-							// @ts-expect-error
 							recursivePredicateFor(AuthorMeta).or(a => a.name.contains('Bob'))
 						).toThrow();
 					});

--- a/packages/datastore/src/predicates/next.ts
+++ b/packages/datastore/src/predicates/next.ts
@@ -578,7 +578,7 @@ export class GroupCondition {
 							applyConditionsToV1Predicate(
 								p,
 								individualRowJoinConditions,
-								negateChildren
+								false
 							);
 						relativesPredicates.push(predicate as any);
 					}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Predicates with `.not()` conditions containing multiple related-table join conditions were selecting the wrong sets. E.g., a query like this:

```
DataStore.query(Post, negation =>
	negation.not(c =>
		c.and(post => [
			post.blog.or(blog => [
				blog.name.contains('Bob'),
				blog.name.contains('Donut'),
			]),
			post.or(post => [
				post.title.contains('post 2'),
				post.title.contains('post 3'),
			]),
		])
	)
),
```

`not()`'s apply De Morgan's Laws to retrieve inverse sets on nested groups. The propagation of this law down the chain was inadvertently added to join conditions as well. **This has been removed.**


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

1. Multiple additional tests added.
2. Tested with local sample app. (This will be added to the integ test suite as well.)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
