### PR TITLE
fix: Codescanning alerts

### DIFF
--- a/packages/core/__tests__/I18n-test.ts
+++ b/packages/core/__tests__/I18n-test.ts
@@ -100,5 +100,26 @@ describe('I18n test', () => {
 				cn: {},
 			};
 		});
+
+		test('multi-call putVocabulariesForLanguage results in correct get result', () => {
+			const i18n = new I18n(null);
+
+			i18n.putVocabulariesForLanguage('cn', {
+				hello: '你好',
+				exciting: '+1s',
+				stable: 'x',
+			});
+
+			i18n.putVocabulariesForLanguage('cn', {
+				exciting: '+2s',
+			});
+
+			expect(i18n.getByLanguage('exciting', 'cn')).toEqual('+2s');
+			expect(i18n.getByLanguage('stable', 'cn')).toEqual('x');
+
+			i18n._dict = {
+				cn: {},
+			};
+		});
 	});
 });

--- a/packages/core/src/I18n/I18n.ts
+++ b/packages/core/src/I18n/I18n.ts
@@ -113,7 +113,7 @@ export class I18n {
 		if (!lang_dict) {
 			lang_dict = this._dict[language] = {};
 		}
-		Object.assign(lang_dict, vocabularies);
+		this._dict[language] = { ...lang_dict, ...vocabularies };
 	}
 
 	/**

--- a/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
@@ -81,7 +81,7 @@ export class AmazonAIIdentifyPredictionsProvider extends AbstractIdentifyPredict
 				Storage.get(source.key, storageConfig)
 					.then((url: string) => {
 						const parser =
-							/https:\/\/([a-zA-Z0-9%-_.]+)\.s3\.[A-Za-z0-9%-._~]+\/([a-zA-Z0-9%-._~/]+)\?/;
+							/https:\/\/([a-zA-Z0-9%\-_.]+)\.s3\.[A-Za-z0-9%\-._~]+\/([a-zA-Z0-9%\-._~/]+)\?/;
 						const parsedURL = url.match(parser);
 						if (parsedURL.length < 3) rej('Invalid S3 key was given.');
 						res({


### PR DESCRIPTION
#### Description of changes
Fixes (I expect) for the errors in the [Amplify JS security tab](https://github.com/aws-amplify/amplify-js/security/code-scanning).

#### Description of how you validated changes
I manually validated that the regex continues to match for a signed s3 url.

The I18N testing didn't seem complete enough so I added a test which I confirmed passes before and after my change (but doesn't pass if I replace the object instead of merging it into the existing object).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
