### PR TITLE
fix(@aws-amplify/datastore): nextjs/swc broken build workaround

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2050,7 +2050,7 @@ workflows:
             - integ_react_datastore_selective_sync
             - integ_react_datastore_nested_predicate
             - integ_next_datastore_13_basic
-            - integ_next_datastore_13
+            # - integ_next_datastore_13
             - integ_next_datastore_13_js
       - post_release:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,6 +391,7 @@ jobs:
             echo $SSH_HOST_PUBLIC_KEY >> ~/.ssh/known_hosts
             git clone $AMPLIFY_JS_SAMPLES_STAGING_URL
             cd amplify-js-samples-staging
+            git checkout ds-nextjs-13
             branchExists=true
             git ls-remote --heads origin <<pipeline.git.branch>> | grep <<pipeline.git.branch>> >/dev/null || branchExists=false
             if [ "$branchExists" = true ]; then git checkout <<pipeline.git.branch>>; fi
@@ -1354,6 +1355,57 @@ jobs:
           spec: nested-predicate
           browser: << parameters.browser >>
 
+  integ_next_datastore_13_basic:
+    parameters:
+      browser:
+        type: string
+    executor: js-test-executor
+    <<: *test_env_vars
+    working_directory: ~/amplify-js-samples-staging/samples/next/datastore/nextjs-13-basic
+    steps:
+      - prepare_test_env
+      - integ_test_js:
+          test_name: 'DataStore - Nextjs basic'
+          framework: nextjs
+          category: datastore
+          sample_name: nextjs-13-basic
+          spec: nextjs-13-basic
+          browser: << parameters.browser >>
+
+  integ_next_datastore_13:
+    parameters:
+      browser:
+        type: string
+    executor: js-test-executor
+    <<: *test_env_vars
+    working_directory: ~/amplify-js-samples-staging/samples/next/datastore/nextjs-13
+    steps:
+      - prepare_test_env
+      - integ_test_js:
+          test_name: 'DataStore - Nextjs TS'
+          framework: nextjs
+          category: datastore
+          sample_name: nextjs-13
+          spec: nextjs-13
+          browser: << parameters.browser >>
+
+  integ_next_datastore_13_js:
+    parameters:
+      browser:
+        type: string
+    executor: js-test-executor
+    <<: *test_env_vars
+    working_directory: ~/amplify-js-samples-staging/samples/next/datastore/nextjs-13-js
+    steps:
+      - prepare_test_env
+      - integ_test_js:
+          test_name: 'DataStore - Nextjs JS'
+          framework: nextjs
+          category: datastore
+          sample_name: nextjs-13-js
+          spec: nextjs-13
+          browser: << parameters.browser >>
+
   deploy:
     executor: macos-executor
     working_directory: ~/amplify-js
@@ -1407,6 +1459,7 @@ releasable_branches: &releasable_branches
       - 1.0-stable
       - geo/main
       - in-app-messaging/main
+      - ds-nextjs-workaround
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]
@@ -1910,7 +1963,33 @@ workflows:
           matrix:
             parameters:
               <<: *test_browsers
-
+      - integ_next_datastore_13_basic:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+          matrix:
+            parameters:
+              <<: *test_browsers
+      - integ_next_datastore_13:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+          matrix:
+            parameters:
+              <<: *test_browsers
+      - integ_next_datastore_13_js:
+          requires:
+            - integ_setup
+            - build
+          filters:
+            <<: *releasable_branches
+          matrix:
+            parameters:
+              <<: *test_browsers
       - deploy:
           filters:
             <<: *releasable_branches
@@ -1970,6 +2049,9 @@ workflows:
             - integ_react_api_reconnect
             - integ_react_datastore_selective_sync
             - integ_react_datastore_nested_predicate
+            - integ_next_datastore_13_basic
+            - integ_next_datastore_13
+            - integ_next_datastore_13_js
       - post_release:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1364,28 +1364,11 @@ jobs:
     steps:
       - prepare_test_env
       - integ_test_js:
-          test_name: 'DataStore - Nextjs basic'
+          test_name: 'DataStore - Nextjs 13 build with SWC - basic JS app'
           framework: next
           category: datastore
           sample_name: next-13-basic
           spec: nextjs-13-basic
-          browser: << parameters.browser >>
-
-  integ_next_datastore_13:
-    parameters:
-      browser:
-        type: string
-    executor: js-test-executor
-    <<: *test_env_vars
-    working_directory: ~/amplify-js-samples-staging/samples/next/datastore/next-13
-    steps:
-      - prepare_test_env
-      - integ_test_js:
-          test_name: 'DataStore - Nextjs TS'
-          framework: next
-          category: datastore
-          sample_name: next-13
-          spec: nextjs-13
           browser: << parameters.browser >>
 
   integ_next_datastore_13_js:
@@ -1398,7 +1381,7 @@ jobs:
     steps:
       - prepare_test_env
       - integ_test_js:
-          test_name: 'DataStore - Nextjs JS'
+          test_name: 'DataStore - Nextjs 13 build with SWC - JS app'
           framework: next
           category: datastore
           sample_name: next-13-js
@@ -1970,15 +1953,6 @@ workflows:
           matrix:
             parameters:
               <<: *test_browsers
-      # - integ_next_datastore_13:
-      #     requires:
-      #       - integ_setup
-      #       - build
-      #     filters:
-      #       <<: *releasable_branches
-      #     matrix:
-      #       parameters:
-      #         <<: *test_browsers
       - integ_next_datastore_13_js:
           requires:
             - integ_setup
@@ -2048,7 +2022,6 @@ workflows:
             - integ_react_datastore_selective_sync
             - integ_react_datastore_nested_predicate
             - integ_next_datastore_13_basic
-            # - integ_next_datastore_13
             - integ_next_datastore_13_js
       - post_release:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1361,14 +1361,14 @@ jobs:
         type: string
     executor: js-test-executor
     <<: *test_env_vars
-    working_directory: ~/amplify-js-samples-staging/samples/next/datastore/nextjs-13-basic
+    working_directory: ~/amplify-js-samples-staging/samples/next/datastore/next-13-basic
     steps:
       - prepare_test_env
       - integ_test_js:
           test_name: 'DataStore - Nextjs basic'
           framework: next
           category: datastore
-          sample_name: nextjs-13-basic
+          sample_name: next-13-basic
           spec: nextjs-13-basic
           browser: << parameters.browser >>
 
@@ -1378,14 +1378,14 @@ jobs:
         type: string
     executor: js-test-executor
     <<: *test_env_vars
-    working_directory: ~/amplify-js-samples-staging/samples/next/datastore/nextjs-13
+    working_directory: ~/amplify-js-samples-staging/samples/next/datastore/next-13
     steps:
       - prepare_test_env
       - integ_test_js:
           test_name: 'DataStore - Nextjs TS'
           framework: next
           category: datastore
-          sample_name: nextjs-13
+          sample_name: next-13
           spec: nextjs-13
           browser: << parameters.browser >>
 
@@ -1395,14 +1395,14 @@ jobs:
         type: string
     executor: js-test-executor
     <<: *test_env_vars
-    working_directory: ~/amplify-js-samples-staging/samples/next/datastore/nextjs-13-js
+    working_directory: ~/amplify-js-samples-staging/samples/next/datastore/next-13-js
     steps:
       - prepare_test_env
       - integ_test_js:
           test_name: 'DataStore - Nextjs JS'
           framework: next
           category: datastore
-          sample_name: nextjs-13-js
+          sample_name: next-13-js
           spec: nextjs-13
           browser: << parameters.browser >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1366,7 +1366,7 @@ jobs:
       - prepare_test_env
       - integ_test_js:
           test_name: 'DataStore - Nextjs basic'
-          framework: nextjs
+          framework: next
           category: datastore
           sample_name: nextjs-13-basic
           spec: nextjs-13-basic
@@ -1383,7 +1383,7 @@ jobs:
       - prepare_test_env
       - integ_test_js:
           test_name: 'DataStore - Nextjs TS'
-          framework: nextjs
+          framework: next
           category: datastore
           sample_name: nextjs-13
           spec: nextjs-13
@@ -1400,7 +1400,7 @@ jobs:
       - prepare_test_env
       - integ_test_js:
           test_name: 'DataStore - Nextjs JS'
-          framework: nextjs
+          framework: next
           category: datastore
           sample_name: nextjs-13-js
           spec: nextjs-13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1972,15 +1972,15 @@ workflows:
           matrix:
             parameters:
               <<: *test_browsers
-      - integ_next_datastore_13:
-          requires:
-            - integ_setup
-            - build
-          filters:
-            <<: *releasable_branches
-          matrix:
-            parameters:
-              <<: *test_browsers
+      # - integ_next_datastore_13:
+      #     requires:
+      #       - integ_setup
+      #       - build
+      #     filters:
+      #       <<: *releasable_branches
+      #     matrix:
+      #       parameters:
+      #         <<: *test_browsers
       - integ_next_datastore_13_js:
           requires:
             - integ_setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,7 +391,6 @@ jobs:
             echo $SSH_HOST_PUBLIC_KEY >> ~/.ssh/known_hosts
             git clone $AMPLIFY_JS_SAMPLES_STAGING_URL
             cd amplify-js-samples-staging
-            git checkout ds-nextjs-13
             branchExists=true
             git ls-remote --heads origin <<pipeline.git.branch>> | grep <<pipeline.git.branch>> >/dev/null || branchExists=false
             if [ "$branchExists" = true ]; then git checkout <<pipeline.git.branch>>; fi
@@ -1459,7 +1458,6 @@ releasable_branches: &releasable_branches
       - 1.0-stable
       - geo/main
       - in-app-messaging/main
-      - ds-nextjs-workaround
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -818,7 +818,7 @@ const createModelClass = <T extends PersistentModel>(
 				throw new Error(msg);
 			}
 
-			let patches;
+			let patches: Patch[] = [];
 			const model = produce(
 				source,
 				draft => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

NextJS 13 enables SWC by default, which sometimes mangles the the build. This PR does two things:

1. Adds integ tests for sample apps that attempt to trigger bad nextjs builds
2. Adds a workaround for one known case, where SWC was over-aggressively dropping a variable declaration, resulting in an exception several lines later.

Note: Depends on https://github.com/aws-amplify/amplify-js-samples-staging/pull/494

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#10732

#### Description of how you validated changes

Runtime failures were seen as in #10732 with NextJS@13 *prod* builds. The breakage was isolated by inserting dummy console logs with unique strings to help us determine where we were in the resulting minified build. By doing so, we could see that a variable declaration and later assignment were being eliminated entirely. Setting the var to a default value caused SWC to leave the declaration in and resolved runtime issues.

One of the newly added integ tests (the "basic" one) successfully triggers the error in CI on prod builds without the fix. The fix makes it pass in CI.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
