### PR TITLE
fix(core): add cache-control header to cognito identity client

### DIFF
--- a/packages/amazon-cognito-identity-js/src/Client.js
+++ b/packages/amazon-cognito-identity-js/src/Client.js
@@ -86,7 +86,7 @@ export default class Client {
 			headers,
 			method: 'POST',
 			mode: 'cors',
-			cache: 'no-store',
+			cache: 'no-cache',
 			body: JSON.stringify(params),
 		});
 

--- a/packages/amazon-cognito-identity-js/src/Client.js
+++ b/packages/amazon-cognito-identity-js/src/Client.js
@@ -49,15 +49,20 @@ export default class Client {
 	requestWithRetry(operation, params, callback) {
 		const MAX_DELAY_IN_MILLIS = 5 * 1000;
 
-		jitteredExponentialRetry((p) => new Promise((res, rej) => {
-			this.request(operation, p, (error, result) => {
-				if (error) {
-					rej(error);
-				} else {
-					res(result);
-				}
-			});
-		}), [params], MAX_DELAY_IN_MILLIS)
+		jitteredExponentialRetry(
+			p =>
+				new Promise((res, rej) => {
+					this.request(operation, p, (error, result) => {
+						if (error) {
+							rej(error);
+						} else {
+							res(result);
+						}
+					});
+				}),
+			[params],
+			MAX_DELAY_IN_MILLIS
+		)
 			.then(result => callback(null, result))
 			.catch(error => callback(error));
 	}
@@ -81,7 +86,7 @@ export default class Client {
 			headers,
 			method: 'POST',
 			mode: 'cors',
-			cache: 'no-cache',
+			cache: 'no-store',
 			body: JSON.stringify(params),
 		});
 
@@ -112,9 +117,9 @@ export default class Client {
 				// Taken from aws-sdk-js/lib/protocol/json.js
 				// eslint-disable-next-line no-underscore-dangle
 				const code = (data.__type || data.code).split('#').pop();
-				const error = new Error(data.message || data.Message || null)
-				error.name = code
-				error.code = code
+				const error = new Error(data.message || data.Message || null);
+				error.name = code;
+				error.code = code;
 				return callback(error);
 			})
 			.catch(err => {
@@ -126,17 +131,19 @@ export default class Client {
 				) {
 					try {
 						const code = response.headers.get('x-amzn-errortype').split(':')[0];
-						const error = new Error(response.status ? response.status.toString() : null)
-						error.code = code
-						error.name = code
-						error.statusCode = response.status
+						const error = new Error(
+							response.status ? response.status.toString() : null
+						);
+						error.code = code;
+						error.name = code;
+						error.statusCode = response.status;
 						return callback(error);
 					} catch (ex) {
 						return callback(err);
 					}
 					// otherwise check if error is Network error
 				} else if (err instanceof Error && err.message === 'Network error') {
-					err.code = 'NetworkError'
+					err.code = 'NetworkError';
 				}
 				return callback(err);
 			});
@@ -146,7 +153,7 @@ export default class Client {
 const logger = {
 	debug: () => {
 		// Intentionally blank. This package doesn't have logging
-	}
+	},
 };
 
 /**
@@ -159,7 +166,7 @@ class NonRetryableError extends Error {
 	}
 }
 
-const isNonRetryableError = (obj) => {
+const isNonRetryableError = obj => {
 	const key = 'nonRetryable';
 	return obj && obj[key];
 };
@@ -169,9 +176,13 @@ function retry(functionToRetry, args, delayFn, attempt = 1) {
 		throw Error('functionToRetry must be a function');
 	}
 
-	logger.debug(`${functionToRetry.name} attempt #${attempt} with args: ${JSON.stringify(args)}`);
+	logger.debug(
+		`${functionToRetry.name} attempt #${attempt} with args: ${JSON.stringify(
+			args
+		)}`
+	);
 
-	return functionToRetry(...args).catch((err) => {
+	return functionToRetry(...args).catch(err => {
 		logger.debug(`error on ${functionToRetry.name}`, err);
 
 		if (isNonRetryableError(err)) {
@@ -184,12 +195,13 @@ function retry(functionToRetry, args, delayFn, attempt = 1) {
 		logger.debug(`${functionToRetry.name} retrying in ${retryIn} ms`);
 
 		if (retryIn !== false) {
-			return new Promise(res => setTimeout(res, retryIn))
-					.then(() => retry(functionToRetry, args, delayFn, attempt + 1))
+			return new Promise(res => setTimeout(res, retryIn)).then(() =>
+				retry(functionToRetry, args, delayFn, attempt + 1)
+			);
 		} else {
 			throw err;
 		}
-	})
+	});
 }
 
 function jitteredBackoff(maxDelayMs) {
@@ -203,6 +215,10 @@ function jitteredBackoff(maxDelayMs) {
 }
 
 const MAX_DELAY_MS = 5 * 60 * 1000;
-function jitteredExponentialRetry(functionToRetry, args, maxDelayMs = MAX_DELAY_MS) {
-	return retry(functionToRetry, args, jitteredBackoff(maxDelayMs))
-};
+function jitteredExponentialRetry(
+	functionToRetry,
+	args,
+	maxDelayMs = MAX_DELAY_MS
+) {
+	return retry(functionToRetry, args, jitteredBackoff(maxDelayMs));
+}

--- a/packages/core/__tests__/Credentials-test.ts
+++ b/packages/core/__tests__/Credentials-test.ts
@@ -126,6 +126,9 @@ describe('Credentials test', () => {
 							};
 						}
 					},
+					middlewareStack: {
+						add: (next, _) => {},
+					},
 				};
 			});
 

--- a/packages/core/__tests__/Util-test.ts
+++ b/packages/core/__tests__/Util-test.ts
@@ -7,13 +7,11 @@ import { ConsoleLogger as Logger } from '../src/Logger';
 import { urlSafeDecode, urlSafeEncode } from '../src/Util/StringUtils';
 import { DateUtils } from '../src/Util/DateUtils';
 import { createCognitoIdentityClient } from '../src/Util/CognitoIdentityClient';
-import { BuildMiddleware, HttpRequest, MiddlewareStack } from '@aws-sdk/types';
-import Client from 'amazon-cognito-identity-js/src/Client';
+import { BuildMiddleware, HttpRequest } from '@aws-sdk/types';
 import {
 	GetCredentialsForIdentityCommand,
 	GetIdCommand,
 } from '@aws-sdk/client-cognito-identity';
-import { FromCognitoIdentityParameters } from '@aws-sdk/credential-provider-cognito-identity';
 
 Logger.LOG_LEVEL = 'DEBUG';
 

--- a/packages/core/__tests__/Util-test.ts
+++ b/packages/core/__tests__/Util-test.ts
@@ -66,6 +66,7 @@ describe('Util', () => {
 				region: 'us-west-1',
 			});
 			expect(cognitoClient).toBeTruthy();
+			expect.assertions(1);
 		});
 
 		test('middlewareArgs helper should merge headers into request object', async () => {
@@ -79,6 +80,7 @@ describe('Util', () => {
 			});
 			expect(args.request.headers['test-header']).toEqual('1234');
 			expect(args.request.headers['cache-control']).toEqual('no-store');
+			expect.assertions(2);
 		});
 
 		test('headers should be added by middleware on GetIdCommand', async () => {

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -4,7 +4,6 @@ import { makeQuerablePromise } from './JS';
 import { FacebookOAuth, GoogleOAuth } from './OAuthHelper';
 import { jitteredExponentialRetry } from './Util';
 import { ICredentials } from './types';
-import { getAmplifyUserAgent } from './Platform';
 import { Amplify } from './Amplify';
 import {
 	fromCognitoIdentity,
@@ -13,11 +12,10 @@ import {
 	FromCognitoIdentityPoolParameters,
 } from '@aws-sdk/credential-provider-cognito-identity';
 import {
-	CognitoIdentityClient,
 	GetIdCommand,
 	GetCredentialsForIdentityCommand,
 } from '@aws-sdk/client-cognito-identity';
-import { CredentialProvider, Provider } from '@aws-sdk/types';
+import { CredentialProvider } from '@aws-sdk/types';
 import { parseAWSExports } from './parseAWSExports';
 import { Hub } from './Hub';
 import { createCognitoIdentityClient } from './Util/CognitoIdentityClient';

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -265,7 +265,8 @@ export class CredentialsClass {
 				parseAWSExports(this._config || {}).Auth
 			);
 		}
-		const { identityPoolId, region, mandatorySignIn, identityPoolRegion } = this._config;
+		const { identityPoolId, region, mandatorySignIn, identityPoolRegion } =
+			this._config;
 
 		if (mandatorySignIn) {
 			return Promise.reject(
@@ -295,6 +296,16 @@ export class CredentialsClass {
 			region: identityPoolRegion || region,
 			customUserAgent: getAmplifyUserAgent(),
 		});
+
+		cognitoClient.middlewareStack.add(
+			(next, _) => (args: any) => {
+				args.request.headers['cache-control'] = 'no-store';
+				return next(args);
+			},
+			{
+				step: 'build',
+			}
+		);
 
 		let credentials = undefined;
 		if (identityId) {
@@ -413,6 +424,16 @@ export class CredentialsClass {
 			customUserAgent: getAmplifyUserAgent(),
 		});
 
+		cognitoClient.middlewareStack.add(
+			(next, _) => (args: any) => {
+				args.request.headers['cache-control'] = 'no-store';
+				return next(args);
+			},
+			{
+				step: 'build',
+			}
+		);
+
 		let credentials = undefined;
 		if (identity_id) {
 			const cognitoIdentityParams: FromCognitoIdentityParameters = {
@@ -435,7 +456,8 @@ export class CredentialsClass {
 	private _setCredentialsFromSession(session): Promise<ICredentials> {
 		logger.debug('set credentials from session');
 		const idToken = session.getIdToken().getJwtToken();
-		const { region, userPoolId, identityPoolId, identityPoolRegion } = this._config;
+		const { region, userPoolId, identityPoolId, identityPoolRegion } =
+			this._config;
 		if (!identityPoolId) {
 			logger.debug('No Cognito Federated Identity pool provided');
 			return Promise.reject('No Cognito Federated Identity pool provided');
@@ -454,6 +476,16 @@ export class CredentialsClass {
 			region: identityPoolRegion || region,
 			customUserAgent: getAmplifyUserAgent(),
 		});
+
+		cognitoClient.middlewareStack.add(
+			(next, _) => (args: any) => {
+				args.request.headers['cache-control'] = 'no-store';
+				return next(args);
+			},
+			{
+				step: 'build',
+			}
+		);
 
 		/* 
 			Retreiving identityId with GetIdCommand to mimic the behavior in the following code in aws-sdk-v3:

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -17,9 +17,10 @@ import {
 	GetIdCommand,
 	GetCredentialsForIdentityCommand,
 } from '@aws-sdk/client-cognito-identity';
-import { CredentialProvider } from '@aws-sdk/types';
+import { CredentialProvider, Provider } from '@aws-sdk/types';
 import { parseAWSExports } from './parseAWSExports';
 import { Hub } from './Hub';
+import { createCognitoIdentityClient } from './Util/CognitoIdentityClient';
 
 const logger = new Logger('Credentials');
 
@@ -292,19 +293,8 @@ export class CredentialsClass {
 
 		const identityId = (this._identityId = await this._getGuestIdentityId());
 
-		const cognitoClient = new CognitoIdentityClient({
-			region: identityPoolRegion || region,
-			customUserAgent: getAmplifyUserAgent(),
-		});
-
-		cognitoClient.middlewareStack.add(
-			(next, _) => (args: any) => {
-				args.request.headers['cache-control'] = 'no-store';
-				return next(args);
-			},
-			{
-				step: 'build',
-			}
+		const cognitoClient = createCognitoIdentityClient(
+			identityPoolRegion || region
 		);
 
 		let credentials = undefined;
@@ -419,19 +409,8 @@ export class CredentialsClass {
 			);
 		}
 
-		const cognitoClient = new CognitoIdentityClient({
-			region: identityPoolRegion || region,
-			customUserAgent: getAmplifyUserAgent(),
-		});
-
-		cognitoClient.middlewareStack.add(
-			(next, _) => (args: any) => {
-				args.request.headers['cache-control'] = 'no-store';
-				return next(args);
-			},
-			{
-				step: 'build',
-			}
+		const cognitoClient = createCognitoIdentityClient(
+			identityPoolRegion || region
 		);
 
 		let credentials = undefined;
@@ -472,19 +451,8 @@ export class CredentialsClass {
 		const logins = {};
 		logins[key] = idToken;
 
-		const cognitoClient = new CognitoIdentityClient({
-			region: identityPoolRegion || region,
-			customUserAgent: getAmplifyUserAgent(),
-		});
-
-		cognitoClient.middlewareStack.add(
-			(next, _) => (args: any) => {
-				args.request.headers['cache-control'] = 'no-store';
-				return next(args);
-			},
-			{
-				step: 'build',
-			}
+		const cognitoClient = createCognitoIdentityClient(
+			identityPoolRegion || region
 		);
 
 		/* 

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -297,16 +297,6 @@ export class CredentialsClass {
 			identityPoolRegion || region
 		);
 
-		cognitoClient.middlewareStack.add(
-			(next, _) => (args: any) => {
-				args.request.headers['cache-control'] = 'no-store';
-				return next(args);
-			},
-			{
-				step: 'build',
-			}
-		);
-
 		let credentials = undefined;
 		if (identityId) {
 			const cognitoIdentityParams: FromCognitoIdentityParameters = {
@@ -423,16 +413,6 @@ export class CredentialsClass {
 			identityPoolRegion || region
 		);
 
-		cognitoClient.middlewareStack.add(
-			(next, _) => (args: any) => {
-				args.request.headers['cache-control'] = 'no-store';
-				return next(args);
-			},
-			{
-				step: 'build',
-			}
-		);
-
 		let credentials = undefined;
 		if (identity_id) {
 			const cognitoIdentityParams: FromCognitoIdentityParameters = {
@@ -473,16 +453,6 @@ export class CredentialsClass {
 
 		const cognitoClient = createCognitoIdentityClient(
 			identityPoolRegion || region
-		);
-
-		cognitoClient.middlewareStack.add(
-			(next, _) => (args: any) => {
-				args.request.headers['cache-control'] = 'no-store';
-				return next(args);
-			},
-			{
-				step: 'build',
-			}
 		);
 
 		/* 

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -291,9 +291,9 @@ export class CredentialsClass {
 
 		const identityId = (this._identityId = await this._getGuestIdentityId());
 
-		const cognitoClient = createCognitoIdentityClient(
-			identityPoolRegion || region
-		);
+		const cognitoClient = createCognitoIdentityClient({
+			region: identityPoolRegion || region,
+		});
 
 		let credentials = undefined;
 		if (identityId) {
@@ -407,9 +407,9 @@ export class CredentialsClass {
 			);
 		}
 
-		const cognitoClient = createCognitoIdentityClient(
-			identityPoolRegion || region
-		);
+		const cognitoClient = createCognitoIdentityClient({
+			region: identityPoolRegion || region,
+		});
 
 		let credentials = undefined;
 		if (identity_id) {
@@ -449,9 +449,9 @@ export class CredentialsClass {
 		const logins = {};
 		logins[key] = idToken;
 
-		const cognitoClient = createCognitoIdentityClient(
-			identityPoolRegion || region
-		);
+		const cognitoClient = createCognitoIdentityClient({
+			region: identityPoolRegion || region,
+		});
 
 		/* 
 			Retreiving identityId with GetIdCommand to mimic the behavior in the following code in aws-sdk-v3:

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -297,6 +297,16 @@ export class CredentialsClass {
 			identityPoolRegion || region
 		);
 
+		cognitoClient.middlewareStack.add(
+			(next, _) => (args: any) => {
+				args.request.headers['cache-control'] = 'no-store';
+				return next(args);
+			},
+			{
+				step: 'build',
+			}
+		);
+
 		let credentials = undefined;
 		if (identityId) {
 			const cognitoIdentityParams: FromCognitoIdentityParameters = {
@@ -413,6 +423,16 @@ export class CredentialsClass {
 			identityPoolRegion || region
 		);
 
+		cognitoClient.middlewareStack.add(
+			(next, _) => (args: any) => {
+				args.request.headers['cache-control'] = 'no-store';
+				return next(args);
+			},
+			{
+				step: 'build',
+			}
+		);
+
 		let credentials = undefined;
 		if (identity_id) {
 			const cognitoIdentityParams: FromCognitoIdentityParameters = {
@@ -453,6 +473,16 @@ export class CredentialsClass {
 
 		const cognitoClient = createCognitoIdentityClient(
 			identityPoolRegion || region
+		);
+
+		cognitoClient.middlewareStack.add(
+			(next, _) => (args: any) => {
+				args.request.headers['cache-control'] = 'no-store';
+				return next(args);
+			},
+			{
+				step: 'build',
+			}
 		);
 
 		/* 

--- a/packages/core/src/Util/CognitoIdentityClient.ts
+++ b/packages/core/src/Util/CognitoIdentityClient.ts
@@ -1,20 +1,23 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity';
+import {
+	CognitoIdentityClient,
+	CognitoIdentityClientConfig,
+} from '@aws-sdk/client-cognito-identity';
 import { Provider } from '@aws-sdk/types';
 import { getAmplifyUserAgent } from '../Platform';
 
 /**
  * Returns a CognitoIdentityClient with middleware
- * @param {string} region
+ * @param {CognitoIdentityClientConfig} config
  * @return {CognitoIdentityClient}
  */
 export function createCognitoIdentityClient(
-	region: string | Provider<string> | undefined
+	config: CognitoIdentityClientConfig
 ): CognitoIdentityClient {
 	const client = new CognitoIdentityClient({
-		region,
+		region: config.region,
 		customUserAgent: getAmplifyUserAgent(),
 	});
 
@@ -31,7 +34,7 @@ export function createCognitoIdentityClient(
 	return client;
 }
 
-function middlewareArgs(args: { request: { headers: any }; input: any }) {
+export function middlewareArgs(args: { request: any; input: any }) {
 	return {
 		...args,
 		request: {

--- a/packages/core/src/Util/CognitoIdentityClient.ts
+++ b/packages/core/src/Util/CognitoIdentityClient.ts
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity';
+import { Provider } from '@aws-sdk/types';
+import { getAmplifyUserAgent } from '../Platform';
+
+/**
+ * Returns a CognitoIdentityClient with middleware
+ * @param {string} region
+ * @return {CognitoIdentityClient}
+ */
+export function createCognitoIdentityClient(
+	region: string | Provider<string> | undefined
+): CognitoIdentityClient {
+	const client = new CognitoIdentityClient({
+		region,
+		customUserAgent: getAmplifyUserAgent(),
+	});
+
+	client.middlewareStack.add(
+		(next, _) => (args: any) => {
+			return next(middlewareArgs(args));
+		},
+		{
+			step: 'build',
+			name: 'cacheControlMiddleWare',
+		}
+	);
+
+	return client;
+}
+
+function middlewareArgs(args: { request: { headers: any }; input: any }) {
+	return {
+		...args,
+		request: {
+			...args.request,
+			headers: {
+				...args.request.headers,
+				'cache-control': 'no-store',
+			},
+		},
+	};
+}


### PR DESCRIPTION
#### Description of changes
Adds the cache-control 'no-store' header via middleware to the various instantiations of the Cognito Identity Pool Client.

Please note: the `Credentials` file instantiates the cognito client multiple times - most likely needlessly. I've left this in place, though, to minimize the scope of the change.

#### Description of how you validated changes
Manual testing.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
