### PR TITLE
fix(amazon-cognito-identity-js): inherit pool storage (#10810)

### DIFF
--- a/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/CognitoUser.test.js
@@ -74,6 +74,23 @@ describe('CognitoUser constructor', () => {
 
 		expect(spyon).toBeCalled();
 	});
+
+	describe('storage', () => {
+		test('inherit from pool', () => {
+			const user = new CognitoUser({ ...userDefaults });
+			expect(user.storage).toBe(userDefaults.Pool.storage);
+		});
+
+		test('allow modification', () => {
+			class TempStorage {
+				constructor() {}
+			}
+			const store = new TempStorage();
+			const user = new CognitoUser({ ...userDefaults, Storage: store });
+			expect(user.storage).toBe(store);
+			expect(user.storage).not.toBe(userDefaults.Pool.storage);
+		});
+	});
 });
 
 describe('getters and setters', () => {
@@ -1660,36 +1677,34 @@ describe('refreshSession()', () => {
 
 	test('update attributes usage of three out of three parameters in callback', () => {
 		const codeDeliverDetailsResult = {
-			'CodeDeliveryDetailsList': [ 
-			   { 
-				  'AttributeName': 'email',
-				  'DeliveryMedium': 'EMAIL',
-				  'Destination': 'e***@e***'
-			   }
-			]
+			CodeDeliveryDetailsList: [
+				{
+					AttributeName: 'email',
+					DeliveryMedium: 'EMAIL',
+					Destination: 'e***@e***',
+				},
+			],
 		};
-		const spyon = jest.spyOn(CognitoUser.prototype, 'updateAttributes')
+		const spyon = jest
+			.spyOn(CognitoUser.prototype, 'updateAttributes')
 			.mockImplementationOnce((attrs, callback) => {
 				callback(null, 'SUCCESS', codeDeliverDetailsResult);
-		});
+			});
 		const attrs = [
 			{
 				Name: 'email',
-				Value: 'email@email.com'
+				Value: 'email@email.com',
 			},
 			{
 				Name: 'family_name',
-				Value: 'familyName'
-			}
+				Value: 'familyName',
+			},
 		];
-		cognitoUser.updateAttributes(
-			attrs,
-			(err, result, details) => {
-				expect(err).toBe(null);
-				expect(result).toBe('SUCCESS');
-				expect(details).toBe(codeDeliverDetailsResult);
-			} 
-		);
+		cognitoUser.updateAttributes(attrs, (err, result, details) => {
+			expect(err).toBe(null);
+			expect(result).toBe('SUCCESS');
+			expect(details).toBe(codeDeliverDetailsResult);
+		});
 		spyon.mockClear();
 	});
 });

--- a/packages/amazon-cognito-identity-js/src/CognitoUser.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUser.js
@@ -70,7 +70,7 @@ export default class CognitoUser {
 	 * @param {object} data Creation options
 	 * @param {string} data.Username The user's username.
 	 * @param {CognitoUserPool} data.Pool Pool containing the user.
-	 * @param {object} data.Storage Optional storage object.
+	 * @param {object} data.Storage Optional storage object, uses Pool storage otherwise.
 	 */
 	constructor(data) {
 		if (data == null || data.Username == null || data.Pool == null) {
@@ -86,7 +86,7 @@ export default class CognitoUser {
 		this.signInUserSession = null;
 		this.authenticationFlowType = 'USER_SRP_AUTH';
 
-		this.storage = data.Storage || new StorageHelper().getStorage();
+		this.storage = data.Storage || data.Pool.storage;
 
 		this.keyPrefix = `CognitoIdentityServiceProvider.${this.pool.getClientId()}`;
 		this.userDataKey = `${this.keyPrefix}.${this.username}.userData`;
@@ -1130,7 +1130,7 @@ export default class CognitoUser {
 				UserAttributes: attributes,
 				ClientMetadata: clientMetadata,
 			},
-			(err,result) => {
+			(err, result) => {
 				if (err) {
 					return callback(err, null);
 				}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Forces `CognitoUser` to inherit Pool's storage, unless explicitly overriden. 


#### Issue #, if available
#10810



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
