### PR TITLE
fix: Revert `getProperties` API

### DIFF
--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -75,7 +75,7 @@
 			"name": "Predictions (Identify provider)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Predictions, AmazonAIIdentifyPredictionsProvider }",
-			"limit": "105 kB"
+			"limit": "104.5 kB"
 		},
 		{
 			"name": "Predictions (Interpret provider)",

--- a/packages/storage/__tests__/Storage-unit-test.ts
+++ b/packages/storage/__tests__/Storage-unit-test.ts
@@ -44,10 +44,6 @@ class TestCustomProvider implements StorageProvider {
 		return Promise.resolve({ newKey: 'get' });
 	}
 
-	getProperties(key: string, options?: CustomProviderConfig) {
-		return Promise.resolve({ newKey: 'getProperties' });
-	}
-
 	put(key: string, object: any, config: CustomProviderConfig) {
 		return Promise.resolve({ newKey: 'put' });
 	}
@@ -613,76 +609,6 @@ describe('Storage', () => {
 				config1: true,
 				config2: false,
 				config3: 'config',
-			});
-			expect(customProviderGetSpy).toBeCalled();
-		});
-	});
-
-	describe('getProperties test', () => {
-		let storage: StorageClass;
-		let provider: StorageProvider;
-		let getPropertiesSpy: jest.SpyInstance;
-
-		beforeEach(() => {
-			storage = new StorageClass();
-			provider = new AWSStorageProvider();
-			storage.addPluggable(provider);
-			storage.configure(options);
-			getPropertiesSpy = jest
-				.spyOn(AWSStorageProvider.prototype, 'getProperties')
-				.mockImplementation(() =>
-					Promise.resolve({
-						contentType: 'text/plain',
-						contentLength: 100,
-						eTag: 'etag',
-						lastModified: new Date('20 Oct 2023'),
-						metadata: { key: '' },
-					})
-				);
-		});
-
-		afterEach(() => {
-			jest.clearAllMocks();
-		});
-
-		describe('with default S3 provider', () => {
-			test('get properties of object successfully', async () => {
-				const result = await storage.getProperties('key');
-				expect(getPropertiesSpy).toBeCalled();
-				expect(result).toEqual({
-					contentType: 'text/plain',
-					contentLength: 100,
-					eTag: 'etag',
-					lastModified: new Date('20 Oct 2023'),
-					metadata: { key: '' },
-				});
-				getPropertiesSpy.mockClear();
-			});
-
-			test('get properties of object with available config', async () => {
-				await storage.getProperties('key', {
-					SSECustomerAlgorithm: 'aes256',
-					SSECustomerKey: 'key',
-					SSECustomerKeyMD5: 'md5',
-				});
-			});
-		});
-
-		test('get properties without provider', async () => {
-			const storage = new StorageClass();
-			try {
-				await storage.getProperties('key');
-			} catch (err) {
-				expect(err).toEqual(new Error('No plugin found with providerName'));
-			}
-		});
-
-		test('get properties with custom provider should work with no generic type provided', async () => {
-			const customProvider = new TestCustomProvider();
-			const customProviderGetSpy = jest.spyOn(customProvider, 'getProperties');
-			storage.addPluggable(customProvider);
-			await storage.getProperties('key', {
-				provider: 'customProvider',
 			});
 			expect(customProviderGetSpy).toBeCalled();
 		});

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -60,7 +60,7 @@
       "name": "Storage (top-level class)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, Storage }",
-      "limit": "87.02 kB"
+      "limit": "87 kB"
     }
   ],
   "jest": {

--- a/packages/storage/src/Storage.ts
+++ b/packages/storage/src/Storage.ts
@@ -23,8 +23,6 @@ import {
 	StorageListOutput,
 	StorageCopyOutput,
 	UploadTask,
-	StorageGetPropertiesConfig,
-	StorageGetPropertiesOutput,
 } from './types';
 import axios, { CancelTokenSource } from 'axios';
 import { PutObjectCommandInput } from '@aws-sdk/client-s3';
@@ -248,22 +246,22 @@ export class Storage {
 		config?: StorageCopyConfig<T>
 	): StorageCopyOutput<T> {
 		const provider = config?.provider || DEFAULT_PROVIDER;
-		const plugin = this._pluggables.find(
+		const prov = this._pluggables.find(
 			pluggable => pluggable.getProviderName() === provider
 		);
-		if (plugin === undefined) {
+		if (prov === undefined) {
 			logger.debug('No plugin found with providerName', provider);
 			return Promise.reject(
 				'No plugin found in Storage for the provider'
 			) as StorageCopyOutput<T>;
 		}
 		const cancelTokenSource = this.getCancellableTokenSource();
-		if (typeof plugin.copy !== 'function') {
+		if (typeof prov.copy !== 'function') {
 			return Promise.reject(
-				`.copy is not implemented on provider ${plugin.getProviderName()}`
+				`.copy is not implemented on provider ${prov.getProviderName()}`
 			) as StorageCopyOutput<T>;
 		}
-		const responsePromise = plugin.copy(src, dest, {
+		const responsePromise = prov.copy(src, dest, {
 			...config,
 			cancelTokenSource,
 		});
@@ -287,17 +285,17 @@ export class Storage {
 		T extends StorageProvider | { [key: string]: any; download?: boolean }
 	>(key: string, config?: StorageGetConfig<T>): StorageGetOutput<T> {
 		const provider = config?.provider || DEFAULT_PROVIDER;
-		const plugin = this._pluggables.find(
+		const prov = this._pluggables.find(
 			pluggable => pluggable.getProviderName() === provider
 		);
-		if (plugin === undefined) {
+		if (prov === undefined) {
 			logger.debug('No plugin found with providerName', provider);
 			return Promise.reject(
 				'No plugin found in Storage for the provider'
 			) as StorageGetOutput<T>;
 		}
 		const cancelTokenSource = this.getCancellableTokenSource();
-		const responsePromise = plugin.get(key, {
+		const responsePromise = prov.get(key, {
 			...config,
 			cancelTokenSource,
 		});
@@ -309,25 +307,6 @@ export class Storage {
 		return axios.isCancel(error);
 	}
 
-	public getProperties<T extends StorageProvider | { [key: string]: any }>(
-		key: string,
-		config?: StorageGetPropertiesConfig<T>
-	): StorageGetPropertiesOutput<T> {
-		const provider = config?.provider || DEFAULT_PROVIDER;
-		const plugin = this._pluggables.find(
-			pluggable => pluggable.getProviderName() === provider
-		);
-		if (plugin === undefined) {
-			logger.debug('No plugin found with providerName', provider);
-			throw new Error('No plugin found with providerName');
-		}
-		const cancelTokenSource = this.getCancellableTokenSource();
-		const responsePromise = plugin.getProperties(key, {
-			...config,
-		});
-		this.updateRequestToBeCancellable(responsePromise, cancelTokenSource);
-		return responsePromise as StorageGetPropertiesOutput<T>;
-	}
 	/**
 	 * Put a file in storage bucket specified to configure method
 	 * @param key - key of the object
@@ -347,17 +326,17 @@ export class Storage {
 		config?: StoragePutConfig<T>
 	): StoragePutOutput<T> {
 		const provider = config?.provider || DEFAULT_PROVIDER;
-		const plugin = this._pluggables.find(
+		const prov = this._pluggables.find(
 			pluggable => pluggable.getProviderName() === provider
 		);
-		if (plugin === undefined) {
+		if (prov === undefined) {
 			logger.debug('No plugin found with providerName', provider);
 			return Promise.reject(
 				'No plugin found in Storage for the provider'
 			) as StoragePutOutput<T>;
 		}
 		const cancelTokenSource = this.getCancellableTokenSource();
-		const response = plugin.put(key, object, {
+		const response = prov.put(key, object, {
 			...config,
 			cancelTokenSource,
 		});
@@ -382,16 +361,16 @@ export class Storage {
 		config?: StorageRemoveConfig<T>
 	): StorageRemoveOutput<T> {
 		const provider = config?.provider || DEFAULT_PROVIDER;
-		const plugin = this._pluggables.find(
+		const prov = this._pluggables.find(
 			pluggable => pluggable.getProviderName() === provider
 		);
-		if (plugin === undefined) {
+		if (prov === undefined) {
 			logger.debug('No plugin found with providerName', provider);
 			return Promise.reject(
 				'No plugin found in Storage for the provider'
 			) as StorageRemoveOutput<T>;
 		}
-		return plugin.remove(key, config) as StorageRemoveOutput<T>;
+		return prov.remove(key, config) as StorageRemoveOutput<T>;
 	}
 
 	/**
@@ -409,16 +388,16 @@ export class Storage {
 		config?: StorageListConfig<T>
 	): StorageListOutput<T> {
 		const provider = config?.provider || DEFAULT_PROVIDER;
-		const plugin = this._pluggables.find(
+		const prov = this._pluggables.find(
 			pluggable => pluggable.getProviderName() === provider
 		);
-		if (plugin === undefined) {
+		if (prov === undefined) {
 			logger.debug('No plugin found with providerName', provider);
 			return Promise.reject(
 				'No plugin found in Storage for the provider'
 			) as StorageListOutput<T>;
 		}
-		return plugin.list(path, config) as StorageListOutput<T>;
+		return prov.list(path, config) as StorageListOutput<T>;
 	}
 }
 

--- a/packages/storage/src/Storage.ts
+++ b/packages/storage/src/Storage.ts
@@ -322,12 +322,6 @@ export class Storage {
 			throw new Error('No plugin found with providerName');
 		}
 		const cancelTokenSource = this.getCancellableTokenSource();
-
-		if (typeof plugin.getProperties !== 'function') {
-			throw new Error(
-				`.getProperties is not implemented on provider ${plugin.getProviderName()}`
-			);
-		}
 		const responsePromise = plugin.getProperties(key, {
 			...config,
 		});

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -21,7 +21,6 @@ import {
 	GetObjectCommandInput,
 	ListObjectsV2Request,
 	HeadObjectCommand,
-	HeadObjectCommandInput,
 } from '@aws-sdk/client-s3';
 import { formatUrl } from '@aws-sdk/util-format-url';
 import { createRequest } from '@aws-sdk/util-create-request';
@@ -50,8 +49,6 @@ import {
 	UploadTask,
 	S3ClientOptions,
 	S3ProviderListOutput,
-	S3ProviderGetPropertiesOutput,
-	S3ProviderGetPropertiesConfig,
 } from '../types';
 import { StorageErrorStrings } from '../common/StorageErrorStrings';
 import { dispatchStorageEvent } from '../common/StorageUtils';
@@ -452,7 +449,7 @@ export class AWSS3Provider implements StorageProvider {
 		}
 		if (validateObjectExistence) {
 			const headObjectCommand = new HeadObjectCommand(params);
-
+			
 			try {
 				await s3.send(headObjectCommand);
 			} catch (error) {
@@ -497,87 +494,6 @@ export class AWSS3Provider implements StorageProvider {
 				null,
 				`Could not get a signed URL for ${key}`
 			);
-			throw error;
-		}
-	}
-
-	/**
-	 * Get Properties of the object
-	 *
-	 * @param {string} key - key of the object
-	 * @param {S3ProviderGetPropertiesConfig} [config] - Optional configuration for the underlying S3 command
-	 * @return {Promise<S3ProviderGetPropertiesOutput>} - A promise resolves to contentType,
-	 * contentLength, eTag, lastModified, metadata
-	 */
-	public async getProperties(
-		key: string,
-		config?: S3ProviderGetPropertiesConfig
-	): Promise<S3ProviderGetPropertiesOutput> {
-		const credentialsOK = await this._ensureCredentials();
-		if (!credentialsOK || !this._isWithCredentials(this._config)) {
-			throw new Error(StorageErrorStrings.NO_CREDENTIALS);
-		}
-		const opt = Object.assign({}, this._config, config);
-		const {
-			bucket,
-			track = false,
-			SSECustomerAlgorithm,
-			SSECustomerKey,
-			SSECustomerKeyMD5,
-		} = opt;
-		const prefix = this._prefix(opt);
-		const final_key = prefix + key;
-		const emitter = new events.EventEmitter();
-		const s3 = this._createNewS3Client(opt, emitter);
-		logger.debug(`getProperties ${key} from ${final_key}`);
-
-		const params: HeadObjectCommandInput = {
-			Bucket: bucket,
-			Key: final_key,
-		};
-
-		if (SSECustomerAlgorithm) {
-			params.SSECustomerAlgorithm = SSECustomerAlgorithm;
-		}
-		if (SSECustomerKey) {
-			params.SSECustomerKey = SSECustomerKey;
-		}
-		if (SSECustomerKeyMD5) {
-			params.SSECustomerKeyMD5 = SSECustomerKeyMD5;
-		}
-		// See: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/classes/headobjectcommand.html
-
-		const headObjectCommand = new HeadObjectCommand(params);
-		try {
-			const response = await s3.send(headObjectCommand);
-			const getPropertiesResponse: S3ProviderGetPropertiesOutput = {
-				contentLength: response.ContentLength,
-				contentType: response.ContentType,
-				eTag: response.ETag,
-				lastModified: response.LastModified,
-				metadata: response.Metadata,
-			};
-			dispatchStorageEvent(
-				track,
-				'getProperties',
-				{ method: 'getProperties', result: 'success' },
-				null,
-				`getProperties successful for ${key}`
-			);
-			return getPropertiesResponse;
-		} catch (error) {
-			if (error.$metadata.httpStatusCode === 404) {
-				dispatchStorageEvent(
-					track,
-					'getProperties',
-					{
-						method: 'getProperties',
-						result: 'failed',
-					},
-					null,
-					`${key} not found`
-				);
-			}
 			throw error;
 		}
 	}

--- a/packages/storage/src/types/AWSS3Provider.ts
+++ b/packages/storage/src/types/AWSS3Provider.ts
@@ -5,7 +5,6 @@ import {
 	CopyObjectRequest,
 	_Object,
 	DeleteObjectCommandOutput,
-	HeadObjectRequest,
 } from '@aws-sdk/client-s3';
 import { StorageOptions, StorageAccessLevel } from './Storage';
 import {
@@ -50,12 +49,6 @@ export type S3ProviderGetConfig = CommonStorageOptions & {
 	SSECustomerKey?: GetObjectRequest['SSECustomerKey'];
 	SSECustomerKeyMD5?: GetObjectRequest['SSECustomerKeyMD5'];
 	validateObjectExistence?: boolean;
-};
-
-export type S3ProviderGetPropertiesConfig = CommonStorageOptions & {
-	SSECustomerAlgorithm?: HeadObjectRequest['SSECustomerAlgorithm'];
-	SSECustomerKey?: HeadObjectRequest['SSECustomerKey'];
-	SSECustomerKeyMD5?: HeadObjectRequest['SSECustomerKeyMD5'];
 };
 
 export type S3ProviderGetOuput<T> = T extends { download: true }
@@ -178,14 +171,6 @@ export type S3ProviderCopyConfig = Omit<CommonStorageOptions, 'level'> & {
 
 export type S3ProviderCopyOutput = {
 	key: string;
-};
-
-export type S3ProviderGetPropertiesOutput = {
-	contentType: string;
-	contentLength: number;
-	eTag: string;
-	lastModified: Date;
-	metadata: Record<string, string>;
 };
 
 export type PutResult = {

--- a/packages/storage/src/types/Provider.ts
+++ b/packages/storage/src/types/Provider.ts
@@ -20,9 +20,6 @@ export interface StorageProvider {
 	// get object/pre-signed url from storage
 	get(key: string, options?): Promise<string | Object>;
 
-	// get properties of object
-	getProperties(key: string, options?): Promise<Object>;
-
 	// upload storage object
 	put(key: string, object, options?): Promise<Object> | UploadTask;
 
@@ -55,10 +52,4 @@ export interface StorageProviderWithCopy extends StorageProvider {
 	): Promise<any>;
 }
 
-export type StorageProviderApi =
-	| 'copy'
-	| 'get'
-	| 'put'
-	| 'remove'
-	| 'list'
-	| 'getProperties';
+export type StorageProviderApi = 'copy' | 'get' | 'put' | 'remove' | 'list';

--- a/packages/storage/src/types/Provider.ts
+++ b/packages/storage/src/types/Provider.ts
@@ -21,7 +21,7 @@ export interface StorageProvider {
 	get(key: string, options?): Promise<string | Object>;
 
 	// get properties of object
-	getProperties?(key: string, options?): Promise<Object>;
+	getProperties(key: string, options?): Promise<Object>;
 
 	// upload storage object
 	put(key: string, object, options?): Promise<Object> | UploadTask;

--- a/packages/storage/src/types/Storage.ts
+++ b/packages/storage/src/types/Storage.ts
@@ -15,7 +15,6 @@ import {
 	S3ProviderListOutput,
 	S3ProviderCopyOutput,
 	S3ProviderPutOutput,
-	S3ProviderGetPropertiesOutput,
 } from '../';
 
 type Tail<T extends any[]> = ((...t: T) => void) extends (
@@ -85,14 +84,6 @@ export type StorageGetConfig<T extends Record<string, any>> =
 		? StorageOperationConfig<T, 'get'>
 		: StorageOperationConfigMap<
 				StorageOperationConfig<AWSS3Provider, 'get'>,
-				T
-		  >;
-
-export type StorageGetPropertiesConfig<T extends Record<string, any>> =
-	T extends StorageProvider
-		? StorageOperationConfig<T, 'getProperties'>
-		: StorageOperationConfigMap<
-				StorageOperationConfig<AWSS3Provider, 'getProperties'>,
 				T
 		  >;
 
@@ -175,12 +166,6 @@ export type StorageCopyOutput<T> = PickProviderOutput<
 	Promise<S3ProviderCopyOutput>,
 	T,
 	'copy'
->;
-
-export type StorageGetPropertiesOutput<T> = PickProviderOutput<
-	Promise<S3ProviderGetPropertiesOutput>,
-	T,
-	'getProperties'
 >;
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change reverts the following commits related to `getProperties` due to type errors.

https://github.com/aws-amplify/amplify-js/commit/5d00b1fc2839a8f1bbd4338a0aa805e48e4e56c0
https://github.com/aws-amplify/amplify-js/commit/3bed12b6960c676095689ee895c60ae55a041c8c

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Build.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
