### PR TITLE
test(integ): Disable Vue Interactions Firefox test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1725,7 +1725,7 @@ workflows:
             <<: *releasable_branches
           matrix:
             parameters:
-              <<: *minimal_browser_list
+              browser: [chrome]
       - integ_angular_interactions:
           requires:
             - integ_setup


### PR DESCRIPTION
#### Description of changes

This PR prevents a flaky Firefox integ test from running.

The root cause of the frequent test failure is that, at times, the UI component used in the test fails to load due to the following error: `Cstr is undefined`

This error is coming from [Stencil](https://github.com/ionic-team/stencil) which was a dependency of the chatbot inside a deprecated `@aws-amplify/ui-components` package. 

Rather than trying to debug an unsupported component in a deprecated package we are disabling this test from running on Firefox.

#### Description of how you validated changes
Validated that the updated circle configuration is valid
```sh
$ circleci config validate
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
