### PR TITLE
feat(auth): add signInWithCustomSRPAuth API

### DIFF
--- a/packages/auth/__tests__/providers/cognito/signInWithCustomSRPAuth.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithCustomSRPAuth.test.ts
@@ -1,0 +1,155 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify, AmplifyErrorString } from '@aws-amplify/core';
+import { RespondToAuthChallengeCommandOutput } from '@aws-sdk/client-cognito-identity-provider';
+import { AuthError } from '../../../src/errors/AuthError';
+import { AuthValidationErrorCode } from '../../../src/errors/types/validation';
+import { authAPITestParams } from './testUtils/authApiTestParams';
+import { signIn } from '../../../src/providers/cognito/apis/signIn';
+import { InitiateAuthException } from '../../../src/providers/cognito/types/errors/service';
+import * as initiateAuthHelpers from '../../../src/providers/cognito/utils/signInHelpers';
+import { signInWithCustomSRPAuth } from '../../../src/providers/cognito/apis/signInWithCustomSRPAuth';
+
+Amplify.configure({
+	aws_cognito_region: 'us-west-2',
+	aws_user_pools_web_client_id: '4a93aeb3-01af-42d8-891d-ee8aa1549398',
+	aws_user_pools_id: 'us-west-2_80ede80b',
+});
+
+describe('signIn API happy path cases', () => {
+	let handleCustomSRPAuthFlowSpy;
+
+	beforeEach(() => {
+		handleCustomSRPAuthFlowSpy = jest
+			.spyOn(initiateAuthHelpers, 'handleCustomSRPAuthFlow')
+			.mockImplementationOnce(
+				async (): Promise<RespondToAuthChallengeCommandOutput> => {
+					return authAPITestParams.RespondToAuthChallengeCommandOutput;
+				}
+			);
+	});
+
+	afterEach(() => {
+		handleCustomSRPAuthFlowSpy.mockClear();
+	});
+
+	test('signIn API invoked with CUSTOM_WITH_SRP authFlowType should return a SignInResult', async () => {
+		const result = await signIn({
+			username: authAPITestParams.user1.username,
+			password: authAPITestParams.user1.password,
+			options: {
+				serviceOptions: {
+					authFlowType: 'CUSTOM_WITH_SRP',
+				},
+			},
+		});
+		expect(result).toEqual(authAPITestParams.signInResult());
+		expect(handleCustomSRPAuthFlowSpy).toBeCalledTimes(1);
+	});
+
+	test('signInWithCustomSRPAuth API should return a SignInResult', async () => {
+		const result = await signInWithCustomSRPAuth({
+			username: authAPITestParams.user1.username,
+			password: authAPITestParams.user1.password,
+		});
+		expect(result).toEqual(authAPITestParams.signInResult());
+		expect(handleCustomSRPAuthFlowSpy).toBeCalledTimes(1);
+	});
+
+	test('handleCustomSRPAuthFlow should be called with clientMetada from request', async () => {
+		const username = authAPITestParams.user1.username;
+		const password = authAPITestParams.user1.password;
+		await signInWithCustomSRPAuth({
+			username,
+			password,
+			options: {
+				serviceOptions: authAPITestParams.configWithClientMetadata,
+			},
+		});
+		expect(handleCustomSRPAuthFlowSpy).toBeCalledWith(
+			username,
+			password,
+			authAPITestParams.configWithClientMetadata.clientMetadata
+		);
+	});
+
+	test('handleCustomSRPAuthFlow should be called with clientMetada from config', async () => {
+		Amplify.configure(authAPITestParams.configWithClientMetadata);
+		const username = authAPITestParams.user1.username;
+		const password = authAPITestParams.user1.password;
+		await signInWithCustomSRPAuth({
+			username,
+			password,
+		});
+		expect(handleCustomSRPAuthFlowSpy).toBeCalledWith(
+			username,
+			password,
+			authAPITestParams.configWithClientMetadata.clientMetadata
+		);
+	});
+});
+
+describe('signIn API error path cases:', () => {
+	const globalMock = global as any;
+
+	test('signIn API should throw a validation AuthError when username is empty', async () => {
+		expect.assertions(2);
+		try {
+			await signIn({ username: '' });
+		} catch (error) {
+			expect(error).toBeInstanceOf(AuthError);
+			expect(error.name).toBe(AuthValidationErrorCode.EmptySignInUsername);
+		}
+	});
+
+	test('signIn API should raise service error', async () => {
+		const serviceError = new Error('service error');
+		serviceError.name = InitiateAuthException.InvalidParameterException;
+		globalMock.fetch = jest.fn(() => Promise.reject(serviceError));
+		expect.assertions(3);
+		try {
+			await signIn({
+				username: authAPITestParams.user1.username,
+				password: authAPITestParams.user1.password,
+			});
+		} catch (error) {
+			expect(fetch).toBeCalled();
+			expect(error).toBeInstanceOf(AuthError);
+			expect(error.name).toBe(InitiateAuthException.InvalidParameterException);
+		}
+	});
+
+	test(`signIn API should raise an unknown error when underlying error is' 
+			not coming from the service`, async () => {
+		expect.assertions(3);
+		globalMock.fetch = jest.fn(() =>
+			Promise.reject(new Error('unknown error'))
+		);
+		try {
+			await signIn({
+				username: authAPITestParams.user1.username,
+				password: authAPITestParams.user1.password,
+			});
+		} catch (error) {
+			expect(error).toBeInstanceOf(AuthError);
+			expect(error.name).toBe(AmplifyErrorString.UNKNOWN);
+			expect(error.underlyingError).toBeInstanceOf(Error);
+		}
+	});
+
+	test('signIn API should raise an unknown error when the underlying error is null', async () => {
+		expect.assertions(3);
+		globalMock.fetch = jest.fn(() => Promise.reject(null));
+		try {
+			await signIn({
+				username: authAPITestParams.user1.username,
+				password: authAPITestParams.user1.password,
+			});
+		} catch (error) {
+			expect(error).toBeInstanceOf(AuthError);
+			expect(error.name).toBe(AmplifyErrorString.UNKNOWN);
+			expect(error.underlyingError).toBe(null);
+		}
+	});
+});

--- a/packages/auth/__tests__/providers/cognito/signInWithCustomSRPAuth.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithCustomSRPAuth.test.ts
@@ -25,7 +25,7 @@ describe('signIn API happy path cases', () => {
 			.spyOn(initiateAuthHelpers, 'handleCustomSRPAuthFlow')
 			.mockImplementationOnce(
 				async (): Promise<RespondToAuthChallengeCommandOutput> => {
-					return authAPITestParams.RespondToAuthChallengeCommandOutput;
+					return authAPITestParams.CustomChallengeResponse;
 				}
 			);
 	});
@@ -44,7 +44,7 @@ describe('signIn API happy path cases', () => {
 				},
 			},
 		});
-		expect(result).toEqual(authAPITestParams.signInResult());
+		expect(result).toEqual(authAPITestParams.signInResultWithCustomAuth());
 		expect(handleCustomSRPAuthFlowSpy).toBeCalledTimes(1);
 	});
 
@@ -53,7 +53,7 @@ describe('signIn API happy path cases', () => {
 			username: authAPITestParams.user1.username,
 			password: authAPITestParams.user1.password,
 		});
-		expect(result).toEqual(authAPITestParams.signInResult());
+		expect(result).toEqual(authAPITestParams.signInResultWithCustomAuth());
 		expect(handleCustomSRPAuthFlowSpy).toBeCalledTimes(1);
 	});
 

--- a/packages/auth/__tests__/providers/cognito/testUtils/authApiTestParams.ts
+++ b/packages/auth/__tests__/providers/cognito/testUtils/authApiTestParams.ts
@@ -116,6 +116,20 @@ export const authAPITestParams = {
 		Session: 'aaabbbcccddd',
 		$metadata: {},
 	},
+	CustomChallengeResponse: {
+		ChallengeName: 'CUSTOM_CHALLENGE',
+		AuthenticationResult: undefined,
+		Session: 'aaabbbcccddd',
+		$metadata: {},
+	},
+	signInResultWithCustomAuth: () => {
+		return {
+			isSignedIn: false,
+			nextStep: {
+				signInStep: AuthSignInStep.CONFIRM_SIGN_IN_WITH_CUSTOM_CHALLENGE,
+			},
+		};
+	},
 	signInResult: (): AuthSignInResult => {
 		return {
 			isSignedIn: true,

--- a/packages/auth/src/providers/cognito/apis/signIn.ts
+++ b/packages/auth/src/providers/cognito/apis/signIn.ts
@@ -7,6 +7,7 @@ import {
 	RespondToAuthChallengeException,
 } from '../types/errors/service';
 import { CognitoSignInOptions } from '../types/options/CognitoSignInOptions';
+import { signInWithCustomSRPAuth } from './signInWithCustomSRPAuth';
 import { signInWithSRP } from './signInWithSRP';
 
 /**
@@ -34,7 +35,7 @@ export async function signIn(
 		case 'CUSTOM_WITHOUT_SRP':
 		// TODO(israx): include CUSTOM_WITHOUT_SRP API here
 		case 'CUSTOM_WITH_SRP':
-		// TODO(israx): include CUSTOM_WITH_SRP API here
+			return signInWithCustomSRPAuth(signInRequest);
 		default:
 			return signInWithSRP(signInRequest);
 	}

--- a/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
@@ -21,14 +21,29 @@ import {
 	getSignInResultFromError,
 } from '../utils/signInHelpers';
 import { setActiveSignInSession } from '../utils/activeSignInSession';
+import {
+	InitiateAuthException,
+	RespondToAuthChallengeException,
+} from '../types/errors/service';
 
+/**
+ * Signs a user in using a custom authentication flow with SRP
+ *
+ * @param signInRequest - The SignInRequest object
+ * @returns AuthSignInResult
+ * @throws service: {@link InitiateAuthException }, {@link RespondToAuthChallengeException } - Cognito
+ * service errors thrown during the sign-in process.
+ * @throws validation: {@link AuthValidationErrorCode  } - Validation errors thrown when either username or password
+ *  are not defined.
+ *
+ * TODO: add config errors
+ */
 export async function signInWithCustomSRPAuth(
 	signInRequest: SignInRequest<CognitoSignInOptions>
 ): Promise<AuthSignInResult> {
 	const { username, password, options } = signInRequest;
 	const metadata =
-		options?.serviceOptions?.clientMetadata ||
-		Amplify.config.clientMetadata;
+		options?.serviceOptions?.clientMetadata || Amplify.config.clientMetadata;
 	assertValidationError(
 		!!username,
 		AuthValidationErrorCode.EmptySignInUsername

--- a/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
@@ -25,9 +25,9 @@ import { setActiveSignInSession } from '../utils/activeSignInSession';
 export async function signInWithCustomSRPAuth(
 	signInRequest: SignInRequest<CognitoSignInOptions>
 ): Promise<AuthSignInResult> {
-	const { username, password } = signInRequest;
+	const { username, password, options } = signInRequest;
 	const metadata =
-		signInRequest.options?.serviceOptions?.clientMetadata ||
+		options?.serviceOptions?.clientMetadata ||
 		Amplify.config.clientMetadata;
 	assertValidationError(
 		!!username,

--- a/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+import { AuthValidationErrorCode } from '../../../errors/types/validation';
+import { assertValidationError } from '../../../errors/utils/assertValidationError';
+import {
+	SignInRequest,
+	AuthSignInResult,
+	AuthSignInStep,
+} from '../../../types';
+import { assertServiceError } from '../../../errors/utils/assertServiceError';
+import { CognitoSignInOptions } from '../types/options/CognitoSignInOptions';
+import {
+	ChallengeName,
+	ChallengeParameters,
+} from '../utils/clients/types/models';
+import {
+	handleCustomSRPAuthFlow,
+	getSignInResult,
+	getSignInResultFromError,
+} from '../utils/signInHelpers';
+import { setActiveSignInSession } from '../utils/activeSignInSession';
+
+export async function signInWithCustomSRPAuth(
+	signInRequest: SignInRequest<CognitoSignInOptions>
+): Promise<AuthSignInResult> {
+	const { username, password } = signInRequest;
+	const metadata =
+		signInRequest.options?.serviceOptions?.clientMetadata ||
+		Amplify.config.clientMetadata;
+	assertValidationError(
+		!!username,
+		AuthValidationErrorCode.EmptySignInUsername
+	);
+	assertValidationError(
+		!!password,
+		AuthValidationErrorCode.EmptySignInPassword
+	);
+
+	try {
+		const {
+			ChallengeName,
+			ChallengeParameters,
+			AuthenticationResult,
+			Session,
+		} = await handleCustomSRPAuthFlow(username, password, metadata);
+
+		// Session used on RespondToAuthChallenge requests.
+		setActiveSignInSession(Session);
+		if (AuthenticationResult) {
+			// TODO(israx): cache tokens
+			return {
+				isSignedIn: true,
+				nextStep: { signInStep: AuthSignInStep.DONE },
+			};
+		}
+
+		// TODO(israx): set AmplifyUserSession via singleton
+		return getSignInResult({
+			challengeName: ChallengeName as ChallengeName,
+			challengeParameters: ChallengeParameters as ChallengeParameters,
+		});
+	} catch (error) {
+		setActiveSignInSession(undefined);
+		assertServiceError(error);
+		const result = getSignInResultFromError(error.name);
+		if (result) return result;
+		throw error;
+	}
+}

--- a/packages/auth/src/providers/cognito/utils/signInHelpers.ts
+++ b/packages/auth/src/providers/cognito/utils/signInHelpers.ts
@@ -62,6 +62,37 @@ export async function handleUserSRPAuthFlow(
 	);
 }
 
+export async function handleCustomSRPAuthFlow(
+	username: string,
+	password: string,
+	clientMetadata: ClientMetadata | undefined
+) {
+	const userPoolId = Amplify.config['aws_user_pools_id'];
+	const userPoolName = userPoolId.split('_')[1];
+	const authenticationHelper = new AuthenticationHelper(userPoolName);
+	const jsonReq: InitiateAuthClientInput = {
+		AuthFlow: 'CUSTOM_AUTH',
+		AuthParameters: {
+			USERNAME: username,
+			SRP_A: ((await getLargeAValue(authenticationHelper)) as any).toString(16),
+			CHALLENGE_NAME: 'SRP_A',
+		},
+		ClientMetadata: clientMetadata,
+	};
+
+	const { ChallengeParameters: challengeParameters, Session: session } =
+		await initiateAuthClient(jsonReq);
+
+	return handlePasswordVerifierChallenge(
+		password,
+		challengeParameters as ChallengeParameters,
+		clientMetadata,
+		session,
+		authenticationHelper,
+		userPoolName
+	);
+}
+
 export async function handlePasswordVerifierChallenge(
 	password: string,
 	challengeParameters: ChallengeParameters,

--- a/packages/auth/src/providers/cognito/utils/srp/AuthenticationHelper.ts
+++ b/packages/auth/src/providers/cognito/utils/srp/AuthenticationHelper.ts
@@ -36,10 +36,10 @@ for (let i = 0; i < 256; i++) {
  * @param {number} nBytes
  * @returns {Uint8Array} fixed-length sequence of random bytes
  */
-function randomBytes(nBytes: number): string {
+function randomBytes(nBytes: number):Uint8Array {
 	const str = new WordArray().random(nBytes).toString();
 
-	return toBase64(fromHex(str));
+	return fromHex(str);
 }
 
 /**
@@ -144,7 +144,7 @@ export default class AuthenticationHelper {
 	generateRandomSmallA(): BigInteger {
 		// This will be interpreted as a postive 128-bit integer
 
-		const hexRandom = randomBytes(128).toString();
+		const hexRandom = toHex(randomBytes(128));
 
 		const randomBigInt = new BigInteger(hexRandom, 16);
 
@@ -159,7 +159,7 @@ export default class AuthenticationHelper {
 	 * @private
 	 */
 	generateRandomString(): string {
-		return randomBytes(40).toString();
+		return toBase64(randomBytes(40));
 	}
 
 	/**
@@ -199,7 +199,7 @@ export default class AuthenticationHelper {
 		const combinedString = `${deviceGroupKey}${username}:${this.randomPassword}`;
 		const hashedString = this.hash(combinedString);
 
-		const hexRandom = randomBytes(16).toString();
+		const hexRandom = toHex(randomBytes(16));
 
 		// The random hex will be unambiguously represented as a postive integer
 		this.SaltToHashDevices = this.padHex(new BigInteger(hexRandom, 16));


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR includes the following:

High level sign-in API that delegates to the signInWithCustomSRPAuth API if `CUSTOM_WITH_SRP` AuthFlowType is passed in the request.

Low level signInWithCustomSRPAuth API

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
- created createAuthChallenge, defineAuthChallenge and verifyAuthChallenge lambda functions
- created a sample app where signIn API returned a `CONFIRMN_SIGN_IN_WITH_CUSTOM_CHALLENGE` when authFlow is `CUSTOM_WITH_SRP`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
