### PR TITLE
[Custom Clients]fix(retry): add metadata to returns from retry middldeware

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -107,7 +107,7 @@
 			"name": "Custom clients (retry middleware)",
 			"path": "./lib-esm/clients/middleware/retry.js",
 			"import": "{ retry }",
-			"limit": "1.2 kB"
+			"limit": "1.22 kB"
 		},
 		{
 			"name": "Custom clients (fetch handler)",

--- a/packages/core/src/clients/middleware/retry.ts
+++ b/packages/core/src/clients/middleware/retry.ts
@@ -66,7 +66,7 @@ export const retry = (options: RetryOptions) => {
 				} catch (e) {
 					error = e;
 				}
-				// context.attemptsCount maybe updated after calling next handler which may retry the request by itself.
+				// context.attemptsCount may be updated after calling next handler which may retry the request by itself.
 				attemptsCount =
 					context.attemptsCount > attemptsCount
 						? context.attemptsCount
@@ -112,7 +112,7 @@ const cancellableSleep = (timeoutMs: number, abortSignal?: AbortSignal) => {
 };
 
 const isMetadataBearer = (response: unknown): response is MetadataBearer =>
-	response && typeof response['$metadata'] === 'object';
+	typeof response?.['$metadata'] === 'object';
 
 const updateMetadataAttempts = (
 	nextHandlerOutput: Object,

--- a/packages/core/src/clients/middleware/retry.ts
+++ b/packages/core/src/clients/middleware/retry.ts
@@ -1,3 +1,4 @@
+import { MetadataBearer } from '@aws-sdk/types';
 import {
 	MiddlewareContext,
 	MiddlewareHandler,
@@ -14,11 +15,11 @@ export interface RetryOptions {
 	/**
 	 * Function to decide if the request should be retried.
 	 *
-	 * @param response Response of the request.
+	 * @param response Optional response of the request.
 	 * @param error Optional error thrown from previous attempts.
 	 * @returns True if the request should be retried.
 	 */
-	retryDecider: (response: Response, error?: unknown) => boolean;
+	retryDecider: (response?: Response, error?: unknown) => boolean;
 	/**
 	 * Function to compute the delay in milliseconds before the next retry based
 	 * on the number of attempts.
@@ -30,7 +31,6 @@ export interface RetryOptions {
 	 * Maximum number of retry attempts, starting from 1. Defaults to 3.
 	 */
 	maxAttempts?: number;
-
 	/**
 	 * Optional AbortSignal to abort the retry attempts.
 	 */
@@ -40,22 +40,24 @@ export interface RetryOptions {
 /**
  * Retry middleware
  */
-export const retry =
-	(options: RetryOptions) =>
-	(next: MiddlewareHandler<Request, Response>, context: MiddlewareContext) => {
-		if (options.maxAttempts < 1) {
-			throw new Error('maxAttempts must be greater than 0');
-		}
-		return async function retry(request: Request) {
+export const retry = (options: RetryOptions) => {
+	if (options.maxAttempts < 1) {
+		throw new Error('maxAttempts must be greater than 0');
+	}
+	return (
+		next: MiddlewareHandler<Request, Response>,
+		context: MiddlewareContext
+	) =>
+		async function retry(request: Request) {
 			const {
 				maxAttempts = DEFAULT_RETRY_ATTEMPTS,
 				retryDecider,
 				computeDelay,
 				abortSignal,
 			} = options;
-			let error = undefined;
+			let error: Error;
 			let attemptsCount = context.attemptsCount ?? 0;
-			let response;
+			let response: Response;
 			while (!abortSignal?.aborted && attemptsCount < maxAttempts) {
 				error = undefined;
 				response = undefined;
@@ -64,18 +66,24 @@ export const retry =
 				} catch (e) {
 					error = e;
 				}
+				// context.attemptsCount maybe updated after calling next handler which may retry the request by itself.
+				attemptsCount =
+					context.attemptsCount > attemptsCount
+						? context.attemptsCount
+						: attemptsCount + 1;
+				context.attemptsCount = attemptsCount;
 				if (retryDecider(response, error)) {
-					attemptsCount += 1;
 					if (!abortSignal?.aborted && attemptsCount < maxAttempts) {
 						// prevent sleep for last attempt or cancelled request;
 						const delay = computeDelay(attemptsCount);
 						await cancellableSleep(delay, abortSignal);
 					}
-					context.attemptsCount = attemptsCount;
 					continue;
 				} else if (response) {
+					updateMetadataAttempts(response, attemptsCount);
 					return response;
 				} else {
+					updateMetadataAttempts(error, attemptsCount);
 					throw error;
 				}
 			}
@@ -83,7 +91,7 @@ export const retry =
 				? new Error('Request aborted')
 				: error ?? new Error('Retry attempts exhausted');
 		};
-	};
+};
 
 const cancellableSleep = (timeoutMs: number, abortSignal?: AbortSignal) => {
 	if (abortSignal?.aborted) {
@@ -101,4 +109,17 @@ const cancellableSleep = (timeoutMs: number, abortSignal?: AbortSignal) => {
 		sleepPromiseResolveFn();
 	});
 	return sleepPromise;
+};
+
+const isMetadataBearer = (response: unknown): response is MetadataBearer =>
+	response && typeof response['$metadata'] === 'object';
+
+const updateMetadataAttempts = (
+	nextHandlerOutput: Object,
+	attempts: number
+) => {
+	if (isMetadataBearer(nextHandlerOutput)) {
+		nextHandlerOutput.$metadata.attempts = attempts;
+	}
+	nextHandlerOutput['$metadata'] = { attempts };
 };

--- a/packages/core/src/clients/types/core.ts
+++ b/packages/core/src/clients/types/core.ts
@@ -33,6 +33,11 @@ export type MiddlewareContext = {
 	attemptsCount?: number;
 };
 
+type ConfiguredMiddleware<Input extends Request, Output extends Response> = (
+	next: MiddlewareHandler<Input, Output>,
+	context: MiddlewareContext
+) => MiddlewareHandler<Input, Output>;
+
 /**
  * A slimmed down version of the AWS SDK v3 middleware, only handling tasks after Serde.
  */
@@ -40,9 +45,4 @@ export type Middleware<
 	Input extends Request,
 	Output extends Response,
 	MiddlewareOptions
-> = (
-	options: MiddlewareOptions
-) => (
-	next: MiddlewareHandler<Input, Output>,
-	context: MiddlewareContext
-) => MiddlewareHandler<Input, Output>;
+> = (options: MiddlewareOptions) => ConfiguredMiddleware<Input, Output>;

--- a/packages/core/src/clients/types/index.ts
+++ b/packages/core/src/clients/types/index.ts
@@ -1,6 +1,5 @@
 export {
 	Middleware,
-	MiddlewareContext,
 	MiddlewareHandler,
 	Request,
 	Response,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
AWS SDK response and error object contains metadata to indicate how many retries the handler had conducted, like `{$metadata: { attempts: 3 }}`. This change adds the same feature to the transfer handler's retry middleware. If retry middleware is added, the thrown error or response would contain the retry information.

See [MetadataBearer interface](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/interfaces/_aws_sdk_types.MetadataBearer.html)

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Unit test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
