### PR TITLE
fix(datastore): normalize deleteTraverse

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1613,6 +1613,7 @@ releasable_branches: &releasable_branches
       - release
       - main
       - next
+      - issue-10864
 
 # List of test browsers that are always used in every E2E test. Tests that aren't expected to interact with browser APIs
 # should use `minimal_browser_list` to keep test execution time low.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1613,7 +1613,6 @@ releasable_branches: &releasable_branches
       - release
       - main
       - next
-      - issue-10864
 
 # List of test browsers that are always used in every E2E test. Tests that aren't expected to interact with browser APIs
 # should use `minimal_browser_list` to keep test execution time low.

--- a/packages/datastore/__tests__/helpers/datastoreFactory.ts
+++ b/packages/datastore/__tests__/helpers/datastoreFactory.ts
@@ -15,6 +15,8 @@ import {
 	Blog,
 	Post,
 	Comment,
+	PostUni,
+	CommentUni,
 	User,
 	Profile,
 	PostComposite,
@@ -224,6 +226,8 @@ export function getDataStore({
 		Blog,
 		Post,
 		Comment,
+		PostUni,
+		CommentUni,
 		User,
 		Profile,
 		PostComposite,
@@ -256,6 +260,8 @@ export function getDataStore({
 		Blog: PersistentModelConstructor<Blog>;
 		Post: PersistentModelConstructor<Post>;
 		Comment: PersistentModelConstructor<Comment>;
+		PostUni: PersistentModelConstructor<PostUni>;
+		CommentUni: PersistentModelConstructor<CommentUni>;
 		User: PersistentModelConstructor<User>;
 		Profile: PersistentModelConstructor<Profile>;
 		PostComposite: PersistentModelConstructor<PostComposite>;
@@ -298,6 +304,8 @@ export function getDataStore({
 		Blog,
 		Post,
 		Comment,
+		PostUni,
+		CommentUni,
 		User,
 		Profile,
 		PostComposite,

--- a/packages/datastore/__tests__/helpers/schemas/default.ts
+++ b/packages/datastore/__tests__/helpers/schemas/default.ts
@@ -87,6 +87,33 @@ export declare class Comment {
 		mutator: (draft: MutableModel<Comment>) => void | Comment
 	): Comment;
 }
+export declare class PostUni {
+	public readonly id: string;
+	public readonly title: string;
+	public readonly comments: AsyncCollection<Comment>;
+	public readonly createdAt?: string;
+	public readonly updatedAt?: string;
+
+	constructor(init: ModelInit<Post>);
+
+	static copyOf(
+		src: Post,
+		mutator: (draft: MutableModel<Post>) => void | Post
+	): Post;
+}
+
+export declare class CommentUni {
+	public readonly id: string;
+	public readonly content: string;
+	public readonly postID: string;
+
+	constructor(init: ModelInit<Comment>);
+
+	static copyOf(
+		src: Comment,
+		mutator: (draft: MutableModel<Comment>) => void | Comment
+	): Comment;
+}
 
 export declare class User {
 	public readonly id: string;
@@ -942,6 +969,102 @@ export function testSchema(): Schema {
 						properties: {
 							name: 'byPost',
 							fields: ['postId'],
+						},
+					},
+				],
+			},
+			PostUni: {
+				name: 'PostUni',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					title: {
+						name: 'title',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					comments: {
+						name: 'comments',
+						isArray: true,
+						type: {
+							model: 'CommentUni',
+						},
+						isRequired: true,
+						attributes: [],
+						isArrayNullable: true,
+						association: {
+							connectionType: 'HAS_MANY',
+							associatedWith: ['postID'],
+						},
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'Posts',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+				],
+			},
+			CommentUni: {
+				name: 'CommentUni',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					postID: {
+						name: 'postID',
+						isArray: false,
+						type: 'ID',
+						isRequired: false,
+						attributes: [],
+					},
+					content: {
+						name: 'content',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'Comments',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							name: 'byPost',
+							fields: ['postID', 'content'],
 						},
 					},
 				],

--- a/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
+++ b/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
@@ -8,20 +8,15 @@ import {
 	PersistentModelConstructor,
 	PredicatesGroup,
 	QueryOne,
-	RelationType,
 } from '../../types';
 import {
 	DEFAULT_PRIMARY_KEY_VALUE_SEPARATOR,
-	getIndex,
-	getIndexFromAssociation,
 	traverseModel,
 	validatePredicate,
 	inMemoryPagination,
-	NAMESPACES,
 	keysEqual,
 	getStorename,
 	getIndexKeys,
-	IDENTIFIER_KEY_SEPARATOR,
 } from '../../util';
 import { StorageAdapterBase } from './StorageAdapterBase';
 
@@ -186,7 +181,7 @@ export class AsyncStorageAdapter extends StorageAdapterBase {
 		return await this.db.getAll(storeName);
 	}
 
-	private async filterOnPredicate<T extends PersistentModel>(
+	protected async filterOnPredicate<T extends PersistentModel>(
 		storeName: string,
 		predicates: PredicatesGroup<T>
 	) {
@@ -233,163 +228,6 @@ export class AsyncStorageAdapter extends StorageAdapterBase {
 				}
 			}
 		}
-	}
-
-	/**
-	 * Gets related Has One record for `model`
-	 *
-	 * @param model
-	 * @param srcModel
-	 * @param namespace
-	 * @param rel
-	 * @returns
-	 */
-	protected async getHasOneChild<T extends PersistentModel>(
-		model: T,
-		srcModel: string,
-		namespace: NAMESPACES,
-		rel: RelationType
-	) {
-		let hasOneIndex;
-		const { modelName, targetNames, associatedWith } = rel;
-		const storeName = getStorename(namespace, modelName);
-		const index: string | undefined =
-			getIndex(
-				this.schema.namespaces[namespace].relationships![modelName]
-					.relationTypes,
-				srcModel
-			) ||
-			// if we were unable to find an index via relationTypes
-			// i.e. for keyName connections, attempt to find one by the
-			// associatedWith property
-			getIndexFromAssociation(
-				this.schema.namespaces[namespace].relationships![modelName].indexes,
-				rel.associatedWith!
-			);
-
-		if (index) {
-			hasOneIndex = index.split(IDENTIFIER_KEY_SEPARATOR);
-		} else if (associatedWith) {
-			if (Array.isArray(associatedWith)) {
-				hasOneIndex = associatedWith;
-			} else {
-				hasOneIndex = [associatedWith];
-			}
-		}
-
-		// iterate over targetNames array and see if each key is present in model object
-		// targetNames here being the keys for the CHILD model
-		const hasConnectedModelFields = targetNames!.every(targetName =>
-			model.hasOwnProperty(targetName)
-		);
-
-		// PK / Composite key for the parent model
-		const keyValuesPath: string = this.getIndexKeyValuesPath(model);
-
-		let values;
-
-		const isUnidirectionalConnection = hasOneIndex === associatedWith;
-
-		if (hasConnectedModelFields && isUnidirectionalConnection) {
-			// Values will be that of the child model
-			values = targetNames!
-				.filter(targetName => model[targetName] ?? false)
-				.map(targetName => model[targetName]);
-		} else {
-			// values will be that of the parent model
-			values = keyValuesPath.split(DEFAULT_PRIMARY_KEY_VALUE_SEPARATOR);
-		}
-
-		if (values.length === 0) return;
-
-		const allRecords = await this.db.getAll(storeName);
-
-		let recordToDelete;
-
-		// values === targetNames
-		if (hasConnectedModelFields) {
-			/**
-			 * Retrieve record by finding the record where all
-			 * targetNames are present on the connected model.
-			 *
-			 */
-
-			recordToDelete = allRecords.find(childItem =>
-				hasOneIndex.every(index => values.includes(childItem[index]))
-			);
-		} else {
-			// values === keyValuePath
-			recordToDelete = allRecords.find(
-				childItem => childItem[hasOneIndex] === values
-			) as T[];
-		}
-
-		return recordToDelete;
-	}
-
-	/**
-	 * Backwards compatability for pre-CPK codegen
-	 * TODO - deprecate this in v6; will need to re-gen MIPR for older unit
-	 * tests that hit this path
-	 */
-	protected async getHasOneChildLegacy<T extends PersistentModel>(
-		model: T,
-		srcModel: string,
-		namespace: NAMESPACES,
-		rel: RelationType
-	) {
-		const { modelName, targetName, associatedWith } = rel;
-		const storeName = getStorename(namespace, modelName);
-		const index: string | undefined =
-			getIndex(
-				this.schema.namespaces[namespace].relationships![modelName]
-					.relationTypes,
-				srcModel
-			) ||
-			// if we were unable to find an index via relationTypes
-			// i.e. for keyName connections, attempt to find one by the
-			// associatedWith property
-			getIndexFromAssociation(
-				this.schema.namespaces[namespace].relationships![modelName].indexes,
-				rel.associatedWith!
-			);
-		const hasOneIndex = index || associatedWith;
-		const hasOneCustomField = targetName! in model;
-		const keyValuesPath: string = this.getIndexKeyValuesPath(model);
-		const value = hasOneCustomField ? model[targetName!] : keyValuesPath;
-
-		if (!value) return;
-
-		const allRecords = await this.db.getAll(storeName);
-
-		const recordToDelete = allRecords.find(
-			childItem => childItem[hasOneIndex as string] === value
-		) as T;
-
-		return recordToDelete;
-	}
-
-	/**
-	 *  Gets related Has Many records by given `storeName`, `index`, and `keyValues`
-	 *
-	 * @param storeName
-	 * @param index
-	 * @param keyValues
-	 * @returns
-	 */
-	protected async getHasManyChildren<T extends PersistentModel>(
-		storeName: string,
-		index: string,
-		keyValues: string[]
-	): Promise<T[]> {
-		const allRecords = await this.db.getAll(storeName);
-		const indices = index!.split(IDENTIFIER_KEY_SEPARATOR);
-
-		const childRecords = allRecords.filter(childItem =>
-			indices.every(index => keyValues.includes(childItem[index]))
-		) as T[];
-
-		return childRecords;
 	}
 
 	//#region platform-specific helper methods

--- a/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
+++ b/packages/datastore/src/storage/adapter/AsyncStorageAdapter.ts
@@ -181,7 +181,7 @@ export class AsyncStorageAdapter extends StorageAdapterBase {
 		return await this.db.getAll(storeName);
 	}
 
-	protected async filterOnPredicate<T extends PersistentModel>(
+	private async filterOnPredicate<T extends PersistentModel>(
 		storeName: string,
 		predicates: PredicatesGroup<T>
 	) {

--- a/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
+++ b/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
@@ -12,15 +12,12 @@ import {
 	PredicateObject,
 	PredicatesGroup,
 	QueryOne,
-	RelationType,
 } from '../../types';
 import {
-	getIndex,
 	isPrivateMode,
 	traverseModel,
 	validatePredicate,
 	inMemoryPagination,
-	NAMESPACES,
 	keysEqual,
 	getStorename,
 	isSafariCompatabilityMode,
@@ -420,112 +417,6 @@ class IndexedDBAdapter extends StorageAdapterBase {
 		}
 	}
 
-	/**
-	 * Gets related Has One record for `model`
-	 *
-	 * @param model
-	 * @param srcModel
-	 * @param namespace
-	 * @param rel
-	 * @returns
-	 */
-	protected async getHasOneChild<T extends PersistentModel>(
-		model: T,
-		srcModel: string,
-		namespace: NAMESPACES,
-		rel: RelationType
-	) {
-		const hasOneIndex = 'byPk';
-		const { modelName, targetNames } = rel;
-		const storeName = getStorename(namespace, modelName);
-
-		const values = targetNames!
-			.filter(targetName => model[targetName] ?? false)
-			.map(targetName => model[targetName]);
-
-		if (values.length === 0) return;
-
-		const recordToDelete = <T>(
-			await this.db
-				.transaction(storeName, 'readwrite')
-				.objectStore(storeName)
-				.index(hasOneIndex)
-				.get(this.canonicalKeyPath(values))
-		);
-
-		return recordToDelete;
-	}
-
-	/**
-	 * Backwards compatability for pre-CPK codegen
-	 * TODO - deprecate this in v6; will need to re-gen MIPR for older unit
-	 * tests that hit this path
-	 */
-	protected async getHasOneChildLegacy<T extends PersistentModel>(
-		model: T,
-		srcModel: string,
-		namespace: NAMESPACES,
-		rel: RelationType
-	) {
-		const hasOneIndex = 'byPk';
-		const { modelName, targetName } = rel;
-		const storeName = getStorename(namespace, modelName);
-
-		let index;
-		let values: string[];
-
-		if (targetName && targetName in model) {
-			index = hasOneIndex;
-			const value = model[targetName];
-			if (value === null) {
-				return;
-			}
-			values = [value];
-		} else {
-			// backwards compatability for older versions of codegen that did not emit targetName for HAS_ONE relations
-			index = getIndex(
-				this.schema.namespaces[namespace].relationships![modelName]
-					.relationTypes,
-				srcModel
-			);
-			values = this.getIndexKeyValuesFromModel(model);
-		}
-
-		if (!values || !index) return;
-
-		const recordToDelete = <T>(
-			await this.db
-				.transaction(storeName, 'readwrite')
-				.objectStore(storeName)
-				.index(index)
-				.get(this.canonicalKeyPath(values))
-		);
-
-		return recordToDelete;
-	}
-
-	/**
-	 * Gets related Has Many records by given `storeName`, `index`, and `keyValues`
-	 *
-	 * @param storeName
-	 * @param index
-	 * @param keyValues
-	 * @returns
-	 */
-	protected async getHasManyChildren<T extends PersistentModel>(
-		storeName: string,
-		index: string,
-		keyValues: string[]
-	): Promise<T[]> {
-		const childRecords = await this.db
-			.transaction(storeName, 'readwrite')
-			.objectStore(storeName)
-			.index(index as string)
-			.getAll(this.canonicalKeyPath(keyValues));
-
-		return childRecords;
-	}
-
 	//#region platform-specific helper methods
 
 	private async checkPrivate() {
@@ -765,7 +656,7 @@ class IndexedDBAdapter extends StorageAdapterBase {
 		return result;
 	}
 
-	private async filterOnPredicate<T extends PersistentModel>(
+	protected async filterOnPredicate<T extends PersistentModel>(
 		storeName: string,
 		predicates: PredicatesGroup<T>
 	) {

--- a/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
+++ b/packages/datastore/src/storage/adapter/IndexedDBAdapter.ts
@@ -381,7 +381,7 @@ class IndexedDBAdapter extends StorageAdapterBase {
 	}
 
 	protected async deleteItem<T extends PersistentModel>(
-		deleteQueue?: {
+		deleteQueue: {
 			storeName: string;
 			items: T[] | IDBValidKey[];
 		}[]
@@ -656,7 +656,7 @@ class IndexedDBAdapter extends StorageAdapterBase {
 		return result;
 	}
 
-	protected async filterOnPredicate<T extends PersistentModel>(
+	private async filterOnPredicate<T extends PersistentModel>(
 		storeName: string,
 		predicates: PredicatesGroup<T>
 	) {

--- a/packages/datastore/src/storage/adapter/StorageAdapterBase.ts
+++ b/packages/datastore/src/storage/adapter/StorageAdapterBase.ts
@@ -15,7 +15,6 @@ import {
 	PredicateObject,
 	PredicatesGroup,
 	QueryOne,
-	RelationType,
 } from '../../types';
 import {
 	NAMESPACES,
@@ -24,12 +23,12 @@ import {
 	extractPrimaryKeyValues,
 	traverseModel,
 	validatePredicate,
-	getIndex,
-	getIndexFromAssociation,
 	isModelConstructor,
+	extractPrimaryKeyFieldNames,
 } from '../../util';
 import type { IDBPDatabase, IDBPObjectStore } from 'idb';
 import type AsyncStorageDatabase from './AsyncStorageDatabase';
+import { ModelRelationship } from '../relationship';
 
 const logger = new Logger('DataStore');
 const DB_NAME = 'amplify-datastore';
@@ -382,20 +381,10 @@ export abstract class StorageAdapterBase implements Adapter {
 			const modelConstructor =
 				modelOrModelConstructor as PersistentModelConstructor<T>;
 			const namespace = this.namespaceResolver(modelConstructor) as NAMESPACES;
-
 			const models = await this.query(modelConstructor, condition);
-			const relations =
-				this.schema.namespaces![namespace].relationships![modelConstructor.name]
-					.relationTypes;
 
 			if (condition !== undefined) {
-				await this.deleteTraverse(
-					relations,
-					models,
-					modelConstructor.name,
-					namespace,
-					deleteQueue
-				);
+				await this.deleteTraverse(models, namespace, deleteQueue);
 
 				await this.deleteItem(deleteQueue);
 
@@ -406,13 +395,7 @@ export abstract class StorageAdapterBase implements Adapter {
 
 				return [models, deletedModels];
 			} else {
-				await this.deleteTraverse(
-					relations,
-					models,
-					modelConstructor.name,
-					namespace,
-					deleteQueue
-				);
+				await this.deleteTraverse(models, namespace, deleteQueue);
 
 				await this.deleteItem(deleteQueue);
 
@@ -428,6 +411,7 @@ export abstract class StorageAdapterBase implements Adapter {
 
 			const modelConstructor = Object.getPrototypeOf(model)
 				.constructor as PersistentModelConstructor<T>;
+
 			const namespaceName = this.namespaceResolver(
 				modelConstructor
 			) as NAMESPACES;
@@ -457,31 +441,14 @@ export abstract class StorageAdapterBase implements Adapter {
 					throw new Error(msg);
 				}
 
-				const relations =
-					this.schema.namespaces[namespaceName].relationships![
-						modelConstructor.name
-					].relationTypes;
-
-				await this.deleteTraverse(
-					relations,
-					[model],
-					modelConstructor.name,
-					namespaceName,
-					deleteQueue
-				);
+				await this.deleteTraverse([model], namespaceName, deleteQueue);
 			} else {
 				const relations =
 					this.schema.namespaces[namespaceName].relationships![
 						modelConstructor.name
 					].relationTypes;
 
-				await this.deleteTraverse(
-					relations,
-					[model],
-					modelConstructor.name,
-					namespaceName,
-					deleteQueue
-				);
+				await this.deleteTraverse([model], namespaceName, deleteQueue);
 			}
 			await this.deleteItem(deleteQueue);
 
@@ -494,6 +461,11 @@ export abstract class StorageAdapterBase implements Adapter {
 		}
 	}
 
+	protected abstract filterOnPredicate<T extends PersistentModel>(
+		storeName: string,
+		predicates: PredicatesGroup<T>
+	);
+
 	protected abstract deleteItem<T extends PersistentModel>(
 		deleteQueue?: {
 			storeName: string;
@@ -501,139 +473,61 @@ export abstract class StorageAdapterBase implements Adapter {
 		}[]
 	);
 
-	protected abstract getHasOneChild<T extends PersistentModel>(
-		model: T,
-		srcModel: string,
-		namespace: NAMESPACES,
-		rel: RelationType
-	): Promise<T | undefined>;
-
-	/**
-	 * Backwards compatability for pre-CPK codegen
-	 * TODO - deprecate this in v6; will need to re-gen MIPR for older unit
-	 * tests that hit this path
-	 */
-	protected abstract getHasOneChildLegacy<T extends PersistentModel>(
-		model: T,
-		srcModel: string,
-		namespace: NAMESPACES,
-		rel: RelationType
-	): Promise<T | undefined>;
-
-	protected abstract getHasManyChildren<T extends PersistentModel>(
-		storeName: string,
-		index: string,
-		keyValues: string[]
-	): Promise<T[] | undefined>;
-
 	/**
 	 * Recursively traverse relationship graph and add
 	 * all Has One and Has Many relations to `deleteQueue` param
 	 *
 	 * Actual deletion of records added to `deleteQueue` occurs in the `delete` method
 	 *
-	 * @param relations
 	 * @param models
-	 * @param srcModel
 	 * @param namespace
 	 * @param deleteQueue
 	 */
-	protected async deleteTraverse<T extends PersistentModel>(
-		relations: RelationType[],
+	private async deleteTraverse<T extends PersistentModel>(
 		models: T[],
-		srcModel: string,
 		namespace: NAMESPACES,
 		deleteQueue: { storeName: string; items: T[] }[]
 	): Promise<void> {
-		for await (const rel of relations) {
-			const { modelName, relationType, targetNames, associatedWith } = rel;
+		const cascadingRelationTypes = ['HAS_ONE', 'HAS_MANY'];
 
-			const storeName = getStorename(namespace, modelName);
-			const index: string =
-				getIndex(
-					this.schema.namespaces[namespace].relationships![modelName]
-						.relationTypes,
-					srcModel
-				) ||
-				// if we were unable to find an index via relationTypes
-				// i.e. for keyName connections, attempt to find one by the
-				// associatedWith property
-				getIndexFromAssociation(
-					this.schema.namespaces[namespace].relationships![modelName].indexes,
-					associatedWith!
-				)!;
+		for await (const model of models) {
+			const modelConstructor = (Object.getPrototypeOf(model) as Object)
+				.constructor as PersistentModelConstructor<T>;
 
-			for await (const model of models) {
-				const childRecords: PersistentModel[] = [];
+			const modelDef =
+				this.schema.namespaces[namespace].models[modelConstructor.name];
 
-				switch (relationType) {
-					case 'HAS_ONE':
-						let childRecord;
-						if (targetNames?.length) {
-							childRecord = await this.getHasOneChild(
-								model,
-								srcModel,
-								namespace,
-								rel
-							);
-						} else {
-							childRecord = await this.getHasOneChildLegacy(
-								model,
-								srcModel,
-								namespace,
-								rel
-							);
-						}
+			const modelMeta = {
+				builder: modelConstructor,
+				schema: modelDef,
+				pkField: extractPrimaryKeyFieldNames(modelDef),
+			};
 
-						if (childRecord) {
-							childRecords.push(childRecord);
-						}
+			const relationships = ModelRelationship.allFrom(modelMeta).filter(r =>
+				cascadingRelationTypes.includes(r.type)
+			);
 
-						break;
-					case 'HAS_MANY':
-						const keyValues: string[] = this.getIndexKeyValuesFromModel(model);
+			for await (const r of relationships) {
+				const queryObject = r.createRemoteQueryObject(model);
+				if (queryObject !== null) {
+					const relatedRecords = await this.query(
+						r.remoteModelConstructor,
+						ModelPredicateCreator.createFromFlatEqualities(
+							r.remoteDefinition!,
+							queryObject
+						)
+					);
 
-						const records = await this.getHasManyChildren(
-							storeName,
-							index,
-							keyValues
-						);
-
-						if (records?.length) {
-							childRecords.push(...records);
-						}
-
-						break;
-					case 'BELONGS_TO':
-						// Intentionally blank
-						break;
-					default:
-						throw new Error(`Invalid relation type ${relationType}`);
+					await this.deleteTraverse(relatedRecords, namespace, deleteQueue);
 				}
-
-				// instantiate models before passing them to next recursive call
-				// necessary for extracting PK metadata in `getHasOneChild` and `getHasManyChildren`
-				const childModels = await this.load(namespace, modelName, childRecords);
-
-				await this.deleteTraverse(
-					this.schema.namespaces[namespace].relationships![modelName]
-						.relationTypes,
-					childModels,
-					modelName,
-					namespace,
-					deleteQueue
-				);
 			}
-		}
 
-		deleteQueue.push({
-			storeName: getStorename(namespace, srcModel),
-			items: models.map(record =>
-				this.modelInstanceCreator(
-					this.getModelConstructorByModelName!(namespace, srcModel),
-					record
-				)
-			),
-		});
+			deleteQueue.push({
+				storeName: getStorename(namespace, modelConstructor.name),
+				items: models.map(record =>
+					this.modelInstanceCreator(modelConstructor, record)
+				),
+			});
+		}
 	}
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Refactors and simplifies cascading delete business logic using `ModelRelationship` class. 

Fixes issues caused by strict reliance on indexes for cascading deletes. Fetching related models will now gracefully fall back to a table scan when we can't match on an index (e.g. for the schema in the linked issue).

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/10864


#### Description of how you validated changes

* red/green unit test with schema from linked issue
* manual testing
* e2e test run: https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/18699/workflows/c42b16da-cdc7-4930-8b32-4940ca623142


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
