### PR TITLE
fix: Add v4-stable release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,6 +388,7 @@ jobs:
             echo $SSH_HOST_PUBLIC_KEY >> ~/.ssh/known_hosts
             git clone $AMPLIFY_JS_SAMPLES_STAGING_URL
             cd amplify-js-samples-staging
+            git checkout v4-stable
             yarn
       - save_cache:
           key: amplify-js-{{ .Branch }}-{{ checksum "amplify-js-samples-staging/yarn.lock" }}
@@ -1285,6 +1286,7 @@ releasable_branches: &releasable_branches
     only:
       - release
       - main
+      - v4-stable
       - ui-components/main
       - 1.0-stable
       - geo/main

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"publish:beta": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=beta --preid=beta --exact --no-verify-access",
 		"publish:release": "lerna publish --conventional-commits --yes --message 'chore(release): Publish [ci skip]' --no-verify-access",
 		"publish:1.0-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-1.0 --message 'chore(release): Publish [ci skip]' --no-verify-access",
+		"publish:v4-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-4 --message 'chore(release): Publish [ci skip]' --no-verify-access",
 		"publish:ui-components/main": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=ui-preview --preid=ui-preview --exact --no-verify-access",
 		"publish:verdaccio": "lerna publish --no-push --canary minor --dist-tag=unstable --preid=unstable --exact --force-publish --yes --no-verify-access",
 		"publish:geo/main": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=geo --preid=geo --exact --no-verify-access"


### PR DESCRIPTION
#### Description of changes
Introduce a process to publish changes to the `stable-4` tag on npm, triggered by merges to the `v4-stable` branch.

#### Description of how you validated changes
Tested by setting up verdaccio and using the new publish command.

```sh
yarn publish:v4-stable
```

(Ensured `origin` was set to my repo to be confident that no github tag issues where introduced)

Outcome:
![Screen Shot 2022-12-12 at 3 18 07 PM](https://user-images.githubusercontent.com/94858815/207157790-1c4fd325-923e-4b92-9f51-698085164772.png)


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
