### PR TITLE
fix(datastore): stale observeQuery snapshot with sort param

### DIFF
--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -14,6 +14,7 @@ import {
 	PersistentModel,
 	PersistentModelConstructor,
 	ModelInit,
+	SortDirection,
 } from '../src/types';
 import {
 	Comment,
@@ -1659,6 +1660,14 @@ describe('DataStore observeQuery, with fake-indexeddb and fake sync', () => {
 });
 
 describe('Model behavior', () => {
+	beforeEach(() => {
+		warpTime();
+	});
+
+	afterEach(() => {
+		unwarpTime();
+	});
+
 	test('newly instantiated models do not lazy load belongsTo', async () => {
 		const { DataStore, DefaultPKChild, DefaultPKParent } = getDataStore();
 
@@ -1841,7 +1850,7 @@ describe('Model behavior', () => {
 				);
 
 				// advance time to trigger another snapshot.
-				jest.advanceTimersByTime(2000);
+				await pause(2000);
 			} catch (error) {
 				done(error);
 			}
@@ -1892,11 +1901,61 @@ describe('Model behavior', () => {
 				);
 
 				// advance time to trigger another snapshot.
-				jest.advanceTimersByTime(2000);
+				await pause(2000);
 			} catch (error) {
 				done(error);
 			}
 		})();
+	});
+
+	// ref: https://github.com/aws-amplify/amplify-js/issues/11101
+	test('returns fresh snapshot when sorting by descending', async done => {
+		const { DataStore, Post } = getDataStore();
+
+		const expectedTitles = ['create', 'update', 'update2'];
+
+		const newPost = await DataStore.save(
+			new Post({
+				title: 'create',
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			})
+		);
+
+		const sub = DataStore.observeQuery(Post, Predicates.ALL, {
+			sort: s => s.updatedAt(SortDirection.DESCENDING),
+		}).subscribe(({ items }) => {
+			if (items.length === 0) {
+				return;
+			}
+
+			const [item] = items;
+			const expected = expectedTitles.shift();
+
+			expect(item!.title).toEqual(expected);
+
+			if (expectedTitles.length === 0) {
+				sub.unsubscribe();
+				done();
+			}
+		});
+
+		await DataStore.save(
+			Post.copyOf(newPost, updated => {
+				updated.title = 'update';
+				updated.updatedAt = new Date().toISOString();
+			})
+		);
+
+		// observeQuery snapshots are debounced by 2s
+		await pause(2000);
+
+		await DataStore.save(
+			Post.copyOf(newPost, updated => {
+				updated.title = 'update2';
+				updated.updatedAt = new Date().toISOString();
+			})
+		);
 	});
 });
 

--- a/packages/datastore/__tests__/commonAdapterTests.ts
+++ b/packages/datastore/__tests__/commonAdapterTests.ts
@@ -395,7 +395,12 @@ export function addCommonQueryTests({
 
 			// comment update should be smashed to together with post
 			expect(mutations.length).toBe(2);
-			expectMutation(mutations[0], { title: 'some post', blogId: null });
+			expectMutation(mutations[0], {
+				title: 'some post',
+				blogId: null,
+				createdAt: null,
+				updatedAt: null,
+			});
 			expectMutation(mutations[1], {
 				content: 'updated content',
 				postId: mutations[0].modelId,

--- a/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
+++ b/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
@@ -6,7 +6,7 @@ import {
 	isModelAttributePrimaryKey,
 	__modelMeta__,
 } from '../../../src/types';
-import { validatePredicate } from '../../../src/util';
+import { validatePredicate, getTimestampFields } from '../../../src/util';
 import { ModelPredicateCreator } from '../../../src/predicates';
 import { initSchema as _initSchema } from '../../../src/datastore/datastore';
 
@@ -21,6 +21,10 @@ export class FakeGraphQLService {
 	public tables = new Map<string, Map<string, any[]>>();
 	public tableDefinitions = new Map<string, SchemaModel>();
 	public PKFields = new Map<string, string[]>();
+	public timestampFields = new Map<
+		string,
+		{ createdAt: string; updatedAt: string }
+	>();
 	public observers = new Map<
 		string,
 		ZenObservable.SubscriptionObserver<any>[]
@@ -38,6 +42,10 @@ export class FakeGraphQLService {
 					break;
 				}
 			}
+
+			const timestamps = getTimestampFields(model);
+			this.timestampFields.set(model.name, timestamps);
+
 			if (!CPKFound) {
 				this.PKFields.set(model.name, ['id']);
 			}
@@ -314,6 +322,7 @@ export class FakeGraphQLService {
 				...this.populatedFields(updated),
 				_version: updated._version + 1,
 				_lastChangedAt: new Date().getTime(),
+				updatedAt: new Date().toISOString(),
 			};
 		} else {
 			merged = {
@@ -392,9 +401,12 @@ export class FakeGraphQLService {
 			}
 		} else if (operation === 'mutation') {
 			const record = variables.input;
+			const timestampFields = this.timestampFields.get(tableName);
+
 			if (type === 'create') {
 				const existing = table.get(this.getPK(tableName, record));
 				const validationError = this.validate(tableName, 'create', record);
+
 				if (validationError) {
 					data = {
 						[selection]: null,
@@ -412,6 +424,9 @@ export class FakeGraphQLService {
 							_deleted: false,
 							_version: 1,
 							_lastChangedAt: new Date().getTime(),
+							// TODO: update test expected values and re-enable
+							// [timestampFields!.createdAt]: new Date().toISOString(),
+							// [timestampFields!.updatedAt]: new Date().toISOString(),
 						},
 					};
 					table.set(this.getPK(tableName, record), data[selection]);
@@ -478,6 +493,8 @@ export class FakeGraphQLService {
 							_deleted: true,
 							_version: existing._version + 1,
 							_lastChangedAt: new Date().getTime(),
+							// TODO: update test expected values and re-enable
+							// [timestampFields!.updatedAt]: new Date().toISOString(),
 						},
 					};
 					table.set(this.getPK(tableName, record), data[selection]);

--- a/packages/datastore/__tests__/helpers/schemas/default.ts
+++ b/packages/datastore/__tests__/helpers/schemas/default.ts
@@ -63,6 +63,8 @@ export declare class Post {
 	public readonly title: string;
 	public readonly comments: AsyncCollection<Comment>;
 	public readonly blogId?: string;
+	public readonly createdAt?: string;
+	public readonly updatedAt?: string;
 
 	constructor(init: ModelInit<Post>);
 
@@ -858,6 +860,20 @@ export function testSchema(): Schema {
 							connectionType: 'HAS_MANY',
 							associatedWith: ['post'],
 						},
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
 					},
 				},
 				syncable: true,

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -1098,3 +1098,36 @@ export const getIndexKeys = (
 };
 
 //#endregion
+
+/**
+ * Determine what the managed timestamp field names are for the given model definition
+ * and return the mapping.
+ *
+ * All timestamp fields are included in the mapping, regardless of whether the final field
+ * names are the defaults or customized in the `@model` directive.
+ *
+ * @see https://docs.amplify.aws/cli/graphql/data-modeling/#customize-creation-and-update-timestamps
+ *
+ * @param definition modelDefinition to inspect.
+ * @returns An object mapping `createdAt` and `updatedAt` to their field names.
+ */
+export const getTimestampFields = (
+	definition: SchemaModel
+): { createdAt: string; updatedAt: string } => {
+	const modelAttributes = definition.attributes?.find(
+		attr => attr.type === 'model'
+	);
+	const timestampFieldsMap = modelAttributes?.properties?.timestamps;
+
+	const defaultFields = {
+		createdAt: 'createdAt',
+		updatedAt: 'updatedAt',
+	};
+
+	const customFields = timestampFieldsMap || {};
+
+	return {
+		...defaultFields,
+		...customFields,
+	};
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Relevant impl change is only in `datastore.ts` ([link to block](https://github.com/aws-amplify/amplify-js/pull/11119/files#diff-10866b5ac7d469b38dd9928d9d7056a3a402904fef591ea8cfe773b4d75d63efR2311-R2318)) remaining changes are for testing purposes.

We were applying `sort` before merging existing and changed snapshot items into the new snapshot.
This was causing stale items to surface in the snapshot.

New PR applies sort after we merge items, fixing the issue.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#11101 

#### Description of how you validated changes

* Manual
* Unit test

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
