### PR TITLE
fix(auth): statemachine bugs rename event and actions

### DIFF
--- a/packages/auth/__tests__/state-machine-manager-test.ts
+++ b/packages/auth/__tests__/state-machine-manager-test.ts
@@ -3,7 +3,7 @@ import { v4 } from 'uuid';
 import { MachineManager } from '../src/stateMachine/stateMachineManager';
 import { Context, TickEvent, tickTockMachine } from './utils/tickTockMachine';
 import { Machine } from '../src/stateMachine/machine';
-import { TransitionEffect } from '../src/stateMachine/types';
+import { TransitionAction } from '../src/stateMachine/types';
 
 jest.mock('uuid');
 
@@ -35,7 +35,7 @@ describe(MachineManager.name, () => {
 			// @ts-ignore
 			const machine = manager._machines[machineName];
 			const mockAccept = jest.spyOn(machine, 'accept');
-			const tick = { toMachine: machineName, name: 'tick', payload: {} };
+			const tick = { toMachine: machineName, type: 'tick', payload: {} };
 			await manager.send(tick);
 			expect(mockAccept).toBeCalledWith(tick);
 		});
@@ -44,7 +44,7 @@ describe(MachineManager.name, () => {
 			expect.assertions(1);
 			const invalidEvent = {
 				toMachine: 'invalidMachine',
-				name: 'tick',
+				type: 'tick',
 				payload: {},
 			};
 			try {
@@ -60,7 +60,7 @@ describe(MachineManager.name, () => {
 
 		it('should handle concurrent events', async () => {
 			const tickEvent = {
-				name: 'tick',
+				type: 'tick',
 				payload: {},
 				toMachine: tickTockMachine().name,
 			};
@@ -85,7 +85,7 @@ describe(MachineManager.name, () => {
 			expect.assertions(1);
 			const mockUUID = 'MOCK_UUID';
 			(v4 as jest.Mock).mockReturnValue(mockUUID);
-			const sendToInvalidMacineEffect: TransitionEffect<
+			const sendToInvalidMacineEffect: TransitionAction<
 				Context,
 				TickEvent
 			> = async (ctxt, event, broker) => {
@@ -96,7 +96,7 @@ describe(MachineManager.name, () => {
 				});
 				broker.dispatch({
 					toMachine: 'AnotherMachine',
-					name: 'foo',
+					type: 'foo',
 					payload: 'bar',
 				});
 			};
@@ -115,7 +115,7 @@ describe(MachineManager.name, () => {
 			await manager.addMachineIfAbsent(machineSendingInvalidEvent);
 			await Promise.all([
 				manager.send({
-					name: 'tick',
+					type: 'tick',
 					payload: {},
 					toMachine: machineSendingInvalidEvent.name,
 				}),

--- a/packages/auth/__tests__/state-machine-single-test.ts
+++ b/packages/auth/__tests__/state-machine-single-test.ts
@@ -14,8 +14,8 @@ import {
 
 let machine: Machine<DummyContext, Events, StateNames>;
 const testSource = 'state-machine-single-tests';
-const goodEvent1: Event1 = { name: 'event1', payload: { p1: 'good' } };
-const badEvent1: Event1 = { name: 'event1', payload: { p1: 'bad' } };
+const goodEvent1: Event1 = { type: 'event1', payload: { p1: 'good' } };
+const badEvent1: Event1 = { type: 'event1', payload: { p1: 'bad' } };
 
 describe('State machine instantiation tests...', () => {
 	beforeEach(() => {
@@ -59,7 +59,7 @@ describe('State machine guard tests...', () => {
 				event1: [
 					{
 						nextState: 'State2',
-						guards: [(ctxt, event1) => event1.payload.p1 === 'bad'],
+						guards: [(ctxt, event1) => event1.payload.p1 !== 'bad'],
 					},
 				],
 			},
@@ -72,7 +72,7 @@ describe('State machine guard tests...', () => {
 	});
 
 	test('...the state transitions does not transition if guard fails', async () => {
-		await machine?.accept({ name: 'event1', payload: { p1: 'bad' } });
+		await machine?.accept({ type: 'event1', payload: { p1: 'bad' } });
 		expect(machine?.getCurrentState().currentState).toEqual('State1');
 	});
 });
@@ -80,7 +80,7 @@ describe('State machine guard tests...', () => {
 describe('State machine effect tests...', () => {
 	const mockDispatch = jest.fn();
 	const goodEvent2: Event2 = {
-		name: 'event2',
+		type: 'event2',
 		payload: { p2: 'good' },
 	};
 
@@ -92,8 +92,8 @@ describe('State machine effect tests...', () => {
 				event1: [
 					{
 						nextState: 'State2',
-						guards: [(ctx, event1) => event1.payload.p1 === 'bad'],
-						effects: [
+						guards: [(ctx, event1) => event1.payload.p1 !== 'bad'],
+						actions: [
 							async (ctx, even1, broker) => {
 								ctx?.testFn ? ctx.testFn() : noop;
 								broker.dispatch(goodEvent2);
@@ -104,7 +104,7 @@ describe('State machine effect tests...', () => {
 				event2: [
 					{
 						nextState: 'State2',
-						effects: [
+						actions: [
 							async (ctx, event1, broker) => {
 								broker.dispatch({
 									...goodEvent2,
@@ -170,7 +170,7 @@ describe('State machine reducer tests...', () => {
 				event1: [
 					{
 						nextState: 'State2',
-						guards: [(ctx, event1) => event1.payload.p1 === 'bad'],
+						guards: [(ctx, event1) => event1.payload.p1 !== 'bad'],
 						reducers: [
 							(ctx, even1) => {
 								ctx.optional1 = even1.payload.p1;
@@ -184,10 +184,10 @@ describe('State machine reducer tests...', () => {
 				event1: [
 					{
 						nextState: 'State2',
-						effects: [
+						actions: [
 							async (ctx, event1, broker) => {
 								broker.dispatch({
-									name: 'CurrentContext',
+									type: 'CurrentContext',
 									payload: {
 										context: ctx,
 									},
@@ -231,7 +231,7 @@ describe('State machine reducer tests...', () => {
 		expect(mockDispatch).toBeCalledTimes(1);
 		expect(mockDispatch).toBeCalledWith(
 			expect.objectContaining({
-				name: 'CurrentContext',
+				type: 'CurrentContext',
 				payload: {
 					context: expect.objectContaining({ optional1: 'good' }),
 				},

--- a/packages/auth/__tests__/utils/dummyMachine.ts
+++ b/packages/auth/__tests__/utils/dummyMachine.ts
@@ -11,14 +11,14 @@ import {
 export type StateNames = 'State1' | 'State2' | 'State3';
 
 export type Event1 = {
-	name: 'event1';
+	type: 'event1';
 	payload: {
 		p1: 'good' | 'bad';
 	};
 };
 
 export type Event2 = {
-	name: 'event2';
+	type: 'event2';
 	payload: {
 		p2: 'good' | 'bad';
 	};

--- a/packages/auth/__tests__/utils/tickTockMachine.ts
+++ b/packages/auth/__tests__/utils/tickTockMachine.ts
@@ -1,5 +1,5 @@
 import { Machine } from '../../src/stateMachine/machine';
-import { TransitionEffect } from '../../src/stateMachine/types';
+import { TransitionAction } from '../../src/stateMachine/types';
 
 const wait = (ms: number) =>
 	new Promise<void>(resolve => {
@@ -8,13 +8,13 @@ const wait = (ms: number) =>
 		}, ms);
 	});
 export type TickEvent = {
-	name: 'tick';
+	type: 'tick';
 	payload: {
 		recordId: string;
 	};
 };
 export type TockEvent = {
-	name: 'tock';
+	type: 'tock';
 	payload: {
 		recordId: string;
 	};
@@ -26,8 +26,8 @@ export type Context = {
 type Machine1States = 'StateA' | 'StateB';
 
 export const tickTockMachine = (
-	tickEffect: TransitionEffect<Context, TickEvent> = async () => {},
-	tockEffect: TransitionEffect<Context, TockEvent> = async () => {}
+	tickEffect: TransitionAction<Context, TickEvent> = async () => {},
+	tockEffect: TransitionAction<Context, TockEvent> = async () => {}
 ) =>
 	new Machine<Context, Events, Machine1States>({
 		context: { events: [] },
@@ -38,12 +38,12 @@ export const tickTockMachine = (
 				tick: [
 					{
 						nextState: 'StateB',
-						effects: [
+						actions: [
 							tickEffect,
 							async (ctxt, event, broker) => {
 								await wait(1000);
 								broker.dispatch({
-									name: 'tock',
+									type: 'tock',
 									payload: 'tock',
 								});
 							},
@@ -55,7 +55,7 @@ export const tickTockMachine = (
 				tock: [
 					{
 						nextState: 'StateA',
-						effects: [
+						actions: [
 							tockEffect,
 							async (ctxt, event, broker) => {
 								await wait(1000);

--- a/packages/auth/src/stateMachine/machine.ts
+++ b/packages/auth/src/stateMachine/machine.ts
@@ -87,11 +87,9 @@ export class Machine<
 	 * @internal
 	 */
 	async accept(event: EventTypes) {
-		const {
-			nextState: nextStateName,
-			newContext,
-			effectsPromise,
-		} = this._current.accept(event);
+		const { nextState: nextStateName, newContext } = await this._current.accept(
+			event
+		);
 		const nextState = this._states[nextStateName];
 		if (!nextState) {
 			// TODO: handle invalid next state.
@@ -101,7 +99,6 @@ export class Machine<
 		if (newContext) {
 			this._context = newContext;
 		}
-		await effectsPromise;
 	}
 
 	/**


### PR DESCRIPTION
* rename event name to event type to be consistent with other libraries
* rename transition effect to transition action
* invoke reducers before actions
* actions can return updated context

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
