### PR TITLE
fix(@aws-amplify/datastore): Remove extra null fields on create mutations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1596,6 +1596,7 @@ releasable_branches: &releasable_branches
       - release
       - main
       - next
+      - remove-extra-null-fields-on-create-b
 
 # List of test browsers that are always used in every E2E test. Tests that aren't expected to interact with browser APIs
 # should use `minimal_browser_list` to keep test execution time low.

--- a/packages/datastore/__tests__/DataStore.ts
+++ b/packages/datastore/__tests__/DataStore.ts
@@ -2554,8 +2554,19 @@ describe('DataStore tests', () => {
 			const [settingsSave, modelCall] = <any>save.mock.calls;
 			const [_model, _condition, _mutator, patches] = modelCall;
 
+			const expectedPatchedFields = [
+				'field1',
+				'dateCreated',
+				'id',
+				'_version',
+				'_lastChangedAt',
+				'_deleted',
+			];
+
 			expect(result).toMatchObject(model);
-			expect(patches).toBeUndefined();
+			expect(patches[0].map(p => p.path.join(''))).toEqual(
+				expectedPatchedFields
+			);
 		});
 
 		test('Save returns the updated model and patches', async () => {
@@ -4073,8 +4084,19 @@ describe('DataStore tests', () => {
 				const [settingsSave, modelCall] = <any>save.mock.calls;
 				const [_model, _condition, _mutator, patches] = modelCall;
 
+				const expectedPatchedFields = [
+					'postId',
+					'title',
+					'dateCreated',
+					'_version',
+					'_lastChangedAt',
+					'_deleted',
+				];
+
 				expect(result).toMatchObject(model);
-				expect(patches).toBeUndefined();
+				expect(patches[0].map(p => p.path.join(''))).toEqual(
+					expectedPatchedFields
+				);
 			});
 
 			test('Save returns the updated model and patches', async () => {

--- a/packages/datastore/__tests__/commonAdapterTests.ts
+++ b/packages/datastore/__tests__/commonAdapterTests.ts
@@ -397,9 +397,6 @@ export function addCommonQueryTests({
 			expect(mutations.length).toBe(2);
 			expectMutation(mutations[0], {
 				title: 'some post',
-				blogId: null,
-				createdAt: null,
-				updatedAt: null,
 			});
 			expectMutation(mutations[1], {
 				content: 'updated content',

--- a/packages/datastore/__tests__/connectivityHandling.test.ts
+++ b/packages/datastore/__tests__/connectivityHandling.test.ts
@@ -117,6 +117,128 @@ describe('DataStore sync engine', () => {
 			expect(savedItem.body).toEqual(m.body);
 		});
 
+		test('omits all unspecified fields from mutation on create', async () => {
+			// make sure our test model still meets requirements to make this test valid.
+			expect(schema.models.Model.fields.optionalField1.isRequired).toBe(false);
+
+			await DataStore.save(
+				new Model({
+					field1: 'whatever and ever',
+					dateCreated: new Date().toISOString(),
+				})
+			);
+
+			const omitted_optional_fields = [
+				'emails',
+				'ips',
+				'logins',
+				'metadata',
+				'optionalField',
+			];
+
+			await waitForEmptyOutbox();
+
+			const table = graphqlService.tables.get('Model')!;
+			expect(table.size).toEqual(1);
+
+			const [mutation] = graphqlService.requests
+				.filter(r => r.operation === 'mutation' && r.tableName === 'Model')
+				.map(req => req.variables.input);
+
+			for (const field of omitted_optional_fields) {
+				expect(mutation[field]).toEqual(undefined);
+			}
+		});
+
+		test('includes explicit null fields from mutation on create', async () => {
+			// make sure our test model still meets requirements to make this test valid.
+			expect(schema.models.Model.fields.optionalField1.isRequired).toBe(false);
+
+			await DataStore.save(
+				new Model({
+					field1: 'whatever and ever',
+					dateCreated: new Date().toISOString(),
+					metadata: null,
+				})
+			);
+
+			await waitForEmptyOutbox();
+
+			const table = graphqlService.tables.get('Model')!;
+			expect(table.size).toEqual(1);
+
+			const [mutation] = graphqlService.requests
+				.filter(r => r.operation === 'mutation' && r.tableName === 'Model')
+				.map(req => req.variables.input);
+
+			expect(mutation.metadata).toEqual(null);
+		});
+
+		test('omits all unchanged fields from mutation on update', async () => {
+			// make sure our test model still meets requirements to make this test valid.
+			expect(schema.models.Model.fields.optionalField1.isRequired).toBe(false);
+
+			const saved = await DataStore.save(
+				new Model({
+					field1: 'whatever and ever',
+					dateCreated: new Date().toISOString(),
+				})
+			);
+
+			await waitForEmptyOutbox();
+			const retrieved = (await DataStore.query(Model, saved.id))!;
+
+			const updated = await DataStore.save(
+				Model.copyOf(retrieved, d => (d.optionalField1 = 'new value'))
+			);
+
+			const omitted_fields = ['field1', 'emails', 'ips', 'logins', 'metadata'];
+
+			await waitForEmptyOutbox();
+
+			const table = graphqlService.tables.get('Model')!;
+			expect(table.size).toEqual(1);
+
+			const [createMutation, updateMutation] = graphqlService.requests
+				.filter(r => r.operation === 'mutation' && r.tableName === 'Model')
+				.map(req => req.variables.input);
+
+			for (const field of omitted_fields) {
+				expect(updateMutation[field]).toEqual(undefined);
+			}
+		});
+
+		test('includes explicit null fields from mutation on update', async () => {
+			// make sure our test model still meets requirements to make this test valid.
+			expect(schema.models.Model.fields.optionalField1.isRequired).toBe(false);
+
+			const saved = await DataStore.save(
+				new Model({
+					field1: 'whatever and ever',
+					dateCreated: new Date().toISOString(),
+					optionalField1: 'something',
+				})
+			);
+
+			await waitForEmptyOutbox();
+			const retrieved = (await DataStore.query(Model, saved.id))!;
+
+			await DataStore.save(
+				Model.copyOf(retrieved, d => (d.optionalField1 = null))
+			);
+
+			await waitForEmptyOutbox();
+
+			const table = graphqlService.tables.get('Model')!;
+			expect(table.size).toEqual(1);
+
+			const [createMutation, updateMutation] = graphqlService.requests
+				.filter(r => r.operation === 'mutation' && r.tableName === 'Model')
+				.map(req => req.variables.input);
+
+			expect(updateMutation.optionalField1).toEqual(null);
+		});
+
 		test('omits null owner fields from mutation events on create', async () => {
 			const m = await DataStore.save(
 				new ModelWithExplicitOwner({

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -752,6 +752,13 @@ const castInstanceType = (
 };
 
 /**
+ * Records the patches (as if against an empty object) used to initialize
+ * an instance of a Model. This can be used for determining which fields to
+ * send to the cloud durnig a CREATE mutation.
+ */
+const initPatches = new WeakMap<PersistentModel, Patch[]>();
+
+/**
  * Attempts to apply type-aware, casted field values from a given `init`
  * object to the given `draft`.
  *
@@ -806,7 +813,11 @@ const createModelClass = <T extends PersistentModel>(
 ) => {
 	const clazz = <PersistentModelConstructor<T>>(<unknown>class Model {
 		constructor(init: ModelInit<T>) {
-			const instance = produce(
+			// we create a base instance first so we can distinguish which fields were explicitly
+			// set by customer code versus those set by normalization. only those fields
+			// which are explicitly set by customers should be part of create mutations.
+			let patches: Patch[] = [];
+			const baseInstance = produce(
 				this,
 				(draft: Draft<T & ModelInstanceMetadata>) => {
 					initializeInstance(init, modelDefinition, draft);
@@ -850,12 +861,24 @@ const createModelClass = <T extends PersistentModel>(
 						draft._lastChangedAt = _lastChangedAt;
 						draft._deleted = _deleted;
 					}
-
-					normalize(modelDefinition, draft);
-				}
+				},
+				p => (patches = p)
 			);
 
-			return instance;
+			// now that we have a list of patches that encapsulate the explicit, customer-provided
+			// fields, we can normalize. patches from normalization are ignored, because the changes
+			// are only create to provide a consistent view of the data for fields pre/post sync
+			// where possible. (not all fields can be normalized pre-sync, because they're generally
+			// "cloud managed" fields, like createdAt and updatedAt.)
+			const normalized = produce(
+				baseInstance,
+				(draft: Draft<T & ModelInstanceMetadata>) =>
+					normalize(modelDefinition, draft)
+			);
+
+			initPatches.set(normalized, patches);
+
+			return normalized;
 		}
 
 		static copyOf(source: T, fn: (draft: MutableModel<T>) => T) {
@@ -913,6 +936,8 @@ const createModelClass = <T extends PersistentModel>(
 					modelPatchesMap.set(model, [patches, source]);
 					checkReadOnlyPropertyOnUpdate(patches, modelDefinition);
 				}
+			} else {
+				modelPatchesMap.set(model, [[], source]);
 			}
 
 			return attached(model, ModelAttachment.DataStore);
@@ -1711,7 +1736,24 @@ class DataStore {
 
 				// Immer patches for constructing a correct update mutation input
 				// Allows us to only include changed fields for updates
-				const patchesTuple = modelPatchesMap.get(model);
+				const updatedPatchesTuple = modelPatchesMap.get(model);
+
+				// Immer patches for initial object construction. These are used if
+				// there are no `update` patches under the assumption we're performing
+				// a CREATE and wish to send only explicitly specified fields to the cloud.
+				const initPatchesTuple = initPatches.has(model)
+					? ([initPatches.get(model)!, {}] as [
+							Patch[],
+							Readonly<Record<string, any>>
+					  ])
+					: undefined;
+
+				// favor update patches over init/create patches, because init patches
+				// are ALWAYS present, whereas update patches are only present if copyOf
+				// was used to create the instance.
+				const patchesTuple:
+					| [Patch[], Readonly<Record<string, any>>]
+					| undefined = updatedPatchesTuple || initPatchesTuple;
 
 				const modelConstructor: PersistentModelConstructor<T> | undefined =
 					model ? <PersistentModelConstructor<T>>model.constructor : undefined;

--- a/packages/datastore/src/storage/storage.ts
+++ b/packages/datastore/src/storage/storage.ts
@@ -123,7 +123,10 @@ class StorageClass implements StorageFacade {
 			let updateMutationInput;
 			// don't attempt to calc mutation input when storage.save
 			// is called by Merger, i.e., when processing an AppSync response
-			if (opType === OpType.UPDATE && !syncResponse) {
+			if (
+				(opType === OpType.UPDATE || opType === OpType.INSERT) &&
+				!syncResponse
+			) {
 				//
 				// TODO: LOOK!!!
 				// the `model` used here is in effect regardless of what model
@@ -136,7 +139,7 @@ class StorageClass implements StorageFacade {
 				// depends on this remaining as-is.
 				//
 
-				updateMutationInput = this.getUpdateMutationInput(
+				updateMutationInput = this.getChangedFieldsInput(
 					model,
 					savedElement,
 					patchesTuple
@@ -344,7 +347,7 @@ class StorageClass implements StorageFacade {
 	}
 
 	// returns null if no user fields were changed (determined by value comparison)
-	private getUpdateMutationInput<T extends PersistentModel>(
+	private getChangedFieldsInput<T extends PersistentModel>(
 		model: T,
 		originalElement: T,
 		patchesTuple?: [Patch[], PersistentModel]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
