### PR TITLE
fix(storage): Storage.list receives nextToken to align with API

### DIFF
--- a/packages/storage/__tests__/providers/AWSS3Provider-unit-test.ts
+++ b/packages/storage/__tests__/providers/AWSS3Provider-unit-test.ts
@@ -994,7 +994,7 @@ describe('StorageProvider test', () => {
 			spyon.mockClear();
 		});
 
-		test('list object with pageSize and pageToken', async () => {
+		test('list object with pageSize and nextToken', async () => {
 			expect.assertions(4);
 			const curCredSpyOn = jest
 				.spyOn(Credentials, 'get')
@@ -1022,7 +1022,7 @@ describe('StorageProvider test', () => {
 			const response = await storage.list('listWithTokenResultsPath', {
 				level: 'public',
 				pageSize: 1,
-				pageToken: 'TEST_TOKEN',
+				nextToken: 'TEST_TOKEN',
 			});
 			expect(response.results).toEqual([
 				{

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -713,7 +713,7 @@ export class AWSS3Provider implements StorageProvider {
 			throw new Error(StorageErrorStrings.NO_CREDENTIALS);
 		}
 		const opt: S3ClientOptions = Object.assign({}, this._config, config);
-		const { bucket, track, pageSize, pageToken } = opt;
+		const { bucket, track, pageSize, nextToken } = opt;
 		const prefix = this._prefix(opt);
 		const final_path = prefix + path;
 		logger.debug('list ' + path + ' from ' + final_path);
@@ -728,9 +728,9 @@ export class AWSS3Provider implements StorageProvider {
 				Bucket: bucket,
 				Prefix: final_path,
 				MaxKeys: MAX_PAGE_SIZE,
-				ContinuationToken: pageToken,
+				ContinuationToken: nextToken,
 			};
-			params.ContinuationToken = pageToken;
+			params.ContinuationToken = nextToken;
 			if (pageSize === 'ALL') {
 				do {
 					listResult = await this._list(params, opt, prefix);

--- a/packages/storage/src/types/AWSS3Provider.ts
+++ b/packages/storage/src/types/AWSS3Provider.ts
@@ -108,7 +108,7 @@ export type S3ProviderListConfig = CommonStorageOptions & {
 	pageSize?: number | 'ALL';
 	provider?: 'AWSS3';
 	identityId?: string;
-	pageToken?: string;
+	nextToken?: string;
 };
 
 export type S3ClientOptions = StorageOptions & {


### PR DESCRIPTION
#### Description of changes
fix(storage): Storage.list receives nextToken to align with API

Storage list pagination should work the same as [API Pagination](https://docs.amplify.aws/guides/api-graphql/graphql-pagination/q/platform/js/), which uses `nextToken` as both the input and output attribute name.

Prior to this change getting the first to pages would look like:
```
const res1 = Storage.list('');
const res2 = Storage.list('', {pageToken: res1.nextToken);
```

After this change getting the first to pages will look like:
```
const res1 = Storage.list('');
const res2 = Storage.list('', {nextToken: res1.nextToken);
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
