### PR TITLE
fix(@aws-amplify/datastore): fix for queries against numeric indexes in IDB

### DIFF
--- a/packages/datastore/__tests__/Predicate.ts
+++ b/packages/datastore/__tests__/Predicate.ts
@@ -2219,6 +2219,26 @@ describe('Predicates', () => {
 				matches: [{ name: 'tim' }, { name: 'sam' }],
 				mismatches: [{ name: 'al' }, { name: 'fran' }],
 			},
+			{
+				gql: {
+					and: [{ rating: { gt: 123 } }],
+				},
+				expectedRegeneration: {
+					and: [{ rating: { gt: 123 } }],
+				},
+				matches: [{ rating: 124 }, { rating: 125 }],
+				mismatches: [{ rating: 122 }, { rating: 123 }],
+			},
+			{
+				gql: {
+					and: [{ rating: { eq: 123 } }],
+				},
+				expectedRegeneration: {
+					and: [{ rating: { eq: 123 } }],
+				},
+				matches: [{ rating: 123 }],
+				mismatches: [{ rating: 122 }, { rating: 124 }],
+			},
 		];
 
 		for (const [i, testCase] of ASTTransalationTestCases.entries()) {
@@ -2227,14 +2247,14 @@ describe('Predicates', () => {
 			)}`, () => {
 				const condition = testCase.gql;
 				const builder = ModelPredicateCreator.createFromAST(
-					BlogMeta.schema,
+					AuthorMeta.schema,
 					condition
 				);
 				const predicate = ModelPredicateCreator.getPredicates(builder)!;
 
 				const regeneratedCondition = predicateToGraphQLCondition(
 					predicate,
-					BlogMeta.schema
+					AuthorMeta.schema
 				);
 				const regeneratedFilter = predicateToGraphQLFilter(predicate);
 
@@ -2270,11 +2290,16 @@ describe('Predicates', () => {
 				matches: [{ name: 'tim' }, { name: 'sam' }],
 				mismatches: [{ name: 'al' }, { name: 'fran' }],
 			},
+			{
+				predicate: p => p.rating.eq(123),
+				matches: [{ rating: 123 }],
+				mismatches: [{ rating: 122 }, { rating: 124 }],
+			},
 		];
 		for (const [i, testCase] of predicateTestCases.entries()) {
 			test(`nested predicate builder can produce storage predicate ${i}: ${testCase.predicate}`, () => {
 				const builder = internals(
-					testCase.predicate(predicateFor(BlogMeta))
+					testCase.predicate(predicateFor(AuthorMeta))
 				).toStoragePredicate();
 
 				const predicate = ModelPredicateCreator.getPredicates(builder)!;

--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -1018,6 +1018,7 @@ export function getDataStore({
 		LegacyJSONComment,
 		CompositePKParent,
 		CompositePKChild,
+		ModelWithIndexes,
 	} = classes as {
 		ModelWithBoolean: PersistentModelConstructor<ModelWithBoolean>;
 		Blog: PersistentModelConstructor<Blog>;
@@ -1043,6 +1044,7 @@ export function getDataStore({
 		LegacyJSONComment: PersistentModelConstructor<LegacyJSONComment>;
 		CompositePKParent: PersistentModelConstructor<CompositePKParent>;
 		CompositePKChild: PersistentModelConstructor<CompositePKChild>;
+		ModelWithIndexes: PersistentModelConstructor<ModelWithIndexes>;
 	};
 
 	return {
@@ -1075,6 +1077,7 @@ export function getDataStore({
 		LegacyJSONComment,
 		CompositePKParent,
 		CompositePKChild,
+		ModelWithIndexes,
 	};
 }
 
@@ -1638,6 +1641,22 @@ export declare class ModelWithBoolean {
 		src: ModelWithBoolean,
 		mutator: (draft: MutableModel<ModelWithBoolean>) => void | ModelWithBoolean
 	): ModelWithBoolean;
+}
+
+export declare class ModelWithIndexes {
+	public readonly id: string;
+	public readonly stringField?: string;
+	public readonly intField?: number;
+	public readonly floatField?: number;
+	public readonly createdAt?: string;
+	public readonly updatedAt?: string;
+
+	constructor(init: ModelInit<ModelWithIndexes>);
+
+	static copyOf(
+		src: ModelWithIndexes,
+		mutator: (draft: MutableModel<ModelWithIndexes>) => void | ModelWithIndexes
+	): ModelWithIndexes;
 }
 
 export function testSchema(): Schema {
@@ -3466,6 +3485,84 @@ export function testSchema(): Schema {
 					{
 						type: 'model',
 						properties: {},
+					},
+				],
+			},
+			ModelWithIndexes: {
+				name: 'ModelWithIndexes',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					stringField: {
+						name: 'stringField',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					floatField: {
+						name: 'floatField',
+						isArray: false,
+						type: 'Float',
+						isRequired: false,
+						attributes: [],
+					},
+					intField: {
+						name: 'intField',
+						isArray: false,
+						type: 'Int',
+						isRequired: false,
+						attributes: [],
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: false,
+						attributes: [],
+						isReadOnly: true,
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: false,
+						attributes: [],
+						isReadOnly: true,
+					},
+				},
+				syncable: true,
+				pluralName: 'ModelWithIndexess',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							name: 'byStringField',
+							fields: ['stringField'],
+						},
+					},
+					{
+						type: 'key',
+						properties: {
+							name: 'byIntField',
+							fields: ['intField'],
+						},
+					},
+					{
+						type: 'key',
+						properties: {
+							name: 'byFloatField',
+							fields: ['floatField'],
+						},
 					},
 				],
 			},

--- a/packages/datastore/__tests__/helpers.ts
+++ b/packages/datastore/__tests__/helpers.ts
@@ -3502,7 +3502,7 @@ export function testSchema(): Schema {
 						name: 'stringField',
 						isArray: false,
 						type: 'String',
-						isRequired: true,
+						isRequired: false,
 						attributes: [],
 					},
 					floatField: {

--- a/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
+++ b/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
@@ -550,12 +550,12 @@ class IndexedDBAdapter implements Adapter {
 		for (const name of store.indexNames) {
 			const idx = store.index(name);
 			const keypath = Array.isArray(idx.keyPath) ? idx.keyPath : [idx.keyPath];
-			const matchingPredicateValues: string[] = [];
+			const matchingPredicateValues: (string | number)[] = [];
 
 			for (const field of keypath) {
 				const p = predicateIndex.get(field);
-				if (p) {
-					matchingPredicateValues.push(String(p.operand));
+				if (p && p.operand !== null && p.operand !== undefined) {
+					matchingPredicateValues.push(p.operand);
 				} else {
 					break;
 				}
@@ -1238,7 +1238,7 @@ class IndexedDBAdapter implements Adapter {
 	 * @returns An array or string, depending on and given key,
 	 * that is ensured to be compatible with the IndexedDB implementation's nuances.
 	 */
-	private canonicalKeyPath = (keyArr: string[]) => {
+	private canonicalKeyPath = (keyArr: (string | number)[]) => {
 		if (this.safariCompatabilityMode) {
 			return keyArr.length > 1 ? keyArr : keyArr[0];
 		}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Queries against indexed fields in IDB were being queried as strings for `eq` matches due to a bad cast, causing missing results. This PR removes the cast.

Due to the removed cast, this also adds filters `null` and `undefined` conditions out of indexed queries, which would otherwise incorrectly be accepted as IDB key lookup values.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#11018


#### Description of how you validated changes

Red-greened tested.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
