### PR TITLE
fix(datastore): rtf errorType conditional

### DIFF
--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -756,7 +756,7 @@ class SubscriptionProcessor {
 				message.includes(errorMsg)
 			) || [];
 
-		if (errorType) {
+		if (errorType !== undefined) {
 			const remediationMessage = generateRTFRemediation(
 				errorType,
 				modelDefinition,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

`errorType` is an enum, which can have value `0`. Conditional was doing a falsey check. Check for `undefined` instead.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
