### PR TITLE
fix localStorage access error in incognito window

### DIFF
--- a/packages/core/src/UniversalStorage/index.ts
+++ b/packages/core/src/UniversalStorage/index.ts
@@ -117,9 +117,13 @@ export class UniversalStorage implements Storage {
 }
 
 function getLocalStorage() {
-	try {
-		return globalThis.localStorage
-	} catch (e) {
-		return Object.create(null)
-	}
+    try {
+        if (globalThis.localStorage) {
+            return globalThis.localStorage
+        }
+    } catch (e) {
+    }
+
+    return Object.create(null)
 }
+

--- a/packages/core/src/UniversalStorage/index.ts
+++ b/packages/core/src/UniversalStorage/index.ts
@@ -12,7 +12,7 @@ const ONE_YEAR_IN_MS = 365 * 24 * 60 * 60 * 1000;
 
 export class UniversalStorage implements Storage {
 	cookies = new Cookies();
-	store: Store = isBrowser ? window.localStorage : Object.create(null);
+	store: Store = getLocalStorage();
 
 	constructor(context: Context = {}) {
 		this.cookies = context.req
@@ -113,5 +113,13 @@ export class UniversalStorage implements Storage {
 			secure:
 				isBrowser && window.location.hostname === 'localhost' ? false : true,
 		});
+	}
+}
+
+function getLocalStorage() {
+	try {
+		return globalThis.localStorage
+	} catch (e) {
+		return Object.create(null)
 	}
 }


### PR DESCRIPTION
An error occurs in Chrome when the following conditions are met

* Access from iframe from another domain
* viewing in incognito window

see more at https://stackoverflow.com/questions/30481516/iframe-in-chrome-error-failed-to-read-localstorage-from-window-access-deni

fix it by wrapping the accessing code in a try block.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
