### PR TITLE
feat(notifications): Add init API

### DIFF
--- a/packages/notifications/src/PushNotification/NotEnabledError.ts
+++ b/packages/notifications/src/PushNotification/NotEnabledError.ts
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export default class NotEnabledError extends Error {
+	constructor() {
+		super(
+			'Function is unavailable as Push has not been enabled. Please call `Push.enable` before calling this function.'
+		);
+		this.name = 'NotEnabledError';
+	}
+}

--- a/packages/notifications/src/PushNotification/Providers/AWSPinpointProvider/index.ts
+++ b/packages/notifications/src/PushNotification/Providers/AWSPinpointProvider/index.ts
@@ -3,7 +3,7 @@
 
 import { ChannelType } from '@aws-sdk/client-pinpoint';
 import { addEventListener, AWSPinpointProviderCommon } from '../../../common';
-import PlatformNotSupportedError from '../..';
+import PlatformNotSupportedError from '../../PlatformNotSupportedError';
 import { Platform } from '../../Platform';
 import {
 	PushNotificationEvent,

--- a/packages/notifications/src/PushNotification/PushNotification.native.ts
+++ b/packages/notifications/src/PushNotification/PushNotification.native.ts
@@ -263,9 +263,7 @@ export default class PushNotification implements PushNotificationInterface {
 	};
 
 	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> => {
-		if (!this.isEnabled) {
-			throw new NotEnabledError();
-		}
+		this.assertIsEnabled();
 		return Promise.all<void>(
 			this.pluggables.map(async pluggable => {
 				try {
@@ -279,32 +277,24 @@ export default class PushNotification implements PushNotificationInterface {
 	};
 
 	getLaunchNotification = async (): Promise<PushNotificationMessage | null> => {
-		if (!this.isEnabled) {
-			throw new NotEnabledError();
-		}
+		this.assertIsEnabled();
 		return normalizeNativeMessage(
 			await this.nativeModule.getLaunchNotification?.()
 		);
 	};
 
 	getBadgeCount = async (): Promise<number | null> => {
-		if (!this.isEnabled) {
-			throw new NotEnabledError();
-		}
+		this.assertIsEnabled();
 		return this.nativeModule.getBadgeCount?.();
 	};
 
 	setBadgeCount = (count: number): void => {
-		if (!this.isEnabled) {
-			throw new NotEnabledError();
-		}
+		this.assertIsEnabled();
 		return this.nativeModule.setBadgeCount?.(count);
 	};
 
 	getPermissionStatus = async (): Promise<PushNotificationPermissionStatus> => {
-		if (!this.isEnabled) {
-			throw new NotEnabledError();
-		}
+		this.assertIsEnabled();
 		return normalizeNativePermissionStatus(
 			await this.nativeModule.getPermissionStatus?.()
 		);
@@ -317,9 +307,7 @@ export default class PushNotification implements PushNotificationInterface {
 			sound: true,
 		}
 	): Promise<boolean> => {
-		if (!this.isEnabled) {
-			throw new NotEnabledError();
-		}
+		this.assertIsEnabled();
 		return this.nativeModule.requestPermissions?.(permissions);
 	};
 
@@ -337,9 +325,7 @@ export default class PushNotification implements PushNotificationInterface {
 	onBackgroundNotificationReceived = (
 		handler: OnPushNotificationMessageHandler
 	): EventListener<OnPushNotificationMessageHandler> => {
-		if (!this.isEnabled) {
-			throw new NotEnabledError();
-		}
+		this.assertIsEnabled();
 		return addEventListener(
 			PushNotificationEvent.BACKGROUND_MESSAGE_RECEIVED,
 			handler
@@ -349,9 +335,7 @@ export default class PushNotification implements PushNotificationInterface {
 	onForegroundNotificationReceived = (
 		handler: OnPushNotificationMessageHandler
 	): EventListener<OnPushNotificationMessageHandler> => {
-		if (!this.isEnabled) {
-			throw new NotEnabledError();
-		}
+		this.assertIsEnabled();
 		return addEventListener(
 			PushNotificationEvent.FOREGROUND_MESSAGE_RECEIVED,
 			handler
@@ -361,18 +345,14 @@ export default class PushNotification implements PushNotificationInterface {
 	onNotificationOpened = (
 		handler: OnPushNotificationMessageHandler
 	): EventListener<OnPushNotificationMessageHandler> => {
-		if (!this.isEnabled) {
-			throw new NotEnabledError();
-		}
+		this.assertIsEnabled();
 		return addEventListener(PushNotificationEvent.NOTIFICATION_OPENED, handler);
 	};
 
 	onTokenReceived = (
 		handler: OnTokenReceivedHandler
 	): EventListener<OnTokenReceivedHandler> => {
-		if (!this.isEnabled) {
-			throw new NotEnabledError();
-		}
+		this.assertIsEnabled();
 		return addEventListener(PushNotificationEvent.TOKEN_RECEIVED, handler);
 	};
 
@@ -387,5 +367,11 @@ export default class PushNotification implements PushNotificationInterface {
 				}
 			})
 		);
+	};
+
+	private assertIsEnabled = (): void => {
+		if (!this.isEnabled) {
+			throw new NotEnabledError();
+		}
 	};
 }

--- a/packages/notifications/src/PushNotification/PushNotification.ts
+++ b/packages/notifications/src/PushNotification/PushNotification.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import PlatformNotSupportedError from '.';
+import PlatformNotSupportedError from './PlatformNotSupportedError';
 import {
 	NotificationsSubCategory,
 	OnPushNotificationMessageHandler,
@@ -51,6 +51,10 @@ export default class PushNotification implements PushNotificationInterface {
 	 * @param {string} providerName - the name of the plugin to remove
 	 */
 	removePluggable = (): void => {
+		throw new PlatformNotSupportedError();
+	};
+
+	enable = (): void => {
 		throw new PlatformNotSupportedError();
 	};
 

--- a/packages/notifications/src/PushNotification/types.ts
+++ b/packages/notifications/src/PushNotification/types.ts
@@ -20,6 +20,7 @@ export interface PushNotificationInterface {
 	getPluggable: (providerName: string) => PushNotificationProvider;
 	addPluggable: (pluggable: PushNotificationProvider) => void;
 	removePluggable: (providerName: string) => void;
+	enable: () => void;
 	identifyUser: (userId: string, userInfo: UserInfo) => Promise<void[]>;
 	getLaunchNotification: () => Promise<PushNotificationMessage>;
 	getBadgeCount: () => Promise<number>;


### PR DESCRIPTION
#### Description of changes
This PR adds an `enable` API which enables notification APIs. The intent of this API is both for registering listeners for react native module events and to give developers an explicit API to call in order to bootstrap the feature outside of the React Native application context.

#### Description of how you validated changes
Tested locally on iOS and Android
* APIs now throw error if called before `enable`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
