### PR TITLE
chore(notifications): Remove unnecessary let block

### DIFF
--- a/packages/rtn-push-notification/android/src/main/kotlin/com/amazonaws/amplify/rtnpushnotification/PushNotificationModule.kt
+++ b/packages/rtn-push-notification/android/src/main/kotlin/com/amazonaws/amplify/rtnpushnotification/PushNotificationModule.kt
@@ -125,15 +125,13 @@ class PushNotificationModule(
     /**
      * Send notification opened app event to JS layer if the app is in a background state
      */
-    override fun onNewIntent(intent: Intent?) {
-        intent?.let {
-            val payload = getPayloadFromExtras(it.extras)
-            if (payload != null) {
-                val params = Arguments.fromBundle(payload.bundle())
-                PushNotificationEventManager.sendEvent(
-                    PushNotificationEventType.NOTIFICATION_OPENED, params
-                )
-            }
+    override fun onNewIntent(intent: Intent) {
+        val payload = getPayloadFromExtras(intent.extras)
+        if (payload != null) {
+            val params = Arguments.fromBundle(payload.bundle())
+            PushNotificationEventManager.sendEvent(
+                PushNotificationEventType.NOTIFICATION_OPENED, params
+            )
         }
     }
 


### PR DESCRIPTION
#### Description of changes
This PR updates the Android module's `onNewIntent` block to expect an intent. When this function is called, it will always have an intent.

#### Description of how you validated changes
Tested with sample app locally to see behavior remained as expected.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
