### PR TITLE
feat(api-graphql): Add affected items in the errors object

### DIFF
--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -302,8 +302,6 @@ export class GraphQLAPIClass {
 			variables,
 		};
 
-		console.log('printing', body);
-
 		const init = Object.assign(
 			{
 				headers,

--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -341,24 +341,25 @@ export class GraphQLAPIClass {
 		}
 		const { errors } = response;
 		if (errors && errors.length) {
-			let queryfield = null;
-			const null_values = errors.find(obj => {
+			let queryfield: string | null;
+			const null_values = errors.find((obj): boolean => {
 				if (obj.message.includes('Cannot return null for non-nullable type')) {
-					queryfield = obj.path[0];
+					queryfield = obj.path[0] as string;
 					return true;
 				}
 			});
 			if (null_values && queryfield) {
-				const data_values = response.data[queryfield].items;
-				const query =
+				const data_values: Array<String> = response.data[queryfield].items;
+				const query: string =
 					body.query.slice(0, body.query.indexOf('id') + 3) +
 					'}' +
 					body.query.slice(body.query.lastIndexOf('nextToken'));
 				init.body.query = query;
 				response.items = [];
 				const new_response = await this._api.post(endpoint, init);
-				let compare_values = new_response.data[queryfield].items;
-				for (let index = 0; index < data_values.length; index++) {
+				const compare_values: Array<String> =
+					new_response.data[queryfield].items;
+				for (let index: number = 0; index < data_values.length; index++) {
 					if (!data_values[index]) {
 						response.items.push(compare_values[index]);
 					}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adding affected items when a relationship is deleted while querying for the data. The code takes the initial query data when non-null entities are encountered, generates a new query where all the entities will be present by returning only the id's from the query, and then compares the new response with the previous response to check for null entities. The respected null entities are then pushed back in the response.items array.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#10847 


#### Description of how you validated changes
I checked the query with the schema table the customer was facing and other tables where non-nullable error messages could be shown and then compared the queries with and without the null returned attributes.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
