### PR TITLE
build: set resolution for octokit/request-error due to breaking change in v4 for node@16 users

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
 		"wml": "0.0.83"
 	},
 	"resolutions": {
-		"@types/babel__traverse": "7.20.0"
+		"@types/babel__traverse": "7.20.0",
+		"@octokit/request-error": "^3.0.0"
 	},
 	"jest": {
 		"resetMocks": true,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
@octokit/core@4.2.2 introduces a breaking change by upgrading their dependency on @octokit/request-error to v4, which no longer supports the use of node@16. This PR sets a resolution for octokit/request-error to unblock our pipeline until octokit fixes their issue.



#### Description of how you validated changes
yarn succeeds locally



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
