### PR TITLE
feat: custom user agent InAppMessasging changes for UI handoff (Option 1)

### DIFF
--- a/packages/core/src/Platform/types.ts
+++ b/packages/core/src/Platform/types.ts
@@ -98,6 +98,7 @@ export enum GeoAction {
 export enum InAppMessagingAction {
 	None = '0',
 	SyncMessages = '1',
+	IdentifyUser = '2',
 }
 export enum InteractionsAction {
 	None = '0',

--- a/packages/core/src/Platform/types.ts
+++ b/packages/core/src/Platform/types.ts
@@ -97,6 +97,7 @@ export enum GeoAction {
 }
 export enum InAppMessagingAction {
 	None = '0',
+	SyncMessages = '1',
 }
 export enum InteractionsAction {
 	None = '0',

--- a/packages/notifications/__tests__/InAppMessaging/InAppMessaging.test.ts
+++ b/packages/notifications/__tests__/InAppMessaging/InAppMessaging.test.ts
@@ -6,6 +6,7 @@ import {
 	Hub,
 	HubCallback,
 	HubCapsule,
+	InAppMessagingAction,
 	StorageHelper,
 } from '@aws-amplify/core';
 
@@ -13,6 +14,7 @@ import {
 	closestExpiryMessage,
 	customHandledMessage,
 	inAppMessages,
+	notificationsConfig,
 	simpleInAppMessages,
 	simpleInAppMessagingEvent,
 	subcategoryConfig,
@@ -27,6 +29,7 @@ import {
 import InAppMessaging, {
 	InAppMessageInteractionEvent,
 } from '../../src/InAppMessaging';
+import { getUserAgentValue } from '../../src/InAppMessaging/internals/utils';
 
 jest.mock('@aws-amplify/core');
 jest.mock('../../src/common/eventListeners');
@@ -114,7 +117,9 @@ describe('InAppMessaging', () => {
 		});
 
 		test('attaches a storage helper to the config', () => {
-			const config = inAppMessaging.configure(subcategoryConfig);
+			const config = inAppMessaging.configure({
+				Notifications: notificationsConfig,
+			});
 
 			expect(config).toStrictEqual({
 				...subcategoryConfig,
@@ -151,7 +156,12 @@ describe('InAppMessaging', () => {
 		});
 
 		test('does not listen to analytics events if `listenForAnalyticsEvents` is false', () => {
-			inAppMessaging.configure({ listenForAnalyticsEvents: false });
+			const config = {
+				Notifications: {
+					InAppMessaging: { listenForAnalyticsEvents: false },
+				},
+			};
+			inAppMessaging.configure(config);
 
 			expect(hubSpy).not.toBeCalled();
 		});
@@ -284,9 +294,14 @@ describe('InAppMessaging', () => {
 		test('identifies users with pluggables', async () => {
 			await inAppMessaging.identifyUser(userId, userInfo);
 
+			const userAgentValue = getUserAgentValue(
+				InAppMessagingAction.IdentifyUser
+			);
+
 			expect(mockInAppMessagingProvider.identifyUser).toBeCalledWith(
 				userId,
-				userInfo
+				userInfo,
+				userAgentValue
 			);
 		});
 

--- a/packages/notifications/internals/inAppMessaging/package.json
+++ b/packages/notifications/internals/inAppMessaging/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@aws-amplify/notifications/internals/inAppMessaging",
+	"types": "../../../lib-esm/InAppMessaging/internals/index.d.ts",
+	"main": "../../../lib/InAppMessaging/internals/index.js",
+	"module": "../../../lib-esm/InAppMessaging/internals/index.js",
+	"react-native": "../../../lib-esm/InAppMessaging/internals/index.js",
+	"sideEffects": false
+}

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -46,7 +46,8 @@
 	"files": [
 		"lib",
 		"lib-esm",
-		"src"
+		"src",
+		"internals"
 	],
 	"dependencies": {
 		"@aws-amplify/cache": "5.1.4",

--- a/packages/notifications/src/InAppMessaging/InAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/InAppMessaging.ts
@@ -2,11 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { UserInfo } from '../types';
-import {
-	InAppMessagingInterface,
-	InAppMessagingEvent,
-	NotificationsSubCategory,
-} from './types';
+import { InAppMessagingInterface, NotificationsSubCategory } from './types';
 import { InternalInAppMessagingClass } from './internals/InternalInAppMessaging';
 
 export default class InAppMessaging

--- a/packages/notifications/src/InAppMessaging/InAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/InAppMessaging.ts
@@ -28,11 +28,6 @@ export default class InAppMessaging
 	 */
 	syncMessages = (): Promise<void[]> => super.syncMessages();
 
-	clearMessages = (): Promise<void[]> => super.clearMessages();
-
-	dispatchEvent = async (event: InAppMessagingEvent): Promise<void> =>
-		super.dispatchEvent(event);
-
 	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> =>
 		super.identifyUser(userId, userInfo);
 }

--- a/packages/notifications/src/InAppMessaging/InAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/InAppMessaging.ts
@@ -1,78 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-	ConsoleLogger as Logger,
-	HubCallback,
-	HubCapsule,
-	Hub,
-	StorageHelper,
-} from '@aws-amplify/core';
-import flatten from 'lodash/flatten';
-
-import {
-	addEventListener,
-	EventListener,
-	notifyEventListeners,
-} from '../common';
 import { UserInfo } from '../types';
-import { AWSPinpointProvider } from './Providers';
 import {
-	InAppMessage,
-	InAppMessageInteractionEvent,
 	InAppMessagingInterface,
-	InAppMessagingConfig,
-	InAppMessageConflictHandler,
 	InAppMessagingEvent,
-	InAppMessagingProvider,
 	NotificationsSubCategory,
-	OnMessageInteractionEventHandler,
 } from './types';
+import { InternalInAppMessagingClass } from './internals/InternalInAppMessaging';
 
-const STORAGE_KEY_SUFFIX = '_inAppMessages';
-
-const logger = new Logger('Notifications.InAppMessaging');
-
-export default class InAppMessaging implements InAppMessagingInterface {
-	private config: Record<string, any> = {};
-	private conflictHandler: InAppMessageConflictHandler;
-	private listeningForAnalyticEvents = false;
-	private pluggables: InAppMessagingProvider[] = [];
-	private storageSynced = false;
-
-	constructor() {
-		this.config = { storage: new StorageHelper().getStorage() };
-		this.setConflictHandler(this.defaultConflictHandler);
-	}
-
-	/**
-	 * Configure InAppMessaging
-	 * @param {Object} config - InAppMessaging configuration object
-	 */
-	configure = ({
-		listenForAnalyticsEvents = true,
-		...config
-	}: InAppMessagingConfig = {}): InAppMessagingConfig => {
-		this.config = { ...this.config, ...config };
-
-		logger.debug('configure InAppMessaging', this.config);
-
-		this.pluggables.forEach(pluggable => {
-			pluggable.configure(this.config[pluggable.getProviderName()]);
-		});
-
-		if (this.pluggables.length === 0) {
-			this.addPluggable(new AWSPinpointProvider());
-		}
-
-		if (listenForAnalyticsEvents && !this.listeningForAnalyticEvents) {
-			Hub.listen('analytics', this.analyticsListener);
-			this.listeningForAnalyticEvents = true;
-		}
-
-		return this.config;
-	};
-
+export default class InAppMessaging
+	extends InternalInAppMessagingClass
+	implements InAppMessagingInterface
+{
 	/**
 	 * Get the name of this module
 	 * @returns {string} name of this module
@@ -82,240 +22,17 @@ export default class InAppMessaging implements InAppMessagingInterface {
 	}
 
 	/**
-	 * Get a plugin from added plugins
-	 * @param {string} providerName - the name of the plugin to get
-	 */
-	getPluggable = (providerName: string): InAppMessagingProvider => {
-		const pluggable =
-			this.pluggables.find(
-				pluggable => pluggable.getProviderName() === providerName
-			) ?? null;
-
-		if (!pluggable) {
-			logger.debug(`No plugin found with name ${providerName}`);
-		}
-
-		return pluggable;
-	};
-
-	/**
-	 * Add plugin into InAppMessaging
-	 * @param {InAppMessagingProvider} pluggable - an instance of the plugin
-	 */
-	addPluggable = (pluggable: InAppMessagingProvider): void => {
-		if (
-			pluggable &&
-			pluggable.getCategory() === 'Notifications' &&
-			pluggable.getSubCategory() === 'InAppMessaging'
-		) {
-			if (this.getPluggable(pluggable.getProviderName())) {
-				throw new Error(
-					`Pluggable ${pluggable.getProviderName()} has already been added.`
-				);
-			}
-			this.pluggables.push(pluggable);
-			pluggable.configure(this.config[pluggable.getProviderName()]);
-		}
-	};
-
-	/**
-	 * Remove a plugin from added plugins
-	 * @param {string} providerName - the name of the plugin to remove
-	 */
-	removePluggable = (providerName: string): void => {
-		const index = this.pluggables.findIndex(
-			pluggable => pluggable.getProviderName() === providerName
-		);
-		if (index === -1) {
-			logger.debug(`No plugin found with name ${providerName}`);
-		} else {
-			this.pluggables.splice(index, 1);
-		}
-	};
-
-	/**
 	 * Get the map resources that are currently available through the provider
 	 * @param {string} provider
 	 * @returns - Array of available map resources
 	 */
-	syncMessages = (): Promise<void[]> =>
-		Promise.all<void>(
-			this.pluggables.map(async pluggable => {
-				try {
-					const messages = await pluggable.getInAppMessages();
-					const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
-					await this.setMessages(key, messages);
-				} catch (err) {
-					logger.error('Failed to sync messages', err);
-					throw err;
-				}
-			})
-		);
+	syncMessages = (): Promise<void[]> => super.syncMessages();
 
-	clearMessages = (): Promise<void[]> =>
-		Promise.all<void>(
-			this.pluggables.map(async pluggable => {
-				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
-				await this.removeMessages(key);
-			})
-		);
+	clearMessages = (): Promise<void[]> => super.clearMessages();
 
-	dispatchEvent = async (event: InAppMessagingEvent): Promise<void> => {
-		const messages: InAppMessage[][] = await Promise.all<InAppMessage[]>(
-			this.pluggables.map(async pluggable => {
-				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
-				const messages = await this.getMessages(key);
-				return pluggable.processInAppMessages(messages, event);
-			})
-		);
-
-		const flattenedMessages = flatten(messages);
-
-		if (flattenedMessages.length) {
-			notifyEventListeners(
-				InAppMessageInteractionEvent.MESSAGE_RECEIVED,
-				this.conflictHandler(flattenedMessages)
-			);
-		}
-	};
+	dispatchEvent = async (event: InAppMessagingEvent): Promise<void> =>
+		super.dispatchEvent(event);
 
 	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> =>
-		Promise.all<void>(
-			this.pluggables.map(async pluggable => {
-				try {
-					await pluggable.identifyUser(userId, userInfo);
-				} catch (err) {
-					logger.error('Failed to identify user', err);
-					throw err;
-				}
-			})
-		);
-
-	onMessageReceived = (
-		handler: OnMessageInteractionEventHandler
-	): EventListener<OnMessageInteractionEventHandler> =>
-		addEventListener(InAppMessageInteractionEvent.MESSAGE_RECEIVED, handler);
-
-	onMessageDisplayed = (
-		handler: OnMessageInteractionEventHandler
-	): EventListener<OnMessageInteractionEventHandler> =>
-		addEventListener(InAppMessageInteractionEvent.MESSAGE_DISPLAYED, handler);
-
-	onMessageDismissed = (
-		handler: OnMessageInteractionEventHandler
-	): EventListener<OnMessageInteractionEventHandler> =>
-		addEventListener(InAppMessageInteractionEvent.MESSAGE_DISMISSED, handler);
-
-	onMessageActionTaken = (
-		handler: OnMessageInteractionEventHandler
-	): EventListener<OnMessageInteractionEventHandler> =>
-		addEventListener(
-			InAppMessageInteractionEvent.MESSAGE_ACTION_TAKEN,
-			handler
-		);
-
-	notifyMessageInteraction = (
-		message: InAppMessage,
-		type: InAppMessageInteractionEvent
-	): void => {
-		notifyEventListeners(type, message);
-	};
-
-	setConflictHandler = (handler: InAppMessageConflictHandler): void => {
-		this.conflictHandler = handler;
-	};
-
-	private analyticsListener: HubCallback = ({ payload }: HubCapsule) => {
-		const { event, data } = payload;
-		switch (event) {
-			case 'record': {
-				this.dispatchEvent(data);
-				break;
-			}
-			default:
-				break;
-		}
-	};
-
-	private syncStorage = async (): Promise<void> => {
-		const { storage } = this.config;
-		try {
-			// Only run sync() if it's available (i.e. React Native)
-			if (typeof storage.sync === 'function') {
-				await storage.sync();
-			}
-			this.storageSynced = true;
-		} catch (err) {
-			logger.error('Failed to sync storage', err);
-		}
-	};
-
-	private getMessages = async (key: string): Promise<any> => {
-		try {
-			if (!this.storageSynced) {
-				await this.syncStorage();
-			}
-			const { storage } = this.config;
-			const storedMessages = storage.getItem(key);
-			return storedMessages ? JSON.parse(storedMessages) : [];
-		} catch (err) {
-			logger.error('Failed to retrieve in-app messages from storage', err);
-		}
-	};
-
-	private setMessages = async (
-		key: string,
-		messages: InAppMessage[]
-	): Promise<void> => {
-		if (!messages) {
-			return;
-		}
-
-		try {
-			if (!this.storageSynced) {
-				await this.syncStorage();
-			}
-			const { storage } = this.config;
-			storage.setItem(key, JSON.stringify(messages));
-		} catch (err) {
-			logger.error('Failed to store in-app messages', err);
-		}
-	};
-
-	private removeMessages = async (key: string): Promise<void> => {
-		try {
-			if (!this.storageSynced) {
-				await this.syncStorage();
-			}
-			const { storage } = this.config;
-			storage.removeItem(key);
-		} catch (err) {
-			logger.error('Failed to remove in-app messages from storage', err);
-		}
-	};
-
-	private defaultConflictHandler = (messages: InAppMessage[]): InAppMessage => {
-		// default behavior is to return the message closest to expiry
-		// this function assumes that messages processed by providers already filters out expired messages
-		const sorted = messages.sort((a, b) => {
-			const endDateA = a.metadata?.endDate;
-			const endDateB = b.metadata?.endDate;
-			// if both message end dates are falsy or have the same date string, treat them as equal
-			if (endDateA === endDateB) {
-				return 0;
-			}
-			// if only message A has an end date, treat it as closer to expiry
-			if (endDateA && !endDateB) {
-				return -1;
-			}
-			// if only message B has an end date, treat it as closer to expiry
-			if (!endDateA && endDateB) {
-				return 1;
-			}
-			// otherwise, compare them
-			return new Date(endDateA) < new Date(endDateB) ? -1 : 1;
-		});
-		// always return the top sorted
-		return sorted[0];
-	};
+		super.identifyUser(userId, userInfo);
 }

--- a/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/index.ts
+++ b/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/index.ts
@@ -111,7 +111,7 @@ export default class AWSPinpointProvider
 		return this.config;
 	};
 
-	getInAppMessages = async () => {
+	getInAppMessages = async (userAgentValue?: string) => {
 		if (!this.initialized) {
 			await this.init();
 		}
@@ -129,7 +129,7 @@ export default class AWSPinpointProvider
 			};
 			this.logger.debug('getting in-app messages');
 			const response: GetInAppMessagesOutput = await getInAppMessages(
-				{ credentials, region },
+				{ credentials, region, userAgentValue },
 				input
 			);
 			const { InAppMessageCampaigns: messages } =

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -1,0 +1,321 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	ConsoleLogger as Logger,
+	HubCallback,
+	HubCapsule,
+	Hub,
+	StorageHelper,
+} from '@aws-amplify/core';
+import flatten from 'lodash/flatten';
+
+import {
+	addEventListener,
+	EventListener,
+	notifyEventListeners,
+} from '../common';
+import { UserInfo } from '../types';
+import { AWSPinpointProvider } from './Providers';
+import {
+	InAppMessage,
+	InAppMessageInteractionEvent,
+	InAppMessagingInterface,
+	InAppMessagingConfig,
+	InAppMessageConflictHandler,
+	InAppMessagingEvent,
+	InAppMessagingProvider,
+	NotificationsSubCategory,
+	OnMessageInteractionEventHandler,
+} from './types';
+
+const STORAGE_KEY_SUFFIX = '_inAppMessages';
+
+const logger = new Logger('Notifications.InAppMessaging');
+
+export default class InAppMessaging implements InAppMessagingInterface {
+	private config: Record<string, any> = {};
+	private conflictHandler: InAppMessageConflictHandler;
+	private listeningForAnalyticEvents = false;
+	private pluggables: InAppMessagingProvider[] = [];
+	private storageSynced = false;
+
+	constructor() {
+		this.config = { storage: new StorageHelper().getStorage() };
+		this.setConflictHandler(this.defaultConflictHandler);
+	}
+
+	/**
+	 * Configure InAppMessaging
+	 * @param {Object} config - InAppMessaging configuration object
+	 */
+	configure = ({
+		listenForAnalyticsEvents = true,
+		...config
+	}: InAppMessagingConfig = {}): InAppMessagingConfig => {
+		this.config = { ...this.config, ...config };
+
+		logger.debug('configure InAppMessaging', this.config);
+
+		this.pluggables.forEach(pluggable => {
+			pluggable.configure(this.config[pluggable.getProviderName()]);
+		});
+
+		if (this.pluggables.length === 0) {
+			this.addPluggable(new AWSPinpointProvider());
+		}
+
+		if (listenForAnalyticsEvents && !this.listeningForAnalyticEvents) {
+			Hub.listen('analytics', this.analyticsListener);
+			this.listeningForAnalyticEvents = true;
+		}
+
+		return this.config;
+	};
+
+	/**
+	 * Get the name of this module
+	 * @returns {string} name of this module
+	 */
+	getModuleName(): NotificationsSubCategory {
+		return 'InAppMessaging';
+	}
+
+	/**
+	 * Get a plugin from added plugins
+	 * @param {string} providerName - the name of the plugin to get
+	 */
+	getPluggable = (providerName: string): InAppMessagingProvider => {
+		const pluggable =
+			this.pluggables.find(
+				pluggable => pluggable.getProviderName() === providerName
+			) ?? null;
+
+		if (!pluggable) {
+			logger.debug(`No plugin found with name ${providerName}`);
+		}
+
+		return pluggable;
+	};
+
+	/**
+	 * Add plugin into InAppMessaging
+	 * @param {InAppMessagingProvider} pluggable - an instance of the plugin
+	 */
+	addPluggable = (pluggable: InAppMessagingProvider): void => {
+		if (
+			pluggable &&
+			pluggable.getCategory() === 'Notifications' &&
+			pluggable.getSubCategory() === 'InAppMessaging'
+		) {
+			if (this.getPluggable(pluggable.getProviderName())) {
+				throw new Error(
+					`Pluggable ${pluggable.getProviderName()} has already been added.`
+				);
+			}
+			this.pluggables.push(pluggable);
+			pluggable.configure(this.config[pluggable.getProviderName()]);
+		}
+	};
+
+	/**
+	 * Remove a plugin from added plugins
+	 * @param {string} providerName - the name of the plugin to remove
+	 */
+	removePluggable = (providerName: string): void => {
+		const index = this.pluggables.findIndex(
+			pluggable => pluggable.getProviderName() === providerName
+		);
+		if (index === -1) {
+			logger.debug(`No plugin found with name ${providerName}`);
+		} else {
+			this.pluggables.splice(index, 1);
+		}
+	};
+
+	/**
+	 * Get the map resources that are currently available through the provider
+	 * @param {string} provider
+	 * @returns - Array of available map resources
+	 */
+	syncMessages = (): Promise<void[]> =>
+		Promise.all<void>(
+			this.pluggables.map(async pluggable => {
+				try {
+					const messages = await pluggable.getInAppMessages();
+					const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
+					await this.setMessages(key, messages);
+				} catch (err) {
+					logger.error('Failed to sync messages', err);
+					throw err;
+				}
+			})
+		);
+
+	clearMessages = (): Promise<void[]> =>
+		Promise.all<void>(
+			this.pluggables.map(async pluggable => {
+				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
+				await this.removeMessages(key);
+			})
+		);
+
+	dispatchEvent = async (event: InAppMessagingEvent): Promise<void> => {
+		const messages: InAppMessage[][] = await Promise.all<InAppMessage[]>(
+			this.pluggables.map(async pluggable => {
+				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
+				const messages = await this.getMessages(key);
+				return pluggable.processInAppMessages(messages, event);
+			})
+		);
+
+		const flattenedMessages = flatten(messages);
+
+		if (flattenedMessages.length) {
+			notifyEventListeners(
+				InAppMessageInteractionEvent.MESSAGE_RECEIVED,
+				this.conflictHandler(flattenedMessages)
+			);
+		}
+	};
+
+	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> =>
+		Promise.all<void>(
+			this.pluggables.map(async pluggable => {
+				try {
+					await pluggable.identifyUser(userId, userInfo);
+				} catch (err) {
+					logger.error('Failed to identify user', err);
+					throw err;
+				}
+			})
+		);
+
+	onMessageReceived = (
+		handler: OnMessageInteractionEventHandler
+	): EventListener<OnMessageInteractionEventHandler> =>
+		addEventListener(InAppMessageInteractionEvent.MESSAGE_RECEIVED, handler);
+
+	onMessageDisplayed = (
+		handler: OnMessageInteractionEventHandler
+	): EventListener<OnMessageInteractionEventHandler> =>
+		addEventListener(InAppMessageInteractionEvent.MESSAGE_DISPLAYED, handler);
+
+	onMessageDismissed = (
+		handler: OnMessageInteractionEventHandler
+	): EventListener<OnMessageInteractionEventHandler> =>
+		addEventListener(InAppMessageInteractionEvent.MESSAGE_DISMISSED, handler);
+
+	onMessageActionTaken = (
+		handler: OnMessageInteractionEventHandler
+	): EventListener<OnMessageInteractionEventHandler> =>
+		addEventListener(
+			InAppMessageInteractionEvent.MESSAGE_ACTION_TAKEN,
+			handler
+		);
+
+	notifyMessageInteraction = (
+		message: InAppMessage,
+		type: InAppMessageInteractionEvent
+	): void => {
+		notifyEventListeners(type, message);
+	};
+
+	setConflictHandler = (handler: InAppMessageConflictHandler): void => {
+		this.conflictHandler = handler;
+	};
+
+	private analyticsListener: HubCallback = ({ payload }: HubCapsule) => {
+		const { event, data } = payload;
+		switch (event) {
+			case 'record': {
+				this.dispatchEvent(data);
+				break;
+			}
+			default:
+				break;
+		}
+	};
+
+	private syncStorage = async (): Promise<void> => {
+		const { storage } = this.config;
+		try {
+			// Only run sync() if it's available (i.e. React Native)
+			if (typeof storage.sync === 'function') {
+				await storage.sync();
+			}
+			this.storageSynced = true;
+		} catch (err) {
+			logger.error('Failed to sync storage', err);
+		}
+	};
+
+	private getMessages = async (key: string): Promise<any> => {
+		try {
+			if (!this.storageSynced) {
+				await this.syncStorage();
+			}
+			const { storage } = this.config;
+			const storedMessages = storage.getItem(key);
+			return storedMessages ? JSON.parse(storedMessages) : [];
+		} catch (err) {
+			logger.error('Failed to retrieve in-app messages from storage', err);
+		}
+	};
+
+	private setMessages = async (
+		key: string,
+		messages: InAppMessage[]
+	): Promise<void> => {
+		if (!messages) {
+			return;
+		}
+
+		try {
+			if (!this.storageSynced) {
+				await this.syncStorage();
+			}
+			const { storage } = this.config;
+			storage.setItem(key, JSON.stringify(messages));
+		} catch (err) {
+			logger.error('Failed to store in-app messages', err);
+		}
+	};
+
+	private removeMessages = async (key: string): Promise<void> => {
+		try {
+			if (!this.storageSynced) {
+				await this.syncStorage();
+			}
+			const { storage } = this.config;
+			storage.removeItem(key);
+		} catch (err) {
+			logger.error('Failed to remove in-app messages from storage', err);
+		}
+	};
+
+	private defaultConflictHandler = (messages: InAppMessage[]): InAppMessage => {
+		// default behavior is to return the message closest to expiry
+		// this function assumes that messages processed by providers already filters out expired messages
+		const sorted = messages.sort((a, b) => {
+			const endDateA = a.metadata?.endDate;
+			const endDateB = b.metadata?.endDate;
+			// if both message end dates are falsy or have the same date string, treat them as equal
+			if (endDateA === endDateB) {
+				return 0;
+			}
+			// if only message A has an end date, treat it as closer to expiry
+			if (endDateA && !endDateB) {
+				return -1;
+			}
+			// if only message B has an end date, treat it as closer to expiry
+			if (!endDateA && endDateB) {
+				return 1;
+			}
+			// otherwise, compare them
+			return new Date(endDateA) < new Date(endDateB) ? -1 : 1;
+		});
+		// always return the top sorted
+		return sorted[0];
+	};
+}

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -9,6 +9,7 @@ import {
 	Hub,
 	StorageHelper,
 	CustomUserAgentDetails,
+	InAppMessagingAction,
 } from '@aws-amplify/core';
 import flatten from 'lodash/flatten';
 
@@ -31,6 +32,7 @@ import {
 	InternalNotifcationsSubCategory,
 	NotificationsSubCategory,
 } from '../types';
+import { getUserAgentValue } from './utils';
 
 const STORAGE_KEY_SUFFIX = '_inAppMessages';
 
@@ -147,7 +149,12 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 		return Promise.all<void>(
 			this.pluggables.map(async pluggable => {
 				try {
-					const messages = await pluggable.getInAppMessages();
+					const messages = await pluggable.getInAppMessages(
+						getUserAgentValue(
+							InAppMessagingAction.SyncMesssages,
+							customUserAgentDetails
+						)
+					);
 					const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
 					await this.setMessages(key, messages);
 				} catch (err) {

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -165,9 +165,7 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 		);
 	}
 
-	public clearMessages(
-		customUserAgentDetails?: CustomUserAgentDetails
-	): Promise<void[]> {
+	public clearMessages(): Promise<void[]> {
 		return Promise.all<void>(
 			this.pluggables.map(async pluggable => {
 				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
@@ -176,10 +174,7 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 		);
 	}
 
-	public async dispatchEvent(
-		event: InAppMessagingEvent,
-		customUserAgentDetails?: CustomUserAgentDetails
-	): Promise<void> {
+	public async dispatchEvent(event: InAppMessagingEvent): Promise<void> {
 		const messages: InAppMessage[][] = await Promise.all<InAppMessage[]>(
 			this.pluggables.map(async pluggable => {
 				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -201,7 +201,14 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 		return Promise.all<void>(
 			this.pluggables.map(async pluggable => {
 				try {
-					await pluggable.identifyUser(userId, userInfo);
+					await pluggable.identifyUser(
+						userId,
+						userInfo,
+						getUserAgentValue(
+							InAppMessagingAction.IdentifyUser,
+							customUserAgentDetails
+						)
+					);
 				} catch (err) {
 					logger.error('Failed to identify user', err);
 					throw err;

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -7,6 +7,7 @@ import {
 	HubCapsule,
 	Hub,
 	StorageHelper,
+	CustomUserAgentDetails,
 } from '@aws-amplify/core';
 import flatten from 'lodash/flatten';
 
@@ -14,9 +15,9 @@ import {
 	addEventListener,
 	EventListener,
 	notifyEventListeners,
-} from '../common';
-import { UserInfo } from '../types';
-import { AWSPinpointProvider } from './Providers';
+} from '../../common';
+import { UserInfo } from '../../types';
+import { AWSPinpointProvider } from '../Providers';
 import {
 	InAppMessage,
 	InAppMessageInteractionEvent,
@@ -25,15 +26,15 @@ import {
 	InAppMessageConflictHandler,
 	InAppMessagingEvent,
 	InAppMessagingProvider,
-	NotificationsSubCategory,
 	OnMessageInteractionEventHandler,
-} from './types';
+	InternalNotifcationsSubCategory,
+} from '../types';
 
 const STORAGE_KEY_SUFFIX = '_inAppMessages';
 
 const logger = new Logger('Notifications.InAppMessaging');
 
-export default class InAppMessaging implements InAppMessagingInterface {
+export default class InternalInAppMessaging implements InAppMessagingInterface {
 	private config: Record<string, any> = {};
 	private conflictHandler: InAppMessageConflictHandler;
 	private listeningForAnalyticEvents = false;
@@ -77,8 +78,8 @@ export default class InAppMessaging implements InAppMessagingInterface {
 	 * Get the name of this module
 	 * @returns {string} name of this module
 	 */
-	getModuleName(): NotificationsSubCategory {
-		return 'InAppMessaging';
+	getModuleName(): InternalNotifcationsSubCategory {
+		return 'InternalInAppMessaging';
 	}
 
 	/**
@@ -138,7 +139,9 @@ export default class InAppMessaging implements InAppMessagingInterface {
 	 * @param {string} provider
 	 * @returns - Array of available map resources
 	 */
-	syncMessages = (): Promise<void[]> =>
+	syncMessages = (
+		customUserAgentDetails?: CustomUserAgentDetails
+	): Promise<void[]> =>
 		Promise.all<void>(
 			this.pluggables.map(async pluggable => {
 				try {
@@ -152,7 +155,9 @@ export default class InAppMessaging implements InAppMessagingInterface {
 			})
 		);
 
-	clearMessages = (): Promise<void[]> =>
+	clearMessages = (
+		customUserAgentDetails?: CustomUserAgentDetails
+	): Promise<void[]> =>
 		Promise.all<void>(
 			this.pluggables.map(async pluggable => {
 				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
@@ -160,7 +165,10 @@ export default class InAppMessaging implements InAppMessagingInterface {
 			})
 		);
 
-	dispatchEvent = async (event: InAppMessagingEvent): Promise<void> => {
+	dispatchEvent = async (
+		event: InAppMessagingEvent,
+		customUserAgentDetails?: CustomUserAgentDetails
+	): Promise<void> => {
 		const messages: InAppMessage[][] = await Promise.all<InAppMessage[]>(
 			this.pluggables.map(async pluggable => {
 				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
@@ -179,7 +187,11 @@ export default class InAppMessaging implements InAppMessagingInterface {
 		}
 	};
 
-	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> =>
+	identifyUser = (
+		userId: string,
+		userInfo: UserInfo,
+		customUserAgentDetails?: CustomUserAgentDetails
+	): Promise<void[]> =>
 		Promise.all<void>(
 			this.pluggables.map(async pluggable => {
 				try {

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -151,7 +151,7 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 				try {
 					const messages = await pluggable.getInAppMessages(
 						getUserAgentValue(
-							InAppMessagingAction.SyncMesssages,
+							InAppMessagingAction.SyncMessages,
 							customUserAgentDetails
 						)
 					);

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -348,5 +348,5 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 	};
 }
 
-const InternalInAppMessaging = new InternalInAppMessagingClass();
+export const InternalInAppMessaging = new InternalInAppMessagingClass();
 Amplify.register(InternalInAppMessaging);

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -18,7 +18,7 @@ import {
 	EventListener,
 	notifyEventListeners,
 } from '../../common';
-import { UserInfo } from '../../types';
+import { NotificationsConfig, UserInfo } from '../../types';
 import { AWSPinpointProvider } from '../Providers';
 import {
 	InAppMessage,
@@ -54,10 +54,12 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 	 * Configure InAppMessaging
 	 * @param {Object} config - InAppMessaging configuration object
 	 */
-	configure = ({
-		listenForAnalyticsEvents = true,
-		...config
-	}: InAppMessagingConfig = {}): InAppMessagingConfig => {
+	configure({
+		Notifications: notificationsConfig,
+	}: NotificationsConfig = {}): InAppMessagingConfig {
+		const { listenForAnalyticsEvents = true, ...config }: InAppMessagingConfig =
+			notificationsConfig?.InAppMessaging || {};
+
 		this.config = { ...this.config, ...config };
 
 		logger.debug('configure InAppMessaging', this.config);
@@ -76,7 +78,7 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 		}
 
 		return this.config;
-	};
+	}
 
 	/**
 	 * Get the name of this module

--- a/packages/notifications/src/InAppMessaging/internals/index.ts
+++ b/packages/notifications/src/InAppMessaging/internals/index.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { InternalInAppMessaging } from './InternalInAppMessaging';

--- a/packages/notifications/src/InAppMessaging/internals/utils.ts
+++ b/packages/notifications/src/InAppMessaging/internals/utils.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	Category,
+	CustomUserAgentDetails,
+	getAmplifyUserAgent,
+	InAppMessagingAction,
+} from '@aws-amplify/core';
+
+export const getUserAgentValue = (
+	action: InAppMessagingAction,
+	customUserAgentDetails?: CustomUserAgentDetails
+) => {
+	return getAmplifyUserAgent({
+		category: Category.InAppMessaging,
+		action,
+		...customUserAgentDetails,
+	});
+};

--- a/packages/notifications/src/InAppMessaging/types.ts
+++ b/packages/notifications/src/InAppMessaging/types.ts
@@ -4,6 +4,7 @@
 import { EventListener } from '../common';
 import { AWSPinpointProviderConfig } from '../common/AWSPinpointProviderCommon/types';
 import {
+	NotificationsConfig,
 	NotificationsProvider,
 	NotificationsSubCategory as NotificationsSubCategories,
 	UserInfo,
@@ -16,7 +17,7 @@ export type NotificationsSubCategory = Extract<
 export type InternalNotifcationsSubCategory = 'InternalInAppMessaging';
 
 export interface InAppMessagingInterface {
-	configure: (config: InAppMessagingConfig) => InAppMessagingConfig;
+	configure: (config: NotificationsConfig) => InAppMessagingConfig;
 	getModuleName: () =>
 		| NotificationsSubCategory
 		| InternalNotifcationsSubCategory;

--- a/packages/notifications/src/InAppMessaging/types.ts
+++ b/packages/notifications/src/InAppMessaging/types.ts
@@ -51,7 +51,7 @@ export interface InAppMessagingProvider extends NotificationsProvider {
 	getSubCategory(): NotificationsSubCategory;
 
 	// get in-app messages from provider
-	getInAppMessages(): Promise<any>;
+	getInAppMessages(userAgentValue?: string): Promise<any>;
 
 	// filters in-app messages based on event input and provider logic
 	processInAppMessages(

--- a/packages/notifications/src/InAppMessaging/types.ts
+++ b/packages/notifications/src/InAppMessaging/types.ts
@@ -13,10 +13,13 @@ export type NotificationsSubCategory = Extract<
 	NotificationsSubCategories,
 	'InAppMessaging'
 >;
+export type InternalNotifcationsSubCategory = 'InternalInAppMessaging';
 
 export interface InAppMessagingInterface {
 	configure: (config: InAppMessagingConfig) => InAppMessagingConfig;
-	getModuleName: () => NotificationsSubCategory;
+	getModuleName: () =>
+		| NotificationsSubCategory
+		| InternalNotifcationsSubCategory;
 	getPluggable: (providerName: string) => InAppMessagingProvider;
 	addPluggable: (pluggable: InAppMessagingProvider) => void;
 	removePluggable: (providerName: string) => void;

--- a/packages/notifications/src/Notifications.ts
+++ b/packages/notifications/src/Notifications.ts
@@ -38,7 +38,7 @@ class NotificationsClass {
 		logger.debug('configure Notifications', config);
 
 		// Configure sub-categories
-		this.inAppMessaging.configure(this.config.InAppMessaging);
+		this.inAppMessaging.configure({ Notifications: this.config });
 
 		if (this.config.Push) {
 			try {

--- a/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
+++ b/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
@@ -77,12 +77,16 @@ export default abstract class AWSPinpointProviderCommon
 		return this.config;
 	}
 
-	identifyUser = async (userId: string, userInfo: UserInfo): Promise<void> => {
+	identifyUser = async (
+		userId: string,
+		userInfo: UserInfo,
+		userAgentValue?: string
+	): Promise<void> => {
 		if (!this.initialized) {
 			await this.init();
 		}
 		try {
-			await this.updateEndpoint(userId, userInfo);
+			await this.updateEndpoint(userId, userInfo, userAgentValue);
 		} catch (err) {
 			this.logger.error('Error identifying user', err);
 			throw err;
@@ -161,7 +165,8 @@ export default abstract class AWSPinpointProviderCommon
 
 	protected updateEndpoint = async (
 		userId: string = null,
-		userInfo: AWSPinpointUserInfo = null
+		userInfo: AWSPinpointUserInfo = null,
+		userAgentValue?: string
 	): Promise<void> => {
 		const credentials = await this.getCredentials();
 		// Shallow compare to determine if credentials stored here are outdated
@@ -230,7 +235,11 @@ export default abstract class AWSPinpointProviderCommon
 			};
 			this.logger.debug('updating endpoint');
 			await updateEndpoint(
-				{ credentials, region, userAgentValue: this.getUserAgentValue() },
+				{
+					credentials,
+					region,
+					userAgentValue: userAgentValue || this.getUserAgentValue(),
+				},
 				input
 			);
 			this.endpointInitialized = true;

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -22,7 +22,11 @@ export interface NotificationsProvider {
 	getProviderName(): string;
 
 	// identify the current user with the provider
-	identifyUser(userId: string, userInfo: UserInfo): Promise<void>;
+	identifyUser(
+		userId: string,
+		userInfo: UserInfo,
+		userAgentValue?: string
+	): Promise<void>;
 }
 
 export interface NotificationsConfig {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Creates and exports InternalInAppMessaging class from /internals/inAppMessaging scope with added customUserAgentDetails parameter on public API's that result in service calls
- Sends received customUserAgentDetails through to storage service calls
- Altered InAppMessaging and InternalInAppMessaging to be able to be configured independently of Notifications Class

NOTES
- This is the first of two options for InternalInAppMessaging: option 2 lives in [this PR](https://github.com/aws-amplify/amplify-js/pull/11631)
- To see the changes to InternalInAppMessaging after moving the changes over from InAppMessaging, see [this comparison](https://github.com/erinleigh90/amplify-js/compare/e7229f15ad6e700412bab91891172b46e332422a...6439c12a3758d60418331ed565b1e52804e22de4#diff-eaa168799ccf04080fe2ca3fdb0f6fcec87a64264d789c1905e653628b6912ec)


#### Description of how you validated changes
yarn tests pass


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x]  Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
