### PR TITLE
feat(s3): custom xhr transfer handler

### DIFF
--- a/packages/core/internals/aws-client-utils/package.json
+++ b/packages/core/internals/aws-client-utils/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "@aws-amplify/core/internals/aws-client-utils",
-	"types": "../../../lib-esm/clients/index.d.ts",
-	"main": "../../../lib/clients/index.js",
-	"module": "../../../lib-esm/clients/index.js",
-	"react-native": "../../../lib-esm/clients/index.js",
+	"types": "../../lib-esm/clients/index.d.ts",
+	"main": "../../lib/clients/index.js",
+	"module": "../../lib-esm/clients/index.js",
+	"react-native": "../../lib-esm/clients/index.js",
 	"sideEffects": false
 }

--- a/packages/storage/__tests__/AwsClients/testUtils/mocks.ts
+++ b/packages/storage/__tests__/AwsClients/testUtils/mocks.ts
@@ -1,0 +1,97 @@
+import { XhrSpy } from './types';
+
+// Mock XMLHttpRequest instance so we can spy on the methods and listeners.
+export const spyOnXhr = (): XhrSpy => {
+	const uploadListeners: XhrSpy['uploadListeners'] = {};
+	const listeners: XhrSpy['listeners'] = {};
+	const mockRequest = {
+		open: jest.fn(),
+		setRequestHeader: jest.fn(),
+		responseType: '',
+		send: jest.fn(),
+		getAllResponseHeaders: jest.fn(),
+		upload: {
+			addEventListener: jest.fn().mockImplementation((event, cb) => {
+				uploadListeners[event] = uploadListeners[event] || [];
+				uploadListeners[event]!.push(cb);
+			}),
+		},
+		addEventListener: jest.fn().mockImplementation((event, cb) => {
+			listeners[event] = listeners[event] || [];
+			listeners[event]!.push(cb);
+		}),
+		abort: jest.fn(),
+	};
+	window['XMLHttpRequest'] = jest.fn(() => mockRequest) as any;
+	return Object.assign(mockRequest, {
+		uploadListeners,
+		listeners,
+	}) as unknown as XhrSpy;
+};
+
+/**
+ * Mock XMLHttpRequest's response and invoke the corresponding listeners on given mock XHR instance.
+ *
+ * @internal
+ */
+export const mockXhrResponse = (
+	mockXhr: XhrSpy,
+	response: {
+		status: number;
+		// XHR's raw header string. @see https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders#return_value
+		headerString: string;
+		body: BodyInit;
+	}
+) => {
+	mockXhr.readyState = XMLHttpRequest.DONE;
+	mockXhr.status = response.status;
+	mockXhr.responseText = `text from raw response: ${response.body}`;
+	mockXhr.response = response.body;
+	(mockXhr.getAllResponseHeaders as jest.Mock).mockReturnValue(
+		response.headerString
+	);
+	mockXhr.uploadListeners.progress?.forEach(cb => {
+		cb({ name: 'MockUploadEvent' } as any);
+	});
+	mockXhr.listeners.progress?.forEach(cb => {
+		cb({ name: 'MockDownloadEvent' } as any);
+	});
+	mockXhr.listeners.readystatechange?.forEach(cb => {
+		cb({} as any);
+	});
+};
+
+/**
+ * Mock XMLHttpRequest's error and invoke the corresponding listeners on given mock XHR instance.
+ *
+ * @internal
+ */
+export const triggerNetWorkError = (mockXhr: XhrSpy) => {
+	const rawError = new Error('Lower level network error');
+	mockXhr.listeners.error?.forEach(cb => {
+		cb(rawError as any);
+	});
+};
+
+/**
+ * Mock XMLHttpRequest's abort and invoke the corresponding listeners on given mock XHR instance.
+ *
+ * @internal
+ */
+export const triggerServerSideAbort = (mockXhr: XhrSpy) => {
+	mockXhr.listeners.abort?.forEach(cb => {
+		cb({} as any);
+	});
+};
+
+/**
+ * Mock XMLHttpRequest's given ready state and invoke the corresponding listeners on given mock XHR instance.
+ *
+ * @internal
+ */
+export const mockXhrReadyState = (mockXhr: XhrSpy, readyState: number) => {
+	mockXhr.readyState = readyState;
+	mockXhr.listeners.readystatechange?.forEach(cb => {
+		cb({} as any);
+	});
+};

--- a/packages/storage/__tests__/AwsClients/testUtils/mocks.ts
+++ b/packages/storage/__tests__/AwsClients/testUtils/mocks.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { XhrSpy } from './types';
 
 // Mock XMLHttpRequest instance so we can spy on the methods and listeners.

--- a/packages/storage/__tests__/AwsClients/testUtils/types.ts
+++ b/packages/storage/__tests__/AwsClients/testUtils/types.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 
 /**

--- a/packages/storage/__tests__/AwsClients/testUtils/types.ts
+++ b/packages/storage/__tests__/AwsClients/testUtils/types.ts
@@ -1,0 +1,19 @@
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };
+
+/**
+ * A spy for XMLHttpRequest instance including attached listeners to xhr instance and upload instance.
+ *
+ * @internal
+ */
+export type XhrSpy = Writeable<XMLHttpRequest> & {
+	uploadListeners: Partial<{
+		[name in keyof XMLHttpRequestEventTargetEventMap]: Array<
+			(event: XMLHttpRequestEventTargetEventMap[name]) => void
+		>;
+	}>;
+	listeners: Partial<{
+		[name in keyof XMLHttpRequestEventMap]: Array<
+			(event: XMLHttpRequestEventMap[name]) => void
+		>;
+	}>;
+};

--- a/packages/storage/__tests__/AwsClients/xhrTransferHandler-util-test.ts
+++ b/packages/storage/__tests__/AwsClients/xhrTransferHandler-util-test.ts
@@ -1,0 +1,376 @@
+import {
+	xhrTransferHandler,
+	SEND_UPLOAD_PROGRESS_EVENT,
+	SEND_DOWNLOAD_PROGRESS_EVENT,
+} from '../../src/AwsClients/S3/utils/xhrTransferHandler';
+import {
+	spyOnXhr,
+	mockXhrResponse,
+	triggerNetWorkError,
+	triggerServerSideAbort,
+	mockXhrReadyState,
+} from './testUtils/mocks';
+
+const defaultRequest = {
+	method: 'GET',
+	url: new URL('https://foo.com'),
+	headers: {
+		foo: 'bar',
+	},
+};
+
+const mock200Response = {
+	status: 200,
+	headerString: 'foo: bar',
+	body: 'hello world',
+};
+
+describe('xhrTransferHandler', () => {
+	const originalXhr = window.XMLHttpRequest;
+	const originalReadableStream = window.ReadableStream;
+	beforeEach(() => {
+		jest.resetAllMocks();
+		window.ReadableStream = jest.fn() as any;
+	});
+
+	afterEach(() => {
+		window.XMLHttpRequest = originalXhr;
+		window.ReadableStream = originalReadableStream;
+	});
+
+	it('should call xhr.open with the correct arguments', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+		});
+		mockXhrResponse(mockXhr, mock200Response);
+		await requestPromise;
+		expect(mockXhr.open).toHaveBeenCalledWith(
+			defaultRequest.method,
+			defaultRequest.url.toString()
+		);
+	});
+
+	it('should call xhr.setRequestHeader ignoring forbidden header -- host', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(
+			{
+				...defaultRequest,
+				headers: {
+					foo: 'bar',
+					host: 'https://example.com',
+				},
+			},
+			{
+				responseType: 'text',
+			}
+		);
+		mockXhrResponse(mockXhr, mock200Response);
+		await requestPromise;
+		expect(mockXhr.setRequestHeader).toBeCalledTimes(1);
+		expect(mockXhr.setRequestHeader).toHaveBeenCalledWith('foo', 'bar');
+	});
+
+	it('should set the xhr.responseType to the responseType option', async () => {
+		let mockXhr = spyOnXhr();
+		let requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+		});
+		mockXhrResponse(mockXhr, mock200Response);
+		await requestPromise;
+		expect(mockXhr.responseType).toBe('text');
+
+		mockXhr = spyOnXhr();
+		requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'blob',
+		});
+		mockXhrResponse(mockXhr, mock200Response);
+		await requestPromise;
+		expect(mockXhr.responseType).toBe('blob');
+	});
+
+	it('should call xhr.send with Body', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(
+			{
+				...defaultRequest,
+				body: 'hello world',
+			},
+			{
+				responseType: 'text',
+			}
+		);
+		mockXhrResponse(mockXhr, mock200Response);
+		await requestPromise;
+		expect(mockXhr.send).toHaveBeenCalledWith('hello world');
+	});
+
+	it('should throw if request Body is a ReadableStream', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(
+			{
+				...defaultRequest,
+				body: new window.ReadableStream(),
+			},
+			{
+				responseType: 'text',
+			}
+		);
+		mockXhrResponse(mockXhr, mock200Response);
+		await expect(requestPromise).rejects.toThrow(
+			'ReadableStream request payload is not supported.'
+		);
+	});
+
+	it('should call xhr.send with null when Body is undefined', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(
+			{
+				...defaultRequest,
+				body: undefined,
+			},
+			{
+				responseType: 'text',
+			}
+		);
+		mockXhrResponse(mockXhr, mock200Response);
+		await requestPromise;
+		expect(mockXhr.send).toHaveBeenCalledWith(null);
+	});
+
+	it('should call xhr.getAllResponseHeaders when xhr.readyState is DONE', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+		});
+		const headerString = [
+			'date: Fri, 08 Dec 2017 21:04:30 GMT',
+			'content-encoding: gzip',
+			'x-content-type-options: nosniff',
+			'server: meinheld/0.6.1',
+			'x-frame-options: DENY',
+			'content-type: text/html; charset=utf-8',
+			'connection: keep-alive',
+			'strict-transport-security: max-age=63072000',
+			'vary: Cookie, Accept-Encoding',
+			'content-length: 6502',
+			'x-xss-protection: 1; mode=block',
+		].join('\r\n');
+		mockXhrResponse(mockXhr, {
+			...mock200Response,
+			headerString,
+		});
+		const { headers } = await requestPromise;
+		expect(mockXhr.getAllResponseHeaders).toHaveBeenCalled();
+		expect(headers).toEqual({
+			date: 'Fri, 08 Dec 2017 21:04:30 GMT',
+			'content-encoding': 'gzip',
+			'x-content-type-options': 'nosniff',
+			server: 'meinheld/0.6.1',
+			'x-frame-options': 'DENY',
+			'content-type': 'text/html; charset=utf-8',
+			connection: 'keep-alive',
+			'strict-transport-security': 'max-age=63072000',
+			vary: 'Cookie, Accept-Encoding',
+			'content-length': '6502',
+			'x-xss-protection': '1; mode=block',
+		});
+	});
+
+	it('should add error event listener to xhr', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+		});
+		triggerNetWorkError(mockXhr);
+		await expect(requestPromise).rejects.toThrow(
+			expect.objectContaining({
+				message: 'Network Error',
+				code: 'ECONNABORTED',
+			})
+		);
+	});
+
+	it('should clear xhr when error event is emitted', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+		});
+		triggerNetWorkError(mockXhr);
+		await expect(requestPromise).rejects.toThrow(
+			expect.objectContaining({
+				message: 'Network Error',
+				code: 'ECONNABORTED',
+			})
+		);
+		// Should be no-op if the xhr is already cleared
+		mockXhrResponse(mockXhr, mock200Response);
+		expect(mockXhr.getAllResponseHeaders).not.toHaveBeenCalled();
+	});
+
+	it('should add progress event listener to xhr.upload and xhr(download) when emitter is supplied', async () => {
+		const mockXhr = spyOnXhr();
+		const emitter = {
+			emit: jest.fn(),
+		} as any;
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+			emitter,
+		});
+		mockXhrResponse(mockXhr, mock200Response);
+		await requestPromise;
+		expect(emitter.emit).toHaveBeenCalledWith(SEND_UPLOAD_PROGRESS_EVENT, {
+			name: 'MockUploadEvent',
+		});
+		expect(emitter.emit).toHaveBeenCalledWith(SEND_DOWNLOAD_PROGRESS_EVENT, {
+			name: 'MockDownloadEvent',
+		});
+	});
+
+	it('should add abort event listener to xhr', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+		});
+		triggerServerSideAbort(mockXhr);
+		await expect(requestPromise).rejects.toThrow(
+			expect.objectContaining({
+				message: 'Request aborted',
+				code: 'ERR_ABORTED',
+			})
+		);
+	});
+
+	it('should clear xhr when abort event is emitted', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+		});
+		triggerServerSideAbort(mockXhr);
+		await expect(requestPromise).rejects.toThrow(
+			expect.objectContaining({
+				message: 'Request aborted',
+				code: 'ERR_ABORTED',
+			})
+		);
+		// Should be no-op if the xhr is already cleared
+		mockXhrResponse(mockXhr, mock200Response);
+		expect(mockXhr.getAllResponseHeaders).not.toHaveBeenCalled();
+	});
+
+	it('should process response only when xhr.readyState is DONE', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+		});
+		[
+			XMLHttpRequest.UNSENT,
+			XMLHttpRequest.OPENED,
+			XMLHttpRequest.HEADERS_RECEIVED,
+			XMLHttpRequest.LOADING,
+		].forEach(readyState => {
+			mockXhrReadyState(mockXhr, readyState);
+			expect(mockXhr.getAllResponseHeaders).not.toHaveBeenCalled();
+		});
+		mockXhrResponse(mockXhr, mock200Response);
+		await requestPromise;
+		expect(mockXhr.getAllResponseHeaders).toBeCalledTimes(1);
+	});
+
+	it('should NOT process response when xhr is cleared', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+		});
+		mockXhrResponse(mockXhr, mock200Response);
+		await requestPromise;
+		mockXhrResponse(mockXhr, mock200Response);
+		expect(mockXhr.getAllResponseHeaders).toBeCalledTimes(1);
+	});
+
+	it('should set Blob response with ResponseBodyMixin when xhr.responseType is blob', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'blob',
+		});
+		mockXhrResponse(mockXhr, {
+			...mock200Response,
+			body: new Blob([mock200Response.body]),
+		});
+		const { body } = await requestPromise;
+		expect(body).toBeInstanceOf(Blob);
+		expect((body! as unknown as Blob).size).toBe(mock200Response.body.length);
+		expect(await body!.blob()).toBe(body);
+		expect(await body!.text()).toEqual(
+			expect.stringMatching(/^text from raw response: .+Blob.+/)
+		);
+		await expect(body!.json()).rejects.toThrow(
+			expect.objectContaining({
+				message: expect.stringContaining(
+					'Parsing response to JSON is not implemented.'
+				),
+			})
+		);
+	});
+
+	it('should set Text response with ResponseBodyMixin when xhr.responseType is not blob', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+		});
+		mockXhrResponse(mockXhr, mock200Response);
+		const { body } = await requestPromise;
+		expect(await body.text()).toEqual(
+			expect.stringMatching(`text from raw response: ${mock200Response.body}`)
+		);
+	});
+
+	it('should clear xhr when xhr.readyState is DONE', async () => {
+		const mockXhr = spyOnXhr();
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+		});
+
+		mockXhrResponse(mockXhr, mock200Response);
+		await requestPromise;
+		// Should be no-op if the xhr is already cleared
+		mockXhrResponse(mockXhr, mock200Response);
+		expect(mockXhr.getAllResponseHeaders).toBeCalledTimes(1);
+	});
+
+	it('should immediately reject with canceled error when signal is already aborted', async () => {
+		const mockXhr = spyOnXhr();
+		const abortController = new AbortController();
+		abortController.abort();
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+			abortSignal: abortController.signal,
+		});
+		await expect(requestPromise).rejects.toThrow(
+			expect.objectContaining({
+				message: 'canceled',
+				code: 'ERR_CANCELED',
+			})
+		);
+		expect(mockXhr.abort).toBeCalledTimes(1);
+		expect(mockXhr.send).not.toBeCalled();
+	});
+
+	it('should reject with canceled error when signal is aborted', async () => {
+		const mockXhr = spyOnXhr();
+		const abortController = new AbortController();
+		const requestPromise = xhrTransferHandler(defaultRequest, {
+			responseType: 'text',
+			abortSignal: abortController.signal,
+		});
+		abortController.abort();
+		await expect(requestPromise).rejects.toThrow(
+			expect.objectContaining({
+				message: 'canceled',
+				code: 'ERR_CANCELED',
+			})
+		);
+		expect(mockXhr.abort).toBeCalledTimes(1);
+		expect(mockXhr.send).toBeCalledTimes(1);
+	});
+});

--- a/packages/storage/__tests__/AwsClients/xhrTransferHandler-util-test.ts
+++ b/packages/storage/__tests__/AwsClients/xhrTransferHandler-util-test.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import {
 	xhrTransferHandler,
 	SEND_UPLOAD_PROGRESS_EVENT,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -80,7 +80,7 @@
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
     "testPathIgnorePatterns": [
       "xmlParser-fixture.ts",
-			"testUtils"
+      "testUtils"
     ],
     "moduleFileExtensions": [
       "ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -79,7 +79,8 @@
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
     "testPathIgnorePatterns": [
-      "xmlParser-fixture.ts"
+      "xmlParser-fixture.ts",
+			"testUtils"
     ],
     "moduleFileExtensions": [
       "ts",

--- a/packages/storage/src/AwsClients/S3/utils/xhrTransferHandler.ts
+++ b/packages/storage/src/AwsClients/S3/utils/xhrTransferHandler.ts
@@ -1,0 +1,226 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	HttpRequest,
+	HttpResponse,
+	TransferHandler,
+	ResponseBodyMixin,
+} from '@aws-amplify/core/internals/aws-client-utils';
+import { ConsoleLogger as Logger } from '@aws-amplify/core';
+import type * as events from 'events';
+
+export const SEND_UPLOAD_PROGRESS_EVENT = 'sendUploadProgress';
+export const SEND_DOWNLOAD_PROGRESS_EVENT = 'sendDownloadProgress';
+
+const NETWORK_ERROR_MESSAGE = 'Network Error';
+const NETWORK_ERROR_CODE = 'ECONNABORTED';
+
+const ABORT_ERROR_MESSAGE = 'Request aborted';
+const ABORT_ERROR_CODE = 'ERR_ABORTED';
+
+const CANCELED_ERROR_MESSAGE = 'canceled';
+const CANCELED_ERROR_CODE = 'ERR_CANCELED';
+
+const logger = new Logger('xhr-http-handler');
+
+/**
+ * @internal
+ */
+export interface XhrTransferHandlerOptions {
+	// Expected response body type. If `blob`, the response will be returned as a Blob object. It's mainly used to
+	// download binary data. Otherwise, use `text` to return the response as a string.
+	responseType: 'text' | 'blob';
+	abortSignal?: AbortSignal;
+	emitter?: events.EventEmitter;
+}
+
+/**
+ * Base transfer handler implementation using XMLHttpRequest to support upload and download progress events.
+ *
+ * @param request - The request object.
+ * @param options - The request options.
+ * @returns A promise that will be resolved with the response object.
+ *
+ * @internal
+ */
+export const xhrTransferHandler: TransferHandler<
+	HttpRequest,
+	HttpResponse,
+	XhrTransferHandlerOptions
+> = (request, options): Promise<HttpResponse> => {
+	const { url, method, headers, body } = request;
+	const { emitter, responseType, abortSignal } = options;
+
+	return new Promise((resolve, reject) => {
+		let xhr: XMLHttpRequest | null = new XMLHttpRequest();
+		xhr.open(method.toUpperCase(), url.toString());
+
+		for (const [header, value] of Object.entries(headers).filter(
+			([header]) => !FORBIDDEN_HEADERS.includes(header)
+		)) {
+			xhr.setRequestHeader(header, value as string);
+		}
+
+		xhr.responseType = responseType;
+
+		if (emitter) {
+			xhr.upload.addEventListener('progress', event => {
+				emitter.emit(SEND_UPLOAD_PROGRESS_EVENT, event);
+				logger.debug(event);
+			});
+			xhr.addEventListener('progress', event => {
+				emitter.emit(SEND_DOWNLOAD_PROGRESS_EVENT, event);
+				logger.debug(event);
+			});
+		}
+
+		xhr.addEventListener('error', () => {
+			const error = simulateAxiosError(
+				NETWORK_ERROR_MESSAGE,
+				NETWORK_ERROR_CODE,
+				xhr!,
+				options
+			);
+			logger.error(NETWORK_ERROR_MESSAGE);
+			reject(error);
+			xhr = null; // clean up request
+		});
+
+		// Handle browser request cancellation (as opposed to a manual cancellation)
+		xhr.addEventListener('abort', () => {
+			if (!xhr) return;
+			const error = simulateAxiosError(
+				ABORT_ERROR_MESSAGE,
+				ABORT_ERROR_CODE,
+				xhr,
+				options
+			);
+			logger.error(ABORT_ERROR_MESSAGE);
+			reject(error);
+			xhr = null; // clean up request
+		});
+
+		// Skip handling timeout error since we don't have a timeout
+
+		xhr.addEventListener('readystatechange', () => {
+			if (!xhr || xhr.readyState !== xhr.DONE) {
+				return;
+			}
+
+			const onloadend = () => {
+				if (!xhr) return;
+				const responseHeaders = convertResponseHeaders(
+					xhr.getAllResponseHeaders()
+				);
+				const responseBlob = xhr.response as Blob;
+				const responseText = xhr.responseText;
+				const bodyMixIn: ResponseBodyMixin = {
+					blob: () => Promise.resolve(responseBlob),
+					text: () => Promise.resolve(responseText),
+					json: () =>
+						Promise.reject(
+							new Error(
+								'Parsing response to JSON is not implemented. Please use response.text() instead.'
+							)
+						),
+				};
+				const response: HttpResponse = {
+					statusCode: xhr.status,
+					headers: responseHeaders,
+					// The xhr.responseType is only set to 'blob' for streaming binary S3 object data. The streaming data is
+					// exposed via public interface of Storage.get(). So we need to return the response as a Blob object for
+					// backward compatibility. In other cases, the response payload is only used internally, we return it is
+					// {@link ResponseBodyMixin}
+					body: (xhr.responseType === 'blob'
+						? Object.assign(responseBlob, bodyMixIn)
+						: bodyMixIn) as HttpResponse['body'],
+				};
+				resolve(response);
+				xhr = null; // clean up request
+			};
+
+			// TODO: V6 use xhr.onloadend() when we officially drop support for IE11. Keep it to reduce surprise even though we
+			// don't support IE11 in v5.
+			setTimeout(onloadend);
+		});
+
+		if (abortSignal) {
+			const onCancelled = () => {
+				if (!xhr) {
+					return;
+				}
+				const canceledError = simulateAxiosCanceledError(
+					CANCELED_ERROR_MESSAGE,
+					CANCELED_ERROR_CODE,
+					xhr,
+					options
+				);
+				reject(canceledError);
+				xhr.abort();
+				xhr = null;
+			};
+			abortSignal.aborted
+				? onCancelled()
+				: abortSignal.addEventListener('abort', onCancelled);
+		}
+
+		if (
+			typeof ReadableStream === 'function' &&
+			body instanceof ReadableStream
+		) {
+			throw new Error('ReadableStream request payload is not supported.');
+		}
+
+		xhr.send((body as Exclude<BodyInit, ReadableStream>) || null);
+	});
+};
+
+// TODO: V6 remove this
+const simulateAxiosError = (
+	message: string,
+	code: string,
+	request: XMLHttpRequest,
+	config: XhrTransferHandlerOptions
+) =>
+	Object.assign(new Error(message), {
+		code,
+		config,
+		request,
+	});
+
+const simulateAxiosCanceledError = (
+	message: string,
+	code: string,
+	request: XMLHttpRequest,
+	config: XhrTransferHandlerOptions
+) => {
+	const error = simulateAxiosError(message, code, request, config);
+	error.name = 'CanceledError';
+	error['__CANCEL__'] = true;
+	return error;
+};
+
+/**
+ * Convert xhr.getAllResponseHeaders() string to a Record<string, string>. Note that modern browser already returns
+ * header names in lowercase.
+ * @param xhrHeaders - string of headers returned from xhr.getAllResponseHeaders()
+ */
+const convertResponseHeaders = (xhrHeaders: string): Record<string, string> => {
+	if (!xhrHeaders) {
+		return {};
+	}
+	return xhrHeaders
+		.split('\r\n')
+		.reduce((headerMap: Record<string, string>, line: string) => {
+			const parts = line.split(': ');
+			const header = parts.shift()!;
+			const value = parts.join(': ');
+			headerMap[header.toLowerCase()] = value;
+			return headerMap;
+		}, {});
+};
+
+// TODO: Add more forbidden headers as found set by S3. Intentionally NOT list all of them here to save bundle size.
+// https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
+const FORBIDDEN_HEADERS = ['host'];

--- a/packages/storage/src/AwsClients/S3/utils/xhrTransferHandler.ts
+++ b/packages/storage/src/AwsClients/S3/utils/xhrTransferHandler.ts
@@ -122,6 +122,7 @@ export const xhrTransferHandler: TransferHandler<
 					text: () => Promise.resolve(responseText),
 					json: () =>
 						Promise.reject(
+							// S3 does not support JSON response. So fail-fast here with nicer error message.
 							new Error(
 								'Parsing response to JSON is not implemented. Please use response.text() instead.'
 							)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
An XHR based HTTP transfer handler to be used by custom S3 client. This is to replace the current Axios based handler injected to AWS SDK S3 client. Like Axios handler, this handler also supports abort and download & upload progress events. The thrown error and events to intentionally compatible with Axios ones.

This xhr handler is 1/4 the size of Axios handler
```
 Axios handler
  Size:       8.66 kB with all dependencies, minified and gzipped
  
  XHR handler
  Size:       2.07 kB with all dependencies, minified and gzipped
```



#### Description of how you validated changes
Manually tested on React Native, browsers.



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
