### PR TITLE
fix(core): Angular web detection and other minor changes

### DIFF
--- a/packages/core/src/Platform/detection/Angular.ts
+++ b/packages/core/src/Platform/detection/Angular.ts
@@ -1,12 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { processExists, windowExists } from './helpers';
+import { documentExists, processExists, windowExists } from './helpers';
 
 // Tested with @angular/core 16.0.0
 
 export function angularWebDetect() {
-	return windowExists() && typeof window['ng'] !== 'undefined';
+	const angularVersionSetInDocument = Boolean(
+		documentExists() && document.querySelector('[ng-version]')
+	);
+	const angularContentSetInWindow = Boolean(
+		// @ts-ignore
+		windowExists() && typeof window['ng'] !== 'undefined'
+	);
+	return angularVersionSetInDocument || angularContentSetInWindow;
 }
 
 export function angularSSRDetect() {

--- a/packages/core/src/Platform/detection/Expo.ts
+++ b/packages/core/src/Platform/detection/Expo.ts
@@ -6,5 +6,6 @@ import { globalExists } from './helpers';
 // Tested with expo 48 / react-native 0.71.3
 
 export function expoDetect() {
+	// @ts-ignore
 	return globalExists() && typeof global['expo'] !== 'undefined';
 }

--- a/packages/core/src/Platform/detection/Next.ts
+++ b/packages/core/src/Platform/detection/Next.ts
@@ -6,6 +6,7 @@ import { globalExists, keyPrefixMatch, windowExists } from './helpers';
 // Tested with next 13.4 / react 18.2
 
 export function nextWebDetect() {
+	// @ts-ignore
 	return windowExists() && window['next'] && typeof window['next'] === 'object';
 }
 

--- a/packages/core/src/Platform/detection/Nuxt.ts
+++ b/packages/core/src/Platform/detection/Nuxt.ts
@@ -8,10 +8,12 @@ import { globalExists, windowExists } from './helpers';
 export function nuxtWebDetect() {
 	return (
 		windowExists() &&
+		// @ts-ignore
 		(window['__NUXT__'] !== undefined || window['$nuxt'] !== undefined)
 	);
 }
 
 export function nuxtSSRDetect() {
+	// @ts-ignore
 	return globalExists() && typeof global['__NUXT_PATHS__'] !== 'undefined';
 }

--- a/packages/core/src/Platform/detection/React.ts
+++ b/packages/core/src/Platform/detection/React.ts
@@ -6,11 +6,11 @@ import { documentExists, processExists, windowExists } from './helpers';
 // Tested with react 18.2 - built using Vite
 
 export function reactWebDetect() {
-	const elementKeyPrefixedWithReact = k => {
-		return k.startsWith('_react') || k.startsWith('__react');
+	const elementKeyPrefixedWithReact = key => {
+		return key.startsWith('_react') || key.startsWith('__react');
 	};
-	const elementIsReactEnabled = e => {
-		return Object.keys(e).find(elementKeyPrefixedWithReact);
+	const elementIsReactEnabled = element => {
+		return Object.keys(element).find(elementKeyPrefixedWithReact);
 	};
 	const allElementsWithId = () => Array.from(document.querySelectorAll('[id]'));
 

--- a/packages/core/src/Platform/detection/helpers.ts
+++ b/packages/core/src/Platform/detection/helpers.ts
@@ -21,6 +21,6 @@ export const processExists = () => {
 	return typeof process !== 'undefined';
 };
 
-export const keyPrefixMatch = (object, prefix) => {
+export const keyPrefixMatch = (object: object, prefix: string) => {
 	return !!Object.keys(object).find(key => key.startsWith(prefix));
 };


### PR DESCRIPTION
#### Description of changes
In the latest version of Angular, it is protecting its updates to window from being visible in code outside of Angular. Maybe this is zones?  Either way, I've added a fallback approach that leverages the dom. From what I'm reading using both of these together should cover all recent versions of Angular.

Also expanded variable names per a comment from Chris earlier and added tsignore in a bunch of places. Angular was happy with no warnings until I started importing internal pieces.  When it is compiling the detection code for itself, it warns on these without the annotations. Should have been fine, but resolved on the off chance that a different strict build environment is rebuilding this code.

#### Description of how you validated changes
Retested with angular using linking (earlier verification was done by injecting the angular code into an app, which is within the zone, so the old approach worked.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
