### PR TITLE
fix(@aws-amplify/datastore): Fix predicate group types

### DIFF
--- a/packages/datastore/__tests__/Predicate.ts
+++ b/packages/datastore/__tests__/Predicate.ts
@@ -376,6 +376,33 @@ describe('Predicates', () => {
 					]);
 				});
 
+				describe('predicate typings', () => {
+					test('not group builders must return single child condition', async () => {
+						expect(() =>
+							recursivePredicateFor(AuthorMeta).not(a => [
+								a.name.contains('Bob'),
+							])
+						).toThrow(
+							"Invalid predicate. Terminate your predicate with a valid condition (e.g., `p => p.field.eq('value')`) or pass `Predicates.ALL`."
+						);
+					});
+
+					test('and group builders must return an array of child conditions', async () => {
+						expect(() =>
+							recursivePredicateFor(AuthorMeta).and(a => a.name.contains('Bob'))
+						).toThrow(
+							'Invalid predicate. `and` groups must return an array of child conditions.'
+						);
+					});
+
+					test('or group builders must return array of child conditions', async () => {
+						expect(() =>
+							recursivePredicateFor(AuthorMeta).or(a => a.name.contains('Bob'))
+						).toThrow(
+							'Invalid predicate. `or` groups must return an array of child conditions.'
+						);
+					});
+				});
 
 				describe('with a logical grouping', () => {
 					test('can perform and() logic, matching an item', async () => {

--- a/packages/datastore/__tests__/Predicate.ts
+++ b/packages/datastore/__tests__/Predicate.ts
@@ -376,27 +376,6 @@ describe('Predicates', () => {
 					]);
 				});
 
-				describe('predicate typings', () => {
-					test('not group must return single', async () => {
-						expect(() =>
-							recursivePredicateFor(AuthorMeta).not(a => [
-								a.name.contains('Bob'),
-							])
-						).toThrow();
-					});
-
-					test('and group must return array', async () => {
-						expect(() =>
-							recursivePredicateFor(AuthorMeta).and(a => a.name.contains('Bob'))
-						).toThrow();
-					});
-
-					test('or group must return array', async () => {
-						expect(() =>
-							recursivePredicateFor(AuthorMeta).or(a => a.name.contains('Bob'))
-						).toThrow();
-					});
-				});
 
 				describe('with a logical grouping', () => {
 					test('can perform and() logic, matching an item', async () => {

--- a/packages/datastore/__tests__/Predicate.ts
+++ b/packages/datastore/__tests__/Predicate.ts
@@ -377,8 +377,10 @@ describe('Predicates', () => {
 				});
 
 				describe('predicate typings', () => {
-					test('not group builders must return single child condition', async () => {
+					test('not group builders must return single child condition - recursive/relational predicates', async () => {
 						expect(() =>
+							// @ts-expect-error doesn't work until TS 3.9 ... until then:
+							// @ts-ignore
 							recursivePredicateFor(AuthorMeta).not(a => [
 								a.name.contains('Bob'),
 							])
@@ -387,17 +389,51 @@ describe('Predicates', () => {
 						);
 					});
 
-					test('and group builders must return an array of child conditions', async () => {
+					test('and group builders must return an array of child conditions - recursive/relational predicates', async () => {
 						expect(() =>
+							// @ts-expect-error doesn't work until TS 3.9 ... until then:
+							// @ts-ignore
 							recursivePredicateFor(AuthorMeta).and(a => a.name.contains('Bob'))
 						).toThrow(
 							'Invalid predicate. `and` groups must return an array of child conditions.'
 						);
 					});
 
-					test('or group builders must return array of child conditions', async () => {
+					test('or group builders must return array of child conditions - recursive/relational predicates', async () => {
 						expect(() =>
+							// @ts-expect-error doesn't work until TS 3.9 ... until then:
+							// @ts-ignore
 							recursivePredicateFor(AuthorMeta).or(a => a.name.contains('Bob'))
+						).toThrow(
+							'Invalid predicate. `or` groups must return an array of child conditions.'
+						);
+					});
+
+					test('not group builders must return single child condition - flat predicates', async () => {
+						expect(() =>
+							// @ts-expect-error doesn't work until TS 3.9 ... until then:
+							// @ts-ignore
+							predicateFor(AuthorMeta).not(a => [a.name.contains('Bob')])
+						).toThrow(
+							"Invalid predicate. Terminate your predicate with a valid condition (e.g., `p => p.field.eq('value')`) or pass `Predicates.ALL`."
+						);
+					});
+
+					test('and group builders must return an array of child conditions - flat predicates', async () => {
+						expect(() =>
+							// @ts-expect-error doesn't work until TS 3.9 ... until then:
+							// @ts-ignore
+							predicateFor(AuthorMeta).and(a => a.name.contains('Bob'))
+						).toThrow(
+							'Invalid predicate. `and` groups must return an array of child conditions.'
+						);
+					});
+
+					test('or group builders must return array of child conditions - flat predicates', async () => {
+						expect(() =>
+							// @ts-expect-error doesn't work until TS 3.9 ... until then:
+							// @ts-ignore
+							predicateFor(AuthorMeta).or(a => a.name.contains('Bob'))
 						).toThrow(
 							'Invalid predicate. `or` groups must return an array of child conditions.'
 						);

--- a/packages/datastore/__tests__/Predicate.ts
+++ b/packages/datastore/__tests__/Predicate.ts
@@ -379,7 +379,6 @@ describe('Predicates', () => {
 				describe('predicate typings', () => {
 					test('not group must return single', async () => {
 						expect(() =>
-							// @ts-expect-error
 							recursivePredicateFor(AuthorMeta).not(a => [
 								a.name.contains('Bob'),
 							])
@@ -388,14 +387,12 @@ describe('Predicates', () => {
 
 					test('and group must return array', async () => {
 						expect(() =>
-							// @ts-expect-error
 							recursivePredicateFor(AuthorMeta).and(a => a.name.contains('Bob'))
 						).toThrow();
 					});
 
 					test('or group must return array', async () => {
 						expect(() =>
-							// @ts-expect-error
 							recursivePredicateFor(AuthorMeta).or(a => a.name.contains('Bob'))
 						).toThrow();
 					});

--- a/packages/datastore/src/predicates/next.ts
+++ b/packages/datastore/src/predicates/next.ts
@@ -578,7 +578,7 @@ export class GroupCondition {
 							applyConditionsToV1Predicate(
 								p,
 								individualRowJoinConditions,
-								negateChildren
+								false
 							);
 						relativesPredicates.push(predicate as any);
 					}

--- a/packages/datastore/src/predicates/next.ts
+++ b/packages/datastore/src/predicates/next.ts
@@ -814,6 +814,15 @@ export function recursivePredicateFor<T extends PersistentModel>(
 			// to head off mutability concerns.
 			const { query, newTail } = copyLink();
 
+			const childConditions = builder(
+				recursivePredicateFor(ModelType, allowRecursion)
+			);
+			if (!Array.isArray(childConditions)) {
+				throw new Error(
+					`Invalid predicate. \`${op}\` groups must return an array of child conditions.`
+				);
+			}
+
 			// the customer will supply a child predicate, which apply to the `model.field`
 			// of the tail GroupCondition.
 			newTail?.operands.push(
@@ -822,9 +831,7 @@ export function recursivePredicateFor<T extends PersistentModel>(
 					field,
 					undefined,
 					op as 'and' | 'or',
-					builder(recursivePredicateFor(ModelType, allowRecursion)).map(c =>
-						internals(c)
-					)
+					childConditions.map(c => internals(c))
 				)
 			);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adds red squiggles and prevents TS builds if `and`/`or`/`not` predicate functions return invalid results. I.e., `and` and `or` predicates should return an array of "completed" child predicates. `not` should return a single, completed child predicate.

![image](https://user-images.githubusercontent.com/8375502/199868468-d34fe127-920b-4021-9bd4-6bf7cf0ae019.png)

![image](https://user-images.githubusercontent.com/8375502/199868578-89c8f25a-7aa9-4f83-81e6-8ec578d1cffc.png)

![image](https://user-images.githubusercontent.com/8375502/199868620-e8a8de0e-2697-406f-a837-b0e58d75f2e2.png)

Along with this change, I removed some unused union members from predicate builder types. The removed members were cruft from prototyping other predicate options.

The runtime error for `and` and `or` conditions was also un-instructive and a more instructive error has been made explicit.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

1. Added tests.
2. Built and verified intellisense in IDE. (See screenshots.)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
