### PR TITLE
chore(clients): Make signing functions synchronous

### DIFF
--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/presignUrl-test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/presignUrl-test.ts
@@ -24,7 +24,7 @@ describe('presignUrl', () => {
 				return [name, updatedRequest, updatedOptions, expectedUrl];
 			}
 		)
-	)('presigns url with %s', async (_, request, options, expected) => {
-		expect((await presignUrl(request, options)).toString()).toBe(expected);
+	)('presigns url with %s', (_, request, options, expected) => {
+		expect(presignUrl(request, options).toString()).toBe(expected);
 	});
 });

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/signRequest-test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/signRequest-test.ts
@@ -23,9 +23,7 @@ describe('signRequest', () => {
 				return [name, updatedRequest, updatedOptions, expectedAuthorization];
 			}
 		)
-	)('signs request with %s', async (_, request, options, expected) => {
-		expect((await signRequest(request, options)).headers.authorization).toBe(
-			expected
-		);
+	)('signs request with %s', (_, request, options, expected) => {
+		expect(signRequest(request, options).headers.authorization).toBe(expected);
 	});
 });

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/dataHashHelpers-test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/dataHashHelpers-test.ts
@@ -13,8 +13,8 @@ describe('dataHashHelpers', () => {
 	const arrayBufferView = new Uint8Array(new ArrayBuffer(8));
 
 	describe('getHashedData', () => {
-		test('returns hashed data from a key and data', async () => {
-			expect(await getHashedData(key, data)).toStrictEqual(
+		test('returns hashed data from a key and data', () => {
+			expect(getHashedData(key, data)).toStrictEqual(
 				new Uint8Array([
 					232, 228, 217, 152, 156, 118, 166, 42, 124, 217, 129, 99, 56, 163,
 					190, 131, 62, 148, 54, 170, 101, 55, 158, 118, 42, 239, 245, 136, 153,
@@ -22,7 +22,7 @@ describe('dataHashHelpers', () => {
 				])
 			);
 
-			expect(await getHashedData(arrayBuffer, arrayBuffer)).toStrictEqual(
+			expect(getHashedData(arrayBuffer, arrayBuffer)).toStrictEqual(
 				new Uint8Array([
 					243, 117, 24, 10, 186, 146, 136, 132, 1, 241, 145, 155, 228, 168, 113,
 					90, 98, 118, 59, 101, 193, 193, 14, 29, 8, 88, 232, 29, 77, 111, 159,
@@ -30,9 +30,7 @@ describe('dataHashHelpers', () => {
 				])
 			);
 
-			expect(
-				await getHashedData(arrayBufferView, arrayBufferView)
-			).toStrictEqual(
+			expect(getHashedData(arrayBufferView, arrayBufferView)).toStrictEqual(
 				new Uint8Array([
 					243, 117, 24, 10, 186, 146, 136, 132, 1, 241, 145, 155, 228, 168, 113,
 					90, 98, 118, 59, 101, 193, 193, 14, 29, 8, 88, 232, 29, 77, 111, 159,
@@ -41,8 +39,8 @@ describe('dataHashHelpers', () => {
 			);
 		});
 
-		test('returns hashed data from just data', async () => {
-			expect(await getHashedData(null, data)).toStrictEqual(
+		test('returns hashed data from just data', () => {
+			expect(getHashedData(null, data)).toStrictEqual(
 				new Uint8Array([
 					113, 23, 15, 47, 24, 62, 16, 92, 220, 133, 238, 126, 50, 50, 172, 161,
 					24, 87, 60, 247, 83, 37, 49, 75, 190, 87, 74, 159, 224, 95, 47, 233,
@@ -52,24 +50,24 @@ describe('dataHashHelpers', () => {
 	});
 
 	describe('getHashedDataAsHex', () => {
-		test('returns hashed data from a key and data', async () => {
-			expect(await getHashedDataAsHex(key, data)).toStrictEqual(
+		test('returns hashed data from a key and data', () => {
+			expect(getHashedDataAsHex(key, data)).toStrictEqual(
 				'e8e4d9989c76a62a7cd9816338a3be833e9436aa65379e762aeff5889973299c'
 			);
 
-			expect(await getHashedDataAsHex(arrayBuffer, arrayBuffer)).toStrictEqual(
+			expect(getHashedDataAsHex(arrayBuffer, arrayBuffer)).toStrictEqual(
 				'f375180aba92888401f1919be4a8715a62763b65c1c10e1d0858e81d4d6f9fd2'
 			);
 
 			expect(
-				await getHashedDataAsHex(arrayBufferView, arrayBufferView)
+				getHashedDataAsHex(arrayBufferView, arrayBufferView)
 			).toStrictEqual(
 				'f375180aba92888401f1919be4a8715a62763b65c1c10e1d0858e81d4d6f9fd2'
 			);
 		});
 
-		test('returns hashed data from just data', async () => {
-			expect(await getHashedDataAsHex(null, data)).toStrictEqual(
+		test('returns hashed data from just data', () => {
+			expect(getHashedDataAsHex(null, data)).toStrictEqual(
 				'71170f2f183e105cdc85ee7e3232aca118573cf75325314bbe574a9fe05f2fe9'
 			);
 		});

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getCanonicalRequest-test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getCanonicalRequest-test.ts
@@ -4,13 +4,13 @@
 import { getCanonicalRequest } from '../../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getCanonicalRequest';
 
 describe('getCanonicalRequest', () => {
-	test('returns a canonical request', async () => {
+	test('returns a canonical request', () => {
 		const request = {
 			headers: {},
 			method: 'POST',
 			url: new URL('https://sub.domain'),
 		};
-		expect(await getCanonicalRequest(request)).toBe(
+		expect(getCanonicalRequest(request)).toBe(
 			'POST\n/\n\n\n\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 		);
 	});

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getHashedPayload-test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getHashedPayload-test.ts
@@ -4,38 +4,34 @@
 import { getHashedPayload } from '../../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getHashedPayload';
 
 describe('getHashedPayload', () => {
-	test('returns empty hash if nullish', async () => {
-		expect(await getHashedPayload(undefined)).toStrictEqual(
+	test('returns empty hash if nullish', () => {
+		expect(getHashedPayload(undefined)).toStrictEqual(
 			'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 		);
-		expect(await getHashedPayload(null as any)).toStrictEqual(
+		expect(getHashedPayload(null as any)).toStrictEqual(
 			'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 		);
 	});
 
-	test('returns hashed payload', async () => {
-		expect(await getHashedPayload('string-body')).toStrictEqual(
+	test('returns hashed payload', () => {
+		expect(getHashedPayload('string-body')).toStrictEqual(
 			'f4241e27b103e1a1d7f88a1556541718250245fe31c8e695f3e068d3fe837572'
 		);
 	});
 
-	test('works with ArrayBuffer', async () => {
-		expect(await getHashedPayload(new ArrayBuffer(8))).toStrictEqual(
+	test('works with ArrayBuffer', () => {
+		expect(getHashedPayload(new ArrayBuffer(8))).toStrictEqual(
 			'af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc'
 		);
 
-		expect(
-			await getHashedPayload(new Uint8Array(new ArrayBuffer(8)))
-		).toStrictEqual(
+		expect(getHashedPayload(new Uint8Array(new ArrayBuffer(8)))).toStrictEqual(
 			'af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc'
 		);
 	});
 
-	test('returns unsigned payload if not hashable', async () => {
+	test('returns unsigned payload if not hashable', () => {
 		for (const scalar of [123.234, true, new Blob()]) {
-			expect(await getHashedPayload(scalar as any)).toStrictEqual(
-				'UNSIGNED-PAYLOAD'
-			);
+			expect(getHashedPayload(scalar as any)).toStrictEqual('UNSIGNED-PAYLOAD');
 		}
 	});
 });

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getSignature-test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getSignature-test.ts
@@ -12,7 +12,7 @@ import {
 import { getSignature } from '../../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getSignature';
 
 describe('getSignature', () => {
-	test('returns signature', async () => {
+	test('returns signature', () => {
 		const { longDate, shortDate } = formattedDates;
 		const signingValues = {
 			...credentials,
@@ -22,9 +22,7 @@ describe('getSignature', () => {
 			signingRegion,
 			signingService,
 		};
-		expect(
-			await getSignature(getDefaultRequest(), signingValues)
-		).toStrictEqual(
+		expect(getSignature(getDefaultRequest(), signingValues)).toStrictEqual(
 			'145191af25230efbe34c7eb79d9d3ce881f7a945d02d0361719107147d0086b3'
 		);
 	});

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getSigningKey-test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getSigningKey-test.ts
@@ -4,9 +4,9 @@
 import { getSigningKey } from '../../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getSigningKey';
 
 describe('getSigningKey', () => {
-	test('returns a signing key', async () => {
+	test('returns a signing key', () => {
 		expect(
-			await getSigningKey('secret-access-key', '20200918', 'region', 'service')
+			getSigningKey('secret-access-key', '20200918', 'region', 'service')
 		).toStrictEqual(
 			new Uint8Array([
 				79, 189, 20, 186, 57, 62, 187, 22, 80, 142, 29, 192, 182, 56, 183, 254,

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getStringToSign-test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getStringToSign-test.ts
@@ -5,9 +5,9 @@ import { credentialScope, formattedDates } from '../testUtils/data';
 import { getStringToSign } from '../../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getStringToSign';
 
 describe('getStringToSign', () => {
-	test('returns signature', async () => {
+	test('returns signature', () => {
 		expect(
-			await getStringToSign(
+			getStringToSign(
 				formattedDates.longDate,
 				credentialScope,
 				'hashed-request'

--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/presignUrl.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/presignUrl.ts
@@ -23,10 +23,10 @@ import { getSignature } from './utils/getSignature';
  * @param presignUrlOptions `PresignUrlOptions` object containing values used to construct the signature.
  * @returns A `URL` with authentication query params which can grant temporary access to AWS resources.
  */
-export const presignUrl = async (
+export const presignUrl = (
 	{ body, method = 'GET', url }: Presignable,
 	{ expiration, ...options }: PresignUrlOptions
-): Promise<URL> => {
+): URL => {
 	const signingValues = getSigningValues(options);
 	const { accessKeyId, credentialScope, longDate, sessionToken } =
 		signingValues;
@@ -51,7 +51,7 @@ export const presignUrl = async (
 	};
 
 	// calculate and add the signature to the url
-	const signature = await getSignature(requestToSign, signingValues);
+	const signature = getSignature(requestToSign, signingValues);
 	presignedUrl.searchParams.append(SIGNATURE_QUERY_PARAM, signature);
 
 	return presignedUrl;

--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/signRequest.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/signRequest.ts
@@ -21,10 +21,10 @@ import { getSignature } from './utils/getSignature';
  * @param signRequestOptions `SignRequestOptions` object containing values used to construct the signature.
  * @returns A `HttpRequest` with authentication headers which can grant temporary access to AWS resources.
  */
-export const signRequest = async (
+export const signRequest = (
 	request: HttpRequest,
 	options: SignRequestOptions
-): Promise<HttpRequest> => {
+): HttpRequest => {
 	const signingValues = getSigningValues(options);
 	const { accessKeyId, credentialScope, longDate, sessionToken } =
 		signingValues;
@@ -39,7 +39,7 @@ export const signRequest = async (
 	const requestToSign = { ...request, headers };
 
 	// calculate and add the signature to the request
-	const signature = await getSignature(requestToSign, signingValues);
+	const signature = getSignature(requestToSign, signingValues);
 	const credentialEntry = `Credential=${accessKeyId}/${credentialScope}`;
 	const signedHeadersEntry = `SignedHeaders=${getSignedHeaders(headers)}`;
 	const signatureEntry = `Signature=${signature}`;

--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/dataHashHelpers.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/dataHashHelpers.ts
@@ -13,13 +13,14 @@ import { toHex } from '@aws-sdk/util-hex-encoding';
  * @param data Hashable `SourceData`.
  * @returns `Uint8Array` created from the data as input to a hash function.
  */
-export const getHashedData = async (
+export const getHashedData = (
 	key: SourceData | null,
 	data: SourceData
-): Promise<Uint8Array> => {
+): Uint8Array => {
 	const sha256 = new Sha256(key);
 	sha256.update(data);
-	const hashedData = await sha256.digest();
+	// TODO: V6 flip to async digest
+	const hashedData = sha256.digestSync();
 	return hashedData;
 };
 
@@ -30,10 +31,10 @@ export const getHashedData = async (
  * @param data Hashable `SourceData`.
  * @returns String using lowercase hexadecimal characters created from the data as input to a hash function.
  */
-export const getHashedDataAsHex = async (
+export const getHashedDataAsHex = (
 	key: SourceData | null,
 	data: SourceData
-): Promise<string> => {
-	const hashedData = await getHashedData(key, data);
+): string => {
+	const hashedData = getHashedData(key, data);
 	return toHex(hashedData);
 };

--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getCanonicalRequest.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getCanonicalRequest.ts
@@ -20,17 +20,17 @@ import { getSignedHeaders } from './getSignedHeaders';
  * - SignedHeaders
  * - HashedPayload
  */
-export const getCanonicalRequest = async ({
+export const getCanonicalRequest = ({
 	body,
 	headers,
 	method,
 	url,
-}: HttpRequest): Promise<string> =>
+}: HttpRequest): string =>
 	[
 		method,
 		getCanonicalUri(url.pathname),
 		getCanonicalQueryString(url.searchParams),
 		getCanonicalHeaders(headers),
 		getSignedHeaders(headers),
-		await getHashedPayload(body),
+		getHashedPayload(body),
 	].join('\n');

--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getHashedPayload.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getHashedPayload.ts
@@ -13,16 +13,14 @@ import { getHashedDataAsHex } from './dataHashHelpers';
  * @returns String created using the payload in the body of the HTTP request as input to a hash function. This string
  * uses lowercase hexadecimal characters. If the payload is empty, return precalculated result of an empty hash.
  */
-export const getHashedPayload = async (
-	body: HttpRequest['body']
-): Promise<string> => {
+export const getHashedPayload = (body: HttpRequest['body']): string => {
 	// return precalculated empty hash if body is undefined or null
 	if (body == null) {
 		return EMPTY_HASH;
 	}
 
 	if (isSourceData(body)) {
-		const hashedData = await getHashedDataAsHex(null, body);
+		const hashedData = getHashedDataAsHex(null, body);
 		return hashedData;
 	}
 

--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getSignature.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getSignature.ts
@@ -16,7 +16,7 @@ import { getStringToSign } from './getStringToSign';
  * @param signRequestOptions `SignRequestOptions` object containing values used to construct the signature.
  * @returns AWS API Signature to sign a request or url with.
  */
-export const getSignature = async (
+export const getSignature = (
 	request: HttpRequest,
 	{
 		credentialScope,
@@ -26,28 +26,23 @@ export const getSignature = async (
 		signingRegion,
 		signingService,
 	}: SigningValues
-): Promise<string> => {
+): string => {
 	// step 1: create a canonical request
-	const canonicalRequest = await getCanonicalRequest(request);
+	const canonicalRequest = getCanonicalRequest(request);
 
 	// step 2: create a hash of the canonical request
-	const hashedRequest = await getHashedDataAsHex(null, canonicalRequest);
+	const hashedRequest = getHashedDataAsHex(null, canonicalRequest);
 
 	// step 3: create a string to sign
-	const stringToSign = await getStringToSign(
+	const stringToSign = getStringToSign(
 		longDate,
 		credentialScope,
 		hashedRequest
 	);
 
 	// step 4: calculate the signature
-	const signature = await getHashedDataAsHex(
-		await getSigningKey(
-			secretAccessKey,
-			shortDate,
-			signingRegion,
-			signingService
-		),
+	const signature = getHashedDataAsHex(
+		getSigningKey(secretAccessKey, shortDate, signingRegion, signingService),
 		stringToSign
 	);
 

--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getSigningKey.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getSigningKey.ts
@@ -14,16 +14,16 @@ import { getHashedData } from './dataHashHelpers';
  *
  * @returns `Uint8Array` calculated from its composite parts.
  */
-export const getSigningKey = async (
+export const getSigningKey = (
 	secretAccessKey: string,
 	date: string,
 	region: string,
 	service: string
-): Promise<Uint8Array> => {
+): Uint8Array => {
 	const key = `${SIGNATURE_IDENTIFIER}${secretAccessKey}`;
-	const dateKey = await getHashedData(key, date);
-	const regionKey = await getHashedData(dateKey, region);
-	const serviceKey = await getHashedData(regionKey, service);
-	const signingKey = await getHashedData(serviceKey, KEY_TYPE_IDENTIFIER);
+	const dateKey = getHashedData(key, date);
+	const regionKey = getHashedData(dateKey, region);
+	const serviceKey = getHashedData(regionKey, service);
+	const signingKey = getHashedData(serviceKey, KEY_TYPE_IDENTIFIER);
 	return signingKey;
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
In order to limit the impact of updating our existing Signer to use the updated signing functions, the underlying signing functions need to be synchronous calls as well. We will revisit this in the future in a breaking change.

#### Description of how you validated changes
Tested that signing functions now generate the same output without being `await`ed.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
