### PR TITLE
chore(clients): Use DNS suffix util in Pinpoint client

### DIFF
--- a/packages/core/src/AwsClients/Pinpoint/base.ts
+++ b/packages/core/src/AwsClients/Pinpoint/base.ts
@@ -1,12 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { getDnsSuffix } from '../../clients/endpoints';
 import {
 	jitteredBackoff,
 	getRetryDecider,
 } from '../../clients/middleware/retry';
 import { parseJsonError } from '../../clients/serde/json';
-import type { Headers } from '../../clients/types';
+import type { EndpointResolverOptions, Headers } from '../../clients/types';
 import { getAmplifyUserAgent } from '../../Platform';
 
 /**
@@ -17,8 +18,8 @@ const SERVICE_NAME = 'mobiletargeting';
 /**
  * The endpoint resolver function that returns the endpoint URL for a given region.
  */
-const endpointResolver = (endpointOptions: { region: string }) => ({
-	url: new URL(`https://pinpoint.${endpointOptions.region}.amazonaws.com`),
+const endpointResolver = ({ region }: EndpointResolverOptions) => ({
+	url: new URL(`https://pinpoint.${region}.${getDnsSuffix(region)}`),
 });
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR updates the Pinpoint client endpoint resolver to leverage the DNS suffix util

#### Description of how you validated changes
`yarn test`
Tested locally with sample app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
