### PR TITLE
fix(datastore): cascade deleted for nested Has Many

### DIFF
--- a/packages/datastore/__tests__/commonAdapterTests.ts
+++ b/packages/datastore/__tests__/commonAdapterTests.ts
@@ -506,6 +506,13 @@ export function addCommonQueryTests({
 			}
 		);
 
+		/**
+		 * Distinct from other hasMany delete cascade tests in that the model
+		 * being deleted has *potential* grandchildren. Hence, delete traversals need
+		 * to be capable of successfully querying the child for its children,
+		 * which has seen a regression at least once!
+		 * See: https://github.com/aws-amplify/amplify-js/issues/10866
+		 */
 		(isSQLiteAdapter() ? test.skip : test)(
 			'deleting nested hasMany cascades',
 			async () => {


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes bug when deleting a record of a model with > 1 nested Has Many descendants
Ex:
```graphql
type Blog @model {
  id: String!
  posts: [Post] @hasMany
}

type Post @model {
  id: String!
  comments: [Comment] @hasMany
}

type Comment @model {
  id: String!
}
```
Behavior before the change in this PR:
1. `await DataStore.delete(Blog, 'some-id')`
2. `deleteTraverse` retrieves all `Post` records from the client database that are related to the Blog record and recursively calls `deleteTraverse`, passing the retrieved post records as POJOs ([link to code](https://github.com/aws-amplify/amplify-js/pull/10880/files#diff-75c76069840355a3f346f2f35c443018e4a5716ed128191602499c3b39935cfcR1076-R1080))
3. since `Post` has a Has Many relationship to `Comment`, `deleteTraverse` attempts to retrieve the related `Comment` records, but first has to extract PK metadata from the posts. Since the posts are POJOs, instead of model instances, they don't contain the necessary data and cause the error in the linked issue.

Note: If the child model does not have descendant relationships defined in the schema (e.g. if Post did not have a Has Many relationship to Comment) we wouldn't attempt to retrieve its descendants in step 3. so the bug would not show up with a relational graph of depth 2. Only 3+.

The change in this PR instantiates models from the records retrieved in step 2 and passes the models in the recursive call, which fixes the bug.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/10866


#### Description of how you validated changes
* Red/green unit test
* Manual testing


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
