### PR TITLE
feat(s3): omit double encoding of path for S3 when signing

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -63,13 +63,13 @@
 			"name": "Analytics (Pinpoint)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Analytics, AWSPinpointProvider }",
-			"limit": "30.95 kB"
+			"limit": "31.05 kB"
 		},
 		{
 			"name": "Analytics (Kinesis)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Analytics, AWSKinesisProvider }",
-			"limit": "59.4 kB"
+			"limit": "59.5 kB"
 		}
 	],
 	"jest": {

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/presignUrl-test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/presignUrl-test.ts
@@ -4,8 +4,26 @@
 import { presignUrl } from '../../../../../../src/clients/middleware/signing/signer/signatureV4/presignUrl';
 import { HttpRequest } from '../../../../../../src/clients/types';
 import { signingTestTable } from './testUtils/signingTestTable';
-import { getDefaultRequest, signingOptions } from './testUtils/data';
+import {
+	formattedDates,
+	getDefaultRequest,
+	signingOptions,
+} from './testUtils/data';
 import { PresignUrlOptions } from '../../../../../../src/clients/middleware/signing/signer/signatureV4/types';
+import { getSignature } from '../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getSignature';
+
+jest.mock(
+	'../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getSignature',
+	() => ({
+		getSignature: jest
+			.fn()
+			.mockImplementation(
+				jest.requireActual(
+					'../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getSignature'
+				).getSignature
+			),
+	})
+);
 
 describe('presignUrl', () => {
 	test.each(
@@ -27,5 +45,25 @@ describe('presignUrl', () => {
 		)
 	)('presigns url with %s', (_, request, options, expected) => {
 		expect(presignUrl(request, options).toString()).toBe(expected);
+	});
+
+	test('should call getSignature with correct parameters', () => {
+		const request = getDefaultRequest();
+		const options = {
+			...signingOptions,
+			uriEscapePath: false,
+		};
+		presignUrl(request, options);
+		expect(getSignature).toHaveBeenCalledWith(expect.anything(), {
+			uriEscapePath: false,
+			accessKeyId: options.credentials.accessKeyId,
+			credentialScope: `${formattedDates.shortDate}/${options.signingRegion}/${options.signingService}/aws4_request`,
+			longDate: formattedDates.longDate,
+			secretAccessKey: options.credentials.secretAccessKey,
+			shortDate: formattedDates.shortDate,
+			sessionToken: undefined,
+			signingRegion: options.signingRegion,
+			signingService: options.signingService,
+		});
 	});
 });

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getCanonicalUri-test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getCanonicalUri-test.ts
@@ -22,4 +22,9 @@ describe('getCanonicalUri', () => {
 		const path = '/👀';
 		expect(getCanonicalUri(path)).toBe('/%F0%9F%91%80');
 	});
+
+	test('can disable double encoding', () => {
+		const encoded = '/%F0%9F%91%80';
+		expect(getCanonicalUri(encoded, false)).toBe(encoded);
+	});
 });

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getSigningValues-test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getSigningValues-test.ts
@@ -28,6 +28,7 @@ describe('getSigningValues', () => {
 			shortDate,
 			signingRegion,
 			signingService,
+			uriEscapePath: true,
 		});
 	});
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -110,7 +110,7 @@
 			"name": "Core (Signer)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Signer }",
-			"limit": "7.3 kB"
+			"limit": "7.4 kB"
 		},
 		{
 			"name": "Custom clients (fetch handler)",
@@ -134,19 +134,19 @@
 			"name": "Custom clients (signing middleware)",
 			"path": "./lib-esm/clients/middleware/signing/middleware.js",
 			"import": "{ signingMiddleware }",
-			"limit": "6.77 kB"
+			"limit": "6.85 kB"
 		},
 		{
 			"name": "Custom clients (request signer)",
 			"path": "./lib-esm/clients/middleware/signing/signer/signatureV4/index.js",
 			"import": "{ signRequest }",
-			"limit": "6.13 kB"
+			"limit": "6.2 kB"
 		},
 		{
 			"name": "Custom clients (url presigner)",
 			"path": "./lib-esm/clients/middleware/signing/signer/signatureV4/index.js",
 			"import": "{ presignUrl }",
-			"limit": "6.25 kB"
+			"limit": "6.3 kB"
 		}
 	],
 	"jest": {

--- a/packages/core/src/clients/middleware/signing/middleware.ts
+++ b/packages/core/src/clients/middleware/signing/middleware.ts
@@ -18,6 +18,14 @@ export interface SigningOptions {
 	credentials: Credentials;
 	region: string;
 	service: string;
+
+	/**
+	 * Whether to uri encode the path as part of canonical uri. It's used for S3 only where the pathname
+	 * is already uri encoded, and the signing process is not expected to uri encode it again.
+	 *
+	 * @default true
+	 */
+	uriEscapePath?: boolean;
 }
 
 /**
@@ -28,6 +36,7 @@ export const signingMiddleware = ({
 	credentials,
 	region,
 	service,
+	uriEscapePath = true,
 }: SigningOptions) => {
 	let currentSystemClockOffset;
 	return (next: MiddlewareHandler<HttpRequest, HttpResponse>) =>
@@ -38,6 +47,7 @@ export const signingMiddleware = ({
 				signingDate: getSkewCorrectedDate(currentSystemClockOffset),
 				signingRegion: region,
 				signingService: service,
+				uriEscapePath,
 			};
 			const signedRequest = await signRequest(request, signRequestOptions);
 			const response = await next(signedRequest);

--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/types/signer.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/types/signer.ts
@@ -14,6 +14,8 @@ export interface SignRequestOptions {
 	 * is already uri encoded, and the signing process is not expected to uri encode it again.
 	 *
 	 * @default true
+	 *
+	 * @see https://github.com/aws/aws-sdk-js-v3/blob/9ba012dfa3a3429aa2db0f90b3b0b3a7a31f9bc3/packages/signature-v4/src/SignatureV4.ts#L76-L83
 	 */
 	uriEscapePath?: boolean;
 }

--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/types/signer.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/types/signer.ts
@@ -8,6 +8,14 @@ export interface SignRequestOptions {
 	signingDate?: Date;
 	signingRegion: string;
 	signingService: string;
+
+	/**
+	 * Whether to uri encode the path as part of canonical uri. It's used for S3 only where the pathname
+	 * is already uri encoded, and the signing process is not expected to uri encode it again.
+	 *
+	 * @default true
+	 */
+	uriEscapePath?: boolean;
 }
 
 export interface PresignUrlOptions extends SignRequestOptions {
@@ -26,6 +34,9 @@ export interface FormattedDates {
 export interface SigningValues
 	extends Credentials,
 		FormattedDates,
-		Pick<SignRequestOptions, 'signingRegion' | 'signingService'> {
+		Pick<
+			SignRequestOptions,
+			'signingRegion' | 'signingService' | 'uriEscapePath'
+		> {
 	credentialScope: string;
 }

--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getCanonicalRequest.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getCanonicalRequest.ts
@@ -12,6 +12,8 @@ import { getSignedHeaders } from './getSignedHeaders';
  * Returns a canonical request.
  *
  * @param request `HttpRequest` from which to create the canonical request from.
+ * @param uriEscapePath Whether to uri encode the path as part of canonical uri. It's used for S3 only where the
+ *   pathname is already uri encoded, and the signing process is not expected to uri encode it again. Defaults to true.
  * @returns String created by by concatenating the following strings, separated by newline characters:
  * - HTTPMethod
  * - CanonicalUri
@@ -22,15 +24,13 @@ import { getSignedHeaders } from './getSignedHeaders';
  *
  * @internal
  */
-export const getCanonicalRequest = ({
-	body,
-	headers,
-	method,
-	url,
-}: HttpRequest): string =>
+export const getCanonicalRequest = (
+	{ body, headers, method, url }: HttpRequest,
+	uriEscapePath = true
+): string =>
 	[
 		method,
-		getCanonicalUri(url.pathname),
+		getCanonicalUri(url.pathname, uriEscapePath),
 		getCanonicalQueryString(url.searchParams),
 		getCanonicalHeaders(headers),
 		getSignedHeaders(headers),

--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getCanonicalUri.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getCanonicalUri.ts
@@ -5,10 +5,19 @@
  * Returns a canonical uri.
  *
  * @param pathname `pathname` from request url.
+ * @param uriEscapePath Whether to uri encode the path as part of canonical uri. It's used for S3 only where the
+ *   pathname is already uri encoded, and the signing process is not expected to uri encode it again. Defaults to true.
  * @returns URI-encoded version of the absolute path component URL (everything between the host and the question mark
  * character (?) that starts the query string parameters). If the absolute path is empty, a forward slash character (/).
  *
  * @internal
  */
-export const getCanonicalUri = (pathname: string): string =>
-	pathname ? encodeURIComponent(pathname).replace(/%2F/g, '/') : '/';
+export const getCanonicalUri = (
+	pathname: string,
+	uriEscapePath = true
+): string =>
+	pathname
+		? uriEscapePath
+			? encodeURIComponent(pathname).replace(/%2F/g, '/')
+			: pathname
+		: '/';

--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getSignature.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getSignature.ts
@@ -27,10 +27,11 @@ export const getSignature = (
 		shortDate,
 		signingRegion,
 		signingService,
+		uriEscapePath,
 	}: SigningValues
 ): string => {
 	// step 1: create a canonical request
-	const canonicalRequest = getCanonicalRequest(request);
+	const canonicalRequest = getCanonicalRequest(request, uriEscapePath);
 
 	// step 2: create a hash of the canonical request
 	const hashedRequest = getHashedDataAsHex(null, canonicalRequest);

--- a/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getSigningValues.ts
+++ b/packages/core/src/clients/middleware/signing/signer/signatureV4/utils/getSigningValues.ts
@@ -19,6 +19,7 @@ export const getSigningValues = ({
 	signingDate = new Date(),
 	signingRegion,
 	signingService,
+	uriEscapePath = true,
 }: SignRequestOptions): SigningValues => {
 	// get properties from credentials
 	const { accessKeyId, secretAccessKey, sessionToken } = credentials;
@@ -39,5 +40,6 @@ export const getSigningValues = ({
 		shortDate,
 		signingRegion,
 		signingService,
+		uriEscapePath,
 	};
 };

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -65,13 +65,13 @@
 			"name": "Notifications (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Notifications }",
-			"limit": "29.8 kB"
+			"limit": "29.9 kB"
 		},
 		{
 			"name": "Notifications (with Analytics)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Notifications, Analytics }",
-			"limit": "29.8 kB"
+			"limit": "29.9 kB"
 		}
 	]
 }

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -65,7 +65,7 @@
       "name": "PubSub (IoT provider)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, PubSub, AWSIoTProvider }",
-      "limit": "80 kB"
+      "limit": "80.1 kB"
     },
     {
       "name": "PubSub (Mqtt provider)",

--- a/packages/storage/src/AwsClients/S3/base.ts
+++ b/packages/storage/src/AwsClients/S3/base.ts
@@ -44,5 +44,5 @@ export const defaultConfig = {
 	computeDelay: jitteredBackoff,
 	userAgentValue: getAmplifyUserAgent(), // TODO: use getAmplifyUserAgentString() when available.
 	useAccelerateEndpoint: false,
-	uriEscapePath: false, // Required by S3. See https://github.com/aws/aws-sdk-js-v3/blob/9ba012dfa3a3429aa2db0f90b3b0b3a7a31f9bc3/packages/signature-v4/src/SignatureV4.ts#L93
+	uriEscapePath: false, // Required by S3. See https://github.com/aws/aws-sdk-js-v3/blob/9ba012dfa3a3429aa2db0f90b3b0b3a7a31f9bc3/packages/signature-v4/src/SignatureV4.ts#L76-L83
 };

--- a/packages/storage/src/AwsClients/S3/base.ts
+++ b/packages/storage/src/AwsClients/S3/base.ts
@@ -44,4 +44,5 @@ export const defaultConfig = {
 	computeDelay: jitteredBackoff,
 	userAgentValue: getAmplifyUserAgent(), // TODO: use getAmplifyUserAgentString() when available.
 	useAccelerateEndpoint: false,
+	uriEscapePath: false, // Required by S3. See https://github.com/aws/aws-sdk-js-v3/blob/9ba012dfa3a3429aa2db0f90b3b0b3a7a31f9bc3/packages/signature-v4/src/SignatureV4.ts#L93
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Similar to [AWS SDK](https://github.com/aws/aws-sdk-js-v3/blob/9ba012dfa3a3429aa2db0f90b3b0b3a7a31f9bc3/packages/signature-v4/src/SignatureV4.ts#L76-L83), by default the SigV4 signer URI encodes the already encoded request path when generating canonical request. However, this behavior must be omitted for S3. 

Added a new `uriEscapePath` config to SigV4 signing for this behavior. It's `true` by default so the signer automatically double encodes the request paths. For S3 only, this config should be disabled.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Unit test; Integration test.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
