### PR TITLE
Revert "fix(@aws-amplify/datastore): strictly define null vs undefined behavior on models"

### DIFF
--- a/packages/datastore-storage-adapter/__tests__/SQLiteUtils.test.ts
+++ b/packages/datastore-storage-adapter/__tests__/SQLiteUtils.test.ts
@@ -201,7 +201,7 @@ describe('SQLiteUtils tests', () => {
 			});
 
 			const expected = [
-				'INSERT INTO "Model" ("field1", "dateCreated", "id", "_version", "_lastChangedAt", "_deleted", "optionalField1", "emails", "ips", "metadata", "createdAt", "updatedAt") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+				'INSERT INTO "Model" ("field1", "dateCreated", "id", "_version", "_lastChangedAt", "_deleted") VALUES (?, ?, ?, ?, ?, ?)',
 				[
 					model.field1,
 					model.dateCreated,
@@ -209,12 +209,6 @@ describe('SQLiteUtils tests', () => {
 					undefined,
 					undefined,
 					undefined,
-					null,
-					null,
-					null,
-					null,
-					null,
-					null,
 				],
 			];
 
@@ -230,19 +224,13 @@ describe('SQLiteUtils tests', () => {
 			});
 
 			const expected = [
-				`UPDATE "Model" SET "field1"=?, "dateCreated"=?, "_version"=?, "_lastChangedAt"=?, "_deleted"=?, "optionalField1"=?, "emails"=?, "ips"=?, "metadata"=?, "createdAt"=?, "updatedAt"=? WHERE id=?`,
+				`UPDATE "Model" SET "field1"=?, "dateCreated"=?, "_version"=?, "_lastChangedAt"=?, "_deleted"=? WHERE id=?`,
 				[
 					model.field1,
 					model.dateCreated,
 					undefined,
 					undefined,
 					undefined,
-					null,
-					null,
-					null,
-					null,
-					null,
-					null,
 					model.id,
 				],
 			];

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -2136,7 +2136,7 @@ describe('DataStore tests', () => {
 				optionalField1: undefined,
 			});
 
-			expect(model1.optionalField1).toBeNull();
+			expect(model1.optionalField1).toBeUndefined();
 		});
 
 		test('Optional field can be initialized with null', () => {
@@ -2179,7 +2179,7 @@ describe('DataStore tests', () => {
 			expect(model1.id).toBe(model2.id);
 
 			expect(model1.optionalField1).toBe('something-else');
-			expect(model2.optionalField1).toBeNull();
+			expect(model2.optionalField1).toBeUndefined();
 		});
 
 		test('Optional field can be set to null inside copyOf', () => {
@@ -2199,7 +2199,7 @@ describe('DataStore tests', () => {
 			// ID should be kept the same
 			expect(model1.id).toBe(model2.id);
 
-			expect(model1.optionalField1).toBeNull();
+			expect(model1.optionalField1).toBeUndefined();
 			expect(model2.optionalField1).toBeNull();
 		});
 
@@ -2699,61 +2699,15 @@ describe('DataStore tests', () => {
 				);
 			});
 
-			test('valid model with null optional fields', () => {
-				const m = new Model({
-					field1: 'someField',
-					dateCreated: new Date().toISOString(),
-					optionalField1: null,
-				});
-				expect(m.optionalField1).toBe(null);
-			});
-
-			test('valid model with `undefined` optional fields', () => {
-				const m = new Model({
-					field1: 'someField',
-					dateCreated: new Date().toISOString(),
-					optionalField1: undefined,
-				});
-				expect(m.optionalField1).toBe(null);
-			});
-
-			test('valid model with omitted optional fields', () => {
-				const m = new Model({
-					field1: 'someField',
-					dateCreated: new Date().toISOString(),
-					/**
-					 * Omitting this:
-					 *
-					 * optionalField: undefined
-					 */
-				});
-				expect(m.optionalField1).toBe(null);
-			});
-
-			test('copyOf() setting optional field to null', () => {
-				const emailsVal = ['test@test.test'];
-				const original = new Model({
-					field1: 'someField',
-					dateCreated: new Date().toISOString(),
-					optionalField1: 'defined value',
-					emails: emailsVal,
-				});
-				const copied = Model.copyOf(original, d => (d.optionalField1 = null));
-				expect(copied.optionalField1).toBe(null);
-				expect(copied.emails).toEqual(emailsVal);
-			});
-
-			test('copyOf() setting optional field to undefined', () => {
-				const original = new Model({
-					field1: 'someField',
-					dateCreated: new Date().toISOString(),
-					optionalField1: 'defined value',
-				});
-				const copied = Model.copyOf(
-					original,
-					d => (d.optionalField1 = undefined)
-				);
-				expect(copied.optionalField1).toBe(null);
+			test('valid model with nulls', () => {
+				expect(() => {
+					new Model({
+						field1: 'someField',
+						dateCreated: new Date().toISOString(),
+						emails: null,
+						ips: null,
+					});
+				}).not.toThrow();
 			});
 
 			test('pass null to non nullable array field', () => {
@@ -3729,7 +3683,7 @@ describe('DataStore tests', () => {
 					dateCreated: new Date().toISOString(),
 				});
 
-				expect(model1.description).toBeNull();
+				expect(model1.description).toBeUndefined();
 			});
 
 			test('Optional field can be initialized with null', () => {
@@ -3767,7 +3721,7 @@ describe('DataStore tests', () => {
 				expect(model1.postId).toBe(model2.postId);
 
 				expect(model1.description).toBe('something-else');
-				expect(model2.description).toBeNull();
+				expect(model2.description).toBeUndefined();
 			});
 
 			test('Optional field can be set to null inside copyOf', () => {
@@ -3788,7 +3742,7 @@ describe('DataStore tests', () => {
 				// postId should be kept the same
 				expect(model1.postId).toBe(model2.postId);
 
-				expect(model1.description).toBeNull();
+				expect(model1.description).toBeUndefined();
 				expect(model2.description).toBeNull();
 			});
 

--- a/packages/datastore/__tests__/Merger.test.ts
+++ b/packages/datastore/__tests__/Merger.test.ts
@@ -44,7 +44,6 @@ describe('Merger', () => {
 					{
 						id: modelId,
 						field1: 'Create',
-						dateCreated: new Date().toISOString(),
 						optionalField1: null,
 						_version: 1,
 						_lastChangedAt: 1619627611860,
@@ -53,7 +52,6 @@ describe('Merger', () => {
 					{
 						id: modelId,
 						field1: 'Create',
-						dateCreated: new Date().toISOString(),
 						optionalField1: null,
 						_version: 2,
 						_lastChangedAt: 1619627619017,
@@ -77,7 +75,6 @@ describe('Merger', () => {
 					{
 						id: modelId,
 						field1: 'Create',
-						dateCreated: new Date().toISOString(),
 						optionalField1: null,
 						_version: 1,
 						_lastChangedAt: 1619627611860,
@@ -86,7 +83,6 @@ describe('Merger', () => {
 					{
 						id: modelId,
 						field1: 'Update',
-						dateCreated: new Date().toISOString(),
 						optionalField1: null,
 						_version: 2,
 						_lastChangedAt: 1619627619017,
@@ -95,7 +91,6 @@ describe('Merger', () => {
 					{
 						id: modelId,
 						field1: 'Another Update',
-						dateCreated: new Date().toISOString(),
 						optionalField1: 'Optional',
 						_version: 2,
 						_lastChangedAt: 1619627621329,
@@ -120,7 +115,6 @@ describe('Merger', () => {
 					{
 						id: modelId,
 						field1: 'Create',
-						dateCreated: new Date().toISOString(),
 						optionalField1: null,
 						_version: 1,
 						_lastChangedAt: 1619627611860,
@@ -129,7 +123,6 @@ describe('Merger', () => {
 					{
 						id: modelId,
 						field1: 'Create',
-						dateCreated: new Date().toISOString(),
 						optionalField1: null,
 						_version: 2,
 						_lastChangedAt: 1619627619017,
@@ -138,7 +131,6 @@ describe('Merger', () => {
 					{
 						id: modelId,
 						field1: 'New Create with the same id',
-						dateCreated: new Date().toISOString(),
 						optionalField1: null,
 						_version: 1,
 						_lastChangedAt: 1619627621329,
@@ -186,7 +178,6 @@ describe('Merger', () => {
 					{
 						postId: customPk,
 						title: 'Create1',
-						dateCreated: new Date().toISOString(),
 						description: null,
 						_version: 1,
 						_lastChangedAt: 1619627611860,
@@ -195,7 +186,6 @@ describe('Merger', () => {
 					{
 						postId: customPk,
 						title: 'Create1',
-						dateCreated: new Date().toISOString(),
 						description: null,
 						_version: 2,
 						_lastChangedAt: 1619627619017,
@@ -224,7 +214,6 @@ describe('Merger', () => {
 					{
 						postId: customPk,
 						title: 'Create1',
-						dateCreated: new Date().toISOString(),
 						description: null,
 						_version: 1,
 						_lastChangedAt: 1619627611860,
@@ -233,7 +222,6 @@ describe('Merger', () => {
 					{
 						postId: customPk,
 						title: 'Update1',
-						dateCreated: new Date().toISOString(),
 						description: null,
 						_version: 2,
 						_lastChangedAt: 1619627619017,
@@ -242,7 +230,6 @@ describe('Merger', () => {
 					{
 						postId: customPk,
 						title: 'Another Update1',
-						dateCreated: new Date().toISOString(),
 						description: 'Optional1',
 						_version: 2,
 						_lastChangedAt: 1619627621329,
@@ -272,7 +259,6 @@ describe('Merger', () => {
 					{
 						postId: customPk,
 						title: 'Create1',
-						dateCreated: new Date().toISOString(),
 						description: null,
 						_version: 1,
 						_lastChangedAt: 1619627611860,
@@ -281,7 +267,6 @@ describe('Merger', () => {
 					{
 						postId: customPk,
 						title: 'Create1',
-						dateCreated: new Date().toISOString(),
 						description: null,
 						_version: 2,
 						_lastChangedAt: 1619627619017,
@@ -290,7 +275,6 @@ describe('Merger', () => {
 					{
 						postId: customPk,
 						title: 'New Create with the same custom pk',
-						dateCreated: new Date().toISOString(),
 						description: null,
 						_version: 1,
 						_lastChangedAt: 1619627621329,

--- a/packages/datastore/__tests__/Predicate.ts
+++ b/packages/datastore/__tests__/Predicate.ts
@@ -24,7 +24,7 @@ import {
 	predicateToGraphQLCondition,
 	predicateToGraphQLFilter,
 } from '../src/sync/utils';
-import { schema, Author, Post, Blog, BlogOwner, Person } from './model';
+import { schema, Author, Post, Blog, BlogOwner } from './model';
 import { AsyncCollection } from '../src';
 
 const AuthorMeta = {
@@ -45,12 +45,6 @@ const PostMeta = {
 	pkField: ['id'],
 };
 
-const PersonMeta = {
-	builder: Person,
-	schema: schema.models['Person'],
-	pkField: ['id'],
-};
-
 const metas = {
 	Author: AuthorMeta,
 	Blog: BlogMeta,
@@ -60,7 +54,6 @@ const metas = {
 		schema: schema.models['BlogOwner'],
 		pkField: ['id'],
 	},
-	Person: PersonMeta,
 };
 
 type ModelOf<T> = T extends PersistentModelConstructor<infer M> ? M : T;
@@ -1050,103 +1043,6 @@ describe('Predicates', () => {
 		});
 	});
 
-	describe('handling of null and undefined', () => {
-		const getFixture = () => {
-			return ['null 01', 'defined 01', 'null 02', 'defined 02', 'null 03'].map(
-				name => {
-					return new Person({
-						firstName: `${name} first name`,
-						lastName: `${name} last name`,
-						username: name.includes('null') ? null : name,
-					});
-				}
-			);
-		};
-
-		[
-			{
-				name: 'filters',
-				execute: async <T>(query: any) =>
-					asyncFilter(getFixture(), i => internals(query).matches(i)),
-			},
-			{
-				name: 'storage predicates',
-				execute: async <T>(query: any) => {
-					return (await internals(query).fetch(
-						getStorageFake({
-							[Person.name]: getFixture(),
-						}) as any
-					)) as T[];
-				},
-			},
-		].forEach(mechanism => {
-			describe(`as ${mechanism.name}`, () => {
-				test('can select non-null values by their defined values', async () => {
-					const query =
-						recursivePredicateFor(PersonMeta).username.eq('defined 01');
-					const matches = await mechanism.execute<ModelOf<typeof Person>>(
-						query
-					);
-
-					expect(matches.length).toBe(1);
-					expect(matches.map(n => n.username)).toEqual(['defined 01']);
-				});
-
-				test('can select non-null values by searching for != null', async () => {
-					const query = recursivePredicateFor(PersonMeta).username.ne(
-						null as any
-					);
-					const matches = await mechanism.execute<ModelOf<typeof Person>>(
-						query
-					);
-
-					expect(matches.length).toBe(2);
-					expect(matches.map(n => n.username)).toEqual([
-						'defined 01',
-						'defined 02',
-					]);
-				});
-
-				test('can select non-null values by searching for != undefined', async () => {
-					const query =
-						recursivePredicateFor(PersonMeta).username.ne(undefined);
-					const matches = await mechanism.execute<ModelOf<typeof Person>>(
-						query
-					);
-
-					expect(matches.length).toBe(2);
-					expect(matches.map(n => n.username)).toEqual([
-						'defined 01',
-						'defined 02',
-					]);
-				});
-
-				test('can select null values by searching for == null', async () => {
-					const query = recursivePredicateFor(PersonMeta).username.eq(
-						null as any
-					);
-					const matches = await mechanism.execute<ModelOf<typeof Person>>(
-						query
-					);
-
-					expect(matches.length).toBe(3);
-					expect(matches.map(n => n.username)).toEqual([null, null, null]);
-				});
-
-				test('can select null values by searching for == undefined', async () => {
-					const query =
-						recursivePredicateFor(PersonMeta).username.eq(undefined);
-					const matches = await mechanism.execute<ModelOf<typeof Person>>(
-						query
-					);
-
-					expect(matches.length).toBe(3);
-					expect(matches.map(n => n.username)).toEqual([null, null, null]);
-				});
-			});
-		});
-	});
-
 	describe('on related/nested properties', () => {
 		const blogOwnerNames = [
 			'Adam West',
@@ -1686,30 +1582,6 @@ describe('Predicates', () => {
 				predicate: p => p.name.gt('j'),
 				matches: [{ name: 'tim' }, { name: 'sam' }],
 				mismatches: [{ name: 'al' }, { name: 'fran' }],
-			},
-
-			// `undefined` in predicates should be treated as `null` for matching purposes.
-			// neither cloud storage nor any correctly implemented adapters respond with
-			// `undefined` values in model instance fields.
-			{
-				predicate: p => p.name.eq(null),
-				matches: [{ name: null }],
-				mismatches: [{ name: '' }, { name: 'abc' }],
-			},
-			{
-				predicate: p => p.name.ne(null),
-				matches: [{ name: '' }, { name: 'abc' }],
-				mismatches: [{ name: null }],
-			},
-			{
-				predicate: p => p.name.eq(undefined),
-				matches: [{ name: null }],
-				mismatches: [{ name: '' }, { name: 'abc' }],
-			},
-			{
-				predicate: p => p.name.ne(undefined),
-				matches: [{ name: '' }, { name: 'abc' }],
-				mismatches: [{ name: null }],
 			},
 		];
 		for (const [i, testCase] of predicateTestCases.entries()) {

--- a/packages/datastore/__tests__/commonAdapterTests.ts
+++ b/packages/datastore/__tests__/commonAdapterTests.ts
@@ -30,7 +30,6 @@ import {
 	MtmJoin,
 	DefaultPKHasOneParent,
 	DefaultPKHasOneChild,
-	UUID_REGEX,
 } from './helpers';
 
 export { pause };
@@ -344,7 +343,7 @@ export function addCommonQueryTests({
 
 			// comment update should be smashed to together with post
 			expect(mutations.length).toBe(2);
-			expectMutation(mutations[0], { title: 'some post', blogId: null });
+			expectMutation(mutations[0], { title: 'some post' });
 			expectMutation(mutations[1], {
 				content: 'updated content',
 				postId: mutations[0].modelId,
@@ -798,7 +797,7 @@ export function addCommonQueryTests({
 
 								expect(lazyLoaded).toEqual(remote);
 							});
-							test(`lazy load does not load aimlessly ${testname}`, async () => {
+							test(`lazy load does load aimlessly ${testname}`, async () => {
 								/**
 								 * Basically, we want to ensure lazy loading never regresses and starts
 								 * loading related instances that are not actually related by FK.
@@ -822,7 +821,6 @@ export function addCommonQueryTests({
 									R.localConstructor,
 									extractPrimaryKeysAndValues(local, R.localPKFields)
 								);
-
 								const lazyLoaded = await fetched[field];
 
 								// HERE'S THE DIFFERENCE IN ASSERTION.

--- a/packages/datastore/__tests__/connectivityHandling.test.ts
+++ b/packages/datastore/__tests__/connectivityHandling.test.ts
@@ -9,34 +9,11 @@ import {
 import { Predicates } from '../src/predicates';
 import { syncExpression } from '../src/types';
 
-/**
- * Surfaces errors sooner and outputs them more clearly if/when
- * a test begins to fail.
- */
-async function waitForEmptyOutboxOrError(service) {
-	const pendingError = new Promise((resolve, reject) => {
-		service.log = (channel, message) => {
-			if (channel.includes('API Response')) {
-				if (message.errors?.length > 0) reject(message);
-			}
-		};
-	});
-
-	return await Promise.race([waitForEmptyOutbox(), pendingError]);
-}
-
 describe('DataStore sync engine', () => {
 	// establish types :)
 	let {
 		DataStore,
-		schema,
 		connectivityMonitor,
-		Model,
-		ModelWithExplicitOwner,
-		ModelWithExplicitCustomOwner,
-		ModelWithMultipleCustomOwner,
-		BasicModel,
-		BasicModelWritableTS,
 		Post,
 		Comment,
 		graphqlService,
@@ -47,14 +24,7 @@ describe('DataStore sync engine', () => {
 	beforeEach(async () => {
 		({
 			DataStore,
-			schema,
 			connectivityMonitor,
-			Model,
-			ModelWithExplicitOwner,
-			ModelWithExplicitCustomOwner,
-			ModelWithMultipleCustomOwner,
-			BasicModel,
-			BasicModelWritableTS,
 			Post,
 			Comment,
 			graphqlService,
@@ -73,175 +43,13 @@ describe('DataStore sync engine', () => {
 			const post = await DataStore.save(new Post({ title: 'post title' }));
 
 			// give thread control back to subscription event handlers.
-			await waitForEmptyOutbox();
+			await pause(1);
 
 			const table = graphqlService.tables.get('Post')!;
 			expect(table.size).toEqual(1);
 
 			const savedItem = table.get(JSON.stringify([post.id])) as any;
 			expect(savedItem.title).toEqual(post.title);
-		});
-
-		test('omits readonly fields from mutation events on create', async () => {
-			// make sure our test model still meets requirements to make this test valid.
-			expect(schema.models.BasicModel.fields.createdAt.isReadOnly).toBe(true);
-
-			const m = await DataStore.save(
-				new BasicModel({
-					body: 'whatever and ever',
-				})
-			);
-
-			await waitForEmptyOutbox();
-
-			const table = graphqlService.tables.get('BasicModel')!;
-			expect(table.size).toEqual(1);
-
-			const savedItem = table.get(JSON.stringify([m.id])) as any;
-			expect(savedItem.body).toEqual(m.body);
-		});
-
-		test('omits null owner fields from mutation events on create', async () => {
-			const m = await DataStore.save(
-				new ModelWithExplicitOwner({
-					title: 'very clever title',
-					owner: null,
-				})
-			);
-
-			await waitForEmptyOutboxOrError(graphqlService);
-
-			const table = graphqlService.tables.get('ModelWithExplicitOwner')!;
-			expect(table.size).toEqual(1);
-
-			const savedItem = table.get(JSON.stringify([m.id])) as any;
-			expect(savedItem.title).toEqual(m.title);
-		});
-
-		test('omits undefined owner fields from mutation events on create', async () => {
-			const m = await DataStore.save(
-				new ModelWithExplicitOwner({
-					title: 'very clever title',
-					owner: undefined,
-				})
-			);
-
-			await waitForEmptyOutboxOrError(graphqlService);
-
-			const table = graphqlService.tables.get('ModelWithExplicitOwner')!;
-			expect(table.size).toEqual(1);
-
-			const savedItem = table.get(JSON.stringify([m.id])) as any;
-			expect(savedItem.title).toEqual(m.title);
-		});
-
-		test('omits null custom owner fields from mutation events on create', async () => {
-			const m = await DataStore.save(
-				new ModelWithExplicitCustomOwner({
-					title: 'very clever title',
-					customowner: null,
-				})
-			);
-
-			await waitForEmptyOutboxOrError(graphqlService);
-
-			const table = graphqlService.tables.get('ModelWithExplicitCustomOwner')!;
-			expect(table.size).toEqual(1);
-
-			const savedItem = table.get(JSON.stringify([m.id])) as any;
-			expect(savedItem.title).toEqual(m.title);
-		});
-
-		test('omits undefined custom owner fields from mutation events on create', async () => {
-			const m = await DataStore.save(
-				new ModelWithExplicitCustomOwner({
-					title: 'very clever title',
-					customowner: undefined,
-				})
-			);
-
-			await waitForEmptyOutboxOrError(graphqlService);
-
-			const table = graphqlService.tables.get('ModelWithExplicitCustomOwner')!;
-			expect(table.size).toEqual(1);
-
-			const savedItem = table.get(JSON.stringify([m.id])) as any;
-			expect(savedItem.title).toEqual(m.title);
-		});
-
-		test('omits empty owner fields (multi, both empty) from mutation events on create', async () => {
-			const m = await DataStore.save(
-				new ModelWithMultipleCustomOwner({
-					title: 'very clever title',
-					customownerOne: undefined,
-					customownerTwo: undefined,
-				})
-			);
-
-			await waitForEmptyOutboxOrError(graphqlService);
-
-			const table = graphqlService.tables.get('ModelWithMultipleCustomOwner')!;
-			expect(table.size).toEqual(1);
-
-			const savedItem = table.get(JSON.stringify([m.id])) as any;
-			expect(savedItem.title).toEqual(m.title);
-		});
-
-		test('omits empty owner fields (multi, owner 1 empty) from mutation events on create', async () => {
-			const m = await DataStore.save(
-				new ModelWithMultipleCustomOwner({
-					title: 'very clever title',
-					customownerOne: undefined,
-					customownerTwo: 'bob',
-				})
-			);
-
-			await waitForEmptyOutboxOrError(graphqlService);
-
-			const table = graphqlService.tables.get('ModelWithMultipleCustomOwner')!;
-			expect(table.size).toEqual(1);
-
-			const savedItem = table.get(JSON.stringify([m.id])) as any;
-			expect(savedItem.title).toEqual(m.title);
-		});
-
-		test('omits null custom owner fields (multi, owner 2 empty) from mutation events on create', async () => {
-			const m = await DataStore.save(
-				new ModelWithMultipleCustomOwner({
-					title: 'very clever title',
-					customownerOne: 'bob',
-					customownerTwo: undefined,
-				})
-			);
-
-			await waitForEmptyOutboxOrError(graphqlService);
-
-			const table = graphqlService.tables.get('ModelWithMultipleCustomOwner')!;
-			expect(table.size).toEqual(1);
-
-			const savedItem = table.get(JSON.stringify([m.id])) as any;
-			expect(savedItem.title).toEqual(m.title);
-		});
-
-		test('includes timestamp fields in mutation events when NOT readonly', async () => {
-			// make sure our test model still meets requirements to make this test valid.
-			expect(
-				schema.models.BasicModelWritableTS.fields.createdAt.isReadOnly
-			).toBe(false);
-
-			const m = await DataStore.save(
-				new BasicModelWritableTS({
-					body: 'whatever else',
-				})
-			);
-
-			await waitForEmptyOutbox();
-
-			const table = graphqlService.tables.get('BasicModelWritableTS')!;
-			expect(table.size).toEqual(1);
-
-			const savedItem = table.get(JSON.stringify([m.id])) as any;
-			expect(savedItem.body).toEqual(m.body);
 		});
 
 		test('uses model create subscription event to populate sync protocol metadata', async () => {
@@ -273,35 +81,6 @@ describe('DataStore sync engine', () => {
 
 			const savedItem = table.get(JSON.stringify([post.id])) as any;
 			expect(savedItem.title).toEqual(updated.title);
-		});
-
-		test('send model updates where field is nullified to the cloud', async () => {
-			const original = await DataStore.save(
-				new Model({
-					field1: 'field 1 value',
-					dateCreated: new Date().toISOString(),
-					optionalField1: 'optional field value',
-				})
-			);
-			await waitForEmptyOutbox();
-
-			const updated = await DataStore.save(
-				Model.copyOf(
-					(await DataStore.query(Model, original.id))!,
-					m => (m.optionalField1 = undefined)
-				)
-			);
-			const retrievedBeforeMutate = await DataStore.query(Model, original.id);
-			await waitForEmptyOutbox();
-
-			const table = graphqlService.tables.get('Model');
-			const cloudItem = table?.get(JSON.stringify([original.id])) as any;
-			const retrievedAfterMutate = await DataStore.query(Model, original.id);
-
-			expect(updated.optionalField1).toBe(null);
-			expect(cloudItem.optionalField1).toBe(null);
-			expect(retrievedBeforeMutate?.optionalField1).toBe(null);
-			expect(retrievedAfterMutate?.optionalField1).toBe(null);
 		});
 
 		test('sends model deletes to the cloud', async () => {

--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -3,7 +3,6 @@ import { parse } from 'graphql';
 import {
 	ModelInit,
 	Schema,
-	SchemaModel,
 	InternalSchema,
 	isModelAttributePrimaryKey,
 	__modelMeta__,
@@ -115,7 +114,7 @@ export function errorsFrom<T extends Object>(
 
 /**
  * Checks to see if a given object contains any extra, unexpected properties.
- * If any are present, it returns the list of unexpected fields.
+ * If any are present, it returns the list of unexpectd fields.
  *
  * @param data the object that MIGHT contain extra fields.
  * @param template the authorative template object.
@@ -522,10 +521,10 @@ class FakeDataStoreConnectivity {
  */
 class FakeGraphQLService {
 	public isConnected = true;
-	public log: (channel: string, ...etc: any) => void = s => undefined;
+	public logRequests = false;
+	public logAST = false;
 	public requests = [] as any[];
 	public tables = new Map<string, Map<string, any[]>>();
-	public tableDefinitions = new Map<string, SchemaModel>();
 	public PKFields = new Map<string, string[]>();
 	public observers = new Map<
 		string,
@@ -535,7 +534,6 @@ class FakeGraphQLService {
 	constructor(public schema: Schema) {
 		for (const model of Object.values(schema.models)) {
 			this.tables.set(model.name, new Map<string, any[]>());
-			this.tableDefinitions.set(model.name, model);
 			let CPKFound = false;
 			for (const attribute of model.attributes || []) {
 				if (isModelAttributePrimaryKey(attribute)) {
@@ -553,7 +551,7 @@ class FakeGraphQLService {
 	public parseQuery(query) {
 		const q = (parse(query) as any).definitions[0];
 
-		this.log('RequestAST', JSON.stringify(q, null, 2));
+		if (this.logAST) console.log('graphqlAST', JSON.stringify(q, null, 2));
 
 		const operation = q.operation;
 		const name = q.name.value;
@@ -583,14 +581,17 @@ class FakeGraphQLService {
 	}
 
 	public satisfiesCondition(tableName, item, condition) {
-		this.log('checking satisfiesCondition', {
-			tableName,
-			item,
-			condition: JSON.stringify(condition),
-		});
+		if (this.logRequests)
+			console.log('checking satisfiesCondition', {
+				tableName,
+				item,
+				condition: JSON.stringify(condition),
+			});
 
 		if (!condition) {
-			this.log('checking satisfiesCondition matches all for `null` conditions');
+			console.log(
+				'checking satisfiesCondition matches all for `null` conditions'
+			);
 			return true;
 		}
 
@@ -603,12 +604,13 @@ class FakeGraphQLService {
 			ModelPredicateCreator.getPredicates(predicate)!,
 		]);
 
-		this.log('satisfiesCondition result', {
-			effectivePredicate: JSON.stringify(
-				ModelPredicateCreator.getPredicates(predicate)
-			),
-			isMatch,
-		});
+		this.logRequests &&
+			console.log('satisfiesCondition result', {
+				effectivePredicate: JSON.stringify(
+					ModelPredicateCreator.getPredicates(predicate)
+				),
+				isMatch,
+			});
 
 		return isMatch;
 	}
@@ -688,39 +690,6 @@ class FakeGraphQLService {
 		};
 	}
 
-	private makeExtraFieldInputError(tableName, operation, fields) {
-		const properOperationName = `${operation[0].toUpperCase()}${operation.substring(
-			1
-		)}`;
-		const inputName = `${properOperationName}${tableName}Input`;
-		return {
-			data: null,
-			errors: fields.map(field => ({
-				path: null,
-				locations: null,
-				message: `The variables input contains a field name '${field}' that is not defined for input object type '${inputName}'`,
-			})),
-		};
-	}
-
-	private makeOwnerFieldNullInputError(tableName, operation) {
-		// Response from AppSync console on non-existent model.
-		return {
-			path: [operation],
-			data: null,
-			errorType: 'Unauthorized',
-			errorInfo: null,
-			locations: [
-				{
-					line: 12,
-					column: 3,
-					sourceName: null,
-				},
-			],
-			message: `Not Authorized to access ${operation} on type ${tableName}`,
-		};
-	}
-
 	private disconnectedError() {
 		return {
 			data: {},
@@ -732,79 +701,9 @@ class FakeGraphQLService {
 		};
 	}
 
-	private ownerFields(tableName) {
-		const def = this.tableDefinitions.get(tableName)!;
-		const auth = def.attributes?.find(a => a.type === 'auth');
-		const ownerFields = auth?.properties?.rules
-			.map(rule => rule.ownerField)
-			.filter(f => f);
-
-		return ownerFields || ['owner'];
-	}
-
-	private identifyExtraValues(expected, actual) {
-		const extraValues: string[] = [];
-		for (const v of actual) {
-			if (!expected.includes(v)) {
-				extraValues.push(v);
-			}
-		}
-
-		return extraValues;
-	}
-
-	private validate(tableName, operation, record) {
-		// very simple validation for an observed *near*-regression from a PR right now.
-		// https://github.com/aws-amplify/amplify-js/pull/10915
-		const def = this.tableDefinitions.get(tableName)!;
-		const writeableFields = Object.keys(def.fields).filter(
-			field => !def.fields[field]?.isReadOnly
-		);
-
-		let error: any;
-
-		switch (operation) {
-			case 'create':
-			case 'update':
-				const unexpectedFields = this.identifyExtraValues(
-					[...writeableFields, '_version'],
-					Object.keys(record)
-				);
-				if (unexpectedFields.length > 0) {
-					error = this.makeExtraFieldInputError(
-						tableName,
-						operation,
-						unexpectedFields
-					);
-				}
-				for (const ownerField of this.ownerFields(tableName)) {
-					if (record[ownerField] === null) {
-						error = this.makeOwnerFieldNullInputError(tableName, operation);
-						break;
-					}
-				}
-				break;
-			case 'delete':
-				break;
-			default:
-				// this is not a GraphQL error. it likely indicates our fake graphql
-				// service is broken.
-				throw new Error('Invalid operation. Should be unreachable.');
-		}
-
-		this.log('validate', {
-			tableName,
-			operation,
-			record,
-			error,
-		});
-
-		return error;
-	}
-
 	private populatedFields(record) {
 		return Object.fromEntries(
-			Object.entries(record).filter(([key, value]) => value !== undefined)
+			Object.entries(record).filter(([key, value]) => value)
 		);
 	}
 
@@ -825,7 +724,6 @@ class FakeGraphQLService {
 				_lastChangedAt: new Date().getTime(),
 			};
 		}
-		this.log('automerge', { existing, updated, merged });
 		return merged;
 	}
 
@@ -847,12 +745,14 @@ class FakeGraphQLService {
 	}
 
 	public request({ query, variables, authMode, authToken }) {
-		this.log('API Request', {
-			query,
-			variables: JSON.stringify(variables, null, 2),
-			authMode,
-			authToken,
-		});
+		if (this.logRequests) {
+			console.log('API request', {
+				query,
+				variables: JSON.stringify(variables, null, 2),
+				authMode,
+				authToken,
+			});
+		}
 
 		if (!this.isConnected) {
 			return this.disconnectedError();
@@ -861,7 +761,9 @@ class FakeGraphQLService {
 		const parsed = this.parseQuery(query);
 		const { operation, selection, table: tableName, type } = parsed;
 
-		this.log('Parsed Request', parsed);
+		if (this.logRequests) {
+			console.log('Parsed request components', parsed);
+		}
 
 		this.requests.push({ query, variables, authMode, authToken });
 		let data;
@@ -888,13 +790,7 @@ class FakeGraphQLService {
 			const record = variables.input;
 			if (type === 'create') {
 				const existing = table.get(this.getPK(tableName, record));
-				const validationError = this.validate(tableName, 'create', record);
-				if (validationError) {
-					data = {
-						[selection]: null,
-					};
-					errors = [validationError];
-				} else if (existing) {
+				if (existing) {
 					data = {
 						[selection]: null,
 					};
@@ -914,13 +810,7 @@ class FakeGraphQLService {
 				// Simulate update using the default (AUTO_MERGE) for now.
 				// NOTE: We're not doing list/set merging. :o
 				const existing = table.get(this.getPK(tableName, record));
-				const validationError = this.validate(tableName, 'update', record);
-				if (validationError) {
-					data = {
-						[selection]: null,
-					};
-					errors = [validationError];
-				} else if (!existing) {
+				if (!existing) {
 					data = {
 						[selection]: null,
 					};
@@ -934,15 +824,8 @@ class FakeGraphQLService {
 				}
 			} else if (type === 'delete') {
 				const existing = table.get(this.getPK(tableName, record));
-				const validationError = this.validate(tableName, 'delete', record);
-				this.log('delete looking for existing', { existing });
-
-				if (validationError) {
-					data = {
-						[selection]: null,
-					};
-					errors = [validationError];
-				} else if (!existing) {
+				if (this.logRequests) console.log({ existing });
+				if (!existing) {
 					data = {
 						[selection]: null,
 					};
@@ -975,11 +858,11 @@ class FakeGraphQLService {
 						},
 					};
 					table.set(this.getPK(tableName, record), data[selection]);
-					this.log('delete applying to table', { data });
+					if (this.logRequests) console.log({ data });
 				}
 			}
 
-			this.log('API Response', { data, errors });
+			if (this.logRequests) console.log('response', { data, errors });
 
 			const observers = this.getObservers(tableName, type);
 			const typeName = {
@@ -996,12 +879,10 @@ class FakeGraphQLService {
 						},
 					},
 				};
-				this.log('API subscription message', { observerMessageName, message });
 				observer.next(message);
 			});
 		} else if (operation === 'subscription') {
 			return new Observable(observer => {
-				this.log('API subscription created', { tableName, type });
 				this.subscribe(tableName, type, observer);
 				// needs to send messages like `{ value: { data: { [opname]: record }, errors: [] } }`
 			});
@@ -1116,8 +997,7 @@ export function getDataStore({
 			'https://0.0.0.0/graphql';
 	}
 
-	const schema = testSchema();
-	const classes = initSchema(schema);
+	const classes = initSchema(testSchema());
 
 	const {
 		ModelWithBoolean,
@@ -1140,15 +1020,8 @@ export function getDataStore({
 		MtmJoin,
 		DefaultPKHasOneParent,
 		DefaultPKHasOneChild,
-		LegacyJSONBlog,
-		LegacyJSONPost,
 		CompositePKParent,
 		CompositePKChild,
-		BasicModel,
-		BasicModelWritableTS,
-		ModelWithExplicitOwner,
-		ModelWithExplicitCustomOwner,
-		ModelWithMultipleCustomOwner,
 	} = classes as {
 		ModelWithBoolean: PersistentModelConstructor<ModelWithBoolean>;
 		Blog: PersistentModelConstructor<Blog>;
@@ -1170,20 +1043,12 @@ export function getDataStore({
 		MtmJoin: PersistentModelConstructor<MtmJoin>;
 		DefaultPKHasOneParent: PersistentModelConstructor<DefaultPKHasOneParent>;
 		DefaultPKHasOneChild: PersistentModelConstructor<DefaultPKHasOneChild>;
-		LegacyJSONBlog: PersistentModelConstructor<LegacyJSONBlog>;
-		LegacyJSONPost: PersistentModelConstructor<LegacyJSONPost>;
 		CompositePKParent: PersistentModelConstructor<CompositePKParent>;
 		CompositePKChild: PersistentModelConstructor<CompositePKChild>;
-		BasicModel: PersistentModelConstructor<BasicModel>;
-		BasicModelWritableTS: PersistentModelConstructor<BasicModelWritableTS>;
-		ModelWithExplicitOwner: PersistentModelConstructor<ModelWithExplicitOwner>;
-		ModelWithExplicitCustomOwner: PersistentModelConstructor<ModelWithExplicitCustomOwner>;
-		ModelWithMultipleCustomOwner: PersistentModelConstructor<ModelWithMultipleCustomOwner>;
 	};
 
 	return {
 		DataStore,
-		schema,
 		connectivityMonitor,
 		graphqlService,
 		simulateConnect,
@@ -1208,15 +1073,8 @@ export function getDataStore({
 		MtmJoin,
 		DefaultPKHasOneParent,
 		DefaultPKHasOneChild,
-		LegacyJSONBlog,
-		LegacyJSONPost,
 		CompositePKParent,
 		CompositePKChild,
-		BasicModel,
-		BasicModelWritableTS,
-		ModelWithExplicitOwner,
-		ModelWithExplicitCustomOwner,
-		ModelWithMultipleCustomOwner,
 	};
 }
 
@@ -1246,14 +1104,14 @@ export const DataStore: typeof DS = (() => {
 export declare class Model {
 	public readonly id: string;
 	public readonly field1: string;
-	public readonly optionalField1?: string | null;
+	public readonly optionalField1?: string;
 	public readonly dateCreated: string;
-	public readonly emails?: string[] | null;
-	public readonly ips?: (string | null)[] | null;
-	public readonly metadata?: Metadata | null;
-	public readonly logins?: Login[] | null;
-	public readonly createdAt?: string | null;
-	public readonly updatedAt?: string | null;
+	public readonly emails?: string[];
+	public readonly ips?: (string | null)[];
+	public readonly metadata?: Metadata;
+	public readonly logins?: Login[];
+	public readonly createdAt?: string;
+	public readonly updatedAt?: string;
 
 	constructor(init: ModelInit<Model>);
 
@@ -1435,24 +1293,6 @@ export declare class BasicModel {
 			draft: MutableModel<BasicModel>
 		) => MutableModel<BasicModel> | void
 	): BasicModel;
-}
-
-export declare class BasicModelWritableTS {
-	readonly [__modelMeta__]: {
-		identifier: OptionallyManagedIdentifier<BasicModelWritableTS, 'id'>;
-		readOnlyFields: never;
-	};
-	readonly id: string;
-	readonly body: string;
-	readonly createdAt?: string | null;
-	readonly updatedAt?: string | null;
-	constructor(init: ModelInit<BasicModelWritableTS>);
-	static copyOf(
-		source: BasicModelWritableTS,
-		mutator: (
-			draft: MutableModel<BasicModelWritableTS>
-		) => MutableModel<BasicModelWritableTS> | void
-	): BasicModelWritableTS;
 }
 
 export declare class HasOneParent {
@@ -1800,64 +1640,6 @@ export declare class ModelWithBoolean {
 	): ModelWithBoolean;
 }
 
-export declare class ModelWithExplicitOwner {
-	readonly [__modelMeta__]: {
-		identifier: OptionallyManagedIdentifier<ModelWithExplicitOwner, 'id'>;
-		readOnlyFields: 'createdAt' | 'updatedAt';
-	};
-	readonly id: string;
-	readonly title: string;
-	readonly owner?: string | null;
-	readonly createdAt?: string | null;
-	readonly updatedAt?: string | null;
-	constructor(init: ModelInit<ModelWithExplicitOwner>);
-	static copyOf(
-		source: ModelWithExplicitOwner,
-		mutator: (
-			draft: MutableModel<ModelWithExplicitOwner>
-		) => MutableModel<ModelWithExplicitOwner> | void
-	): ModelWithExplicitOwner;
-}
-
-export declare class ModelWithExplicitCustomOwner {
-	readonly [__modelMeta__]: {
-		identifier: OptionallyManagedIdentifier<ModelWithExplicitCustomOwner, 'id'>;
-		readOnlyFields: 'createdAt' | 'updatedAt';
-	};
-	readonly id: string;
-	readonly title: string;
-	readonly customowner?: string | null;
-	readonly createdAt?: string | null;
-	readonly updatedAt?: string | null;
-	constructor(init: ModelInit<ModelWithExplicitCustomOwner>);
-	static copyOf(
-		source: ModelWithExplicitCustomOwner,
-		mutator: (
-			draft: MutableModel<ModelWithExplicitCustomOwner>
-		) => MutableModel<ModelWithExplicitCustomOwner> | void
-	): ModelWithExplicitCustomOwner;
-}
-
-export declare class ModelWithMultipleCustomOwner {
-	readonly [__modelMeta__]: {
-		identifier: OptionallyManagedIdentifier<ModelWithMultipleCustomOwner, 'id'>;
-		readOnlyFields: 'createdAt' | 'updatedAt';
-	};
-	readonly id: string;
-	readonly title: string;
-	readonly customownerOne?: string | null;
-	readonly customownerTwo?: string | null;
-	readonly createdAt?: string | null;
-	readonly updatedAt?: string | null;
-	constructor(init: ModelInit<ModelWithMultipleCustomOwner>);
-	static copyOf(
-		source: ModelWithMultipleCustomOwner,
-		mutator: (
-			draft: MutableModel<ModelWithMultipleCustomOwner>
-		) => MutableModel<ModelWithMultipleCustomOwner> | void
-	): ModelWithMultipleCustomOwner;
-}
-
 export function testSchema(): Schema {
 	return {
 		enums: {},
@@ -2170,7 +1952,7 @@ export function testSchema(): Schema {
 						name: 'profileID',
 						isArray: false,
 						type: 'ID',
-						isRequired: false,
+						isRequired: true,
 						attributes: [],
 					},
 					profile: {
@@ -2495,55 +2277,6 @@ export function testSchema(): Schema {
 				},
 				syncable: true,
 				pluralName: 'BasicModels',
-				attributes: [
-					{
-						type: 'model',
-						properties: {},
-					},
-					{
-						type: 'key',
-						properties: {
-							fields: ['id'],
-						},
-					},
-				],
-			},
-			BasicModelWritableTS: {
-				name: 'BasicModelWritableTS',
-				fields: {
-					id: {
-						name: 'id',
-						isArray: false,
-						type: 'ID',
-						isRequired: true,
-						attributes: [],
-					},
-					body: {
-						name: 'body',
-						isArray: false,
-						type: 'String',
-						isRequired: true,
-						attributes: [],
-					},
-					createdAt: {
-						name: 'createdAt',
-						isArray: false,
-						type: 'AWSDateTime',
-						isRequired: false,
-						attributes: [],
-						isReadOnly: false,
-					},
-					updatedAt: {
-						name: 'updatedAt',
-						isArray: false,
-						type: 'AWSDateTime',
-						isRequired: false,
-						attributes: [],
-						isReadOnly: false,
-					},
-				},
-				syncable: true,
-				pluralName: 'BasicModelWritableTimestampss',
 				attributes: [
 					{
 						type: 'model',
@@ -3733,212 +3466,6 @@ export function testSchema(): Schema {
 					{
 						type: 'model',
 						properties: {},
-					},
-				],
-			},
-			ModelWithExplicitOwner: {
-				name: 'ModelWithExplicitOwner',
-				fields: {
-					id: {
-						name: 'id',
-						isArray: false,
-						type: 'ID',
-						isRequired: true,
-						attributes: [],
-					},
-					title: {
-						name: 'title',
-						isArray: false,
-						type: 'String',
-						isRequired: true,
-						attributes: [],
-					},
-					owner: {
-						name: 'owner',
-						isArray: false,
-						type: 'String',
-						isRequired: false,
-						attributes: [],
-					},
-					createdAt: {
-						name: 'createdAt',
-						isArray: false,
-						type: 'AWSDateTime',
-						isRequired: false,
-						attributes: [],
-						isReadOnly: true,
-					},
-					updatedAt: {
-						name: 'updatedAt',
-						isArray: false,
-						type: 'AWSDateTime',
-						isRequired: false,
-						attributes: [],
-						isReadOnly: true,
-					},
-				},
-				syncable: true,
-				pluralName: 'ModelWithExplicitOwners',
-				attributes: [
-					{
-						type: 'model',
-						properties: {},
-					},
-					{
-						type: 'auth',
-						properties: {
-							rules: [
-								{
-									provider: 'userPools',
-									ownerField: 'owner',
-									allow: 'owner',
-									identityClaim: 'cognito:username',
-									operations: ['create', 'update', 'delete', 'read'],
-								},
-							],
-						},
-					},
-				],
-			},
-			ModelWithExplicitCustomOwner: {
-				name: 'ModelWithExplicitCustomOwner',
-				fields: {
-					id: {
-						name: 'id',
-						isArray: false,
-						type: 'ID',
-						isRequired: true,
-						attributes: [],
-					},
-					title: {
-						name: 'title',
-						isArray: false,
-						type: 'String',
-						isRequired: true,
-						attributes: [],
-					},
-					customowner: {
-						name: 'customowner',
-						isArray: false,
-						type: 'String',
-						isRequired: false,
-						attributes: [],
-					},
-					createdAt: {
-						name: 'createdAt',
-						isArray: false,
-						type: 'AWSDateTime',
-						isRequired: false,
-						attributes: [],
-						isReadOnly: true,
-					},
-					updatedAt: {
-						name: 'updatedAt',
-						isArray: false,
-						type: 'AWSDateTime',
-						isRequired: false,
-						attributes: [],
-						isReadOnly: true,
-					},
-				},
-				syncable: true,
-				pluralName: 'ModelWithExplicitCustomOwners',
-				attributes: [
-					{
-						type: 'model',
-						properties: {},
-					},
-					{
-						type: 'auth',
-						properties: {
-							rules: [
-								{
-									provider: 'userPools',
-									ownerField: 'customowner',
-									allow: 'owner',
-									identityClaim: 'cognito:username',
-									operations: ['create', 'update', 'delete', 'read'],
-								},
-							],
-						},
-					},
-				],
-			},
-			ModelWithMultipleCustomOwner: {
-				name: 'ModelWithMultipleCustomOwner',
-				fields: {
-					id: {
-						name: 'id',
-						isArray: false,
-						type: 'ID',
-						isRequired: true,
-						attributes: [],
-					},
-					title: {
-						name: 'title',
-						isArray: false,
-						type: 'String',
-						isRequired: true,
-						attributes: [],
-					},
-					customownerOne: {
-						name: 'customownerOne',
-						isArray: false,
-						type: 'String',
-						isRequired: false,
-						attributes: [],
-					},
-					customownerTwo: {
-						name: 'customownerTwo',
-						isArray: false,
-						type: 'String',
-						isRequired: false,
-						attributes: [],
-					},
-					createdAt: {
-						name: 'createdAt',
-						isArray: false,
-						type: 'AWSDateTime',
-						isRequired: false,
-						attributes: [],
-						isReadOnly: true,
-					},
-					updatedAt: {
-						name: 'updatedAt',
-						isArray: false,
-						type: 'AWSDateTime',
-						isRequired: false,
-						attributes: [],
-						isReadOnly: true,
-					},
-				},
-				syncable: true,
-				pluralName: 'ModelWithMultipleCustomOwners',
-				attributes: [
-					{
-						type: 'model',
-						properties: {},
-					},
-					{
-						type: 'auth',
-						properties: {
-							rules: [
-								{
-									provider: 'userPools',
-									ownerField: 'customownerOne',
-									allow: 'owner',
-									identityClaim: 'cognito:username',
-									operations: ['create', 'update', 'delete', 'read'],
-								},
-								{
-									provider: 'userPools',
-									ownerField: 'customownerTwo',
-									allow: 'owner',
-									identityClaim: 'cognito:username',
-									operations: ['create', 'read'],
-								},
-							],
-						},
 					},
 				],
 			},

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -482,6 +482,7 @@ const checkSchemaInitialized = () => {
  * @param codegenVersion schema codegenVersion
  */
 const checkSchemaCodegenVersion = (codegenVersion: string) => {
+	// TODO: set to correct version when released in codegen
 	const majorVersion = 3;
 	const minorVersion = 2;
 	let isValid = false;
@@ -740,54 +741,18 @@ const castInstanceType = (
 	return v;
 };
 
-/**
- * Attempts to apply type-aware, casted field values from a given `init`
- * object to the given `draft`.
- *
- * @param init The initialization object to extract field values from.
- * @param modelDefinition The definition describing the target object shape.
- * @param draft The draft to apply field values to.
- */
 const initializeInstance = <T extends PersistentModel>(
 	init: ModelInit<T>,
 	modelDefinition: SchemaModel | SchemaNonModel,
 	draft: Draft<T & ModelInstanceMetadata>
 ) => {
 	const modelValidator = validateModelFields(modelDefinition);
-
 	Object.entries(init).forEach(([k, v]) => {
 		const parsedValue = castInstanceType(modelDefinition, k, v);
+
 		modelValidator(k, parsedValue);
 		(<any>draft)[k] = parsedValue;
 	});
-};
-
-/**
- * Updates a draft to standardize its customer-defined fields so that they are
- * consistent with the data as it would look after having been synchronized from
- * Cloud storage.
- *
- * The exceptions to this are:
- *
- * 1. Non-schema/Internal [sync] metadata fields.
- * 2. Cloud-managed fields, which are `null` until set by cloud storage.
- *
- * This function should be expanded if/when deviations between canonical Cloud
- * storage data and locally managed data are found. For now, the known areas
- * that require normalization are:
- *
- * 1. Ensuring all non-metadata fields are *defined*. (I.e., turn `undefined` -> `null`.)
- *
- * @param modelDefinition Definition for the draft. Used to discover all fields.
- * @param draft The instance draft to apply normalizations to.
- */
-const normalize = <T extends PersistentModel>(
-	modelDefinition: SchemaModel | SchemaNonModel,
-	draft: Draft<T>
-) => {
-	for (const k of Object.keys(modelDefinition.fields)) {
-		if (draft[k] === undefined) (<any>draft)[k] = null;
-	}
 };
 
 const createModelClass = <T extends PersistentModel>(
@@ -839,8 +804,6 @@ const createModelClass = <T extends PersistentModel>(
 						draft._lastChangedAt = _lastChangedAt;
 						draft._deleted = _deleted;
 					}
-
-					normalize(modelDefinition, draft);
 				}
 			);
 
@@ -876,10 +839,9 @@ const createModelClass = <T extends PersistentModel>(
 					const modelValidator = validateModelFields(modelDefinition);
 					Object.entries(draft).forEach(([k, v]) => {
 						const parsedValue = castInstanceType(modelDefinition, k, v);
+
 						modelValidator(k, parsedValue);
 					});
-
-					normalize(modelDefinition, draft);
 				},
 				p => (patches = p)
 			);

--- a/packages/datastore/src/predicates/next.ts
+++ b/packages/datastore/src/predicates/next.ts
@@ -26,9 +26,7 @@ type GroupOperator = 'and' | 'or' | 'not';
 type UntypedCondition = {
 	fetch: (storage: StorageAdapter) => Promise<Record<string, any>[]>;
 	matches: (item: Record<string, any>) => Promise<boolean>;
-	copy(
-		extract?: GroupCondition
-	): [UntypedCondition, GroupCondition | undefined];
+	copy(extract: GroupCondition): [UntypedCondition, GroupCondition | undefined];
 	toAST(): any;
 };
 
@@ -153,29 +151,13 @@ export class FieldCondition {
 	 * @param extract Not used. Present only to fulfill the `UntypedCondition` interface.
 	 * @returns A new, identitical `FieldCondition`.
 	 */
-	copy(extract?: GroupCondition): [FieldCondition, GroupCondition | undefined] {
+	copy(extract: GroupCondition): [FieldCondition, GroupCondition | undefined] {
 		return [
 			new FieldCondition(this.field, this.operator, [...this.operands]),
 			undefined,
 		];
 	}
 
-	/**
-	 * Produces a tree structure similar to a graphql condition. The returned
-	 * structure is "dumb" and is intended for another query/condition
-	 * generation mechanism to interpret, such as the cloud or storage query
-	 * builders.
-	 *
-	 * E.g.,
-	 *
-	 * ```json
-	 * {
-	 * 	"name": {
-	 * 		"eq": "robert"
-	 * 	}
-	 * }
-	 * ```
-	 */
 	toAST() {
 		return {
 			[this.field]: {
@@ -185,37 +167,6 @@ export class FieldCondition {
 						: this.operands[0],
 			},
 		};
-	}
-
-	/**
-	 * Produces a new condition (`FieldCondition` or `GroupCondition`) that
-	 * matches the opposite of this condition.
-	 *
-	 * Intended to be used when applying De Morgan's Law, which can be done to
-	 * produce more efficient queries against the storage layer if a negation
-	 * appears in the query tree.
-	 *
-	 * For example:
-	 *
-	 * 1. `name.eq('robert')` becomes `name.ne('robert')`
-	 * 2. `price.between(100, 200)` becomes `m => m.or(m => [m.price.lt(100), m.price.gt(200)])`
-	 *
-	 * @param model The model meta to use when construction a new `GroupCondition`
-	 * for cases where the negation requires multiple `FieldCondition`'s.
-	 */
-	negated(model: ModelMeta<any>) {
-		if (this.operator === 'between') {
-			return new GroupCondition(model, undefined, undefined, 'or', [
-				new FieldCondition(this.field, 'lt', [this.operands[0]]),
-				new FieldCondition(this.field, 'gt', [this.operands[1]]),
-			]);
-		} else {
-			return new FieldCondition(
-				this.field,
-				negations[this.operator],
-				this.operands
-			);
-		}
 	}
 
 	/**
@@ -387,7 +338,7 @@ export class GroupCondition {
 	 * @param extract A node of interest. Its copy will *also* be returned if the node exists.
 	 * @returns [The full copy, the copy of `extract` | undefined]
 	 */
-	copy(extract?: GroupCondition): [GroupCondition, GroupCondition | undefined] {
+	copy(extract: GroupCondition): [GroupCondition, GroupCondition | undefined] {
 		const copied = new GroupCondition(
 			this.model,
 			this.field,
@@ -406,33 +357,6 @@ export class GroupCondition {
 		});
 
 		return [copied, extractedCopy];
-	}
-
-	/**
-	 * Creates a new `GroupCondition` that contains only the local field conditions,
-	 * omitting related model conditions. That resulting `GroupCondition` can be
-	 * used to produce predicates that are compatible with the storage adapters and
-	 * Cloud storage.
-	 *
-	 * @param negate Whether the condition tree should be negated according
-	 * to De Morgan's law.
-	 */
-	withFieldConditionsOnly(negate: boolean) {
-		const negateChildren = negate !== (this.operator === 'not');
-		return new GroupCondition(
-			this.model,
-			undefined,
-			undefined,
-			(negate ? negations[this.operator] : this.operator) as
-				| 'or'
-				| 'and'
-				| 'not',
-			this.operands
-				.filter(o => o instanceof FieldCondition)
-				.map(o =>
-					negateChildren ? (o as FieldCondition).negated(this.model) : o
-				)
-		);
 	}
 
 	/**
@@ -611,6 +535,7 @@ export class GroupCondition {
 						}
 						allJoinConditions.push({ and: relativeConditions });
 					}
+
 					const predicate = FlatModelPredicateCreator.createFromAST(
 						this.model.schema,
 						{
@@ -633,9 +558,17 @@ export class GroupCondition {
 		// if conditions is empty at this point, child predicates found no matches.
 		// i.e., we can stop looking and return empty.
 		if (conditions.length > 0) {
-			const predicate =
-				this.withFieldConditionsOnly(negateChildren).toStoragePredicate();
-			resultGroups.push(await storage.query(this.model.builder, predicate));
+			const predicate = FlatModelPredicateCreator.createFromExisting(
+				this.model.schema,
+				p =>
+					p[operator](c =>
+						applyConditionsToV1Predicate(c, conditions, negateChildren)
+					)
+			);
+
+			resultGroups.push(
+				await storage.query(this.model.builder, predicate as any)
+			);
 		} else if (conditions.length === 0 && resultGroups.length === 0) {
 			resultGroups.push(await storage.query(this.model.builder));
 		}
@@ -903,7 +836,7 @@ export function recursivePredicateFor<T extends PersistentModel>(
 		Object.defineProperty(link, fieldName, {
 			enumerable: true,
 			get: () => {
-				const def = ModelType.schema.fields![fieldName];
+				const def = ModelType.schema.fields[fieldName];
 
 				if (!def.association) {
 					// we're looking at a value field. we need to return a
@@ -923,16 +856,10 @@ export function recursivePredicateFor<T extends PersistentModel>(
 								// the same link is being used elsewhere by the customer.
 								const { query, newTail } = copyLink();
 
-								// normalize operands. if any of the values are `undefiend`, use
-								// `null` instead, because that's what will be stored cross-platform.
-								const normalizedOperands = operands.map(o =>
-									o === undefined ? null : o
-								);
-
 								// add the given condition to the link's TAIL node.
 								// remember: the base link might go N nodes deep! e.g.,
 								newTail?.operands.push(
-									new FieldCondition(fieldName, operator, normalizedOperands)
+									new FieldCondition(fieldName, operator, operands)
 								);
 
 								// A `FinalModelPredicate`.

--- a/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
+++ b/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
@@ -443,17 +443,6 @@ class IndexedDBAdapter implements Adapter {
 		const hasPagination = pagination && pagination.limit;
 
 		const records: T[] = (await (async () => {
-			//
-			// NOTE: @svidgen explored removing this and letting query() take care of automatic
-			// index leveraging. This would eliminate some amount of very similar code.
-			// But, getAll is slightly slower than get()
-			//
-			// On Chrome:
-			//   ~700ms vs ~1175ms per 10k reads.
-			//
-			// You can (and should) check my work here:
-			// 	https://gist.github.com/svidgen/74e55d573b19c3e5432b1b5bdf0f4d96
-			//
 			if (queryByKey) {
 				const record = await this.getByKey(storeName, queryByKey);
 				return record ? [record] : [];
@@ -506,16 +495,7 @@ class IndexedDBAdapter implements Adapter {
 
 		for (const key of keyPath) {
 			const predicateObj = predicateObjs.find(
-				p =>
-					// it's a relevant predicate object only if it's an equality
-					// operation for a key field from the key:
-					isPredicateObj(p) &&
-					p.field === key &&
-					p.operator === 'eq' &&
-					// it's only valid if it's not nullish.
-					// (IDB will throw a fit if it's nullish.)
-					p.operand !== null &&
-					p.operand !== undefined
+				p => isPredicateObj(p) && p.field === key && p.operator === 'eq'
 			) as PredicateObject<T>;
 
 			predicateObj && keyValues.push(predicateObj.operand);

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -484,11 +484,6 @@ class MutationProcessor {
 		const modelDefinition = this.schema.namespaces[namespaceName].models[model];
 		const { primaryKey } = this.schema.namespaces[namespaceName].keys![model];
 
-		const auth = modelDefinition.attributes?.find(a => a.type === 'auth');
-		const ownerFields: string[] = auth?.properties?.rules
-			.map(rule => rule.ownerField)
-			.filter(f => f) || ['owner'];
-
 		const queriesTuples = this.typeQuery.get(modelDefinition);
 
 		const [, opName, query] = queriesTuples!.find(
@@ -517,17 +512,7 @@ class MutationProcessor {
 			mutationInput = {};
 			const modelFields = Object.values(modelDefinition.fields);
 
-			for (const { name, type, association, isReadOnly } of modelFields) {
-				// omit readonly fields. cloud storage doesn't need them and won't take them!
-				if (isReadOnly) {
-					continue;
-				}
-
-				// omit owner fields if it's `null`. cloud storage doesn't allow it.
-				if (ownerFields.includes(name) && parsedData[name] === null) {
-					continue;
-				}
-
+			for (const { name, type, association } of modelFields) {
 				// model fields should be stripped out from the input
 				if (isModelFieldType(type)) {
 					// except for belongs to relations - we need to replace them with the correct foreign key(s)


### PR DESCRIPTION
Reverts aws-amplify/amplify-js#10932

This PR caused explicit timestamp fields to fall into required field validation, which they were not previously. The fields are marked as `required` fields, and the TS types requires they be provided. But, in JS, they haven't strictly been required. Nor are they technically required at sync time.

Rolling back for now while we determine how to handle these.