### PR TITLE
fix: Storage action enum update

### DIFF
--- a/packages/core/src/Platform/types.ts
+++ b/packages/core/src/Platform/types.ts
@@ -82,15 +82,11 @@ export enum PushNotificationAction {
 	None = '0',
 }
 export enum StorageAction {
-	// UploadFile = '1',
-	UploadData = '2',
-	DownloadData = '3',
-	// DownloadFile = '4',
-	GetUrl = '5',
-	// GetProperties = '6',
-	List = '7',
-	Copy = '8',
-	Remove = '9',
+	Put = '1',
+	Get = '2',
+	List = '3',
+	Copy = '4',
+	Remove = '5',
 }
 
 type ActionMap = {

--- a/packages/storage/__tests__/common/S3ClientUtils-unit-test.ts
+++ b/packages/storage/__tests__/common/S3ClientUtils-unit-test.ts
@@ -127,13 +127,13 @@ describe('S3ClientUtils tests', () => {
 				region: 'us-west-2',
 				useAccelerateEndpoint: true,
 			},
-			StorageAction.GetUrl
+			StorageAction.Get
 		);
 		// ensure customUserAgent is set properly
 		expect(s3client.config.customUserAgent).toEqual(
 			getAmplifyUserAgent({
 				category: Category.Storage,
-				action: StorageAction.GetUrl,
+				action: StorageAction.Get,
 			})
 		);
 		expect(await s3client.config.region()).toEqual('us-west-2');
@@ -146,7 +146,7 @@ describe('S3ClientUtils tests', () => {
 				region: 'us-west-2',
 				dangerouslyConnectToHttpEndpointForTesting: true,
 			},
-			StorageAction.GetUrl
+			StorageAction.Get
 		);
 		expect(await s3client.config.endpoint()).toStrictEqual({
 			hostname: 'localhost',

--- a/packages/storage/__tests__/providers/CustomUserAgent.test.ts
+++ b/packages/storage/__tests__/providers/CustomUserAgent.test.ts
@@ -43,7 +43,7 @@ describe('Each Storage call should create a client with the right StorageAction'
 		await storage.get('test');
 		expect(utils.createS3Client).toBeCalledWith(
 			expect.anything(),
-			StorageAction.GetUrl,
+			StorageAction.Get,
 			expect.anything()
 		);
 	});
@@ -60,7 +60,7 @@ describe('Each Storage call should create a client with the right StorageAction'
 		await storage.get('test', { download: true });
 		expect(utils.createS3Client).toBeCalledWith(
 			expect.anything(),
-			StorageAction.DownloadData,
+			StorageAction.Get,
 			expect.anything()
 		);
 	});
@@ -69,7 +69,7 @@ describe('Each Storage call should create a client with the right StorageAction'
 		await storage.put('test', 'testData');
 		expect(utils.createS3Client).toBeCalledWith(
 			expect.anything(),
-			StorageAction.UploadData,
+			StorageAction.Put,
 			expect.anything()
 		);
 	});

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -383,10 +383,7 @@ export class AWSS3Provider implements StorageProvider {
 		const prefix = this._prefix(opt);
 		const final_key = prefix + key;
 		const emitter = new events.EventEmitter();
-		const storageAction = download
-			? StorageAction.DownloadData
-			: StorageAction.GetUrl;
-		const s3 = this._createNewS3Client(opt, storageAction, emitter);
+		const s3 = this._createNewS3Client(opt, StorageAction.Get, emitter);
 		logger.debug('get ' + key + ' from ' + final_key);
 
 		const params: GetObjectCommandInput = {
@@ -584,7 +581,7 @@ export class AWSS3Provider implements StorageProvider {
 		}
 
 		if (resumable === true) {
-			const s3Client = this._createNewS3Client(opt, StorageAction.UploadData);
+			const s3Client = this._createNewS3Client(opt, StorageAction.Put);
 			// we are using aws sdk middleware to inject the prefix to key, this way we don't have to call
 			// this._ensureCredentials() which allows us to make this function sync so we can return non-Promise like UploadTask
 			s3Client.middlewareStack.add(

--- a/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
+++ b/packages/storage/src/providers/AWSS3ProviderManagedUpload.ts
@@ -321,7 +321,7 @@ export class AWSS3ProviderManagedUpload {
 	}
 
 	protected _createNewS3Client(config, emitter?: events.EventEmitter) {
-		const s3client = createS3Client(config, StorageAction.UploadData, emitter);
+		const s3client = createS3Client(config, StorageAction.Put, emitter);
 		s3client.middlewareStack.add(
 			createPrefixMiddleware(this.opts, this.params.Key),
 			prefixMiddlewareOptions


### PR DESCRIPTION
#### Description of changes
Change the Storage enum to align with the current storage API and update related code/tests.



#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
