### PR TITLE
fix(notifications): the launch notification should be nullified when …

### DIFF
--- a/packages/rtn-push-notification/ios/AmplifyRTNPushNotificationManager.swift
+++ b/packages/rtn-push-notification/ios/AmplifyRTNPushNotificationManager.swift
@@ -231,6 +231,13 @@ class AmplifyRTNPushNotificationManager  {
             name: UIApplication.didBecomeActiveNotification,
             object: nil
         )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
     }
 
     private func removeObservers() {
@@ -239,11 +246,25 @@ class AmplifyRTNPushNotificationManager  {
             name: UIApplication.didBecomeActiveNotification,
             object: nil
         )
+
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
     }
 
     @objc
     private func applicationDidBecomeActive() {
         registerForRemoteNotifications()
+    }
+
+    @objc
+    private func applicationDidEnterBackground() {
+        // When App enters background we remove the cached launchNotification
+        // as when the App reopens after this point, there won't be a notification
+        // that launched the App.
+        launchNotification = nil
     }
 
     private func registerForRemoteNotifications() {


### PR DESCRIPTION
…App enters background

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

The launch notification should be nullified when the App enters background and it has never been consumed.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

Local App test.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
