### PR TITLE
fix(datastore): add missing errorHandler errors for sync and mutation unauth responses 

### DIFF
--- a/packages/datastore/__tests__/connectivityHandling.test.ts
+++ b/packages/datastore/__tests__/connectivityHandling.test.ts
@@ -1049,4 +1049,26 @@ describe('DataStore sync engine', () => {
 		`);
 		});
 	});
+
+	describe.only('error handling', () => {
+		test('unauthorized exception', async () => {
+			graphqlService.intercept = (request, next) => {
+				if (request.query.includes('syncLegacyJSONComments')) {
+					// e.g., not logged in.
+					// comes back as an HTTP 401, but also includes `errors` array.
+					throw {
+						errors: [
+							{
+								errorType: 'UnauthorizedException',
+								message: 'Valid authorization header not provided.',
+							},
+						],
+					};
+				} else {
+					return next();
+				}
+			};
+			await waitForDataStoreReady();
+		});
+	});
 });

--- a/packages/datastore/__tests__/connectivityHandling.test.ts
+++ b/packages/datastore/__tests__/connectivityHandling.test.ts
@@ -26,13 +26,17 @@ async function waitForEmptyOutboxOrError(service) {
 	return await Promise.race([waitForEmptyOutbox(), pendingError]);
 }
 
-function waitForNextErrorHandlerError(
-	errorHandler: Observable<SyncError<any>>
-) {
+/**
+ * Creates a promise to wait for the next subscription message and
+ * returns it when it arrives.
+ *
+ * @param observable Any `Observable`
+ */
+function waitForNextMessage<T>(observable: Observable<T>) {
 	return new Promise(resolve => {
-		const subscription = errorHandler.subscribe(error => {
+		const subscription = observable.subscribe(message => {
 			subscription.unsubscribe();
-			resolve(error);
+			resolve(message);
 		});
 	});
 }
@@ -1100,7 +1104,7 @@ describe('DataStore sync engine', () => {
 				}
 			};
 
-			const error: any = await waitForNextErrorHandlerError(errorHandler);
+			const error: any = await waitForNextMessage(errorHandler);
 			expect(error.errorType).toBe('Unauthorized');
 		});
 
@@ -1134,7 +1138,7 @@ describe('DataStore sync engine', () => {
 				})
 			);
 
-			const error: any = await waitForNextErrorHandlerError(errorHandler);
+			const error: any = await waitForNextMessage(errorHandler);
 			expect(error.errorType).toBe('Unauthorized');
 		});
 	});

--- a/packages/datastore/__tests__/connectivityHandling.test.ts
+++ b/packages/datastore/__tests__/connectivityHandling.test.ts
@@ -1051,16 +1051,45 @@ describe('DataStore sync engine', () => {
 	});
 
 	describe.only('error handling', () => {
-		test('unauthorized exception', async () => {
+		// test('global UnauthorizedException', async () => {
+		// 	graphqlService.intercept = (request, next) => {
+		// 		if (request.query.includes('syncLegacyJSONComments')) {
+		// 			// e.g., not logged in.
+		// 			// comes back as an HTTP 401, but also includes `errors` array.
+		// 			throw {
+		// 				errors: [
+		// 					{
+		// 						errorType: 'UnauthorizedException',
+		// 						message: 'Valid authorization header not provided.',
+		// 					},
+		// 				],
+		// 			};
+		// 		} else {
+		// 			return next();
+		// 		}
+		// 	};
+		// 	await waitForDataStoreReady();
+		// });
+
+		// Individual unauthorized error with `null` items indicates that AppSync
+		// recognizes the auth, but the resolver rejected with $util.unauthorized()
+		// in the request mapper.
+		test('request mapper $util.unauthorized error', async () => {
 			graphqlService.intercept = (request, next) => {
 				if (request.query.includes('syncLegacyJSONComments')) {
 					// e.g., not logged in.
 					// comes back as an HTTP 401, but also includes `errors` array.
 					throw {
+						data: { syncLegacyJSONComments: null },
 						errors: [
 							{
-								errorType: 'UnauthorizedException',
-								message: 'Valid authorization header not provided.',
+								path: ['syncLegacyJSONComments'],
+								data: null,
+								errorType: 'Unauthorized',
+								errorInfo: null,
+								locations: [{ line: 2, column: 3, sourceName: null }],
+								message:
+									'Not Authorized to access syncLegacyJSONComments on type Query',
 							},
 						],
 					};
@@ -1069,6 +1098,11 @@ describe('DataStore sync engine', () => {
 				}
 			};
 			await waitForDataStoreReady();
+
+			// TODO: replace with errorHandler check.
+			// possibly make datastore factory create an error handler spy or aggregator
+			// that's passed back through getDatastore();
+			expect(true).toBe(false);
 		});
 	});
 });

--- a/packages/datastore/__tests__/connectivityHandling.test.ts
+++ b/packages/datastore/__tests__/connectivityHandling.test.ts
@@ -1065,7 +1065,7 @@ describe('DataStore sync engine', () => {
 		});
 	});
 
-	describe.only('error handling', () => {
+	describe('error handling', () => {
 		/**
 		 * NOTE that some of these tests mock sync responses, which are initiated
 		 * in the `beforeEach` one `describe` level up. This should still allow us
@@ -1074,26 +1074,6 @@ describe('DataStore sync engine', () => {
 		 * and only `DataStore.start()` in the individual tests, or instantiate
 		 * `errorHandler` listeners up a level.
 		 */
-
-		// test('global UnauthorizedException', async () => {
-		// 	graphqlService.intercept = (request, next) => {
-		// 		if (request.query.includes('syncLegacyJSONComments')) {
-		// 			// e.g., not logged in.
-		// 			// comes back as an HTTP 401, but also includes `errors` array.
-		// 			throw {
-		// 				errors: [
-		// 					{
-		// 						errorType: 'UnauthorizedException',
-		// 						message: 'Valid authorization header not provided.',
-		// 					},
-		// 				],
-		// 			};
-		// 		} else {
-		// 			return next();
-		// 		}
-		// 	};
-		// 	await waitForDataStoreReady();
-		// });
 
 		// Individual unauthorized error with `null` items indicates that AppSync
 		// recognizes the auth, but the resolver rejected with $util.unauthorized()

--- a/packages/datastore/__tests__/helpers/datastoreFactory.ts
+++ b/packages/datastore/__tests__/helpers/datastoreFactory.ts
@@ -1,3 +1,4 @@
+import { Observable, ZenObservable } from 'zen-observable-ts';
 import {
 	CONTROL_MSG as PUBSUB_CONTROL_MSG,
 	CONNECTION_STATE_CHANGE as PUBSUB_CONNECTION_STATE_CHANGE,
@@ -8,6 +9,7 @@ import {
 	initSchema as _initSchema,
 	DataStore as DataStoreInstance,
 } from '../../src/datastore/datastore';
+import { SyncError } from '../../src/types';
 import { FakeGraphQLService, FakeDataStoreConnectivity } from './fakes';
 import {
 	testSchema,
@@ -206,8 +208,23 @@ export function getDataStore({
 		DataStore: DataStoreType;
 	} = require('../../src/datastore/datastore');
 
+	let errorHandlerSubscriber: ZenObservable.SubscriptionObserver<
+		SyncError<any>
+	> | null = null;
+
+	const errorHandler = new Observable<SyncError<any>>(subscriber => {
+		errorHandlerSubscriber = subscriber;
+	});
+
+	const _errorHandler: (error: SyncError<any>) => void = error => {
+		if (errorHandlerSubscriber) {
+			errorHandlerSubscriber.next(error);
+		}
+	};
+
 	DataStore.configure({
 		storageAdapter: storageAdapterFactory(),
+		errorHandler: _errorHandler,
 	});
 
 	// private, test-only DI's.
@@ -293,6 +310,7 @@ export function getDataStore({
 
 	return {
 		DataStore,
+		errorHandler,
 		schema,
 		connectivityMonitor,
 		graphqlService,

--- a/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
+++ b/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
@@ -10,6 +10,13 @@ import { validatePredicate, getTimestampFields } from '../../../src/util';
 import { ModelPredicateCreator } from '../../../src/predicates';
 import { initSchema as _initSchema } from '../../../src/datastore/datastore';
 
+type GraphQLRequest = {
+	query: string;
+	variables: Record<string, any>;
+	authMode: string | undefined | null;
+	authToken: string | undefined | null;
+};
+
 /**
  * Statefully pretends to be AppSync, with minimal built-in asertions with
  * error callbacks and settings to help simulate various conditions.
@@ -30,6 +37,14 @@ export class FakeGraphQLService {
 		string,
 		ZenObservable.SubscriptionObserver<any>[]
 	>();
+
+	/**
+	 * Singleton middleware, basically.
+	 */
+	public intercept: (request: GraphQLRequest, next: () => any) => any = (
+		request,
+		next
+	) => next();
 
 	constructor(public schema: Schema) {
 		for (const model of Object.values(schema.models)) {
@@ -382,8 +397,8 @@ export class FakeGraphQLService {
 	 *
 	 * @param param0
 	 */
-	public graphql({ query, variables, authMode, authToken }) {
-		return this.request({ query, variables, authMode, authToken });
+	public graphql(request: GraphQLRequest) {
+		return this.intercept(request, () => this.request(request));
 	}
 
 	public request({ query, variables, authMode, authToken }) {

--- a/packages/datastore/src/sync/processors/errorMaps.ts
+++ b/packages/datastore/src/sync/processors/errorMaps.ts
@@ -22,6 +22,7 @@ export const mutationErrorMap: ErrorMap = {
 	ConfigError: () => false,
 	Transient: error => connectionTimeout(error) || serverError(error),
 	Unauthorized: error =>
+		error.message === 'Unauthorized' ||
 		/^Request failed with status code 401/.test(error.message),
 };
 
@@ -44,7 +45,7 @@ export const syncErrorMap: ErrorMap = {
 	BadRecord: error => /^Cannot return \w+ for [\w-_]+ type/.test(error.message),
 	ConfigError: () => false,
 	Transient: error => connectionTimeout(error) || serverError(error),
-	Unauthorized: () => false,
+	Unauthorized: error => (error as any).errorType === 'Unauthorized',
 };
 
 /**

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -231,6 +231,22 @@ class MutationProcessor {
 											operationAuthModes[authModeAttempts - 1]
 										}`
 									);
+									try {
+										await this.errorHandler({
+											recoverySuggestion:
+												'Ensure app code is up to date, auth directives exist and are correct on each model, and that server-side data has not been invalidated by a schema change. If the problem persists, search for or create an issue: https://github.com/aws-amplify/amplify-js/issues',
+											localModel: null!,
+											message: error.message,
+											model: modelConstructor.name,
+											operation: opName,
+											errorType: getMutationErrorType(error),
+											process: ProcessName.sync,
+											remoteModel: null!,
+											cause: error,
+										});
+									} catch (e) {
+										logger.error('Mutation error handler failed with:', e);
+									}
 									throw error;
 								}
 								logger.debug(

--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -414,11 +414,6 @@ class SyncProcessor {
 											onTerminate
 										));
 									} catch (error) {
-										console.log(
-											'received error',
-											error,
-											getSyncErrorType(error)
-										);
 										try {
 											await this.errorHandler({
 												recoverySuggestion:
@@ -435,6 +430,13 @@ class SyncProcessor {
 										} catch (e) {
 											logger.error('Sync error handler failed with:', e);
 										}
+										/**
+										 * If there's an error, this model fails, but the rest of the sync should
+										 * continue. To facilitate this, we explicitly mark this model as `done`
+										 * with no items and allow the loop to continue organically. This ensures
+										 * all callbacks (subscription messages) happen as normal, so anything
+										 * waiting on them knows the model is as done as it can be.
+										 */
 										done = true;
 										items = [];
 									}

--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -317,7 +317,7 @@ class SyncProcessor {
 							message: error.message,
 							model: modelDefinition.name,
 							operation: opName,
-							errorType: getSyncErrorType(error),
+							errorType: getSyncErrorType(error.errors[0]),
 							process: ProcessName.sync,
 							remoteModel: null!,
 							cause: error,

--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -224,10 +224,10 @@ class SyncProcessor {
 
 					// TODO: onTerminate.then(() => API.cancel(...))
 				} catch (error) {
-					console.log('error caught', error);
 					// Catch client-side (GraphQLAuthError) & 401/403 errors here so that we don't continue to retry
 					const clientOrForbiddenErrorMessage =
 						getClientSideAuthError(error) || getForbiddenError(error);
+
 					if (clientOrForbiddenErrorMessage) {
 						logger.error('Sync processor retry error:', error);
 						throw new NonRetryableError(clientOrForbiddenErrorMessage);
@@ -285,20 +285,44 @@ class SyncProcessor {
 						});
 					}
 
+					/**
+					 * Handle $util.unauthorized() in resolver request mapper, which responses with something
+					 * like this:
+					 *
+					 * ```
+					 * {
+					 * 	data: { syncYourModel: null },
+					 * 	errors: [
+					 * 		{
+					 * 			path: ['syncLegacyJSONComments'],
+					 * 			data: null,
+					 * 			errorType: 'Unauthorized',
+					 * 			errorInfo: null,
+					 * 			locations: [{ line: 2, column: 3, sourceName: null }],
+					 * 			message:
+					 * 				'Not Authorized to access syncYourModel on type Query',
+					 * 			},
+					 * 		],
+					 * 	}
+					 * ```
+					 *
+					 * The correct handling for this is to signal that we've encountered a non-retryable error,
+					 * since the server has responded with an auth error and *NO DATA* at this point.
+					 */
 					if (unauthorized) {
-						logger.warn(
-							'queryError',
-							`User is unauthorized to query ${opName}, some items could not be returned.`
-						);
-
-						result.data = result.data || {};
-
-						result.data[opName] = {
-							...opResultDefaults,
-							...result.data[opName],
-						};
-
-						return result;
+						this.errorHandler({
+							recoverySuggestion:
+								'Ensure app code is up to date, auth directives exist and are correct on each model, and that server-side data has not been invalidated by a schema change. If the problem persists, search for or create an issue: https://github.com/aws-amplify/amplify-js/issues',
+							localModel: null!,
+							message: error.message,
+							model: modelDefinition.name,
+							operation: opName,
+							errorType: getSyncErrorType(error),
+							process: ProcessName.sync,
+							remoteModel: null!,
+							cause: error,
+						});
+						throw new NonRetryableError(error);
 					}
 
 					if (result.data?.[opName].items?.length) {
@@ -390,6 +414,11 @@ class SyncProcessor {
 											onTerminate
 										));
 									} catch (error) {
+										console.log(
+											'received error',
+											error,
+											getSyncErrorType(error)
+										);
 										try {
 											await this.errorHandler({
 												recoverySuggestion:
@@ -406,7 +435,8 @@ class SyncProcessor {
 										} catch (e) {
 											logger.error('Sync error handler failed with:', e);
 										}
-										return res();
+										done = true;
+										items = [];
 									}
 
 									recordsReceived += items.length;

--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -224,6 +224,7 @@ class SyncProcessor {
 
 					// TODO: onTerminate.then(() => API.cancel(...))
 				} catch (error) {
+					console.log('error caught', error);
 					// Catch client-side (GraphQLAuthError) & 401/403 errors here so that we don't continue to retry
 					const clientOrForbiddenErrorMessage =
 						getClientSideAuthError(error) || getForbiddenError(error);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adds missing `errorHandler` events for "top level" unauthorized errors in AppSync resolvers (i.e., when resolver VTL calls `$util.unauthorized()`).

To support the testing for this, this PR adds:

1. Ability to hook into `errorHandler` using an `Observable` from the `getDatastore()` test factory.
2. Ability to inject a single `intercept` method into the graphql fake, so that individual responses can be faked in the context of a full sync. (Helpful if/when we clamp on what a single failed sync, mutation, or subscription means to the overall state of DataStore.)

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#11042

#### Description of how you validated changes

Added protocol tests based on:

1. Forcing relevant resolvers to call `$util.unauthorize`.
3. Capturing responses.
4. Added simulated responses to protocol test.
5. Add assertion for `errorHandler` to trigger an `Unauthorized` error.
6. Made the tests pass.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
