### PR TITLE
chore: Pins the version of `url` used in the library

### DIFF
--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -48,7 +48,8 @@
   "dependencies": {
     "@aws-amplify/core": "5.4.0",
     "axios": "0.26.0",
-    "tslib": "^1.8.0"
+    "tslib": "^1.8.0",
+    "url": "0.11.0"
   },
   "size-limit": [
     {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -48,7 +48,8 @@
   "dependencies": {
     "@aws-amplify/core": "5.4.0",
     "amazon-cognito-identity-js": "6.2.0",
-    "tslib": "^1.8.0"
+    "tslib": "^1.8.0",
+    "url": "0.11.0"
   },
   "devDependencies": {
     "@jest/test-sequencer": "^24.9.0"

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -56,7 +56,8 @@
     "graphql": "15.8.0",
     "tslib": "^1.8.0",
     "uuid": "^3.2.1",
-    "zen-observable-ts": "0.8.19"
+    "zen-observable-ts": "0.8.19",
+    "url": "0.11.0"
   },
   "size-limit": [
     {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change pins the version of `url` that we're using in the library to temporarily resolve a bundle size regression.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Ran `yarn test:size`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
