### PR TITLE
fix: Revert make XR package private & prevent publication

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,9 +7,6 @@
 	"command": {
 		"run": {
 			"private": false
-		},
-		"bootstrap": {
-			"ignore": "@aws-amplify/xr"
 		}
 	}
 }

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -52,7 +52,7 @@
     "@aws-amplify/predictions": "5.0.17",
     "@aws-amplify/pubsub": "5.1.0",
     "@aws-amplify/storage": "5.1.7",
-    "@aws-amplify/xr": "latest",
+    "@aws-amplify/xr": "4.0.15",
     "tslib": "^2.0.0"
   },
   "jest": {

--- a/packages/xr/package.json
+++ b/packages/xr/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@aws-amplify/xr",
   "version": "4.0.17",
-  "private": true,
   "description": "XR category of aws-amplify",
   "main": "./lib/index.js",
   "module": "./lib-esm/index.js",


### PR DESCRIPTION
This reverts commit 4765105ce284f66d822be75e5e279bb015a39451.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR reverts the change to make the XR package private, which was creating a problem where multiple versions of `core` might get installed.

Original PR: https://github.com/aws-amplify/amplify-js/pull/11001/files

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
