### PR TITLE
 chore(auth): temporary class members to enable library build success

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -11,7 +11,9 @@ import {
 	AuthPluginProvider, 
 	AuthSignUpResult, 
 	AuthUserAttributeKey, 
+	CognitoConfirmResetPasswordOptions, 
 	CognitoUserAttributeKey, 
+	ConfirmResetPasswordRequest, 
 	SignUpRequest 
 } from './types';
 import { assertPluginAvailable } from './utils/assertPluginAvailable';

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1,18 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Amplify, ConsoleLogger as Logger, Hub } from '@aws-amplify/core';
 import {
-	Amplify,
-	ConsoleLogger as Logger,
-	Hub,
-} from '@aws-amplify/core';
-import { 
-	AuthPluginOptions, 
-	AuthPluginProvider, 
-	AuthSignUpResult, 
-	AuthUserAttributeKey, 
-	CognitoUserAttributeKey, 
-	SignUpRequest 
+	AuthPluginOptions,
+	AuthPluginProvider,
+	AuthSignUpResult,
+	AuthUserAttributeKey,
+	CognitoUserAttributeKey,
+	SignUpRequest,
 } from './types';
 import { assertPluginAvailable } from './utils/assertPluginAvailable';
 
@@ -49,6 +45,16 @@ export class AuthClass {
 	private _config;
 	private _pluggable: AuthPluginProvider | null;
 	private _storage;
+
+	/* BEGIN LEGACY CLASS MEMBERS TO ALLOW LIBRARY BUILD */
+
+	/// TODO: These values are included temporarily as they are called from other libraries. They should be removed once fetchAuthSession has been implemented and replaced in other library locations.
+
+	public currentAuthenticatedUser;
+	public currentSession;
+	public currentCredentials;
+
+	/* END LEGACY CLASS MEMBERS TO ALLOW LIBRARY BUILD */
 
 	/**
 	 * Instantiates the Auth category
@@ -112,8 +118,7 @@ export class AuthClass {
 	 */
 	signUp<PluginOptions extends AuthPluginOptions>(
 		req: SignUpRequest<CognitoUserAttributeKey, PluginOptions>
-	): Promise<AuthSignUpResult<CognitoUserAttributeKey>>
-	{
+	): Promise<AuthSignUpResult<CognitoUserAttributeKey>> {
 		assertPluginAvailable(this._pluggable);
 		return this._pluggable.signUp(req);
 	}

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -48,11 +48,11 @@ export class AuthClass {
 
 	/* BEGIN LEGACY CLASS MEMBERS TO ALLOW LIBRARY BUILD */
 
-	/// TODO: These values are included temporarily as they are called from other libraries. They should be removed once fetchAuthSession has been implemented and replaced in other library locations.
+	/// TODO: These members are called from other libraries and can be uncommented temporarily to allow the library to build. Do not check-in uncommented member declarations to source.
 
-	public currentAuthenticatedUser;
-	public currentSession;
-	public currentCredentials;
+	// public currentAuthenticatedUser;
+	// public currentSession;
+	// public currentCredentials;
 
 	/* END LEGACY CLASS MEMBERS TO ALLOW LIBRARY BUILD */
 


### PR DESCRIPTION
#### Description of changes
Adds temporary, commented-out class members in Auth.ts that will allow the full library to build. 
The reasoning for making these commented out is that we want integration tests in other packages to continue failing until the requisite changes have been made in them using the new Auth methods.

#### Description of how you validated changes
Ran `yarn build` at root while uncommented.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
