### PR TITLE
fix: export DataStore predicate types

### DIFF
--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -72,6 +72,8 @@ import {
 	isIdentifierObject,
 	AmplifyContext,
 	isFieldAssociation,
+	RecursiveModelPredicateExtender,
+	ModelPredicateExtender,
 } from '../types';
 // tslint:disable:no-duplicate-imports
 import type { __modelMeta__ } from '../types';
@@ -98,8 +100,6 @@ import {
 	mergePatches,
 } from '../util';
 import {
-	RecursiveModelPredicateExtender,
-	ModelPredicateExtender,
 	recursivePredicateFor,
 	predicateFor,
 	GroupCondition,

--- a/packages/datastore/src/predicates/next.ts
+++ b/packages/datastore/src/predicates/next.ts
@@ -1,11 +1,14 @@
 import {
-	Scalar,
 	PersistentModel,
 	ModelFieldType,
 	ModelMeta,
-	AllOperators,
-	PredicateFieldType,
 	ModelPredicate as StoragePredicate,
+	AllFieldOperators,
+	PredicateInternalsKey,
+	V5ModelPredicate as ModelPredicate,
+	RecursiveModelPredicate,
+	RecursiveModelPredicateExtender,
+	RecursiveModelPredicateAggregateExtender,
 } from '../types';
 
 import {
@@ -16,128 +19,7 @@ import { ExclusiveStorage as StorageAdapter } from '../storage/storage';
 import { ModelRelationship } from '../storage/relationship';
 import { asyncSome, asyncEvery } from '../util';
 
-type MatchableTypes =
-	| string
-	| string[]
-	| number
-	| number[]
-	| boolean
-	| boolean[];
-
-type AllFieldOperators = keyof AllOperators;
-
 const ops = [...comparisonKeys] as AllFieldOperators[];
-
-type NonNeverKeys<T> = {
-	[K in keyof T]: T[K] extends never ? never : K;
-}[keyof T];
-
-type WithoutNevers<T> = Pick<T, NonNeverKeys<T>>;
-
-/**
- * A function that accepts a RecursiveModelPrecicate<T>, which it must use to
- * return a final condition.
- *
- * This is used in `DataStore.query()`, `DataStore.observe()`, and
- * `DataStore.observeQuery()` as the second argument. E.g.,
- *
- * ```
- * DataStore.query(MyModel, model => model.field.eq('some value'))
- * ```
- *
- * More complex queries should also be supported. E.g.,
- *
- * ```
- * DataStore.query(MyModel, model => model.and(m => [
- *   m.relatedEntity.or(relative => [
- *     relative.relativeField.eq('whatever'),
- *     relative.relativeField.eq('whatever else')
- *   ]),
- *   m.myModelField.ne('something')
- * ]))
- * ```
- */
-export type RecursiveModelPredicateExtender<RT extends PersistentModel> = (
-	lambda: RecursiveModelPredicate<RT>
-) => PredicateInternalsKey;
-
-export type RecursiveModelPredicateAggregateExtender<
-	RT extends PersistentModel
-> = (lambda: RecursiveModelPredicate<RT>) => PredicateInternalsKey[];
-
-type RecursiveModelPredicateOperator<RT extends PersistentModel> = (
-	predicates: RecursiveModelPredicateAggregateExtender<RT>
-) => PredicateInternalsKey;
-
-type RecursiveModelPredicateNegation<RT extends PersistentModel> = (
-	predicate: RecursiveModelPredicateExtender<RT>
-) => PredicateInternalsKey;
-
-export type RecursiveModelPredicate<RT extends PersistentModel> = {
-	[K in keyof RT]-?: PredicateFieldType<RT[K]> extends PersistentModel
-		? RecursiveModelPredicate<PredicateFieldType<RT[K]>>
-		: ValuePredicate<RT, RT[K]>;
-} & {
-	or: RecursiveModelPredicateOperator<RT>;
-	and: RecursiveModelPredicateOperator<RT>;
-	not: RecursiveModelPredicateNegation<RT>;
-} & PredicateInternalsKey;
-
-/**
- * A function that accepts a ModelPrecicate<T>, which it must use to return a
- * final condition.
- *
- * This is used as predicates in `DataStore.save()`, `DataStore.delete()`, and
- * DataStore sync expressions.
- *
- * ```
- * DataStore.save(record, model => model.field.eq('some value'))
- * ```
- *
- * Logical operators are supported. But, condtiions are related records are
- * NOT supported. E.g.,
- *
- * ```
- * DataStore.delete(record, model => model.or(m => [
- * 	m.field.eq('whatever'),
- * 	m.field.eq('whatever else')
- * ]))
- * ```
- */
-export type ModelPredicateExtender<RT extends PersistentModel> = (
-	lambda: ModelPredicate<RT>
-) => PredicateInternalsKey;
-
-export type ModelPredicateAggregateExtender<RT extends PersistentModel> = (
-	lambda: ModelPredicate<RT>
-) => PredicateInternalsKey[];
-
-type ValuePredicate<RT extends PersistentModel, MT extends MatchableTypes> = {
-	[K in AllFieldOperators]: K extends 'between'
-		? (
-				inclusiveLowerBound: Scalar<MT>,
-				inclusiveUpperBound: Scalar<MT>
-		  ) => PredicateInternalsKey
-		: (operand: Scalar<MT>) => PredicateInternalsKey;
-};
-
-export type ModelPredicate<RT extends PersistentModel> = WithoutNevers<{
-	[K in keyof RT]-?: PredicateFieldType<RT[K]> extends PersistentModel
-		? never
-		: ValuePredicate<RT, RT[K]>;
-}> & {
-	or: ModelPredicateOperator<RT>;
-	and: ModelPredicateOperator<RT>;
-	not: ModelPredicateNegation<RT>;
-} & PredicateInternalsKey;
-
-type ModelPredicateOperator<RT extends PersistentModel> = (
-	predicates: ModelPredicateAggregateExtender<RT>
-) => PredicateInternalsKey;
-
-type ModelPredicateNegation<RT extends PersistentModel> = (
-	predicate: ModelPredicateExtender<RT>
-) => PredicateInternalsKey;
 
 type GroupOperator = 'and' | 'or' | 'not';
 
@@ -147,14 +29,6 @@ type UntypedCondition = {
 	copy(extract: GroupCondition): [UntypedCondition, GroupCondition | undefined];
 	toAST(): any;
 };
-
-/**
- * A pointer used by DataStore internally to lookup predicate details
- * that should not be exposed on public customer interfaces.
- */
-export class PredicateInternalsKey {
-	private __isPredicateInternalsKeySentinel: boolean = true;
-}
 
 /**
  * A map from keys (exposed to customers) to the internal predicate data

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -20,9 +20,19 @@ import { Cache } from '@aws-amplify/cache';
 import { Adapter } from './storage/adapter';
 import {
 	ModelPredicateExtender,
+	RecursiveModelPredicateExtender,
 	PredicateInternalsKey,
 	ModelPredicate as V5ModelPredicate,
+	RecursiveModelPredicate as V5RecursiveModelPredicate,
 } from './predicates/next';
+
+export {
+	V5ModelPredicate,
+	V5RecursiveModelPredicate,
+	PredicateInternalsKey,
+	ModelPredicateExtender,
+	RecursiveModelPredicateExtender,
+};
 
 export type Scalar<T> = T extends Array<infer InnerType> ? InnerType : T;
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Exposes DataStore predicate types to allow customers to easily write type-safe wrapper functions. E.g.,

![image](https://user-images.githubusercontent.com/8375502/200940314-eadda3e0-aa0e-4a9b-b1d7-91524985357e.png)



#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

1. Created a new DataStore project
2. Linked the build
3. Imported the newly exported types from `@aws-amplify/datastore`
4. Wrote a simple wrapper
5. Observed that IDE autocomplete and type checking was correct.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
