### PR TITLE
fix(core): add @types/node-fetch to runtime dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,6 +69,7 @@
 		"@aws-sdk/client-cloudwatch-logs": "3.6.1",
 		"@aws-sdk/types": "3.6.1",
 		"@aws-sdk/util-hex-encoding": "3.6.1",
+		"@types/node-fetch": "2.6.4",
 		"isomorphic-unfetch": "^3.0.0",
 		"react-native-url-polyfill": "^1.3.0",
 		"tslib": "^1.8.0",


### PR DESCRIPTION
The isomorphic-unfetch dependency re-exports artifacts from node-fetch package in its .d.ts file. However, the node-fetch package does not contain any .d.ts file with itself. So the exported artifacts can not be resolved by tsc. It's not an issue before possibly because the client-s3 contains transitive runtime dependency of @types/node-fetch. Since it's removed now, we are encountered with this error.

Adding the dependency to runtime instead of dev or peer deps to prevent brokage for customers

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
* https://github.com/aws-amplify/amplify-ui/actions/runs/5407197729/jobs/9824935017?pr=4182

* https://github.com/developit/unfetch/issues/96


#### Description of how you validated changes
Local test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
