### PR TITLE
fix(notifications): Intermediary activty not always created

### DIFF
--- a/packages/rtn-push-notification/android/src/main/AndroidManifest.xml
+++ b/packages/rtn-push-notification/android/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <application>
         <activity
             android:name=".PushNotificationLaunchActivity"
+            android:launchMode="singleInstance"
             android:exported="false" />
 
         <service android:name=".PushNotificationHeadlessTaskService" />


### PR DESCRIPTION
#### Description of changes
This PR fixes an issue where our module launch activity did not always get created when the app was previously awoken in the background via headless service.

#### Description of how you validated changes
Validated changes allowed sample app to function as expected in various states.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
