### PR TITLE
Adds config client metadata to sign up function

### DIFF
--- a/packages/auth/src/Providers/AmazonCognitoProvider.ts
+++ b/packages/auth/src/Providers/AmazonCognitoProvider.ts
@@ -88,7 +88,7 @@ export class AmazonCognitoProvider implements AuthPluginProvider {
 		const userAttr: AttributeType[] | undefined = this.mapAttributes(req.options?.userAttributes);
 
 		let validationData: AttributeType[] | undefined;
-		let clientMetadata: Record<string, string> | undefined;
+		let clientMetadata: Record<string, string> | undefined = this._config.clientMetadata;
 		const pluginOptions = req.options?.pluginOptions;
 		if (pluginOptions) {
 			// TODO: change to pluginOptions.ValidationData if type of PluginOptions is mapped

--- a/packages/auth/src/types/aws-plugins/cognito-plugin/types/models/authOptions.ts
+++ b/packages/auth/src/types/aws-plugins/cognito-plugin/types/models/authOptions.ts
@@ -15,7 +15,7 @@ export type AuthOptions = {
 	storage?: CognitoStorage;
 	authenticationFlowType?: string;
 	identityPoolRegion?: string;
-	clientMetaData?: ClientMetadata;
+	clientMetadata?: ClientMetadata;
 	endpoint?: string;
 	signUpVerificationMethod?: 'code' | 'link';
 };

--- a/packages/auth/src/types/models/index.ts
+++ b/packages/auth/src/types/models/index.ts
@@ -6,7 +6,7 @@ import { AuthCodeDeliveryDetails, DeliveryMedium } from './authCodeDeliveryDetai
 import { AuthNextSignInStep } from './authNextSignInStep';
 import { AuthNextSignUpStep } from './authNextSignUpStep';
 import { AuthPluginOptions } from './authPluginOptions';
-import { AuthPluginProvider } from './AuthPluginProvider';
+import { AuthPluginProvider } from './authPluginProvider';
 import { AuthSignInStep } from './authSignInStep';
 import { AuthSignUpStep } from './authSignUpStep';
 import { AuthUserAttribute } from './authUserAttribute';


### PR DESCRIPTION

#### Description of changes
adds clientMetadata from auth config to sign up function


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
