### PR TITLE
chore: Fixed NextJS canary configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2327,16 +2327,18 @@ workflows:
       - getting-started-smoke-test/web:
           name: Next.js - latest
           npx-command: create-next-app
+          npx-post: --use-npm --ts --tailwind --no-eslint --no-src-dir --no-app --import-alias "@/*"`
           framework: nextjs
-          main-file-path: pages/_app.js
+          main-file-path: pages/_app.tsx
           dev-start: dev
           build-dir: build
           ssr: true
       - getting-started-smoke-test/web:
           name: Next.js - next
           npx-command: create-next-app@canary
+          npx-post: --use-npm --ts --tailwind --no-eslint --no-src-dir --no-app --import-alias "@/*"`
           framework: nextjs
-          main-file-path: pages/_app.js
+          main-file-path: pages/_app.tsx
           dev-start: dev
           build-dir: build
           ssr: true


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change updates our Next.js canaries to use TypeScript and explicitly sets `create-next-app` params via the `npx-post` configuration.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Tested locally against sample NextJS apps.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
