### PR TITLE
Removes old AppSyncProvider to load automatically on PubSub

### DIFF
--- a/packages/pubsub/__tests__/PubSub-unit-test.ts
+++ b/packages/pubsub/__tests__/PubSub-unit-test.ts
@@ -16,15 +16,9 @@ import {
 	mqttTopicMatch,
 } from '../src/Providers';
 
-import {
-	Credentials,
-	Hub,
-	INTERNAL_AWS_APPSYNC_REALTIME_PUBSUB_PROVIDER,
-	Logger,
-	Reachability,
-} from '@aws-amplify/core';
+import { Credentials, Reachability } from '@aws-amplify/core';
 import * as Paho from 'paho-mqtt';
-import { ConnectionState, CONNECTION_STATE_CHANGE } from '../src';
+import { ConnectionState } from '../src';
 import { HubConnectionListener } from './helpers';
 import Observable from 'zen-observable-ts';
 import * as constants from '../src/Providers/constants';

--- a/packages/pubsub/src/PubSub.ts
+++ b/packages/pubsub/src/PubSub.ts
@@ -7,11 +7,10 @@ import {
 	Amplify,
 	browserOrNode,
 	ConsoleLogger as Logger,
-	INTERNAL_AWS_APPSYNC_PUBSUB_PROVIDER,
 	INTERNAL_AWS_APPSYNC_REALTIME_PUBSUB_PROVIDER,
 } from '@aws-amplify/core';
 import { PubSubProvider, PubSubOptions, ProviderOptions } from './types';
-import { AWSAppSyncProvider, AWSAppSyncRealTimeProvider } from './Providers';
+import { AWSAppSyncRealTimeProvider } from './Providers';
 
 const { isNode } = browserOrNode();
 const logger = new Logger('PubSub');
@@ -22,24 +21,9 @@ export class PubSubClass {
 	private _pluggables: PubSubProvider[];
 
 	/**
-	 * Internal instance of AWSAppSyncProvider used by the API category to subscribe to AppSync
-	 */
-	private _awsAppSyncProvider?: AWSAppSyncProvider;
-
-	/**
 	 * Internal instance of AWSAppSyncRealTimeProvider used by the API category to subscribe to AppSync
 	 */
 	private _awsAppSyncRealTimeProvider?: AWSAppSyncRealTimeProvider;
-
-	/**
-	 * Lazy instantiate AWSAppSyncProvider when it is required by the API category
-	 */
-	private get awsAppSyncProvider() {
-		if (!this._awsAppSyncProvider) {
-			this._awsAppSyncProvider = new AWSAppSyncProvider(this._options);
-		}
-		return this._awsAppSyncProvider;
-	}
 
 	/**
 	 * Lazy instantiate AWSAppSyncRealTimeProvider when it is required by the API category
@@ -111,9 +95,6 @@ export class PubSubClass {
 	}
 
 	private getProviderByName(providerName: string | symbol) {
-		if (providerName === INTERNAL_AWS_APPSYNC_PUBSUB_PROVIDER) {
-			return this.awsAppSyncProvider;
-		}
 		if (providerName === INTERNAL_AWS_APPSYNC_REALTIME_PUBSUB_PROVIDER) {
 			return this.awsAppSyncRealTimeProvider;
 		}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Remove old `AppSyncProvider` to be loaded from `PubSub` module. This reduces bundle size in `9.8KB` when using `API.graphql`.

This is not a breaking change because since version`@aws-amplify/api@2.x` that provider has not been used by `API` category anymore. 


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->


#### Description of how you validated changes
Tested on local App.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
