### PR TITLE
chore: Align datastore UUID dependency with rest of repo.

### DIFF
--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -41,8 +41,8 @@
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
 		"@react-native-community/netinfo": "4.7.0",
-		"@types/uuid": "3.4.5",
-		"@types/uuid-validate": "^0.0.1",
+		"@types/uuid": "^3.4.0",
+		"@types/uuid-validate": "^0.0.3",
 		"dexie": "3.2.2",
 		"dexie-export-import": "1.0.3",
 		"fake-indexeddb": "3.0.0"
@@ -62,7 +62,7 @@
 		"idb": "5.0.6",
 		"immer": "9.0.6",
 		"ulid": "2.3.0",
-		"uuid": "3.3.2",
+		"uuid": "3.4.0",
 		"zen-observable-ts": "0.8.19",
 		"zen-push": "0.2.1"
 	},

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -41,7 +41,7 @@
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
 		"@react-native-community/netinfo": "4.7.0",
-		"@types/uuid": "^3.4.0",
+		"@types/uuid": "3.4.0",
 		"@types/uuid-validate": "^0.0.1",
 		"dexie": "3.2.2",
 		"dexie-export-import": "1.0.3",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -42,7 +42,7 @@
 	"devDependencies": {
 		"@react-native-community/netinfo": "4.7.0",
 		"@types/uuid": "^3.4.0",
-		"@types/uuid-validate": "^0.0.3",
+		"@types/uuid-validate": "^0.0.1",
 		"dexie": "3.2.2",
 		"dexie-export-import": "1.0.3",
 		"fake-indexeddb": "3.0.0"

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -41,7 +41,7 @@
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
 		"@react-native-community/netinfo": "4.7.0",
-		"@types/uuid": "3.4.0",
+		"@types/uuid": "3.4.6",
 		"@types/uuid-validate": "^0.0.1",
 		"dexie": "3.2.2",
 		"dexie-export-import": "1.0.3",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change aligns the `datastore` UUID dependency with the rest of the repository to improve dependency flattening and remove one of our install warnings.

```
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated uuid@3.3.2: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Local testing in React Native, creating & reading entries from Datastore.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
