### PR TITLE
feat: Add custom user agent enhancements for Predictions

### DIFF
--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -64,7 +64,7 @@
       "name": "API (GraphQL client)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, GraphQLAPI }",
-      "limit": "105.6 kB"
+      "limit": "106 kB"
     }
   ],
   "jest": {

--- a/packages/core/src/Platform/types.ts
+++ b/packages/core/src/Platform/types.ts
@@ -63,7 +63,9 @@ export enum InAppMessagingAction {
 	None = '0',
 }
 export enum PredictionsAction {
-	None = '0',
+	Convert = '1',
+	Identify = '2',
+	Interpret = '3',
 }
 export enum PubSubAction {
 	None = '0',

--- a/packages/predictions/__tests__/Providers/AWSAIIdentifyPredictionsProvider-unit-test.ts
+++ b/packages/predictions/__tests__/Providers/AWSAIIdentifyPredictionsProvider-unit-test.ts
@@ -1,4 +1,9 @@
-import { Credentials } from '@aws-amplify/core';
+import {
+	Category,
+	Credentials,
+	PredictionsAction,
+	getAmplifyUserAgent,
+} from '@aws-amplify/core';
 import { Storage } from '@aws-amplify/storage';
 import {
 	IdentifyEntitiesInput,
@@ -681,6 +686,83 @@ describe('Predictions identify provider test', () => {
 			return expect(
 				predictionsProvider.identify(detectLabelInput)
 			).rejects.toMatch('not configured correctly');
+		});
+	});
+
+	describe('custom user agent', () => {
+		test('identify for label initializes a client with the correct custom user agent', async () => {
+			predictionsProvider = new AmazonAIIdentifyPredictionsProvider();
+			predictionsProvider.configure(options);
+			jest.spyOn(TextractClient.prototype, 'send');
+			jest.spyOn(RekognitionClient.prototype, 'send');
+			const fileInput = new File([Buffer.from('file')], 'file');
+			const detectLabelInput: IdentifyLabelsInput = {
+				labels: { source: { bytes: fileInput }, type: 'LABELS' },
+			};
+			await predictionsProvider.identify(detectLabelInput);
+			expect(
+				predictionsProvider['rekognitionClient'].config.customUserAgent
+			).toEqual(
+				getAmplifyUserAgent({
+					category: Category.Predictions,
+					action: PredictionsAction.Identify,
+				})
+			);
+			expect(predictionsProvider['textractClient']).toBeUndefined();
+		});
+
+		test('identify for entities initializes a client with the correct custom user agent', async () => {
+			predictionsProvider = new AmazonAIIdentifyPredictionsProvider();
+			predictionsProvider.configure(options);
+			jest.spyOn(TextractClient.prototype, 'send');
+			jest.spyOn(RekognitionClient.prototype, 'send');
+			const fileInput = new File([Buffer.from('file')], 'file');
+			const detectFacesInput: IdentifyEntitiesInput = {
+				entities: {
+					source: {
+						key: 'key',
+					},
+					celebrityDetection: true,
+				},
+			};
+			await predictionsProvider.identify(detectFacesInput);
+			expect(
+				predictionsProvider['rekognitionClient'].config.customUserAgent
+			).toEqual(
+				getAmplifyUserAgent({
+					category: Category.Predictions,
+					action: PredictionsAction.Identify,
+				})
+			);
+			expect(predictionsProvider['textractClient']).toBeUndefined();
+		});
+
+		test('identify for text initializes a client with the correct custom user agent', async () => {
+			predictionsProvider = new AmazonAIIdentifyPredictionsProvider();
+			predictionsProvider.configure(options);
+			jest.spyOn(TextractClient.prototype, 'send');
+			jest.spyOn(RekognitionClient.prototype, 'send');
+			const fileInput = new File([Buffer.from('file')], 'file');
+			const detectTextInput: IdentifyTextInput = {
+				text: { source: { key: 'key' }, format: 'PLAIN' },
+			};
+			await predictionsProvider.identify(detectTextInput);
+			expect(
+				predictionsProvider['rekognitionClient'].config.customUserAgent
+			).toEqual(
+				getAmplifyUserAgent({
+					category: Category.Predictions,
+					action: PredictionsAction.Identify,
+				})
+			);
+			expect(
+				predictionsProvider['textractClient'].config.customUserAgent
+			).toEqual(
+				getAmplifyUserAgent({
+					category: Category.Predictions,
+					action: PredictionsAction.Identify,
+				})
+			);
 		});
 	});
 });

--- a/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
@@ -18,6 +18,8 @@ import {
 	ConsoleLogger as Logger,
 	Signer,
 	getAmplifyUserAgent,
+	Category,
+	PredictionsAction,
 } from '@aws-amplify/core';
 import {
 	EventStreamMarshaller,
@@ -72,7 +74,10 @@ export class AmazonAIConvertPredictionsProvider extends AbstractConvertPredictio
 		this.translateClient = new TranslateClient({
 			region,
 			credentials,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgent({
+				category: Category.Predictions,
+				action: PredictionsAction.Convert,
+			}),
 		});
 		const translateTextCommand = new TranslateTextCommand({
 			SourceLanguageCode: sourceLanguageCode,
@@ -105,7 +110,6 @@ export class AmazonAIConvertPredictionsProvider extends AbstractConvertPredictio
 			return Promise.reject('Source needs to be provided in the input');
 		}
 		const voiceId = input.textToSpeech.voiceId || VoiceId;
-
 		if (!region) {
 			return Promise.reject(
 				'Region was undefined. Did you enable speech generator using amplify CLI?'
@@ -119,7 +123,10 @@ export class AmazonAIConvertPredictionsProvider extends AbstractConvertPredictio
 		this.pollyClient = new PollyClient({
 			region,
 			credentials,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgent({
+				category: Category.Predictions,
+				action: PredictionsAction.Convert,
+			}),
 		});
 		const synthesizeSpeechCommand = new SynthesizeSpeechCommand({
 			OutputFormat: 'mp3',

--- a/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
@@ -1,6 +1,8 @@
 import {
+	Category,
 	Credentials,
 	ConsoleLogger as Logger,
+	PredictionsAction,
 	getAmplifyUserAgent,
 } from '@aws-amplify/core';
 import { Storage } from '@aws-amplify/storage';
@@ -138,12 +140,18 @@ export class AmazonAIIdentifyPredictionsProvider extends AbstractIdentifyPredict
 		this.rekognitionClient = new RekognitionClient({
 			region,
 			credentials,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgent({
+				category: Category.Predictions,
+				action: PredictionsAction.Identify,
+			}),
 		});
 		this.textractClient = new TextractClient({
 			region,
 			credentials,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgent({
+				category: Category.Predictions,
+				action: PredictionsAction.Identify,
+			}),
 		});
 		let inputDocument: Document;
 
@@ -240,7 +248,10 @@ export class AmazonAIIdentifyPredictionsProvider extends AbstractIdentifyPredict
 			this.rekognitionClient = new RekognitionClient({
 				region,
 				credentials,
-				customUserAgent: getAmplifyUserAgent(),
+				customUserAgent: getAmplifyUserAgent({
+					category: Category.Predictions,
+					action: PredictionsAction.Identify,
+				}),
 			});
 			let inputImage: Image;
 			await this.configureSource(input.labels.source)
@@ -359,7 +370,10 @@ export class AmazonAIIdentifyPredictionsProvider extends AbstractIdentifyPredict
 		this.rekognitionClient = new RekognitionClient({
 			region,
 			credentials,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgent({
+				category: Category.Predictions,
+				action: PredictionsAction.Identify,
+			}),
 		});
 		let inputImage: Image;
 		await this.configureSource(input.entities.source)

--- a/packages/predictions/src/Providers/AmazonAIInterpretPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIInterpretPredictionsProvider.ts
@@ -260,7 +260,8 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 			const data = await this.comprehendClient.send(
 				detectDominantLanguageCommand
 			);
-			const { Languages: [{ LanguageCode }] = [''] } = ({} = data || {});
+			const x = data?.Languages?.[0];
+			const { Languages: [{ LanguageCode }] = [{}] } = ({} = data || {});
 			if (!LanguageCode) {
 				Promise.reject('Language not detected');
 			}

--- a/packages/predictions/src/Providers/AmazonAIInterpretPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIInterpretPredictionsProvider.ts
@@ -1,4 +1,9 @@
-import { Credentials, getAmplifyUserAgent } from '@aws-amplify/core';
+import {
+	Category,
+	Credentials,
+	PredictionsAction,
+	getAmplifyUserAgent,
+} from '@aws-amplify/core';
 import { AbstractInterpretPredictionsProvider } from '../types/Providers';
 
 import {
@@ -20,6 +25,8 @@ import {
 } from '@aws-sdk/client-comprehend';
 
 export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredictionsProvider {
+	private comprehendClient: ComprehendClient;
+
 	constructor() {
 		super();
 	}
@@ -48,10 +55,13 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 			const { text: { source: { language = undefined } = {} } = {} } = ({} =
 				input as any); // language is only required for specific interpret types
 
-			const comprehendClient = new ComprehendClient({
+			this.comprehendClient = new ComprehendClient({
 				credentials,
 				region,
-				customUserAgent: getAmplifyUserAgent(),
+				customUserAgent: getAmplifyUserAgent({
+					category: Category.Predictions,
+					action: PredictionsAction.Interpret,
+				}),
 			});
 
 			const doAll = interpretType === InterpretTextCategories.ALL;
@@ -61,10 +71,7 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 				const languageDetectionParams = {
 					Text: text,
 				};
-				languagePromise = this.detectLanguage(
-					languageDetectionParams,
-					comprehendClient
-				);
+				languagePromise = this.detectLanguage(languageDetectionParams);
 			}
 
 			let entitiesPromise: Promise<Array<TextEntities>>;
@@ -77,10 +84,7 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 					Text: text,
 					LanguageCode,
 				};
-				entitiesPromise = this.detectEntities(
-					entitiesDetectionParams,
-					comprehendClient
-				);
+				entitiesPromise = this.detectEntities(entitiesDetectionParams);
 			}
 
 			let sentimentPromise: Promise<TextSentiment>;
@@ -93,10 +97,7 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 					Text: text,
 					LanguageCode,
 				};
-				sentimentPromise = this.detectSentiment(
-					sentimentParams,
-					comprehendClient
-				);
+				sentimentPromise = this.detectSentiment(sentimentParams);
 			}
 
 			let syntaxPromise: Promise<Array<TextSyntax>>;
@@ -109,7 +110,7 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 					Text: text,
 					LanguageCode,
 				};
-				syntaxPromise = this.detectSyntax(syntaxParams, comprehendClient);
+				syntaxPromise = this.detectSyntax(syntaxParams);
 			}
 
 			let keyPhrasesPromise: Promise<Array<KeyPhrases>>;
@@ -122,10 +123,7 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 					Text: text,
 					LanguageCode,
 				};
-				keyPhrasesPromise = this.detectKeyPhrases(
-					keyPhrasesParams,
-					comprehendClient
-				);
+				keyPhrasesPromise = this.detectKeyPhrases(keyPhrasesParams);
 			}
 			try {
 				const results = await Promise.all([
@@ -150,13 +148,10 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 		});
 	}
 
-	private async detectKeyPhrases(
-		params,
-		comprehend
-	): Promise<Array<KeyPhrases>> {
+	private async detectKeyPhrases(params): Promise<Array<KeyPhrases>> {
 		try {
 			const detectKeyPhrasesCommand = new DetectKeyPhrasesCommand(params);
-			const data = await comprehend.send(detectKeyPhrasesCommand);
+			const data = await this.comprehendClient.send(detectKeyPhrasesCommand);
 			const { KeyPhrases = [] } = data || {};
 			return KeyPhrases.map(({ Text: text }) => {
 				return { text };
@@ -173,10 +168,10 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 		}
 	}
 
-	private async detectSyntax(params, comprehend): Promise<Array<TextSyntax>> {
+	private async detectSyntax(params): Promise<Array<TextSyntax>> {
 		try {
 			const detectSyntaxCommand = new DetectSyntaxCommand(params);
-			const data = await comprehend.send(detectSyntaxCommand);
+			const data = await this.comprehendClient.send(detectSyntaxCommand);
 			const { SyntaxTokens = [] } = data || {};
 			return this.serializeSyntaxFromComprehend(SyntaxTokens);
 		} catch (err) {
@@ -203,10 +198,10 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 		return response;
 	}
 
-	private async detectSentiment(params, comprehend): Promise<TextSentiment> {
+	private async detectSentiment(params): Promise<TextSentiment> {
 		try {
 			const detectSentimentCommand = new DetectSentimentCommand(params);
-			const data = await comprehend.send(detectSentimentCommand);
+			const data = await this.comprehendClient.send(detectSentimentCommand);
 			const {
 				Sentiment: predominant = '',
 				SentimentScore: {
@@ -229,13 +224,10 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 		}
 	}
 
-	private async detectEntities(
-		params,
-		comprehend
-	): Promise<Array<TextEntities>> {
+	private async detectEntities(params): Promise<Array<TextEntities>> {
 		try {
 			const detectEntitiesCommand = new DetectEntitiesCommand(params);
-			const data = await comprehend.send(detectEntitiesCommand);
+			const data = await this.comprehendClient.send(detectEntitiesCommand);
 			const { Entities = [] } = data || {};
 			return this.serializeEntitiesFromComprehend(Entities);
 		} catch (err) {
@@ -260,12 +252,14 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 		return response;
 	}
 
-	private async detectLanguage(params, comprehend): Promise<string> {
+	private async detectLanguage(params): Promise<string> {
 		try {
 			const detectDominantLanguageCommand = new DetectDominantLanguageCommand(
 				params
 			);
-			const data = await comprehend.send(detectDominantLanguageCommand);
+			const data = await this.comprehendClient.send(
+				detectDominantLanguageCommand
+			);
 			const { Languages: [{ LanguageCode }] = [''] } = ({} = data || {});
 			if (!LanguageCode) {
 				Promise.reject('Language not detected');

--- a/packages/predictions/src/Providers/AmazonAIInterpretPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIInterpretPredictionsProvider.ts
@@ -260,7 +260,6 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 			const data = await this.comprehendClient.send(
 				detectDominantLanguageCommand
 			);
-			const x = data?.Languages?.[0];
 			const { Languages: [{ LanguageCode }] = [{}] } = ({} = data || {});
 			if (!LanguageCode) {
 				Promise.reject('Language not detected');


### PR DESCRIPTION
#### Description of changes
Add Predictions category with specific actions for the custom user agent in all predictions call *except "convert" for voice to text (transcription), which uses websocket streams and doesn't currently support custom user agent.*



#### Description of how you validated changes

Unit tests added to cover user agent detection in sdk client. I'll be going through manual testing for predictions before this is merged to main.


#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
