### PR TITLE
chore: Update release command to enable v5 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"publish:main": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=unstable --preid=unstable --exact --no-verify-access",
 		"publish:next-major-version/5": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=next --preid=next --exact --no-verify-access",
 		"publish:beta": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=beta --preid=beta --exact --no-verify-access",
-		"publish:release": "lerna publish --conventional-commits --yes --message 'chore(release): Publish [ci skip]' --no-verify-access",
+		"publish:release": "lerna exec npm publish",
 		"publish:1.0-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-1.0 --message 'chore(release): Publish [ci skip]' --no-verify-access",
 		"publish:ui-components/main": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=ui-preview --preid=ui-preview --exact --no-verify-access",
 		"publish:verdaccio": "lerna publish --no-push --canary minor --dist-tag=unstable --preid=unstable --exact --force-publish --yes --no-verify-access",


### PR DESCRIPTION
#### Description of changes
We want to release v5 without incrementing the version and with manual control over the CHANGE_LOG.

This will be rolled back as the first commit after the release.

#### Description of how you validated changes
Tested by running against verdaccio locally to confirm behavior


#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
