### PR TITLE
Adjust event message size

### DIFF
--- a/packages/core/src/Providers/AWSCloudWatchProvider.ts
+++ b/packages/core/src/Providers/AWSCloudWatchProvider.ts
@@ -443,7 +443,8 @@ class AWSCloudWatchProvider implements LoggingProvider {
 				const errString = `Log entry exceeds maximum size for CloudWatch logs. Log size: ${eventSize}. Truncating log message.`;
 				logger.warn(errString);
 
-				currentEvent.message = currentEvent.message.substring(0, eventSize);
+				currentEvent.message = currentEvent.message.substring(0, AWS_CLOUDWATCH_MAX_EVENT_SIZE - AWS_CLOUDWATCH_BASE_BUFFER_SIZE);
+				eventSize = new TextEncoder().encode(currentEvent.message).length
 			}
 
 			if (totalByteSize + eventSize > AWS_CLOUDWATCH_MAX_BATCH_EVENT_SIZE)


### PR DESCRIPTION
The substring was previously running to the eventSize so not cutting down the message. Changed to set a hard limit of max event size with its buffer. Restated eventsize for downstream logic.

Ideally it should be changed to split a large `message` into chunks of max size and submit multiple events.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
