### PR TITLE
chore: Added Next.js App Router canaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2332,20 +2332,29 @@ workflows:
           build-dir: build
       # Next
       - getting-started-smoke-test/web:
-          name: Next.js - latest
+          name: Next.js (Page Router) - latest
           npx-command: create-next-app
-          npx-post: --use-npm --ts --tailwind --no-eslint --no-src-dir --no-app --import-alias "@/*"`
+          npx-post: --use-npm --ts --tailwind --no-eslint --no-src-dir --no-app --import-alias "@/*"
           framework: nextjs
           main-file-path: pages/_app.tsx
           dev-start: dev
           build-dir: build
           ssr: true
       - getting-started-smoke-test/web:
-          name: Next.js - next
-          npx-command: create-next-app@canary
-          npx-post: --use-npm --ts --tailwind --no-eslint --no-src-dir --no-app --import-alias "@/*"`
+          name: Next.js (App Router) - latest
+          npx-command: create-next-app
+          npx-post: --use-npm --ts --tailwind --no-eslint --no-src-dir --app --import-alias "@/*"
           framework: nextjs
-          main-file-path: pages/_app.tsx
+          main-file-path: app/page.tsx
+          dev-start: dev
+          build-dir: build
+          ssr: true
+      - getting-started-smoke-test/web:
+          name: Next.js (App Router) - next
+          npx-command: create-next-app@canary
+          npx-post: --use-npm --ts --tailwind --no-eslint --no-src-dir --app --import-alias "@/*"
+          framework: nextjs
+          main-file-path: app/page.tsx
           dev-start: dev
           build-dir: build
           ssr: true


### PR DESCRIPTION
This reverts commit c19590e51500f3f00da28611e52bb2ac869f10d0.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds basic Next.js App Router canaries. Removed the `@canary` Page Router canary considering App Router will be the default going forward.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Local test workspace will same commands.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
