### PR TITLE
fix: Update getAmplifyUserAgent to retain original interface

### DIFF
--- a/packages/amazon-cognito-identity-js/__tests__/UserAgent.test.js
+++ b/packages/amazon-cognito-identity-js/__tests__/UserAgent.test.js
@@ -3,7 +3,7 @@ import UserAgent, {
 	addAuthCategoryToCognitoUserAgent,
 	addFrameworkToCognitoUserAgent,
 	appendToCognitoUserAgent,
-	getAmplifyUserAgentString,
+	getAmplifyUserAgent,
 } from '../src/UserAgent';
 
 const DEFAULT_USER_AGENT = 'aws-amplify/0.1.x';
@@ -29,7 +29,7 @@ describe('UserAgent test', () => {
 		appendToCognitoUserAgent('test');
 		expect(UserAgent.prototype.userAgent).toBe(`${DEFAULT_USER_AGENT} test`);
 
-		expect(getAmplifyUserAgentString()).toBe(`${DEFAULT_USER_AGENT} test`);
+		expect(getAmplifyUserAgent()).toBe(`${DEFAULT_USER_AGENT} test`);
 	});
 
 	test('appendToCognitoUserAgent does not append duplicate content', () => {
@@ -41,7 +41,7 @@ describe('UserAgent test', () => {
 
 		expect(UserAgent.prototype.userAgent).toBe(`${DEFAULT_USER_AGENT} test`);
 
-		expect(getAmplifyUserAgentString()).toBe(`${DEFAULT_USER_AGENT} test`);
+		expect(getAmplifyUserAgent()).toBe(`${DEFAULT_USER_AGENT} test`);
 	});
 
 	test('appendToCognitoUserAgent sets userAgent if userAgent has no content', () => {
@@ -58,7 +58,7 @@ describe('UserAgent test', () => {
 		addAuthCategoryToCognitoUserAgent();
 		expect(UserAgent.category).toBe(AUTH_CATEGORY);
 
-		expect(getAmplifyUserAgentString()).toBe(
+		expect(getAmplifyUserAgent()).toBe(
 			`${DEFAULT_USER_AGENT} ${USER_AGENT_AUTH}`
 		);
 	});
@@ -67,7 +67,7 @@ describe('UserAgent test', () => {
 		addFrameworkToCognitoUserAgent('0');
 		expect(UserAgent.framework).toBe('0');
 
-		expect(getAmplifyUserAgentString()).toBe(
+		expect(getAmplifyUserAgent()).toBe(
 			`${DEFAULT_USER_AGENT} ${USER_AGENT_FRAMEWORK0}`
 		);
 	});

--- a/packages/amazon-cognito-identity-js/src/Client.js
+++ b/packages/amazon-cognito-identity-js/src/Client.js
@@ -1,6 +1,6 @@
 import 'isomorphic-unfetch';
 
-import { getAmplifyUserAgentString } from './UserAgent';
+import { getAmplifyUserAgent } from './UserAgent';
 
 class CognitoError extends Error {
 	constructor(message, code, name, statusCode) {
@@ -79,7 +79,7 @@ export default class Client {
 		const headers = {
 			'Content-Type': 'application/x-amz-json-1.1',
 			'X-Amz-Target': `AWSCognitoIdentityProviderService.${operation}`,
-			'X-Amz-User-Agent': getAmplifyUserAgentString(),
+			'X-Amz-User-Agent': getAmplifyUserAgent(),
 			'Cache-Control': 'no-store',
 		};
 

--- a/packages/amazon-cognito-identity-js/src/UserAgent.js
+++ b/packages/amazon-cognito-identity-js/src/UserAgent.js
@@ -32,7 +32,7 @@ export const addFrameworkToCognitoUserAgent = framework => {
 	UserAgent.framework = framework;
 };
 
-export const getAmplifyUserAgentString = action => {
+export const getAmplifyUserAgent = action => {
 	const uaCategoryAction = UserAgent.category ? ` ${UserAgent.category}` : '';
 	const uaFramework = UserAgent.framework
 		? ` framework/${UserAgent.framework}`

--- a/packages/analytics/src/utils/UserAgent.ts
+++ b/packages/analytics/src/utils/UserAgent.ts
@@ -1,19 +1,19 @@
 import {
 	AnalyticsAction,
 	Category,
+	getAmplifyUserAgentObject,
 	getAmplifyUserAgent,
-	getAmplifyUserAgentString,
 } from '@aws-amplify/core';
 
 export function getAnalyticsUserAgent(action: AnalyticsAction) {
-	return getAmplifyUserAgent({
+	return getAmplifyUserAgentObject({
 		category: Category.Analytics,
 		action,
 	});
 }
 
 export function getAnalyticsUserAgentString(action: AnalyticsAction) {
-	return getAmplifyUserAgentString({
+	return getAmplifyUserAgent({
 		category: Category.Analytics,
 		action,
 	});

--- a/packages/api-graphql/src/internals/InternalGraphQLAPI.ts
+++ b/packages/api-graphql/src/internals/InternalGraphQLAPI.ts
@@ -14,7 +14,7 @@ import {
 	ConsoleLogger as Logger,
 	Credentials,
 	CustomUserAgentDetails,
-	getAmplifyUserAgentString,
+	getAmplifyUserAgent,
 	INTERNAL_AWS_APPSYNC_REALTIME_PUBSUB_PROVIDER,
 } from '@aws-amplify/core';
 import { InternalPubSub } from '@aws-amplify/pubsub/internals';
@@ -293,7 +293,7 @@ export class InternalGraphQLAPIClass {
 			...(await graphql_headers({ query, variables })),
 			...additionalHeaders,
 			...(!customGraphqlEndpoint && {
-				[USER_AGENT_HEADER]: getAmplifyUserAgentString(customUserAgentDetails),
+				[USER_AGENT_HEADER]: getAmplifyUserAgent(customUserAgentDetails),
 			}),
 		};
 

--- a/packages/auth/__tests__/oauth-test.ts
+++ b/packages/auth/__tests__/oauth-test.ts
@@ -26,7 +26,7 @@ jest.mock('@aws-amplify/core', () => ({
 	urlSafeEncode: jest.fn(),
 	Category: { Auth: 'auth' },
 	AuthAction: { FederatedSignIn: '30' },
-	getAmplifyUserAgentString: () => jest.fn(),
+	getAmplifyUserAgent: () => jest.fn(),
 }));
 
 function fetchMockReturn(response) {

--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -17,7 +17,7 @@ import {
 	Category,
 	ConsoleLogger as Logger,
 	CustomUserAgentDetails,
-	getAmplifyUserAgentString,
+	getAmplifyUserAgent,
 	Hub,
 	urlSafeEncode,
 	USER_AGENT_HEADER,
@@ -179,9 +179,7 @@ export default class OAuth {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/x-www-form-urlencoded',
-					[USER_AGENT_HEADER]: getAmplifyUserAgentString(
-						customUserAgentDetails
-					),
+					[USER_AGENT_HEADER]: getAmplifyUserAgent(customUserAgentDetails),
 				},
 				body,
 			})) as any

--- a/packages/core/__tests__/Platform-test.ts
+++ b/packages/core/__tests__/Platform-test.ts
@@ -1,6 +1,6 @@
 import {
+	getAmplifyUserAgentObject,
 	getAmplifyUserAgent,
-	getAmplifyUserAgentString,
 	Platform,
 } from '../src/Platform';
 import { version } from '../src/Platform/version';
@@ -16,9 +16,9 @@ describe('Platform test', () => {
 		});
 	});
 
-	describe('getAmplifyUserAgent test', () => {
+	describe('getAmplifyUserAgentObject test', () => {
 		test('without customUserAgentDetails', () => {
-			expect(getAmplifyUserAgent()).toStrictEqual([
+			expect(getAmplifyUserAgentObject()).toStrictEqual([
 				['aws-amplify', version],
 				['framework', Framework.WebUnknown],
 			]);
@@ -27,7 +27,7 @@ describe('Platform test', () => {
 		/* TODO: test with actual API action */
 		test('with customUserAgentDetails', () => {
 			expect(
-				getAmplifyUserAgent({
+				getAmplifyUserAgentObject({
 					category: Category.API,
 					action: ApiAction.None,
 				})
@@ -39,16 +39,16 @@ describe('Platform test', () => {
 		});
 	});
 
-	describe('getAmplifyUserAgentString test', () => {
+	describe('getAmplifyUserAgent test', () => {
 		test('without customUserAgentDetails', () => {
-			expect(getAmplifyUserAgentString()).toBe(
+			expect(getAmplifyUserAgent()).toBe(
 				`${Platform.userAgent} framework/${Framework.WebUnknown}`
 			);
 		});
 
 		test('with customUserAgentDetails', () => {
 			expect(
-				getAmplifyUserAgentString({
+				getAmplifyUserAgent({
 					category: Category.API,
 					action: ApiAction.None,
 				})

--- a/packages/core/src/AwsClients/CognitoIdentity/base.ts
+++ b/packages/core/src/AwsClients/CognitoIdentity/base.ts
@@ -17,7 +17,7 @@ import {
 	jitteredBackoff,
 	getRetryDecider,
 } from '../../clients/middleware/retry';
-import { getAmplifyUserAgentString } from '../../Platform';
+import { getAmplifyUserAgent } from '../../Platform';
 import { observeFrameworkChanges } from '../../Platform/detectFramework';
 
 /**
@@ -63,11 +63,11 @@ export const defaultConfig = {
 	endpointResolver,
 	retryDecider: getRetryDecider(parseJsonError),
 	computeDelay: jitteredBackoff,
-	userAgentValue: getAmplifyUserAgentString(),
+	userAgentValue: getAmplifyUserAgent(),
 };
 
 observeFrameworkChanges(() => {
-	defaultConfig.userAgentValue = getAmplifyUserAgentString();
+	defaultConfig.userAgentValue = getAmplifyUserAgent();
 });
 
 /**

--- a/packages/core/src/AwsClients/Pinpoint/base.ts
+++ b/packages/core/src/AwsClients/Pinpoint/base.ts
@@ -8,7 +8,7 @@ import {
 } from '../../clients/middleware/retry';
 import { parseJsonError } from '../../clients/serde/json';
 import type { EndpointResolverOptions, Headers } from '../../clients/types';
-import { getAmplifyUserAgentString } from '../../Platform';
+import { getAmplifyUserAgent } from '../../Platform';
 
 /**
  * The service name used to sign requests if the API requires authentication.
@@ -30,7 +30,7 @@ export const defaultConfig = {
 	endpointResolver,
 	retryDecider: getRetryDecider(parseJsonError),
 	computeDelay: jitteredBackoff,
-	userAgentValue: getAmplifyUserAgentString(),
+	userAgentValue: getAmplifyUserAgent(),
 };
 
 /**

--- a/packages/core/src/Platform/index.ts
+++ b/packages/core/src/Platform/index.ts
@@ -25,7 +25,7 @@ class PlatformBuilder {
 
 export const Platform = new PlatformBuilder();
 
-export const getAmplifyUserAgent = ({
+export const getAmplifyUserAgentObject = ({
 	category,
 	action,
 	framework,
@@ -39,10 +39,10 @@ export const getAmplifyUserAgent = ({
 	return userAgent;
 };
 
-export const getAmplifyUserAgentString = (
+export const getAmplifyUserAgent = (
 	customUserAgentDetails?: CustomUserAgentDetails
 ): string => {
-	const userAgent = getAmplifyUserAgent(customUserAgentDetails);
+	const userAgent = getAmplifyUserAgentObject(customUserAgentDetails);
 	const userAgentString = userAgent
 		.map(([agentKey, agentValue]) => `${agentKey}/${agentValue}`)
 		.join(' ');

--- a/packages/core/src/Providers/AWSCloudWatchProvider.ts
+++ b/packages/core/src/Providers/AWSCloudWatchProvider.ts
@@ -32,7 +32,7 @@ import {
 } from '../types/types';
 import { Credentials } from '../..';
 import { ConsoleLogger as Logger } from '../Logger';
-import { getAmplifyUserAgent } from '../Platform';
+import { getAmplifyUserAgentObject } from '../Platform';
 import { parseAWSExports } from '../parseAWSExports';
 import {
 	AWS_CLOUDWATCH_BASE_BUFFER_SIZE,
@@ -321,7 +321,7 @@ class AWSCloudWatchProvider implements LoggingProvider {
 		return new CloudWatchLogsClient({
 			region: this._config.region,
 			credentials: this._config.credentials,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgentObject(),
 			endpoint: this._config.endpoint,
 		});
 	}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,8 +37,8 @@ export { StorageHelper, MemoryStorage } from './StorageHelper';
 export { UniversalStorage } from './UniversalStorage';
 export {
 	Platform,
+	getAmplifyUserAgentObject,
 	getAmplifyUserAgent,
-	getAmplifyUserAgentString,
 } from './Platform';
 export {
 	ApiAction,

--- a/packages/datastore/__tests__/mutation.test.ts
+++ b/packages/datastore/__tests__/mutation.test.ts
@@ -21,7 +21,7 @@ import {
 	Category,
 	CustomUserAgentDetails,
 	DataStoreAction,
-	getAmplifyUserAgentString,
+	getAmplifyUserAgent,
 } from '@aws-amplify/core';
 
 let syncClasses: any;
@@ -168,9 +168,7 @@ describe('MutationProcessor', () => {
 				expect.anything(),
 				expect.objectContaining({
 					headers: expect.objectContaining({
-						'x-amz-user-agent': getAmplifyUserAgentString(
-							datastoreUserAgentDetails
-						),
+						'x-amz-user-agent': getAmplifyUserAgent(datastoreUserAgentDetails),
 					}),
 				})
 			);

--- a/packages/datastore/__tests__/subscription.test.ts
+++ b/packages/datastore/__tests__/subscription.test.ts
@@ -8,7 +8,7 @@ import {
 	Category,
 	CustomUserAgentDetails,
 	DataStoreAction,
-	getAmplifyUserAgent,
+	getAmplifyUserAgentObject,
 } from '@aws-amplify/core';
 import { CONTROL_MSG as PUBSUB_CONTROL_MSG } from '@aws-amplify/pubsub';
 import {

--- a/packages/geo/src/Providers/AmazonLocationServiceProvider.ts
+++ b/packages/geo/src/Providers/AmazonLocationServiceProvider.ts
@@ -5,7 +5,7 @@ import camelcaseKeys from 'camelcase-keys';
 import {
 	ConsoleLogger as Logger,
 	Credentials,
-	getAmplifyUserAgent,
+	getAmplifyUserAgentObject,
 } from '@aws-amplify/core';
 import {
 	Place as PlaceResult,
@@ -181,7 +181,7 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 		const client = new LocationClient({
 			credentials: this._config.credentials,
 			region: this._config.region,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgentObject(),
 		});
 		const command = new SearchPlaceIndexForTextCommand(locationServiceInput);
 
@@ -247,7 +247,7 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 		const client = new LocationClient({
 			credentials: this._config.credentials,
 			region: this._config.region,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgentObject(),
 		});
 		const command = new SearchPlaceIndexForSuggestionsCommand(
 			locationServiceInput
@@ -295,7 +295,7 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 		const client = new LocationClient({
 			credentials: this._config.credentials,
 			region: this._config.region,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgentObject(),
 		});
 
 		const searchByPlaceIdInput: GetPlaceCommandInput = {
@@ -353,7 +353,7 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 		const client = new LocationClient({
 			credentials: this._config.credentials,
 			region: this._config.region,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgentObject(),
 		});
 		const command = new SearchPlaceIndexForPositionCommand(
 			locationServiceInput
@@ -517,7 +517,7 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 		const client = new LocationClient({
 			credentials: this._config.credentials,
 			region: this._config.region,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgentObject(),
 		});
 
 		// Create Amazon Location Service command
@@ -579,7 +579,7 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 		const client = new LocationClient({
 			credentials: this._config.credentials,
 			region: this._config.region,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgentObject(),
 		});
 
 		// Create Amazon Location Service input
@@ -784,7 +784,7 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 		const client = new LocationClient({
 			credentials: this._config.credentials,
 			region: this._config.region,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgentObject(),
 		});
 		const command = new BatchPutGeofenceCommand(geofenceInput);
 
@@ -811,7 +811,7 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 		const client = new LocationClient({
 			credentials: this._config.credentials,
 			region: this._config.region,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgentObject(),
 		});
 		const command = new BatchDeleteGeofenceCommand(deleteGeofencesInput);
 

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -19,7 +19,7 @@ import {
 import {
 	ConsoleLogger as Logger,
 	Credentials,
-	getAmplifyUserAgent,
+	getAmplifyUserAgentObject,
 } from '@aws-amplify/core';
 import { convert } from './AWSLexProviderHelper/utils';
 
@@ -126,7 +126,7 @@ export class AWSLexProvider extends AbstractInteractionsProvider {
 		this.lexRuntimeServiceClient = new LexRuntimeServiceClient({
 			region: this._config[botname].region,
 			credentials,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgentObject(),
 		});
 
 		let params: PostTextCommandInput | PostContentCommandInput;

--- a/packages/interactions/src/Providers/AWSLexV2Provider.ts
+++ b/packages/interactions/src/Providers/AWSLexV2Provider.ts
@@ -19,7 +19,7 @@ import {
 import {
 	ConsoleLogger as Logger,
 	Credentials,
-	getAmplifyUserAgent,
+	getAmplifyUserAgentObject,
 } from '@aws-amplify/core';
 import { convert } from './AWSLexProviderHelper/utils';
 import { unGzipBase64AsJson } from './AWSLexProviderHelper/commonUtils';
@@ -129,7 +129,7 @@ export class AWSLexV2Provider extends AbstractInteractionsProvider {
 		this._lexRuntimeServiceV2Client = new LexRuntimeV2Client({
 			region: this._config[botname].region,
 			credentials,
-			customUserAgent: getAmplifyUserAgent(),
+			customUserAgent: getAmplifyUserAgentObject(),
 		});
 
 		let response: AWSLexV2ProviderSendResponse;

--- a/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
+++ b/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
@@ -7,7 +7,7 @@ import {
 	ConsoleLogger,
 	Credentials,
 	CustomUserAgentDetails,
-	getAmplifyUserAgentString,
+	getAmplifyUserAgent,
 	InAppMessagingAction,
 	PushNotificationAction,
 	StorageHelper,
@@ -121,7 +121,7 @@ export default abstract class AWSPinpointProviderCommon
 			};
 		}
 
-		return getAmplifyUserAgentString(customUserAgentDetails);
+		return getAmplifyUserAgent(customUserAgentDetails);
 	};
 
 	protected recordAnalyticsEvent = async (

--- a/packages/predictions/__tests__/Providers/AWSAIConvertPredictionsProvider-unit-test.ts
+++ b/packages/predictions/__tests__/Providers/AWSAIConvertPredictionsProvider-unit-test.ts
@@ -2,7 +2,7 @@ import {
 	Category,
 	Credentials,
 	PredictionsAction,
-	getAmplifyUserAgent,
+	getAmplifyUserAgentObject,
 } from '@aws-amplify/core';
 import {
 	TranslateTextInput,
@@ -335,7 +335,7 @@ describe('Predictions convert provider test', () => {
 			await predictionsProvider.convert(validTextToSpeechInput);
 
 			expect(predictionsProvider['pollyClient'].config.customUserAgent).toEqual(
-				getAmplifyUserAgent({
+				getAmplifyUserAgentObject({
 					category: Category.Predictions,
 					action: PredictionsAction.Convert,
 				})
@@ -353,7 +353,7 @@ describe('Predictions convert provider test', () => {
 			expect(
 				predictionsProvider['translateClient'].config.customUserAgent
 			).toEqual(
-				getAmplifyUserAgent({
+				getAmplifyUserAgentObject({
 					category: Category.Predictions,
 					action: PredictionsAction.Convert,
 				})

--- a/packages/predictions/__tests__/Providers/AWSAIIdentifyPredictionsProvider-unit-test.ts
+++ b/packages/predictions/__tests__/Providers/AWSAIIdentifyPredictionsProvider-unit-test.ts
@@ -2,7 +2,7 @@ import {
 	Category,
 	Credentials,
 	PredictionsAction,
-	getAmplifyUserAgent,
+	getAmplifyUserAgentObject,
 } from '@aws-amplify/core';
 import { Storage } from '@aws-amplify/storage';
 import {
@@ -703,7 +703,7 @@ describe('Predictions identify provider test', () => {
 			expect(
 				predictionsProvider['rekognitionClient'].config.customUserAgent
 			).toEqual(
-				getAmplifyUserAgent({
+				getAmplifyUserAgentObject({
 					category: Category.Predictions,
 					action: PredictionsAction.Identify,
 				})
@@ -729,7 +729,7 @@ describe('Predictions identify provider test', () => {
 			expect(
 				predictionsProvider['rekognitionClient'].config.customUserAgent
 			).toEqual(
-				getAmplifyUserAgent({
+				getAmplifyUserAgentObject({
 					category: Category.Predictions,
 					action: PredictionsAction.Identify,
 				})
@@ -750,7 +750,7 @@ describe('Predictions identify provider test', () => {
 			expect(
 				predictionsProvider['rekognitionClient'].config.customUserAgent
 			).toEqual(
-				getAmplifyUserAgent({
+				getAmplifyUserAgentObject({
 					category: Category.Predictions,
 					action: PredictionsAction.Identify,
 				})
@@ -758,7 +758,7 @@ describe('Predictions identify provider test', () => {
 			expect(
 				predictionsProvider['textractClient'].config.customUserAgent
 			).toEqual(
-				getAmplifyUserAgent({
+				getAmplifyUserAgentObject({
 					category: Category.Predictions,
 					action: PredictionsAction.Identify,
 				})

--- a/packages/predictions/__tests__/Providers/AWSAIInterpretPredictionsProvider-unit-test.ts
+++ b/packages/predictions/__tests__/Providers/AWSAIInterpretPredictionsProvider-unit-test.ts
@@ -2,7 +2,7 @@ import {
 	Category,
 	Credentials,
 	PredictionsAction,
-	getAmplifyUserAgent,
+	getAmplifyUserAgentObject,
 } from '@aws-amplify/core';
 import {
 	ComprehendClient,
@@ -492,7 +492,7 @@ describe('Predictions interpret provider test', () => {
 			expect(
 				predictionsProvider['comprehendClient'].config.customUserAgent
 			).toEqual(
-				getAmplifyUserAgent({
+				getAmplifyUserAgentObject({
 					category: Category.Predictions,
 					action: PredictionsAction.Interpret,
 				})

--- a/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
@@ -17,7 +17,7 @@ import {
 	Credentials,
 	ConsoleLogger as Logger,
 	Signer,
-	getAmplifyUserAgent,
+	getAmplifyUserAgentObject,
 	Category,
 	PredictionsAction,
 } from '@aws-amplify/core';
@@ -74,7 +74,7 @@ export class AmazonAIConvertPredictionsProvider extends AbstractConvertPredictio
 		this.translateClient = new TranslateClient({
 			region,
 			credentials,
-			customUserAgent: getAmplifyUserAgent({
+			customUserAgent: getAmplifyUserAgentObject({
 				category: Category.Predictions,
 				action: PredictionsAction.Convert,
 			}),
@@ -123,7 +123,7 @@ export class AmazonAIConvertPredictionsProvider extends AbstractConvertPredictio
 		this.pollyClient = new PollyClient({
 			region,
 			credentials,
-			customUserAgent: getAmplifyUserAgent({
+			customUserAgent: getAmplifyUserAgentObject({
 				category: Category.Predictions,
 				action: PredictionsAction.Convert,
 			}),

--- a/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
@@ -3,7 +3,7 @@ import {
 	Credentials,
 	ConsoleLogger as Logger,
 	PredictionsAction,
-	getAmplifyUserAgent,
+	getAmplifyUserAgentObject,
 } from '@aws-amplify/core';
 import { Storage } from '@aws-amplify/storage';
 import { AbstractIdentifyPredictionsProvider } from '../types/Providers';
@@ -484,7 +484,7 @@ export class AmazonAIIdentifyPredictionsProvider extends AbstractIdentifyPredict
 }
 
 function _getPredictionsIdentifyAmplifyUserAgent() {
-	return getAmplifyUserAgent({
+	return getAmplifyUserAgentObject({
 		category: Category.Predictions,
 		action: PredictionsAction.Identify,
 	});

--- a/packages/predictions/src/Providers/AmazonAIInterpretPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIInterpretPredictionsProvider.ts
@@ -2,7 +2,7 @@ import {
 	Category,
 	Credentials,
 	PredictionsAction,
-	getAmplifyUserAgent,
+	getAmplifyUserAgentObject,
 } from '@aws-amplify/core';
 import { AbstractInterpretPredictionsProvider } from '../types/Providers';
 
@@ -58,7 +58,7 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 			this.comprehendClient = new ComprehendClient({
 				credentials,
 				region,
-				customUserAgent: getAmplifyUserAgent({
+				customUserAgent: getAmplifyUserAgentObject({
 					category: Category.Predictions,
 					action: PredictionsAction.Interpret,
 				}),

--- a/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider/index.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider/index.ts
@@ -18,7 +18,7 @@ import {
 	ICredentials,
 	isNonRetryableError,
 	CustomUserAgentDetails,
-	getAmplifyUserAgentString,
+	getAmplifyUserAgent,
 } from '@aws-amplify/core';
 import { Cache } from '@aws-amplify/cache';
 import { Auth, GRAPHQL_AUTH_MODE } from '@aws-amplify/auth';
@@ -353,7 +353,7 @@ export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider<AWSAppSyn
 			})),
 			...(await graphql_headers()),
 			...additionalHeaders,
-			[USER_AGENT_HEADER]: getAmplifyUserAgentString(customUserAgentDetails),
+			[USER_AGENT_HEADER]: getAmplifyUserAgent(customUserAgentDetails),
 		};
 
 		const subscriptionMessage = {

--- a/packages/storage/__tests__/common/S3ClientUtils-unit-test.ts
+++ b/packages/storage/__tests__/common/S3ClientUtils-unit-test.ts
@@ -8,7 +8,7 @@ import {
 import {
 	ICredentials,
 	Credentials,
-	getAmplifyUserAgent,
+	getAmplifyUserAgentObject,
 	StorageAction,
 	Category,
 } from '@aws-amplify/core';
@@ -131,7 +131,7 @@ describe('S3ClientUtils tests', () => {
 		);
 		// ensure customUserAgent is set properly
 		expect(s3client.config.customUserAgent).toEqual(
-			getAmplifyUserAgent({
+			getAmplifyUserAgentObject({
 				category: Category.Storage,
 				action: StorageAction.Get,
 			})

--- a/packages/storage/src/common/S3ClientUtils.ts
+++ b/packages/storage/src/common/S3ClientUtils.ts
@@ -5,7 +5,7 @@ import {
 	ICredentials,
 	Logger,
 	StorageAction,
-	getAmplifyUserAgent,
+	getAmplifyUserAgentObject,
 } from '@aws-amplify/core';
 import { StorageAccessLevel, CustomPrefix } from '../types';
 import {
@@ -161,7 +161,7 @@ export const createS3Client = (
 		// Using provider instead of a static credentials, so that if an upload task was in progress, but credentials gets
 		// changed or invalidated (e.g user signed out), the subsequent requests will fail.
 		credentials: credentialsProvider,
-		customUserAgent: getAmplifyUserAgent({
+		customUserAgent: getAmplifyUserAgentObject({
 			category: Category.Storage,
 			action: storageAction,
 		}),


### PR DESCRIPTION
#### Description of changes
Custom user agent enhancements changed the interface for `getAmplifyUserAgent` from returning a string to returning an object. This changes it back at introduces `getAmplifyUserAgentObject` to keep our public interface consistent.

#### Issue #, if available
https://github.com/aws-amplify/amplify-ui/issues/4142

#### Description of how you validated changes
Validating with unit tests, manual testing and integration testing (testing flight parallel to this PR)


#### Checklist

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
