### PR TITLE
fix: For bug when cookies are disabled using window side-effects

### DIFF
--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -10,7 +10,9 @@
   },
   "sideEffects": [
     "./lib/PubSub.js",
-    "./lib-esm/PubSub.js"
+    "./lib-esm/PubSub.js",
+    "./lib/utils/PatchLocalStorage.js",
+    "./lib-esm/utils/PatchLocalStorage.js"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/pubsub/src/Providers/MqttOverWSProvider.ts
+++ b/packages/pubsub/src/Providers/MqttOverWSProvider.ts
@@ -1,5 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+import { reinstateLocalStorageError } from '../utils/PatchLocalStorage';
 import * as Paho from 'paho-mqtt';
 import { v4 as uuid } from 'uuid';
 import Observable, { ZenObservable } from 'zen-observable-ts';
@@ -19,6 +21,8 @@ import {
 import { AMPLIFY_SYMBOL, CONNECTION_STATE_CHANGE } from './constants';
 
 const logger = new Logger('MqttOverWSProvider');
+
+reinstateLocalStorageError();
 
 export function mqttTopicMatch(filter: string, topic: string) {
 	const filterArray = filter.split('/');

--- a/packages/pubsub/src/utils/PatchLocalStorage.ts
+++ b/packages/pubsub/src/utils/PatchLocalStorage.ts
@@ -1,0 +1,34 @@
+import { ConsoleLogger as Logger } from '@aws-amplify/core';
+
+const logger = new Logger('PatchLocalStorage');
+
+let error = undefined;
+
+function patchLocalStorage() {
+	try {
+		console.log('before');
+		const x = window['localStorage'];
+		console.log('after');
+		window.localStorage;
+	} catch (e) {
+		logger.error(e);
+		error = e;
+		Object.defineProperty(window, 'localStorage', {
+			value: null,
+		});
+	}
+}
+
+export function reinstateLocalStorageError() {
+	console.log('Put back?');
+	if (error) {
+		console.log('Putting it back');
+		Object.defineProperty(window, 'localStorage', {
+			get: () => {
+				throw error;
+			},
+		});
+	}
+}
+
+patchLocalStorage();

--- a/packages/pubsub/src/utils/PatchLocalStorage.ts
+++ b/packages/pubsub/src/utils/PatchLocalStorage.ts
@@ -6,9 +6,6 @@ let error = undefined;
 
 function patchLocalStorage() {
 	try {
-		console.log('before');
-		const x = window['localStorage'];
-		console.log('after');
 		window.localStorage;
 	} catch (e) {
 		logger.error(e);
@@ -20,9 +17,7 @@ function patchLocalStorage() {
 }
 
 export function reinstateLocalStorageError() {
-	console.log('Put back?');
 	if (error) {
-		console.log('Putting it back');
 		Object.defineProperty(window, 'localStorage', {
 			get: () => {
 				throw error;


### PR DESCRIPTION
#### Description of changes

As an alternative to pulling in and[ fixing the paho-mqtt vendor library](https://github.com/aws-amplify/amplify-js/pull/10841), this uses side-effects to catch the localStorage error, which it then replaces after Paho has loaded.

The replacement is shallow and this may very well result in unexpected side-effects in other libraries behavior.

#### Issue #, if available


#### Description of how you validated changes

Tested by:
- loading the page with cookies enabled to confirm the base case works as expected
- loading the page with cookies disabled to confirm that the page works with mqtt in this case as well


#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
