### PR TITLE
chore: Upgrade `uuid` across library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1537,6 +1537,7 @@ releasable_branches: &releasable_branches
       - 1.0-stable
       - geo/main
       - in-app-messaging/main
+      - chore/uuid-upgrade
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1537,7 +1537,6 @@ releasable_branches: &releasable_branches
       - 1.0-stable
       - geo/main
       - in-app-messaging/main
-      - chore/uuid-upgrade
 
 test_browsers: &test_browsers
   browser: [chrome, firefox]

--- a/packages/analytics/__tests__/Providers/AWSPinpointProvider.test.ts
+++ b/packages/analytics/__tests__/Providers/AWSPinpointProvider.test.ts
@@ -162,7 +162,7 @@ let resolve = null;
 let reject = null;
 
 jest.mock('uuid', () => {
-	return { v1: () => 'uuid' };
+	return { v4: () => 'uuid' };
 });
 
 beforeEach(() => {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -56,7 +56,7 @@
 		"@aws-sdk/util-utf8-browser": "3.6.1",
 		"lodash": "^4.17.20",
 		"tslib": "^1.8.0",
-		"uuid": "^3.2.1"
+		"uuid": "^9.0.0"
 	},
 	"size-limit": [
 		{

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -63,7 +63,7 @@
 			"name": "Analytics (Pinpoint)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Analytics, AWSPinpointProvider }",
-			"limit": "56.5 kB"
+			"limit": "56.75 kB"
 		},
 		{
 			"name": "Analytics (Kinesis)",

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -28,7 +28,7 @@ import {
 	EventObject,
 	EndpointFailureData,
 } from '../types';
-import { v1 as uuid } from 'uuid';
+import { v4 as uuid } from 'uuid';
 import EventsBuffer from './EventBuffer';
 
 const AMPLIFY_SYMBOL = (

--- a/packages/analytics/src/Providers/AmazonPersonalizeHelper/SessionInfoManager.ts
+++ b/packages/analytics/src/Providers/AmazonPersonalizeHelper/SessionInfoManager.ts
@@ -3,7 +3,7 @@
 import { SessionInfo } from './DataType';
 import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
-import { v1 as uuid } from 'uuid';
+import { v4 as uuid } from 'uuid';
 import { ConsoleLogger as Logger, browserOrNode } from '@aws-amplify/core';
 import { Cache } from '@aws-amplify/cache';
 

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -55,7 +55,6 @@
     "@aws-amplify/pubsub": "5.0.11",
     "graphql": "15.8.0",
     "tslib": "^1.8.0",
-    "uuid": "^3.2.1",
     "zen-observable-ts": "0.8.19"
   },
   "size-limit": [

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -41,8 +41,7 @@
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
 		"@react-native-community/netinfo": "4.7.0",
-		"@types/uuid": "3.4.5",
-		"@types/uuid-validate": "^0.0.1",
+		"@types/uuid": "^9.0.0",
 		"dexie": "3.2.2",
 		"dexie-export-import": "1.0.3",
 		"fake-indexeddb": "3.0.0"
@@ -62,7 +61,7 @@
 		"idb": "5.0.6",
 		"immer": "9.0.6",
 		"ulid": "2.3.0",
-		"uuid": "3.3.2",
+		"uuid": "^9.0.0",
 		"zen-observable-ts": "0.8.19",
 		"zen-push": "0.2.1"
 	},

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -70,7 +70,7 @@
 			"name": "DataStore (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, DataStore }",
-			"limit": "153 kB"
+			"limit": "153.25 kB"
 		}
 	],
 	"jest": {

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -57,13 +57,13 @@
 			"name": "Notifications (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Notifications }",
-			"limit": "70 kB"
+			"limit": "70.25 kB"
 		},
 		{
 			"name": "Notifications (with Analytics)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Notifications, Analytics }",
-			"limit": "70 kB"
+			"limit": "70.25 kB"
 		}
 	],
 	"jest": {

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -50,7 +50,7 @@
 		"@aws-amplify/core": "5.0.11",
 		"@aws-sdk/client-pinpoint": "3.186.0",
 		"lodash": "^4.17.21",
-		"uuid": "^3.2.1"
+		"uuid": "^9.0.0"
 	},
 	"size-limit": [
 		{

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -54,7 +54,7 @@
 		"@aws-sdk/eventstream-marshaller": "3.6.1",
 		"@aws-sdk/util-utf8-node": "3.6.1",
 		"tslib": "^1.8.0",
-		"uuid": "^3.2.1"
+		"uuid": "^9.0.0"
 	},
 	"size-limit": [
 		{

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -55,7 +55,7 @@
     "graphql": "15.8.0",
     "paho-mqtt": "^1.1.0",
     "tslib": "^1.8.0",
-    "uuid": "^3.2.1",
+    "uuid": "^9.0.0",
     "zen-observable-ts": "0.8.19"
   },
   "size-limit": [


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change upgrades to the latest version of the `uuid` (v9) and updates `analytics` to use v4 UUIDs. 

Other changes:
- Tweaked bundle size limits. v9 yielded a smaller increase over v7 & v8 and I confirmed that we're using the tree-shakable export from UUID.
- Removed unused `uuid` dependency from `api-graphql`.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Integration tests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
