### PR TITLE
fix: Add upkeep to platform/framework caches

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -63,7 +63,7 @@
 			"name": "Analytics (Pinpoint)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Analytics, AWSPinpointProvider }",
-			"limit": "30.9 kB"
+			"limit": "30.95 kB"
 		},
 		{
 			"name": "Analytics (Kinesis)",

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -56,7 +56,7 @@
       "name": "API (rest client)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, RestAPI }",
-      "limit": "30.8 kB"
+      "limit": "30.9 kB"
     }
   ],
   "jest": {

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -139,6 +139,9 @@ export class AuthClass {
 
 		addAuthCategoryToCognitoUserAgent();
 		addFrameworkToCognitoUserAgent(Platform.framework);
+		Platform.observeFrameworkChanges(() => {
+			addFrameworkToCognitoUserAgent(Platform.framework);
+		});
 	}
 
 	public getModuleName() {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,7 @@
 			"name": "Core (Credentials)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Credentials }",
-			"limit": "13.25 kB"
+			"limit": "13.3 kB"
 		},
 		{
 			"name": "Core (Signer)",

--- a/packages/core/src/AwsClients/CognitoIdentity/base.ts
+++ b/packages/core/src/AwsClients/CognitoIdentity/base.ts
@@ -18,6 +18,7 @@ import {
 	getRetryDecider,
 } from '../../clients/middleware/retry';
 import { getAmplifyUserAgentString } from '../../Platform';
+import { observeFrameworkChanges } from '../../Platform/detectFramework';
 
 /**
  * The service name used to sign requests if the API requires authentication.
@@ -64,6 +65,10 @@ export const defaultConfig = {
 	computeDelay: jitteredBackoff,
 	userAgentValue: getAmplifyUserAgentString(),
 };
+
+observeFrameworkChanges(() => {
+	defaultConfig.userAgentValue = getAmplifyUserAgentString();
+});
 
 /**
  * @internal

--- a/packages/core/src/Platform/detectFramework.ts
+++ b/packages/core/src/Platform/detectFramework.ts
@@ -13,6 +13,7 @@ const frameworkChangeObservers: (() => void)[] = [];
 let resetTriggered = false;
 const SSR_RESET_TIMEOUT = 10; // ms
 const WEB_RESET_TIMEOUT = 10; // ms
+const PRIME_FRAMEWORK_DELAY = 1_000; // ms
 
 export const detectFramework = (): Framework => {
 	if (!frameworkCache) {
@@ -50,7 +51,7 @@ function resetTimeout(framework: Framework, delay: number) {
 		setTimeout(() => {
 			clearCache();
 			resetTriggered = true;
-			detectFramework();
+			setTimeout(detectFramework, PRIME_FRAMEWORK_DELAY);
 		}, delay);
 	}
 }

--- a/packages/core/src/Platform/detectFramework.ts
+++ b/packages/core/src/Platform/detectFramework.ts
@@ -7,6 +7,8 @@ import { detect } from './detection';
 // We want to cache detection since the framework won't change
 let frameworkCache: Framework | undefined;
 
+const frameworkChangeObservers: (() => void)[] = [];
+
 // Setup the detection reset tracking / timeout delays
 let resetTriggered = false;
 const SSR_RESET_TIMEOUT = 10; // ms
@@ -16,11 +18,21 @@ export const detectFramework = (): Framework => {
 	if (!frameworkCache) {
 		frameworkCache = detect();
 
+		// Everytime we update the cache, call each observer function
+		frameworkChangeObservers.forEach(fcn => fcn());
+
 		// Retry once for either Unknown type after a delay (explained below)
 		resetTimeout(Framework.ServerSideUnknown, SSR_RESET_TIMEOUT);
 		resetTimeout(Framework.WebUnknown, WEB_RESET_TIMEOUT);
 	}
 	return frameworkCache;
+};
+
+/**
+ * @internal Setup observer callback that will be called everytime the framework changes
+ */
+export const observeFrameworkChanges = (fcn: () => void) => {
+	frameworkChangeObservers.push(fcn);
 };
 
 export function clearCache() {
@@ -38,6 +50,7 @@ function resetTimeout(framework: Framework, delay: number) {
 		setTimeout(() => {
 			clearCache();
 			resetTriggered = true;
+			detectFramework();
 		}, delay);
 	}
 }

--- a/packages/core/src/Platform/index.ts
+++ b/packages/core/src/Platform/index.ts
@@ -3,7 +3,7 @@
 
 import { CustomUserAgentDetails, Framework } from './types';
 import { version } from './version';
-import { detectFramework } from './detectFramework';
+import { detectFramework, observeFrameworkChanges } from './detectFramework';
 import { UserAgent as AWSUserAgent } from '@aws-sdk/types';
 
 const BASE_USER_AGENT = `aws-amplify`;
@@ -16,6 +16,10 @@ class PlatformBuilder {
 
 	get isReactNative() {
 		return this.framework === Framework.ReactNative;
+	}
+
+	observeFrameworkChanges(fcn: () => void) {
+		observeFrameworkChanges(fcn);
 	}
 }
 

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -57,7 +57,7 @@
 			"name": "Geo (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Geo }",
-			"limit": "51.6 kB"
+			"limit": "51.7 kB"
 		}
 	],
 	"jest": {

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -59,7 +59,7 @@
 			"name": "Interactions (top-level class with Lex v2)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Interactions, AWSLexV2Provider }",
-			"limit": "75.6 kB"
+			"limit": "76 kB"
 		}
 	],
 	"jest": {

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -65,13 +65,13 @@
 			"name": "Notifications (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Notifications }",
-			"limit": "29.75 kB"
+			"limit": "29.8 kB"
 		},
 		{
 			"name": "Notifications (with Analytics)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Notifications, Analytics }",
-			"limit": "29.75 kB"
+			"limit": "29.8 kB"
 		}
 	]
 }


### PR DESCRIPTION
#### Description of changes
**Problem:** In testing we are observing that Angular passes no framework for all Cognito and Analytics calls.  I can verify that framework detection is working, but only after the DOM is rendered. Some of our calls are depending upon a cached/default/primed version of the user agent, which isn't maintained.

**Solution:**
For the `defaultConfig` and the Auth platform, add upkeep to keep the platform current when this value is updated.

This value gets updated because sometimes the first calls to detect happen earlier than the framework can be detected. There is a timed invalidation and second run to ensure we are working with accurate framework information for as many calls as possible.

Caching the initial framework call for cases where it is unknown makes all future framework references also unknown without this upkeep logic.


#### Description of how you validated changes
Tested manually with Angular where the problem was observed.


#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
