### PR TITLE
Upgrade buffer dependency to 6.0.3

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -64,7 +64,7 @@
   "types": "./index.d.ts",
   "dependencies": {
     "@aws-crypto/sha256-js": "1.2.2",
-    "buffer": "4.9.2",
+    "buffer": "6.0.3",
     "fast-base64-decode": "^1.0.0",
     "isomorphic-unfetch": "^3.0.0",
     "js-cookie": "^2.2.1"


### PR DESCRIPTION
Using 4.9.2 version of the buffer package package causes an error on Lambda

Since it's a console.error, this logs to AWS CloudWatch every time a request is made.  This problem exists only on Lambda, on local, it doesn't show any such errors.

ERROR    (node:8) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

![Screenshot 2023-03-10 at 1 41 43 AM](https://user-images.githubusercontent.com/800668/224146019-4b64bf47-25a3-4d63-9373-05418afafb8a.png)
![Screenshot 2023-03-10 at 1 40 08 AM](https://user-images.githubusercontent.com/800668/224146026-24ed508f-f060-4c66-bcdd-67bb26c1e324.png)
![Screenshot 2023-03-10 at 1 39 56 AM](https://user-images.githubusercontent.com/800668/224146028-360b818c-a988-449e-b1d0-0f021feaa4dc.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
