### PR TITLE
ci: pin verdaccio image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,25 +26,25 @@ executors:
   js-test-executor:
     docker:
       - image: cypress/included:12.4.1
-      - image: verdaccio/verdaccio
+      - image: verdaccio/verdaccio:5.20
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_ACCESS_TOKEN
     resource_class: large
 
   # TODO: Update tests that use this image to use the updated `js-test-executor`
-  # After upgrading the Docker image to 12.4.1, we had to make several updates to our samples (see 
-  # https://github.com/aws-amplify/amplify-js-samples-staging/pull/522). 
-  # This is because our current implementation of setting network status in our E2E tests began to 
-  # fail (i.e. this is no longer supported). We updated our samples to instead use the Reachability 
+  # After upgrading the Docker image to 12.4.1, we had to make several updates to our samples (see
+  # https://github.com/aws-amplify/amplify-js-samples-staging/pull/522).
+  # This is because our current implementation of setting network status in our E2E tests began to
+  # fail (i.e. this is no longer supported). We updated our samples to instead use the Reachability
   # component's helper function for setting network status
   # (see https://github.com/aws-amplify/amplify-js/blob/main/packages/core/src/Util/Reachability.ts#L42-L54).
-  # However, several JS tests were still failing after attempting to remediate. An item has been 
+  # However, several JS tests were still failing after attempting to remediate. An item has been
   # added to the JS backlog for follow-up.
   js-test-executor-prev:
     docker:
       - image: cypress/included:8.7.0
-      - image: verdaccio/verdaccio
+      - image: verdaccio/verdaccio:5.20
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_ACCESS_TOKEN
@@ -58,7 +58,7 @@ executors:
   webkit-test-executor:
     docker:
       - image: mcr.microsoft.com/playwright:v1.30.0-focal
-      - image: verdaccio/verdaccio
+      - image: verdaccio/verdaccio:5.20
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_ACCESS_TOKEN
@@ -1581,10 +1581,10 @@ releasable_branches: &releasable_branches
 minimal_browser_list: &minimal_browser_list
   browser: [chrome, firefox]
 
-# List of test browsers that are used in E2E tests where we want to also test browser APIs. For functionality that 
-# interacts with browser APIs (e.g. IndexedDB), use `extended_browser_list`. Includes Microsoft Edge. Note: WebKit 
-# is not included in this list because WebKit requires a different Docker image. Any test that uses this browser 
-# list should also test against WebKit. 
+# List of test browsers that are used in E2E tests where we want to also test browser APIs. For functionality that
+# interacts with browser APIs (e.g. IndexedDB), use `extended_browser_list`. Includes Microsoft Edge. Note: WebKit
+# is not included in this list because WebKit requires a different Docker image. Any test that uses this browser
+# list should also test against WebKit.
 extended_browser_list: &extended_browser_list
   browser: [chrome, firefox, edge]
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Pins the tag of the verdaccio/verdaccio Docker image to mitigate this issue: https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/18011/workflows/84e64b56-a4a2-4f42-a1fd-2bbf05a9a8fe/jobs/232466


#### Description of how you validated changes
integ jobs start up fine after pinning the version: https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/18014/workflows/5f94f47a-7ced-4a07-9cc0-22fabd0e2a4c/jobs/232687


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
