### PR TITLE
feat(clients): allow fetch handler to read body multiple times

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -66,7 +66,7 @@
 			"name": "Analytics (Pinpoint)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Analytics, AWSPinpointProvider }",
-			"limit": "29.65 kB"
+			"limit": "29.7 kB"
 		},
 		{
 			"name": "Analytics (Kinesis)",

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -64,7 +64,7 @@
       "name": "API (GraphQL client)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, GraphQLAPI }",
-      "limit": "87.05 kB"
+      "limit": "87.1 kB"
     }
   ],
   "jest": {

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -55,7 +55,7 @@
       "name": "API (rest client)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, RestAPI }",
-      "limit": "29.7 kB"
+      "limit": "29.75 kB"
     }
   ],
   "jest": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -66,7 +66,7 @@
 			"name": "API (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, API }",
-			"limit": "88.3 kB"
+			"limit": "88.35 kB"
 		}
 	],
 	"jest": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -58,7 +58,7 @@
       "name": "Auth (top-level class)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, Auth }",
-      "limit": "53.7 kB"
+      "limit": "53.8 kB"
     }
   ],
   "jest": {

--- a/packages/core/__tests__/clients/fetch-test.ts
+++ b/packages/core/__tests__/clients/fetch-test.ts
@@ -47,30 +47,36 @@ describe(fetchTransferHandler.name, () => {
 		expect(headers).toEqual({ bar: 'foo' });
 	});
 
-	test('should support text() in response.body', async () => {
+	test('should support text() in response.body with caching', async () => {
+		mockBody.text.mockResolvedValue('payload value');
 		const { body } = await fetchTransferHandler(mockRequest, {});
 		if (!body) {
 			fail('body should exist');
 		}
 		await body.text();
+		await body.text(); // test caching
 		expect(mockBody.text).toBeCalledTimes(1);
 	});
 
-	test('should support blob() in response.body', async () => {
+	test('should support blob() in response.body with caching', async () => {
+		mockBody.blob.mockResolvedValue('payload value');
 		const { body } = await fetchTransferHandler(mockRequest, {});
 		if (!body) {
 			fail('body should exist');
 		}
 		await body.blob();
+		await body.blob(); // test caching
 		expect(mockBody.blob).toBeCalledTimes(1);
 	});
 
-	test('should support json() in response.body', async () => {
+	test('should support json() in response.body with caching', async () => {
+		mockBody.json.mockResolvedValue('payload value');
 		const { body } = await fetchTransferHandler(mockRequest, {});
 		if (!body) {
 			fail('body should exist');
 		}
 		await body.json();
+		await body.json(); // test caching
 		expect(mockBody.json).toBeCalledTimes(1);
 	});
 

--- a/packages/core/__tests__/clients/fetch-test.ts
+++ b/packages/core/__tests__/clients/fetch-test.ts
@@ -24,6 +24,7 @@ describe(fetchTransferHandler.name, () => {
 		headers: {},
 		url: new URL('https://foo.bar'),
 	};
+	const mockPayloadValue = 'payload value';
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -48,36 +49,36 @@ describe(fetchTransferHandler.name, () => {
 	});
 
 	test('should support text() in response.body with caching', async () => {
-		mockBody.text.mockResolvedValue('payload value');
+		mockBody.text.mockResolvedValue(mockPayloadValue);
 		const { body } = await fetchTransferHandler(mockRequest, {});
 		if (!body) {
 			fail('body should exist');
 		}
-		await body.text();
-		await body.text(); // test caching
-		expect(mockBody.text).toBeCalledTimes(1);
+		expect(await body.text()).toBe(mockPayloadValue);
+		expect(await body.text()).toBe(mockPayloadValue);
+		expect(mockBody.text).toBeCalledTimes(1); // test caching
 	});
 
 	test('should support blob() in response.body with caching', async () => {
-		mockBody.blob.mockResolvedValue('payload value');
+		mockBody.blob.mockResolvedValue(mockPayloadValue);
 		const { body } = await fetchTransferHandler(mockRequest, {});
 		if (!body) {
 			fail('body should exist');
 		}
-		await body.blob();
-		await body.blob(); // test caching
-		expect(mockBody.blob).toBeCalledTimes(1);
+		expect(await body.blob()).toBe(mockPayloadValue);
+		expect(await body.blob()).toBe(mockPayloadValue);
+		expect(mockBody.blob).toBeCalledTimes(1); // test caching
 	});
 
 	test('should support json() in response.body with caching', async () => {
-		mockBody.json.mockResolvedValue('payload value');
+		mockBody.json.mockResolvedValue(mockPayloadValue);
 		const { body } = await fetchTransferHandler(mockRequest, {});
 		if (!body) {
 			fail('body should exist');
 		}
-		await body.json();
-		await body.json(); // test caching
-		expect(mockBody.json).toBeCalledTimes(1);
+		expect(await body.json()).toBe(mockPayloadValue);
+		expect(await body.json()).toBe(mockPayloadValue);
+		expect(mockBody.json).toBeCalledTimes(1); // test caching
 	});
 
 	test.each(['GET', 'HEAD', 'DELETE'])(

--- a/packages/core/internals/aws-client-utils/package.json
+++ b/packages/core/internals/aws-client-utils/package.json
@@ -1,7 +1,8 @@
 {
-	"name": "@aws-amplify/core/aws-client-utils",
+	"name": "@aws-amplify/core/internals/aws-client-utils",
 	"types": "../../../lib-esm/clients/index.d.ts",
 	"main": "../../../lib/clients/index.js",
 	"module": "../../../lib-esm/clients/index.js",
+	"react-native": "../../../lib-esm/clients/index.js",
 	"sideEffects": false
 }

--- a/packages/core/internals/aws-clients/pinpoint/package.json
+++ b/packages/core/internals/aws-clients/pinpoint/package.json
@@ -1,7 +1,8 @@
 {
-	"name": "@aws-amplify/core/aws-clients/pinpoint",
+	"name": "@aws-amplify/core/internals/aws-clients/pinpoint",
 	"types": "../../../lib-esm/AwsClients/Pinpoint/index.d.ts",
 	"main": "../../../lib/AwsClients/Pinpoint/index.js",
 	"module": "../../../lib-esm/AwsClients/Pinpoint/index.js",
+	"react-native": "../../../lib-esm/AwsClients/Pinpoint/index.js",
 	"sideEffects": false
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -104,7 +104,7 @@
 			"name": "Core (Credentials)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Credentials }",
-			"limit": "12 kB"
+			"limit": "12.05 kB"
 		},
 		{
 			"name": "Core (Signer)",
@@ -116,13 +116,13 @@
 			"name": "Custom clients (fetch handler)",
 			"path": "./lib-esm/clients/handlers/fetch.js",
 			"import": "{ fetchTransferHandler }",
-			"limit": "1.73 kB"
+			"limit": "1.85 kB"
 		},
 		{
 			"name": "Custom clients (unauthenticated handler)",
 			"path": "./lib-esm/clients/handlers/unauthenticated.js",
 			"import": "{ unauthenticatedHandler }",
-			"limit": "2.75 kB"
+			"limit": "2.85 kB"
 		},
 		{
 			"name": "Custom clients (retry middleware)",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -72,7 +72,7 @@
 			"name": "DataStore (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, DataStore }",
-			"limit": "136.45 kB"
+			"limit": "136.5 kB"
 		}
 	],
 	"jest": {

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -63,13 +63,13 @@
       "name": "PubSub (IoT provider)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, PubSub, AWSIoTProvider }",
-      "limit": "79.1 kB"
+      "limit": "79.15 kB"
     },
     {
       "name": "PubSub (Mqtt provider)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, PubSub, MqttOverWSProvider }",
-      "limit": "78.95 kB"
+      "limit": "79 kB"
     }
   ],
   "jest": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -60,7 +60,7 @@
       "name": "Storage (top-level class)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, Storage }",
-      "limit": "84.8 kB"
+      "limit": "84.85 kB"
     }
   ],
   "jest": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Cache the payload of a response body when accessor is called(`body.json()`, `body.blob()`, `body.text()`, etc.). It allows multiple calls to the body accessors, for example, when reading the body in both retry decider and error deserializer. Otherwise, the API will throw the body has been read error.

Caching body is allowed here because customers will keep a reference to the data in memory anyway without the cache when they use these accessors.

This change also add a `react-native` entry point for cross-category internal components.(cc @erinleigh90 )

#### Description of how you validated changes
Unit tests, Integration test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
