### PR TITLE
fix(storage): not pass the input to SSE-C serializer output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1632,6 +1632,7 @@ releasable_branches: &releasable_branches
       - release
       - main
       - next
+      - fix-unblock-main-07/10
 
 # List of test browsers that are always used in every E2E test. Tests that aren't expected to interact with browser APIs
 # should use `minimal_browser_list` to keep test execution time low.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1632,7 +1632,6 @@ releasable_branches: &releasable_branches
       - release
       - main
       - next
-      - fix-unblock-main-07/10
 
 # List of test browsers that are always used in every E2E test. Tests that aren't expected to interact with browser APIs
 # should use `minimal_browser_list` to keep test execution time low.

--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
 	},
 	"resolutions": {
 		"@types/babel__traverse": "7.20.0",
-		"path-scurry": "1.10.0"
+		"path-scurry": "1.10.0",
+		"**/glob/minipass": "6.0.2"
 	},
 	"jest": {
 		"resetMocks": true,

--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
 		"wml": "0.0.83"
 	},
 	"resolutions": {
-		"@types/babel__traverse": "7.20.0"
+		"@types/babel__traverse": "7.20.0",
+		"path-scurry/minipass": "6.0.2"
 	},
 	"jest": {
 		"resetMocks": true,

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 	},
 	"resolutions": {
 		"@types/babel__traverse": "7.20.0",
-		"path-scurry/minipass": "6.0.2"
+		"path-scurry": "1.10.0"
 	},
 	"jest": {
 		"resetMocks": true,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -59,7 +59,7 @@
       "name": "Storage (top-level class)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, Storage }",
-      "limit": "38.08 kB"
+      "limit": "38.15 kB"
     }
   ],
   "jest": {

--- a/packages/storage/src/AwsClients/S3/utils/serializeHelpers.ts
+++ b/packages/storage/src/AwsClients/S3/utils/serializeHelpers.ts
@@ -29,13 +29,11 @@ interface ObjectSsecOptions {
 export const serializeObjectSsecOptionsToHeaders = async (
 	input: ObjectSsecOptions
 ) => {
-	if (!input.SSECustomerAlgorithm || !input.SSECustomerKey) {
-		return input as Record<string, string>;
-	}
-
-	const sseCustomKeyMD5 = new Md5();
-	sseCustomKeyMD5.update(utf8Encode(input.SSECustomerKey));
-	const sseCustomKeyMD5Digest = await sseCustomKeyMD5.digest();
+	const getMd5Digest = async (content: any) => {
+		const md5Hasher = new Md5();
+		md5Hasher.update(utf8Encode(content));
+		return await md5Hasher.digest();
+	};
 
 	return assignStringVariables({
 		'x-amz-server-side-encryption-customer-algorithm':
@@ -45,7 +43,8 @@ export const serializeObjectSsecOptionsToHeaders = async (
 		'x-amz-server-side-encryption-customer-key':
 			input.SSECustomerKey && toBase64(input.SSECustomerKey),
 		'x-amz-server-side-encryption-customer-key-md5':
-			input.SSECustomerKeyMD5 && toBase64(sseCustomKeyMD5Digest),
+			input.SSECustomerKey &&
+			toBase64(await getMd5Digest(input.SSECustomerKey)),
 	});
 };
 

--- a/packages/storage/src/AwsClients/S3/utils/serializeHelpers.ts
+++ b/packages/storage/src/AwsClients/S3/utils/serializeHelpers.ts
@@ -32,7 +32,7 @@ export const serializeObjectSsecOptionsToHeaders = async (
 	const getMd5Digest = async (content: any) => {
 		const md5Hasher = new Md5();
 		md5Hasher.update(utf8Encode(content));
-		return await md5Hasher.digest();
+		return md5Hasher.digest();
 	};
 
 	return assignStringVariables({

--- a/packages/storage/src/AwsClients/S3/utils/serializeHelpers.ts
+++ b/packages/storage/src/AwsClients/S3/utils/serializeHelpers.ts
@@ -42,6 +42,8 @@ export const serializeObjectSsecOptionsToHeaders = async (
 		// see: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html#specifying-s3-c-encryption
 		'x-amz-server-side-encryption-customer-key':
 			input.SSECustomerKey && toBase64(input.SSECustomerKey),
+		// Calculate the md5 digest of the the SSE-C key, for compatibility with AWS SDK
+		// see: https://github.com/aws/aws-sdk-js-v3/blob/91fc83307c38cc9cbe0b3acd919557d5b5b831d6/packages/middleware-ssec/src/index.ts#L36
 		'x-amz-server-side-encryption-customer-key-md5':
 			input.SSECustomerKey &&
 			toBase64(await getMd5Digest(input.SSECustomerKey)),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
2 changes in this PR:
1. `serializeObjectSsecOptionsToHeaders` passes the `input` to output in some code path causing the input like `Bucket` or `Key` serialized to headers, hence the signer throws encountering non-string headers
2. Pin the associated `minipass` dependency to unblock the integration tests. In a few integration test cases, we are stucked on older Cypress and Node.js. The minipass made a major version bump and made into
the dependency graph. It deprecates the Node.js 14 hence broke the integration test in older image. See [failed build](see: https://app.circleci.com/pipelines/github/aws-amplify/amplify-js/20379/workflows/74a58937-dfe4-4d09-b676-7ac79bc59708/jobs/301782)

#### Description of how you validated changes
Integration test; Unit test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
