### PR TITLE
fix(storage): make getProperties param optional

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -60,7 +60,7 @@
       "name": "Storage (top-level class)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, Storage }",
-      "limit": "87 kB"
+      "limit": "87.02 kB"
     }
   ],
   "jest": {

--- a/packages/storage/src/Storage.ts
+++ b/packages/storage/src/Storage.ts
@@ -322,11 +322,11 @@ export class Storage {
 			throw new Error('No plugin found with providerName');
 		}
 		const cancelTokenSource = this.getCancellableTokenSource();
-		
+
 		if (typeof plugin.getProperties !== 'function') {
 			throw new Error(
 				`.getProperties is not implemented on provider ${plugin.getProviderName()}`
-			) 
+			);
 		}
 		const responsePromise = plugin.getProperties(key, {
 			...config,

--- a/packages/storage/src/Storage.ts
+++ b/packages/storage/src/Storage.ts
@@ -322,6 +322,12 @@ export class Storage {
 			throw new Error('No plugin found with providerName');
 		}
 		const cancelTokenSource = this.getCancellableTokenSource();
+		
+		if (typeof plugin.getProperties !== 'function') {
+			throw new Error(
+				`.getProperties is not implemented on provider ${plugin.getProviderName()}`
+			) 
+		}
 		const responsePromise = plugin.getProperties(key, {
 			...config,
 		});

--- a/packages/storage/src/types/Provider.ts
+++ b/packages/storage/src/types/Provider.ts
@@ -21,7 +21,7 @@ export interface StorageProvider {
 	get(key: string, options?): Promise<string | Object>;
 
 	// get properties of object
-	getProperties(key: string, options?): Promise<Object>;
+	getProperties?(key: string, options?): Promise<Object>;
 
 	// upload storage object
 	put(key: string, object, options?): Promise<Object> | UploadTask;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Release 5.2.3 brought a braking change by introducing a getProperties required field in the StorageProvider interface. The solution was to make this field optional

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
