### PR TITLE
feat(clients): compose transfer handler with middleware & retry middleware

### DIFF
--- a/packages/core/__tests__/clients/composeTransferHandler-test.ts
+++ b/packages/core/__tests__/clients/composeTransferHandler-test.ts
@@ -12,11 +12,7 @@ describe(composeTransferHandler.name, () => {
 		const coreHandler: TransferHandler<Request, Response, HandlerOptions> = jest
 			.fn()
 			.mockResolvedValue({ body: 'Response' } as Response);
-		const handler = composeTransferHandler<
-			Request,
-			Response,
-			TransferHandler<Request, Response, HandlerOptions>
-		>(coreHandler, []);
+		const handler = composeTransferHandler(coreHandler, []);
 		const resp = await handler({ url: new URL('https://a.b') }, { foo: 'bar' });
 		expect(resp).toEqual({ body: 'Response' });
 		expect(coreHandler).toBeCalledWith(
@@ -46,12 +42,10 @@ describe(composeTransferHandler.name, () => {
 		const coreHandler: TransferHandler<Request, Response, {}> = jest
 			.fn()
 			.mockResolvedValue({ body: '' } as Response);
-		const handler = composeTransferHandler<
-			Request,
-			Response,
-			TransferHandler<Request, Response, {}>,
-			[OptionsType, OptionsType]
-		>(coreHandler, [middlewareA, middlewareB]);
+		const handler = composeTransferHandler<[OptionsType, OptionsType]>(
+			coreHandler,
+			[middlewareA, middlewareB]
+		);
 		const options = {
 			mockFnInOptions: jest.fn(),
 		};

--- a/packages/core/__tests__/clients/composeTransferHandler-test.ts
+++ b/packages/core/__tests__/clients/composeTransferHandler-test.ts
@@ -28,18 +28,18 @@ describe(composeTransferHandler.name, () => {
 	test('should call execute middleware in order', async () => {
 		type OptionsType = { mockFnInOptions: (calledFrom: string) => void };
 		const middlewareA: Middleware<Request, Response, OptionsType> =
-			(next, context) => async (request, options) => {
+			(options: OptionsType) => (next, context) => async request => {
 				request.body += 'A';
 				options.mockFnInOptions('A');
-				const resp = await next(request, options);
+				const resp = await next(request);
 				resp.body += 'A';
 				return resp;
 			};
 		const middlewareB: Middleware<Request, Response, OptionsType> =
-			(next, context) => async (request, options) => {
+			(options: OptionsType) => (next, context) => async request => {
 				request.body += 'B';
 				options.mockFnInOptions('B');
-				const resp = await next(request, options);
+				const resp = await next(request);
 				resp.body += 'B';
 				return resp;
 			};

--- a/packages/core/__tests__/clients/composeTransferHandler-test.ts
+++ b/packages/core/__tests__/clients/composeTransferHandler-test.ts
@@ -1,0 +1,71 @@
+import { composeTransferHandler } from '../../src/clients/internal/composeTransferHandler';
+import {
+	Middleware,
+	Request,
+	Response,
+	TransferHandler,
+} from '../../src/clients/types';
+
+describe(composeTransferHandler.name, () => {
+	test('should call core handler', async () => {
+		type HandlerOptions = { foo: string };
+		const coreHandler: TransferHandler<Request, Response, HandlerOptions> = jest
+			.fn()
+			.mockResolvedValue({ body: 'Response' } as Response);
+		const handler = composeTransferHandler<
+			Request,
+			Response,
+			TransferHandler<Request, Response, HandlerOptions>
+		>(coreHandler, []);
+		const resp = await handler({ url: new URL('https://a.b') }, { foo: 'bar' });
+		expect(resp).toEqual({ body: 'Response' });
+		expect(coreHandler).toBeCalledWith(
+			{ url: new URL('https://a.b') },
+			{ foo: 'bar' }
+		);
+	});
+
+	test('should call execute middleware in order', async () => {
+		type OptionsType = { mockFnInOptions: (calledFrom: string) => void };
+		const middlewareA: Middleware<Request, Response, OptionsType> =
+			(next, context) => async (request, options) => {
+				request.body += 'A';
+				options.mockFnInOptions('A');
+				const resp = await next(request, options);
+				resp.body += 'A';
+				return resp;
+			};
+		const middlewareB: Middleware<Request, Response, OptionsType> =
+			(next, context) => async (request, options) => {
+				request.body += 'B';
+				options.mockFnInOptions('B');
+				const resp = await next(request, options);
+				resp.body += 'B';
+				return resp;
+			};
+		const coreHandler: TransferHandler<Request, Response, {}> = jest
+			.fn()
+			.mockResolvedValue({ body: '' } as Response);
+		const handler = composeTransferHandler<
+			Request,
+			Response,
+			TransferHandler<Request, Response, {}>,
+			[OptionsType, OptionsType]
+		>(coreHandler, [middlewareA, middlewareB]);
+		const options = {
+			mockFnInOptions: jest.fn(),
+		};
+		const resp = await handler(
+			{ url: new URL('https://a.b'), body: '' },
+			options
+		);
+		expect(resp).toEqual({ body: 'BA' });
+		expect(coreHandler).toBeCalledWith(
+			expect.objectContaining({ body: 'AB' }),
+			expect.anything()
+		);
+		// Validate middleware share a same option object
+		expect(options.mockFnInOptions).toHaveBeenNthCalledWith(1, 'A');
+		expect(options.mockFnInOptions).toHaveBeenNthCalledWith(2, 'B');
+	});
+});

--- a/packages/core/__tests__/clients/retry-middleware-test.ts
+++ b/packages/core/__tests__/clients/retry-middleware-test.ts
@@ -1,30 +1,102 @@
 import { retry } from '../../src/clients/middleware/retry';
 
 describe(`${retry.name} middleware`, () => {
+	beforeEach(() => {
+		// jest.useFakeTimers();
+		jest.clearAllMocks();
+	});
 	const defaultRetryOptions = {
 		retryDecider: () => true,
 		backOffStrategy: { computeDelay: () => 1 },
 	};
+	const defaultRequest = { url: new URL('https://a.b') };
+
 	test('should retry specified times', async () => {
 		const retryMiddleware = retry();
 		const nextHandler = jest.fn().mockResolvedValue('foo');
 		const retryableHandler = retryMiddleware(nextHandler, {});
 		let resp;
 		try {
-			resp = await retryableHandler(
-				{ url: new URL('https://a.b') },
-				{
-					...defaultRetryOptions,
-					maxAttempts: 6,
-				}
-			);
+			resp = await retryableHandler(defaultRequest, {
+				...defaultRetryOptions,
+				maxAttempts: 6,
+			});
+			fail('this test should fail');
 		} catch (error) {
 			expect(nextHandler).toBeCalledTimes(6);
+			expect(error.message).toEqual('Retry attempts exhausted');
 		}
 	});
-	test('should call retry decider on whether response is retryable', async () => {});
-	test('should call retry decider on whether error is retryable', async () => {});
-	test('should call backoff strategy for intervals', async () => {});
-	test('can be cancelled', async () => {});
+	test('should call retry decider on whether response is retryable', async () => {
+		const retryMiddleware = retry();
+		const nextHandler = jest.fn().mockResolvedValue('foo');
+		const retryableHandler = retryMiddleware(nextHandler, {});
+		const retryDecider = jest
+			.fn()
+			.mockImplementation(response => response !== 'foo'); // retry if response is not foo
+		const resp = await retryableHandler(defaultRequest, {
+			...defaultRetryOptions,
+			retryDecider,
+		});
+		expect.assertions(3);
+		expect(nextHandler).toBeCalledTimes(1);
+		expect(retryDecider).toBeCalledTimes(1);
+		expect(resp).toEqual('foo');
+	});
+	test('should call retry decider on whether error is retryable', async () => {
+		const retryMiddleware = retry();
+		const nextHandler = jest.fn().mockRejectedValue('UnretryableError');
+		const retryableHandler = retryMiddleware(nextHandler, {});
+		const retryDecider = jest
+			.fn()
+			.mockImplementation((resp, error) => error !== 'UnretryableError');
+		try {
+			const resp = await retryableHandler(defaultRequest, {
+				...defaultRetryOptions,
+				retryDecider,
+			});
+			fail('this test should fail');
+		} catch (e) {
+			expect(e).toBe('UnretryableError');
+			expect(nextHandler).toBeCalledTimes(1);
+			expect(retryDecider).toBeCalledTimes(1);
+			expect(retryDecider).toBeCalledWith(undefined, 'UnretryableError');
+		}
+		expect.assertions(4);
+	});
+	test('should call backoff strategy for intervals', async () => {
+		const retryMiddleware = retry();
+		const nextHandler = jest.fn().mockResolvedValue('foo');
+		const retryableHandler = retryMiddleware(nextHandler, {});
+		const backOffStrategy = {
+			computeDelay: jest.fn().mockImplementation(retry => retry * 100),
+		};
+		try {
+			await retryableHandler(defaultRequest, {
+				...defaultRetryOptions,
+				maxAttempts: 6,
+				backOffStrategy,
+			});
+			fail('this test should fail');
+		} catch (error) {
+			expect(error.message).toBe('Retry attempts exhausted');
+			expect(nextHandler).toBeCalledTimes(6);
+			expect(backOffStrategy.computeDelay).toBeCalledTimes(6);
+		}
+		expect.assertions(3);
+	});
+	test('can be cancelled', async () => {
+		const retryMiddleware = retry();
+		const nextHandler = jest.fn().mockResolvedValue('foo');
+		const retryableHandler = retryMiddleware(nextHandler, {});
+		const controller = new AbortController();
+		controller.abort();
+		const resp = await retryableHandler(defaultRequest, {
+			...defaultRetryOptions,
+			abortSignal: controller.signal,
+		});
+		expect(resp).toEqual('foo');
+	});
 	test('should not proceed if already cancelled', async () => {});
+	test('track attempts count in context across 2 retry middleware', async () => {});
 });

--- a/packages/core/__tests__/clients/retry-middleware-test.ts
+++ b/packages/core/__tests__/clients/retry-middleware-test.ts
@@ -1,24 +1,22 @@
 import { MiddlewareHandler } from '../../src/clients/types';
 import { composeTransferHandler } from '../../src/clients/internal/composeTransferHandler';
+import { retry, RetryOptions } from '../../src/clients/middleware/retry';
 
 jest.spyOn(global, 'setTimeout');
 jest.spyOn(global, 'clearTimeout');
-import { retry, RetryOptions } from '../../src/clients/middleware/retry';
 
 describe(`${retry.name} middleware`, () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
+
 	const defaultRetryOptions = {
 		retryDecider: () => true,
 		backOffStrategy: { computeDelay: () => 1 },
 	};
 	const defaultRequest = { url: new URL('https://a.b') };
-	const getRetryableHandler = (nextHandler: MiddlewareHandler<any, any>) => {
-		return composeTransferHandler<any, any, any, [RetryOptions]>(nextHandler, [
-			retry,
-		]);
-	};
+	const getRetryableHandler = (nextHandler: MiddlewareHandler<any, any>) =>
+		composeTransferHandler<any, any, any, [RetryOptions]>(nextHandler, [retry]);
 
 	test('should retry specified times', async () => {
 		const nextHandler = jest.fn().mockResolvedValue('foo');

--- a/packages/core/__tests__/clients/retry-middleware-test.ts
+++ b/packages/core/__tests__/clients/retry-middleware-test.ts
@@ -1,8 +1,12 @@
-import { retry } from '../../src/clients/middleware/retry';
+import { MiddlewareHandler } from '../../src/clients/types';
+import { composeTransferHandler } from '../../src/clients/internal/composeTransferHandler';
+
+jest.spyOn(global, 'setTimeout');
+jest.spyOn(global, 'clearTimeout');
+import { retry, RetryOptions } from '../../src/clients/middleware/retry';
 
 describe(`${retry.name} middleware`, () => {
 	beforeEach(() => {
-		// jest.useFakeTimers();
 		jest.clearAllMocks();
 	});
 	const defaultRetryOptions = {
@@ -10,11 +14,15 @@ describe(`${retry.name} middleware`, () => {
 		backOffStrategy: { computeDelay: () => 1 },
 	};
 	const defaultRequest = { url: new URL('https://a.b') };
+	const getRetryableHandler = (nextHandler: MiddlewareHandler<any, any>) => {
+		return composeTransferHandler<any, any, any, [RetryOptions]>(nextHandler, [
+			retry,
+		]);
+	};
 
 	test('should retry specified times', async () => {
-		const retryMiddleware = retry();
 		const nextHandler = jest.fn().mockResolvedValue('foo');
-		const retryableHandler = retryMiddleware(nextHandler, {});
+		const retryableHandler = getRetryableHandler(nextHandler);
 		let resp;
 		try {
 			resp = await retryableHandler(defaultRequest, {
@@ -27,10 +35,10 @@ describe(`${retry.name} middleware`, () => {
 			expect(error.message).toEqual('Retry attempts exhausted');
 		}
 	});
+
 	test('should call retry decider on whether response is retryable', async () => {
-		const retryMiddleware = retry();
 		const nextHandler = jest.fn().mockResolvedValue('foo');
-		const retryableHandler = retryMiddleware(nextHandler, {});
+		const retryableHandler = getRetryableHandler(nextHandler);
 		const retryDecider = jest
 			.fn()
 			.mockImplementation(response => response !== 'foo'); // retry if response is not foo
@@ -44,12 +52,15 @@ describe(`${retry.name} middleware`, () => {
 		expect(resp).toEqual('foo');
 	});
 	test('should call retry decider on whether error is retryable', async () => {
-		const retryMiddleware = retry();
-		const nextHandler = jest.fn().mockRejectedValue('UnretryableError');
-		const retryableHandler = retryMiddleware(nextHandler, {});
+		const nextHandler = jest
+			.fn()
+			.mockRejectedValue(new Error('UnretryableError'));
+		const retryableHandler = getRetryableHandler(nextHandler);
 		const retryDecider = jest
 			.fn()
-			.mockImplementation((resp, error) => error !== 'UnretryableError');
+			.mockImplementation(
+				(resp, error) => error.message !== 'UnretryableError'
+			);
 		try {
 			const resp = await retryableHandler(defaultRequest, {
 				...defaultRetryOptions,
@@ -57,17 +68,17 @@ describe(`${retry.name} middleware`, () => {
 			});
 			fail('this test should fail');
 		} catch (e) {
-			expect(e).toBe('UnretryableError');
+			expect(e.message).toBe('UnretryableError');
 			expect(nextHandler).toBeCalledTimes(1);
 			expect(retryDecider).toBeCalledTimes(1);
-			expect(retryDecider).toBeCalledWith(undefined, 'UnretryableError');
+			expect(retryDecider).toBeCalledWith(undefined, expect.any(Error));
 		}
 		expect.assertions(4);
 	});
+
 	test('should call backoff strategy for intervals', async () => {
-		const retryMiddleware = retry();
 		const nextHandler = jest.fn().mockResolvedValue('foo');
-		const retryableHandler = retryMiddleware(nextHandler, {});
+		const retryableHandler = getRetryableHandler(nextHandler);
 		const backOffStrategy = {
 			computeDelay: jest.fn().mockImplementation(retry => retry * 100),
 		};
@@ -81,22 +92,101 @@ describe(`${retry.name} middleware`, () => {
 		} catch (error) {
 			expect(error.message).toBe('Retry attempts exhausted');
 			expect(nextHandler).toBeCalledTimes(6);
-			expect(backOffStrategy.computeDelay).toBeCalledTimes(6);
+			expect(backOffStrategy.computeDelay).toBeCalledTimes(5); // no interval after last attempt
 		}
 		expect.assertions(3);
 	});
-	test('can be cancelled', async () => {
-		const retryMiddleware = retry();
+
+	test('should throw error if request already cancelled', async () => {
 		const nextHandler = jest.fn().mockResolvedValue('foo');
-		const retryableHandler = retryMiddleware(nextHandler, {});
+		const retryableHandler = getRetryableHandler(nextHandler);
 		const controller = new AbortController();
 		controller.abort();
-		const resp = await retryableHandler(defaultRequest, {
-			...defaultRetryOptions,
-			abortSignal: controller.signal,
-		});
-		expect(resp).toEqual('foo');
+		try {
+			await retryableHandler(defaultRequest, {
+				...defaultRetryOptions,
+				abortSignal: controller.signal,
+			});
+			fail('this test should fail');
+		} catch (error) {
+			expect(error.message).toBe('Request aborted');
+			expect(nextHandler).toBeCalledTimes(0);
+		}
+		expect.assertions(2);
 	});
-	test('should not proceed if already cancelled', async () => {});
-	test('track attempts count in context across 2 retry middleware', async () => {});
+
+	test('can be cancelled', async () => {
+		// Not using fake timers because of Jest limit: https://github.com/facebook/jest/issues/7151
+		const nextHandler = jest.fn().mockResolvedValue('foo');
+		const retryableHandler = getRetryableHandler(nextHandler);
+		const controller = new AbortController();
+		const retryDecider = () => true;
+		const backOffStrategy = {
+			computeDelay: jest.fn().mockImplementation(attempt => {
+				if (attempt === 1) {
+					setTimeout(() => controller.abort(), 100);
+				}
+				return 200;
+			}),
+		};
+		try {
+			await retryableHandler(defaultRequest, {
+				...defaultRetryOptions,
+				abortSignal: controller.signal,
+				backOffStrategy,
+				retryDecider,
+			});
+			fail('this test should fail');
+		} catch (error) {
+			expect(error.message).toBe('Request aborted');
+			expect(setTimeout).toBeCalledTimes(2); // 1st attempt + mock back-off strategy
+			expect(clearTimeout).toBeCalledTimes(1); // cancel 2nd attempt
+		}
+	});
+	test('track attempts count in context across 2 retry middleware', async () => {
+		// middleware after 2nd retry middleware;
+		const coreHandler = jest
+			.fn()
+			.mockRejectedValueOnce(new Error('CoreRetryableError'))
+			.mockResolvedValue('foo');
+		const betweenRetryFunction = jest
+			.fn()
+			.mockRejectedValueOnce(new Error('MiddlewareRetryableError'))
+			.mockResolvedValue(void 0);
+		const betweenRetryMiddleware =
+			() => (next: any, context: any) => async (args: any) => {
+				await betweenRetryFunction(args, context);
+				return next(args);
+			};
+
+		const doubleRetryableHandler = composeTransferHandler<
+			any,
+			any,
+			any,
+			[RetryOptions, {}, RetryOptions]
+		>(coreHandler, [retry, betweenRetryMiddleware, retry]);
+
+		const retryDecider = jest
+			.fn()
+			.mockImplementation((response, error: Error) => {
+				if (error && error.message.endsWith('RetryableError')) return true;
+				return false;
+			});
+		const backOffStrategy = {
+			computeDelay: jest.fn().mockReturnValue(0),
+		};
+		const response = await doubleRetryableHandler(defaultRequest, {
+			...defaultRetryOptions,
+			retryDecider,
+			backOffStrategy,
+		});
+
+		expect(response).toEqual('foo');
+		expect(coreHandler).toBeCalledTimes(2);
+		expect(betweenRetryFunction).toBeCalledTimes(2);
+		expect(retryDecider).toBeCalledTimes(4);
+		// backOffStrategy is called regardless whether from different retry middleware.
+		expect(backOffStrategy.computeDelay).toHaveBeenNthCalledWith(1, 1);
+		expect(backOffStrategy.computeDelay).toHaveBeenNthCalledWith(2, 2);
+	});
 });

--- a/packages/core/__tests__/clients/retry-middleware-test.ts
+++ b/packages/core/__tests__/clients/retry-middleware-test.ts
@@ -1,0 +1,30 @@
+import { retry } from '../../src/clients/middleware/retry';
+
+describe(`${retry.name} middleware`, () => {
+	const defaultRetryOptions = {
+		retryDecider: () => true,
+		backOffStrategy: { computeDelay: () => 1 },
+	};
+	test('should retry specified times', async () => {
+		const retryMiddleware = retry();
+		const nextHandler = jest.fn().mockResolvedValue('foo');
+		const retryableHandler = retryMiddleware(nextHandler, {});
+		let resp;
+		try {
+			resp = await retryableHandler(
+				{ url: new URL('https://a.b') },
+				{
+					...defaultRetryOptions,
+					maxAttempts: 6,
+				}
+			);
+		} catch (error) {
+			expect(nextHandler).toBeCalledTimes(6);
+		}
+	});
+	test('should call retry decider on whether response is retryable', async () => {});
+	test('should call retry decider on whether error is retryable', async () => {});
+	test('should call backoff strategy for intervals', async () => {});
+	test('can be cancelled', async () => {});
+	test('should not proceed if already cancelled', async () => {});
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -102,6 +102,18 @@
 			"path": "./lib-esm/index.js",
 			"import": "{ Credentials }",
 			"limit": "35.5 kB"
+		},
+		{
+			"name": "Custom clients (retry middleware)",
+			"path": "./lib-esm/clients/middleware/retry.js",
+			"import": "{ retry }",
+			"limit": "1.2 kB"
+		},
+		{
+			"name": "Custom clients (fetch handler)",
+			"path": "./lib-esm/clients/fetch.js",
+			"import": "{ fetchTransferHandler }",
+			"limit": "1.73 kB"
 		}
 	],
 	"jest": {

--- a/packages/core/src/clients/internal/composeTransferHandler.ts
+++ b/packages/core/src/clients/internal/composeTransferHandler.ts
@@ -86,13 +86,13 @@ export const composeTransferHandler =
 			[...MiddlewareOptionsArr, InferOptionTypeFromTransferHandler<CoreHandler>]
 		>
 	) => {
-		let composedHandler = coreHandler as unknown as MiddlewareHandler<
-			Request,
-			Response,
-			MiddlewareOptionsArr[number]
-		>;
+		const context = {};
+		let composedHandler: MiddlewareHandler<Request, Response> = (
+			request: Request
+		) => coreHandler(request, options);
 		for (const m of middleware.reverse()) {
-			composedHandler = m(composedHandler, {});
+			const resolvedMiddleware = m(options);
+			composedHandler = resolvedMiddleware(composedHandler, context);
 		}
-		return composedHandler(request, options);
+		return composedHandler(request);
 	};

--- a/packages/core/src/clients/internal/composeTransferHandler.ts
+++ b/packages/core/src/clients/internal/composeTransferHandler.ts
@@ -1,0 +1,98 @@
+import {
+	Middleware,
+	MiddlewareHandler,
+	TransferHandler,
+	Request as RequestBase,
+	Response as ResponseBase,
+} from '../types';
+
+/**
+ * Type to convert a middleware option type to a middleware type with the given
+ * option type.
+ */
+type OptionToMiddleware<
+	Request extends RequestBase,
+	Response extends ResponseBase,
+	Options extends any[]
+> = Options extends []
+	? []
+	: Options extends [infer LastOption]
+	? [Middleware<Request, Response, LastOption>]
+	: Options extends [infer FirstOption, ...infer RestOptions]
+	? [
+			Middleware<Request, Response, FirstOption>,
+			...OptionToMiddleware<Request, Response, RestOptions>
+	  ]
+	: never;
+
+/**
+ * Type to merge two types to validate if 2 types have no conflict keys.
+ */
+type EnsureNoConflictKeys<T, U> = Pick<U, keyof T & keyof U> extends Pick<
+	T,
+	keyof T & keyof U
+>
+	? true
+	: false;
+
+/**
+ * Type to intersect two types if they have no conflict keys.
+ */
+type MergeTwoNoConflictKeys<T, U> = EnsureNoConflictKeys<T, U> extends true
+	? T & U
+	: never;
+
+/**
+ * Type to intersect multiple types if they have no conflict keys.
+ */
+type MergeNoConflictKeys<Options extends any[]> = Options extends [
+	infer OnlyOption
+]
+	? OnlyOption
+	: Options extends [infer FirstOption, infer SecondOption]
+	? MergeTwoNoConflictKeys<FirstOption, SecondOption>
+	: Options extends [infer FirstOption, ...infer RestOptions]
+	? MergeTwoNoConflictKeys<FirstOption, MergeNoConflictKeys<RestOptions>>
+	: never;
+
+/**
+ * Type to infer the option type of a transfer handler type.
+ */
+type InferOptionTypeFromTransferHandler<
+	T extends TransferHandler<any, any, any>
+> = Parameters<T>[1];
+
+/**
+ * Compose a transfer handler with a core transfer handler and a list of middleware.
+ * @param coreHandler Core transfer handler
+ * @param middleware	List of middleware
+ * @returns A transfer handler whose option type is the union of the core
+ * 	transfer handler's option type and the middleware's option type.
+ * @internal
+ */
+export const composeTransferHandler =
+	<
+		Request extends RequestBase,
+		Response extends ResponseBase,
+		CoreHandler extends TransferHandler<Request, Response, any>,
+		MiddlewareOptionsArr extends any[] = []
+	>(
+		coreHandler: CoreHandler,
+		middleware: OptionToMiddleware<Request, Response, MiddlewareOptionsArr>
+	) =>
+	(
+		request: Request,
+		options: MergeNoConflictKeys<
+			[...MiddlewareOptionsArr, InferOptionTypeFromTransferHandler<CoreHandler>]
+		>
+	) => {
+		let composedHandler = coreHandler as unknown as MiddlewareHandler<
+			Request,
+			Response,
+			MiddlewareOptionsArr[number]
+		>;
+		for (const m of middleware.reverse()) {
+			composedHandler = m(composedHandler, {});
+		}
+		return composedHandler(request, options);
+	};

--- a/packages/core/src/clients/internal/composeTransferHandler.ts
+++ b/packages/core/src/clients/internal/composeTransferHandler.ts
@@ -16,10 +16,14 @@ import {
  */
 export const composeTransferHandler =
 	<
-		Request extends RequestBase,
-		Response extends ResponseBase,
-		CoreHandler extends TransferHandler<Request, Response, any>,
-		MiddlewareOptionsArr extends any[] = []
+		MiddlewareOptionsArr extends any[] = [],
+		Request extends RequestBase = RequestBase,
+		Response extends ResponseBase = ResponseBase,
+		CoreHandler extends TransferHandler<
+			Request,
+			Response,
+			any
+		> = TransferHandler<Request, Response, {}>
 	>(
 		coreHandler: CoreHandler,
 		middleware: OptionToMiddleware<Request, Response, MiddlewareOptionsArr>
@@ -61,23 +65,6 @@ type OptionToMiddleware<
 	: never;
 
 /**
- * Type to merge two types to validate if 2 types have no conflict keys.
- */
-type EnsureNoConflictKeys<T, U> = Pick<U, keyof T & keyof U> extends Pick<
-	T,
-	keyof T & keyof U
->
-	? true
-	: false;
-
-/**
- * Type to intersect two types if they have no conflict keys.
- */
-type MergeTwoNoConflictKeys<T, U> = EnsureNoConflictKeys<T, U> extends true
-	? T & U
-	: never;
-
-/**
  * Type to intersect multiple types if they have no conflict keys.
  */
 type MergeNoConflictKeys<Options extends any[]> = Options extends [
@@ -85,9 +72,9 @@ type MergeNoConflictKeys<Options extends any[]> = Options extends [
 ]
 	? OnlyOption
 	: Options extends [infer FirstOption, infer SecondOption]
-	? MergeTwoNoConflictKeys<FirstOption, SecondOption>
+	? FirstOption & SecondOption
 	: Options extends [infer FirstOption, ...infer RestOptions]
-	? MergeTwoNoConflictKeys<FirstOption, MergeNoConflictKeys<RestOptions>>
+	? FirstOption & MergeNoConflictKeys<RestOptions>
 	: never;
 
 /**

--- a/packages/core/src/clients/middleware/retry.ts
+++ b/packages/core/src/clients/middleware/retry.ts
@@ -1,0 +1,78 @@
+import { HttpResponse } from '../types';
+import {
+	MiddlewareContext,
+	MiddlewareHandler,
+	Request,
+	Response,
+} from '../types/core';
+
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const CONTEXT_KEY_RETRY_COUNT = 'retryCount';
+
+/**
+ * Configuration of the retry middleware
+ */
+export interface RetryOptions {
+	retryDecider: (response: HttpResponse, error?: unknown) => boolean;
+	backOffStrategy: {
+		computeDelay: (attempt: number) => number;
+	}; // MS to wait
+	maxAttempts?: number;
+	abortSignal?: AbortSignal;
+}
+
+/**
+ * Retry middleware
+ */
+export const retry =
+	<T extends Request, U extends Response>() =>
+	(next: MiddlewareHandler<T, U, RetryOptions>, context: MiddlewareContext) => {
+		return async function retry(request: T, options: RetryOptions) {
+			const {
+				maxAttempts = DEFAULT_RETRY_ATTEMPTS,
+				retryDecider,
+				backOffStrategy,
+				abortSignal,
+			} = options;
+			let error = undefined;
+			let retryCount = (context[CONTEXT_KEY_RETRY_COUNT] as number) ?? 0;
+			let response;
+			do {
+				try {
+					response = await next(request, options);
+				} catch (e) {
+					error = e;
+				}
+				if (retryDecider(response, error)) {
+					const delay = backOffStrategy.computeDelay(retryCount);
+					retryCount += 1;
+					context[CONTEXT_KEY_RETRY_COUNT] = retryCount;
+					await cancellableSleep(delay, abortSignal);
+					continue;
+				} else if (response) {
+					return response;
+				} else {
+					throw error;
+				}
+			} while (retryCount < maxAttempts && !abortSignal?.aborted);
+			throw new Error(`Retry attempts exhausted, ${error ?? response}`);
+		};
+	};
+
+const cancellableSleep = (timeoutMs: number, abortSignal?: AbortSignal) => {
+	if (abortSignal?.aborted) {
+		return Promise.resolve();
+	}
+	let timeoutId;
+	let sleepPromiseResolveFn;
+	const sleepPromise = new Promise<void>(resolve => {
+		sleepPromiseResolveFn = resolve;
+		timeoutId = setTimeout(resolve, timeoutMs);
+	});
+	abortSignal?.addEventListener('abort', function cancelSleep(event) {
+		clearTimeout(timeoutId);
+		abortSignal?.removeEventListener('abort', cancelSleep);
+		sleepPromiseResolveFn();
+	});
+	return sleepPromise;
+};

--- a/packages/core/src/clients/types/core.ts
+++ b/packages/core/src/clients/types/core.ts
@@ -26,7 +26,12 @@ export type MiddlewareHandler<
 	Output extends Response
 > = (request: Input) => Promise<Output>;
 
-export type MiddlewareContext = Record<string, unknown>;
+export type MiddlewareContext = {
+	/**
+	 * The number of times the request has been attempted. This is set by retry middleware
+	 */
+	attemptsCount?: number;
+};
 
 /**
  * A slimmed down version of the AWS SDK v3 middleware, only handling tasks after Serde.

--- a/packages/core/src/clients/types/core.ts
+++ b/packages/core/src/clients/types/core.ts
@@ -23,9 +23,8 @@ export interface TransferHandler<
  */
 export type MiddlewareHandler<
 	Input extends Request,
-	Output extends Response,
-	MiddlewareOptions
-> = (request: Input, options: MiddlewareOptions) => Promise<Output>;
+	Output extends Response
+> = (request: Input) => Promise<Output>;
 
 export type MiddlewareContext = Record<string, unknown>;
 
@@ -37,6 +36,8 @@ export type Middleware<
 	Output extends Response,
 	MiddlewareOptions
 > = (
-	next: MiddlewareHandler<Input, Output, MiddlewareOptions>,
+	options: MiddlewareOptions
+) => (
+	next: MiddlewareHandler<Input, Output>,
 	context: MiddlewareContext
-) => MiddlewareHandler<Input, Output, MiddlewareOptions>;
+) => MiddlewareHandler<Input, Output>;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
* Propose a function composing HTTP handler(fetch transfer handler) and middleware into a transfer handler.
* Minor update to the middleware interface
* Propse a general retry middleware implementation for client side. Removing overly complexed retry token mechanism from AWS SDK.

This change is intended to replace the current [`Core/Util/Retry.ts`](https://github.com/aws-amplify/amplify-js/blob/0fa40e6efb67def43f0eb912b3f2ed34da883f5f/packages/core/src/Util/Retry.ts#L21) and standardize the retry behaviors across the board.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Unit test



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
