### PR TITLE
chore(notifications): Deprecate previous push notifications

### DIFF
--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -19,7 +19,7 @@ const REMOTE_TOKEN_RECEIVED = 'remoteTokenReceived';
 const REMOTE_NOTIFICATION_OPENED = 'remoteNotificationOpened';
 
 /**
- * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+ * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
  * instructions on how to migrate to a new version of Amplify Push Notifications.
  *
  * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -33,7 +33,7 @@ export default class PushNotification {
 	private _notificationOpenedHandlers: Function[];
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -59,7 +59,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -69,7 +69,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -105,7 +105,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -122,7 +122,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -137,7 +137,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -154,7 +154,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -189,7 +189,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -204,7 +204,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -214,7 +214,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -239,7 +239,7 @@ export default class PushNotification {
 	 * And checks if the app was launched by a Push Notification
 	 * Note: Current AppState will be null or 'unknown' if the app is coming from killed state to active
 	 * @param nextAppState The next state the app is changing to as part of the event
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -268,7 +268,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -316,7 +316,7 @@ export default class PushNotification {
 	};
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -357,7 +357,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -394,7 +394,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -442,7 +442,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -468,7 +468,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -491,7 +491,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
@@ -536,7 +536,7 @@ export default class PushNotification {
 	}
 
 	/**
-	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * @deprecated This package (@aws-amplify/pushnotification) is on a deprecation path. Please see the following link for
 	 * instructions on how to migrate to a new version of Amplify Push Notifications.
 	 *
 	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/

--- a/packages/pushnotification/src/PushNotification.ts
+++ b/packages/pushnotification/src/PushNotification.ts
@@ -18,6 +18,12 @@ const REMOTE_NOTIFICATION_RECEIVED = 'remoteNotificationReceived';
 const REMOTE_TOKEN_RECEIVED = 'remoteTokenReceived';
 const REMOTE_NOTIFICATION_OPENED = 'remoteNotificationOpened';
 
+/**
+ * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+ * instructions on how to migrate to a new version of Amplify Push Notifications.
+ *
+ * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+ */
 export default class PushNotification {
 	private _config;
 	private _currentState;
@@ -26,6 +32,12 @@ export default class PushNotification {
 
 	private _notificationOpenedHandlers: Function[];
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	constructor(config) {
 		if (config) {
 			this.configure(config);
@@ -46,10 +58,22 @@ export default class PushNotification {
 		this._notificationOpenedHandlers = [];
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	getModuleName() {
 		return 'Pushnotification';
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	configure(config) {
 		if (isEmpty(config)) return this._config;
 		let conf = config ? config.PushNotification || config : {};
@@ -80,6 +104,12 @@ export default class PushNotification {
 		return this._config;
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	onNotification(handler) {
 		if (typeof handler === 'function') {
 			// check platform
@@ -91,6 +121,12 @@ export default class PushNotification {
 		}
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	onNotificationOpened(handler) {
 		if (typeof handler === 'function') {
 			this._notificationOpenedHandlers = [
@@ -100,6 +136,12 @@ export default class PushNotification {
 		}
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	onRegister(handler) {
 		if (typeof handler === 'function') {
 			// check platform
@@ -111,6 +153,12 @@ export default class PushNotification {
 		}
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	async initializeAndroid() {
 		this.addEventListenerForAndroid(REMOTE_TOKEN_RECEIVED, this.updateEndpoint);
 		this.addEventListenerForAndroid(
@@ -140,6 +188,12 @@ export default class PushNotification {
 		}
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	async _registerTokenCached(): Promise<boolean> {
 		const { appId } = this._config;
 		const cacheKey = 'push_token' + appId;
@@ -149,10 +203,22 @@ export default class PushNotification {
 		});
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	requestIOSPermissions(options = { alert: true, badge: true, sound: true }) {
 		PushNotificationIOS.requestPermissions(options);
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	initializeIOS() {
 		if (this._config.requestIOSPermissions) {
 			this.requestIOSPermissions();
@@ -173,6 +239,10 @@ export default class PushNotification {
 	 * And checks if the app was launched by a Push Notification
 	 * Note: Current AppState will be null or 'unknown' if the app is coming from killed state to active
 	 * @param nextAppState The next state the app is changing to as part of the event
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
 	 */
 	_checkIfOpenedByNotification(nextAppState, handler) {
 		// the App state changes from killed state to active
@@ -197,6 +267,12 @@ export default class PushNotification {
 		this._currentState = nextAppState;
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	parseMessageData = rawMessage => {
 		let eventSource = null;
 		let eventSourceAttributes = {};
@@ -239,6 +315,12 @@ export default class PushNotification {
 		};
 	};
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	handleNotificationReceived(rawMessage) {
 		logger.debug('handleNotificationReceived, raw data', rawMessage);
 		const { eventSource, eventSourceAttributes } =
@@ -274,6 +356,12 @@ export default class PushNotification {
 		}
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	handleNotificationOpened(rawMessage) {
 		this._notificationOpenedHandlers.forEach(handler => {
 			handler(rawMessage);
@@ -305,6 +393,12 @@ export default class PushNotification {
 		}
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	updateEndpoint(token) {
 		if (!token) {
 			logger.debug('no device token recieved on register');
@@ -347,7 +441,12 @@ export default class PushNotification {
 			});
 	}
 
-	// only for android
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	addEventListenerForAndroid(event, handler) {
 		const that = this;
 		const listener = DeviceEventEmitter.addListener(event, data => {
@@ -368,6 +467,12 @@ export default class PushNotification {
 		});
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	addEventListenerForIOS(event, handler) {
 		if (event === REMOTE_TOKEN_RECEIVED) {
 			PushNotificationIOS.addEventListener('register', data => {
@@ -385,6 +490,12 @@ export default class PushNotification {
 		}
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	parseMessagefromAndroid(message, from?) {
 		let dataObj = null;
 		try {
@@ -424,6 +535,12 @@ export default class PushNotification {
 		return ret;
 	}
 
+	/**
+	 * @deprecated This package (@aws-sdk/pushnotifications) is on a deprecation path. Please see the following link for
+	 * instructions on how to migrate to a new version of Amplify Push Notifications.
+	 *
+	 * https://docs.amplify.aws/lib/push-notifications/migrate-from-previous-version/q/platform/react-native/
+	 */
 	parseMessageFromIOS(message) {
 		const _data = message && message._data ? message._data : null;
 		const _alert = message && message._alert ? message._alert : {};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR marks the previous version of Amplify Push Notifications as being on deprecation path. This only adds comments to the APIs and makes no breaking changes to the functionality itself.

#### Description of how you validated changes
Validated the deprecation messages show up in IDE
`yarn test`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
