### PR TITLE
chore: inc idb time clamps in tests due to CI slowness

### DIFF
--- a/packages/datastore/__tests__/IndexedDBAdapter.test.ts
+++ b/packages/datastore/__tests__/IndexedDBAdapter.test.ts
@@ -517,7 +517,7 @@ describe('IndexedDB benchmarks', () => {
 
 		// actual time on a decent dev machine is around 15ms, compared
 		// to over 130ms when the optimization is disabled.
-		expect(time).toBeLessThan(50);
+		expect(time).toBeLessThan(100);
 	});
 
 	test('deep joins are within time limits expected if indexes are being used using custom PK', async () => {
@@ -552,7 +552,7 @@ describe('IndexedDB benchmarks', () => {
 
 		// actual time on a decent dev machine is around 20ms, compared
 		// to over 150ms when the optimization is disabled.
-		expect(time).toBeLessThan(50);
+		expect(time).toBeLessThan(100);
 	});
 
 	test('wide joins operate within expeted time limits', async () => {
@@ -583,7 +583,7 @@ describe('IndexedDB benchmarks', () => {
 			expect(fetched.length).toBe(100);
 		}, 1);
 
-		expect(time).toBeLessThan(50);
+		expect(time).toBeLessThan(100);
 	});
 
 	test('wide joins with outer level ORs operate within expected time limits', async () => {
@@ -615,7 +615,7 @@ describe('IndexedDB benchmarks', () => {
 			expect(fetched.length).toBe(100);
 		}, 1);
 
-		expect(time).toBeLessThan(50);
+		expect(time).toBeLessThan(100);
 	});
 
 	test('semi-wide joins (limit 7) with outer level ORs operate within expected time limits', async () => {
@@ -650,6 +650,6 @@ describe('IndexedDB benchmarks', () => {
 			expect(fetched.length).toBe(size);
 		}, 1);
 
-		expect(time).toBeLessThan(50);
+		expect(time).toBeLessThan(100);
 	});
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Some IndexedDB time limit clamps were too aggressive for the CI execution environment. I had hesitations about including some of these as straight-up time limits. I favored this for some of the scenarios to keep test times down -- the alternative was to run scenarios twice on different schemas to demonstrate an increase in performance due to index usage.

For now, I'm bumping the time limits up for the CI execution environment.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

Re-ran the tests. We'll have to see whether integ tests pass. If they don't, I'll temporarily disable the tests until I can rewrite them as comparative tests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
