### PR TITLE
fix(@aws-amplify/datastore): mutation hub event drops during reconnect

### DIFF
--- a/packages/datastore/__tests__/connectivityHandling.test.ts
+++ b/packages/datastore/__tests__/connectivityHandling.test.ts
@@ -50,6 +50,10 @@ describe('DataStore sync engine', () => {
 	} = getDataStore({ online: true, isNode: false });
 
 	beforeEach(async () => {
+		// we don't need to see all the console warnings for these tests ...
+		(console as any)._warn = console.warn;
+		console.warn = () => {};
+
 		({
 			DataStore,
 			schema,
@@ -77,6 +81,7 @@ describe('DataStore sync engine', () => {
 
 	afterEach(async () => {
 		await DataStore.clear();
+		console.warn = (console as any)._warn;
 	});
 
 	describe('basic protocol', () => {
@@ -498,16 +503,7 @@ describe('DataStore sync engine', () => {
 			expect(cloudAnotherPost.title).toEqual('another title');
 		});
 
-		/**
-		 * Existing bug. (Sort of.)
-		 *
-		 * Outbox mutations are processed, but the hub events are not sent, so
-		 * the test hangs and times out. :shrug:
-		 *
-		 * It is notable that the data is correct in this case, we just don't
-		 * receive all of the expected Hub events.
-		 */
-		test.skip('survives online -> offline -> save/online race', async () => {
+		test('survives online -> offline -> save/online race', async () => {
 			const post = await DataStore.save(
 				new Post({
 					title: 'a title',

--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -451,6 +451,7 @@ export class SyncEngine {
 
 								await startPromise;
 
+								// Set by the this.datastoreConnectivity.status().subscribe() loop
 								if (this.online) {
 									this.mutationsProcessor.resume();
 								}

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -139,7 +139,7 @@ class MutationProcessor {
 
 			return this.runningProcesses.addCleaner(async () => {
 				// The observer has unsubscribed and/or `stop()` has been called.
-				this.observer = undefined;
+				this.removeObserver();
 				this.pause();
 			});
 		});
@@ -148,9 +148,14 @@ class MutationProcessor {
 	}
 
 	public async stop() {
-		this.observer = undefined;
+		this.removeObserver();
 		await this.runningProcesses.close();
 		await this.runningProcesses.open();
+	}
+
+	public removeObserver() {
+		this.observer?.complete?.();
+		this.observer = undefined;
 	}
 
 	public async resume(): Promise<void> {

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -56,7 +56,15 @@ type MutationProcessorEvent = {
 };
 
 class MutationProcessor {
-	private observer!: ZenObservable.Observer<MutationProcessorEvent>;
+	/**
+	 * The observer that receives messages when mutations are successfully completed
+	 * against cloud storage.
+	 *
+	 * A value of `undefined` signals that the sync has either been stopped or has not
+	 * yet started. In this case, `isReady()` will be `false` and `resume()` will exit
+	 * early.
+	 */
+	private observer?: ZenObservable.Observer<MutationProcessorEvent>;
 	private readonly typeQuery = new WeakMap<
 		SchemaModel,
 		[TransformerMutationType, string, string][]
@@ -130,6 +138,8 @@ class MutationProcessor {
 			}
 
 			return this.runningProcesses.addCleaner(async () => {
+				// The observer has unsubscribed and/or `stop()` has been called.
+				this.observer = undefined;
 				this.pause();
 			});
 		});
@@ -138,6 +148,7 @@ class MutationProcessor {
 	}
 
 	public async stop() {
+		this.observer = undefined;
 		await this.runningProcesses.close();
 		await this.runningProcesses.open();
 	}
@@ -256,7 +267,7 @@ class MutationProcessor {
 						hasMore = (await this.outbox.peek(storage)) !== undefined;
 					});
 
-					this.observer.next!({
+					this.observer?.next?.({
 						operation,
 						modelDefinition,
 						model: record,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

[`outboxMutationProcessed`](https://docs.amplify.aws/lib/datastore/datastore-events/q/platform/js/#outboxmutationprocessed) Hub events were being dropped for mutations that were being raced against reconnect activities. A fringe case, but during reconnect, this could lead to customer code waiting for `outboxMutationProcessed` events that would never arrive.

This PR fixes the issue by properly removing the observer from the mutation processor during an unsubscribe or `stop()`. An `undefined` observer signals to the mutation processor not to immediately resume on mutation, but instead wait for an observer (the sync engine) to register itself and re-`start()` the mutation processor.

This PR also incidentally tamps down on `console.warn` noise in the scope of `connectivityHandler.test.ts`.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

Un-skipped the test that originally caught the error. Made it pass.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
