### PR TITLE
TypeScript support for Amplify Hub channels

### DIFF
--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Auth } from './Auth';
+import { Auth, AuthHubChannelMap } from './Auth';
 import {
 	CognitoHostedUIIdentityProvider,
 	SignUpParams,
@@ -20,6 +20,7 @@ import { AuthErrorStrings } from './common/AuthErrorStrings';
 export default Auth;
 export {
 	Auth,
+	AuthHubChannelMap,
 	CognitoUser,
 	CookieStorage,
 	CognitoHostedUIIdentityProvider,

--- a/packages/aws-amplify/__tests__/exports-test.ts
+++ b/packages/aws-amplify/__tests__/exports-test.ts
@@ -28,14 +28,15 @@ describe('aws-amplify', () => {
 			  "Notifications",
 			  "Predictions",
 			  "Logger",
-			  "Hub",
 			  "ClientDevice",
+			  "HubClass",
 			  "Signer",
 			  "I18n",
 			  "ServiceWorker",
 			  "AWSCloudWatchProvider",
 			  "withSSRContext",
 			  "Geo",
+			  "Hub",
 			]
 		`);
 		});

--- a/packages/aws-amplify/src/index.ts
+++ b/packages/aws-amplify/src/index.ts
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { AuthHubChannelMap } from '@aws-amplify/auth';
+import { Hub as HubBase, HubClass } from '@aws-amplify/core';
+
 export { Amplify } from '@aws-amplify/core';
 export {
 	Analytics,
@@ -27,8 +30,9 @@ export { Notifications } from '@aws-amplify/notifications';
 export { Predictions } from '@aws-amplify/predictions';
 export {
 	ConsoleLogger as Logger,
-	Hub,
 	ClientDevice,
+	HubClass,
+	InferHubTypes,
 	Signer,
 	I18n,
 	ServiceWorker,
@@ -36,3 +40,5 @@ export {
 } from '@aws-amplify/core';
 export { withSSRContext } from './withSSRContext';
 export { Geo } from '@aws-amplify/geo';
+
+export const Hub = HubBase as unknown as HubClass<AuthHubChannelMap>;

--- a/packages/core/__tests__/HubTypes-test.ts
+++ b/packages/core/__tests__/HubTypes-test.ts
@@ -1,0 +1,74 @@
+import { HubClass, InferHubTypes } from '../src';
+
+function assertType<T>(_: T): void {}
+
+type ChannelMap = {
+	channel1: {
+		event: {
+			field1: boolean;
+			field2: number;
+		};
+		event2: number | undefined;
+		event3: undefined;
+	};
+	channel2: {
+		event: {
+			field1: boolean;
+			field2: number;
+		};
+		event2: boolean | undefined;
+	};
+};
+
+const hub = new HubClass<ChannelMap>('TypedHub');
+
+describe('Hub type tests', () => {
+	test('Typed listen', () => {
+		hub.listen('channel1', test => {
+			if (test.payload.event === 'event') {
+				assertType<boolean>(test.payload.data.field1);
+			} else if (test.payload.event === 'event2') {
+				assertType<number | undefined>(test.payload.data);
+			} else if (test.payload.event === 'event3') {
+				assertType<undefined>(test.payload.data);
+			}
+		});
+
+		hub.listen('unknownChannel', test => {
+			assertType<any>(test.payload.data);
+			assertType<string>(test.payload.event);
+		});
+
+		const regex = /test/;
+		hub.listen(regex, test => {
+			assertType<any>(test.payload.data);
+			assertType<string>(test.payload.event);
+		});
+	});
+
+	test('Typed dispatch', () => {
+		hub.dispatch('channel1', {
+			event: 'event',
+			data: { field1: true, field2: 2 },
+		});
+		hub.dispatch('channel1', { event: 'event2', data: 42 });
+		hub.dispatch('channel1', { event: 'event3' });
+
+		// NOTE [Nikola Milovic] If typescript version gets updated to > 3.9.0 we can also use expect errors to further test the types
+		// (@)ts-expect-error
+		/* testHub.dispatch("channel1", { event: "event" }); */
+	});
+
+	test('Composite Hubs', () => {
+		type CustomPayloadType = { channel1: { event: boolean } };
+		type OtherPayloadType = { channel2: { event: number; event2: boolean } };
+		const OtherHub = new HubClass<OtherPayloadType>('__default__');
+		const CompositeHub = new HubClass<
+			CustomPayloadType & InferHubTypes<typeof OtherHub>
+		>('HubName');
+
+		// Has access to channels from both Hubs
+		CompositeHub.listen('channel1', _ => {});
+		CompositeHub.listen('channel2', _ => {});
+	});
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,15 @@ export { AmplifyClass } from './Amplify';
 export { ClientDevice } from './ClientDevice';
 export { ConsoleLogger, ConsoleLogger as Logger } from './Logger';
 export { invalidParameter, missingConfig } from './Errors';
-export { Hub, HubCapsule, HubCallback, HubPayload } from './Hub';
+export {
+	Hub,
+	HubCapsule,
+	HubCallback,
+	HubPayload,
+	HubClass,
+	InferHubTypes,
+	GetHubPayloads,
+} from './Hub';
 export { I18n } from './I18n';
 export {
 	browserOrNode,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
As I was getting started with Amplify and trying to get the Auth working, I noticed that figuring out the payloads of the Auth events was very difficult, I encountered the issue from 2020 https://github.com/aws-amplify/amplify-js/issues/5997, and even though there is an RFC for it now, it doesn't seem to be worked on, so I thought to try and help out. This PR adds type support and type safety for existing codebases and channels, as well as support for custom channels in the Hub. The changes include full support for typed `listen`, `dispatch`, and `remove` functions, along with some utility types. This PR covers both internal channels, as well as custom user-defined channels and their type-safety.

There are probably some quirks or things missing, feel free to push changes where you see fit, I am by no means a Typescript expert nor very familiar with the inner workings of the library.

Goals:

- Non-breaking changes, purely focused on type enhancements, ensuring no disruption to existing user code.
- Preserve the functionality of the existing Hub code. Everything defaults to `any`.
- Enable users to pass in their own channels for the Hub.
- Prevent Hub from depending on other packages. Each package should define its own types for hub channels, maintaining Hub's independence.
- Added tests for the new features.
- Provided support for autocompletion on known channels, while also allowing arbitrary channels that default to any (helps with adoption of typed hub).
- Support for RegExp (`payload.data` defaults to any).
- Supported arbitrary channels without type safety.

### Notes
1. This PR adds type definitions for channels in the Auth package as a proof of concept. If this approach is well-received, we can implement type definitions for other packages as well.
2. If there are any TS wizards up for a challenge you can look into simplifying and improving the types present in this PR. I tried to make it as clean as possible while keeping all of the functionality that I aimed for. There are some weird things that I had to navigate due to the older version of TS `v3.8.3`
3. `RegExp` and Unknown channels default to `data?: any`, I couldn't find any magic way of having type-safety for `RegExp`
4. This is only a POC, there might be a better implementation, so this can serve as an inspiration at the very least


### Acknowledgment
Many thanks to `@angryzor`, `@ssalbdivad`, and `@Ascor` from the TypeScript community for their invaluable assistance on navigating the quirks of Typescript. `@arlyon` for the original issue and inspiration

### Issue #, if available
https://github.com/aws-amplify/amplify-js/issues/11113
https://github.com/aws-amplify/amplify-js/issues/5997

### Description of how you validated changes

Wrote tests for the types, in the [HubTypes-test.ts](https://github.com/Nikola-Milovic/amplify-js/blob/poc/typed-hub/packages/core/__tests__/HubTypes-test.ts)

Also tried it in a local project with the help of `Verdaccio` so the examples should be very close to what the end user would experience. 

### New behavior 

#### Typesafe Auth channel
https://user-images.githubusercontent.com/50072027/235685955-3e88112e-ddba-42e7-b2ed-3a585e35a647.mp4

#### Autocompletion
https://user-images.githubusercontent.com/50072027/235686230-a6133547-f2e8-47ef-915e-d1b4ee6e869d.mp4

#### User defined Hubs
You can use the helper type `InferHubTypes` to get the types of another Hub. Useful when you want to wrap the default Hub with your own custom channels.

**Types**
https://user-images.githubusercontent.com/50072027/235686925-b4e9cec3-d52a-4eb8-bb60-d6b78d5f4751.mp4

**Dispatch**

https://user-images.githubusercontent.com/50072027/235687474-6f7943f4-c285-4858-b186-824437b091cf.mp4

**Listen**

https://user-images.githubusercontent.com/50072027/235687514-b31cdb51-55f1-4685-9d5d-fe332fa1b902.mp4

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] PR description included
- [ x ] `yarn test` passes (had to ignore `amazon-cognito-identity.js`, as it fails lint and tests without much information, I haven't touched that package)
- [ x ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced). Since this is a POC and a draft, if this gets accepted/ looks okay I can add more info to the Hub docs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
