### PR TITLE
fix(storage): missing Size in listParts output

### DIFF
--- a/packages/storage/__tests__/AwsClients/S3/cases/listParts.ts
+++ b/packages/storage/__tests__/AwsClients/S3/cases/listParts.ts
@@ -36,10 +36,12 @@ const listPartsHappyCase: ApiFunctionalTestCase<typeof listParts> = [
 			'<Part>' +
 			'<PartNumber>1</PartNumber>' +
 			'<ETag>etag1</ETag>' +
+			'<Size>5242880</Size>' +
 			'</Part>' +
 			'<Part>' +
 			'<PartNumber>2</PartNumber>' +
 			'<ETag>etag2</ETag>' +
+			'<Size>1024</Size>' +
 			'</Part>' +
 			'</ListPartsResult>',
 	},
@@ -50,10 +52,12 @@ const listPartsHappyCase: ApiFunctionalTestCase<typeof listParts> = [
 			{
 				PartNumber: 1,
 				ETag: 'etag1',
+				Size: 5242880,
 			},
 			{
 				PartNumber: 2,
 				ETag: 'etag2',
+				Size: 1024,
 			},
 		],
 	},

--- a/packages/storage/src/AwsClients/S3/listParts.ts
+++ b/packages/storage/src/AwsClients/S3/listParts.ts
@@ -84,6 +84,7 @@ const deserializeCompletedPartList = (input: any[]): CompletedPart[] =>
 		map(item, {
 			PartNumber: ['PartNumber', deserializeNumber],
 			ETag: 'ETag',
+			Size: ['Size', deserializeNumber],
 		})
 	);
 

--- a/packages/storage/src/providers/AWSS3UploadTask.ts
+++ b/packages/storage/src/providers/AWSS3UploadTask.ts
@@ -447,7 +447,11 @@ export class AWSS3UploadTask implements UploadTask {
 				this.uploadId = uploadId;
 				this.queued = this._createParts();
 				this._initCachedUploadParts(parts);
-				this._startUpload();
+				if (this._isDone()) {
+					this._completeUpload();
+				} else {
+					this._startUpload();
+				}
 			} else {
 				if (!this.uploadId) {
 					const uploadId = await this._initMultipartUpload();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Fix multipart upload doesn't complete on resume when all parts have been uploaded previously
* Fix custom S3 client `listParts` output doesn't include the `Size` property

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* Local testing
* Unit testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
