### PR TITLE
fix(notifications): Surface missing native module error

### DIFF
--- a/packages/notifications/src/Notifications.ts
+++ b/packages/notifications/src/Notifications.ts
@@ -52,21 +52,21 @@ class NotificationsClass {
 		return this.config;
 	};
 
-	get InAppMessaging() {
+	get InAppMessaging(): InAppMessaging {
 		return this.inAppMessaging;
 	}
 
-	get Push() {
-		return this.pushNotification;
+	get Push(): PushNotification {
+		return this.pushNotification ?? ({} as PushNotification);
 	}
 
 	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> => {
 		const identifyFunctions: Function[] = [];
-		if (this.InAppMessaging) {
-			identifyFunctions.push(this.InAppMessaging.identifyUser);
+		if (this.inAppMessaging) {
+			identifyFunctions.push(this.inAppMessaging.identifyUser);
 		}
-		if (this.Push) {
-			identifyFunctions.push(this.Push.identifyUser);
+		if (this.pushNotification) {
+			identifyFunctions.push(this.pushNotification.identifyUser);
 		}
 		return Promise.all<void>(
 			identifyFunctions.map(async identifyFunction => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
If customer is trying to use Amplify Push Notifications but did not install the required native module, the library is supposed to throw an error. However, if the getter for `Notifications.Push` returns `null`, accessing a function on `null` will supersede and bury the native module error - customers will not know their issue stems from a missing module. This PR updates the `Push` getter to return an empty object instead of null, so that the error will be surfaced to give them some direction.

#### Description of how you validated changes
Tested locally with sample app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
