### PR TITLE
fix(datastore): normalize deleteTraverse 1:M

### DIFF
--- a/packages/datastore/__tests__/helpers/datastoreFactory.ts
+++ b/packages/datastore/__tests__/helpers/datastoreFactory.ts
@@ -10,6 +10,8 @@ import {
 	Blog,
 	Post,
 	Comment,
+	PostUni,
+	CommentUni,
 	User,
 	Profile,
 	PostComposite,
@@ -151,6 +153,8 @@ export function getDataStore({
 		Blog,
 		Post,
 		Comment,
+		PostUni,
+		CommentUni,
 		User,
 		Profile,
 		PostComposite,
@@ -183,6 +187,8 @@ export function getDataStore({
 		Blog: PersistentModelConstructor<Blog>;
 		Post: PersistentModelConstructor<Post>;
 		Comment: PersistentModelConstructor<Comment>;
+		PostUni: PersistentModelConstructor<PostUni>;
+		CommentUni: PersistentModelConstructor<CommentUni>;
 		User: PersistentModelConstructor<User>;
 		Profile: PersistentModelConstructor<Profile>;
 		PostComposite: PersistentModelConstructor<PostComposite>;
@@ -223,6 +229,8 @@ export function getDataStore({
 		Blog,
 		Post,
 		Comment,
+		PostUni,
+		CommentUni,
 		User,
 		Profile,
 		PostComposite,

--- a/packages/datastore/__tests__/helpers/schemas/default.ts
+++ b/packages/datastore/__tests__/helpers/schemas/default.ts
@@ -87,6 +87,33 @@ export declare class Comment {
 		mutator: (draft: MutableModel<Comment>) => void | Comment
 	): Comment;
 }
+export declare class PostUni {
+	public readonly id: string;
+	public readonly title: string;
+	public readonly comments: AsyncCollection<Comment>;
+	public readonly createdAt?: string;
+	public readonly updatedAt?: string;
+
+	constructor(init: ModelInit<Post>);
+
+	static copyOf(
+		src: Post,
+		mutator: (draft: MutableModel<Post>) => void | Post
+	): Post;
+}
+
+export declare class CommentUni {
+	public readonly id: string;
+	public readonly content: string;
+	public readonly postID: string;
+
+	constructor(init: ModelInit<Comment>);
+
+	static copyOf(
+		src: Comment,
+		mutator: (draft: MutableModel<Comment>) => void | Comment
+	): Comment;
+}
 
 export declare class User {
 	public readonly id: string;
@@ -942,6 +969,102 @@ export function testSchema(): Schema {
 						properties: {
 							name: 'byPost',
 							fields: ['postId'],
+						},
+					},
+				],
+			},
+			PostUni: {
+				name: 'PostUni',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					title: {
+						name: 'title',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					comments: {
+						name: 'comments',
+						isArray: true,
+						type: {
+							model: 'CommentUni',
+						},
+						isRequired: true,
+						attributes: [],
+						isArrayNullable: true,
+						association: {
+							connectionType: 'HAS_MANY',
+							associatedWith: ['postID'],
+						},
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'Posts',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+				],
+			},
+			CommentUni: {
+				name: 'CommentUni',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					postID: {
+						name: 'postID',
+						isArray: false,
+						type: 'ID',
+						isRequired: false,
+						attributes: [],
+					},
+					content: {
+						name: 'content',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'Comments',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							name: 'byPost',
+							fields: ['postID', 'content'],
 						},
 					},
 				],

--- a/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
+++ b/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
@@ -186,7 +186,7 @@ export class AsyncStorageAdapter extends StorageAdapterBase {
 		return await this.db.getAll(storeName);
 	}
 
-	private async filterOnPredicate<T extends PersistentModel>(
+	protected async filterOnPredicate<T extends PersistentModel>(
 		storeName: string,
 		predicates: PredicatesGroup<T>
 	) {
@@ -367,29 +367,6 @@ export class AsyncStorageAdapter extends StorageAdapterBase {
 		) as T;
 
 		return recordToDelete;
-	}
-
-	/**
-	 *  Gets related Has Many records by given `storeName`, `index`, and `keyValues`
-	 *
-	 * @param storeName
-	 * @param index
-	 * @param keyValues
-	 * @returns
-	 */
-	protected async getHasManyChildren<T extends PersistentModel>(
-		storeName: string,
-		index: string,
-		keyValues: string[]
-	): Promise<T[]> {
-		const allRecords = await this.db.getAll(storeName);
-		const indices = index!.split(IDENTIFIER_KEY_SEPARATOR);
-
-		const childRecords = allRecords.filter(childItem =>
-			indices.every(index => keyValues.includes(childItem[index]))
-		) as T[];
-
-		return childRecords;
 	}
 
 	//#region platform-specific helper methods

--- a/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
+++ b/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
@@ -504,28 +504,6 @@ class IndexedDBAdapter extends StorageAdapterBase {
 		return recordToDelete;
 	}
 
-	/**
-	 * Gets related Has Many records by given `storeName`, `index`, and `keyValues`
-	 *
-	 * @param storeName
-	 * @param index
-	 * @param keyValues
-	 * @returns
-	 */
-	protected async getHasManyChildren<T extends PersistentModel>(
-		storeName: string,
-		index: string,
-		keyValues: string[]
-	): Promise<T[]> {
-		const childRecords = await this.db
-			.transaction(storeName, 'readwrite')
-			.objectStore(storeName)
-			.index(index as string)
-			.getAll(this.canonicalKeyPath(keyValues));
-
-		return childRecords;
-	}
-
 	//#region platform-specific helper methods
 
 	private async checkPrivate() {
@@ -765,7 +743,7 @@ class IndexedDBAdapter extends StorageAdapterBase {
 		return result;
 	}
 
-	private async filterOnPredicate<T extends PersistentModel>(
+	protected async filterOnPredicate<T extends PersistentModel>(
 		storeName: string,
 		predicates: PredicatesGroup<T>
 	) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Before the change in this PR our business logical for performing cascading deletes only worked correctly when we could retrieve child relations using an index. This worked in most cases, but was not flexible enough, e.g. for the schema in the linked issue where the child index does not map back to the parent due to a different number of key fields in the index.

This PR leverages existing predicate logic in the storage adapters to attempt to use an index for retrieval when possible, but fall back to a scan when an appropriate index does not exist.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#10864 


#### Description of how you validated changes
* red/green unit test with schema from linked issue
* manual testing


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
