### PR TITLE
chore(storage): upgrade typescript to 5.0.2

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -19,10 +19,10 @@
     "test": "npm run lint && jest -w 1 --coverage",
     "test:size": "size-limit",
     "build-with-test": "npm test && npm run build",
-    "build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
-    "build:esm": "node ./build es6",
-    "build:cjs:watch": "node ./build es5 --watch",
-    "build:esm:watch": "node ./build es6 --watch",
+    "build:cjs": "rimraf lib && tsc -m commonjs --outDir lib && webpack && webpack --config ./webpack.config.dev.js",
+    "build:esm": "rimraf lib-esm && tsc -m esnext --outDir lib-esm",
+    "build:cjs:watch": "rimraf lib && tsc -m commonjs --outDir lib --watch",
+    "build:esm:watch": "rimraf lib-esm && tsc -m esnext --outDir lib-esm --watch",
     "build": "npm run clean && npm run build:esm && npm run build:cjs",
     "clean": "npm run clean:size && rimraf lib-esm lib dist",
     "clean:size": "rimraf dual-publish-tmp tmp*",
@@ -54,14 +54,15 @@
     "axios": "0.26.0",
     "events": "^3.1.0",
     "fast-xml-parser": "4.2.4",
-    "tslib": "^1.8.0"
+    "tslib": "^1.8.0",
+    "typescript": "5.0.2"
   },
   "size-limit": [
     {
       "name": "Storage (top-level class)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, Storage }",
-      "limit": "87 kB"
+      "limit": "90.7 kB"
     }
   ],
   "jest": {
@@ -70,16 +71,7 @@
         "diagnostics": {
           "pathRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$"
         },
-        "tsConfig": {
-          "lib": [
-            "es5",
-            "es2015",
-            "dom",
-            "esnext.asynciterable",
-            "es2017.object"
-          ],
-          "allowJs": true
-        }
+        "tsConfig": false
       }
     },
     "transform": {

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../tsconfig.base.json",
+	"compilerOptions": {
+		"importHelpers": false
+	},
+	"include": ["./src"],
+	"watchOptions": {
+		"excludeDirectories": ["lib*"]
+	}
+}


### PR DESCRIPTION
similar to #11077; This change adds 5.8kB to bundle size limit because it disables importHelpers to keep tslib version aligned. We may need to revisit whether to bump tslib to 2.x. For now the bundle size increase is temporary because it will decrease after the S3 AWS SDK client is removed.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
