### PR TITLE
chore(clients): Replace SDK Pinpoint Client

### DIFF
--- a/packages/analytics/__tests__/Providers/AWSPinpointProvider.test.ts
+++ b/packages/analytics/__tests__/Providers/AWSPinpointProvider.test.ts
@@ -1,10 +1,7 @@
 import { Credentials, ClientDevice } from '@aws-amplify/core';
+import { putEvents } from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint/putEvents';
+import { updateEndpoint } from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint/updateEndpoint';
 import { AWSPinpointProvider as AnalyticsProvider } from '../../src/Providers/AWSPinpointProvider';
-import {
-	PinpointClient,
-	UpdateEndpointCommand,
-	PutEventsCommand,
-} from '@aws-sdk/client-pinpoint';
 
 const endpointConfigure = {
 	address: 'configured', // The unique identifier for the recipient. For example, an address could be a device token, email address, or mobile phone number.
@@ -143,49 +140,34 @@ const optionsWithClientContext = {
 	},
 };
 
-let response = {
-	EventsResponse: {
-		Results: {
-			endpointId: {
-				EventsItemResponse: {
-					uuid: {
-						Message: 'Accepted',
-						StatusCode: 202,
-					},
-				},
-			},
-		},
-	},
-};
-
 let resolve = null;
 let reject = null;
 
 jest.mock('uuid', () => {
 	return { v1: () => 'uuid' };
 });
+jest.mock('@aws-amplify/core/lib-esm/AwsClients/Pinpoint/putEvents');
+jest.mock('@aws-amplify/core/lib-esm/AwsClients/Pinpoint/updateEndpoint');
+
+const mockPutEvents = putEvents as jest.Mock;
+const mockUpdateEndpoint = updateEndpoint as jest.Mock;
 
 beforeEach(() => {
-	PinpointClient.prototype.send = jest.fn(async command => {
-		if (command instanceof UpdateEndpointCommand) {
-			return 'data';
-		}
-		if (command instanceof PutEventsCommand) {
-			return {
-				EventsResponse: {
-					Results: {
-						endpointId: {
-							EventsItemResponse: {
-								uuid: {
-									Message: 'Accepted',
-									StatusCode: 202,
-								},
-							},
+	jest.clearAllMocks();
+	mockUpdateEndpoint.mockReturnValue('data');
+	mockPutEvents.mockReturnValue({
+		EventsResponse: {
+			Results: {
+				endpointId: {
+					EventsItemResponse: {
+						uuid: {
+							Message: 'Accepted',
+							StatusCode: 202,
 						},
 					},
 				},
-			};
-		}
+			},
+		},
 	});
 
 	jest.spyOn(Date.prototype, 'getTime').mockImplementation(() => {
@@ -295,48 +277,47 @@ describe('AnalyticsProvider test', () => {
 			test('custom events', async () => {
 				const analytics = new AnalyticsProvider();
 				analytics.configure(options);
-				const spyon = jest.spyOn(PinpointClient.prototype, 'send');
 
 				jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
 					return Promise.resolve(credentials);
 				});
 				const params = { event: { name: 'custom event', immediate: true } };
 				await analytics.record(params, { resolve, reject });
-				expect(spyon.mock.calls[0][0].input).toEqual({
-					ApplicationId: 'appId',
-					EventsRequest: {
-						BatchItem: {
-							endpointId: {
-								Endpoint: {},
-								Events: {
-									uuid: {
-										Attributes: undefined,
-										EventType: 'custom event',
-										Metrics: undefined,
-										Session: {
-											Id: 'uuid',
-											StartTimestamp: 'isoString',
+				expect(mockPutEvents).toBeCalledWith(
+					{ credentials, region: 'region' },
+					{
+						ApplicationId: 'appId',
+						EventsRequest: {
+							BatchItem: {
+								endpointId: {
+									Endpoint: {},
+									Events: {
+										uuid: {
+											Attributes: undefined,
+											EventType: 'custom event',
+											Metrics: undefined,
+											Session: {
+												Id: 'uuid',
+												StartTimestamp: 'isoString',
+											},
+											Timestamp: 'isoString',
 										},
-										Timestamp: 'isoString',
 									},
 								},
 							},
 						},
-					},
-				});
+					}
+				);
 				expect(resolve).toBeCalled();
-				spyon.mockRestore();
 			});
 
 			test('custom event error', async () => {
 				const analytics = new AnalyticsProvider();
 				analytics.configure(options);
 
-				const spyon = jest
-					.spyOn(PinpointClient.prototype, 'send')
-					.mockImplementationOnce(async () => {
-						throw 'data';
-					});
+				mockPutEvents.mockImplementation(async () => {
+					throw 'data';
+				});
 
 				jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
 					return Promise.resolve(credentials);
@@ -346,7 +327,6 @@ describe('AnalyticsProvider test', () => {
 
 				await analytics.record(params, { resolve, reject });
 				expect(reject).toBeCalled();
-				spyon.mockRestore();
 			});
 		});
 
@@ -354,7 +334,6 @@ describe('AnalyticsProvider test', () => {
 			test('happy case', async () => {
 				const analytics = new AnalyticsProvider();
 				analytics.configure(options);
-				const spyon = jest.spyOn(PinpointClient.prototype, 'send');
 
 				jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
 					return Promise.resolve(credentials);
@@ -363,40 +342,40 @@ describe('AnalyticsProvider test', () => {
 				const params = { event: { name: '_session.start', immediate: true } };
 				await analytics.record(params, { resolve, reject });
 
-				expect(spyon.mock.calls[0][0].input).toEqual({
-					ApplicationId: 'appId',
-					EventsRequest: {
-						BatchItem: {
-							endpointId: {
-								Endpoint: {},
-								Events: {
-									uuid: {
-										Attributes: undefined,
-										EventType: '_session.start',
-										Metrics: undefined,
-										Session: {
-											Id: 'uuid',
-											StartTimestamp: 'isoString',
+				expect(mockPutEvents).toBeCalledWith(
+					{ credentials, region: 'region' },
+					{
+						ApplicationId: 'appId',
+						EventsRequest: {
+							BatchItem: {
+								endpointId: {
+									Endpoint: {},
+									Events: {
+										uuid: {
+											Attributes: undefined,
+											EventType: '_session.start',
+											Metrics: undefined,
+											Session: {
+												Id: 'uuid',
+												StartTimestamp: 'isoString',
+											},
+											Timestamp: 'isoString',
 										},
-										Timestamp: 'isoString',
 									},
 								},
 							},
 						},
-					},
-				});
+					}
+				);
 				expect(resolve).toBeCalled();
-				spyon.mockRestore();
 			});
 
 			test('session start error', async () => {
 				const analytics = new AnalyticsProvider();
 				analytics.configure(options);
-				const spyon = jest
-					.spyOn(PinpointClient.prototype, 'send')
-					.mockImplementationOnce(() => {
-						throw 'data';
-					});
+				mockPutEvents.mockImplementation(() => {
+					throw 'data';
+				});
 
 				jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
 					return Promise.resolve(credentials);
@@ -407,7 +386,6 @@ describe('AnalyticsProvider test', () => {
 				await analytics.record(params, { resolve, reject });
 				expect(resolve).not.toBeCalled();
 				expect(reject).toBeCalled();
-				spyon.mockRestore();
 			});
 		});
 
@@ -454,17 +432,14 @@ describe('AnalyticsProvider test', () => {
 
 				expect(spyon).toBeCalledWith(expectedUrl, expectedData);
 				expect(resolve).toBeCalled();
-				spyon.mockRestore();
 			});
 
 			test('session stop error', async () => {
 				const analytics = new AnalyticsProvider();
 				analytics.configure(options);
-				const spyon = jest
-					.spyOn(PinpointClient.prototype, 'send')
-					.mockImplementationOnce(async () => {
-						throw 'data';
-					});
+				mockPutEvents.mockImplementation(async () => {
+					throw 'data';
+				});
 
 				jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
 					return Promise.resolve(credentials);
@@ -474,7 +449,6 @@ describe('AnalyticsProvider test', () => {
 
 				await analytics.record(params, { resolve, reject });
 				expect(reject).toBeCalled();
-				spyon.mockRestore();
 			});
 		});
 
@@ -482,11 +456,6 @@ describe('AnalyticsProvider test', () => {
 			test('happy case with default client info', async () => {
 				const analytics = new AnalyticsProvider();
 				analytics.configure(options);
-				const spyon = jest
-					.spyOn(PinpointClient.prototype, 'send')
-					.mockImplementationOnce(async params => {
-						return 'data';
-					});
 
 				jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
 					return Promise.resolve(credentials);
@@ -494,41 +463,38 @@ describe('AnalyticsProvider test', () => {
 
 				const params = { event: { name: '_update_endpoint', immediate: true } };
 				await analytics.record(params, { resolve, reject });
-				expect(spyon.mock.calls[0][0].input).toEqual({
-					ApplicationId: 'appId',
-					EndpointId: 'endpointId',
-					EndpointRequest: {
-						Attributes: {},
-						ChannelType: undefined,
-						Demographic: {
-							AppVersion: 'clientInfoAppVersion',
-							Make: 'clientInfoMake',
-							Model: 'clientInfoModel',
-							ModelVersion: 'clientInfoVersion',
-							Platform: 'clientInfoPlatform',
+				expect(mockUpdateEndpoint).toBeCalledWith(
+					{ credentials, region: 'region' },
+					{
+						ApplicationId: 'appId',
+						EndpointId: 'endpointId',
+						EndpointRequest: {
+							Attributes: {},
+							ChannelType: undefined,
+							Demographic: {
+								AppVersion: 'clientInfoAppVersion',
+								Make: 'clientInfoMake',
+								Model: 'clientInfoModel',
+								ModelVersion: 'clientInfoVersion',
+								Platform: 'clientInfoPlatform',
+							},
+							EffectiveDate: 'isoString',
+							Location: {},
+							Metrics: {},
+							RequestId: 'uuid',
+							User: {
+								UserAttributes: {},
+								UserId: 'identityId',
+							},
 						},
-						EffectiveDate: 'isoString',
-						Location: {},
-						Metrics: {},
-						RequestId: 'uuid',
-						User: {
-							UserAttributes: {},
-							UserId: 'identityId',
-						},
-					},
-				});
+					}
+				);
 				expect(resolve).toBeCalled();
-				spyon.mockRestore();
 			});
 
 			test('happy case with client context provided', async () => {
 				const analytics = new AnalyticsProvider();
 				analytics.configure(optionsWithClientContext);
-				const spyon = jest
-					.spyOn(PinpointClient.prototype, 'send')
-					.mockImplementationOnce(async params => {
-						return 'data';
-					});
 
 				jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
 					return Promise.resolve(credentials);
@@ -536,43 +502,39 @@ describe('AnalyticsProvider test', () => {
 
 				const params = { event: { name: '_update_endpoint', immediate: true } };
 				await analytics.record(params, { resolve, reject });
-				expect(spyon.mock.calls[0][0].input).toEqual({
-					ApplicationId: 'appId',
-					EndpointId: 'endpointId',
-					EndpointRequest: {
-						Attributes: {},
-						ChannelType: undefined,
-						Demographic: {
-							AppVersion: 'clientInfoAppVersion',
-							Locale: 'locale',
-							Make: 'make',
-							Model: 'model',
-							ModelVersion: 'clientInfoVersion',
-							Platform: 'platform',
-							PlatformVersion: 'platformVersion',
+				expect(mockUpdateEndpoint).toBeCalledWith(
+					{ credentials, region: 'region' },
+					{
+						ApplicationId: 'appId',
+						EndpointId: 'endpointId',
+						EndpointRequest: {
+							Attributes: {},
+							ChannelType: undefined,
+							Demographic: {
+								AppVersion: 'clientInfoAppVersion',
+								Locale: 'locale',
+								Make: 'make',
+								Model: 'model',
+								ModelVersion: 'clientInfoVersion',
+								Platform: 'platform',
+								PlatformVersion: 'platformVersion',
+							},
+							EffectiveDate: 'isoString',
+							Location: {},
+							Metrics: {},
+							RequestId: 'uuid',
+							User: {
+								UserAttributes: {},
+								UserId: 'identityId',
+							},
 						},
-						EffectiveDate: 'isoString',
-						Location: {},
-						Metrics: {},
-						RequestId: 'uuid',
-						User: {
-							UserAttributes: {},
-							UserId: 'identityId',
-						},
-					},
-				});
-
-				spyon.mockRestore();
+					}
+				);
 			});
 
 			test('happy case with default enpoint configure provided', async () => {
 				const analytics = new AnalyticsProvider();
 				analytics.configure(optionsWithDefaultEndpointConfigure);
-				const spyon = jest
-					.spyOn(PinpointClient.prototype, 'send')
-					.mockImplementationOnce(async params => {
-						return 'data';
-					});
 
 				jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
 					return Promise.resolve(credentials);
@@ -581,57 +543,53 @@ describe('AnalyticsProvider test', () => {
 				const params = { event: { name: '_update_endpoint', immediate: true } };
 				await analytics.record(params, { resolve, reject });
 
-				expect(spyon.mock.calls[0][0].input).toEqual({
-					ApplicationId: 'appId',
-					EndpointId: 'endpointId',
-					EndpointRequest: {
-						Address: 'default',
-						Attributes: {
-							hobbies: ['default'],
-						},
-						ChannelType: 'default',
-						Demographic: {
-							AppVersion: 'default',
-							Locale: 'default',
-							Make: 'default',
-							Model: 'default',
-							ModelVersion: 'default',
-							Platform: 'default',
-							PlatformVersion: 'default',
-							Timezone: 'default',
-						},
-						EffectiveDate: 'isoString',
-						Location: {
-							City: 'default',
-							Country: 'default',
-							Latitude: 0,
-							Longitude: 0,
-							PostalCode: 'default',
-							Region: 'default',
-						},
-						Metrics: {},
-						OptOut: 'default',
-						RequestId: 'uuid',
-						User: {
-							UserAttributes: {
-								interests: ['default'],
+				expect(mockUpdateEndpoint).toBeCalledWith(
+					{ credentials, region: 'region' },
+					{
+						ApplicationId: 'appId',
+						EndpointId: 'endpointId',
+						EndpointRequest: {
+							Address: 'default',
+							Attributes: {
+								hobbies: ['default'],
 							},
-							UserId: 'default',
+							ChannelType: 'default',
+							Demographic: {
+								AppVersion: 'default',
+								Locale: 'default',
+								Make: 'default',
+								Model: 'default',
+								ModelVersion: 'default',
+								Platform: 'default',
+								PlatformVersion: 'default',
+								Timezone: 'default',
+							},
+							EffectiveDate: 'isoString',
+							Location: {
+								City: 'default',
+								Country: 'default',
+								Latitude: 0,
+								Longitude: 0,
+								PostalCode: 'default',
+								Region: 'default',
+							},
+							Metrics: {},
+							OptOut: 'default',
+							RequestId: 'uuid',
+							User: {
+								UserAttributes: {
+									interests: ['default'],
+								},
+								UserId: 'default',
+							},
 						},
-					},
-				});
-
-				spyon.mockRestore();
+					}
+				);
 			});
 
 			test('happy case with specified enpoint configure provided', async () => {
 				const analytics = new AnalyticsProvider();
 				analytics.configure(optionsWithDefaultEndpointConfigure);
-				const spyon = jest
-					.spyOn(PinpointClient.prototype, 'send')
-					.mockImplementationOnce(async params => {
-						return 'data';
-					});
 
 				jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
 					return Promise.resolve(credentials);
@@ -646,47 +604,48 @@ describe('AnalyticsProvider test', () => {
 				};
 				await analytics.record(params, { resolve, reject });
 
-				expect(spyon.mock.calls[0][0].input).toEqual({
-					ApplicationId: 'appId',
-					EndpointId: 'endpointId',
-					EndpointRequest: {
-						Address: 'configured',
-						Attributes: {
-							hobbies: ['configured'],
-						},
-						ChannelType: 'configured',
-						Demographic: {
-							AppVersion: 'configured',
-							Locale: 'configured',
-							Make: 'configured',
-							Model: 'configured',
-							ModelVersion: 'configured',
-							Platform: 'configured',
-							PlatformVersion: 'configured',
-							Timezone: 'configured',
-						},
-						EffectiveDate: 'isoString',
-						Location: {
-							City: 'configured',
-							Country: 'configured',
-							Latitude: 0,
-							Longitude: 0,
-							PostalCode: 'configured',
-							Region: 'configured',
-						},
-						Metrics: {},
-						OptOut: 'configured',
-						RequestId: 'uuid',
-						User: {
-							UserAttributes: {
-								interests: ['configured'],
+				expect(mockUpdateEndpoint).toBeCalledWith(
+					{ credentials, region: 'region' },
+					{
+						ApplicationId: 'appId',
+						EndpointId: 'endpointId',
+						EndpointRequest: {
+							Address: 'configured',
+							Attributes: {
+								hobbies: ['configured'],
 							},
-							UserId: 'configured',
+							ChannelType: 'configured',
+							Demographic: {
+								AppVersion: 'configured',
+								Locale: 'configured',
+								Make: 'configured',
+								Model: 'configured',
+								ModelVersion: 'configured',
+								Platform: 'configured',
+								PlatformVersion: 'configured',
+								Timezone: 'configured',
+							},
+							EffectiveDate: 'isoString',
+							Location: {
+								City: 'configured',
+								Country: 'configured',
+								Latitude: 0,
+								Longitude: 0,
+								PostalCode: 'configured',
+								Region: 'configured',
+							},
+							Metrics: {},
+							OptOut: 'configured',
+							RequestId: 'uuid',
+							User: {
+								UserAttributes: {
+									interests: ['configured'],
+								},
+								UserId: 'configured',
+							},
 						},
-					},
-				});
-
-				spyon.mockRestore();
+					}
+				);
 			});
 
 			test('error case', async () => {
@@ -694,11 +653,9 @@ describe('AnalyticsProvider test', () => {
 				const mockError = { message: 'error' };
 
 				analytics.configure(options);
-				const spyon = jest
-					.spyOn(PinpointClient.prototype, 'send')
-					.mockImplementationOnce(async params => {
-						throw { message: 'error' };
-					});
+				mockUpdateEndpoint.mockImplementation(async params => {
+					throw { message: 'error' };
+				});
 
 				jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
 					return Promise.resolve(credentials);
@@ -708,7 +665,6 @@ describe('AnalyticsProvider test', () => {
 
 				await analytics.record(params, { resolve, reject });
 				expect(reject).toBeCalledWith(mockError);
-				spyon.mockRestore();
 			});
 
 			test('BAD_REQUEST_CODE without message rejects error', async () => {
@@ -716,11 +672,9 @@ describe('AnalyticsProvider test', () => {
 				const mockError = { debug: 'error', statusCode: 400 };
 
 				analytics.configure(options);
-				const spyon = jest
-					.spyOn(PinpointClient.prototype, 'send')
-					.mockImplementationOnce(async params => {
-						throw mockError;
-					});
+				mockUpdateEndpoint.mockImplementation(async params => {
+					throw mockError;
+				});
 
 				jest.spyOn(Credentials, 'get').mockImplementationOnce(() => {
 					return Promise.resolve(credentials);
@@ -730,7 +684,6 @@ describe('AnalyticsProvider test', () => {
 
 				await analytics.record(params, { resolve, reject });
 				expect(reject).toBeCalledWith(mockError);
-				spyon.mockRestore();
 			});
 
 			test('Exceeded maximum endpoint per user count', async () => {
@@ -744,12 +697,9 @@ describe('AnalyticsProvider test', () => {
 
 				analytics.configure(options);
 
-				const spyonUpdateEndpoint = jest
-					.spyOn(PinpointClient.prototype, 'send')
-					// Reject with error the first time we execute updateEndpoint
-					.mockImplementationOnce(async params => {
-						throw mockExceededMaxError;
-					});
+				mockUpdateEndpoint.mockImplementation(async params => {
+					throw mockExceededMaxError;
+				});
 
 				jest
 					.spyOn(Credentials, 'get')
@@ -759,9 +709,7 @@ describe('AnalyticsProvider test', () => {
 
 				await analytics.record(params, { resolve, reject });
 
-				expect(spyonUpdateEndpoint).toHaveBeenCalledTimes(1);
-
-				spyonUpdateEndpoint.mockRestore();
+				expect(mockUpdateEndpoint).toHaveBeenCalledTimes(1);
 			});
 		});
 	});

--- a/packages/analytics/__tests__/Providers/EventBuffer.test.ts
+++ b/packages/analytics/__tests__/Providers/EventBuffer.test.ts
@@ -41,13 +41,13 @@ describe('EventBuffer', () => {
 	});
 
 	test('can be constructed', () => {
-		const buffer = new EventBuffer({}, DEFAULT_CONFIG);
+		const buffer = new EventBuffer(DEFAULT_CONFIG);
 		expect(buffer).toBeDefined();
 	});
 
 	test('does not allow buffer size to be exceeded', () => {
 		const config = { ...DEFAULT_CONFIG, bufferSize: 1 };
-		const buffer = new EventBuffer({}, config);
+		const buffer = new EventBuffer(config);
 		buffer.push(EVENT_OBJECT);
 		buffer.push(EVENT_OBJECT);
 		expect(EVENT_OBJECT.handlers.reject).toBeCalledWith(

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -66,13 +66,13 @@
 			"name": "Analytics (Pinpoint)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Analytics, AWSPinpointProvider }",
-			"limit": "54.7 kB"
+			"limit": "29.45 kB"
 		},
 		{
 			"name": "Analytics (Kinesis)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Analytics, AWSKinesisProvider }",
-			"limit": "68.5 kB"
+			"limit": "57.91 kB"
 		}
 	],
 	"jest": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -53,11 +53,13 @@
 		"@aws-sdk/client-firehose": "3.6.1",
 		"@aws-sdk/client-kinesis": "3.6.1",
 		"@aws-sdk/client-personalize-events": "3.6.1",
-		"@aws-sdk/client-pinpoint": "3.6.1",
 		"@aws-sdk/util-utf8-browser": "3.6.1",
 		"lodash": "^4.17.20",
 		"tslib": "^1.8.0",
 		"uuid": "^3.2.1"
+	},
+	"devDependencies": {
+		"@aws-sdk/client-pinpoint": "3.186.1"
 	},
 	"size-limit": [
 		{

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -1,24 +1,24 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Cache } from '@aws-amplify/cache';
 import {
 	ConsoleLogger as Logger,
 	ClientDevice,
 	Credentials,
 	Signer,
 	Hub,
-	getAmplifyUserAgent,
 	transferKeyToLowerCase,
 	transferKeyToUpperCase,
 } from '@aws-amplify/core';
 import {
-	EventsBatch,
-	PinpointClient,
-	PutEventsCommand,
-	PutEventsCommandInput,
-	UpdateEndpointCommand,
-} from '@aws-sdk/client-pinpoint';
-import { Cache } from '@aws-amplify/cache';
+	putEvents,
+	PutEventsInput,
+	PutEventsOutput,
+	updateEndpoint,
+	UpdateEndpointInput,
+	UpdateEndpointOutput,
+} from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint';
 
 import {
 	AnalyticsProvider,
@@ -29,7 +29,7 @@ import {
 	EndpointFailureData,
 } from '../types';
 import { v1 as uuid } from 'uuid';
-import EventsBuffer from './EventBuffer';
+import EventBuffer from './EventBuffer';
 
 const AMPLIFY_SYMBOL = (
 	typeof Symbol !== 'undefined' && typeof Symbol.for === 'function'
@@ -68,10 +68,9 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 	static providerName = 'AWSPinpoint';
 
 	private _config;
-	private pinpointClient;
 	private _sessionId;
 	private _sessionStartTimestamp;
-	private _buffer: EventsBuffer;
+	private _buffer: EventBuffer | null;
 	private _endpointBuffer: EndpointBuffer;
 	private _clientInfo;
 	private _endpointGenerating = true;
@@ -152,7 +151,7 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 			);
 		}
 
-		this._initClients(credentials);
+		this._init(credentials);
 
 		const timestamp = new Date().getTime();
 		// attach the session and eventId
@@ -194,7 +193,7 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 			return;
 		}
 
-		this._buffer && this._buffer.push({ params, handlers });
+		this._buffer?.push({ params, handlers });
 	}
 
 	private _generateSession(params) {
@@ -249,34 +248,31 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 		}
 	}
 
-	private _generateBatchItemContext(params) {
+	private _generateBatchItemContext(params): PutEventsInput {
 		const { event, timestamp, config } = params;
 		const { name, attributes, metrics, eventId, session } = event;
 		const { appId, endpointId } = config;
-
 		const endpointContext = {};
 
-		const eventParams: PutEventsCommandInput = {
+		return {
 			ApplicationId: appId,
 			EventsRequest: {
-				BatchItem: {},
+				BatchItem: {
+					[endpointId]: {
+						Endpoint: endpointContext,
+						Events: {
+							[eventId]: {
+								EventType: name,
+								Timestamp: new Date(timestamp).toISOString(),
+								Attributes: attributes,
+								Metrics: metrics,
+								Session: session,
+							},
+						},
+					},
+				},
 			},
 		};
-
-		const endpointObj: EventsBatch = {} as EventsBatch;
-		endpointObj.Endpoint = endpointContext;
-		endpointObj.Events = {
-			[eventId]: {
-				EventType: name,
-				Timestamp: new Date(timestamp).toISOString(),
-				Attributes: attributes,
-				Metrics: metrics,
-				Session: session,
-			},
-		};
-		eventParams.EventsRequest.BatchItem[endpointId] = endpointObj;
-
-		return eventParams;
 	}
 
 	private async _pinpointPutEvents(params, handlers) {
@@ -285,26 +281,24 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 			config: { endpointId },
 		} = params;
 		const eventParams = this._generateBatchItemContext(params);
-		const command: PutEventsCommand = new PutEventsCommand(eventParams);
 
 		try {
-			const data = await this.pinpointClient.send(command);
-			const {
-				EventsResponse: {
-					Results: {
-						[endpointId]: {
-							EventsItemResponse: {
-								[eventId]: { StatusCode, Message },
-							},
-						},
-					},
-				},
-			} = data;
-			if (ACCEPTED_CODES.includes(StatusCode)) {
+			const { credentials, region } = this._config;
+			const data: PutEventsOutput = await putEvents(
+				{ credentials, region },
+				eventParams
+			);
+
+			const { StatusCode, Message } =
+				data.EventsResponse?.Results?.[endpointId]?.EventsItemResponse?.[
+					eventId
+				] ?? {};
+
+			if (StatusCode && ACCEPTED_CODES.includes(StatusCode)) {
 				logger.debug('record event success. ', data);
 				return handlers.resolve(data);
 			} else {
-				if (RETRYABLE_CODES.includes(StatusCode)) {
+				if (StatusCode && RETRYABLE_CODES.includes(StatusCode)) {
 					this._retry(params, handlers);
 				} else {
 					logger.error(
@@ -319,7 +313,7 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 		}
 	}
 
-	private _pinpointSendStopSession(params, handlers): Promise<string> {
+	private _pinpointSendStopSession(params, handlers): Promise<string> | void {
 		if (!BEACON_SUPPORTED) {
 			this._pinpointPutEvents(params, handlers);
 			return;
@@ -348,12 +342,7 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 
 		const serviceInfo = { region, service: MOBILE_SERVICE_NAME };
 
-		const requestUrl: string = Signer.signUrl(
-			request,
-			accessInfo,
-			serviceInfo,
-			null
-		);
+		const requestUrl: string = Signer.signUrl(request, accessInfo, serviceInfo);
 
 		const success: boolean = navigator.sendBeacon(requestUrl, body);
 
@@ -393,18 +382,18 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 				['attributes', 'userAttributes', 'Attributes', 'UserAttributes']
 			)
 		);
-		const update_params = {
+		const update_params: UpdateEndpointInput = {
 			ApplicationId: appId,
 			EndpointId: endpointId,
 			EndpointRequest: request,
 		};
 
 		try {
-			const command: UpdateEndpointCommand = new UpdateEndpointCommand(
+			const { credentials, region } = this._config;
+			const data: UpdateEndpointOutput = await updateEndpoint(
+				{ credentials, region },
 				update_params
 			);
-			const data = await this.pinpointClient.send(command);
-
 			logger.debug('updateEndpoint success', data);
 			this._endpointGenerating = false;
 			this._resumeBuffer();
@@ -492,13 +481,12 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 	/**
 	 * @private
 	 * @param config
-	 * Init the clients
+	 * Configure credentials and init buffer
 	 */
-	private async _initClients(credentials) {
-		logger.debug('init clients');
+	private async _init(credentials) {
+		logger.debug('init provider');
 
 		if (
-			this.pinpointClient &&
 			this._config.credentials &&
 			this._config.credentials.sessionToken === credentials.sessionToken &&
 			this._config.credentials.identityId === credentials.identityId
@@ -512,43 +500,17 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 			: null;
 
 		this._config.credentials = credentials;
-		const { region } = this._config;
-		logger.debug('init clients with credentials', credentials);
-		this.pinpointClient = new PinpointClient({
-			region,
-			credentials,
-			customUserAgent: getAmplifyUserAgent(),
-		});
 
-		// TODO: remove this middleware once a long term fix is implemented by aws-sdk-js team.
-		this.pinpointClient.middlewareStack.addRelativeTo(
-			next => args => {
-				delete args.request.headers['amz-sdk-invocation-id'];
-				delete args.request.headers['amz-sdk-request'];
-				return next(args);
-			},
-			{
-				step: 'finalizeRequest',
-				relation: 'after',
-				toMiddleware: 'retryMiddleware',
-			}
-		);
-
-		if (this._bufferExists() && identityId === credentials.identityId) {
-			// if the identity has remained the same, pass the updated client to the buffer
-			this._updateBufferClient();
-		} else {
-			// otherwise flush the buffer and instantiate a new one
+		if (!this._bufferExists() || identityId !== credentials.identityId) {
+			// if the identity has changed, flush the buffer and instantiate a new one
 			// this will cause the old buffer to send any remaining events
 			// with the old credentials and then stop looping and shortly thereafter get picked up by GC
 			this._initBuffer();
 		}
-
-		this._customizePinpointClientReq();
 	}
 
 	private _bufferExists() {
-		return this._buffer && this._buffer instanceof EventsBuffer;
+		return this._buffer && this._buffer instanceof EventBuffer;
 	}
 
 	private _initBuffer() {
@@ -556,7 +518,7 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 			this._flushBuffer();
 		}
 
-		this._buffer = new EventsBuffer(this.pinpointClient, this._config);
+		this._buffer = new EventBuffer(this._config);
 
 		// if the first endpoint update hasn't yet resolved pause the buffer to
 		// prevent race conditions. It will be resumed as soon as that request succeeds
@@ -565,34 +527,17 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 		}
 	}
 
-	private _updateBufferClient() {
-		if (this._bufferExists()) {
-			this._buffer.updateClient(this.pinpointClient);
-		}
-	}
-
 	private _flushBuffer() {
 		if (this._bufferExists()) {
-			this._buffer.flush();
+			this._buffer?.flush();
 			this._buffer = null;
 		}
 	}
 
 	private _resumeBuffer() {
 		if (this._bufferExists()) {
-			this._buffer.resume();
+			this._buffer?.resume();
 		}
-	}
-
-	private _customizePinpointClientReq() {
-		// TODO FIXME: Find a middleware to do this with AWS V3 SDK
-		// if (Platform.isReactNative) {
-		// 	this.pinpointClient.customizeRequests(request => {
-		// 		request.on('build', req => {
-		// 			req.httpRequest.headers['user-agent'] = Platform.userAgent;
-		// 		});
-		// 	});
-		// }
 	}
 
 	private async _getEndpointId(cacheKey) {

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -18,7 +18,7 @@ import {
 	updateEndpoint,
 	UpdateEndpointInput,
 	UpdateEndpointOutput,
-} from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint';
+} from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint'; // TODO: convert to subpath import from core
 
 import {
 	AnalyticsProvider,
@@ -297,15 +297,14 @@ export class AWSPinpointProvider implements AnalyticsProvider {
 			if (StatusCode && ACCEPTED_CODES.includes(StatusCode)) {
 				logger.debug('record event success. ', data);
 				return handlers.resolve(data);
+			} else if (StatusCode && RETRYABLE_CODES.includes(StatusCode)) {
+				// TODO: v6 integrate retry to the service handler retryDecider
+				this._retry(params, handlers);
 			} else {
-				if (StatusCode && RETRYABLE_CODES.includes(StatusCode)) {
-					this._retry(params, handlers);
-				} else {
-					logger.error(
-						`Event ${eventId} is not accepted, the error is ${Message}`
-					);
-					return handlers.reject(data);
-				}
+				logger.error(
+					`Event ${eventId} is not accepted, the error is ${Message}`
+				);
+				return handlers.reject(data);
 			}
 		} catch (err) {
 			this._eventError(err);

--- a/packages/analytics/src/Providers/EventBuffer.ts
+++ b/packages/analytics/src/Providers/EventBuffer.ts
@@ -3,7 +3,7 @@ import {
 	putEvents,
 	PutEventsInput,
 	PutEventsOutput,
-} from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint';
+} from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint'; // TODO: convert to subpath import from core
 import { EventBuffer, EventObject, EventMap } from '../types';
 import { isAppInForeground } from '../utils/AppUtils';
 
@@ -170,6 +170,10 @@ export default class EventsBuffer {
 
 			Object.entries(responses).forEach(([eventId, eventValues]) => {
 				const eventObject = eventMap[eventId];
+				if (!eventObject) {
+					return;
+				}
+
 				const { StatusCode, Message } = eventValues ?? {};
 
 				// manually crafting handlers response to keep API consistant

--- a/packages/notifications/__mocks__/data.ts
+++ b/packages/notifications/__mocks__/data.ts
@@ -1,12 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-	Alignment,
-	ButtonAction,
-	DimensionType,
+import type {
 	Event,
-	FilterType,
 	InAppMessageCampaign as PinpointInAppMessage,
 } from '@aws-sdk/client-pinpoint';
 import { InAppMessage, InAppMessagingEvent } from '../src/InAppMessaging';
@@ -139,12 +135,12 @@ export const pinpointInAppMessage: PinpointInAppMessage = {
 			{
 				BackgroundColor: '#FFFF88',
 				BodyConfig: {
-					Alignment: Alignment.LEFT,
+					Alignment: 'LEFT',
 					Body: 'Body content',
 					TextColor: '#FF8888',
 				},
 				HeaderConfig: {
-					Alignment: Alignment.CENTER,
+					Alignment: 'CENTER',
 					Header: 'Header content',
 					TextColor: '#88FF88',
 				},
@@ -153,7 +149,7 @@ export const pinpointInAppMessage: PinpointInAppMessage = {
 					DefaultConfig: {
 						BackgroundColor: '#8888FF',
 						BorderRadius: 4,
-						ButtonAction: ButtonAction.CLOSE,
+						ButtonAction: 'CLOSE',
 						Link: undefined,
 						Text: 'Close button',
 						TextColor: '#FF88FF',
@@ -163,7 +159,7 @@ export const pinpointInAppMessage: PinpointInAppMessage = {
 					DefaultConfig: {
 						BackgroundColor: '#88FFFF',
 						BorderRadius: 4,
-						ButtonAction: ButtonAction.LINK,
+						ButtonAction: 'LINK',
 						Link: 'http://link.fakeurl',
 						Text: 'Link button',
 						TextColor: '#FFFFFF',
@@ -178,11 +174,11 @@ export const pinpointInAppMessage: PinpointInAppMessage = {
 	Schedule: {
 		EndDate: '2021-01-01T00:00:00Z',
 		EventFilter: {
-			FilterType: FilterType.SYSTEM,
+			FilterType: 'SYSTEM',
 			Dimensions: {
 				Attributes: {},
 				EventType: {
-					DimensionType: DimensionType.INCLUSIVE,
+					DimensionType: 'INCLUSIVE',
 					Values: ['clicked', 'swiped'],
 				},
 				Metrics: {},

--- a/packages/notifications/__tests__/InAppMessaging/Providers/AWSPinpointProvider/index.test.ts
+++ b/packages/notifications/__tests__/InAppMessaging/Providers/AWSPinpointProvider/index.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Credentials, StorageHelper } from '@aws-amplify/core';
-import { PinpointClient } from '@aws-sdk/client-pinpoint';
+import { getInAppMessages } from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint/getInAppMessages';
 import cloneDeep from 'lodash/cloneDeep';
 
 import { addEventListener } from '../../../../src/common/eventListeners';
@@ -29,7 +29,8 @@ import {
 import { mockStorage } from '../../../../__mocks__/mocks';
 
 jest.mock('@aws-amplify/core');
-jest.mock('@aws-sdk/client-pinpoint');
+jest.mock('@aws-amplify/core/lib-esm/AwsClients/Pinpoint/getInAppMessages');
+jest.mock('@aws-amplify/core/lib-esm/AwsClients/Pinpoint/updateEndpoint');
 jest.mock('../../../../src/common/eventListeners');
 jest.mock('../../../../src/InAppMessaging/Providers/AWSPinpointProvider/utils');
 jest.mock(
@@ -45,12 +46,12 @@ jest.mock(
 const getStorageSpy = jest.spyOn(StorageHelper.prototype, 'getStorage');
 const credentialsGetSpy = jest.spyOn(Credentials, 'get');
 const credentialsShearSpy = jest.spyOn(Credentials, 'shear');
-const clientSendSpy = jest.spyOn(PinpointClient.prototype, 'send') as jest.Mock;
 const mockAddEventListener = addEventListener as jest.Mock;
 const mockIsBeforeEndDate = isBeforeEndDate as jest.Mock;
 const mockMatchesAttributes = matchesAttributes as jest.Mock;
 const mockMatchesEventType = matchesEventType as jest.Mock;
 const mockMatchesMetrics = matchesMetrics as jest.Mock;
+const mockGetInAppMessages = getInAppMessages as jest.Mock;
 
 describe('AWSPinpoint InAppMessaging Provider', () => {
 	let provider: AWSPinpointProvider;
@@ -85,7 +86,7 @@ describe('AWSPinpoint InAppMessaging Provider', () => {
 		});
 
 		test('gets in-app messages from Pinpoint', async () => {
-			clientSendSpy.mockResolvedValueOnce(null).mockResolvedValueOnce({
+			mockGetInAppMessages.mockResolvedValueOnce({
 				InAppMessagesResponse: {
 					InAppMessageCampaigns: messages,
 				},
@@ -95,7 +96,7 @@ describe('AWSPinpoint InAppMessaging Provider', () => {
 		});
 
 		test('throws an error on client failure', async () => {
-			clientSendSpy.mockImplementationOnce(() => {
+			mockGetInAppMessages.mockImplementationOnce(() => {
 				throw new Error();
 			});
 

--- a/packages/notifications/__tests__/InAppMessaging/Providers/AWSPinpointProvider/utils.test.ts
+++ b/packages/notifications/__tests__/InAppMessaging/Providers/AWSPinpointProvider/utils.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { InAppMessageCampaign as PinpointInAppMessage } from '@aws-sdk/client-pinpoint';
+import type { InAppMessageCampaign as PinpointInAppMessage } from '@aws-sdk/client-pinpoint';
 import { Amplify, ConsoleLogger, Hub } from '@aws-amplify/core';
 import cloneDeep from 'lodash/cloneDeep';
 

--- a/packages/notifications/__tests__/PushNotification/Providers/AWSPinpointProvider/index.test.ts
+++ b/packages/notifications/__tests__/PushNotification/Providers/AWSPinpointProvider/index.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Credentials, StorageHelper } from '@aws-amplify/core';
-import { PinpointClient } from '@aws-sdk/client-pinpoint';
+import { updateEndpoint } from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint/updateEndpoint';
 
 import { addEventListener } from '../../../../src/common/eventListeners';
 import { Platform } from '../../../../src/PushNotification/Platform';
@@ -24,7 +24,7 @@ import {
 import { mockStorage } from '../../../../__mocks__/mocks';
 
 jest.mock('@aws-amplify/core');
-jest.mock('@aws-sdk/client-pinpoint');
+jest.mock('@aws-amplify/core/lib-esm/AwsClients/Pinpoint/updateEndpoint');
 jest.mock('../../../../src/common/eventListeners');
 jest.mock('../../../../src/PushNotification/Platform');
 jest.mock(
@@ -34,8 +34,8 @@ jest.mock(
 const getStorageSpy = jest.spyOn(StorageHelper.prototype, 'getStorage');
 const credentialsGetSpy = jest.spyOn(Credentials, 'get');
 const credentialsShearSpy = jest.spyOn(Credentials, 'shear');
-const clientSendSpy = jest.spyOn(PinpointClient.prototype, 'send');
 const mockAddEventListener = addEventListener as jest.Mock;
+const mockUpdateEndpoint = updateEndpoint as jest.Mock;
 
 describe('AWSPinpoint InAppMessaging Provider', () => {
 	let provider: AWSPinpointProvider;
@@ -136,11 +136,11 @@ describe('AWSPinpoint InAppMessaging Provider', () => {
 
 		test('registers device with Pinpoint', async () => {
 			await provider.registerDevice(pushToken);
-			expect(clientSendSpy).toBeCalled();
+			expect(mockUpdateEndpoint).toBeCalled();
 		});
 
 		test('throws an error on client failure', async () => {
-			clientSendSpy.mockImplementationOnce(() => {
+			mockUpdateEndpoint.mockImplementationOnce(() => {
 				throw new Error();
 			});
 

--- a/packages/notifications/__tests__/common/AWSPinpointProviderCommon/index.test.ts
+++ b/packages/notifications/__tests__/common/AWSPinpointProviderCommon/index.test.ts
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Credentials, StorageHelper } from '@aws-amplify/core';
-import { putEvents } from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint/putEvents';
-import { updateEndpoint } from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint/updateEndpoint';
+import {
+	putEvents,
+	updateEndpoint,
+} from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint'; // TODO: convert to subpath import from core
 
 import { AWSPinpointProviderCommon } from '../../../src/common';
 

--- a/packages/notifications/__tests__/common/AWSPinpointProviderCommon/index.test.ts
+++ b/packages/notifications/__tests__/common/AWSPinpointProviderCommon/index.test.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Credentials, StorageHelper } from '@aws-amplify/core';
-import { PinpointClient } from '@aws-sdk/client-pinpoint';
+import { putEvents } from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint/putEvents';
+import { updateEndpoint } from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint/updateEndpoint';
 
 import { AWSPinpointProviderCommon } from '../../../src/common';
 
@@ -17,13 +18,13 @@ import { mockLogger, mockStorage } from '../../../__mocks__/mocks';
 import { NotificationsSubCategory } from '../../../src/types';
 
 jest.mock('@aws-amplify/core');
-jest.mock('@aws-sdk/client-pinpoint');
+jest.mock('@aws-amplify/core/lib-esm/AwsClients/Pinpoint/putEvents');
+jest.mock('@aws-amplify/core/lib-esm/AwsClients/Pinpoint/updateEndpoint');
 jest.mock('../../../src/common/eventListeners');
 
 const SUB_CATEGORY = 'SubCategory';
 
 const getStorageSpy = jest.spyOn(StorageHelper.prototype, 'getStorage');
-const clientSendSpy = jest.spyOn(PinpointClient.prototype, 'send');
 
 class AWSPinpointProviderTest extends AWSPinpointProviderCommon {
 	getSubCategory() {
@@ -41,6 +42,8 @@ class AWSPinpointProviderTest extends AWSPinpointProviderCommon {
 
 const credentialsGetSpy = jest.spyOn(Credentials, 'get');
 const credentialsShearSpy = jest.spyOn(Credentials, 'shear');
+const mockPutEvents = putEvents as jest.Mock;
+const mockUpdateEndpoint = updateEndpoint as jest.Mock;
 
 describe('AWSPinpoint Common Provider', () => {
 	let provider: AWSPinpointProviderTest;
@@ -113,7 +116,7 @@ describe('AWSPinpoint Common Provider', () => {
 			await provider.testRecordAnalyticsEvent(analyticsEvent);
 
 			expect(mockLogger.debug).toBeCalledWith('recording analytics event');
-			expect(clientSendSpy).toBeCalled();
+			expect(mockPutEvents).toBeCalled();
 		});
 
 		test('throws an error if credentials are empty', async () => {
@@ -124,7 +127,7 @@ describe('AWSPinpoint Common Provider', () => {
 			).rejects.toThrow();
 
 			expect(mockLogger.debug).toBeCalledWith('no credentials found');
-			expect(clientSendSpy).not.toBeCalled();
+			expect(mockPutEvents).not.toBeCalled();
 		});
 
 		test('throws an error on credentials get failure', async () => {
@@ -140,11 +143,11 @@ describe('AWSPinpoint Common Provider', () => {
 				expect.stringContaining('Error getting credentials'),
 				expect.any(Error)
 			);
-			expect(clientSendSpy).not.toBeCalled();
+			expect(mockPutEvents).not.toBeCalled();
 		});
 
 		test('throws an error on client failure', async () => {
-			clientSendSpy.mockImplementationOnce(() => {
+			mockPutEvents.mockImplementationOnce(() => {
 				throw new Error();
 			});
 
@@ -168,11 +171,11 @@ describe('AWSPinpoint Common Provider', () => {
 			await provider.identifyUser(userId, userInfo);
 
 			expect(mockLogger.debug).toBeCalledWith('updating endpoint');
-			expect(clientSendSpy).toBeCalled();
+			expect(mockUpdateEndpoint).toBeCalled();
 		});
 
 		test('throws an error on client failure', async () => {
-			clientSendSpy.mockImplementationOnce(() => {
+			mockUpdateEndpoint.mockImplementationOnce(() => {
 				throw new Error();
 			});
 

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -63,13 +63,13 @@
 			"name": "Notifications (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Notifications }",
-			"limit": "59.3 kB"
+			"limit": "28.75 kB"
 		},
 		{
 			"name": "Notifications (with Analytics)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Notifications, Analytics }",
-			"limit": "59.3 kB"
+			"limit": "28.76 kB"
 		}
 	]
 }

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -51,9 +51,12 @@
 	"dependencies": {
 		"@aws-amplify/cache": "5.0.25",
 		"@aws-amplify/core": "5.1.8",
-		"@aws-sdk/client-pinpoint": "3.186.1",
 		"lodash": "^4.17.21",
 		"uuid": "^3.2.1"
+	},
+	"devDependencies": {
+		"@aws-amplify/rtn-push-notification": "1.0.0",
+		"@aws-sdk/client-pinpoint": "3.186.1"
 	},
 	"size-limit": [
 		{
@@ -68,8 +71,5 @@
 			"import": "{ Amplify, Notifications, Analytics }",
 			"limit": "59.3 kB"
 		}
-	],
-	"devDependencies": {
-		"@aws-amplify/rtn-push-notification": "1.0.0"
-	}
+	]
 }

--- a/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/index.ts
+++ b/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/index.ts
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { InAppMessageCampaign as PinpointInAppMessage } from '@aws-sdk/client-pinpoint';
 import {
-	ChannelType,
-	GetInAppMessagesCommand,
-	GetInAppMessagesCommandInput,
-	InAppMessageCampaign as PinpointInAppMessage,
-} from '@aws-sdk/client-pinpoint';
+	getInAppMessages,
+	GetInAppMessagesInput,
+	GetInAppMessagesOutput,
+} from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint';
 
 import { addEventListener, AWSPinpointProviderCommon } from '../../../common';
 import SessionTracker, {
@@ -69,7 +69,7 @@ export default class AWSPinpointProvider
 	configure = (config = {}): Record<string, any> => {
 		this.config = {
 			...super.configure(config),
-			endpointInfo: { channelType: ChannelType.IN_APP },
+			endpointInfo: { channelType: 'IN_APP' },
 		};
 
 		// some configuration steps should not be re-run even if provider is re-configured for some reason
@@ -121,16 +121,16 @@ export default class AWSPinpointProvider
 		clearMemo();
 		try {
 			await this.updateEndpoint();
-			const { appId, endpointId, pinpointClient } = this.config;
-			const input: GetInAppMessagesCommandInput = {
+			const { appId, credentials, endpointId, region } = this.config;
+			const input: GetInAppMessagesInput = {
 				ApplicationId: appId,
 				EndpointId: endpointId,
 			};
-			const command: GetInAppMessagesCommand = new GetInAppMessagesCommand(
+			this.logger.debug('getting in-app messages');
+			const response: GetInAppMessagesOutput = await getInAppMessages(
+				{ credentials, region },
 				input
 			);
-			this.logger.debug('getting in-app messages');
-			const response = await pinpointClient.send(command);
 			const { InAppMessageCampaigns: messages } =
 				response.InAppMessagesResponse;
 			dispatchInAppMessagingEvent('getInAppMessages', messages);

--- a/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/index.ts
+++ b/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/index.ts
@@ -6,7 +6,7 @@ import {
 	getInAppMessages,
 	GetInAppMessagesInput,
 	GetInAppMessagesOutput,
-} from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint';
+} from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint'; // TODO: convert to subpath import from core
 
 import { addEventListener, AWSPinpointProviderCommon } from '../../../common';
 import SessionTracker, {

--- a/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/utils.ts
+++ b/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/utils.ts
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Amplify, ConsoleLogger, Hub } from '@aws-amplify/core';
-import {
-	InAppMessageCampaign as PinpointInAppMessage,
-	Layout as PinpointInAppMessageLayout,
-} from '@aws-sdk/client-pinpoint';
+import type { InAppMessageCampaign as PinpointInAppMessage } from '@aws-sdk/client-pinpoint';
 import isEmpty from 'lodash/isEmpty';
 import { AMPLIFY_SYMBOL } from '../../../common';
 import {
@@ -218,11 +215,11 @@ export const clearMemo = () => {
 export const interpretLayout = (
 	layout: PinpointInAppMessage['InAppMessage']['Layout']
 ): InAppMessageLayout => {
-	if (layout === PinpointInAppMessageLayout.MOBILE_FEED) {
+	if (layout === 'MOBILE_FEED') {
 		return 'MODAL';
 	}
 
-	if (layout === PinpointInAppMessageLayout.OVERLAYS) {
+	if (layout === 'OVERLAYS') {
 		return 'FULL_SCREEN';
 	}
 

--- a/packages/notifications/src/PushNotification/Providers/AWSPinpointProvider/index.ts
+++ b/packages/notifications/src/PushNotification/Providers/AWSPinpointProvider/index.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ChannelType } from '@aws-sdk/client-pinpoint';
 import { addEventListener, AWSPinpointProviderCommon } from '../../../common';
+import { ChannelType } from '../../../common/AWSPinpointProviderCommon/types';
 import PlatformNotSupportedError from '../../PlatformNotSupportedError';
 import { Platform } from '../../Platform';
 import {
@@ -108,11 +108,11 @@ export default class AWSPinpointProvider
 		switch (Platform.OS) {
 			case 'android': {
 				// FCM was previously known as GCM and continues to be the channel type in Pinpoint
-				return ChannelType.GCM;
+				return 'GCM';
 			}
 			case 'ios': {
 				// If building in debug mode, use the APNs sandbox
-				return global['__DEV__'] ? ChannelType.APNS_SANDBOX : ChannelType.APNS;
+				return global['__DEV__'] ? 'APNS_SANDBOX' : 'APNS';
 			}
 			default: {
 				throw new PlatformNotSupportedError();

--- a/packages/notifications/src/PushNotification/Providers/AWSPinpointProvider/utils.ts
+++ b/packages/notifications/src/PushNotification/Providers/AWSPinpointProvider/utils.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Event as AWSPinpointAnalyticsEvent } from '@aws-sdk/client-pinpoint';
+import type { Event as AWSPinpointAnalyticsEvent } from '@aws-sdk/client-pinpoint';
 import { ConsoleLogger, Hub } from '@aws-amplify/core';
 import { AMPLIFY_SYMBOL } from '../../../common';
 import { PushNotificationMessage } from '../../types';

--- a/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
+++ b/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
@@ -15,7 +15,7 @@ import {
 	PutEventsInput,
 	updateEndpoint,
 	UpdateEndpointInput,
-} from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint';
+} from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint'; // TODO: convert to subpath import from core
 import { v4 as uuid } from 'uuid';
 
 import {

--- a/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
+++ b/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
@@ -5,19 +5,17 @@ import {
 	ClientDevice,
 	ConsoleLogger,
 	Credentials,
-	getAmplifyUserAgent,
 	StorageHelper,
 	transferKeyToUpperCase,
 } from '@aws-amplify/core';
 import { Cache } from '@aws-amplify/cache';
+import type { Event as AWSPinpointAnalyticsEvent } from '@aws-sdk/client-pinpoint';
 import {
-	Event as AWSPinpointAnalyticsEvent,
-	UpdateEndpointCommand,
-	UpdateEndpointCommandInput,
-	PinpointClient,
-	PutEventsCommand,
-	PutEventsCommandInput,
-} from '@aws-sdk/client-pinpoint';
+	putEvents,
+	PutEventsInput,
+	updateEndpoint,
+	UpdateEndpointInput,
+} from '@aws-amplify/core/lib-esm/AwsClients/Pinpoint';
 import { v4 as uuid } from 'uuid';
 
 import {
@@ -107,23 +105,15 @@ export default abstract class AWSPinpointProviderCommon
 	protected recordAnalyticsEvent = async (
 		event: AWSPinpointAnalyticsEvent
 	): Promise<void> => {
-		const { appId, credentials, endpointId, pinpointClient } = this.config;
-		const currentCredentials = await this.getCredentials();
-		// Shallow compare to determine if credentials stored here are outdated
-		const credentialsUpdated =
-			!credentials ||
-			Object.keys(currentCredentials).some(
-				key => currentCredentials[key] !== credentials[key]
-			);
 		// Update credentials
-		this.config.credentials = currentCredentials;
+		this.config.credentials = await this.getCredentials();
+		// Assert required configuration properties to make `putEvents` request are present
+		this.assertValidConfiguration();
+		const { appId, credentials, endpointId, region } = this.config;
+
 		try {
-			// Initialize a new pinpoint client if one isn't already configured or if credentials changed
-			if (!pinpointClient || credentialsUpdated) {
-				await this.initPinpointClient();
-			}
 			// Create the PutEvents input
-			const input: PutEventsCommandInput = {
+			const input: PutEventsInput = {
 				ApplicationId: appId,
 				EventsRequest: {
 					BatchItem: {
@@ -136,9 +126,8 @@ export default abstract class AWSPinpointProviderCommon
 					},
 				},
 			};
-			const command: PutEventsCommand = new PutEventsCommand(input);
 			this.logger.debug('recording analytics event');
-			await this.config.pinpointClient.send(command);
+			await putEvents({ credentials, region }, input);
 		} catch (err) {
 			this.logger.error('Error recording analytics event', err);
 			throw err;
@@ -149,19 +138,12 @@ export default abstract class AWSPinpointProviderCommon
 		userId: string = null,
 		userInfo: AWSPinpointUserInfo = null
 	): Promise<void> => {
-		const {
-			appId,
-			credentials,
-			endpointId,
-			endpointInfo = {},
-			pinpointClient,
-		} = this.config;
-		const currentCredentials = await this.getCredentials();
+		const credentials = await this.getCredentials();
 		// Shallow compare to determine if credentials stored here are outdated
 		const credentialsUpdated =
-			!credentials ||
-			Object.keys(currentCredentials).some(
-				key => currentCredentials[key] !== credentials[key]
+			!this.config.credentials ||
+			Object.keys(credentials).some(
+				key => credentials[key] !== this.config.credentials[key]
 			);
 		// If endpoint is already initialized, and nothing else is changing, just early return
 		if (
@@ -173,18 +155,17 @@ export default abstract class AWSPinpointProviderCommon
 			return;
 		}
 		// Update credentials
-		this.config.credentials = currentCredentials;
+		this.config.credentials = credentials;
+		// Assert required configuration properties to make `updateEndpoint` request are present
+		this.assertValidConfiguration();
+		const { appId, endpointId, endpointInfo = {}, region } = this.config;
 		try {
-			// Initialize a new pinpoint client if one isn't already configured or if credentials changed
-			if (!pinpointClient || credentialsUpdated) {
-				this.initPinpointClient();
-			}
 			const { address, attributes, demographic, location, metrics, optOut } =
 				userInfo ?? {};
 			const { appVersion, make, model, platform, version } = this.clientInfo;
 			// Create the UpdateEndpoint input, prioritizing passed in user info and falling back to
 			// defaults (if any) obtained from the config
-			const input: UpdateEndpointCommandInput = {
+			const input: UpdateEndpointInput = {
 				ApplicationId: appId,
 				EndpointId: endpointId,
 				EndpointRequest: {
@@ -217,39 +198,17 @@ export default abstract class AWSPinpointProviderCommon
 					},
 					OptOut: optOut ?? endpointInfo.optOut,
 					User: {
-						UserId:
-							userId ?? endpointInfo.userId ?? currentCredentials.identityId,
+						UserId: userId ?? endpointInfo.userId ?? credentials.identityId,
 						UserAttributes: attributes ?? endpointInfo.userAttributes,
 					},
 				},
 			};
-			const command: UpdateEndpointCommand = new UpdateEndpointCommand(input);
 			this.logger.debug('updating endpoint');
-			await this.config.pinpointClient.send(command);
+			await updateEndpoint({ credentials, region }, input);
 			this.endpointInitialized = true;
 		} catch (err) {
 			throw err;
 		}
-	};
-
-	private initPinpointClient = (): void => {
-		const { appId, credentials, pinpointClient, region } = this.config;
-
-		if (!appId || !credentials || !region) {
-			throw new Error(
-				'One or more of credentials, appId or region is not configured'
-			);
-		}
-
-		if (pinpointClient) {
-			pinpointClient.destroy();
-		}
-
-		this.config.pinpointClient = new PinpointClient({
-			region,
-			credentials,
-			customUserAgent: getAmplifyUserAgent(`/${this.getSubCategory()}`),
-		});
 	};
 
 	private getEndpointId = async (): Promise<string> => {
@@ -290,6 +249,15 @@ export default abstract class AWSPinpointProviderCommon
 		} catch (err) {
 			this.logger.error('Error getting credentials:', err);
 			return null;
+		}
+	};
+
+	private assertValidConfiguration = () => {
+		const { appId, credentials, region } = this.config;
+		if (!appId || !credentials || !region) {
+			throw new Error(
+				'One or more of credentials, appId or region is not configured'
+			);
 		}
 	};
 }

--- a/packages/notifications/src/common/AWSPinpointProviderCommon/types.ts
+++ b/packages/notifications/src/common/AWSPinpointProviderCommon/types.ts
@@ -12,3 +12,18 @@ export interface AWSPinpointUserInfo extends UserInfo {
 	address?: string;
 	optOut?: 'ALL' | 'NONE';
 }
+
+export type ChannelType =
+	| 'ADM'
+	| 'APNS'
+	| 'APNS_SANDBOX'
+	| 'APNS_VOIP'
+	| 'APNS_VOIP_SANDBOX'
+	| 'BAIDU'
+	| 'CUSTOM'
+	| 'EMAIL'
+	| 'GCM'
+	| 'IN_APP'
+	| 'PUSH'
+	| 'SMS'
+	| 'VOICE';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR replaces the Pinpoint client vended by the AWS SDK with internally crafted APIs

#### Description of how you validated changes
Updated unit tests without changing test expectations. Tested the execution of `updateEndpoint`, `putEvents` and `getInAppMessages` in Analytics (with and without buffer) and Notification categories. Tested using sample NextJS app on web + React Native on both Android and iOS.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
