### PR TITLE
fix(clients): add missing export for getHashedPayload in RN

### DIFF
--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/index.native.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/index.native.ts
@@ -7,3 +7,4 @@ import '@aws-amplify/core/polyfills/URL';
 export { signRequest } from './signRequest';
 export { presignUrl } from './presignUrl';
 export { TOKEN_QUERY_PARAM } from './constants';
+export { getHashedPayload } from './utils/getHashedPayload';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fix a bug found in RN manual test of S3 client. The `getHashedPayload()` is exported in the browser path but missed in the RN path.

#### Description of how you validated changes
Manual test on RN app.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
