### PR TITLE
Bare-bones api client v6

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use node 14
+use node 16

--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -42,7 +42,224 @@ export class APIClass extends InternalAPIClass {
 	): Promise<GraphQLResult<any>> | Observable<object> {
 		return super.graphql(options, additionalHeaders);
 	}
+
+	/**
+	 * Generates an API client that can work with models or raw GraphQL
+	 */
+	generateClient<T = never>(): V6Client<T> {
+		const config = super.configure({});
+
+		const { modelIntrospection } = config;
+
+		const client: V6Client<any> = {
+			graphql: this.graphql.bind(this),
+			models: {},
+		};
+
+		for (const model of Object.values(modelIntrospection.models)) {
+			const { name } = model as any;
+
+			client.models[name] = {} as any;
+
+			Object.entries(graphQLOperationsInfo).forEach(
+				([key, { operationPrefix }]) => {
+					const operation = key as ModelOperation;
+
+					// e.g. clients.models.Todo.update
+					client.models[name][operationPrefix] = async (arg: any) => {
+						const query = generateGraphQLDocument(model, operation);
+						const variables = buildGraphQLVariables(model, operation, arg);
+
+						return this.graphql({
+							query,
+							variables,
+						});
+					};
+				}
+			);
+		}
+
+		return client as V6Client<T>;
+	}
 }
+
+const graphQLOperationsInfo = {
+	CREATE: { operationPrefix: 'create' as const, usePlural: false },
+	READ: { operationPrefix: 'get' as const, usePlural: false },
+	UPDATE: { operationPrefix: 'update' as const, usePlural: false },
+	DELETE: { operationPrefix: 'delete' as const, usePlural: false },
+	LIST: { operationPrefix: 'list' as const, usePlural: true },
+};
+type ModelOperation = keyof typeof graphQLOperationsInfo;
+type OperationPrefix =
+	(typeof graphQLOperationsInfo)[ModelOperation]['operationPrefix'];
+
+const graphQLDocumentsCache = new Map<string, Map<ModelOperation, string>>();
+
+function generateGraphQLDocument(
+	modelDefinition: any,
+	modelOperation: ModelOperation
+): string {
+	const {
+		name,
+		pluralName,
+		fields,
+		primaryKeyInfo: {
+			isCustomPrimaryKey,
+			primaryKeyFieldName,
+			sortKeyFieldNames,
+		},
+	} = modelDefinition;
+	const { operationPrefix, usePlural } = graphQLOperationsInfo[modelOperation];
+
+	let fromCache = graphQLDocumentsCache.get(name)?.get(modelOperation);
+
+	if (fromCache !== undefined) {
+		return fromCache;
+	}
+
+	if (!graphQLDocumentsCache.has(name)) {
+		graphQLDocumentsCache.set(name, new Map());
+	}
+
+	let graphQLFieldName = `${operationPrefix}${usePlural ? pluralName : name}`;
+	let graphQLOperationType: 'mutation' | 'query' | undefined;
+	let graphQLSelectionSet: string | undefined;
+	let graphQLArguments: Record<string, any> | undefined;
+
+	const selectionSetFields = Object.values<any>(fields)
+		.map(({ type, name }) => typeof type === 'string' && name) // Only scalars for now
+		.filter(Boolean)
+		.join(' ');
+
+	switch (modelOperation) {
+		case 'CREATE':
+		case 'UPDATE':
+		case 'DELETE':
+			graphQLArguments ??
+				(graphQLArguments = {
+					input: `${
+						operationPrefix.charAt(0).toLocaleUpperCase() +
+						operationPrefix.slice(1)
+					}${name}Input!`,
+				});
+			graphQLOperationType ?? (graphQLOperationType = 'mutation');
+		case 'READ':
+			graphQLArguments ??
+				(graphQLArguments = isCustomPrimaryKey
+					? [primaryKeyFieldName, ...sortKeyFieldNames].reduce(
+							(acc, fieldName) => {
+								acc[fieldName] = fields[fieldName].type;
+
+								return acc;
+							},
+							{}
+					  )
+					: {
+							[primaryKeyFieldName]: `${fields[primaryKeyFieldName].type}!`,
+					  });
+			graphQLSelectionSet ?? (graphQLSelectionSet = selectionSetFields);
+		case 'LIST':
+			graphQLOperationType ?? (graphQLOperationType = 'query');
+			graphQLSelectionSet ??
+				(graphQLSelectionSet = `items { ${selectionSetFields} }`);
+	}
+
+	const graphQLDocument = `${graphQLOperationType}${
+		graphQLArguments
+			? `(${Object.entries(graphQLArguments).map(
+					([fieldName, type]) => `\$${fieldName}: ${type}`
+			  )})`
+			: ''
+	} { ${graphQLFieldName}${
+		graphQLArguments
+			? `(${Object.keys(graphQLArguments).map(
+					fieldName => `${fieldName}: \$${fieldName}`
+			  )})`
+			: ''
+	} { ${graphQLSelectionSet} } }`;
+
+	graphQLDocumentsCache.get(name)?.set(modelOperation, graphQLDocument);
+
+	return graphQLDocument;
+}
+
+function buildGraphQLVariables(
+	modelDefinition: any,
+	operation: ModelOperation,
+	arg: any
+): object {
+	const {
+		fields,
+		primaryKeyInfo: {
+			isCustomPrimaryKey,
+			primaryKeyFieldName,
+			sortKeyFieldNames,
+		},
+	} = modelDefinition;
+
+	let variables = {};
+
+	switch (operation) {
+		case 'CREATE':
+			variables = { input: arg };
+			break;
+		case 'UPDATE':
+			// readonly fields are not  updated
+			variables = {
+				input: Object.fromEntries(
+					Object.entries(arg).filter(([fieldName]) => {
+						const { isReadOnly } = fields[fieldName];
+
+						return !isReadOnly;
+					})
+				),
+			};
+			break;
+		case 'READ':
+		case 'DELETE':
+			// only identifiers are sent
+			variables = isCustomPrimaryKey
+				? [primaryKeyFieldName, ...sortKeyFieldNames].reduce(
+						(acc, fieldName) => {
+							acc[fieldName] = arg[fieldName];
+
+							return acc;
+						},
+						{}
+				  )
+				: { [primaryKeyFieldName]: arg[primaryKeyFieldName] };
+
+			if (operation === 'DELETE') {
+				variables = { input: variables };
+			}
+			break;
+		case 'LIST':
+			break;
+		default:
+			const exhaustiveCheck: never = operation;
+			throw new Error(`Unhandled operation case: ${exhaustiveCheck}`);
+	}
+
+	return variables;
+}
+
+type FilteredKeys<T> = {
+	[P in keyof T]: T[P] extends never ? never : P;
+}[keyof T];
+type ExcludeNeverFields<O> = {
+	[K in FilteredKeys<O>]: O[K];
+};
+
+// If no T is passed, ExcludeNeverFields removes "models" from the client
+type V6Client<T = never> = ExcludeNeverFields<{
+	graphql: typeof APIClass.prototype.graphql;
+	models: {
+		[K in keyof T]: {
+			[K in OperationPrefix]: (...args: any[]) => Promise<any>;
+		};
+	};
+}>;
 
 export const API = new APIClass(null);
 Amplify.register(API);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- Create a test `aws-exports.js` file that includes a model-introspection schema
- Verify that adding an introspection schema does NOT break the any validation logic within the JS library.
- `API.generateClient()` returns an "empty" object without any implementation fully hooked up yet. (Just stubbed out)
	- Available stubs are:
		- graphql
		- models
- `generateClient` accepts a generic that extends a "stubbed" Schema type and can represent it internally. For now, we can pass in "`{}`" or "`any`" into `generateClient<T>`.
- the generated client is aware of the model-introspection schema and "can print" the model introspection schema upon client generation.
- Generates a GraphQL document given model name and operation (create, update, delete, list, get)
- Allows customers to pass in input variables
- Makes network request to the cloud with the default authorization mode
- ~All~ Scalar fields are part of selection set.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
N/A


#### Description of how you validated changes

From an annotated graphql schema (with `@model` directives), you can run `amplify codegen model-introspection --output-dir .` to get a model introspection to get started.

Validated on a nextjs app using app router and the following client component:

```tsx
"use client";

import { Amplify, API } from "aws-amplify";
import { default as awsConfig } from "../aws-exports";
import { default as modelIntrospection } from "../model-introspection.json";

import { ulid } from 'ulid';

Amplify.configure({
  ...awsConfig,
  API: {
    modelIntrospection,
  }
});

// These two types are not going to be needed in the future
type FakeSchemaFromIntrospection<T extends typeof modelIntrospection> = {[K in keyof T['models']]: any};
type TemporaryMadeUpSchema = FakeSchemaFromIntrospection<typeof modelIntrospection>;

const client = API.generateClient<TemporaryMadeUpSchema>();

const btnHandlers = {
  create: async () => {
    console.log(await client.models.Post.create({
      postId: ulid(),
      postedOn: new Date().toISOString(),
      title: `New post - ${Date.now()}`,
      content: 'Some content',
    }));
  },
  read: async () => {
    const { data: { listPosts: { items: posts } } } = await client.models.Post.list();
    const [ { id } ] = posts;

    console.log(await client.models.Post.get({id}));
  },
  update: async () => {
    const { data: { listPosts: { items: posts } } } = await client.models.Post.list();
    const [ post ] = posts;
  
    console.log(await client.models.Post.update({
      ...post,
      title: `UPDATED - ${post.title}`,
    }));
  },
  delete: async () => {
    const { data: { listPosts: { items: posts } } } = await client.models.Post.list();
    const [ post ] = posts;
  
    console.log(await client.models.Post.delete(post));
  },
  list: async () => {
    console.log(await client.models.Post.list());
  },
};

export function ClientComponent() {
  return (
    <>
      <button onClick={btnHandlers['create']}>Create</button>
      <button onClick={btnHandlers['read']}>Read</button>
      <button onClick={btnHandlers['update']}>Update</button>
      <button onClick={btnHandlers['delete']}>Delete</button>
      <button onClick={btnHandlers['list']}>List</button>
    </>
  );
}

```

Bundle size impact is minimal so far (as expected):

```diff
Route (app)                                Size     First Load JS
┌ ○ /                                      0 B                0 B
└ ○ /favicon.ico                           0 B                0 B
- First Load JS shared by all              77.6 kB
+ First Load JS shared by all              77.7 kB
  ├ chunks/769-3efea3db3a1a867c.js         25.2 kB
  ├ chunks/bce60fc1-49ee79ad31766ac6.js    50.5 kB
  ├ chunks/main-app-3b19c77581670b86.js    216 B
- └ chunks/webpack-4e1473a5f6694102.js     1.68 kB
+ └ chunks/webpack-27936e12ce64efbd.js     1.77 kB
Route (pages)                              Size     First Load JS
- ─ ○ /404                                   182 B          74.8 kB
+ ─ ○ /404                                   182 B          74.9 kB
- First Load JS shared by all              74.6 kB
+ First Load JS shared by all              74.7 kB
  ├ chunks/framework-8883d1e9be70c3da.js   45 kB
  ├ chunks/main-6a050bdd50e19c45.js        27.7 kB
  ├ chunks/pages/_app-998b8fceeadee23e.js  195 B
- └ chunks/webpack-4e1473a5f6694102.js     1.68 kB
+ └ chunks/webpack-27936e12ce64efbd.js     1.77 kB
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
