### PR TITLE
fix(@aws-amplify/datastore): adds serialization for empty predicates

### DIFF
--- a/packages/datastore/__tests__/Predicate.ts
+++ b/packages/datastore/__tests__/Predicate.ts
@@ -2274,6 +2274,12 @@ describe('Predicates', () => {
 	describe('non-recursive predicate to storage predicate generation', () => {
 		const ASTTransalationTestCases = [
 			{
+				gql: {},
+				expectedRegeneration: {},
+				matches: [{ name: 'abc' }],
+				mismatches: [],
+			},
+			{
 				gql: { and: [] },
 				expectedRegeneration: {},
 				matches: [{ name: 'abc' }],
@@ -2379,6 +2385,11 @@ describe('Predicates', () => {
 			});
 		}
 		const predicateTestCases = [
+			{
+				predicate: p => p,
+				matches: [{ name: 'abc' }],
+				mismatches: [],
+			},
 			{
 				predicate: p => p.name.eq('abc'),
 				matches: [{ name: 'abc' }],

--- a/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
+++ b/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
@@ -92,7 +92,10 @@ export class FakeGraphQLService {
 		});
 
 		if (!condition) {
-			this.log('checking satisfiesCondition matches all for `null` conditions');
+			this.log(
+				'checking satisfiesCondition',
+				'matches all for `null` conditions'
+			);
 			return true;
 		}
 

--- a/packages/datastore/src/predicates/index.ts
+++ b/packages/datastore/src/predicates/index.ts
@@ -41,6 +41,16 @@ const isGroup = o => {
 };
 
 /**
+ * Determines whether an object specifies no conditions and should match everything,
+ * as would be the case with `Predicates.ALL`.
+ *
+ * @param o The object to test.
+ */
+const isEmpty = o => {
+	return !Array.isArray(o) && Object.keys(o).length === 0;
+};
+
+/**
  * The valid comparison operators that can be used as keys in a predicate comparison object.
  */
 export const comparisonKeys = new Set([
@@ -77,7 +87,7 @@ const isValid = o => {
 	if (Array.isArray(o)) {
 		return o.every(v => isValid(v));
 	} else {
-		return Object.keys(o).length === 1;
+		return Object.keys(o).length <= 1;
 	}
 };
 
@@ -207,7 +217,12 @@ export class ModelPredicateCreator {
 			throw new Error('Invalid GraphQL Condition or subtree: ' + gql);
 		}
 
-		if (isGroup(gql)) {
+		if (isEmpty(gql)) {
+			return {
+				type: 'and',
+				predicates: [],
+			};
+		} else if (isGroup(gql)) {
 			const groupkey = Object.keys(gql)[0];
 			const children = this.transformGraphQLFilterNodeToPredicateAST(
 				gql[groupkey]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

AFAIK, this only affects test mocks which need to execute predicates. Whereas DataStore API's normally short-circuit when `Predicate.ALL` is supplied, the test mocks can't always do this reliably.

This PR adds a branch to allow empty predicates (`model => model`) to be serialized in a way that can just be executed like a normal storage predicate.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

Added a test. Made the test pass.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
