### PR TITLE
chore: Fix Github action step versions

### DIFF
--- a/.github/workflows/aws-amplify-dependency-check.yml
+++ b/.github/workflows/aws-amplify-dependency-check.yml
@@ -10,16 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
         with:
           persist-credentials: true
       - name: Determine if "aws-amplify" package.json has been changed
         id: aws-amplify-package-check
-        uses: tj-actions/changed-files@v36
+        uses: tj-actions/changed-files@54479c37f5eb47a43e595c6b71e1df2c112ce7f1 # v36 https://github.com/tj-actions/changed-files/commit/54479c37f5eb47a43e595c6b71e1df2c112ce7f1
         with:
           files: packages/aws-amplify/package.json
       - name: Write a PR comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0 https://github.com/actions/github-script/commit/98814c53be79b1d30f795b907e553d8679345975
         if: steps.aws-amplify-package-check.outputs.any_changed == 'true'
         with:
           script: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,23 +21,23 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
         with:
           # Minimal depth 2 so we can checkout the commit before possible merge commit.
           fetch-depth: 2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@d23060145bc9131d50558d5d4185494a20208101 # v2.12.5 https://github.com/github/codeql-action/commit/d23060145bc9131d50558d5d4185494a20208101
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@d23060145bc9131d50558d5d4185494a20208101 # v2.12.5 https://github.com/github/codeql-action/commit/d23060145bc9131d50558d5d4185494a20208101
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@d23060145bc9131d50558d5d4185494a20208101 # v2.12.5 https://github.com/github/codeql-action/commit/d23060145bc9131d50558d5d4185494a20208101
         with:
           category: '/language:${{matrix.language}}'

--- a/.github/workflows/issue-pending-response.yml
+++ b/.github/workflows/issue-pending-response.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ !github.event.issue.pull_request  && contains(github.event.issue.labels.*.name, 'pending-response') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: siegerts/pending-author-response@v1
+      - uses: siegerts/pending-author-response@409a63bf27370ba9a0e98e8d5fbda7a12398d456 # v1 https://github.com/siegerts/pending-author-response/commit/409a63bf27370ba9a0e98e8d5fbda7a12398d456
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pending-response-label: pending-response

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -8,7 +8,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@f1a42f0f44eb83361d617a014663e1a76cf282d2 # v2 https://github.com/dessant/lock-threads/commit/f1a42f0f44eb83361d617a014663e1a76cf282d2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-lock-inactive-days: '365'

--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -18,9 +18,9 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
       - name: Set up Snyk CLI to check for security issues
-        uses: snyk/actions/setup@806182742461562b67788a64410098c9d9b96adb
+        uses: snyk/actions/setup@806182742461562b67788a64410098c9d9b96adb # v0.4.0 https://github.com/snyk/actions/commit/806182742461562b67788a64410098c9d9b96adb
       - name: Build
         run: yarn install || true
         # Using `|| true` to not fail the pipeline
@@ -31,6 +31,6 @@ jobs:
 
       # Push the Snyk Code results into GitHub Code Scanning tab
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@6c089f53dd51dc3fc7e599c3cb5356453a52ca9e # v2 https://github.com/github/codeql-action/commit/6c089f53dd51dc3fc7e599c3cb5356453a52ca9e
         with:
           sarif_file: snyk-code.sarif


### PR DESCRIPTION
#### Description of changes
Following the UI teams best practices, this fixes every GH Action used to a specific commit to avoid accepting any unintended security changes across external committer changes.

#### Description of how you validated changes
Tested on a fork to confirm jobs continue to work.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
