### PR TITLE
chore: log a warning when DataStore is ignoring an attempted PK update

### DIFF
--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -2096,6 +2096,8 @@ describe('DataStore tests', () => {
 		});
 
 		test('Id cannot be changed inside copyOf', () => {
+			const consoleWarn = jest.spyOn(console, 'warn');
+
 			const { Model } = initSchema(testSchema()) as {
 				Model: PersistentModelConstructor<Model>;
 			};
@@ -2111,6 +2113,16 @@ describe('DataStore tests', () => {
 
 			// ID should be kept the same
 			expect(model1.id).toBe(model2.id);
+
+			// we should always be told *in some way* when an "update" will not actually
+			// be applied. for now, this is a warning, because throwing an error, updating
+			// the record's PK, or creating a new record are all breaking changes.
+			expect(consoleWarn).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"copyOf() does not update PK fields. The 'id' update is being ignored."
+				),
+				expect.objectContaining({ source: model1 })
+			);
 		});
 
 		test('Optional field can be initialized with undefined', () => {
@@ -3629,6 +3641,8 @@ describe('DataStore tests', () => {
 			});
 
 			test('postId cannot be changed inside copyOf', () => {
+				const consoleWarn = jest.spyOn(console, 'warn');
+
 				const { PostCustomPK } = initSchema(testSchema()) as {
 					PostCustomPK: PersistentModelConstructor<PostCustomPKType>;
 				};
@@ -3645,6 +3659,16 @@ describe('DataStore tests', () => {
 
 				// postId should be kept the same
 				expect(model1.postId).toBe(model2.postId);
+
+				// we should always be told *in some way* when an "update" will not actually
+				// be applied. for now, this is a warning, because throwing an error, updating
+				// the record's PK, or creating a new record are all breaking changes.
+				expect(consoleWarn).toHaveBeenCalledWith(
+					expect.stringContaining(
+						"copyOf() does not update PK fields. The 'postId' update is being ignored."
+					),
+					expect.objectContaining({ source: model1 })
+				);
 			});
 
 			test('Optional field can be initialized with undefined', () => {

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -826,7 +826,15 @@ const createModelClass = <T extends PersistentModel>(
 
 					const keyNames = extractPrimaryKeyFieldNames(modelDefinition);
 					// Keys are immutable
-					keyNames.forEach(key => ((draft as Object)[key] = source[key]));
+					keyNames.forEach(key => {
+						if (draft[key] !== source[key]) {
+							logger.warn(
+								`copyOf() does not update PK fields. The '${key}' update is being ignored.`,
+								{ source }
+							);
+						}
+						(draft as Object)[key] = source[key];
+					});
 
 					const modelValidator = validateModelFields(modelDefinition);
 					Object.entries(draft).forEach(([k, v]) => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

DataStore does not update PK values on existing records. This behavior is by design, but has proven to be confusing when customers are not aware of it. This PR attempts to inform customers by logging a warning when a `copyOf` invocation attempts to update a PK field.

Warnings will look similar to this:

```
[WARN] 32:03.272 DataStore - copyOf() does not update PK fields. The 'id' update is being ignored. {
  source: Model {
    field1: 'something',
    dateCreated: '2022-12-09T16:32:03.272Z',
    id: 'b47c45a9-7ac4-405b-a07f-152fda83813c',
    _version: undefined,
    _lastChangedAt: undefined,
    _deleted: undefined
  }
}
```

We considered changes to this `save()` behavior to update the item, create a new item, or throw an error. But, these have been deemed breaking changes. This change will provide some guidance without breaking changes.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

Added tests to spy on console warn calls.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
