### PR TITLE
chore(core): bump to ts 5.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
 		"@aws-sdk/credential-provider-cognito-identity": "3.6.1",
 		"@aws-sdk/types": "3.6.1",
 		"@aws-sdk/util-hex-encoding": "3.6.1",
-		"tslib": "^2.0.0",
+		"tslib": "^1.8.0",
 		"universal-cookie": "^4.0.4",
 		"zen-observable-ts": "0.8.19"
 	},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,7 @@
 		"genversion": "^2.2.0",
 		"prepend-file": "^1.3.1",
 		"react-native": "^0.64.1",
-		"typescript": "4.9.5"
+		"typescript": "5.0.2"
 	},
 	"files": [
 		"lib",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
 		"@aws-sdk/credential-provider-cognito-identity": "3.6.1",
 		"@aws-sdk/types": "3.6.1",
 		"@aws-sdk/util-hex-encoding": "3.6.1",
-		"tslib": "^1.8.0",
+		"tslib": "^2.0.0",
 		"universal-cookie": "^4.0.4",
 		"zen-observable-ts": "0.8.19"
 	},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,17 +18,17 @@
 		"test": "npm run lint && jest -w 1 --coverage",
 		"test:size": "size-limit",
 		"build-with-test": "npm test && npm run build",
-		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
-		"build:esm": "rimraf lib-esm && node ./build es6",
-		"build:cjs:watch": "node ./build es5 --watch",
-		"build:esm:watch": "rimraf lib-esm && node ./build es6 --watch",
+		"build:cjs": "rimraf lib && tsc -m commonjs --outDir lib && webpack && webpack --config ./webpack.config.dev.js",
+		"build:esm": "rimraf lib-esm && tsc -m esnext --outDir lib-esm",
+		"build:cjs:watch": "rimraf lib && tsc -m commonjs --outDir lib --watch",
+		"build:esm:watch": "rimraf lib-esm && tsc -m esnext --outDir lib-esm --watch",
 		"build": "npm run clean && npm run generate-version && npm run build:esm && npm run build:cjs",
 		"generate-version": "genversion src/Platform/version.ts --es6 --semi",
 		"clean": "npm run clean:size && rimraf lib-esm lib dist",
 		"clean:size": "rimraf dual-publish-tmp tmp*",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
-		"ts-coverage": "typescript-coverage-report -p ./tsconfig.build.json -t 76.41"
+		"ts-coverage": "typescript-coverage-report -p ./tsconfig.json -t 76.41"
 	},
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js",
@@ -51,7 +51,8 @@
 		"find": "^0.2.7",
 		"genversion": "^2.2.0",
 		"prepend-file": "^1.3.1",
-		"react-native": "^0.64.1"
+		"react-native": "^0.64.1",
+		"typescript": "4.9.5"
 	},
 	"files": [
 		"lib",
@@ -106,16 +107,7 @@
 		"globals": {
 			"ts-jest": {
 				"diagnostics": false,
-				"tsConfig": {
-					"lib": [
-						"es5",
-						"es2015",
-						"dom",
-						"esnext.asynciterable",
-						"es2017.object"
-					],
-					"allowJs": true
-				}
+				"tsConfig": false
 			}
 		},
 		"transform": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,13 +82,13 @@
 			"name": "Core (Hub)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Hub }",
-			"limit": "2 kB"
+			"limit": "2.05 kB"
 		},
 		{
 			"name": "Core (I18n)",
 			"path": "./lib-esm/index.js",
 			"import": "{ I18n }",
-			"limit": "2 kB"
+			"limit": "2.05 kB"
 		},
 		{
 			"name": "Core (Logger)",
@@ -100,7 +100,7 @@
 			"name": "Core (Credentials)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Credentials }",
-			"limit": "34.5 kB"
+			"limit": "35.5 kB"
 		}
 	],
 	"jest": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
 		"clean:size": "rimraf dual-publish-tmp tmp*",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
-		"ts-coverage": "typescript-coverage-report -p ./tsconfig.json -t 76.41"
+		"ts-coverage": "typescript-coverage-report -p ./tsconfig.build.json -t 76.41"
 	},
 	"react-native": {
 		"./lib/index": "./lib-esm/index.js",

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -49,7 +49,7 @@ export class CredentialsClass {
 	private _storage;
 	private _storageSync;
 	private _identityId;
-	private _nextCredentialsRefresh: Number;
+	private _nextCredentialsRefresh: number;
 
 	// Allow `Auth` to be injected for SSR, but Auth isn't a required dependency for Credentials
 	Auth = undefined;

--- a/packages/core/src/OAuthHelper/FacebookOAuth.ts
+++ b/packages/core/src/OAuthHelper/FacebookOAuth.ts
@@ -6,7 +6,7 @@ import { NonRetryableError } from '../Util';
 
 const logger = new Logger('CognitoCredentials');
 
-const waitForInit = new Promise((res, rej) => {
+const waitForInit = new Promise<void>((res, rej) => {
 	if (!browserOrNode().isBrowser) {
 		logger.debug('not in the browser, directly resolved');
 		return res();

--- a/packages/core/src/OAuthHelper/GoogleOAuth.ts
+++ b/packages/core/src/OAuthHelper/GoogleOAuth.ts
@@ -6,7 +6,7 @@ import { NonRetryableError } from '../Util';
 
 const logger = new Logger('CognitoCredentials');
 
-const waitForInit = new Promise((res, rej) => {
+const waitForInit = new Promise<void>((res, rej) => {
 	if (!browserOrNode().isBrowser) {
 		logger.debug('not in the browser, directly resolved');
 		return res();

--- a/packages/core/src/StorageHelper/reactnative.ts
+++ b/packages/core/src/StorageHelper/reactnative.ts
@@ -59,7 +59,7 @@ class MemoryStorage {
 	 */
 	static sync() {
 		if (!MemoryStorage.syncPromise) {
-			MemoryStorage.syncPromise = new Promise((res, rej) => {
+			MemoryStorage.syncPromise = new Promise<void>((res, rej) => {
 				AsyncStorage.getAllKeys((errKeys, keys) => {
 					if (errKeys) rej(errKeys);
 					const memoryKeys = keys.filter(key =>

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+	"extends": "../tsconfig.base.json",
+	"compilerOptions": {},
+	"include": ["lib*/**/*.ts", "src"]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,5 +1,7 @@
 {
 	"extends": "../tsconfig.base.json",
-	"compilerOptions": {},
+	"compilerOptions": {
+		"downlevelIteration": true
+	},
 	"include": ["lib*/**/*.ts", "src"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,5 +3,8 @@
 	"compilerOptions": {
 		"importHelpers": false
 	},
-	"include": ["lib*/**/*.ts", "src"]
+	"include": ["./src"],
+	"watchOptions": {
+		"excludeDirectories": ["lib*"]
+	}
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
-		"downlevelIteration": true
+		"importHelpers": false
 	},
 	"include": ["lib*/**/*.ts", "src"]
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This is the first commit to lay the ground for the custom clients work. Bump the core to ts 5.0 so we can utilize the better type resolution compared to ts3.8. It is not a breaking change because we are not exporting any ts interfaces differently than main branch.

The bundle size increased because the ts config `importHelpers` is turned off. Otherwise the build error is show:
```bash
error TS2343: This syntax requires an imported helper named '__spreadArray' which does not exist in 'tslib'. Consider upgrading your version of 'tslib'.
```
This is because ts3.x generates spread helper function `__spread`. The helper function was deprecated in ts4.x and new helper function `__spreadArray` from tslib 2.x is favored. We cannot bump tslib version yet because the tslib version misalignment with dependency package will cause mutliple copies of the tslib in users `node_modules`, hence bigger bundle size. 

The bundle size increase of the `core` package as temporary as custom clients will bring greater reduction of bundle size.


#### Description of how you validated changes
Verified with build & ts-coverage & watch mode



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
