### PR TITLE
fix: predicate logic against bools

### DIFF
--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -1733,12 +1733,14 @@ describe('Model behavior', () => {
 		expect(await disconnectedParent.child).toBeUndefined();
 	});
 
-	test('removes items update out of the from the snapshot with an eq predicate on boolean field', done => {
+	test('removes no-longer-matching items from the snapshot when using an eq() predicate on boolean field', done => {
 		(async () => {
 			const { DataStore, ModelWithBoolean } = getDataStore();
 			try {
+				// the number of records we expect in each snapshot
 				const expecteds = [5, 4];
 
+				// initial data set, 5 records that will match our predicate.
 				for (let i = 0; i < 5; i++) {
 					await DataStore.save(
 						new ModelWithBoolean({
@@ -1750,10 +1752,10 @@ describe('Model behavior', () => {
 				const sub = DataStore.observeQuery(ModelWithBoolean, m =>
 					m.boolField.eq(true)
 				).subscribe(({ items, isSynced }) => {
+					// we don't actually expect 0 records in our snapshots after our list runs out.
+					// we just want to make TS happy.
 					const expected = expecteds.shift() || 0;
 					expect(items.length).toBe(expected);
-
-					console.log({ items });
 
 					for (let i = 0; i < expected; i++) {
 						expect(items[i].boolField).toEqual(true);
@@ -1765,12 +1767,16 @@ describe('Model behavior', () => {
 					}
 				});
 
+				// update an item to no longer match our criteria.
+				// we want to see a snapshot come through WITHOUT this item.
 				const itemToUpdate = (await DataStore.query(ModelWithBoolean)).pop()!;
 				await DataStore.save(
 					ModelWithBoolean.copyOf(itemToUpdate, m => {
 						m.boolField = false;
 					})
 				);
+
+				// advance time to trigger another snapshot.
 				jest.advanceTimersByTime(2000);
 			} catch (error) {
 				done(error);
@@ -1778,12 +1784,14 @@ describe('Model behavior', () => {
 		})();
 	});
 
-	test('removes items update out of the from the snapshot with a ne predicate on boolean field', done => {
+	test('removes no-longer-matching items from the snapshot when using an ne() predicate on boolean field', done => {
 		(async () => {
 			const { DataStore, ModelWithBoolean } = getDataStore();
 			try {
+				// the number of records we expect in each snapshot
 				const expecteds = [5, 4];
 
+				// initial data set, 5 records that will match our predicate.
 				for (let i = 0; i < 5; i++) {
 					await DataStore.save(
 						new ModelWithBoolean({
@@ -1795,10 +1803,10 @@ describe('Model behavior', () => {
 				const sub = DataStore.observeQuery(ModelWithBoolean, m =>
 					m.boolField.ne(false)
 				).subscribe(({ items, isSynced }) => {
+					// we don't actually expect 0 records in our snapshots after our list runs out.
+					// we just want to make TS happy.
 					const expected = expecteds.shift() || 0;
 					expect(items.length).toBe(expected);
-
-					console.log({ items });
 
 					for (let i = 0; i < expected; i++) {
 						expect(items[i].boolField).toEqual(true);
@@ -1810,12 +1818,16 @@ describe('Model behavior', () => {
 					}
 				});
 
+				// update an item to no longer match our criteria.
+				// we want to see a snapshot come through WITHOUT this item.
 				const itemToUpdate = (await DataStore.query(ModelWithBoolean)).pop()!;
 				await DataStore.save(
 					ModelWithBoolean.copyOf(itemToUpdate, m => {
 						m.boolField = false;
 					})
 				);
+
+				// advance time to trigger another snapshot.
 				jest.advanceTimersByTime(2000);
 			} catch (error) {
 				done(error);

--- a/packages/datastore/__tests__/Predicate.ts
+++ b/packages/datastore/__tests__/Predicate.ts
@@ -171,7 +171,9 @@ describe('Predicates', () => {
 				'Clarice Starling',
 				'Debbie Donut',
 				'Zelda from the Legend of Zelda',
-			].map(name => new Author({ name }));
+			].map((name, index) => {
+				return new Author({ name, isActive: index % 2 === 0 });
+			});
 		};
 
 		[
@@ -214,6 +216,24 @@ describe('Predicates', () => {
 
 					expect(matches.length).toBe(getFlatAuthorsArrayFixture().length - 1);
 					expect(matches.some(a => a.name === 'Adam West')).toBe(false);
+				});
+
+				test('match on eq on booleans', async () => {
+					const query = recursivePredicateFor(AuthorMeta).isActive.eq(true);
+					const matches = await mechanism.execute<
+						ModelOf<ModelOf<typeof Author>>
+					>(query);
+
+					expect(matches.length).toBe(3);
+				});
+
+				test('match on ne on booleans', async () => {
+					const query = recursivePredicateFor(AuthorMeta).isActive.ne(true);
+					const matches = await mechanism.execute<
+						ModelOf<ModelOf<typeof Author>>
+					>(query);
+
+					expect(matches.length).toBe(2);
 				});
 
 				test('match on gt', async () => {

--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -983,6 +983,7 @@ export function getDataStore({ online = false, isNode = true } = {}) {
 
 	const classes = initSchema(testSchema());
 	const {
+		ModelWithBoolean,
 		Post,
 		Comment,
 		User,
@@ -996,6 +997,7 @@ export function getDataStore({ online = false, isNode = true } = {}) {
 		HasOneParent,
 		HasOneChild,
 	} = classes as {
+		ModelWithBoolean: PersistentModelConstructor<ModelWithBoolean>;
 		Post: PersistentModelConstructor<Post>;
 		Comment: PersistentModelConstructor<Comment>;
 		User: PersistentModelConstructor<User>;
@@ -1016,6 +1018,7 @@ export function getDataStore({ online = false, isNode = true } = {}) {
 		graphqlService,
 		simulateConnect,
 		simulateDisconnect,
+		ModelWithBoolean,
 		Post,
 		Comment,
 		User,
@@ -1073,6 +1076,7 @@ export declare class Model {
 		mutator: (draft: MutableModel<Model>) => void | Model
 	): Model;
 }
+
 export declare class Metadata {
 	readonly author: string;
 	readonly tags?: string[];
@@ -1478,6 +1482,20 @@ export declare class LegacyJSONComment {
 	): LegacyJSONComment;
 }
 
+export declare class ModelWithBoolean {
+	public readonly id: string;
+	public readonly boolField: boolean;
+	public readonly createdAt?: string;
+	public readonly updatedAt?: string;
+
+	constructor(init: ModelInit<ModelWithBoolean>);
+
+	static copyOf(
+		src: ModelWithBoolean,
+		mutator: (draft: MutableModel<ModelWithBoolean>) => void | ModelWithBoolean
+	): ModelWithBoolean;
+}
+
 export function testSchema(): Schema {
 	return {
 		enums: {},
@@ -1546,6 +1564,41 @@ export function testSchema(): Schema {
 						isRequired: false,
 						attributes: [],
 						isArrayNullable: true,
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: false,
+						attributes: [],
+						isReadOnly: true,
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: false,
+						attributes: [],
+						isReadOnly: true,
+					},
+				},
+			},
+			ModelWithBoolean: {
+				name: 'ModelWithBoolean',
+				pluralName: 'ModelWithBooleans',
+				syncable: true,
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+					},
+					boolField: {
+						name: 'boolField',
+						isArray: false,
+						type: 'Boolean',
+						isRequired: false,
 					},
 					createdAt: {
 						name: 'createdAt',

--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -1484,7 +1484,7 @@ export declare class LegacyJSONComment {
 
 export declare class ModelWithBoolean {
 	public readonly id: string;
-	public readonly boolField: boolean;
+	public readonly boolField?: boolean;
 	public readonly createdAt?: string;
 	public readonly updatedAt?: string;
 

--- a/packages/datastore/__tests__/model.ts
+++ b/packages/datastore/__tests__/model.ts
@@ -138,6 +138,7 @@ declare class EditorModel {
 
 declare class AuthorModel {
 	readonly id: string;
+	readonly isActive: boolean;
 	readonly name: string;
 	readonly posts: AsyncCollection<PostAuthorJoinModel>;
 	constructor(init: ModelInit<AuthorModel>);

--- a/packages/datastore/__tests__/model.ts
+++ b/packages/datastore/__tests__/model.ts
@@ -138,7 +138,7 @@ declare class EditorModel {
 
 declare class AuthorModel {
 	readonly id: string;
-	readonly isActive: boolean;
+	readonly isActive?: boolean;
 	readonly name: string;
 	readonly posts: AsyncCollection<PostAuthorJoinModel>;
 	constructor(init: ModelInit<AuthorModel>);

--- a/packages/datastore/__tests__/model.ts
+++ b/packages/datastore/__tests__/model.ts
@@ -138,8 +138,27 @@ declare class EditorModel {
 
 declare class AuthorModel {
 	readonly id: string;
+
+	/**
+	 * For testing Boolean comparisions.
+	 */
 	readonly isActive?: boolean;
+
+	/**
+	 * For testing Float comparisions.
+	 */
+	readonly rating?: number;
+
+	/**
+	 * For testing Int comparisions.
+	 */
+	readonly karma?: number;
+
+	/**
+	 * For testing String comparisons.
+	 */
 	readonly name: string;
+
 	readonly posts: AsyncCollection<PostAuthorJoinModel>;
 	constructor(init: ModelInit<AuthorModel>);
 	static copyOf(

--- a/packages/datastore/__tests__/schema.ts
+++ b/packages/datastore/__tests__/schema.ts
@@ -357,6 +357,12 @@ export const newSchema: Schema = {
 					isRequired: true,
 					attributes: [],
 				},
+				isActive: {
+					name: 'isActive',
+					isArray: false,
+					type: 'Boolean',
+					isRequired: false,
+				},
 				name: {
 					name: 'name',
 					isArray: false,

--- a/packages/datastore/__tests__/schema.ts
+++ b/packages/datastore/__tests__/schema.ts
@@ -363,6 +363,18 @@ export const newSchema: Schema = {
 					type: 'Boolean',
 					isRequired: false,
 				},
+				rating: {
+					name: 'rating',
+					isArray: false,
+					type: 'Float',
+					isRequired: false,
+				},
+				karma: {
+					name: 'karma',
+					isArray: false,
+					type: 'Int',
+					isRequired: false,
+				},
 				name: {
 					name: 'name',
 					isArray: false,

--- a/packages/datastore/src/predicates/next.ts
+++ b/packages/datastore/src/predicates/next.ts
@@ -185,7 +185,7 @@ export class FieldCondition {
 	 * @returns `Promise<boolean>`, `true` if matches; `false` otherwise.
 	 */
 	async matches(item: Record<string, any>): Promise<boolean> {
-		const v = String(item[this.field]);
+		const v = item[this.field];
 		const operations = {
 			eq: () => v === this.operands[0],
 			ne: () => v !== this.operands[0],
@@ -200,7 +200,8 @@ export class FieldCondition {
 		};
 		const operation = operations[this.operator as keyof typeof operations];
 		if (operation) {
-			return operation();
+			const result = operation();
+			return result;
 		} else {
 			throw new Error(`Invalid operator given: ${this.operator}`);
 		}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Predicate filtering logic (used by `observe` and `observeQuery`) was not working correctly against bools, because we were casting field values to strings before comparison. This appears to be cruft from POC work &mdash; I can't otherwise tell why this cast would have been in place.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

Added tests that were red. Made the change. Tests turned green.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
