### PR TITLE
fix(auth): fixed getpreferred mfa result when mfa options is activate…

### DIFF
--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -4574,6 +4574,28 @@ describe('auth unit test', () => {
 			expect(getUserDataSpy).toHaveBeenCalledTimes(1);
 		});
 
+		test('return NOMFA when PreferredMFASetting is not there', async () => {
+			const auth = new Auth(authOptions);
+			const user = new CognitoUser({
+				Username: 'username',
+				Pool: userPool
+			});
+			const getUserDataSpy = jest
+				.spyOn(user, 'getUserData')
+				.mockImplementationOnce((callback: any) => {
+					const data = {
+						Username: 'username',
+						MFAOptions: {
+							phone_number: '+1234567890'
+						}
+					};
+					callback(null, data);
+				});
+			const res = await auth.getPreferredMFA(user);
+			expect(res).toEqual('NOMFA');
+			expect(getUserDataSpy).toHaveBeenCalledTimes(1);
+		});
+
 		test('should allow bypassCache', async () => {
 			const auth = new Auth(authOptions);
 			const user = new CognitoUser({

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -880,7 +880,7 @@ export class AuthClass {
 		});
 	}
 
-	private async _getMfaTypeFromUserData(data) {
+	private _getMfaTypeFromUserData(data) {
 		let ret = null;
 		const preferredMFA = data.PreferredMfaSetting;
 		// if the user has used Auth.setPreferredMFA() to setup the mfa type


### PR DESCRIPTION
…d but not set as preferred

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
getPreferredMFA function should only check for PreferredMfaSetting from getUser call to Cognito. MFA options are no longer supported and have no way of identifying TOTP.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
