### PR TITLE
fix(clients): middleware chain revert after every invocation

### DIFF
--- a/packages/core/__tests__/clients/composeTransferHandler-test.ts
+++ b/packages/core/__tests__/clients/composeTransferHandler-test.ts
@@ -44,7 +44,7 @@ describe(composeTransferHandler.name, () => {
 			};
 		const coreHandler: TransferHandler<Request, Response, {}> = jest
 			.fn()
-			.mockResolvedValue({ body: '' } as Response);
+			.mockResolvedValueOnce({ body: '' } as Response);
 		const handler = composeTransferHandler<[OptionsType, OptionsType]>(
 			coreHandler,
 			[middlewareA, middlewareB]
@@ -64,5 +64,17 @@ describe(composeTransferHandler.name, () => {
 		// Validate middleware share a same option object
 		expect(options.mockFnInOptions).toHaveBeenNthCalledWith(1, 'A');
 		expect(options.mockFnInOptions).toHaveBeenNthCalledWith(2, 'B');
+
+		// order does not change in consecutive calls
+		(coreHandler as jest.Mock).mockResolvedValueOnce({ body: '' } as Response);
+		const resp2 = await handler(
+			{ url: new URL('https://a.b'), body: '' },
+			options
+		);
+		expect(resp2).toEqual({ body: 'BA' });
+		expect(coreHandler).toBeCalledWith(
+			expect.objectContaining({ body: 'AB' }),
+			expect.anything()
+		);
 	});
 });

--- a/packages/core/src/clients/internal/composeTransferHandler.ts
+++ b/packages/core/src/clients/internal/composeTransferHandler.ts
@@ -41,7 +41,8 @@ export const composeTransferHandler =
 		let composedHandler: MiddlewareHandler<Request, Response> = (
 			request: Request
 		) => coreHandler(request, options);
-		for (const m of middleware.reverse()) {
+		for (let i = middleware.length - 1; i >= 0; i--) {
+			const m = middleware[i];
 			const resolvedMiddleware = m(options);
 			composedHandler = resolvedMiddleware(composedHandler, context);
 		}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change fixes a bug that the order of middleware in a transfer handler reverts in-place after each API invocation. This would cause the x-amz-user-agent header not being signed in every other API calls.

This bug does not cause issue with existing Pinpoint client because it does not require the header to be signed. It does not affect Cognito Identity client either because it does not need a signer. This bug would cause issue for S3 WIP client as it requires the header to be signed.


#### Description of how you validated changes
Unit test. Manual integration test with WIP S3 client


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
