### PR TITLE
fix(notifications): Fix double registration issue

### DIFF
--- a/packages/notifications/__tests__/PushNotification/PushNotification.native.test.ts
+++ b/packages/notifications/__tests__/PushNotification/PushNotification.native.test.ts
@@ -275,6 +275,30 @@ describe('PushNotification', () => {
 			);
 		});
 
+		test('token received should not be invoked with the same token twice', () => {
+			mockAddListener.mockImplementation((heardEvent, handler) => {
+				if (heardEvent === NativeEvent.TOKEN_RECEIVED) {
+					handler({ token: pushToken });
+					handler({ token: pushToken });
+				}
+			});
+			pushNotification.enable();
+
+			expect(notifyEventListeners).toBeCalledTimes(1);
+		});
+
+		test('token received should be invoked with different tokens', () => {
+			mockAddListener.mockImplementation((heardEvent, handler) => {
+				if (heardEvent === NativeEvent.TOKEN_RECEIVED) {
+					handler({ token: pushToken });
+					handler({ token: 'bar-foo' });
+				}
+			});
+			pushNotification.enable();
+
+			expect(notifyEventListeners).toBeCalledTimes(2);
+		});
+
 		test('handles device registration failure', () => {
 			mockPushNotificationProvider.registerDevice.mockImplementationOnce(() => {
 				throw new Error();

--- a/packages/notifications/src/PushNotification/PushNotification.native.ts
+++ b/packages/notifications/src/PushNotification/PushNotification.native.ts
@@ -254,6 +254,10 @@ export default class PushNotification implements PushNotificationInterface {
 			// broadcast to library listeners
 			TOKEN_RECEIVED,
 			({ token }) => {
+				// avoid a race condition where two endpoints are created with the same token on a fresh install
+				if (this.token === token) {
+					return;
+				}
 				this.token = token;
 				this.registerDevice();
 				notifyEventListeners(PushNotificationEvent.TOKEN_RECEIVED, token);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR fixes an issue where, upon a fresh install, the Android module will send off two token received events (from the service onNewToken and module launch). This triggers a race condition where both events are handled in parallel and ends up creating two separate endpoints.

#### Description of how you validated changes
Tested locally with sample app and verified only one endpoint is created on fresh install

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
