### PR TITLE
feat(notifications): Add getPermissionStatus API

### DIFF
--- a/packages/notifications/src/PushNotification/PushNotification.native.ts
+++ b/packages/notifications/src/PushNotification/PushNotification.native.ts
@@ -274,18 +274,18 @@ export default class PushNotification implements PushNotificationInterface {
 		return normalizeNativeMessage(await getLaunchNotification?.());
 	};
 
+	getPermissionStatus = async (): Promise<PushNotificationPermissionStatus> => {
+		const { getPermissionStatus } = this.nativeModule;
+		return normalizeNativePermissionStatus(await getPermissionStatus?.());
+	};
+
 	requestPermissions = async (
 		permissions: PushNotificationPermissions = {
 			alert: true,
 			badge: true,
 			sound: true,
 		}
-	): Promise<PushNotificationPermissionStatus> => {
-		const { requestPermissions } = this.nativeModule;
-		return normalizeNativePermissionStatus(
-			await requestPermissions?.(permissions)
-		);
-	};
+	): Promise<boolean> => this.nativeModule.requestPermissions?.(permissions);
 
 	/**
 	 * Background notifications on will start the app (as a headless JS instance running on a background service on

--- a/packages/notifications/src/PushNotification/PushNotification.native.ts
+++ b/packages/notifications/src/PushNotification/PushNotification.native.ts
@@ -132,8 +132,9 @@ export default class PushNotification implements PushNotificationInterface {
 							logger.error(err);
 						} finally {
 							// notify native module that handlers have completed their work (or timed out)
-							const { completeNotification } = this.nativeModule;
-							completeNotification?.(message.completionHandlerId);
+							this.nativeModule.completeNotification?.(
+								message.completionHandlerId
+							);
 						}
 					}
 				);
@@ -269,15 +270,13 @@ export default class PushNotification implements PushNotificationInterface {
 			})
 		);
 
-	getLaunchNotification = async (): Promise<PushNotificationMessage | null> => {
-		const { getLaunchNotification } = this.nativeModule;
-		return normalizeNativeMessage(await getLaunchNotification?.());
-	};
+	getLaunchNotification = async (): Promise<PushNotificationMessage | null> =>
+		normalizeNativeMessage(await this.nativeModule.getLaunchNotification?.());
 
-	getPermissionStatus = async (): Promise<PushNotificationPermissionStatus> => {
-		const { getPermissionStatus } = this.nativeModule;
-		return normalizeNativePermissionStatus(await getPermissionStatus?.());
-	};
+	getPermissionStatus = async (): Promise<PushNotificationPermissionStatus> =>
+		normalizeNativePermissionStatus(
+			await this.nativeModule.getPermissionStatus?.()
+		);
 
 	requestPermissions = async (
 		permissions: PushNotificationPermissions = {

--- a/packages/notifications/src/PushNotification/PushNotification.ts
+++ b/packages/notifications/src/PushNotification/PushNotification.ts
@@ -62,9 +62,11 @@ export default class PushNotification implements PushNotificationInterface {
 		throw new PlatformNotSupportedError();
 	};
 
-	requestPermissions = (
-		_?: PushNotificationPermissions
-	): Promise<PushNotificationPermissionStatus> => {
+	getPermissionStatus = (): Promise<PushNotificationPermissionStatus> => {
+		throw new PlatformNotSupportedError();
+	};
+
+	requestPermissions = (_?: PushNotificationPermissions): Promise<boolean> => {
 		throw new PlatformNotSupportedError();
 	};
 

--- a/packages/notifications/src/PushNotification/types.ts
+++ b/packages/notifications/src/PushNotification/types.ts
@@ -22,9 +22,10 @@ export interface PushNotificationInterface {
 	removePluggable: (providerName: string) => void;
 	identifyUser: (userId: string, userInfo: UserInfo) => Promise<void[]>;
 	getLaunchNotification: () => Promise<PushNotificationMessage>;
+	getPermissionStatus: () => Promise<PushNotificationPermissionStatus>;
 	requestPermissions: (
 		permissions?: PushNotificationPermissions
-	) => Promise<PushNotificationPermissionStatus>;
+	) => Promise<boolean>;
 	onBackgroundNotificationReceived: (
 		handler: OnPushNotificationMessageHandler
 	) => EventListener<OnPushNotificationMessageHandler>;
@@ -86,7 +87,8 @@ export interface PushNotificationPermissions extends Record<string, boolean> {
 export enum PushNotificationPermissionStatus {
 	DENIED = 'DENIED',
 	GRANTED = 'GRANTED',
-	UNDETERMINED = 'UNDETERMINED',
+	NOT_REQUESTED = 'NOT_REQUESTED',
+	SHOULD_REQUEST_WITH_RATIONALE = 'SHOULD_REQUEST_WITH_RATIONALE',
 }
 
 export type OnTokenReceivedHandler = (token: PushNotificationTokenMap) => any;

--- a/packages/notifications/src/PushNotification/utils.ts
+++ b/packages/notifications/src/PushNotification/utils.ts
@@ -18,8 +18,10 @@ export const normalizeNativePermissionStatus = (
 			return PushNotificationPermissionStatus.DENIED;
 		case 'Granted':
 			return PushNotificationPermissionStatus.GRANTED;
-		default:
-			return PushNotificationPermissionStatus.UNDETERMINED;
+		case 'NotRequested':
+			return PushNotificationPermissionStatus.NOT_REQUESTED;
+		case 'ShouldRequestWithRationale':
+			return PushNotificationPermissionStatus.SHOULD_REQUEST_WITH_RATIONALE;
 	}
 };
 

--- a/packages/rtn-push-notification/android/src/main/kotlin/com/amazonaws/amplify/rtnpushnotification/PushNotificationFirebaseMessagingService.kt
+++ b/packages/rtn-push-notification/android/src/main/kotlin/com/amazonaws/amplify/rtnpushnotification/PushNotificationFirebaseMessagingService.kt
@@ -16,6 +16,13 @@ private const val ACTION_NEW_TOKEN = "com.google.firebase.messaging.NEW_TOKEN"
 
 class PushNotificationFirebaseMessagingService : FirebaseMessagingService() {
 
+    private lateinit var utils: PushNotificationsUtils
+
+    override fun onCreate() {
+        super.onCreate()
+        utils = PushNotificationsUtils(baseContext)
+    }
+
     override fun onNewToken(token: String) {
         val params = Arguments.createMap()
         params.putString("token", token)
@@ -42,7 +49,6 @@ class PushNotificationFirebaseMessagingService : FirebaseMessagingService() {
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
-        val utils = PushNotificationsUtils(baseContext)
         val payload = getPayloadFromRemoteMessage(remoteMessage)
         if (utils.isAppInForeground()) {
             Log.d(TAG, "Send foreground message received event")

--- a/packages/rtn-push-notification/android/src/main/kotlin/com/amazonaws/amplify/rtnpushnotification/PushNotificationModule.kt
+++ b/packages/rtn-push-notification/android/src/main/kotlin/com/amazonaws/amplify/rtnpushnotification/PushNotificationModule.kt
@@ -4,8 +4,11 @@
 package com.amazonaws.amplify.rtnpushnotification
 
 import android.app.Activity
+import android.content.Context.MODE_PRIVATE
 import android.content.Intent
+import android.content.SharedPreferences
 import android.util.Log
+import androidx.core.app.ActivityCompat
 import com.amplifyframework.pushnotifications.pinpoint.utils.permissions.PermissionRequestResult
 import com.amplifyframework.pushnotifications.pinpoint.utils.permissions.PushNotificationPermission
 import com.facebook.react.bridge.*
@@ -16,11 +19,17 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
-private val TAG = PushNotificationModule::class.java.simpleName
 
-enum class PushNotificationPermissionStatus(val value: String) {
-    GRANTED("Granted"),
-    DENIED("Denied"),
+private val TAG = PushNotificationModule::class.java.simpleName
+private const val PERMISSION = "android.permission.POST_NOTIFICATIONS"
+private const val PREF_FILE_KEY = "com.amazonaws.amplify.rtnpushnotification"
+private const val PREF_PREVIOUSLY_DENIED = "wasPermissionPreviouslyDenied"
+
+enum class PushNotificationPermissionStatus {
+    NotRequested,
+    ShouldRequestWithRationale,
+    Granted,
+    Denied,
 }
 
 class PushNotificationModule(
@@ -29,11 +38,13 @@ class PushNotificationModule(
 
     private var isAppLaunch: Boolean = true
     private var launchNotification: WritableMap? = null
+    private var sharedPreferences: SharedPreferences
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Main)
 
     init {
         reactContext.addActivityEventListener(this)
         reactContext.addLifecycleEventListener(this)
+        sharedPreferences = reactContext.getSharedPreferences(PREF_FILE_KEY, MODE_PRIVATE)
     }
 
     @ReactMethod
@@ -45,14 +56,46 @@ class PushNotificationModule(
     }
 
     @ReactMethod
+    fun getPermissionStatus(promise: Promise) {
+        val permission = PushNotificationPermission(reactApplicationContext)
+        // If permission has already been granted
+        if (permission.hasRequiredPermission) {
+            return promise.resolve(PushNotificationPermissionStatus.Granted.name)
+        }
+        // If the shouldShowRequestPermissionRationale flag is true, permission must have been
+        // denied once (and only once) previously
+        if (shouldShowRequestPermissionRationale()) {
+            return promise.resolve(PushNotificationPermissionStatus.ShouldRequestWithRationale.name)
+        }
+        // If the shouldShowRequestPermissionRationale flag is false and the permission was
+        // already previously denied then user has denied permissions twice
+        if (sharedPreferences.getBoolean(PREF_PREVIOUSLY_DENIED, false)) {
+            return promise.resolve(PushNotificationPermissionStatus.Denied.name)
+        }
+        // Otherwise it's never been requested (or user could have dismissed the request without
+        // explicitly denying)
+        promise.resolve(PushNotificationPermissionStatus.NotRequested.name)
+    }
+
+    @ReactMethod
     fun requestPermissions(permissions: ReadableMap, promise: Promise) {
         scope.launch {
             val permission = PushNotificationPermission(reactApplicationContext)
             val result = permission.requestPermission()
             if (result is PermissionRequestResult.Granted) {
-                promise.resolve(PushNotificationPermissionStatus.GRANTED.value)
+                promise.resolve(true)
             } else {
-                promise.resolve(PushNotificationPermissionStatus.DENIED.value)
+                // If permission was not granted and the shouldShowRequestPermissionRationale flag
+                // is true then user must have denied for the first time. We will set the
+                // wasPermissionPreviouslyDenied value to true only in this scenario since it's
+                // possible to dismiss the permission request without explicitly denying as well.
+                if (shouldShowRequestPermissionRationale()) {
+                    with(sharedPreferences.edit()) {
+                        putBoolean(PREF_PREVIOUSLY_DENIED, true)
+                        apply()
+                    }
+                }
+                promise.resolve(false)
             }
         }
     }
@@ -84,7 +127,7 @@ class PushNotificationModule(
      */
     override fun onNewIntent(intent: Intent?) {
         intent?.let {
-            val payload = getPayloadFromTempExtras(it.extras)
+            val payload = getPayloadFromExtras(it.extras)
             if (payload != null) {
                 val params = Arguments.fromBundle(payload.bundle())
                 PushNotificationEventManager.sendEvent(
@@ -111,10 +154,13 @@ class PushNotificationModule(
                 val params = Arguments.createMap()
                 params.putString("token", task.result)
                 Log.d(TAG, "Send device token event")
-                PushNotificationEventManager.sendEvent(PushNotificationEventType.TOKEN_RECEIVED, params)
+                PushNotificationEventManager.sendEvent(
+                    PushNotificationEventType.TOKEN_RECEIVED,
+                    params
+                )
             })
             currentActivity?.intent?.let {
-                val payload = getPayloadFromTempExtras(it.extras)
+                val payload = getPayloadFromExtras(it.extras)
                 if (payload != null) {
                     launchNotification = Arguments.fromBundle(payload.bundle())
                     // Launch notification opened event is emitted for internal use only
@@ -136,5 +182,9 @@ class PushNotificationModule(
 
     override fun onHostDestroy() {
         scope.cancel()
+    }
+
+    private fun shouldShowRequestPermissionRationale(): Boolean {
+        return ActivityCompat.shouldShowRequestPermissionRationale(currentActivity!!, PERMISSION)
     }
 }

--- a/packages/rtn-push-notification/src/types.ts
+++ b/packages/rtn-push-notification/src/types.ts
@@ -14,5 +14,8 @@ export interface PushNotificationNativeModule {
 		NativeHeadlessTaskKey: string;
 	};
 	getLaunchNotification: () => Promise<Record<string, string>>;
-	requestPermissions: (permissions: Record<string, boolean>) => Promise<string>;
+	getPermissionStatus: () => Promise<string>;
+	requestPermissions: (
+		permissions: Record<string, boolean>
+	) => Promise<boolean>;
 }


### PR DESCRIPTION
#### Description of changes
This PR adds the `getPermissionStatus` API which is the companion API to `requestPermissions`.

Previously, the latter API directly returned either a granted or denied status. But this failed to enable use cases where developers may want to display rationale UIs before attempting to request permissions. The `getPermissionStatus` API will give them additional insight into the current permission state and enable them to better control their permission workflow.

#### Description of how you validated changes
Tested locally against React Native Android app on API 33

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
