### PR TITLE
feat(auth): implement addMachineIfAbsent and pass unit test

### DIFF
--- a/packages/auth/__tests__/state-machine-manager-test.ts
+++ b/packages/auth/__tests__/state-machine-manager-test.ts
@@ -1,71 +1,147 @@
-import { Machine } from '../src/stateMachine/machine';
+import { Logger } from '@aws-amplify/core';
 import { MachineManager } from '../src/stateMachine/stateMachineManager';
+import { Context, TickEvent, tickTockMachine } from './utils/tickTockMachine';
+import { Machine } from '../src/stateMachine/machine';
+import { TransitionEffect } from '../src/stateMachine/types';
 
 describe(MachineManager.name, () => {
-	const wait = (ms: number) =>
-		new Promise<void>(resolve => {
-			setTimeout(() => {
-				resolve();
-			}, ms);
-		});
-	type Context = {
-		events: Events[];
-	};
-	type Events = {
-		name: 'tick' | 'tock';
-		payload: {
-			recordId: string;
-		};
-	};
-	type Machine1States = 'StateA' | 'StateB';
-	const machine1 = new Machine<Context, Events, Machine1States>({
-		context: { events: [] },
-		name: 'Machine1' as const,
-		initial: 'StateA',
-		states: {
-			StateA: {
-				tick: [
-					{
-						nextState: 'StateB',
-						effects: [
-							async (ctxt, event, broker) => {
-								console.log('tick');
-								await wait(1000);
-								broker.dispatch({
-									name: 'tock',
-									payload: 'tock',
-								});
-							},
-						],
-					},
-				],
-			},
-			StateB: {
-				tock: [
-					{
-						nextState: 'StateA',
-						effects: [
-							async (ctxt, event, broker) => {
-								console.log('tock');
-								await wait(1000);
-							},
-						],
-					},
-				],
-			},
-		},
+	const mockLogger = {
+		debug: jest.fn(),
+	} as any as Logger;
+	let manager = new MachineManager({
+		name: 'TestManager',
+		logger: mockLogger,
 	});
 
-	const manager = new MachineManager(machine1);
+	beforeEach(() => {
+		jest.resetAllMocks();
+		manager = new MachineManager({
+			name: 'TestManager',
+			logger: mockLogger,
+		});
+	});
 
-	describe('event queueing', () => {
+	describe('send()', () => {
+		beforeEach(async () => {
+			await manager.addMachineIfAbsent(tickTockMachine());
+		});
+
+		it('should relay events to containing machines', async () => {
+			expect.assertions(1);
+			const machineName = tickTockMachine().name;
+			// @ts-ignore
+			const machine = manager._machines[machineName];
+			const mockAccept = jest.spyOn(machine, 'accept');
+			const tick = { toMachine: machineName, name: 'tick', payload: {} };
+			await manager.send(tick);
+			expect(mockAccept).toBeCalledWith(tick);
+		});
+
+		it("should throw if event is sent to machine that doesn't exist", async () => {
+			expect.assertions(1);
+			const invalidEvent = {
+				toMachine: 'invalidMachine',
+				name: 'tick',
+				payload: {},
+			};
+			try {
+				await manager.send(invalidEvent);
+			} catch (e) {
+				expect(e.message).toEqual(
+					expect.stringContaining(
+						`No state machine ${invalidEvent.toMachine} configured`
+					)
+				);
+			}
+		});
+
 		it('should handle concurrent events', async () => {
-			const tickEvent = { name: 'tick', payload: {}, toMachine: 'Machine1' };
+			const tickEvent = {
+				name: 'tick',
+				payload: {},
+				toMachine: tickTockMachine().name,
+			};
 			const contexts = await Promise.all([
 				manager.send(tickEvent),
 				manager.send(tickEvent),
 				manager.send(tickEvent),
 			]);
 		}, 30000);
+	});
+
+	describe('addMachineIfAbsent()', () => {
+		it('should add machine', async () => {
+			const machine = tickTockMachine();
+			expect.assertions(1);
+			await manager.addMachineIfAbsent(machine);
+			// @ts-ignore
+			expect(manager._machines[machine.name]).toBe(machine);
+		});
+
+		it('should not affect current events', async () => {
+			expect.assertions(1);
+			const sendToInvalidMacineEffect: TransitionEffect<
+				Context,
+				TickEvent
+			> = async (ctxt, event, broker) => {
+				await new Promise<void>(resolve => {
+					setTimeout(() => {
+						resolve();
+					}, 500);
+				});
+				broker.dispatch({
+					toMachine: 'AnotherMachine',
+					name: 'foo',
+					payload: 'bar',
+				});
+			};
+			// This machine should fail if 'AnotherMachine' hasn't been added to manager.
+			const machineSendingInvalidEvent = tickTockMachine(
+				sendToInvalidMacineEffect
+			);
+			const anothermachine = new Machine<{}, any, any>({
+				context: {},
+				name: 'AnotherMachine',
+				initial: 'StateA',
+				states: {
+					StateA: {},
+				},
+			});
+			await manager.addMachineIfAbsent(machineSendingInvalidEvent);
+			await Promise.all([
+				manager.send({
+					name: 'tick',
+					payload: {},
+					toMachine: machineSendingInvalidEvent.name,
+				}),
+				manager.addMachineIfAbsent(anothermachine),
+			]);
+			expect(mockLogger.debug).toBeCalledWith(
+				expect.stringContaining(
+					`Cannot route event to machine ${anothermachine.name}`
+				)
+			);
+		});
+
+		it('should log if added manchine name already exists', async () => {
+			expect.assertions(2);
+			await manager.addMachineIfAbsent(tickTockMachine());
+			expect(mockLogger.debug).not.toBeCalled();
+			await manager.addMachineIfAbsent(tickTockMachine());
+			expect(mockLogger.debug).toBeCalledWith(
+				expect.stringContaining('already exists in machine manager')
+			);
+		});
+	});
+
+	describe('getCurrentState', () => {
+		it('should return the state of specified machine', async () => {
+			const machine = tickTockMachine();
+			await manager.addMachineIfAbsent(machine);
+			expect(await manager.getCurrentState(machine.name)).toEqual({
+				context: { events: [] },
+				currentState: 'StateA',
+			});
+		});
 	});
 });

--- a/packages/auth/__tests__/state-machine-manager-test.ts
+++ b/packages/auth/__tests__/state-machine-manager-test.ts
@@ -1,8 +1,11 @@
 import { Logger } from '@aws-amplify/core';
+import { v4 } from 'uuid';
 import { MachineManager } from '../src/stateMachine/stateMachineManager';
 import { Context, TickEvent, tickTockMachine } from './utils/tickTockMachine';
 import { Machine } from '../src/stateMachine/machine';
 import { TransitionEffect } from '../src/stateMachine/types';
+
+jest.mock('uuid');
 
 describe(MachineManager.name, () => {
 	const mockLogger = {
@@ -80,6 +83,8 @@ describe(MachineManager.name, () => {
 
 		it('should not affect current events', async () => {
 			expect.assertions(1);
+			const mockUUID = 'MOCK_UUID';
+			(v4 as jest.Mock).mockReturnValue(mockUUID);
 			const sendToInvalidMacineEffect: TransitionEffect<
 				Context,
 				TickEvent
@@ -118,7 +123,7 @@ describe(MachineManager.name, () => {
 			]);
 			expect(mockLogger.debug).toBeCalledWith(
 				expect.stringContaining(
-					`Cannot route event to machine ${anothermachine.name}`
+					`Cannot route event name foo to machine ${anothermachine.name}. Event id ${mockUUID}`
 				)
 			);
 		});

--- a/packages/auth/__tests__/state-machine-single-test.ts
+++ b/packages/auth/__tests__/state-machine-single-test.ts
@@ -59,7 +59,7 @@ describe('State machine guard tests...', () => {
 				event1: [
 					{
 						nextState: 'State2',
-						guards: [(ctxt, event1) => event1.payload.p1 == 'bad'],
+						guards: [(ctxt, event1) => event1.payload.p1 === 'bad'],
 					},
 				],
 			},
@@ -92,7 +92,7 @@ describe('State machine effect tests...', () => {
 				event1: [
 					{
 						nextState: 'State2',
-						guards: [(ctx, event1) => event1.payload.p1 == 'bad'],
+						guards: [(ctx, event1) => event1.payload.p1 === 'bad'],
 						effects: [
 							async (ctx, even1, broker) => {
 								ctx?.testFn ? ctx.testFn() : noop;
@@ -170,7 +170,7 @@ describe('State machine reducer tests...', () => {
 				event1: [
 					{
 						nextState: 'State2',
-						guards: [(ctx, event1) => event1.payload.p1 == 'bad'],
+						guards: [(ctx, event1) => event1.payload.p1 === 'bad'],
 						reducers: [
 							(ctx, even1) => {
 								ctx.optional1 = even1.payload.p1;

--- a/packages/auth/__tests__/utils/tickTockMachine.ts
+++ b/packages/auth/__tests__/utils/tickTockMachine.ts
@@ -1,0 +1,69 @@
+import { Machine } from '../../src/stateMachine/machine';
+import { TransitionEffect } from '../../src/stateMachine/types';
+
+const wait = (ms: number) =>
+	new Promise<void>(resolve => {
+		setTimeout(() => {
+			resolve();
+		}, ms);
+	});
+export type TickEvent = {
+	name: 'tick';
+	payload: {
+		recordId: string;
+	};
+};
+export type TockEvent = {
+	name: 'tock';
+	payload: {
+		recordId: string;
+	};
+};
+export type Events = TickEvent | TockEvent;
+export type Context = {
+	events: Events[];
+};
+type Machine1States = 'StateA' | 'StateB';
+
+export const tickTockMachine = (
+	tickEffect: TransitionEffect<Context, TickEvent> = async () => {},
+	tockEffect: TransitionEffect<Context, TockEvent> = async () => {}
+) =>
+	new Machine<Context, Events, Machine1States>({
+		context: { events: [] },
+		name: 'TickTock' as const,
+		initial: 'StateA',
+		states: {
+			StateA: {
+				tick: [
+					{
+						nextState: 'StateB',
+						effects: [
+							tickEffect,
+							async (ctxt, event, broker) => {
+								await wait(1000);
+								broker.dispatch({
+									name: 'tock',
+									payload: 'tock',
+								});
+							},
+						],
+					},
+				],
+			},
+			StateB: {
+				tock: [
+					{
+						nextState: 'StateA',
+						effects: [
+							tockEffect,
+							async (ctxt, event, broker) => {
+								await wait(1000);
+								ctxt;
+							},
+						],
+					},
+				],
+			},
+		},
+	});

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -73,7 +73,7 @@
       "^.+\\.(js|jsx|ts|tsx)$": "ts-jest"
     },
     "preset": "ts-jest",
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+    "testRegex": "(/__tests__/.*-test|\\.(test|spec))\\.(tsx?|jsx?)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/packages/auth/src/stateMachine/machine.ts
+++ b/packages/auth/src/stateMachine/machine.ts
@@ -88,7 +88,6 @@ export class Machine<
 	 * @internal
 	 */
 	async accept(event: EventTypes) {
-		event.id = v4();
 		const {
 			nextState: nextStateName,
 			newContext,

--- a/packages/auth/src/stateMachine/machine.ts
+++ b/packages/auth/src/stateMachine/machine.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { v4 } from 'uuid';
 import { MachineState } from './machineState';
 import {
 	CurrentStateAndContext,
@@ -63,7 +64,7 @@ export class Machine<
 					StateNames
 				>({
 					name: castedStateName,
-					transitions: transitions,
+					transitions,
 					machineContextGetter: () => this._context,
 					machineManager: {
 						dispatch: dispatchToBrokers,
@@ -87,7 +88,7 @@ export class Machine<
 	 * @internal
 	 */
 	async accept(event: EventTypes) {
-		event.id = uuid();
+		event.id = v4();
 		const {
 			nextState: nextStateName,
 			newContext,

--- a/packages/auth/src/stateMachine/types.ts
+++ b/packages/auth/src/stateMachine/types.ts
@@ -108,7 +108,8 @@ export type StateTransitions<
  * @typeParam ContextType - The type of the enclosing Machine's context
  * @typeParam EventType - The type of event being handled.
  * @typeParam StateNames - The type of all the state names. Expecting a union of strings.
- * @param nextState - The name of the State which will become the current State of the enclosing Machine, if the transition is triggered.
+ * @param nextState - The name of the State which will become the current State of the enclosing Machine, if the
+ * 			transition is triggered.
  * @param guards - An array of {@link TransitionGuard}, to be invoked before the transition is completed.
  * @param reducers - An array of {@link TransitionReducer}, to be invoked when the transition is completed.
  * @param effects - An array of {@link TransitionEffect}, to be invoked when the transition is completed.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
* Remove the statemachines from the manager contructor, and add an `addMachineIfAbsent()` to support adding statemachine dynamically. We can add the state machines to the class contructor later of there's an use case
* Add more unit tests and make sure the unit test passes. There will be followup PR to unblock the CI
* Fix formatting.


#### Description of how you validated changes
```bash
cd packages/auth && yarn jest __tests__/state-machine-*.ts
yarn run v1.22.19
$ .../amplify-js/node_modules/.bin/jest __tests__/state-machine-manager-test.ts __tests__/state-machine-single-test.ts
 PASS  __tests__/state-machine-single-test.ts
 PASS  __tests__/state-machine-manager-test.ts (10.972s)
````


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
