### PR TITLE
updated storage config type doc

### DIFF
--- a/packages/storage/src/types/AWSS3Provider.ts
+++ b/packages/storage/src/types/AWSS3Provider.ts
@@ -88,8 +88,9 @@ export type ResumableUploadConfig = {
  * Configuration options for the S3 put function.
  *
  * @remarks
- * The acl parameter may now only be used for S3 buckets with specific Object Owner
- * settings. Usage of this parameter is not considered a recommended practice. {@link https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html}
+ * The acl parameter may now only be used for S3 buckets with specific Object Owner settings.
+ * Usage of this parameter is not considered a recommended practice:
+ *  {@link https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html}
  *
  */
 export type S3ProviderPutConfig = CommonStorageOptions &
@@ -145,8 +146,9 @@ export type S3CopyDestination = Omit<S3CopyTarget, 'identityId'>;
  * Configuration options for the S3 copy function.
  *
  * @remarks
- * The acl parameter may now only be used for S3 buckets with specific Object Owner
- * settings. Usage of this parameter is not considered a recommended practice. {@link https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html}
+ * The acl parameter may now only be used for S3 buckets with specific Object Owner settings.
+ * Usage of this parameter is not considered a recommended practice:
+ *  {@link https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html}
  *
  */
 export type S3ProviderCopyConfig = Omit<CommonStorageOptions, 'level'> & {

--- a/packages/storage/src/types/AWSS3Provider.ts
+++ b/packages/storage/src/types/AWSS3Provider.ts
@@ -84,6 +84,14 @@ export type ResumableUploadConfig = {
 	errorCallback?: (err: any) => any;
 };
 
+/**
+ * Configuration options for the S3 put function.
+ *
+ * @remarks
+ * The acl parameter may now only be used for S3 buckets with specific Object Owner
+ * settings. Usage of this parameter is not considered a recommended practice. {@link https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html}
+ *
+ */
 export type S3ProviderPutConfig = CommonStorageOptions &
 	(
 		| _S3ProviderPutConfig
@@ -133,6 +141,14 @@ export type S3CopySource = S3CopyTarget;
 
 export type S3CopyDestination = Omit<S3CopyTarget, 'identityId'>;
 
+/**
+ * Configuration options for the S3 copy function.
+ *
+ * @remarks
+ * The acl parameter may now only be used for S3 buckets with specific Object Owner
+ * settings. Usage of this parameter is not considered a recommended practice. {@link https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html}
+ *
+ */
 export type S3ProviderCopyConfig = Omit<CommonStorageOptions, 'level'> & {
 	provider?: 'AWSS3';
 	bucket?: CopyObjectRequest['Bucket'];


### PR DESCRIPTION
#### Description of changes
Adds type documentation for put and copy S3 config objects noting that `acl` is not recommended.


#### Description of how you validated changes
N/A


#### Checklist
- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
