### PR TITLE
feat(notifications): Add Notifications-level identifyUser

### DIFF
--- a/packages/notifications/src/Notifications.ts
+++ b/packages/notifications/src/Notifications.ts
@@ -6,7 +6,7 @@ import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
 import InAppMessagingClass from './InAppMessaging';
 import { InAppMessagingInterface as InAppMessaging } from './InAppMessaging/types';
 import { PushNotificationInterface as PushNotification } from './PushNotification/types';
-import { NotificationsCategory, NotificationsConfig } from './types';
+import { NotificationsCategory, NotificationsConfig, UserInfo } from './types';
 
 const logger = new Logger('Notifications');
 
@@ -59,6 +59,17 @@ class NotificationsClass {
 	get Push() {
 		return this.pushNotification;
 	}
+
+	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[][]> => {
+		const promises: Promise<void[]>[] = [];
+		if (this.InAppMessaging) {
+			promises.push(this.InAppMessaging.identifyUser(userId, userInfo));
+		}
+		if (this.Push) {
+			promises.push(this.Push.identifyUser(userId, userInfo));
+		}
+		return Promise.all<void[]>(promises);
+	};
 }
 
 const Notifications = new NotificationsClass();


### PR DESCRIPTION
#### Description of changes
This PR adds the `identifyUser` API to the Notifications category as a convenience function for calling registered subcategories' (i.e. channels) respective `identifyUser` APIs.

#### Description of how you validated changes
Validated changes locally - calling `Notifications.identifyUser` will call `InAppMessaging.identifyUser` and `Push.identifyUser`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
