### PR TITLE
feat: add auth token migration

### DIFF
--- a/packages/auth/__tests__/providers/cognito/auth-token-migration.test.ts
+++ b/packages/auth/__tests__/providers/cognito/auth-token-migration.test.ts
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { UserPoolTokenManager } from '../../../src/storage/UserPoolTokenManager';
+import { LocalStorage } from '@aws-amplify/core';
+import { LegacyUserPoolTokenManager } from '../../../src/storage/LegacyUserPoolManager';
+import { LegacyDeviceKeyTokenManager } from '../../../src/storage/LegacyDeviceKeyTokenManager';
+import {
+	cognitoUserPoolTokens,
+	config,
+	devicekeyTokens,
+} from './testUtils/mocks';
+import {
+	setLegacyDeviceKeysTokens,
+	setLegacyUserPoolTokens,
+} from './testUtils/helpers';
+import {
+	AuthTokenStorageManagerVersion,
+	DEVICE_KEY_MANAGER_VERSION_KEY,
+	USER_POOL_MANAGER_VERSION_KEY,
+} from '../../../src/storage/keys';
+import { DeviceKeyTokenManager } from '../../../src/storage/DeviceKeyTokenManager';
+
+describe('migrate legacy user pool tokens', () => {
+	const userPoolManager = new UserPoolTokenManager(config, LocalStorage);
+
+	test('user pool manager should migrate tokens on load action.', async () => {
+		await setLegacyUserPoolTokens();
+		expect(await userPoolManager.loadTokens()).toEqual(cognitoUserPoolTokens);
+	});
+
+	test('user pool token migration should clear legacy tokens.', async () => {
+		const legacyUserPoolManager = new LegacyUserPoolTokenManager(
+			config,
+			LocalStorage
+		);
+
+		expect(await legacyUserPoolManager.loadTokens()).toEqual(null);
+	});
+
+	test('user pool token migration should setup a version key', async () => {
+		const tokenManagerVersion = await LocalStorage.getItem(
+			USER_POOL_MANAGER_VERSION_KEY
+		);
+		expect(tokenManagerVersion).toEqual(AuthTokenStorageManagerVersion.v1);
+	});
+});
+
+describe('migrate legacy device key tokens', () => {
+	const deviceKeyManager = new DeviceKeyTokenManager(config, LocalStorage);
+
+	test('device key manager should migrate tokens on load action.', async () => {
+		await setLegacyDeviceKeysTokens();
+		expect(await deviceKeyManager.loadTokens()).toEqual(devicekeyTokens);
+	});
+
+	test('device key token migration should clear legacy tokens.', async () => {
+		const legacyDeviceKeyManager = new LegacyDeviceKeyTokenManager(
+			config,
+			LocalStorage
+		);
+
+		expect(await legacyDeviceKeyManager.loadTokens()).toEqual(null);
+	});
+
+	test('device key token migration should setup a version key', async () => {
+		const deviceKeytokenManagerVersion = await LocalStorage.getItem(
+			DEVICE_KEY_MANAGER_VERSION_KEY
+		);
+		expect(deviceKeytokenManagerVersion).toEqual(
+			AuthTokenStorageManagerVersion.v1
+		);
+	});
+});

--- a/packages/auth/src/storage/DeviceKeyTokenManager.ts
+++ b/packages/auth/src/storage/DeviceKeyTokenManager.ts
@@ -2,16 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AuthStorage } from '@aws-amplify/core';
-import { getCognitoKeys } from './helpers';
-import { CognitoDeviceKey } from './keys';
+import { getCognitoKeys, migrateTokens } from './helpers';
+import { CognitoDeviceKey, DEVICE_KEY_MANAGER_VERSION_KEY } from './keys';
 import { AuthTokenManager } from './types';
 import { CognitoDeviceKeyTokens, CognitoKeys } from './types/models';
 import { KEY_PREFIX } from './constants';
+import { LegacyDeviceKeyTokenManager } from './LegacyDeviceKeyTokenManager';
 
 export class DeviceKeyTokenManager implements AuthTokenManager {
 	// TODO: change to config interface once defined
 	private config: any;
-	private storage: AuthStorage;
+	storage: AuthStorage;
 	private prefix = KEY_PREFIX;
 	private keys: CognitoKeys<CognitoDeviceKey>;
 	constructor(config: any, storage: AuthStorage) {
@@ -22,6 +23,16 @@ export class DeviceKeyTokenManager implements AuthTokenManager {
 	}
 
 	async loadTokens(): Promise<CognitoDeviceKeyTokens | null> {
+		const legacyDeviceKeyTokenManager = new LegacyDeviceKeyTokenManager(
+			this.config,
+			this.storage
+		);
+
+		await migrateTokens(
+			legacyDeviceKeyTokenManager,
+			this,
+			DEVICE_KEY_MANAGER_VERSION_KEY
+		);
 		const tokens = {} as CognitoDeviceKeyTokens;
 
 		const deviceKey = await this.storage.getItem(this.keys.deviceKey);

--- a/packages/auth/src/storage/LegacyDeviceKeyTokenManager.ts
+++ b/packages/auth/src/storage/LegacyDeviceKeyTokenManager.ts
@@ -13,7 +13,7 @@ import { LEGACY_KEY_PREFIX } from './constants';
 export class LegacyDeviceKeyTokenManager implements AuthTokenManager {
 	// TODO: change to config interface once defined
 	private config: any;
-	private storage: AuthStorage;
+	storage: AuthStorage;
 	private prefix: string = LEGACY_KEY_PREFIX;
 	private clientId: string;
 	constructor(config: any, storage: AuthStorage) {

--- a/packages/auth/src/storage/LegacyUserPoolManager.ts
+++ b/packages/auth/src/storage/LegacyUserPoolManager.ts
@@ -16,7 +16,7 @@ import { LEGACY_KEY_PREFIX } from './constants';
 export class LegacyUserPoolTokenManager implements AuthTokenManager {
 	// TODO: change to config interface once defined
 	private config: any;
-	private storage: AuthStorage;
+	storage: AuthStorage;
 	private prefix: string = LEGACY_KEY_PREFIX;
 
 	private clientId: string;

--- a/packages/auth/src/storage/UserPoolTokenManager.ts
+++ b/packages/auth/src/storage/UserPoolTokenManager.ts
@@ -2,15 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AuthStorage } from '@aws-amplify/core';
-import { getCognitoKeys } from './helpers';
-import { CognitoUserPoolKey } from './keys';
+import { getCognitoKeys, migrateTokens } from './helpers';
+import { CognitoUserPoolKey, USER_POOL_MANAGER_VERSION_KEY } from './keys';
 import { CognitoUserPoolTokens, AuthTokenManager, CognitoKeys } from './types';
 import { KEY_PREFIX } from './constants';
+import { LegacyUserPoolTokenManager } from './LegacyUserPoolManager';
 
 export class UserPoolTokenManager implements AuthTokenManager {
 	// TODO: change to config interface once defined
 	private config: any;
-	private storage: AuthStorage;
+	storage: AuthStorage;
 	private prefix = KEY_PREFIX;
 	private keys: CognitoKeys<CognitoUserPoolKey>;
 
@@ -22,6 +23,15 @@ export class UserPoolTokenManager implements AuthTokenManager {
 	}
 
 	async loadTokens(): Promise<CognitoUserPoolTokens | null> {
+		const legacyTokenManager = new LegacyUserPoolTokenManager(
+			this.config,
+			this.storage
+		);
+		await migrateTokens(
+			legacyTokenManager,
+			this,
+			USER_POOL_MANAGER_VERSION_KEY
+		);
 		const tokens = {} as CognitoUserPoolTokens;
 
 		const accessToken = await this.storage.getItem(this.keys.accessToken);

--- a/packages/auth/src/storage/helpers.ts
+++ b/packages/auth/src/storage/helpers.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AuthStorage } from '@aws-amplify/core';
-import { CognitoKeys } from './types';
+import { AuthTokenManager, CognitoKeys } from './types';
+import { AuthTokenStorageManagerVersion } from './keys';
 
 export function getCognitoKeys<T extends Record<string, string>>(
 	cognitoKeys: T
@@ -24,4 +25,37 @@ export async function getUsernameFromStorage(
 	legacyKey: string
 ): Promise<string | null> {
 	return storage.getItem(legacyKey);
+}
+
+export async function migrateTokens<
+	TokenManager extends AuthTokenManager,
+	LegacyTokenManager extends AuthTokenManager
+>(
+	legacyManager: LegacyTokenManager,
+	tokenManager: TokenManager,
+	versionManagerKey: string
+): Promise<void> {
+	const storage = tokenManager.storage;
+	const tokenManagerVersion =
+		(await storage.getItem(versionManagerKey)) ??
+		AuthTokenStorageManagerVersion.none;
+
+	if (tokenManagerVersion !== AuthTokenStorageManagerVersion.none) return;
+
+	try {
+		const legacyTokens = await legacyManager.loadTokens();
+		if (legacyTokens !== null) {
+			await tokenManager.storeTokens(legacyTokens);
+		}
+	} catch (error) {
+		// TODO: log error
+	} finally {
+		try {
+			await legacyManager.clearTokens();
+		} catch (error) {
+			// TODO: log error
+		}
+	}
+	// set the token manager version after
+	await storage.setItem(versionManagerKey, AuthTokenStorageManagerVersion.v1);
 }

--- a/packages/auth/src/storage/keys.ts
+++ b/packages/auth/src/storage/keys.ts
@@ -24,9 +24,36 @@ export enum LegacyCognitoUserPoolKeys {
 }
 
 export enum CognitoDeviceKey {
-    deviceKey = 'deviceKey',
+	deviceKey = 'deviceKey',
 
-    deviceGroupKey = 'deviceGroupKey',
+	deviceGroupKey = 'deviceGroupKey',
 
-    randomPasswordKey = 'randomPasswordKey',
+	randomPasswordKey = 'randomPasswordKey',
+}
+
+/**
+ * The key to get/set the auth token storage manager version.
+ */
+export const USER_POOL_MANAGER_VERSION_KEY = 'UserPoolManagerVersionKey';
+
+/**
+ * The key to get/set the device key storage manager version.
+ */
+export const DEVICE_KEY_MANAGER_VERSION_KEY = 'DeviceKeyManagerVersionKey';
+
+/**
+ * The token manager version.
+ */
+export enum AuthTokenStorageManagerVersion {
+	/**
+	 * No auth token store manager version is present.
+	 *
+	 * Either the token manager has never been initialized, or
+	 * the tokens are stored in a legacy format.
+	 * */
+	none = 'none',
+	/**
+	 * The initial implementation of auth token manager version
+	 */
+	v1 = 'v1',
 }

--- a/packages/auth/src/storage/types/models.ts
+++ b/packages/auth/src/storage/types/models.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { AuthStorage } from '@aws-amplify/core';
 
 export type CognitoKeys<CognitoKey extends string> = {
 	[Key in CognitoKey]: string;
@@ -21,6 +22,7 @@ export type LegacyCognitoUserPoolTokens = {
 };
 
 export interface AuthTokenManager {
+	storage: AuthStorage;
 	loadTokens(): Promise<Record<string, string> | null>;
 	storeTokens(tokens: Record<string, string>): Promise<void>;
 	clearTokens(): Promise<void>;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR adds auth token migration flows for legacy user pool and device key tokens.

The migration flow will start on a single `load` tokens action and then will set up a version flag in storage. 

This flaw is to avoid running the migration flow if it was already ran. This flag [strategy](https://github.com/aws-amplify/amplify-flutter/blob/main/packages/auth/amplify_auth_cognito_dart/lib/src/state/machines/credential_store_state_machine.dart#L309) was already implemented in Flutter's migration plan

Pending:
- log possible errors in the token migration flow.
- RN migration flow.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
