### PR TITLE
Changed returned event.key value when using resumable:t…

### DIFF
--- a/packages/storage/src/providers/AWSS3UploadTask.ts
+++ b/packages/storage/src/providers/AWSS3UploadTask.ts
@@ -57,7 +57,7 @@ export interface InProgressRequest {
 }
 
 export interface UploadTaskCompleteEvent {
-	key: string;
+	key?: string;
 }
 
 export interface UploadTaskProgressEvent {
@@ -229,8 +229,9 @@ export class AWSS3UploadTask implements UploadTask {
 	private _validateParams() {
 		if (this.file.size / this.partSize > MAX_PARTS) {
 			throw new Error(
-				`Too many parts. Number of parts is ${this.file.size /
-					this.partSize}, maximum is ${MAX_PARTS}.`
+				`Too many parts. Number of parts is ${
+					this.file.size / this.partSize
+				}, maximum is ${MAX_PARTS}.`
 			);
 		}
 	}
@@ -304,7 +305,7 @@ export class AWSS3UploadTask implements UploadTask {
 			);
 			this._verifyFileSize();
 			this._emitEvent<UploadTaskCompleteEvent>(TaskEvents.UPLOAD_COMPLETE, {
-				key: `${this.params.Bucket}/${this.params.Key}`,
+				key: this.params.Key,
 			});
 			this._removeFromCache();
 			this.state = AWSS3UploadTaskState.COMPLETED;


### PR DESCRIPTION
…rue to be consistent with returned object keys in storage.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Changed de response key when uploading a file with resumable from:
```json
{"key":"<bucket>/<key>"}
``` 
To:
```json
{"key":"<key>"}
```

This is because according to the [documentation](https://docs.amplify.aws/lib/storage/upload/q/platform/js/) regarding the `Put` method:
> The `Put` method uploads files into Amazon S3.
> It returns a `{key: S3 Object key}` object on success

Not a `{key: bucket/S3 Object key}` object on success.

This was first introduced in a feature addition in #8935 with an arbitrary bucket added at the beginning of the returning key:

https://github.com/aws-amplify/amplify-js/blob/80729d8671713d29703f1e809f44e14f36517cc7/packages/storage/src/providers/AWSS3UploadTask.ts#L149

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Closes #10644


#### Description of how you validated changes

Created a custom app which uploaded a file and got the returned key value. Then `yarn link` the storage package with the new changes and get the expected return value.

Wasn't able to `yarn test` as storage tests are not working properly. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes (Not possible to try as storage tests aren't working)
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
