### PR TITLE
Update AWSS3ProviderManagedUpload.ts Passed

### DIFF
--- a/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
+++ b/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
@@ -4,6 +4,7 @@
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import {
 	PutObjectCommandInput,
+	PutObjectCommand,
 	PutObjectRequest,
 	CreateMultipartUploadCommand,
 	UploadPartCommand,

--- a/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
+++ b/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
@@ -57,7 +57,7 @@ export class AWSS3ProviderManagedUpload {
 	private totalBytesToUpload = 0;
 	private emitter: events.EventEmitter | null = null;
 
-	constructor(params: PutObjectRequest, opts, emitter: events.EventEmitter) {
+	constructor(params: PutObjectCommandInput, opts, emitter: events.EventEmitter) {
 		this.params = params;
 		this.opts = opts;
 		this.emitter = emitter;

--- a/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
+++ b/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
@@ -3,7 +3,7 @@
 
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import {
-	PutObjectCommand,
+	PutObjectCommandInput,
 	PutObjectRequest,
 	CreateMultipartUploadCommand,
 	UploadPartCommand,


### PR DESCRIPTION
Changing params to type PutObjectCommandInput allows for AWSS3Provider line 556 const uploader = new AWSS3ProviderManagedUpload(params, opt, emitter); to not fail on compilation in typescript/angular. Without this change, typescript will always fail on compilation due to type mismatch

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
