### PR TITLE
fix(notifications): Support use_frameworks!

### DIFF
--- a/packages/rtn-push-notification/ios/AmplifyPushNotification.m
+++ b/packages/rtn-push-notification/ios/AmplifyPushNotification.m
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#if __has_include ("AmplifyRTNPushNotification/AmplifyRTNPushNotification-Swift.h")
+#import "AmplifyRTNPushNotification/AmplifyRTNPushNotification-Swift.h"
+#else
 #import "AmplifyRTNPushNotification-Swift.h"
+#endif
 #import "AmplifyPushNotification.h"
 
 @implementation AmplifyPushNotification


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR updates the iOS Push Notification native module to look for the generated umbrella Swift header in a namespaced location if `use_frameworks!` is in the `Podfile`

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Addresses #11246

#### Description of how you validated changes
Validated this change now builds for both types of projects - with or without `use_frameworks!`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
