### PR TITLE
feat(clients): support CN partition by adding DNS suffix resolver

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -64,7 +64,7 @@
 			"name": "Analytics (Pinpoint)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Analytics, AWSPinpointProvider }",
-			"limit": "56.5 kB"
+			"limit": "54.7 kB"
 		},
 		{
 			"name": "Analytics (Kinesis)",

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -64,7 +64,7 @@
       "name": "API (GraphQL client)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, GraphQLAPI }",
-      "limit": "86.49 kB"
+      "limit": "86.5 kB"
     }
   ],
   "jest": {

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -64,7 +64,7 @@
       "name": "API (GraphQL client)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, GraphQLAPI }",
-      "limit": "86.5 kB"
+      "limit": "86.85 kB"
     }
   ],
   "jest": {

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -55,7 +55,7 @@
       "name": "API (rest client)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, RestAPI }",
-      "limit": "29.22 kB"
+      "limit": "29.5 kB"
     }
   ],
   "jest": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -66,7 +66,7 @@
 			"name": "API (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, API }",
-			"limit": "87.85 kB"
+			"limit": "88.1 kB"
 		}
 	],
 	"jest": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -58,7 +58,7 @@
       "name": "Auth (top-level class)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, Auth }",
-      "limit": "53.5 kB"
+      "limit": "53.7 kB"
     }
   ],
   "jest": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -62,7 +62,7 @@
       "name": "Cache (in-memory)",
       "path": "./lib-esm/index.js",
       "import": "{ InMemoryCache }",
-      "limit": "3.75 kB"
+      "limit": "3.7 kB"
     }
   ],
   "jest": {

--- a/packages/core/__tests__/clients/endpoints-test.ts
+++ b/packages/core/__tests__/clients/endpoints-test.ts
@@ -1,0 +1,22 @@
+import { getDnsSuffix } from '../../src/clients/endpoints';
+
+describe(getDnsSuffix.name, () => {
+	test.each([
+		['happy case aws partition', 'af-south-1', 'amazonaws.com'],
+		['happy case aws partition', 'us-east-1', 'amazonaws.com'],
+		['infer aws partition', 'us-unspecified-99', 'amazonaws.com'],
+		['infer aws partition', 'eu-unspecified-99', 'amazonaws.com'],
+		['infer aws partition', 'ap-unspecified-99', 'amazonaws.com'],
+		['infer aws partition', 'sa-unspecified-99', 'amazonaws.com'],
+		['infer aws partition', 'ca-unspecified-99', 'amazonaws.com'],
+		['infer aws partition', 'me-unspecified-99', 'amazonaws.com'],
+		['infer aws partition', 'af-unspecified-99', 'amazonaws.com'],
+		['aws partition global', 'aws-global', 'amazonaws.com'],
+		['happy case cn partition', 'cn-north-1', 'amazonaws.com.cn'],
+		['infer cn partition', 'cn-unspecified-99', 'amazonaws.com.cn'],
+		['cn partition global', 'aws-cn-global', 'amazonaws.com.cn'],
+		['fallback to default partition', 'unrecognized-region', 'amazonaws.com'],
+	])(`%s -- resolve region %s to dnsSuffix %s`, (_, region, dnsSuffix) => {
+		expect(getDnsSuffix(region)).toEqual(dnsSuffix);
+	});
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -100,7 +100,7 @@
 			"name": "Core (Credentials)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Credentials }",
-			"limit": "11.7 kB"
+			"limit": "12 kB"
 		},
 		{
 			"name": "Core (Signer)",

--- a/packages/core/src/AwsClients/CognitoIdentity/base.ts
+++ b/packages/core/src/AwsClients/CognitoIdentity/base.ts
@@ -3,6 +3,7 @@
 
 import type {
 	Endpoint,
+	EndpointResolverOptions,
 	Headers,
 	HttpRequest,
 	HttpResponse,
@@ -23,11 +24,10 @@ import { getAmplifyUserAgent } from '../../Platform';
  */
 const SERVICE_NAME = 'cognito-identity';
 
-type EndpointOptions = { region: string };
 /**
  * The endpoint resolver function that returns the endpoint URL for a given region.
  */
-const endpointResolver = ({ region }: EndpointOptions) => ({
+const endpointResolver = ({ region }: EndpointResolverOptions) => ({
 	url: new URL(`https://cognito-identity.${region}.${getDnsSuffix(region)}`),
 });
 

--- a/packages/core/src/AwsClients/CognitoIdentity/base.ts
+++ b/packages/core/src/AwsClients/CognitoIdentity/base.ts
@@ -8,6 +8,7 @@ import type {
 	HttpResponse,
 	Middleware,
 } from '../../clients/types';
+import { getDnsSuffix } from '../../clients/endpoints';
 import { composeTransferHandler } from '../../clients/internal/composeTransferHandler';
 import { unauthenticatedHandler } from '../../clients/handlers/unauthenticated';
 import {
@@ -22,13 +23,12 @@ import { getAmplifyUserAgent } from '../../Platform';
  */
 const SERVICE_NAME = 'cognito-identity';
 
+type EndpointOptions = { region: string };
 /**
  * The endpoint resolver function that returns the endpoint URL for a given region.
  */
-const endpointResolver = (endpointOptions: { region: string }) => ({
-	url: new URL(
-		`https://cognito-identity.${endpointOptions.region}.amazonaws.com`
-	),
+const endpointResolver = ({ region }: EndpointOptions) => ({
+	url: new URL(`https://cognito-identity.${region}.${getDnsSuffix(region)}`),
 });
 
 /**

--- a/packages/core/src/clients/endpoints/getDnsSuffix.ts
+++ b/packages/core/src/clients/endpoints/getDnsSuffix.ts
@@ -1,0 +1,26 @@
+import partitionsInfo from './partitions';
+
+/**
+ * Get the AWS Services endpoint URL's DNS suffix for a given region. A typical AWS regional service endpoint URL will
+ * follow this pattern: {endpointPrefix}.{region}.{dnsSuffix}. For example, the endpoint URL for Cognito Identity in
+ * us-east-1 will be cognito-identity.us-east-1.amazonaws.com. Here the DnsSuffix is `amazonaws.com`.
+ *
+ * @param region
+ * @returns The DNS suffix
+ *
+ * @internal
+ */
+export const getDnsSuffix = (region: string): string => {
+	const { partitions } = partitionsInfo;
+	for (const { regions, outputs, regionRegex } of partitions) {
+		const regex = new RegExp(regionRegex);
+		if (regions.includes(region) || regex.test(region)) {
+			return outputs.dnsSuffix;
+		}
+	}
+
+	const defaultPartition = partitions.find(
+		partition => partition.id === 'aws'
+	)!;
+	return defaultPartition.outputs.dnsSuffix;
+};

--- a/packages/core/src/clients/endpoints/getDnsSuffix.ts
+++ b/packages/core/src/clients/endpoints/getDnsSuffix.ts
@@ -1,4 +1,7 @@
-import partitionsInfo from './partitions';
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { defaultPartition, partitionsInfo } from './partitions';
 
 /**
  * Get the AWS Services endpoint URL's DNS suffix for a given region. A typical AWS regional service endpoint URL will
@@ -18,9 +21,5 @@ export const getDnsSuffix = (region: string): string => {
 			return outputs.dnsSuffix;
 		}
 	}
-
-	const defaultPartition = partitions.find(
-		partition => partition.id === 'aws'
-	)!;
 	return defaultPartition.outputs.dnsSuffix;
 };

--- a/packages/core/src/clients/endpoints/index.ts
+++ b/packages/core/src/clients/endpoints/index.ts
@@ -1,0 +1,1 @@
+export { getDnsSuffix } from './getDnsSuffix';

--- a/packages/core/src/clients/endpoints/index.ts
+++ b/packages/core/src/clients/endpoints/index.ts
@@ -1,1 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 export { getDnsSuffix } from './getDnsSuffix';

--- a/packages/core/src/clients/endpoints/partitions.ts
+++ b/packages/core/src/clients/endpoints/partitions.ts
@@ -1,22 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
- * This file is adapted from the partition file from AWS SDK shared utilities but remove some contents for bundle size
+ * Default partition for AWS services. This is used when the region is not provided or the region is not recognized.
+ *
+ * @internal
+ */
+export const defaultPartition = {
+	id: 'aws',
+	outputs: {
+		dnsSuffix: 'amazonaws.com',
+	},
+	regionRegex: '^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$',
+	regions: ['aws-global'],
+};
+
+/**
+ * This data is adapted from the partition file from AWS SDK shared utilities but remove some contents for bundle size
  * concern. Information removed are `dualStackDnsSuffix`, `supportDualStack`, `supportFIPS`, restricted partitions, and
  * list of regions for each partition other than global regions.
  *
  * * Ref: https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints
  * * Ref: https://github.com/aws/aws-sdk-js-v3/blob/0201baef03c2379f1f6f7150b9d401d4b230d488/packages/util-endpoints/src/lib/aws/partitions.json#L1
+ *
  * @internal
  */
-const partitionsInfo = {
+export const partitionsInfo = {
 	partitions: [
-		{
-			id: 'aws',
-			outputs: {
-				dnsSuffix: 'amazonaws.com',
-			},
-			regionRegex: '^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$',
-			regions: ['aws-global'],
-		},
+		defaultPartition,
 		{
 			id: 'aws-cn',
 			outputs: {
@@ -27,8 +38,3 @@ const partitionsInfo = {
 		},
 	],
 };
-
-/**
- * @internal
- */
-export default partitionsInfo;

--- a/packages/core/src/clients/endpoints/partitions.ts
+++ b/packages/core/src/clients/endpoints/partitions.ts
@@ -1,0 +1,34 @@
+/**
+ * This file is adapted from the partition file from AWS SDK shared utilities but remove some contents for bundle size
+ * concern. Information removed are `dualStackDnsSuffix`, `supportDualStack`, `supportFIPS`, restricted partitions, and
+ * list of regions for each partition other than global regions.
+ *
+ * * Ref: https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints
+ * * Ref: https://github.com/aws/aws-sdk-js-v3/blob/0201baef03c2379f1f6f7150b9d401d4b230d488/packages/util-endpoints/src/lib/aws/partitions.json#L1
+ * @internal
+ */
+const partitionsInfo = {
+	partitions: [
+		{
+			id: 'aws',
+			outputs: {
+				dnsSuffix: 'amazonaws.com',
+			},
+			regionRegex: '^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$',
+			regions: ['aws-global'],
+		},
+		{
+			id: 'aws-cn',
+			outputs: {
+				dnsSuffix: 'amazonaws.com.cn',
+			},
+			regionRegex: '^cn\\-\\w+\\-\\d+$',
+			regions: ['aws-cn-global'],
+		},
+	],
+};
+
+/**
+ * @internal
+ */
+export default partitionsInfo;

--- a/packages/core/src/clients/types/aws.ts
+++ b/packages/core/src/clients/types/aws.ts
@@ -8,9 +8,14 @@ export type { Credentials } from '@aws-sdk/types';
 
 export type SourceData = string | ArrayBuffer | ArrayBufferView;
 
+/**
+ * Basic option type for endpoint resolvers. It contains region only.
+ */
+export type EndpointResolverOptions = { region: string };
+
 export interface ServiceClientOptions {
 	region: string;
-	endpointResolver: (input: { region: string }) => Endpoint;
+	endpointResolver: (options: EndpointResolverOptions) => Endpoint;
 }
 
 /**

--- a/packages/core/src/clients/types/index.ts
+++ b/packages/core/src/clients/types/index.ts
@@ -17,4 +17,9 @@ export {
 	HttpTransferOptions,
 	ResponseBodyMixin,
 } from './http';
-export { Credentials, ServiceClientOptions, ErrorParser } from './aws';
+export {
+	Credentials,
+	EndpointResolverOptions,
+	ErrorParser,
+	ServiceClientOptions,
+} from './aws';

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -72,7 +72,7 @@
 			"name": "DataStore (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, DataStore }",
-			"limit": "135.85 kB"
+			"limit": "136.1 kB"
 		}
 	],
 	"jest": {

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -57,7 +57,7 @@
 			"name": "Geo (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Geo }",
-			"limit": "50.2 kB"
+			"limit": "50.5 kB"
 		}
 	],
 	"jest": {

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -59,7 +59,7 @@
 			"name": "Interactions (top-level class with Lex v2)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Interactions, AWSLexV2Provider }",
-			"limit": "74.1 kB"
+			"limit": "74.5 kB"
 		}
 	],
 	"jest": {

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -60,13 +60,13 @@
 			"name": "Notifications (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Notifications }",
-			"limit": "59 kB"
+			"limit": "59.3 kB"
 		},
 		{
 			"name": "Notifications (with Analytics)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Notifications, Analytics }",
-			"limit": "59 kB"
+			"limit": "59.3 kB"
 		}
 	],
 	"devDependencies": {

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -63,13 +63,13 @@
       "name": "PubSub (IoT provider)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, PubSub, AWSIoTProvider }",
-      "limit": "78.76 kB"
+      "limit": "79.1 kB"
     },
     {
       "name": "PubSub (Mqtt provider)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, PubSub, MqttOverWSProvider }",
-      "limit": "78.61 kB"
+      "limit": "78.9 kB"
     }
   ],
   "jest": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -60,7 +60,7 @@
       "name": "Storage (top-level class)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, Storage }",
-      "limit": "87 kB"
+      "limit": "84.8 kB"
     }
   ],
   "jest": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Make sure the custom endpoint resolver can resolve endpoint suffix to `amazonaws.com.cn` when region is in CN partition.


#### Description of how you validated changes
Unit test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
