### PR TITLE
fix(s3): add missing default content-type & support body.text() in RN & optimize retry

### DIFF
--- a/packages/core/__tests__/clients/middleware/retry/middleware-test.ts
+++ b/packages/core/__tests__/clients/middleware/retry/middleware-test.ts
@@ -116,7 +116,11 @@ describe(`${retryMiddleware.name} middleware`, () => {
 				maxAttempts: 6,
 				computeDelay,
 			});
-			expect(res).toEqual({ ...defaultResponse, $metadata: { attempts: 6 } });
+			expect(res).toEqual(
+			  expect.objectContaining(
+			    { $metadata: { attempts: 6 } }
+			  )
+			);
 			expect(nextHandler).toBeCalledTimes(6);
 			expect(computeDelay).toBeCalledTimes(5); // no interval after last attempt
 		} catch (error) {

--- a/packages/core/__tests__/clients/middleware/retry/middleware-test.ts
+++ b/packages/core/__tests__/clients/middleware/retry/middleware-test.ts
@@ -117,9 +117,7 @@ describe(`${retryMiddleware.name} middleware`, () => {
 				computeDelay,
 			});
 			expect(res).toEqual(
-			  expect.objectContaining(
-			    { $metadata: { attempts: 6 } }
-			  )
+				expect.objectContaining({ $metadata: { attempts: 6 } })
 			);
 			expect(nextHandler).toBeCalledTimes(6);
 			expect(computeDelay).toBeCalledTimes(5); // no interval after last attempt
@@ -141,7 +139,7 @@ describe(`${retryMiddleware.name} middleware`, () => {
 			});
 			fail('this test should fail');
 		} catch (error) {
-			expect(error.message).toBe('Request aborted');
+			expect(error.message).toBe('Request aborted.');
 			expect(nextHandler).toBeCalledTimes(0);
 		}
 		expect.assertions(2);
@@ -168,7 +166,7 @@ describe(`${retryMiddleware.name} middleware`, () => {
 			});
 			fail('this test should fail');
 		} catch (error) {
-			expect(error.message).toBe('Request aborted');
+			expect(error.message).toBe('Request aborted.');
 			expect(setTimeout).toBeCalledTimes(2); // 1st attempt + mock back-off strategy
 			expect(clearTimeout).toBeCalledTimes(1); // cancel 2nd attempt
 		}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -128,7 +128,7 @@
 			"name": "Custom clients (retry middleware)",
 			"path": "./lib-esm/clients/middleware/retry/middleware.js",
 			"import": "{ retryMiddleware }",
-			"limit": "1.24 kB"
+			"limit": "1.35 kB"
 		},
 		{
 			"name": "Custom clients (signing middleware)",

--- a/packages/core/src/clients/middleware/retry/middleware.ts
+++ b/packages/core/src/clients/middleware/retry/middleware.ts
@@ -1,14 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { MetadataBearer } from '@aws-sdk/types';
 import {
 	MiddlewareContext,
 	MiddlewareHandler,
 	Request,
 	Response,
 } from '../../types/core';
-import { type } from 'os';
 
 const DEFAULT_RETRY_ATTEMPTS = 3;
 
@@ -100,7 +98,7 @@ export const retryMiddleware = <TInput = Request, TOutput = Response>({
 			}
 
 			if (abortSignal?.aborted) {
-				throw new Error('Request aborted');
+				throw new Error('Request aborted.');
 			} else {
 				return handleTerminalErrorOrResponse();
 			}
@@ -129,7 +127,7 @@ const addOrIncrementMetadataAttempts = (
 	nextHandlerOutput: Object,
 	attempts: number
 ) => {
-	if (typeof nextHandlerOutput !== 'object') {
+	if (Object.prototype.toString.call(nextHandlerOutput) !== '[object Object]') {
 		return;
 	}
 	nextHandlerOutput['$metadata'] = {

--- a/packages/core/src/clients/serde/responseInfo.ts
+++ b/packages/core/src/clients/serde/responseInfo.ts
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ResponseMetadata } from '@aws-sdk/types';
-import { isMetadataBearer } from '../middleware/retry/middleware';
+import { ResponseMetadata, MetadataBearer } from '@aws-sdk/types';
 import { HttpResponse } from '../types/http';
 
 export const parseMetadata = (response: HttpResponse): ResponseMetadata => {
@@ -18,3 +17,6 @@ export const parseMetadata = (response: HttpResponse): ResponseMetadata => {
 		cfId: headers['x-amz-cf-id'],
 	};
 };
+
+const isMetadataBearer = (response: unknown): response is MetadataBearer =>
+	typeof response?.['$metadata'] === 'object';

--- a/packages/storage/__tests__/AwsClients/S3/cases/completeMultipartUpload.ts
+++ b/packages/storage/__tests__/AwsClients/S3/cases/completeMultipartUpload.ts
@@ -46,6 +46,7 @@ const completeMultipartUploadHappyCase: ApiFunctionalTestCase<
 			'x-amz-server-side-encryption-customer-algorithm': 'SSECustomerAlgorithm',
 			'x-amz-server-side-encryption-customer-key': 'SSECustomerKey',
 			'x-amz-server-side-encryption-customer-key-md5': 'SSECustomerKeyMD5',
+			'content-type': 'application/xml',
 		}),
 		body:
 			'<?xml version="1.0" encoding="UTF-8"?>' +

--- a/packages/storage/__tests__/AwsClients/S3/cases/putObject.ts
+++ b/packages/storage/__tests__/AwsClients/S3/cases/putObject.ts
@@ -46,6 +46,16 @@ export const expectedPutObjectRequestHeaders = {
 	'x-amz-meta-param1': 'value 1',
 };
 
+const putObjectSuccessResponse = {
+	status: 200,
+	headers: {
+		...DEFAULT_RESPONSE_HEADERS,
+		'x-amz-version-id': 'versionId',
+		etag: 'etag',
+	},
+	body: '',
+};
+
 const putObjectHappyCase: ApiFunctionalTestCase<typeof putObject> = [
 	'happy case',
 	'putObject',
@@ -59,15 +69,7 @@ const putObjectHappyCase: ApiFunctionalTestCase<typeof putObject> = [
 		headers: expect.objectContaining(expectedPutObjectRequestHeaders),
 		body: 'body',
 	}),
-	{
-		status: 200,
-		headers: {
-			...DEFAULT_RESPONSE_HEADERS,
-			'x-amz-version-id': 'versionId',
-			etag: 'etag',
-		},
-		body: '',
-	},
+	putObjectSuccessResponse,
 	{
 		$metadata: expect.objectContaining(expectedMetadata),
 		ETag: 'etag',
@@ -75,4 +77,22 @@ const putObjectHappyCase: ApiFunctionalTestCase<typeof putObject> = [
 	},
 ];
 
-export default [putObjectHappyCase];
+const pubObjectDefaultContentType: ApiFunctionalTestCase<typeof putObject> = [
+	'happy case',
+	'putObject default content type',
+	putObject,
+	defaultConfig,
+	{
+		...putObjectRequest,
+		ContentType: undefined,
+	},
+	expect.objectContaining({
+		headers: expect.objectContaining({
+			'content-type': 'application/octet-stream',
+		}),
+	}),
+	putObjectSuccessResponse,
+	expect.anything(),
+];
+
+export default [putObjectHappyCase, pubObjectDefaultContentType];

--- a/packages/storage/__tests__/AwsClients/S3/cases/uploadPart.ts
+++ b/packages/storage/__tests__/AwsClients/S3/cases/uploadPart.ts
@@ -34,6 +34,7 @@ const uploadPartHappyCase: ApiFunctionalTestCase<typeof uploadPart> = [
 			'x-amz-server-side-encryption-customer-algorithm': 'SSECustomerAlgorithm',
 			'x-amz-server-side-encryption-customer-key': 'SSECustomerKey',
 			'x-amz-server-side-encryption-customer-key-md5': 'SSECustomerKeyMD5',
+			'content-type': 'application/octet-stream', // required by RN Android if body exists
 		}),
 		body: 'body',
 	}),

--- a/packages/storage/__tests__/AwsClients/testUtils/mocks.ts
+++ b/packages/storage/__tests__/AwsClients/testUtils/mocks.ts
@@ -37,13 +37,6 @@ export const spyOnXhr = (): XhrSpy => {
 };
 
 /**
- * Mock a blob response payload.
- *
- * @internal
- */
-export const mockBlobResponsePayload = (body: string) => 'blob: ' + body;
-
-/**
  * Mock XMLHttpRequest's response and invoke the corresponding listeners on given mock XHR instance.
  *
  * @internal
@@ -54,7 +47,7 @@ export const mockXhrResponse = (
 		status: number;
 		// XHR's raw header string. @see https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders#return_value
 		headerString: string;
-		body: string;
+		body: Blob | string;
 	}
 ) => {
 	mockXhr.readyState = XMLHttpRequest.DONE;
@@ -69,17 +62,6 @@ export const mockXhrResponse = (
 			);
 		},
 		configurable: true,
-	});
-	(Blob.prototype.text as jest.Mock).mockImplementation(async () => {
-		if (
-			typeof response.body !== 'string' ||
-			!response.body.startsWith('blob: ')
-		) {
-			throw new Error(
-				'Attempt to read blob response body that is not mocked as blob'
-			);
-		}
-		return response.body.slice('blob: '.length);
 	});
 	mockXhr.response = response.body;
 	(mockXhr.getAllResponseHeaders as jest.Mock).mockReturnValue(

--- a/packages/storage/src/AwsClients/S3/completeMultipartUpload.ts
+++ b/packages/storage/src/AwsClients/S3/completeMultipartUpload.ts
@@ -47,6 +47,7 @@ const completeMultipartUploadSerializer = (
 	endpoint: Endpoint
 ): HttpRequest => {
 	const headers = serializeObjectSsecOptionsToHeaders(input);
+	headers['content-type'] = 'application/xml';
 	const url = new URL(endpoint.url.toString());
 	url.hostname = `${input.Bucket}.${url.hostname}`;
 	url.pathname = `/${input.Key}`;

--- a/packages/storage/src/AwsClients/S3/putObject.ts
+++ b/packages/storage/src/AwsClients/S3/putObject.ts
@@ -53,7 +53,10 @@ const putObjectSerializer = (
 	input: PutObjectInput,
 	endpoint: Endpoint
 ): HttpRequest => {
-	const headers = serializeObjectConfigsToHeaders(input);
+	const headers = serializeObjectConfigsToHeaders({
+		...input,
+		ContentType: input.ContentType ?? 'application/octet-stream',
+	});
 	const url = new URL(endpoint.url.toString());
 	url.hostname = `${input.Bucket}.${url.hostname}`;
 	url.pathname = `/${input.Key}`;

--- a/packages/storage/src/AwsClients/S3/uploadPart.ts
+++ b/packages/storage/src/AwsClients/S3/uploadPart.ts
@@ -41,7 +41,10 @@ const uploadPartSerializer = (
 	input: UploadPartInput,
 	endpoint: Endpoint
 ): HttpRequest => {
-	const headers = serializeObjectSsecOptionsToHeaders(input);
+	const headers = {
+		...serializeObjectSsecOptionsToHeaders(input),
+		'content-type': 'application/octet-stream',
+	};
 	const url = new URL(endpoint.url.toString());
 	url.hostname = `${input.Bucket}.${url.hostname}`;
 	url.pathname = `/${input.Key}`;

--- a/packages/storage/src/AwsClients/S3/uploadPart.ts
+++ b/packages/storage/src/AwsClients/S3/uploadPart.ts
@@ -41,10 +41,8 @@ const uploadPartSerializer = (
 	input: UploadPartInput,
 	endpoint: Endpoint
 ): HttpRequest => {
-	const headers = {
-		...serializeObjectSsecOptionsToHeaders(input),
-		'content-type': 'application/octet-stream',
-	};
+	const headers = serializeObjectSsecOptionsToHeaders(input);
+	headers['content-type'] = 'application/octet-stream';
 	const url = new URL(endpoint.url.toString());
 	url.hostname = `${input.Bucket}.${url.hostname}`;
 	url.pathname = `/${input.Key}`;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixed 3 compatible issues:
* The retry middleware return `max attempts exhausted` error instead of last error or response. This is a breaking change of behavior compared to AWS SDK
* `Blob.text()` is not available RN. Replace it with `FileReader` based implementation. It's supported in both browsers and RN
* [`uploadPart`](https://github.com/aws/aws-sdk-js-v3/blob/7ed7101dcc4e81038b6c7f581162b959e6b33a04/clients/client-s3/src/protocols/Aws_restXml.ts#L3770), [`completeMultipartUpload`](https://github.com/aws/aws-sdk-js-v3/blob/7ed7101dcc4e81038b6c7f581162b959e6b33a04/clients/client-s3/src/protocols/Aws_restXml.ts#L474) and [`putObject`](https://github.com/aws/aws-sdk-js-v3/blob/7ed7101dcc4e81038b6c7f581162b959e6b33a04/clients/client-s3/src/protocols/Aws_restXml.ts#L3302) each need change to behavior to add `content-type` header. Added the missing logic after cross-check with AWS SDK

#### Description of how you validated changes
* Unit test added
* Integration test on RN iOS, Android and Web


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
