### PR TITLE
refactor(datastore): storage adapters

### DIFF
--- a/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
+++ b/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
@@ -1,19 +1,11 @@
-import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import AsyncStorageDatabase from './AsyncStorageDatabase';
-import { Adapter } from './index';
-import { ModelInstanceCreator } from '../../datastore/datastore';
-import { ModelPredicateCreator } from '../../predicates';
 import {
-	InternalSchema,
-	isPredicateObj,
 	ModelInstanceMetadata,
 	ModelPredicate,
-	NamespaceResolver,
 	OpType,
 	PaginationInput,
 	PersistentModel,
 	PersistentModelConstructor,
-	PredicateObject,
 	PredicatesGroup,
 	QueryOne,
 	RelationType,
@@ -22,7 +14,6 @@ import {
 	DEFAULT_PRIMARY_KEY_VALUE_SEPARATOR,
 	getIndex,
 	getIndexFromAssociation,
-	isModelConstructor,
 	traverseModel,
 	validatePredicate,
 	inMemoryPagination,
@@ -30,162 +21,114 @@ import {
 	keysEqual,
 	getStorename,
 	getIndexKeys,
-	extractPrimaryKeyValues,
 	IDENTIFIER_KEY_SEPARATOR,
 } from '../../util';
+import { StorageAdapterBase } from './StorageAdapterBase';
 
-const logger = new Logger('DataStore');
+export class AsyncStorageAdapter extends StorageAdapterBase {
+	protected db!: AsyncStorageDatabase;
 
-export class AsyncStorageAdapter implements Adapter {
-	// Non-null assertions (bang operators) added to most properties to make TS happy.
-	// For now, we can be reasonably sure they're available when they're needed, because
-	// the adapter is not used directly outside the library boundary.
-	// TODO: rejigger for DI?
-	private schema!: InternalSchema;
-	private namespaceResolver!: NamespaceResolver;
-	private modelInstanceCreator!: ModelInstanceCreator;
-	private getModelConstructorByModelName!: (
-		namsespaceName: NAMESPACES,
-		modelName: string
-	) => PersistentModelConstructor<any>;
-	private db!: AsyncStorageDatabase;
-	private initPromise!: Promise<void>;
-	private resolve!: (value?: any) => void;
-	private reject!: (value?: any) => void;
+	// no-ops for this adapter
+	protected async preSetUpChecks() {}
+	protected async preOpCheck() {}
 
-	private getStorenameForModel(
-		modelConstructor: PersistentModelConstructor<any>
-	) {
-		const namespace = this.namespaceResolver(modelConstructor);
-		const { name: modelName } = modelConstructor;
-
-		return getStorename(namespace, modelName);
+	/**
+	 * Open AsyncStorage database
+	 * Create new DB if one doesn't exist
+	 *
+	 * Called by `StorageAdapterBase.setUp()`
+	 *
+	 * @returns AsyncStorageDatabase instance
+	 */
+	protected async initDb(): Promise<AsyncStorageDatabase> {
+		const db = new AsyncStorageDatabase();
+		await db.init();
+		return db;
 	}
 
-	// Retrieves primary key values from a model
-	private getIndexKeyValuesFromModel<T extends PersistentModel>(
-		model: T
-	): string[] {
-		const modelConstructor = Object.getPrototypeOf(model)
-			.constructor as PersistentModelConstructor<T>;
+	async clear(): Promise<void> {
+		await this.db.clear();
+
+		this.db = undefined!;
+		this.initPromise = undefined!;
+	}
+
+	async batchSave<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<any>,
+		items: ModelInstanceMetadata[]
+	): Promise<[T, OpType][]> {
+		if (items.length === 0) {
+			return [];
+		}
+
+		const modelName = modelConstructor.name;
 		const namespaceName = this.namespaceResolver(modelConstructor);
-		const keys = getIndexKeys(
-			this.schema.namespaces[namespaceName],
-			modelConstructor.name
-		);
+		const storeName = getStorename(namespaceName, modelName);
+		const keys = getIndexKeys(this.schema.namespaces[namespaceName], modelName);
+		const batch: ModelInstanceMetadata[] = [];
 
-		return extractPrimaryKeyValues(model, keys);
+		for (const item of items) {
+			const model = this.modelInstanceCreator(modelConstructor, item);
+
+			const connectedModels = traverseModel(
+				modelName,
+				model,
+				this.schema.namespaces[namespaceName],
+				this.modelInstanceCreator,
+				this.getModelConstructorByModelName
+			);
+
+			const keyValuesPath = this.getIndexKeyValuesPath(model);
+
+			const { instance } = connectedModels.find(({ instance }) => {
+				const instanceKeyValuesPath = this.getIndexKeyValuesPath(instance);
+				return keysEqual([instanceKeyValuesPath], [keyValuesPath]);
+			})!;
+
+			batch.push(instance);
+		}
+
+		return await this.db.batchSave(storeName, batch, keys);
 	}
 
-	// Retrieves concatenated primary key values from a model
-	private getIndexKeyValuesPath<T extends PersistentModel>(model: T): string {
-		return this.getIndexKeyValuesFromModel(model).join(
+	protected async _get<T>(storeName: string, keyArr: string[]): Promise<T> {
+		const itemKeyValuesPath: string = keyArr.join(
 			DEFAULT_PRIMARY_KEY_VALUE_SEPARATOR
 		);
-	}
 
-	async setUp(
-		theSchema: InternalSchema,
-		namespaceResolver: NamespaceResolver,
-		modelInstanceCreator: ModelInstanceCreator,
-		getModelConstructorByModelName: (
-			namsespaceName: NAMESPACES,
-			modelName: string
-		) => PersistentModelConstructor<any>
-	) {
-		if (!this.initPromise) {
-			this.initPromise = new Promise((res, rej) => {
-				this.resolve = res;
-				this.reject = rej;
-			});
-		} else {
-			await this.initPromise;
-			return;
-		}
-		this.schema = theSchema;
-		this.namespaceResolver = namespaceResolver;
-		this.modelInstanceCreator = modelInstanceCreator;
-		this.getModelConstructorByModelName = getModelConstructorByModelName;
-		try {
-			if (!this.db) {
-				this.db = new AsyncStorageDatabase();
-				await this.db.init();
-				this.resolve();
-			}
-		} catch (error) {
-			this.reject(error);
-		}
+		return <T>await this.db.get(itemKeyValuesPath, storeName);
 	}
 
 	async save<T extends PersistentModel>(
 		model: T,
 		condition?: ModelPredicate<T>
 	): Promise<[T, OpType.INSERT | OpType.UPDATE][]> {
-		const modelConstructor = Object.getPrototypeOf(model)
-			.constructor as PersistentModelConstructor<T>;
-		const storeName = this.getStorenameForModel(modelConstructor);
+		const { storeName, connectionStoreNames, modelKeyValues } =
+			this.saveMetadata(model);
 
-		const namespaceName = this.namespaceResolver(modelConstructor);
+		const fromDB = await this._get(storeName, modelKeyValues);
 
-		const connectedModels = traverseModel(
-			modelConstructor.name,
-			model,
-			this.schema.namespaces[namespaceName],
-			this.modelInstanceCreator,
-			this.getModelConstructorByModelName
-		);
-
-		const set = new Set<string>();
-		const connectionStoreNames = Object.values(connectedModels).map(
-			({ modelName, item, instance }) => {
-				const storeName = getStorename(namespaceName, modelName);
-				set.add(storeName);
-				const keys = getIndexKeys(
-					this.schema.namespaces[namespaceName],
-					modelName
-				);
-				return { storeName, item, instance, keys };
-			}
-		);
-		const keyValuesPath = this.getIndexKeyValuesPath(model);
-
-		const fromDB = await this.db.get(keyValuesPath, storeName);
-
-		if (condition && fromDB) {
-			const predicates = ModelPredicateCreator.getPredicates(condition);
-			const { predicates: predicateObjs, type } = predicates!;
-
-			const isValid = validatePredicate(fromDB, type, predicateObjs);
-
-			if (!isValid) {
-				const msg = 'Conditional update failed';
-				logger.error(msg, { model: fromDB, condition: predicateObjs });
-
-				throw new Error(msg);
-			}
-		}
+		this.validateSaveCondition(condition, fromDB);
 
 		const result: [T, OpType.INSERT | OpType.UPDATE][] = [];
-
 		for await (const resItem of connectionStoreNames) {
 			const { storeName, item, instance, keys } = resItem;
 
-			/* Find the key values in the item, and concatenate them */
 			const itemKeyValues: string[] = keys.map(key => item[key]);
-			const itemKeyValuesPath: string = itemKeyValues.join(
-				DEFAULT_PRIMARY_KEY_VALUE_SEPARATOR
-			);
 
-			const fromDB = <T>await this.db.get(itemKeyValuesPath, storeName);
+			const fromDB = <T>await this._get(storeName, itemKeyValues);
 			const opType: OpType = fromDB ? OpType.UPDATE : OpType.INSERT;
-			const modelKeyValues = this.getIndexKeyValuesFromModel(model);
 
-			// If item key values and model key values are equal, save to db
 			if (
 				keysEqual(itemKeyValues, modelKeyValues) ||
 				opType === OpType.INSERT
 			) {
-				await this.db.save(item, storeName, keys, itemKeyValuesPath);
+				await this.db.save(
+					item,
+					storeName,
+					keys,
+					itemKeyValues.join(DEFAULT_PRIMARY_KEY_VALUE_SEPARATOR)
+				);
 
 				result.push([instance, opType]);
 			}
@@ -193,57 +136,24 @@ export class AsyncStorageAdapter implements Adapter {
 		return result;
 	}
 
-	private async load<T>(
-		namespaceName: NAMESPACES,
-		srcModelName: string,
-		records: T[]
-	): Promise<T[]> {
-		const namespace = this.schema.namespaces[namespaceName];
-		const relations = namespace.relationships![srcModelName].relationTypes;
-		const connectionStoreNames = relations.map(({ modelName }) => {
-			return getStorename(namespaceName, modelName);
-		});
-		const modelConstructor = this.getModelConstructorByModelName(
-			namespaceName,
-			srcModelName
-		);
-
-		if (connectionStoreNames.length === 0) {
-			return records.map(record =>
-				this.modelInstanceCreator(modelConstructor, record)
-			);
-		}
-
-		return records.map(record =>
-			this.modelInstanceCreator(modelConstructor, record)
-		);
-	}
-
 	async query<T extends PersistentModel>(
 		modelConstructor: PersistentModelConstructor<T>,
 		predicate?: ModelPredicate<T>,
 		pagination?: PaginationInput<T>
 	): Promise<T[]> {
-		const storeName = this.getStorenameForModel(modelConstructor);
-		const namespaceName = this.namespaceResolver(
-			modelConstructor
-		) as NAMESPACES;
-
-		const predicates =
-			predicate && ModelPredicateCreator.getPredicates(predicate);
-		const keys = getIndexKeys(
-			this.schema.namespaces[namespaceName],
-			modelConstructor.name
-		);
-		const queryByKey =
-			predicates && this.keyValueFromPredicate(predicates, keys);
-
-		const hasSort = pagination && pagination.sort;
-		const hasPagination = pagination && pagination.limit;
+		const {
+			storeName,
+			namespaceName,
+			queryByKey,
+			predicates,
+			hasSort,
+			hasPagination,
+		} = this.queryMetadata(modelConstructor, predicate, pagination);
 
 		const records: T[] = (await (async () => {
 			if (queryByKey) {
-				const record = await this.getByKey(storeName, queryByKey);
+				const keyValues = queryByKey.join(DEFAULT_PRIMARY_KEY_VALUE_SEPARATOR);
+				const record = await this.getByKey(storeName, keyValues);
 				return record ? [record] : [];
 			}
 
@@ -267,39 +177,13 @@ export class AsyncStorageAdapter implements Adapter {
 		storeName: string,
 		keyValuePath: string
 	): Promise<T> {
-		const record = <T>await this.db.get(keyValuePath, storeName);
-		return record;
+		return <T>await this.db.get(keyValuePath, storeName);
 	}
 
 	private async getAll<T extends PersistentModel>(
 		storeName: string
 	): Promise<T[]> {
 		return await this.db.getAll(storeName);
-	}
-
-	private keyValueFromPredicate<T extends PersistentModel>(
-		predicates: PredicatesGroup<T>,
-		keys: string[]
-	): string | undefined {
-		const { predicates: predicateObjs } = predicates;
-
-		if (predicateObjs.length !== keys.length) {
-			return;
-		}
-
-		const keyValues = [] as any[];
-
-		for (const key of keys) {
-			const predicateObj = predicateObjs.find(
-				p => isPredicateObj(p) && p.field === key && p.operator === 'eq'
-			) as PredicateObject<T>;
-
-			predicateObj && keyValues.push(predicateObj.operand);
-		}
-
-		return keyValues.length === keys.length
-			? keyValues.join(DEFAULT_PRIMARY_KEY_VALUE_SEPARATOR)
-			: undefined;
 	}
 
 	private async filterOnPredicate<T extends PersistentModel>(
@@ -334,129 +218,7 @@ export class AsyncStorageAdapter implements Adapter {
 		return result && this.modelInstanceCreator(modelConstructor, result);
 	}
 
-	async delete<T extends PersistentModel>(
-		modelOrModelConstructor: T | PersistentModelConstructor<T>,
-		condition?: ModelPredicate<T>
-	): Promise<[T[], T[]]> {
-		const deleteQueue: { storeName: string; items: T[] }[] = [];
-
-		if (isModelConstructor(modelOrModelConstructor)) {
-			const modelConstructor =
-				modelOrModelConstructor as PersistentModelConstructor<T>;
-			const nameSpace = this.namespaceResolver(modelConstructor) as NAMESPACES;
-
-			// models to be deleted.
-			const models = await this.query(modelConstructor, condition!);
-			// TODO: refactor this to use a function like getRelations()
-			const relations =
-				this.schema.namespaces[nameSpace].relationships![modelConstructor.name]
-					.relationTypes;
-
-			if (condition !== undefined) {
-				await this.deleteTraverse(
-					relations,
-					models,
-					modelConstructor.name,
-					nameSpace,
-					deleteQueue
-				);
-
-				await this.deleteItem(deleteQueue);
-
-				const deletedModels = deleteQueue.reduce(
-					(acc, { items }) => acc.concat(items),
-					<T[]>[]
-				);
-
-				return [models, deletedModels];
-			} else {
-				await this.deleteTraverse(
-					relations,
-					models,
-					modelConstructor.name,
-					nameSpace,
-					deleteQueue
-				);
-
-				await this.deleteItem(deleteQueue);
-
-				const deletedModels = deleteQueue.reduce(
-					(acc, { items }) => acc.concat(items),
-					<T[]>[]
-				);
-
-				return [models, deletedModels];
-			}
-		} else {
-			const model = modelOrModelConstructor as T;
-
-			const modelConstructor = Object.getPrototypeOf(model)
-				.constructor as PersistentModelConstructor<T>;
-			const nameSpace = this.namespaceResolver(modelConstructor) as NAMESPACES;
-
-			const storeName = this.getStorenameForModel(modelConstructor);
-
-			if (condition) {
-				const keyValuePath = this.getIndexKeyValuesPath(model);
-
-				const fromDB = await this.db.get(keyValuePath, storeName);
-
-				if (fromDB === undefined) {
-					const msg = 'Model instance not found in storage';
-					logger.warn(msg, { model });
-
-					return [[model], []];
-				}
-
-				const predicates = ModelPredicateCreator.getPredicates(condition);
-				const { predicates: predicateObjs, type } = predicates!;
-
-				const isValid = validatePredicate(fromDB, type, predicateObjs);
-				if (!isValid) {
-					const msg = 'Conditional update failed';
-					logger.error(msg, { model: fromDB, condition: predicateObjs });
-
-					throw new Error(msg);
-				}
-
-				const relations =
-					this.schema.namespaces[nameSpace].relationships![
-						modelConstructor.name
-					].relationTypes;
-				await this.deleteTraverse(
-					relations,
-					[model],
-					modelConstructor.name,
-					nameSpace,
-					deleteQueue
-				);
-			} else {
-				const relations =
-					this.schema.namespaces[nameSpace].relationships![
-						modelConstructor.name
-					].relationTypes;
-
-				await this.deleteTraverse(
-					relations,
-					[model],
-					modelConstructor.name,
-					nameSpace,
-					deleteQueue
-				);
-			}
-
-			await this.deleteItem(deleteQueue);
-
-			const deletedModels = deleteQueue.reduce(
-				(acc, { items }) => acc.concat(items),
-				<T[]>[]
-			);
-
-			return [[model], deletedModels];
-		}
-	}
-
-	private async deleteItem<T extends PersistentModel>(
+	protected async deleteItem<T extends PersistentModel>(
 		deleteQueue?: { storeName: string; items: T[] | IDBValidKey[] }[]
 	) {
 		for await (const deleteItem of deleteQueue!) {
@@ -474,243 +236,177 @@ export class AsyncStorageAdapter implements Adapter {
 	}
 
 	/**
-	 * Populates the delete Queue with all the items to delete
-	 * @param relations
-	 * @param models
+	 * Gets related Has One record for `model`
+	 *
+	 * @param model
 	 * @param srcModel
-	 * @param nameSpace
-	 * @param deleteQueue
+	 * @param namespace
+	 * @param rel
+	 * @returns
 	 */
-	private async deleteTraverse<T extends PersistentModel>(
-		relations: RelationType[],
-		models: T[],
+	protected async getHasOneChild<T extends PersistentModel>(
+		model: T,
 		srcModel: string,
-		nameSpace: NAMESPACES,
-		deleteQueue: { storeName: string; items: T[] }[]
-	): Promise<void> {
-		for await (const rel of relations) {
-			const {
-				relationType,
-				modelName,
-				targetName,
-				targetNames,
-				associatedWith,
-			} = rel;
-			const storeName = getStorename(nameSpace, modelName);
+		namespace: NAMESPACES,
+		rel: RelationType
+	) {
+		let hasOneIndex;
+		const { modelName, targetNames, associatedWith } = rel;
+		const storeName = getStorename(namespace, modelName);
+		const index: string | undefined =
+			getIndex(
+				this.schema.namespaces[namespace].relationships![modelName]
+					.relationTypes,
+				srcModel
+			) ||
+			// if we were unable to find an index via relationTypes
+			// i.e. for keyName connections, attempt to find one by the
+			// associatedWith property
+			getIndexFromAssociation(
+				this.schema.namespaces[namespace].relationships![modelName].indexes,
+				rel.associatedWith!
+			);
 
-			const index: string | undefined =
-				getIndex(
-					this.schema.namespaces[nameSpace].relationships![modelName]
-						.relationTypes,
-					srcModel
-				) ||
-				// if we were unable to find an index via relationTypes
-				// i.e. for keyName connections, attempt to find one by the
-				// associatedWith property
-				getIndexFromAssociation(
-					this.schema.namespaces[nameSpace].relationships![modelName].indexes,
-					rel.associatedWith!
-				);
-
-			switch (relationType) {
-				case 'HAS_ONE':
-					for await (const model of models) {
-						if (targetNames && targetNames?.length) {
-							let hasOneIndex;
-
-							if (index) {
-								hasOneIndex = index.split(IDENTIFIER_KEY_SEPARATOR);
-							} else if (associatedWith) {
-								if (Array.isArray(associatedWith)) {
-									hasOneIndex = associatedWith;
-								} else {
-									hasOneIndex = [associatedWith];
-								}
-							}
-
-							// iterate over targetNames array and see if each key is present in model object
-							// targetNames here being the keys for the CHILD model
-							const hasConnectedModelFields = targetNames.every(targetName =>
-								model.hasOwnProperty(targetName)
-							);
-
-							// PK / Composite key for the parent model
-							const keyValuesPath: string = this.getIndexKeyValuesPath(model);
-
-							let values;
-
-							const isUnidirectionalConnection = hasOneIndex === associatedWith;
-
-							if (hasConnectedModelFields && isUnidirectionalConnection) {
-								// Values will be that of the child model
-								values = targetNames
-									.filter(targetName => model[targetName] ?? false)
-									.map(targetName => model[targetName]) as any;
-							} else {
-								// values will be that of the parent model
-								values = keyValuesPath.split(
-									DEFAULT_PRIMARY_KEY_VALUE_SEPARATOR
-								);
-							}
-
-							if (values.length === 0) break;
-
-							const allRecords = await this.db.getAll(storeName);
-
-							let recordToDelete;
-
-							// values === targetNames
-							if (hasConnectedModelFields) {
-								/**
-								 * Retrieve record by finding the record where all
-								 * targetNames are present on the connected model.
-								 *
-								 */
-								// recordToDelete = allRecords.filter(childItem =>
-								// 	values.every(value => childItem[value] != null)
-								// ) as T[];
-
-								recordToDelete = allRecords.filter(childItem =>
-									hasOneIndex.every(index => values.includes(childItem[index]))
-								);
-							} else {
-								// values === keyValuePath
-								recordToDelete = allRecords.filter(
-									childItem => childItem[hasOneIndex] === values
-								) as T[];
-							}
-
-							await this.deleteTraverse<T>(
-								this.schema.namespaces[nameSpace].relationships![modelName]
-									.relationTypes,
-								recordToDelete,
-								modelName,
-								nameSpace,
-								deleteQueue
-							);
-						} else {
-							const hasOneIndex = index || associatedWith;
-							const hasOneCustomField = targetName! in model;
-							const keyValuesPath: string = this.getIndexKeyValuesPath(model);
-							const value = hasOneCustomField
-								? model[targetName!]
-								: keyValuesPath;
-
-							if (!value) break;
-
-							const allRecords = await this.db.getAll(storeName);
-
-							const recordsToDelete = allRecords.filter(
-								childItem => childItem[hasOneIndex as string] === value
-							) as T[];
-
-							// instantiate models before passing to deleteTraverse
-							// necessary for extracting PK values via getIndexKeyValuesFromModel
-							const modelsToDelete = recordsToDelete.length
-								? await this.load(nameSpace, modelName, recordsToDelete)
-								: [];
-
-							await this.deleteTraverse<T>(
-								this.schema.namespaces[nameSpace].relationships![modelName]
-									.relationTypes,
-								modelsToDelete,
-								modelName,
-								nameSpace,
-								deleteQueue
-							);
-						}
-					}
-					break;
-				case 'HAS_MANY':
-					for await (const model of models) {
-						// Key values for the parent model:
-						const keyValues: string[] = this.getIndexKeyValuesFromModel(model);
-
-						const allRecords = await this.db.getAll(storeName);
-
-						const indices = index!.split(IDENTIFIER_KEY_SEPARATOR);
-
-						const childRecords = allRecords.filter(childItem =>
-							indices.every(index => keyValues.includes(childItem[index]))
-						) as T[];
-
-						// instantiate models before passing to deleteTraverse
-						// necessary for extracting PK values via getIndexKeyValuesFromModel
-						const childModels = await this.load(
-							nameSpace,
-							modelName,
-							childRecords
-						);
-
-						await this.deleteTraverse<T>(
-							this.schema.namespaces[nameSpace].relationships![modelName]
-								.relationTypes,
-							childModels,
-							modelName,
-							nameSpace,
-							deleteQueue
-						);
-					}
-					break;
-				case 'BELONGS_TO':
-					// Intentionally blank
-					break;
-				default:
-					throw new Error(`Invalid relationType ${relationType}`);
+		if (index) {
+			hasOneIndex = index.split(IDENTIFIER_KEY_SEPARATOR);
+		} else if (associatedWith) {
+			if (Array.isArray(associatedWith)) {
+				hasOneIndex = associatedWith;
+			} else {
+				hasOneIndex = [associatedWith];
 			}
 		}
 
-		deleteQueue.push({
-			storeName: getStorename(nameSpace, srcModel),
-			items: models.map(record =>
-				this.modelInstanceCreator(
-					this.getModelConstructorByModelName(nameSpace, srcModel),
-					record
-				)
-			),
-		});
-	}
+		// iterate over targetNames array and see if each key is present in model object
+		// targetNames here being the keys for the CHILD model
+		const hasConnectedModelFields = targetNames!.every(targetName =>
+			model.hasOwnProperty(targetName)
+		);
 
-	async clear(): Promise<void> {
-		await this.db.clear();
+		// PK / Composite key for the parent model
+		const keyValuesPath: string = this.getIndexKeyValuesPath(model);
 
-		this.db = undefined!;
-		this.initPromise = undefined!;
-	}
+		let values;
 
-	async batchSave<T extends PersistentModel>(
-		modelConstructor: PersistentModelConstructor<any>,
-		items: ModelInstanceMetadata[]
-	): Promise<[T, OpType][]> {
-		const { name: modelName } = modelConstructor;
-		const namespaceName = this.namespaceResolver(modelConstructor);
-		const storeName = getStorename(namespaceName, modelName);
-		const keys = getIndexKeys(this.schema.namespaces[namespaceName], modelName);
-		const batch: ModelInstanceMetadata[] = [];
+		const isUnidirectionalConnection = hasOneIndex === associatedWith;
 
-		for (const item of items) {
-			const model = this.modelInstanceCreator(modelConstructor, item);
-
-			const connectedModels = traverseModel(
-				modelName,
-				model,
-				this.schema.namespaces[namespaceName],
-				this.modelInstanceCreator,
-				this.getModelConstructorByModelName
-			);
-
-			const keyValuesPath = this.getIndexKeyValuesPath(model);
-
-			const { instance } = connectedModels.find(({ instance }) => {
-				const instanceKeyValuesPath = this.getIndexKeyValuesPath(instance);
-				return keysEqual([instanceKeyValuesPath], [keyValuesPath]);
-			})!;
-
-			batch.push(instance);
+		if (hasConnectedModelFields && isUnidirectionalConnection) {
+			// Values will be that of the child model
+			values = targetNames!
+				.filter(targetName => model[targetName] ?? false)
+				.map(targetName => model[targetName]);
+		} else {
+			// values will be that of the parent model
+			values = keyValuesPath.split(DEFAULT_PRIMARY_KEY_VALUE_SEPARATOR);
 		}
 
-		return await this.db.batchSave(storeName, batch, keys);
+		if (values.length === 0) return;
+
+		const allRecords = await this.db.getAll(storeName);
+
+		let recordToDelete;
+
+		// values === targetNames
+		if (hasConnectedModelFields) {
+			/**
+			 * Retrieve record by finding the record where all
+			 * targetNames are present on the connected model.
+			 *
+			 */
+
+			recordToDelete = allRecords.find(childItem =>
+				hasOneIndex.every(index => values.includes(childItem[index]))
+			);
+		} else {
+			// values === keyValuePath
+			recordToDelete = allRecords.find(
+				childItem => childItem[hasOneIndex] === values
+			) as T[];
+		}
+
+		return recordToDelete;
 	}
+
+	/**
+	 * Backwards compatability for pre-CPK codegen
+	 * TODO - deprecate this in v6; will need to re-gen MIPR for older unit
+	 * tests that hit this path
+	 */
+	protected async getHasOneChildLegacy<T extends PersistentModel>(
+		model: T,
+		srcModel: string,
+		namespace: NAMESPACES,
+		rel: RelationType
+	) {
+		const { modelName, targetName, associatedWith } = rel;
+		const storeName = getStorename(namespace, modelName);
+		const index: string | undefined =
+			getIndex(
+				this.schema.namespaces[namespace].relationships![modelName]
+					.relationTypes,
+				srcModel
+			) ||
+			// if we were unable to find an index via relationTypes
+			// i.e. for keyName connections, attempt to find one by the
+			// associatedWith property
+			getIndexFromAssociation(
+				this.schema.namespaces[namespace].relationships![modelName].indexes,
+				rel.associatedWith!
+			);
+		const hasOneIndex = index || associatedWith;
+		const hasOneCustomField = targetName! in model;
+		const keyValuesPath: string = this.getIndexKeyValuesPath(model);
+		const value = hasOneCustomField ? model[targetName!] : keyValuesPath;
+
+		if (!value) return;
+
+		const allRecords = await this.db.getAll(storeName);
+
+		const recordToDelete = allRecords.find(
+			childItem => childItem[hasOneIndex as string] === value
+		) as T;
+
+		return recordToDelete;
+	}
+
+	/**
+	 *  Gets related Has Many records by given `storeName`, `index`, and `keyValues`
+	 *
+	 * @param storeName
+	 * @param index
+	 * @param keyValues
+	 * @returns
+	 */
+	protected async getHasManyChildren<T extends PersistentModel>(
+		storeName: string,
+		index: string,
+		keyValues: string[]
+	): Promise<T[]> {
+		const allRecords = await this.db.getAll(storeName);
+		const indices = index!.split(IDENTIFIER_KEY_SEPARATOR);
+
+		const childRecords = allRecords.filter(childItem =>
+			indices.every(index => keyValues.includes(childItem[index]))
+		) as T[];
+
+		return childRecords;
+	}
+
+	//#region platform-specific helper methods
+
+	/**
+	 * Retrieves concatenated primary key values from a model
+	 *
+	 * @param model
+	 * @returns
+	 */
+	private getIndexKeyValuesPath<T extends PersistentModel>(model: T): string {
+		return this.getIndexKeyValuesFromModel(model).join(
+			DEFAULT_PRIMARY_KEY_VALUE_SEPARATOR
+		);
+	}
+
+	//#endregion
 }
 
 export default new AsyncStorageAdapter();

--- a/packages/datastore/src/storage/adapter/AsyncStorageDatabase.ts
+++ b/packages/datastore/src/storage/adapter/AsyncStorageDatabase.ts
@@ -176,7 +176,7 @@ class AsyncStorageDatabase {
 			.reduce((set, [k]) => set.add(k), new Set<string>());
 
 		// Delete
-		await new Promise((resolve, reject) => {
+		await new Promise<void>((resolve, reject) => {
 			if (keysToDelete.size === 0) {
 				resolve();
 				return;
@@ -204,7 +204,7 @@ class AsyncStorageDatabase {
 		});
 
 		// Save
-		await new Promise((resolve, reject) => {
+		await new Promise<void>((resolve, reject) => {
 			if (keysToSave.size === 0) {
 				resolve();
 				return;

--- a/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
+++ b/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
@@ -1,14 +1,10 @@
 import { ConsoleLogger as Logger } from '@aws-amplify/core';
 import * as idb from 'idb';
-import { ModelInstanceCreator } from '../../datastore/datastore';
-import { ModelPredicateCreator } from '../../predicates';
 import {
-	InternalSchema,
 	isPredicateObj,
 	isPredicateGroup,
 	ModelInstanceMetadata,
 	ModelPredicate,
-	NamespaceResolver,
 	OpType,
 	PaginationInput,
 	PersistentModel,
@@ -20,8 +16,6 @@ import {
 } from '../../types';
 import {
 	getIndex,
-	getIndexFromAssociation,
-	isModelConstructor,
 	isPrivateMode,
 	traverseModel,
 	validatePredicate,
@@ -29,11 +23,9 @@ import {
 	NAMESPACES,
 	keysEqual,
 	getStorename,
-	getIndexKeys,
-	extractPrimaryKeyValues,
 	isSafariCompatabilityMode,
 } from '../../util';
-import { Adapter } from './index';
+import { StorageAdapterBase } from './StorageAdapterBase';
 
 const logger = new Logger('DataStore');
 
@@ -59,47 +51,482 @@ const logger = new Logger('DataStore');
  *
  */
 const MULTI_OR_CONDITION_SCAN_BREAKPOINT = 7;
+//
+const DB_VERSION = 3;
 
-const DB_NAME = 'amplify-datastore';
-class IndexedDBAdapter implements Adapter {
-	private schema!: InternalSchema;
-	private namespaceResolver!: NamespaceResolver;
-	private modelInstanceCreator!: ModelInstanceCreator;
-	private getModelConstructorByModelName?: (
-		namsespaceName: NAMESPACES,
-		modelName: string
-	) => PersistentModelConstructor<any>;
-	private db!: idb.IDBPDatabase;
-	private initPromise!: Promise<void>;
-	private resolve!: (value?: any) => void;
-	private reject!: (value?: any) => void;
-	private dbName: string = DB_NAME;
+class IndexedDBAdapter extends StorageAdapterBase {
+	protected db!: idb.IDBPDatabase;
 	private safariCompatabilityMode: boolean = false;
 
-	private getStorenameForModel(
-		modelConstructor: PersistentModelConstructor<any>
-	) {
-		const namespace = this.namespaceResolver(modelConstructor);
-		const { name: modelName } = modelConstructor;
-
-		return getStorename(namespace, modelName);
+	// checks are called by StorageAdapterBase class
+	protected async preSetUpChecks() {
+		await this.checkPrivate();
+		await this.setSafariCompatabilityMode();
 	}
 
-	// Retrieves primary key values from a model
-	private getIndexKeyValuesFromModel<T extends PersistentModel>(
-		model: T
-	): string[] {
-		const modelConstructor = Object.getPrototypeOf(model)
-			.constructor as PersistentModelConstructor<T>;
-		const namespaceName = this.namespaceResolver(modelConstructor);
+	protected async preOpCheck() {
+		await this.checkPrivate();
+	}
 
-		const keys = getIndexKeys(
-			this.schema.namespaces[namespaceName],
-			modelConstructor.name
+	/**
+	 * Initialize IndexedDB database
+	 * Create new DB if one doesn't exist
+	 * Upgrade outdated DB
+	 *
+	 * Called by `StorageAdapterBase.setUp()`
+	 *
+	 * @returns IDB Database instance
+	 */
+	protected async initDb(): Promise<idb.IDBPDatabase> {
+		return await idb.openDB(this.dbName, DB_VERSION, {
+			upgrade: async (db, oldVersion, newVersion, txn) => {
+				// create new database
+				if (oldVersion === 0) {
+					Object.keys(this.schema.namespaces).forEach(namespaceName => {
+						const namespace = this.schema.namespaces[namespaceName];
+
+						Object.keys(namespace.models).forEach(modelName => {
+							const storeName = getStorename(namespaceName, modelName);
+							this.createObjectStoreForModel(
+								db,
+								namespaceName,
+								storeName,
+								modelName
+							);
+						});
+					});
+
+					return;
+				}
+
+				// migrate existing database to latest schema
+				if ((oldVersion === 1 || oldVersion === 2) && newVersion === 3) {
+					try {
+						for (const storeName of txn.objectStoreNames) {
+							const origStore = txn.objectStore(storeName);
+
+							// rename original store
+							const tmpName = `tmp_${storeName}`;
+							origStore.name = tmpName;
+
+							const { namespaceName, modelName } =
+								this.getNamespaceAndModelFromStorename(storeName);
+
+							const modelInCurrentSchema =
+								modelName in this.schema.namespaces[namespaceName].models;
+
+							if (!modelInCurrentSchema) {
+								// delete original
+								db.deleteObjectStore(tmpName);
+								continue;
+							}
+
+							const newStore = this.createObjectStoreForModel(
+								db,
+								namespaceName,
+								storeName,
+								modelName
+							);
+
+							let cursor = await origStore.openCursor();
+							let count = 0;
+
+							// Copy data from original to new
+							while (cursor && cursor.value) {
+								// we don't pass key, since they are all new entries in the new store
+								await newStore.put(cursor.value);
+
+								cursor = await cursor.continue();
+								count++;
+							}
+
+							// delete original
+							db.deleteObjectStore(tmpName);
+
+							logger.debug(`${count} ${storeName} records migrated`);
+						}
+
+						// add new models created after IndexedDB, but before migration
+						// this case may happen when a user has not opened an app for
+						// some time and a new model is added during that time
+						Object.keys(this.schema.namespaces).forEach(namespaceName => {
+							const namespace = this.schema.namespaces[namespaceName];
+							const objectStoreNames = new Set(txn.objectStoreNames);
+
+							Object.keys(namespace.models)
+								.map(modelName => {
+									return [modelName, getStorename(namespaceName, modelName)];
+								})
+								.filter(([, storeName]) => !objectStoreNames.has(storeName))
+								.forEach(([modelName, storeName]) => {
+									this.createObjectStoreForModel(
+										db,
+										namespaceName,
+										storeName,
+										modelName
+									);
+								});
+						});
+					} catch (error) {
+						logger.error('Error migrating IndexedDB data', error);
+						txn.abort();
+						throw error;
+					}
+
+					return;
+				}
+			},
+		});
+	}
+
+	protected async _get<T>(
+		storeOrStoreName: idb.IDBPObjectStore | string,
+		keyArr: string[]
+	): Promise<T> {
+		let index: idb.IDBPIndex;
+
+		if (typeof storeOrStoreName === 'string') {
+			const storeName = storeOrStoreName;
+			index = this.db.transaction(storeName, 'readonly').store.index('byPk');
+		} else {
+			const store = storeOrStoreName;
+			index = store.index('byPk');
+		}
+
+		const result = await index.get(this.canonicalKeyPath(keyArr));
+
+		return <T>result;
+	}
+
+	async clear(): Promise<void> {
+		await this.checkPrivate();
+
+		this.db?.close();
+		await idb.deleteDB(this.dbName);
+
+		this.db = undefined!;
+		this.initPromise = undefined!;
+	}
+
+	async save<T extends PersistentModel>(
+		model: T,
+		condition?: ModelPredicate<T>
+	): Promise<[T, OpType.INSERT | OpType.UPDATE][]> {
+		await this.checkPrivate();
+
+		const { storeName, set, connectionStoreNames, modelKeyValues } =
+			this.saveMetadata(model);
+
+		const tx = this.db.transaction(
+			[storeName, ...Array.from(set.values())],
+			'readwrite'
 		);
 
-		return extractPrimaryKeyValues(model, keys);
+		const store = tx.objectStore(storeName);
+		const fromDB = await this._get(store, modelKeyValues);
+
+		this.validateSaveCondition(condition, fromDB);
+
+		const result: [T, OpType.INSERT | OpType.UPDATE][] = [];
+		for await (const resItem of connectionStoreNames) {
+			const { storeName, item, instance, keys } = resItem;
+			const store = tx.objectStore(storeName);
+
+			const itemKeyValues: string[] = keys.map(key => item[key]);
+
+			const fromDB = <T>await this._get(store, itemKeyValues);
+			const opType: OpType = fromDB ? OpType.UPDATE : OpType.INSERT;
+
+			if (
+				keysEqual(itemKeyValues, modelKeyValues) ||
+				opType === OpType.INSERT
+			) {
+				const key = await store
+					.index('byPk')
+					.getKey(this.canonicalKeyPath(itemKeyValues));
+				await store.put(item, key);
+				result.push([instance, opType]);
+			}
+		}
+		await tx.done;
+
+		return result;
 	}
+
+	async query<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		predicate?: ModelPredicate<T>,
+		pagination?: PaginationInput<T>
+	): Promise<T[]> {
+		await this.checkPrivate();
+		const {
+			storeName,
+			namespaceName,
+			queryByKey,
+			predicates,
+			hasSort,
+			hasPagination,
+		} = this.queryMetadata(modelConstructor, predicate, pagination);
+
+		const records: T[] = (await (async () => {
+			//
+			// NOTE: @svidgen explored removing this and letting query() take care of automatic
+			// index leveraging. This would eliminate some amount of very similar code.
+			// But, getAll is slightly slower than get()
+			//
+			// On Chrome:
+			//   ~700ms vs ~1175ms per 10k reads.
+			//
+			// You can (and should) check my work here:
+			// 	https://gist.github.com/svidgen/74e55d573b19c3e5432b1b5bdf0f4d96
+			//
+			if (queryByKey) {
+				const record = await this.getByKey(storeName, queryByKey);
+				return record ? [record] : [];
+			}
+
+			if (predicates) {
+				const filtered = await this.filterOnPredicate(storeName, predicates);
+				return this.inMemoryPagination(filtered, pagination);
+			}
+
+			if (hasSort) {
+				const all = await this.getAll(storeName);
+				return this.inMemoryPagination(all, pagination);
+			}
+
+			if (hasPagination) {
+				return this.enginePagination(storeName, pagination);
+			}
+
+			return this.getAll(storeName);
+		})()) as T[];
+
+		return await this.load(namespaceName, modelConstructor.name, records);
+	}
+
+	async queryOne<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		firstOrLast: QueryOne = QueryOne.FIRST
+	): Promise<T | undefined> {
+		await this.checkPrivate();
+		const storeName = this.getStorenameForModel(modelConstructor);
+
+		const cursor = await this.db
+			.transaction([storeName], 'readonly')
+			.objectStore(storeName)
+			.openCursor(undefined, firstOrLast === QueryOne.FIRST ? 'next' : 'prev');
+
+		const result = cursor ? <T>cursor.value : undefined;
+
+		return result && this.modelInstanceCreator(modelConstructor, result);
+	}
+
+	async batchSave<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<any>,
+		items: ModelInstanceMetadata[]
+	): Promise<[T, OpType][]> {
+		await this.checkPrivate();
+
+		if (items.length === 0) {
+			return [];
+		}
+
+		const modelName = modelConstructor.name;
+		const namespaceName = this.namespaceResolver(modelConstructor);
+		const storeName = this.getStorenameForModel(modelConstructor);
+		const result: [T, OpType][] = [];
+
+		const txn = this.db.transaction(storeName, 'readwrite');
+		const store = txn.store;
+
+		for (const item of items) {
+			const model = this.modelInstanceCreator(modelConstructor, item);
+
+			const connectedModels = traverseModel(
+				modelName,
+				model,
+				this.schema.namespaces[namespaceName],
+				this.modelInstanceCreator,
+				this.getModelConstructorByModelName!
+			);
+
+			const keyValues = this.getIndexKeyValuesFromModel(model);
+			const { _deleted } = item;
+
+			const index = store.index('byPk');
+
+			const key = await index.getKey(this.canonicalKeyPath(keyValues));
+
+			if (!_deleted) {
+				const { instance } = connectedModels.find(({ instance }) => {
+					const instanceKeyValues = this.getIndexKeyValuesFromModel(instance);
+					return keysEqual(instanceKeyValues, keyValues);
+				})!;
+
+				result.push([
+					<T>(<unknown>instance),
+					key ? OpType.UPDATE : OpType.INSERT,
+				]);
+				await store.put(instance, key);
+			} else {
+				result.push([<T>(<unknown>item), OpType.DELETE]);
+
+				if (key) {
+					await store.delete(key);
+				}
+			}
+		}
+
+		await txn.done;
+
+		return result;
+	}
+
+	protected async deleteItem<T extends PersistentModel>(
+		deleteQueue?: {
+			storeName: string;
+			items: T[] | IDBValidKey[];
+		}[]
+	) {
+		const connectionStoreNames = deleteQueue!.map(({ storeName }) => {
+			return storeName;
+		});
+
+		const tx = this.db.transaction([...connectionStoreNames], 'readwrite');
+		for await (const deleteItem of deleteQueue!) {
+			const { storeName, items } = deleteItem;
+			const store = tx.objectStore(storeName);
+
+			for await (const item of items) {
+				if (item) {
+					let key: IDBValidKey | undefined;
+
+					if (typeof item === 'object') {
+						const keyValues = this.getIndexKeyValuesFromModel(item as T);
+						key = await store
+							.index('byPk')
+							.getKey(this.canonicalKeyPath(keyValues));
+					} else {
+						const itemKey = item.toString();
+						key = await store.index('byPk').getKey(itemKey);
+					}
+
+					if (key !== undefined) {
+						await store.delete(key);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Gets related Has One record for `model`
+	 *
+	 * @param model
+	 * @param srcModel
+	 * @param namespace
+	 * @param rel
+	 * @returns
+	 */
+	protected async getHasOneChild<T extends PersistentModel>(
+		model: T,
+		srcModel: string,
+		namespace: NAMESPACES,
+		rel: RelationType
+	) {
+		const hasOneIndex = 'byPk';
+		const { modelName, targetNames } = rel;
+		const storeName = getStorename(namespace, modelName);
+
+		const values = targetNames!
+			.filter(targetName => model[targetName] ?? false)
+			.map(targetName => model[targetName]);
+
+		if (values.length === 0) return;
+
+		const recordToDelete = <T>(
+			await this.db
+				.transaction(storeName, 'readwrite')
+				.objectStore(storeName)
+				.index(hasOneIndex)
+				.get(this.canonicalKeyPath(values))
+		);
+
+		return recordToDelete;
+	}
+
+	/**
+	 * Backwards compatability for pre-CPK codegen
+	 * TODO - deprecate this in v6; will need to re-gen MIPR for older unit
+	 * tests that hit this path
+	 */
+	protected async getHasOneChildLegacy<T extends PersistentModel>(
+		model: T,
+		srcModel: string,
+		namespace: NAMESPACES,
+		rel: RelationType
+	) {
+		const hasOneIndex = 'byPk';
+		const { modelName, targetName } = rel;
+		const storeName = getStorename(namespace, modelName);
+
+		let index;
+		let values: string[];
+
+		if (targetName && targetName in model) {
+			index = hasOneIndex;
+			const value = model[targetName];
+			if (value === null) {
+				return;
+			}
+			values = [value];
+		} else {
+			// backwards compatability for older versions of codegen that did not emit targetName for HAS_ONE relations
+			index = getIndex(
+				this.schema.namespaces[namespace].relationships![modelName]
+					.relationTypes,
+				srcModel
+			);
+			values = this.getIndexKeyValuesFromModel(model);
+		}
+
+		if (!values || !index) return;
+
+		const recordToDelete = <T>(
+			await this.db
+				.transaction(storeName, 'readwrite')
+				.objectStore(storeName)
+				.index(index)
+				.get(this.canonicalKeyPath(values))
+		);
+
+		return recordToDelete;
+	}
+
+	/**
+	 * Gets related Has Many records by given `storeName`, `index`, and `keyValues`
+	 *
+	 * @param storeName
+	 * @param index
+	 * @param keyValues
+	 * @returns
+	 */
+	protected async getHasManyChildren<T extends PersistentModel>(
+		storeName: string,
+		index: string,
+		keyValues: string[]
+	): Promise<T[]> {
+		const childRecords = await this.db
+			.transaction(storeName, 'readwrite')
+			.objectStore(storeName)
+			.index(index as string)
+			.getAll(this.canonicalKeyPath(keyValues));
+
+		return childRecords;
+	}
+
+	//#region platform-specific helper methods
 
 	private async checkPrivate() {
 		const isPrivate = await isPrivateMode().then(isPrivate => {
@@ -141,342 +568,24 @@ class IndexedDBAdapter implements Adapter {
 		};
 	}
 
-	async setUp(
-		theSchema: InternalSchema,
-		namespaceResolver: NamespaceResolver,
-		modelInstanceCreator: ModelInstanceCreator,
-		getModelConstructorByModelName: (
-			namsespaceName: NAMESPACES,
-			modelName: string
-		) => PersistentModelConstructor<any>,
-		sessionId?: string
-	) {
-		await this.checkPrivate();
-		await this.setSafariCompatabilityMode();
-
-		if (!this.initPromise) {
-			this.initPromise = new Promise((res, rej) => {
-				this.resolve = res;
-				this.reject = rej;
-			});
-		} else {
-			await this.initPromise;
-		}
-		if (sessionId) {
-			this.dbName = `${DB_NAME}-${sessionId}`;
-		}
-		this.schema = theSchema;
-		this.namespaceResolver = namespaceResolver;
-		this.modelInstanceCreator = modelInstanceCreator;
-		this.getModelConstructorByModelName = getModelConstructorByModelName;
-
-		try {
-			if (!this.db) {
-				const VERSION = 3;
-				this.db = await idb.openDB(this.dbName, VERSION, {
-					upgrade: async (db, oldVersion, newVersion, txn) => {
-						if (oldVersion === 0) {
-							Object.keys(theSchema.namespaces).forEach(namespaceName => {
-								const namespace = theSchema.namespaces[namespaceName];
-
-								Object.keys(namespace.models).forEach(modelName => {
-									const storeName = getStorename(namespaceName, modelName);
-									this.createObjectStoreForModel(
-										db,
-										namespaceName,
-										storeName,
-										modelName
-									);
-								});
-							});
-
-							return;
-						}
-
-						if ((oldVersion === 1 || oldVersion === 2) && newVersion === 3) {
-							try {
-								for (const storeName of txn.objectStoreNames) {
-									const origStore = txn.objectStore(storeName);
-
-									// rename original store
-									const tmpName = `tmp_${storeName}`;
-									origStore.name = tmpName;
-
-									const { namespaceName, modelName } =
-										this.getNamespaceAndModelFromStorename(storeName);
-
-									const modelInCurrentSchema =
-										modelName in this.schema.namespaces[namespaceName].models;
-
-									if (!modelInCurrentSchema) {
-										// delete original
-										db.deleteObjectStore(tmpName);
-										continue;
-									}
-
-									const newStore = this.createObjectStoreForModel(
-										db,
-										namespaceName,
-										storeName,
-										modelName
-									);
-
-									let cursor = await origStore.openCursor();
-									let count = 0;
-
-									// Copy data from original to new
-									while (cursor && cursor.value) {
-										// we don't pass key, since they are all new entries in the new store
-										await newStore.put(cursor.value);
-
-										cursor = await cursor.continue();
-										count++;
-									}
-
-									// delete original
-									db.deleteObjectStore(tmpName);
-
-									logger.debug(`${count} ${storeName} records migrated`);
-								}
-
-								// add new models created after IndexedDB, but before migration
-								// this case may happen when a user has not opened an app for
-								// some time and a new model is added during that time
-								Object.keys(theSchema.namespaces).forEach(namespaceName => {
-									const namespace = theSchema.namespaces[namespaceName];
-									const objectStoreNames = new Set(txn.objectStoreNames);
-
-									Object.keys(namespace.models)
-										.map(modelName => {
-											return [
-												modelName,
-												getStorename(namespaceName, modelName),
-											];
-										})
-										.filter(([, storeName]) => !objectStoreNames.has(storeName))
-										.forEach(([modelName, storeName]) => {
-											this.createObjectStoreForModel(
-												db,
-												namespaceName,
-												storeName,
-												modelName
-											);
-										});
-								});
-							} catch (error) {
-								logger.error('Error migrating IndexedDB data', error);
-								txn.abort();
-								throw error;
-							}
-
-							return;
-						}
-					},
-				});
-
-				this.resolve();
-			}
-		} catch (error) {
-			this.reject(error);
-		}
-	}
-
-	private async _get<T>(
-		storeOrStoreName: idb.IDBPObjectStore | string,
-		keyArr: string[]
-	): Promise<T> {
-		let index: idb.IDBPIndex;
-
-		if (typeof storeOrStoreName === 'string') {
-			const storeName = storeOrStoreName;
-			index = this.db.transaction(storeName, 'readonly').store.index('byPk');
-		} else {
-			const store = storeOrStoreName;
-			index = store.index('byPk');
-		}
-
-		const result = await index.get(this.canonicalKeyPath(keyArr));
-
-		return result;
-	}
-
-	async save<T extends PersistentModel>(
-		model: T,
-		condition?: ModelPredicate<T>
-	): Promise<[T, OpType.INSERT | OpType.UPDATE][]> {
-		await this.checkPrivate();
-		const modelConstructor = Object.getPrototypeOf(model)
-			.constructor as PersistentModelConstructor<T>;
-		const storeName = this.getStorenameForModel(modelConstructor);
-		const namespaceName = this.namespaceResolver(modelConstructor);
-
-		const connectedModels = traverseModel(
-			modelConstructor.name,
-			model,
-			this.schema.namespaces[namespaceName],
-			this.modelInstanceCreator,
-			this.getModelConstructorByModelName!
-		);
-
-		const set = new Set<string>();
-		const connectionStoreNames = Object.values(connectedModels).map(
-			({ modelName, item, instance }) => {
-				const storeName = getStorename(namespaceName, modelName);
-				set.add(storeName);
-				const keys = getIndexKeys(
-					this.schema.namespaces[namespaceName],
-					modelName
-				);
-				return { storeName, item, instance, keys };
-			}
-		);
-
-		const tx = this.db.transaction(
-			[storeName, ...Array.from(set.values())],
-			'readwrite'
-		);
-		const store = tx.objectStore(storeName);
-
-		const keyValues = this.getIndexKeyValuesFromModel(model);
-
-		const fromDB = await this._get(store, keyValues);
-
-		if (condition && fromDB) {
-			const predicates = ModelPredicateCreator.getPredicates(condition);
-			const { predicates: predicateObjs, type } = predicates || {};
-
-			const isValid = validatePredicate(
-				fromDB as any,
-				type as any,
-				predicateObjs as any
-			);
-
-			if (!isValid) {
-				const msg = 'Conditional update failed';
-				logger.error(msg, { model: fromDB, condition: predicateObjs });
-
-				throw new Error(msg);
-			}
-		}
-
-		const result: [T, OpType.INSERT | OpType.UPDATE][] = [];
-		for await (const resItem of connectionStoreNames) {
-			const { storeName, item, instance, keys } = resItem;
-			const store = tx.objectStore(storeName);
-
-			const itemKeyValues = keys.map(key => {
-				const value = item[key];
-				return value;
-			});
-
-			const fromDB = <T>await this._get(store, itemKeyValues);
-			const opType: OpType =
-				fromDB === undefined ? OpType.INSERT : OpType.UPDATE;
-
-			const modelKeyValues = this.getIndexKeyValuesFromModel(model);
-
-			// Even if the parent is an INSERT, the child might not be, so we need to get its key
-			if (
-				keysEqual(itemKeyValues, modelKeyValues) ||
-				opType === OpType.INSERT
-			) {
-				const key = await store
-					.index('byPk')
-					.getKey(this.canonicalKeyPath(itemKeyValues));
-				await store.put(item, key);
-				result.push([instance, opType]);
-			}
-		}
-
-		await tx.done;
-
-		return result;
-	}
-
-	private async load<T>(
-		namespaceName: NAMESPACES,
-		srcModelName: string,
-		records: T[]
-	): Promise<T[]> {
-		const namespace = this.schema.namespaces[namespaceName];
-		const relations = namespace.relationships![srcModelName].relationTypes;
-		const connectionStoreNames = relations.map(({ modelName }) => {
-			return getStorename(namespaceName, modelName);
+	private createObjectStoreForModel(
+		db: idb.IDBPDatabase,
+		namespaceName: string,
+		storeName: string,
+		modelName: string
+	): idb.IDBPObjectStore {
+		const store = db.createObjectStore(storeName, {
+			autoIncrement: true,
 		});
-		const modelConstructor = this.getModelConstructorByModelName!(
-			namespaceName,
-			srcModelName
-		);
 
-		if (connectionStoreNames.length === 0) {
-			return records.map(record =>
-				this.modelInstanceCreator(modelConstructor, record)
-			);
-		}
+		const { indexes } =
+			this.schema.namespaces[namespaceName].relationships![modelName];
 
-		return records.map(record =>
-			this.modelInstanceCreator(modelConstructor, record)
-		);
-	}
+		indexes.forEach(([idxName, keyPath, options]) => {
+			store.createIndex(idxName, keyPath, options);
+		});
 
-	async query<T extends PersistentModel>(
-		modelConstructor: PersistentModelConstructor<T>,
-		predicate?: ModelPredicate<T>,
-		pagination?: PaginationInput<T>
-	): Promise<T[]> {
-		await this.checkPrivate();
-		const storeName = this.getStorenameForModel(modelConstructor);
-		const namespaceName = this.namespaceResolver(
-			modelConstructor
-		) as NAMESPACES;
-
-		const predicates =
-			predicate && ModelPredicateCreator.getPredicates(predicate);
-		const keyPath = getIndexKeys(
-			this.schema.namespaces[namespaceName],
-			modelConstructor.name
-		);
-		const queryByKey =
-			predicates && this.keyValueFromPredicate(predicates, keyPath);
-
-		const hasSort = pagination && pagination.sort;
-		const hasPagination = pagination && pagination.limit;
-
-		const records: T[] = (await (async () => {
-			//
-			// NOTE: @svidgen explored removing this and letting query() take care of automatic
-			// index leveraging. This would eliminate some amount of very similar code.
-			// But, getAll is slightly slower than get()
-			//
-			// On Chrome:
-			//   ~700ms vs ~1175ms per 10k reads.
-			//
-			// You can (and should) check my work here:
-			// 	https://gist.github.com/svidgen/74e55d573b19c3e5432b1b5bdf0f4d96
-			//
-			if (queryByKey) {
-				const record = await this.getByKey(storeName, queryByKey);
-				return record ? [record] : [];
-			}
-
-			if (predicates) {
-				const filtered = await this.filterOnPredicate(storeName, predicates);
-				return this.inMemoryPagination(filtered, pagination);
-			}
-
-			if (hasSort) {
-				const all = await this.getAll(storeName);
-				return this.inMemoryPagination(all, pagination);
-			}
-
-			if (hasPagination) {
-				return this.enginePagination(storeName, pagination);
-			}
-
-			return this.getAll(storeName);
-		})()) as T[];
-
-		return await this.load(namespaceName, modelConstructor.name, records);
+		return store;
 	}
 
 	private async getByKey<T extends PersistentModel>(
@@ -490,38 +599,6 @@ class IndexedDBAdapter implements Adapter {
 		storeName: string
 	): Promise<T[]> {
 		return await this.db.getAll(storeName);
-	}
-
-	private keyValueFromPredicate<T extends PersistentModel>(
-		predicates: PredicatesGroup<T>,
-		keyPath: string[]
-	): string[] | undefined {
-		const { predicates: predicateObjs } = predicates;
-
-		if (predicateObjs.length !== keyPath.length) {
-			return;
-		}
-
-		const keyValues = [] as any[];
-
-		for (const key of keyPath) {
-			const predicateObj = predicateObjs.find(
-				p =>
-					// it's a relevant predicate object only if it's an equality
-					// operation for a key field from the key:
-					isPredicateObj(p) &&
-					p.field === key &&
-					p.operator === 'eq' &&
-					// it's only valid if it's not nullish.
-					// (IDB will throw a fit if it's nullish.)
-					p.operand !== null &&
-					p.operand !== undefined
-			) as PredicateObject<T>;
-
-			predicateObj && keyValues.push(predicateObj.operand);
-		}
-
-		return keyValues.length === keyPath.length ? keyValues : undefined;
 	}
 
 	/**
@@ -789,447 +866,6 @@ class IndexedDBAdapter implements Adapter {
 		return result;
 	}
 
-	async queryOne<T extends PersistentModel>(
-		modelConstructor: PersistentModelConstructor<T>,
-		firstOrLast: QueryOne = QueryOne.FIRST
-	): Promise<T | undefined> {
-		await this.checkPrivate();
-		const storeName = this.getStorenameForModel(modelConstructor);
-
-		const cursor = await this.db
-			.transaction([storeName], 'readonly')
-			.objectStore(storeName)
-			.openCursor(undefined, firstOrLast === QueryOne.FIRST ? 'next' : 'prev');
-
-		const result = cursor ? <T>cursor.value : undefined;
-
-		return result && this.modelInstanceCreator(modelConstructor, result);
-	}
-
-	async delete<T extends PersistentModel>(
-		modelOrModelConstructor: T | PersistentModelConstructor<T>,
-		condition?: ModelPredicate<T>
-	): Promise<[T[], T[]]> {
-		await this.checkPrivate();
-		const deleteQueue: { storeName: string; items: T[] }[] = [];
-
-		if (isModelConstructor(modelOrModelConstructor)) {
-			const modelConstructor =
-				modelOrModelConstructor as PersistentModelConstructor<T>;
-			const nameSpace = this.namespaceResolver(modelConstructor) as NAMESPACES;
-
-			const storeName = this.getStorenameForModel(modelConstructor);
-
-			const models = await this.query(modelConstructor, condition);
-			const relations =
-				this.schema.namespaces![nameSpace].relationships![modelConstructor.name]
-					.relationTypes;
-
-			if (condition !== undefined) {
-				await this.deleteTraverse(
-					relations,
-					models,
-					modelConstructor.name,
-					nameSpace,
-					deleteQueue
-				);
-
-				await this.deleteItem(deleteQueue);
-
-				const deletedModels = deleteQueue.reduce(
-					(acc, { items }) => acc.concat(items),
-					<T[]>[]
-				);
-
-				return [models, deletedModels];
-			} else {
-				await this.deleteTraverse(
-					relations,
-					models,
-					modelConstructor.name,
-					nameSpace,
-					deleteQueue
-				);
-
-				// Delete all
-				await this.db
-					.transaction([storeName], 'readwrite')
-					.objectStore(storeName)
-					.clear();
-
-				const deletedModels = deleteQueue.reduce(
-					(acc, { items }) => acc.concat(items),
-					<T[]>[]
-				);
-
-				return [models, deletedModels];
-			}
-		} else {
-			const model = modelOrModelConstructor as T;
-
-			const modelConstructor = Object.getPrototypeOf(model)
-				.constructor as PersistentModelConstructor<T>;
-			const namespaceName = this.namespaceResolver(
-				modelConstructor
-			) as NAMESPACES;
-
-			const storeName = this.getStorenameForModel(modelConstructor);
-
-			if (condition) {
-				const tx = this.db.transaction([storeName], 'readwrite');
-				const store = tx.objectStore(storeName);
-				const keyValues = this.getIndexKeyValuesFromModel(model);
-
-				const fromDB = await this._get(store, keyValues);
-
-				if (fromDB === undefined) {
-					const msg = 'Model instance not found in storage';
-					logger.warn(msg, { model });
-
-					return [[model], []];
-				}
-
-				const predicates = ModelPredicateCreator.getPredicates(condition);
-				const { predicates: predicateObjs, type } =
-					predicates as PredicatesGroup<T>;
-
-				const isValid = validatePredicate(fromDB as T, type, predicateObjs);
-
-				if (!isValid) {
-					const msg = 'Conditional update failed';
-					logger.error(msg, { model: fromDB, condition: predicateObjs });
-
-					throw new Error(msg);
-				}
-				await tx.done;
-
-				const relations =
-					this.schema.namespaces[namespaceName].relationships![
-						modelConstructor.name
-					].relationTypes;
-
-				await this.deleteTraverse(
-					relations,
-					[model],
-					modelConstructor.name,
-					namespaceName,
-					deleteQueue
-				);
-			} else {
-				const relations =
-					this.schema.namespaces[namespaceName].relationships![
-						modelConstructor.name
-					].relationTypes;
-
-				await this.deleteTraverse(
-					relations,
-					[model],
-					modelConstructor.name,
-					namespaceName,
-					deleteQueue
-				);
-			}
-
-			await this.deleteItem(deleteQueue);
-
-			const deletedModels = deleteQueue.reduce(
-				(acc, { items }) => acc.concat(items),
-				<T[]>[]
-			);
-
-			return [[model], deletedModels];
-		}
-	}
-
-	private async deleteItem<T extends PersistentModel>(
-		deleteQueue?: {
-			storeName: string;
-			items: T[] | IDBValidKey[];
-		}[]
-	) {
-		const connectionStoreNames = deleteQueue!.map(({ storeName }) => {
-			return storeName;
-		});
-
-		const tx = this.db.transaction([...connectionStoreNames], 'readwrite');
-		for await (const deleteItem of deleteQueue!) {
-			const { storeName, items } = deleteItem;
-			const store = tx.objectStore(storeName);
-
-			for await (const item of items) {
-				if (item) {
-					let key: IDBValidKey | undefined;
-
-					if (typeof item === 'object') {
-						const keyValues = this.getIndexKeyValuesFromModel(item as T);
-						key = await store
-							.index('byPk')
-							.getKey(this.canonicalKeyPath(keyValues));
-					} else {
-						const itemKey = item.toString();
-						key = await store.index('byPk').getKey(itemKey);
-					}
-
-					if (key !== undefined) {
-						await store.delete(key);
-					}
-				}
-			}
-		}
-	}
-
-	private async deleteTraverse<T extends PersistentModel>(
-		relations: RelationType[],
-		models: T[],
-		srcModel: string,
-		nameSpace: NAMESPACES,
-		deleteQueue: { storeName: string; items: T[] }[]
-	): Promise<void> {
-		for await (const rel of relations) {
-			const {
-				relationType,
-				modelName,
-				targetName,
-				targetNames,
-				associatedWith,
-			} = rel;
-
-			const storeName = getStorename(nameSpace, modelName);
-
-			switch (relationType) {
-				case 'HAS_ONE':
-					for await (const model of models) {
-						const hasOneIndex = 'byPk';
-
-						if (targetNames?.length) {
-							// CPK codegen
-							const values = targetNames
-								.filter(targetName => model[targetName] ?? false)
-								.map(targetName => model[targetName]);
-
-							if (values.length === 0) break;
-
-							const recordToDelete = <T>(
-								await this.db
-									.transaction(storeName, 'readwrite')
-									.objectStore(storeName)
-									.index(hasOneIndex)
-									.get(this.canonicalKeyPath(values))
-							);
-
-							await this.deleteTraverse(
-								this.schema.namespaces[nameSpace].relationships![modelName]
-									.relationTypes,
-								recordToDelete ? [recordToDelete] : [],
-								modelName,
-								nameSpace,
-								deleteQueue
-							);
-							break;
-						} else {
-							// PRE-CPK codegen
-							let index;
-							let values: string[];
-
-							if (targetName && targetName in model) {
-								index = hasOneIndex;
-								const value = model[targetName];
-								if (value === null) break;
-								values = [value];
-							} else {
-								// backwards compatability for older versions of codegen that did not emit targetName for HAS_ONE relations
-								// TODO: can we deprecate this? it's been ~2 years since codegen started including targetName for HAS_ONE
-								// If we deprecate, we'll need to re-gen the MIPR in __tests__/schema.ts > newSchema
-								// otherwise some unit tests will fail
-								index = getIndex(
-									this.schema.namespaces[nameSpace].relationships![modelName]
-										.relationTypes,
-									srcModel
-								);
-								values = this.getIndexKeyValuesFromModel(model);
-							}
-
-							if (!values || !index) break;
-
-							const recordToDelete = <T>(
-								await this.db
-									.transaction(storeName, 'readwrite')
-									.objectStore(storeName)
-									.index(index)
-									.get(this.canonicalKeyPath(values))
-							);
-
-							// instantiate models before passing to deleteTraverse
-							// necessary for extracting PK values via getIndexKeyValuesFromModel
-							const modelsToDelete = recordToDelete
-								? await this.load(nameSpace, modelName, [recordToDelete])
-								: [];
-
-							await this.deleteTraverse(
-								this.schema.namespaces[nameSpace].relationships![modelName]
-									.relationTypes,
-								modelsToDelete,
-								modelName,
-								nameSpace,
-								deleteQueue
-							);
-						}
-					}
-					break;
-				case 'HAS_MANY':
-					for await (const model of models) {
-						const index =
-							// explicit bi-directional @hasMany and @manyToMany
-							getIndex(
-								this.schema.namespaces[nameSpace].relationships![modelName]
-									.relationTypes,
-								srcModel
-							) ||
-							// uni and/or implicit @hasMany
-							getIndexFromAssociation(
-								this.schema.namespaces[nameSpace].relationships![modelName]
-									.indexes,
-								associatedWith!
-							);
-						const keyValues = this.getIndexKeyValuesFromModel(model);
-
-						const childRecords = await this.db
-							.transaction(storeName, 'readwrite')
-							.objectStore(storeName)
-							.index(index as string)
-							.getAll(this.canonicalKeyPath(keyValues));
-
-						// instantiate models before passing to deleteTraverse
-						// necessary for extracting PK values via getIndexKeyValuesFromModel
-						const childModels = await this.load(
-							nameSpace,
-							modelName,
-							childRecords
-						);
-
-						await this.deleteTraverse(
-							this.schema.namespaces[nameSpace].relationships![modelName]
-								.relationTypes,
-							childModels,
-							modelName,
-							nameSpace,
-							deleteQueue
-						);
-					}
-					break;
-				case 'BELONGS_TO':
-					// Intentionally blank
-					break;
-				default:
-					throw new Error(`Invalid relation type ${relationType}`);
-					break;
-			}
-		}
-
-		deleteQueue.push({
-			storeName: getStorename(nameSpace, srcModel),
-			items: models.map(record =>
-				this.modelInstanceCreator(
-					this.getModelConstructorByModelName!(nameSpace, srcModel),
-					record
-				)
-			),
-		});
-	}
-
-	async clear(): Promise<void> {
-		await this.checkPrivate();
-
-		this.db?.close();
-
-		await idb.deleteDB(this.dbName);
-
-		this.db = undefined!;
-		this.initPromise = undefined!;
-	}
-
-	async batchSave<T extends PersistentModel>(
-		modelConstructor: PersistentModelConstructor<any>,
-		items: ModelInstanceMetadata[]
-	): Promise<[T, OpType][]> {
-		if (items.length === 0) {
-			return [];
-		}
-
-		await this.checkPrivate();
-
-		const result: [T, OpType][] = [];
-
-		const storeName = this.getStorenameForModel(modelConstructor);
-
-		const txn = this.db.transaction(storeName, 'readwrite');
-		const store = txn.store;
-
-		for (const item of items) {
-			const namespaceName = this.namespaceResolver(modelConstructor);
-			const modelName = modelConstructor.name;
-			const model = this.modelInstanceCreator(modelConstructor, item);
-
-			const connectedModels = traverseModel(
-				modelName,
-				model,
-				this.schema.namespaces[namespaceName],
-				this.modelInstanceCreator,
-				this.getModelConstructorByModelName!
-			);
-
-			const keyValues = this.getIndexKeyValuesFromModel(model);
-			const { _deleted } = item;
-
-			const index = store.index('byPk');
-
-			const key = await index.getKey(this.canonicalKeyPath(keyValues));
-
-			if (!_deleted) {
-				const { instance } = connectedModels.find(({ instance }) => {
-					const instanceKeyValues = this.getIndexKeyValuesFromModel(instance);
-					return keysEqual(instanceKeyValues, keyValues);
-				})!;
-
-				result.push([
-					<T>(<unknown>instance),
-					key ? OpType.UPDATE : OpType.INSERT,
-				]);
-				await store.put(instance, key);
-			} else {
-				result.push([<T>(<unknown>item), OpType.DELETE]);
-
-				if (key) {
-					await store.delete(key);
-				}
-			}
-		}
-
-		await txn.done;
-
-		return result;
-	}
-
-	private createObjectStoreForModel(
-		db: idb.IDBPDatabase,
-		namespaceName: string,
-		storeName: string,
-		modelName: string
-	) {
-		const store = db.createObjectStore(storeName, {
-			autoIncrement: true,
-		});
-
-		const { indexes } =
-			this.schema.namespaces[namespaceName].relationships![modelName];
-
-		indexes.forEach(([idxName, keyPath, options]) => {
-			store.createIndex(idxName, keyPath, options);
-		});
-
-		return store;
-	}
-
 	/**
 	 * Checks the given path against the browser's IndexedDB implementation for
 	 * necessary compatibility transformations, applying those transforms if needed.
@@ -1244,6 +880,7 @@ class IndexedDBAdapter implements Adapter {
 		}
 		return keyArr;
 	};
+	//#endregion
 }
 
 export default new IndexedDBAdapter();

--- a/packages/datastore/src/storage/adapter/StorageAdapterBase.ts
+++ b/packages/datastore/src/storage/adapter/StorageAdapterBase.ts
@@ -1,0 +1,641 @@
+import { ConsoleLogger as Logger } from '@aws-amplify/core';
+import { Adapter } from './index';
+import { ModelInstanceCreator } from '../../datastore/datastore';
+import { ModelPredicateCreator } from '../../predicates';
+import {
+	InternalSchema,
+	isPredicateObj,
+	ModelInstanceMetadata,
+	ModelPredicate,
+	NamespaceResolver,
+	OpType,
+	PaginationInput,
+	PersistentModel,
+	PersistentModelConstructor,
+	PredicateObject,
+	PredicatesGroup,
+	QueryOne,
+	RelationType,
+} from '../../types';
+import {
+	NAMESPACES,
+	getStorename,
+	getIndexKeys,
+	extractPrimaryKeyValues,
+	traverseModel,
+	validatePredicate,
+	getIndex,
+	getIndexFromAssociation,
+	isModelConstructor,
+} from '../../util';
+import type { IDBPDatabase, IDBPObjectStore } from 'idb';
+import type AsyncStorageDatabase from './AsyncStorageDatabase';
+
+const logger = new Logger('DataStore');
+const DB_NAME = 'amplify-datastore';
+
+export abstract class StorageAdapterBase implements Adapter {
+	// Non-null assertions (bang operators) added to most properties to make TS happy.
+	// For now, we can be reasonably sure they're available when they're needed, because
+	// the adapter is not used directly outside the library boundary.
+	protected schema!: InternalSchema;
+	protected namespaceResolver!: NamespaceResolver;
+	protected modelInstanceCreator!: ModelInstanceCreator;
+	protected getModelConstructorByModelName!: (
+		namsespaceName: NAMESPACES,
+		modelName: string
+	) => PersistentModelConstructor<any>;
+	protected initPromise!: Promise<void>;
+	protected resolve!: (value?: any) => void;
+	protected reject!: (value?: any) => void;
+	protected dbName: string = DB_NAME;
+	protected abstract db: IDBPDatabase | AsyncStorageDatabase;
+
+	protected abstract preSetUpChecks(): Promise<void>;
+	protected abstract preOpCheck(): Promise<void>;
+	protected abstract initDb(): Promise<IDBPDatabase | AsyncStorageDatabase>;
+
+	/**
+	 * Initializes local DB
+	 *
+	 * @param theSchema
+	 * @param namespaceResolver
+	 * @param modelInstanceCreator
+	 * @param getModelConstructorByModelName
+	 * @param sessionId
+	 */
+	public async setUp(
+		theSchema: InternalSchema,
+		namespaceResolver: NamespaceResolver,
+		modelInstanceCreator: ModelInstanceCreator,
+		getModelConstructorByModelName: (
+			namsespaceName: NAMESPACES,
+			modelName: string
+		) => PersistentModelConstructor<any>,
+		sessionId?: string
+	): Promise<void> {
+		await this.preSetUpChecks();
+
+		if (!this.initPromise) {
+			this.initPromise = new Promise((res, rej) => {
+				this.resolve = res;
+				this.reject = rej;
+			});
+		} else {
+			await this.initPromise;
+			return;
+		}
+		if (sessionId) {
+			this.dbName = `${DB_NAME}-${sessionId}`;
+		}
+		this.schema = theSchema;
+		this.namespaceResolver = namespaceResolver;
+		this.modelInstanceCreator = modelInstanceCreator;
+		this.getModelConstructorByModelName = getModelConstructorByModelName;
+
+		try {
+			if (!this.db) {
+				this.db = await this.initDb();
+				this.resolve();
+			}
+		} catch (error) {
+			this.reject(error);
+		}
+	}
+
+	/*
+	 * Abstract Methods for Adapter interface
+	 * Not enough implementation similarities between the adapters
+	 * to consolidate in the base class
+	 */
+	public abstract clear(): Promise<void>;
+
+	public abstract save<T extends PersistentModel>(
+		model: T,
+		condition?: ModelPredicate<T>
+	);
+
+	public abstract query<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		predicate?: ModelPredicate<T>,
+		pagination?: PaginationInput<T>
+	): Promise<T[]>;
+
+	public abstract queryOne<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		firstOrLast: QueryOne
+	): Promise<T | undefined>;
+
+	public abstract batchSave<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<any>,
+		items: ModelInstanceMetadata[]
+	): Promise<[T, OpType][]>;
+
+	/**
+	 * @param modelConstructor
+	 * @returns local DB table name
+	 */
+	protected getStorenameForModel(
+		modelConstructor: PersistentModelConstructor<any>
+	): string {
+		const namespace = this.namespaceResolver(modelConstructor);
+		const { name: modelName } = modelConstructor;
+
+		return getStorename(namespace, modelName);
+	}
+
+	/**
+	 *
+	 * @param model - instantiated model record
+	 * @returns the record's primary key values
+	 */
+	protected getIndexKeyValuesFromModel<T extends PersistentModel>(
+		model: T
+	): string[] {
+		const modelConstructor = Object.getPrototypeOf(model)
+			.constructor as PersistentModelConstructor<T>;
+		const namespaceName = this.namespaceResolver(modelConstructor);
+
+		const keys = getIndexKeys(
+			this.schema.namespaces[namespaceName],
+			modelConstructor.name
+		);
+
+		return extractPrimaryKeyValues(model, keys);
+	}
+
+	/**
+	 * Common metadata for `save` operation
+	 * used by individual storage adapters
+	 *
+	 * @param model
+	 */
+	protected saveMetadata<T extends PersistentModel>(
+		model: T
+	): {
+		storeName: string;
+		set: Set<string>;
+		connectionStoreNames;
+		modelKeyValues: string[];
+	} {
+		const modelConstructor = Object.getPrototypeOf(model)
+			.constructor as PersistentModelConstructor<T>;
+		const storeName = this.getStorenameForModel(modelConstructor);
+		const namespaceName = this.namespaceResolver(modelConstructor);
+
+		const connectedModels = traverseModel(
+			modelConstructor.name,
+			model,
+			this.schema.namespaces[namespaceName],
+			this.modelInstanceCreator,
+			this.getModelConstructorByModelName!
+		);
+
+		const set = new Set<string>();
+		const connectionStoreNames = Object.values(connectedModels).map(
+			({ modelName, item, instance }) => {
+				const storeName = getStorename(namespaceName, modelName);
+				set.add(storeName);
+				const keys = getIndexKeys(
+					this.schema.namespaces[namespaceName],
+					modelName
+				);
+				return { storeName, item, instance, keys };
+			}
+		);
+
+		const modelKeyValues = this.getIndexKeyValuesFromModel(model);
+
+		return { storeName, set, connectionStoreNames, modelKeyValues };
+	}
+
+	/**
+	 * Enforces conditional save. Throws if condition is not met.
+	 * used by individual storage adapters
+	 *
+	 * @param model
+	 */
+	protected validateSaveCondition<T extends PersistentModel>(
+		condition?: ModelPredicate<T>,
+		fromDB?: unknown
+	): void {
+		if (!(condition && fromDB)) {
+			return;
+		}
+
+		const predicates = ModelPredicateCreator.getPredicates(condition);
+		const { predicates: predicateObjs, type } = predicates!;
+
+		const isValid = validatePredicate(fromDB, type, predicateObjs);
+
+		if (!isValid) {
+			const msg = 'Conditional update failed';
+			logger.error(msg, { model: fromDB, condition: predicateObjs });
+
+			throw new Error(msg);
+		}
+	}
+
+	protected abstract _get<T>(
+		storeOrStoreName: IDBPObjectStore | string,
+		keyArr: string[]
+	): Promise<T>;
+
+	/**
+	 * Instantiate models from POJO records returned from the database
+	 *
+	 * @param namespaceName - string model namespace
+	 * @param srcModelName - string model name
+	 * @param records - array of uninstantiated records
+	 * @returns
+	 */
+	protected async load<T>(
+		namespaceName: NAMESPACES,
+		srcModelName: string,
+		records: T[]
+	): Promise<T[]> {
+		const namespace = this.schema.namespaces[namespaceName];
+		const relations = namespace.relationships![srcModelName].relationTypes;
+		const connectionStoreNames = relations.map(({ modelName }) => {
+			return getStorename(namespaceName, modelName);
+		});
+		const modelConstructor = this.getModelConstructorByModelName!(
+			namespaceName,
+			srcModelName
+		);
+
+		if (connectionStoreNames.length === 0) {
+			return records.map(record =>
+				this.modelInstanceCreator(modelConstructor, record)
+			);
+		}
+
+		return records.map(record =>
+			this.modelInstanceCreator(modelConstructor, record)
+		);
+	}
+
+	/**
+	 * Extracts operands from a predicate group into an array of key values
+	 * Used in the query method
+	 *
+	 * @param predicates - predicate group
+	 * @param keyPath - string array of key names ['id', 'sortKey']
+	 * @returns string[] of key values
+	 *
+	 * @example
+	 * ```js
+	 * { and:[{ id: { eq: 'abc' }}, { sortKey: { eq: 'def' }}] }
+	 * ```
+	 * Becomes
+	 * ```
+	 * ['abc', 'def']
+	 * ```
+	 */
+	private keyValueFromPredicate<T extends PersistentModel>(
+		predicates: PredicatesGroup<T>,
+		keyPath: string[]
+	): string[] | undefined {
+		const { predicates: predicateObjs } = predicates;
+
+		if (predicateObjs.length !== keyPath.length) {
+			return;
+		}
+
+		const keyValues = [] as any[];
+
+		for (const key of keyPath) {
+			const predicateObj = predicateObjs.find(
+				p =>
+					// it's a relevant predicate object only if it's an equality
+					// operation for a key field from the key:
+					isPredicateObj(p) &&
+					p.field === key &&
+					p.operator === 'eq' &&
+					// it's only valid if it's not nullish.
+					// (IDB will throw a fit if it's nullish.)
+					p.operand !== null &&
+					p.operand !== undefined
+			) as PredicateObject<T>;
+
+			predicateObj && keyValues.push(predicateObj.operand);
+		}
+
+		return keyValues.length === keyPath.length ? keyValues : undefined;
+	}
+
+	/**
+	 * Common metadata for `query` operation
+	 * used by individual storage adapters
+	 *
+	 * @param modelConstructor
+	 * @param predicate
+	 * @param pagination
+	 */
+	protected queryMetadata<T extends PersistentModel>(
+		modelConstructor: PersistentModelConstructor<T>,
+		predicate?: ModelPredicate<T>,
+		pagination?: PaginationInput<T>
+	) {
+		const storeName = this.getStorenameForModel(modelConstructor);
+		const namespaceName = this.namespaceResolver(
+			modelConstructor
+		) as NAMESPACES;
+
+		const predicates =
+			predicate && ModelPredicateCreator.getPredicates(predicate);
+		const keyPath = getIndexKeys(
+			this.schema.namespaces[namespaceName],
+			modelConstructor.name
+		);
+		const queryByKey =
+			predicates && this.keyValueFromPredicate(predicates, keyPath);
+
+		const hasSort = pagination && pagination.sort;
+		const hasPagination = pagination && pagination.limit;
+
+		return {
+			storeName,
+			namespaceName,
+			queryByKey,
+			predicates,
+			hasSort,
+			hasPagination,
+		};
+	}
+
+	/**
+	 * Delete record
+	 * Cascades to related records (for Has One and Has Many relationships)
+	 *
+	 * @param modelOrModelConstructor
+	 * @param condition
+	 * @returns
+	 */
+	public async delete<T extends PersistentModel>(
+		modelOrModelConstructor: T | PersistentModelConstructor<T>,
+		condition?: ModelPredicate<T>
+	): Promise<[T[], T[]]> {
+		await this.preOpCheck();
+
+		const deleteQueue: { storeName: string; items: T[] }[] = [];
+
+		if (isModelConstructor(modelOrModelConstructor)) {
+			const modelConstructor =
+				modelOrModelConstructor as PersistentModelConstructor<T>;
+			const namespace = this.namespaceResolver(modelConstructor) as NAMESPACES;
+
+			const models = await this.query(modelConstructor, condition);
+			const relations =
+				this.schema.namespaces![namespace].relationships![modelConstructor.name]
+					.relationTypes;
+
+			if (condition !== undefined) {
+				await this.deleteTraverse(
+					relations,
+					models,
+					modelConstructor.name,
+					namespace,
+					deleteQueue
+				);
+
+				await this.deleteItem(deleteQueue);
+
+				const deletedModels = deleteQueue.reduce(
+					(acc, { items }) => acc.concat(items),
+					<T[]>[]
+				);
+
+				return [models, deletedModels];
+			} else {
+				await this.deleteTraverse(
+					relations,
+					models,
+					modelConstructor.name,
+					namespace,
+					deleteQueue
+				);
+
+				await this.deleteItem(deleteQueue);
+
+				const deletedModels = deleteQueue.reduce(
+					(acc, { items }) => acc.concat(items),
+					<T[]>[]
+				);
+
+				return [models, deletedModels];
+			}
+		} else {
+			const model = modelOrModelConstructor as T;
+
+			const modelConstructor = Object.getPrototypeOf(model)
+				.constructor as PersistentModelConstructor<T>;
+			const namespaceName = this.namespaceResolver(
+				modelConstructor
+			) as NAMESPACES;
+
+			const storeName = this.getStorenameForModel(modelConstructor);
+
+			if (condition) {
+				const keyValues = this.getIndexKeyValuesFromModel(model);
+				const fromDB = await this._get(storeName, keyValues);
+
+				if (fromDB === undefined) {
+					const msg = 'Model instance not found in storage';
+					logger.warn(msg, { model });
+
+					return [[model], []];
+				}
+
+				const predicates = ModelPredicateCreator.getPredicates(condition);
+				const { predicates: predicateObjs, type } =
+					predicates as PredicatesGroup<T>;
+
+				const isValid = validatePredicate(fromDB as T, type, predicateObjs);
+				if (!isValid) {
+					const msg = 'Conditional update failed';
+					logger.error(msg, { model: fromDB, condition: predicateObjs });
+
+					throw new Error(msg);
+				}
+
+				const relations =
+					this.schema.namespaces[namespaceName].relationships![
+						modelConstructor.name
+					].relationTypes;
+
+				await this.deleteTraverse(
+					relations,
+					[model],
+					modelConstructor.name,
+					namespaceName,
+					deleteQueue
+				);
+			} else {
+				const relations =
+					this.schema.namespaces[namespaceName].relationships![
+						modelConstructor.name
+					].relationTypes;
+
+				await this.deleteTraverse(
+					relations,
+					[model],
+					modelConstructor.name,
+					namespaceName,
+					deleteQueue
+				);
+			}
+			await this.deleteItem(deleteQueue);
+
+			const deletedModels = deleteQueue.reduce(
+				(acc, { items }) => acc.concat(items),
+				<T[]>[]
+			);
+
+			return [[model], deletedModels];
+		}
+	}
+
+	protected abstract deleteItem<T extends PersistentModel>(
+		deleteQueue?: {
+			storeName: string;
+			items: T[] | IDBValidKey[];
+		}[]
+	);
+
+	protected abstract getHasOneChild<T extends PersistentModel>(
+		model: T,
+		srcModel: string,
+		namespace: NAMESPACES,
+		rel: RelationType
+	): Promise<T | undefined>;
+
+	/**
+	 * Backwards compatability for pre-CPK codegen
+	 * TODO - deprecate this in v6; will need to re-gen MIPR for older unit
+	 * tests that hit this path
+	 */
+	protected abstract getHasOneChildLegacy<T extends PersistentModel>(
+		model: T,
+		srcModel: string,
+		namespace: NAMESPACES,
+		rel: RelationType
+	): Promise<T | undefined>;
+
+	protected abstract getHasManyChildren<T extends PersistentModel>(
+		storeName: string,
+		index: string,
+		keyValues: string[]
+	): Promise<T[] | undefined>;
+
+	/**
+	 * Recursively traverse relationship graph and add
+	 * all Has One and Has Many relations to `deleteQueue` param
+	 *
+	 * Actual deletion of records added to `deleteQueue` occurs in the `delete` method
+	 *
+	 * @param relations
+	 * @param models
+	 * @param srcModel
+	 * @param namespace
+	 * @param deleteQueue
+	 */
+	protected async deleteTraverse<T extends PersistentModel>(
+		relations: RelationType[],
+		models: T[],
+		srcModel: string,
+		namespace: NAMESPACES,
+		deleteQueue: { storeName: string; items: T[] }[]
+	): Promise<void> {
+		for await (const rel of relations) {
+			const { modelName, relationType, targetNames, associatedWith } = rel;
+
+			const storeName = getStorename(namespace, modelName);
+			const index: string =
+				getIndex(
+					this.schema.namespaces[namespace].relationships![modelName]
+						.relationTypes,
+					srcModel
+				) ||
+				// if we were unable to find an index via relationTypes
+				// i.e. for keyName connections, attempt to find one by the
+				// associatedWith property
+				getIndexFromAssociation(
+					this.schema.namespaces[namespace].relationships![modelName].indexes,
+					associatedWith!
+				)!;
+
+			for await (const model of models) {
+				const childRecords: PersistentModel[] = [];
+
+				switch (relationType) {
+					case 'HAS_ONE':
+						let childRecord;
+						if (targetNames?.length) {
+							childRecord = await this.getHasOneChild(
+								model,
+								srcModel,
+								namespace,
+								rel
+							);
+						} else {
+							childRecord = await this.getHasOneChildLegacy(
+								model,
+								srcModel,
+								namespace,
+								rel
+							);
+						}
+
+						if (childRecord) {
+							childRecords.push(childRecord);
+						}
+
+						break;
+					case 'HAS_MANY':
+						const keyValues: string[] = this.getIndexKeyValuesFromModel(model);
+
+						const records = await this.getHasManyChildren(
+							storeName,
+							index,
+							keyValues
+						);
+
+						if (records?.length) {
+							childRecords.push(...records);
+						}
+
+						break;
+					case 'BELONGS_TO':
+						// Intentionally blank
+						break;
+					default:
+						throw new Error(`Invalid relation type ${relationType}`);
+				}
+
+				// instantiate models before passing them to next recursive call
+				// necessary for extracting PK metadata in `getHasOneChild` and `getHasManyChildren`
+				const childModels = await this.load(namespace, modelName, childRecords);
+
+				await this.deleteTraverse(
+					this.schema.namespaces[namespace].relationships![modelName]
+						.relationTypes,
+					childModels,
+					modelName,
+					namespace,
+					deleteQueue
+				);
+			}
+		}
+
+		deleteQueue.push({
+			storeName: getStorename(namespace, srcModel),
+			items: models.map(record =>
+				this.modelInstanceCreator(
+					this.getModelConstructorByModelName!(namespace, srcModel),
+					record
+				)
+			),
+		});
+	}
+}

--- a/packages/datastore/src/storage/adapter/StorageAdapterBase.ts
+++ b/packages/datastore/src/storage/adapter/StorageAdapterBase.ts
@@ -312,8 +312,6 @@ export abstract class StorageAdapterBase implements Adapter {
 					isPredicateObj(p) &&
 					p.field === key &&
 					p.operator === 'eq' &&
-					// it's only valid if it's not nullish.
-					// (IDB will throw a fit if it's nullish.)
 					p.operand !== null &&
 					p.operand !== undefined
 			) as PredicateObject<T>;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adds an abstract base class - `StorageAdapterBase` that encapsulates common storage adapter business logic.
Individual storage adapters, e.g. IndexedDBStorageAdapter extend the base class and only implement platform-specific business logic

This PR migrates IndexedDB and AsyncStorage to this pattern. I would like to get a sanity check from the team on the soundness of this approach before migrating the remaining 2 adapters (SQLite and Expo SQLite)

#### Description of how you validated changes
* unit tests
* manual testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
