### PR TITLE
Datastore/feat add per model sync page size

### DIFF
--- a/packages/datastore/__tests__/sync.test.ts
+++ b/packages/datastore/__tests__/sync.test.ts
@@ -299,6 +299,55 @@ describe('Sync', () => {
 		});
 	});
 
+	/*
+	 *  This is where new tests would be added for per-model syncPageSize
+	 *  Proposed test cases are added below with // comments
+	 */
+
+	// describe('syncPageSize', () => {
+	// 	test('should use default syncPageSize if not specified (null, undefined or zero)', async () => {
+	// 		const resolveResponse = {
+	// 			data: {
+	// 				syncPosts: {
+	// 					items: [
+	// 						{
+	// 							id: '1',
+	// 							title: 'Item 1',
+	// 						},
+	// 						{
+	// 							id: '2',
+	// 							title: 'Item 2',
+	// 						},
+	// 					],
+	// 				},
+	// 			},
+	// 		};
+
+	// 		const SyncProcessor = jitteredRetrySyncProcessorSetup({
+	// 			resolveResponse,
+	// 		});
+
+	// 		await SyncProcessor.jitteredRetry({
+	// 			query: defaultQuery,
+	// 			variables: defaultVariables,
+	// 			opName: defaultOpName,
+	// 			modelDefinition: defaultModelDefinition,
+	// 		});
+
+	// 		expect(mockGraphQl).toHaveBeenCalledWith(
+	// 			expect.objectContaining({
+	// 				variables: {
+	// 					syncPageSize: DEFAULT_SYNC_PAGE_SIZE,
+	// 				},
+	// 			})
+	// 		);
+	// 	});
+	// 	test('the limit for the sync query should equal syncPageSize if it is defined as a natural number', async () => {});
+	// 	test('a meaningful error should be thrown if syncPageSize is not defined as a natural number', async () => {});
+	// 	test('the limit for the sync query should equal perModelSyncPageSize[`modelName`] if it is defined as a natural number', async () => {});
+	// 	test('a meaningful error should be thrown if perModelSyncPageSize[`modelName`] is not a natural number', async () => {});
+	// }
+
 	describe('error handler', () => {
 		const errorHandler = jest.fn();
 		const data = {

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -1374,6 +1374,7 @@ class DataStore {
 	private storage?: Storage;
 	private sync?: SyncEngine;
 	private syncPageSize!: number;
+	private perModelSyncPageSize?: { [modelName: string]: number };
 	private syncExpressions!: SyncExpression[];
 	private syncPredicates: WeakMap<SchemaModel, ModelPredicate<any> | null> =
 		new WeakMap<SchemaModel, ModelPredicate<any>>();
@@ -2459,6 +2460,9 @@ class DataStore {
 
 		// store on config object, so that Sync, Subscription, and Mutation processors can have access
 		this.amplifyConfig.syncPageSize = this.syncPageSize;
+
+		// also store perModelSyncPageSize on config object, so that Sync, Subscription, and Mutation processors can have access
+		this.amplifyConfig.perModelSyncPageSize = this.perModelSyncPageSize;
 
 		this.fullSyncInterval =
 			(configDataStore && configDataStore.fullSyncInterval) ||

--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -315,7 +315,8 @@ class SyncProcessor {
 	start(
 		typesLastSync: Map<SchemaModel, [string, number]>
 	): Observable<SyncModelPage> {
-		const { maxRecordsToSync, syncPageSize } = this.amplifyConfig;
+		const { maxRecordsToSync, syncPageSize, perModelSyncPageSize } =
+			this.amplifyConfig;
 		const parentPromises = new Map<string, Promise<void>>();
 		const observable = new Observable<SyncModelPage>(observer => {
 			const sortedTypesLastSyncs = Object.values(this.schema.namespaces).reduce(
@@ -360,10 +361,15 @@ class SyncProcessor {
 										return;
 									}
 
-									const limit = Math.min(
-										maxRecordsToSync - recordsReceived,
-										syncPageSize
-									);
+									const limit = perModelSyncPageSize?.[modelDefinition.name]
+										? Math.min(
+												maxRecordsToSync - recordsReceived,
+												perModelSyncPageSize[modelDefinition.name]
+										  )
+										: Math.min(
+												maxRecordsToSync - recordsReceived,
+												syncPageSize
+										  );
 
 									({ items, nextToken, startedAt } = await this.retrievePage(
 										modelDefinition,

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -934,6 +934,7 @@ export type DataStoreConfig = {
 		errorHandler?: (error: SyncError<PersistentModel>) => void; // default : logger.warn
 		maxRecordsToSync?: number; // merge
 		syncPageSize?: number;
+		perModelSyncPageSize?: { [modelName: string]: number }; // over-ride syncPageSize for specific models
 		fullSyncInterval?: number;
 		syncExpressions?: SyncExpression[];
 		authProviders?: AuthProviders;
@@ -944,6 +945,7 @@ export type DataStoreConfig = {
 	errorHandler?: (error: SyncError<PersistentModel>) => void; // default : logger.warn
 	maxRecordsToSync?: number; // merge
 	syncPageSize?: number;
+	perModelSyncPageSize?: { [modelName: string]: number }; // over-ride syncPageSize for specific models
 	fullSyncInterval?: number;
 	syncExpressions?: SyncExpression[];
 	authProviders?: AuthProviders;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This is a DRAFT PR for implementing perModelSyncPageSize.

Currently, it is possible to set the syncPageSize value, but here is no way to set it to a different value for any one specific data model. This proposed solution would allow users to provide a perModelSyncPageSize option in their DataStore config to set different syncPageSize values for different data models.

The perModelSyncPageSize option would be completely optional, so most users could ignore it altogether.
However, this will be very helpful to developers who may have a heavy data model, since the default syncPageSize is 1000 and the max data volume allowed per request over appSync is 1mb.


#### Description of how you validated changes
So far the only validation has been to run the tests (with the new tests commented out), and verify that they still all pass.

NOTE: this is a draft PR, and the goal is to confirm the approach. If this approach is agreed upon, I will follow up with test implementation to verify the intended behavior.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
