### PR TITLE
chore(predictions): add missing buffer dependency

### DIFF
--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -54,6 +54,7 @@
 		"@aws-sdk/client-translate": "3.6.1",
 		"@aws-sdk/eventstream-marshaller": "3.6.1",
 		"@aws-sdk/util-utf8-node": "3.6.1",
+		"buffer": "4.9.2",
 		"tslib": "^1.8.0",
 		"uuid": "^3.2.1"
 	},

--- a/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
@@ -24,6 +24,7 @@ import {
 	MessageHeaderValue,
 } from '@aws-sdk/eventstream-marshaller';
 import { fromUtf8, toUtf8 } from '@aws-sdk/util-utf8-node';
+import { Buffer } from 'buffer/';
 
 const logger = new Logger('AmazonAIConvertPredictionsProvider');
 const eventBuilder = new EventStreamMarshaller(toUtf8, fromUtf8);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add the missing buffer dependency used by the Predictions transcribe component: https://github.com/aws-amplify/amplify-js/blob/0fa40e6efb67def43f0eb912b3f2ed34da883f5f/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts#L293

The `buffer` dependency is the same version used in `amazon-cognito-identity-js` package:
https://github.com/aws-amplify/amplify-js/blob/88b5c26daf30304e9f4b2bf5064bfce545ad06b7/packages/amazon-cognito-identity-js/package.json#L67

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
React Native customer seeing `ReferenceError: Property 'Buffer' doesn't exist` error when following the [doc code snippet](https://docs.amplify.aws/lib/predictions/transcribe/q/platform/react-native/)

P88158994

#### Description of how you validated changes
Manual test on RN.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
