### PR TITLE
feat(notifications): Add badge count APIs

### DIFF
--- a/packages/notifications/src/PushNotification/PushNotification.native.ts
+++ b/packages/notifications/src/PushNotification/PushNotification.native.ts
@@ -273,6 +273,12 @@ export default class PushNotification implements PushNotificationInterface {
 	getLaunchNotification = async (): Promise<PushNotificationMessage | null> =>
 		normalizeNativeMessage(await this.nativeModule.getLaunchNotification?.());
 
+	getBadgeCount = async (): Promise<number | null> =>
+		this.nativeModule.getBadgeCount?.();
+
+	setBadgeCount = (count: number): void =>
+		this.nativeModule.setBadgeCount?.(count);
+
 	getPermissionStatus = async (): Promise<PushNotificationPermissionStatus> =>
 		normalizeNativePermissionStatus(
 			await this.nativeModule.getPermissionStatus?.()

--- a/packages/notifications/src/PushNotification/PushNotification.ts
+++ b/packages/notifications/src/PushNotification/PushNotification.ts
@@ -62,6 +62,14 @@ export default class PushNotification implements PushNotificationInterface {
 		throw new PlatformNotSupportedError();
 	};
 
+	getBadgeCount = async (): Promise<number | null> => {
+		throw new PlatformNotSupportedError();
+	};
+
+	setBadgeCount = (_: number): void => {
+		throw new PlatformNotSupportedError();
+	};
+
 	getPermissionStatus = (): Promise<PushNotificationPermissionStatus> => {
 		throw new PlatformNotSupportedError();
 	};

--- a/packages/notifications/src/PushNotification/types.ts
+++ b/packages/notifications/src/PushNotification/types.ts
@@ -22,6 +22,8 @@ export interface PushNotificationInterface {
 	removePluggable: (providerName: string) => void;
 	identifyUser: (userId: string, userInfo: UserInfo) => Promise<void[]>;
 	getLaunchNotification: () => Promise<PushNotificationMessage>;
+	getBadgeCount: () => Promise<number>;
+	setBadgeCount: (count: number) => void;
 	getPermissionStatus: () => Promise<PushNotificationPermissionStatus>;
 	requestPermissions: (
 		permissions?: PushNotificationPermissions

--- a/packages/rtn-push-notification/src/types.ts
+++ b/packages/rtn-push-notification/src/types.ts
@@ -14,6 +14,8 @@ export interface PushNotificationNativeModule {
 		NativeHeadlessTaskKey: string;
 	};
 	getLaunchNotification: () => Promise<Record<string, string>>;
+	getBadgeCount: () => Promise<number>;
+	setBadgeCount: (count: number) => void;
 	getPermissionStatus: () => Promise<string>;
 	requestPermissions: (
 		permissions: Record<string, boolean>


### PR DESCRIPTION
#### Description of changes
This PR adds badge count APIs to Push Notification:
* getBadgeCount
* setBadgeCount

These APIs were already added to the native module but were missed earlier during integration

#### Description of how you validated changes
Tested with both iOS and Android to see that APIs behave as expected

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
