### PR TITLE
chore: Updated bundle size debugging documantation & datastore limits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,11 +196,15 @@ The configuration for each category can be found in the associated package's `pa
 
 ##### Local Invocation & Regression Debugging
 
-The bundle size test can be performed locally (after building) by invoking the `test:size` build target in each package or in the mono-repo package. Bundle size regressions associated with a given change can be debugged by specifying the `--why` flag, e.g. `yarn test:size --why`, which will open a Statoscope instance to permit analysis of the generated bundle.
+The bundle size test can be performed locally (after building) by invoking the `test:size` build target from either a specific category or from the mono-repo package. Bundle size regressions associated with a given change can be debugged by specifying the `--why` flag, e.g. `yarn test:size --why`, which will open a Statoscope instance to permit analysis of the generated bundle. Some specific techniques for digging into regressions are outlined below.
 
-To dump the generated `stats.json` for analysis in different tools: `yarn test:size --save-bundle test_bundle` (bundle will be saved to `test_bundle` directory)
+**Compare yarn.lock files**
+Comparing `yarn.lock` files for each build can be a useful way to determine if your dependency graph has changed (which may have trickle down effect on Amplify's bundle size). The easiest way to do this is to download the `yarn.lock` files from the `build` step in CircleCI (under the "Artifacts" tab) for the failing build and an older passing build. These files can then be diffed locally to see if your dependency graph has changed: `diff yarn-passing.lock yarn-failing.lock`.
 
-To compare & diff one build with another: `yarn test:size --why --compare-with test_bundle/stats.json`
+**Compare `stats.json` files**
+The Webpack `stats.json` file contains a [static analysis](https://webpack.js.org/api/stats/) for a particular bundle. To generate these files locally, checkout & build the failing change, navigate to the category that's failing, and execute the following command: `yarn test:size --save-bundle test_bundle`. The generated `stats.json` file can be found in the new `test_bundle` directory. Make sure to copy this file somewhere safe for analysis. Next rebuild your parent branch (typically `main`) and compare bundles using the following command: `yarn test:size --why --compare-with stats-failing.json`. This will open a Statoscope instance in your browser. The "Choose stats" & "Diff" buttons on the top right can be used to inspect & compare your bundles.
+
+`stats.json` files can also be plugged into other popular bundle analysis tools if desired.
 
 ## Bug Reports
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"@size-limit/dual-publish": "^8.1.0",
 		"@size-limit/file": "^8.1.0",
 		"@size-limit/webpack": "^8.1.0",
+		"@size-limit/webpack-why": "^8.1.0",
 		"@types/jest": "^24.0.18",
 		"@types/lodash": "4.14.182",
 		"@types/node": "^8.9.5",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -71,7 +71,7 @@
 			"name": "DataStore (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, DataStore }",
-			"limit": "152.5 kB"
+			"limit": "153 kB"
 		}
 	],
 	"jest": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change adds more documentation on debugging bundle size regressions and adds a dependency that was missed from the original PR. It also slightly loosens the `datastore` category limits in anticipation of a pending customer PR.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
