### PR TITLE
feat(clients) Add getInAppMessages API

### DIFF
--- a/packages/core/__tests__/AwsClients/Pinpoint/getInAppMessages-test.ts
+++ b/packages/core/__tests__/AwsClients/Pinpoint/getInAppMessages-test.ts
@@ -38,7 +38,7 @@ describe('Pinpoint - getInAppMessages', () => {
 				authorization: expect.stringContaining('Signature'),
 				'content-type': 'application/json',
 				host: 'pinpoint.us-east-1.amazonaws.com',
-				'x-amz-date': expect.anything(),
+				'x-amz-date': expect.stringMatching(/^\d{8}T\d{6}Z/),
 				'x-amz-user-agent': expect.stringContaining('aws-amplify'),
 			}),
 		});

--- a/packages/core/__tests__/AwsClients/Pinpoint/getInAppMessages-test.ts
+++ b/packages/core/__tests__/AwsClients/Pinpoint/getInAppMessages-test.ts
@@ -3,13 +3,13 @@
 
 import { fetchTransferHandler } from '../../../src/clients/handlers/fetch';
 import {
-	putEvents,
-	PutEventsInput,
-	PutEventsOutput,
+	getInAppMessages,
+	GetInAppMessagesInput,
+	GetInAppMessagesOutput,
 } from '../../../src/AwsClients/Pinpoint';
 import {
 	mockApplicationId,
-	mockEventsRequest,
+	mockEndpointId,
 	mockFailureResponse,
 	mockJsonResponse,
 	mockRequestId,
@@ -18,38 +18,39 @@ import {
 
 jest.mock('../../../src/clients/handlers/fetch');
 
-// API reference: https://docs.aws.amazon.com/pinpoint/latest/apireference/apps-application-id-events.html#PutEvents
-describe('Pinpoint - putEvents', () => {
-	const EventsResponse = { Results: {} };
-	const params: PutEventsInput = {
+// API reference: https://docs.aws.amazon.com/pinpoint/latest/apireference/apps-application-id-endpoints-endpoint-id-inappmessages.html#GetInAppMessages
+describe('Pinpoint - getInAppMessages', () => {
+	const InAppMessagesResponse = {
+		InAppMessageCampaigns: [],
+	};
+	const params: GetInAppMessagesInput = {
 		ApplicationId: mockApplicationId,
-		EventsRequest: mockEventsRequest,
+		EndpointId: mockEndpointId,
 	};
 
 	test('happy case', async () => {
 		const expectedRequest = expect.objectContaining({
 			url: expect.objectContaining({
-				href: `https://pinpoint.us-east-1.amazonaws.com/v1/apps/${mockApplicationId}/events`,
+				href: `https://pinpoint.us-east-1.amazonaws.com/v1/apps/${mockApplicationId}/endpoints/${mockEndpointId}/inappmessages`,
 			}),
-			method: 'POST',
+			method: 'GET',
 			headers: expect.objectContaining({
 				authorization: expect.stringContaining('Signature'),
 				'content-type': 'application/json',
 				host: 'pinpoint.us-east-1.amazonaws.com',
-				'x-amz-date': expect.stringMatching(/^\d{8}T\d{6}Z/),
+				'x-amz-date': expect.anything(),
 				'x-amz-user-agent': expect.stringContaining('aws-amplify'),
 			}),
-			body: JSON.stringify(mockEventsRequest),
 		});
 		const successfulResponse = {
 			status: 200,
 			headers: {
 				'x-amzn-requestid': mockRequestId,
 			},
-			body: { ...EventsResponse },
+			body: { ...InAppMessagesResponse },
 		};
-		const expectedOutput: PutEventsOutput = {
-			EventsResponse,
+		const expectedOutput: GetInAppMessagesOutput = {
+			InAppMessagesResponse,
 			$metadata: expect.objectContaining({
 				attempts: 1,
 				requestId: mockRequestId,
@@ -59,7 +60,7 @@ describe('Pinpoint - putEvents', () => {
 		(fetchTransferHandler as jest.Mock).mockResolvedValue(
 			mockJsonResponse(successfulResponse)
 		);
-		const response = await putEvents(pinpointHandlerOptions, params);
+		const response = await getInAppMessages(pinpointHandlerOptions, params);
 		expect(response).toEqual(expectedOutput);
 		expect(fetchTransferHandler).toBeCalledWith(
 			expectedRequest,
@@ -77,7 +78,7 @@ describe('Pinpoint - putEvents', () => {
 		);
 		expect.assertions(1);
 		try {
-			await putEvents(pinpointHandlerOptions, params);
+			await getInAppMessages(pinpointHandlerOptions, params);
 			fail('test should fail');
 		} catch (e) {
 			expect(e).toEqual(expect.objectContaining(expectedError));

--- a/packages/core/__tests__/AwsClients/Pinpoint/updateEndpoint-test.ts
+++ b/packages/core/__tests__/AwsClients/Pinpoint/updateEndpoint-test.ts
@@ -11,6 +11,7 @@ import {
 	mockApplicationId,
 	mockEndpointId,
 	mockEndpointRequest,
+	mockFailureResponse,
 	mockJsonResponse,
 	mockRequestId,
 	pinpointHandlerOptions,
@@ -72,23 +73,12 @@ describe('Pinpoint - updateEndpoint', () => {
 	});
 
 	test('error case', async () => {
-		const failureResponse = {
-			status: 400,
-			headers: {
-				'x-amzn-requestid': mockRequestId,
-				'x-amzn-errortype': 'ForbiddenException',
-			},
-			body: {
-				__type: 'ForbiddenException',
-				message: `Forbidden`,
-			},
-		};
 		const expectedError = {
 			name: 'ForbiddenException',
-			message: failureResponse.body.message,
+			message: mockFailureResponse.body.message,
 		};
 		(fetchTransferHandler as jest.Mock).mockResolvedValue(
-			mockJsonResponse(failureResponse)
+			mockJsonResponse(mockFailureResponse)
 		);
 		expect.assertions(1);
 		try {

--- a/packages/core/__tests__/AwsClients/testUtils/data.ts
+++ b/packages/core/__tests__/AwsClients/testUtils/data.ts
@@ -77,7 +77,7 @@ export const mockEventsRequest = {
 };
 
 export const mockFailureResponse = {
-	status: 400,
+	status: 403,
 	headers: {
 		'x-amzn-requestid': mockRequestId,
 		'x-amzn-errortype': 'ForbiddenException',

--- a/packages/core/__tests__/AwsClients/testUtils/data.ts
+++ b/packages/core/__tests__/AwsClients/testUtils/data.ts
@@ -76,6 +76,18 @@ export const mockEventsRequest = {
 	},
 };
 
+export const mockFailureResponse = {
+	status: 400,
+	headers: {
+		'x-amzn-requestid': mockRequestId,
+		'x-amzn-errortype': 'ForbiddenException',
+	},
+	body: {
+		__type: 'ForbiddenException',
+		message: `Forbidden`,
+	},
+};
+
 export const pinpointHandlerOptions = {
 	credentials: {
 		accessKeyId: mockCredentials.AccessKeyId,

--- a/packages/core/src/AwsClients/Pinpoint/getInAppMessages.ts
+++ b/packages/core/src/AwsClients/Pinpoint/getInAppMessages.ts
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+	GetInAppMessagesCommandInput as GetInAppMessagesInput,
+	GetInAppMessagesCommandOutput as GetInAppMessagesOutput,
+} from '@aws-sdk/client-pinpoint';
+import { authenticatedHandler } from '../../clients/handlers/authenticated';
+import { composeServiceApi } from '../../clients/internal/composeServiceApi';
+import { extendedEncodeURIComponent } from '../../clients/middleware/signing/utils/extendedEncodeURIComponent';
+import {
+	parseJsonBody,
+	parseJsonError,
+	parseMetadata,
+} from '../../clients/serde';
+import { Endpoint, HttpRequest, HttpResponse } from '../../clients/types';
+import { defaultConfig, getSharedHeaders } from './base';
+
+export type { GetInAppMessagesInput, GetInAppMessagesOutput };
+
+const getInAppMessagesSerializer = (
+	{ ApplicationId, EndpointId }: GetInAppMessagesInput,
+	endpoint: Endpoint
+): HttpRequest => {
+	const headers = getSharedHeaders();
+	const url = new URL(endpoint.url);
+	url.pathname = `v1/apps/${extendedEncodeURIComponent(
+		ApplicationId
+	)}/endpoints/${extendedEncodeURIComponent(EndpointId)}/inappmessages`;
+	return { method: 'GET', headers, url };
+};
+
+const getInAppMessagesDeserializer = async (
+	response: HttpResponse
+): Promise<GetInAppMessagesOutput> => {
+	if (response.statusCode >= 300) {
+		const error = await parseJsonError(response);
+		throw error;
+	} else {
+		const { InAppMessageCampaigns } = await parseJsonBody(response);
+		return {
+			InAppMessagesResponse: { InAppMessageCampaigns },
+			$metadata: parseMetadata(response),
+		};
+	}
+};
+
+/**
+ * @internal
+ */
+export const getInAppMessages = composeServiceApi(
+	authenticatedHandler,
+	getInAppMessagesSerializer,
+	getInAppMessagesDeserializer,
+	defaultConfig
+);

--- a/packages/core/src/AwsClients/Pinpoint/index.ts
+++ b/packages/core/src/AwsClients/Pinpoint/index.ts
@@ -2,8 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export {
+	getInAppMessages,
+	GetInAppMessagesInput,
+	GetInAppMessagesOutput,
+} from './getInAppMessages';
+export { putEvents, PutEventsInput, PutEventsOutput } from './putEvents';
+export {
 	updateEndpoint,
 	UpdateEndpointInput,
 	UpdateEndpointOutput,
 } from './updateEndpoint';
-export { putEvents, PutEventsInput, PutEventsOutput } from './putEvents';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR adds the Pinpoint client `getInAppMessages` API

#### Description of how you validated changes
Locally replaced API calls from Notifications.InAppMessaging and verified network request performed as expected

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
