### PR TITLE
chore(notifications): Force Push channel to share endpoint with Analy…

### DIFF
--- a/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
+++ b/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
@@ -255,7 +255,11 @@ export default abstract class AWSPinpointProviderCommon
 	private getEndpointId = async (): Promise<string> => {
 		const { appId } = this.config;
 		// Each Pinpoint channel requires its own Endpoint ID
-		const cacheKey = `${this.getSubCategory()}:${this.getProviderName()}:${appId}`;
+		// However, Push will share the Analytics endpoint for now so as to not break existing customers
+		const cacheKey =
+			this.getSubCategory() === 'PushNotification'
+				? `${this.getProviderName()}_${appId}`
+				: `${this.getSubCategory()}:${this.getProviderName()}:${appId}`;
 		// First attempt to retrieve the ID from cache
 		const cachedEndpointId = await Cache.getItem(cacheKey);
 		// Found in cache, just return it


### PR DESCRIPTION
…tics

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR updates the endpointId resolution for Push to share an endpoint with Analytics.

The current implementation of Push Notifications for React Native relies exclusively upon Analytics for its Pinpoint communications. As a result, once it has been enabled, the Analytics endpoint is effectively converted to a Push endpoint. To avoid a situation where creating a new Push endpoint for a single device would result in two endpoints sharing a token (address), we have to continue to share the endpoint until our next major version bump where we can effectively recreate the Analytics endpoint.

#### Description of how you validated changes
Tested locally with sample app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
