### PR TITLE
fix: remove x-amz-user-agent header from api-rest calls to prevent CORS failures

### DIFF
--- a/packages/api-rest/__tests__/RestAPI-test.ts
+++ b/packages/api-rest/__tests__/RestAPI-test.ts
@@ -1,14 +1,7 @@
 import axios, { CancelTokenStatic } from 'axios';
 import { RestAPIClass as API } from '../src/';
 import { RestClient } from '../src/RestClient';
-import {
-	Signer,
-	Credentials,
-	DateUtils,
-	getAmplifyUserAgentString,
-	Category,
-	ApiAction,
-} from '@aws-amplify/core';
+import { Signer, Credentials, DateUtils } from '@aws-amplify/core';
 
 jest.mock('axios');
 
@@ -186,23 +179,12 @@ describe('Rest API test', () => {
 						res({});
 					});
 				});
-			await api.get('apiName', 'path', {
-				customUserAgentDetails: {
-					category: Category.API,
-					action: ApiAction.Get,
-				},
-			});
+			await api.get('apiName', 'path', {});
 
 			expect(spyonRequest).toBeCalledWith(
 				{
 					data: null,
-					headers: {
-						Authorization: 'mytoken',
-						'x-amz-user-agent': getAmplifyUserAgentString({
-							category: Category.API,
-							action: ApiAction.Get,
-						}),
-					},
+					headers: { Authorization: 'mytoken' },
 					host: 'www.amazonaws.compath',
 					method: 'GET',
 					path: '/',
@@ -265,7 +247,7 @@ describe('Rest API test', () => {
 			await api.get('apiName', '/items', init);
 			const expectedParams = {
 				data: null,
-				headers: { 'x-amz-user-agent': getAmplifyUserAgentString() },
+				headers: {},
 				host: undefined,
 				method: 'GET',
 				path: '/',
@@ -331,7 +313,7 @@ describe('Rest API test', () => {
 			await api.get('apiName', '/items', init);
 			const expectedParams = {
 				data: null,
-				headers: { 'x-amz-user-agent': getAmplifyUserAgentString() },
+				headers: {},
 				host: undefined,
 				method: 'GET',
 				path: '/',
@@ -400,10 +382,7 @@ describe('Rest API test', () => {
 			await api.get('apiName', '/items', init);
 			const expectedParams = {
 				data: null,
-				headers: {
-					Authorization: 'apikey',
-					'x-amz-user-agent': getAmplifyUserAgentString(),
-				},
+				headers: { Authorization: 'apikey' },
 				host: undefined,
 				method: 'GET',
 				path: '/',
@@ -466,7 +445,7 @@ describe('Rest API test', () => {
 			await api.get('apiName', '/items?key1=value1&key2=value', init);
 			const expectedParams = {
 				data: null,
-				headers: { 'x-amz-user-agent': getAmplifyUserAgentString() },
+				headers: {},
 				host: undefined,
 				method: 'GET',
 				path: '/',

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -55,7 +55,7 @@
       "name": "API (rest client)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, RestAPI }",
-      "limit": "31 kB"
+      "limit": "30.75 kB"
     }
   ],
   "jest": {

--- a/packages/api-rest/src/RestClient.ts
+++ b/packages/api-rest/src/RestClient.ts
@@ -6,8 +6,6 @@ import {
 	Credentials,
 	DateUtils,
 	Signer,
-	getAmplifyUserAgentString,
-	USER_AGENT_HEADER,
 } from '@aws-amplify/core';
 
 import { apiOptions, ApiInfo } from './types';
@@ -110,12 +108,7 @@ export class RestClient {
 			cancelToken: null,
 		};
 
-		const libraryHeaders = {
-			[USER_AGENT_HEADER]: getAmplifyUserAgentString(
-				init.customUserAgentDetails
-			),
-		};
-
+		const libraryHeaders = {};
 		const initParams = Object.assign({}, init);
 		const isAllResponse = initParams.response;
 		if (initParams.body) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Reverts most x-amz-user-agent-related changes to api-rest category, with the exception of ceasing to override the UserAgent for ReactNative customers.


#### Description of how you validated changes
yarn tests passing.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
