### PR TITLE
feat: custom user agent InAppMessaging changes for UI handoff (Option 2)

### DIFF
--- a/packages/core/src/Platform/types.ts
+++ b/packages/core/src/Platform/types.ts
@@ -98,6 +98,7 @@ export enum GeoAction {
 export enum InAppMessagingAction {
 	None = '0',
 	SyncMessages = '1',
+	IdentifyUser = '2',
 }
 export enum InteractionsAction {
 	None = '0',

--- a/packages/core/src/Platform/types.ts
+++ b/packages/core/src/Platform/types.ts
@@ -97,6 +97,7 @@ export enum GeoAction {
 }
 export enum InAppMessagingAction {
 	None = '0',
+	SyncMessages = '1',
 }
 export enum InteractionsAction {
 	None = '0',

--- a/packages/notifications/__tests__/InAppMessaging/InAppMessaging.test.ts
+++ b/packages/notifications/__tests__/InAppMessaging/InAppMessaging.test.ts
@@ -6,6 +6,7 @@ import {
 	Hub,
 	HubCallback,
 	HubCapsule,
+	InAppMessagingAction,
 	StorageHelper,
 } from '@aws-amplify/core';
 
@@ -27,6 +28,7 @@ import {
 import InAppMessaging, {
 	InAppMessageInteractionEvent,
 } from '../../src/InAppMessaging';
+import { getUserAgentValue } from '../../src/InAppMessaging/internals/utils';
 
 jest.mock('@aws-amplify/core');
 jest.mock('../../src/common/eventListeners');
@@ -286,7 +288,8 @@ describe('InAppMessaging', () => {
 
 			expect(mockInAppMessagingProvider.identifyUser).toBeCalledWith(
 				userId,
-				userInfo
+				userInfo,
+				getUserAgentValue(InAppMessagingAction.IdentifyUser)
 			);
 		});
 

--- a/packages/notifications/internals/package.json
+++ b/packages/notifications/internals/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@aws-amplify/notifications/internals",
+	"types": "../lib-esm/internals/index.d.ts",
+	"main": "../lib/internals/index.js",
+	"module": "../lib-esm/internals/index.js",
+	"react-native": "../lib-esm/internals/index.js",
+	"sideEffects": false
+}

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -46,7 +46,8 @@
 	"files": [
 		"lib",
 		"lib-esm",
-		"src"
+		"src",
+		"internals"
 	],
 	"dependencies": {
 		"@aws-amplify/cache": "5.1.4",

--- a/packages/notifications/src/InAppMessaging/InAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/InAppMessaging.ts
@@ -2,11 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { UserInfo } from '../types';
-import {
-	InAppMessagingInterface,
-	InAppMessagingEvent,
-	NotificationsSubCategory,
-} from './types';
+import { InAppMessagingInterface, NotificationsSubCategory } from './types';
 import { InternalInAppMessagingClass } from './internals/InternalInAppMessaging';
 
 export default class InAppMessaging

--- a/packages/notifications/src/InAppMessaging/InAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/InAppMessaging.ts
@@ -28,11 +28,6 @@ export default class InAppMessaging
 	 */
 	syncMessages = (): Promise<void[]> => super.syncMessages();
 
-	clearMessages = (): Promise<void[]> => super.clearMessages();
-
-	dispatchEvent = async (event: InAppMessagingEvent): Promise<void> =>
-		super.dispatchEvent(event);
-
 	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> =>
 		super.identifyUser(userId, userInfo);
 }

--- a/packages/notifications/src/InAppMessaging/InAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/InAppMessaging.ts
@@ -1,78 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-	ConsoleLogger as Logger,
-	HubCallback,
-	HubCapsule,
-	Hub,
-	StorageHelper,
-} from '@aws-amplify/core';
-import flatten from 'lodash/flatten';
-
-import {
-	addEventListener,
-	EventListener,
-	notifyEventListeners,
-} from '../common';
 import { UserInfo } from '../types';
-import { AWSPinpointProvider } from './Providers';
 import {
-	InAppMessage,
-	InAppMessageInteractionEvent,
 	InAppMessagingInterface,
-	InAppMessagingConfig,
-	InAppMessageConflictHandler,
 	InAppMessagingEvent,
-	InAppMessagingProvider,
 	NotificationsSubCategory,
-	OnMessageInteractionEventHandler,
 } from './types';
+import { InternalInAppMessagingClass } from './internals/InternalInAppMessaging';
 
-const STORAGE_KEY_SUFFIX = '_inAppMessages';
-
-const logger = new Logger('Notifications.InAppMessaging');
-
-export default class InAppMessaging implements InAppMessagingInterface {
-	private config: Record<string, any> = {};
-	private conflictHandler: InAppMessageConflictHandler;
-	private listeningForAnalyticEvents = false;
-	private pluggables: InAppMessagingProvider[] = [];
-	private storageSynced = false;
-
-	constructor() {
-		this.config = { storage: new StorageHelper().getStorage() };
-		this.setConflictHandler(this.defaultConflictHandler);
-	}
-
-	/**
-	 * Configure InAppMessaging
-	 * @param {Object} config - InAppMessaging configuration object
-	 */
-	configure = ({
-		listenForAnalyticsEvents = true,
-		...config
-	}: InAppMessagingConfig = {}): InAppMessagingConfig => {
-		this.config = { ...this.config, ...config };
-
-		logger.debug('configure InAppMessaging', this.config);
-
-		this.pluggables.forEach(pluggable => {
-			pluggable.configure(this.config[pluggable.getProviderName()]);
-		});
-
-		if (this.pluggables.length === 0) {
-			this.addPluggable(new AWSPinpointProvider());
-		}
-
-		if (listenForAnalyticsEvents && !this.listeningForAnalyticEvents) {
-			Hub.listen('analytics', this.analyticsListener);
-			this.listeningForAnalyticEvents = true;
-		}
-
-		return this.config;
-	};
-
+export default class InAppMessaging
+	extends InternalInAppMessagingClass
+	implements InAppMessagingInterface
+{
 	/**
 	 * Get the name of this module
 	 * @returns {string} name of this module
@@ -82,240 +22,17 @@ export default class InAppMessaging implements InAppMessagingInterface {
 	}
 
 	/**
-	 * Get a plugin from added plugins
-	 * @param {string} providerName - the name of the plugin to get
-	 */
-	getPluggable = (providerName: string): InAppMessagingProvider => {
-		const pluggable =
-			this.pluggables.find(
-				pluggable => pluggable.getProviderName() === providerName
-			) ?? null;
-
-		if (!pluggable) {
-			logger.debug(`No plugin found with name ${providerName}`);
-		}
-
-		return pluggable;
-	};
-
-	/**
-	 * Add plugin into InAppMessaging
-	 * @param {InAppMessagingProvider} pluggable - an instance of the plugin
-	 */
-	addPluggable = (pluggable: InAppMessagingProvider): void => {
-		if (
-			pluggable &&
-			pluggable.getCategory() === 'Notifications' &&
-			pluggable.getSubCategory() === 'InAppMessaging'
-		) {
-			if (this.getPluggable(pluggable.getProviderName())) {
-				throw new Error(
-					`Pluggable ${pluggable.getProviderName()} has already been added.`
-				);
-			}
-			this.pluggables.push(pluggable);
-			pluggable.configure(this.config[pluggable.getProviderName()]);
-		}
-	};
-
-	/**
-	 * Remove a plugin from added plugins
-	 * @param {string} providerName - the name of the plugin to remove
-	 */
-	removePluggable = (providerName: string): void => {
-		const index = this.pluggables.findIndex(
-			pluggable => pluggable.getProviderName() === providerName
-		);
-		if (index === -1) {
-			logger.debug(`No plugin found with name ${providerName}`);
-		} else {
-			this.pluggables.splice(index, 1);
-		}
-	};
-
-	/**
 	 * Get the map resources that are currently available through the provider
 	 * @param {string} provider
 	 * @returns - Array of available map resources
 	 */
-	syncMessages = (): Promise<void[]> =>
-		Promise.all<void>(
-			this.pluggables.map(async pluggable => {
-				try {
-					const messages = await pluggable.getInAppMessages();
-					const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
-					await this.setMessages(key, messages);
-				} catch (err) {
-					logger.error('Failed to sync messages', err);
-					throw err;
-				}
-			})
-		);
+	syncMessages = (): Promise<void[]> => super.syncMessages();
 
-	clearMessages = (): Promise<void[]> =>
-		Promise.all<void>(
-			this.pluggables.map(async pluggable => {
-				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
-				await this.removeMessages(key);
-			})
-		);
+	clearMessages = (): Promise<void[]> => super.clearMessages();
 
-	dispatchEvent = async (event: InAppMessagingEvent): Promise<void> => {
-		const messages: InAppMessage[][] = await Promise.all<InAppMessage[]>(
-			this.pluggables.map(async pluggable => {
-				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
-				const messages = await this.getMessages(key);
-				return pluggable.processInAppMessages(messages, event);
-			})
-		);
-
-		const flattenedMessages = flatten(messages);
-
-		if (flattenedMessages.length) {
-			notifyEventListeners(
-				InAppMessageInteractionEvent.MESSAGE_RECEIVED,
-				this.conflictHandler(flattenedMessages)
-			);
-		}
-	};
+	dispatchEvent = async (event: InAppMessagingEvent): Promise<void> =>
+		super.dispatchEvent(event);
 
 	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> =>
-		Promise.all<void>(
-			this.pluggables.map(async pluggable => {
-				try {
-					await pluggable.identifyUser(userId, userInfo);
-				} catch (err) {
-					logger.error('Failed to identify user', err);
-					throw err;
-				}
-			})
-		);
-
-	onMessageReceived = (
-		handler: OnMessageInteractionEventHandler
-	): EventListener<OnMessageInteractionEventHandler> =>
-		addEventListener(InAppMessageInteractionEvent.MESSAGE_RECEIVED, handler);
-
-	onMessageDisplayed = (
-		handler: OnMessageInteractionEventHandler
-	): EventListener<OnMessageInteractionEventHandler> =>
-		addEventListener(InAppMessageInteractionEvent.MESSAGE_DISPLAYED, handler);
-
-	onMessageDismissed = (
-		handler: OnMessageInteractionEventHandler
-	): EventListener<OnMessageInteractionEventHandler> =>
-		addEventListener(InAppMessageInteractionEvent.MESSAGE_DISMISSED, handler);
-
-	onMessageActionTaken = (
-		handler: OnMessageInteractionEventHandler
-	): EventListener<OnMessageInteractionEventHandler> =>
-		addEventListener(
-			InAppMessageInteractionEvent.MESSAGE_ACTION_TAKEN,
-			handler
-		);
-
-	notifyMessageInteraction = (
-		message: InAppMessage,
-		type: InAppMessageInteractionEvent
-	): void => {
-		notifyEventListeners(type, message);
-	};
-
-	setConflictHandler = (handler: InAppMessageConflictHandler): void => {
-		this.conflictHandler = handler;
-	};
-
-	private analyticsListener: HubCallback = ({ payload }: HubCapsule) => {
-		const { event, data } = payload;
-		switch (event) {
-			case 'record': {
-				this.dispatchEvent(data);
-				break;
-			}
-			default:
-				break;
-		}
-	};
-
-	private syncStorage = async (): Promise<void> => {
-		const { storage } = this.config;
-		try {
-			// Only run sync() if it's available (i.e. React Native)
-			if (typeof storage.sync === 'function') {
-				await storage.sync();
-			}
-			this.storageSynced = true;
-		} catch (err) {
-			logger.error('Failed to sync storage', err);
-		}
-	};
-
-	private getMessages = async (key: string): Promise<any> => {
-		try {
-			if (!this.storageSynced) {
-				await this.syncStorage();
-			}
-			const { storage } = this.config;
-			const storedMessages = storage.getItem(key);
-			return storedMessages ? JSON.parse(storedMessages) : [];
-		} catch (err) {
-			logger.error('Failed to retrieve in-app messages from storage', err);
-		}
-	};
-
-	private setMessages = async (
-		key: string,
-		messages: InAppMessage[]
-	): Promise<void> => {
-		if (!messages) {
-			return;
-		}
-
-		try {
-			if (!this.storageSynced) {
-				await this.syncStorage();
-			}
-			const { storage } = this.config;
-			storage.setItem(key, JSON.stringify(messages));
-		} catch (err) {
-			logger.error('Failed to store in-app messages', err);
-		}
-	};
-
-	private removeMessages = async (key: string): Promise<void> => {
-		try {
-			if (!this.storageSynced) {
-				await this.syncStorage();
-			}
-			const { storage } = this.config;
-			storage.removeItem(key);
-		} catch (err) {
-			logger.error('Failed to remove in-app messages from storage', err);
-		}
-	};
-
-	private defaultConflictHandler = (messages: InAppMessage[]): InAppMessage => {
-		// default behavior is to return the message closest to expiry
-		// this function assumes that messages processed by providers already filters out expired messages
-		const sorted = messages.sort((a, b) => {
-			const endDateA = a.metadata?.endDate;
-			const endDateB = b.metadata?.endDate;
-			// if both message end dates are falsy or have the same date string, treat them as equal
-			if (endDateA === endDateB) {
-				return 0;
-			}
-			// if only message A has an end date, treat it as closer to expiry
-			if (endDateA && !endDateB) {
-				return -1;
-			}
-			// if only message B has an end date, treat it as closer to expiry
-			if (!endDateA && endDateB) {
-				return 1;
-			}
-			// otherwise, compare them
-			return new Date(endDateA) < new Date(endDateB) ? -1 : 1;
-		});
-		// always return the top sorted
-		return sorted[0];
-	};
+		super.identifyUser(userId, userInfo);
 }

--- a/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/index.ts
+++ b/packages/notifications/src/InAppMessaging/Providers/AWSPinpointProvider/index.ts
@@ -111,7 +111,7 @@ export default class AWSPinpointProvider
 		return this.config;
 	};
 
-	getInAppMessages = async () => {
+	getInAppMessages = async (userAgentValue?: string) => {
 		if (!this.initialized) {
 			await this.init();
 		}
@@ -129,7 +129,7 @@ export default class AWSPinpointProvider
 			};
 			this.logger.debug('getting in-app messages');
 			const response: GetInAppMessagesOutput = await getInAppMessages(
-				{ credentials, region },
+				{ credentials, region, userAgentValue },
 				input
 			);
 			const { InAppMessageCampaigns: messages } =

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -1,0 +1,321 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	ConsoleLogger as Logger,
+	HubCallback,
+	HubCapsule,
+	Hub,
+	StorageHelper,
+} from '@aws-amplify/core';
+import flatten from 'lodash/flatten';
+
+import {
+	addEventListener,
+	EventListener,
+	notifyEventListeners,
+} from '../common';
+import { UserInfo } from '../types';
+import { AWSPinpointProvider } from './Providers';
+import {
+	InAppMessage,
+	InAppMessageInteractionEvent,
+	InAppMessagingInterface,
+	InAppMessagingConfig,
+	InAppMessageConflictHandler,
+	InAppMessagingEvent,
+	InAppMessagingProvider,
+	NotificationsSubCategory,
+	OnMessageInteractionEventHandler,
+} from './types';
+
+const STORAGE_KEY_SUFFIX = '_inAppMessages';
+
+const logger = new Logger('Notifications.InAppMessaging');
+
+export default class InAppMessaging implements InAppMessagingInterface {
+	private config: Record<string, any> = {};
+	private conflictHandler: InAppMessageConflictHandler;
+	private listeningForAnalyticEvents = false;
+	private pluggables: InAppMessagingProvider[] = [];
+	private storageSynced = false;
+
+	constructor() {
+		this.config = { storage: new StorageHelper().getStorage() };
+		this.setConflictHandler(this.defaultConflictHandler);
+	}
+
+	/**
+	 * Configure InAppMessaging
+	 * @param {Object} config - InAppMessaging configuration object
+	 */
+	configure = ({
+		listenForAnalyticsEvents = true,
+		...config
+	}: InAppMessagingConfig = {}): InAppMessagingConfig => {
+		this.config = { ...this.config, ...config };
+
+		logger.debug('configure InAppMessaging', this.config);
+
+		this.pluggables.forEach(pluggable => {
+			pluggable.configure(this.config[pluggable.getProviderName()]);
+		});
+
+		if (this.pluggables.length === 0) {
+			this.addPluggable(new AWSPinpointProvider());
+		}
+
+		if (listenForAnalyticsEvents && !this.listeningForAnalyticEvents) {
+			Hub.listen('analytics', this.analyticsListener);
+			this.listeningForAnalyticEvents = true;
+		}
+
+		return this.config;
+	};
+
+	/**
+	 * Get the name of this module
+	 * @returns {string} name of this module
+	 */
+	getModuleName(): NotificationsSubCategory {
+		return 'InAppMessaging';
+	}
+
+	/**
+	 * Get a plugin from added plugins
+	 * @param {string} providerName - the name of the plugin to get
+	 */
+	getPluggable = (providerName: string): InAppMessagingProvider => {
+		const pluggable =
+			this.pluggables.find(
+				pluggable => pluggable.getProviderName() === providerName
+			) ?? null;
+
+		if (!pluggable) {
+			logger.debug(`No plugin found with name ${providerName}`);
+		}
+
+		return pluggable;
+	};
+
+	/**
+	 * Add plugin into InAppMessaging
+	 * @param {InAppMessagingProvider} pluggable - an instance of the plugin
+	 */
+	addPluggable = (pluggable: InAppMessagingProvider): void => {
+		if (
+			pluggable &&
+			pluggable.getCategory() === 'Notifications' &&
+			pluggable.getSubCategory() === 'InAppMessaging'
+		) {
+			if (this.getPluggable(pluggable.getProviderName())) {
+				throw new Error(
+					`Pluggable ${pluggable.getProviderName()} has already been added.`
+				);
+			}
+			this.pluggables.push(pluggable);
+			pluggable.configure(this.config[pluggable.getProviderName()]);
+		}
+	};
+
+	/**
+	 * Remove a plugin from added plugins
+	 * @param {string} providerName - the name of the plugin to remove
+	 */
+	removePluggable = (providerName: string): void => {
+		const index = this.pluggables.findIndex(
+			pluggable => pluggable.getProviderName() === providerName
+		);
+		if (index === -1) {
+			logger.debug(`No plugin found with name ${providerName}`);
+		} else {
+			this.pluggables.splice(index, 1);
+		}
+	};
+
+	/**
+	 * Get the map resources that are currently available through the provider
+	 * @param {string} provider
+	 * @returns - Array of available map resources
+	 */
+	syncMessages = (): Promise<void[]> =>
+		Promise.all<void>(
+			this.pluggables.map(async pluggable => {
+				try {
+					const messages = await pluggable.getInAppMessages();
+					const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
+					await this.setMessages(key, messages);
+				} catch (err) {
+					logger.error('Failed to sync messages', err);
+					throw err;
+				}
+			})
+		);
+
+	clearMessages = (): Promise<void[]> =>
+		Promise.all<void>(
+			this.pluggables.map(async pluggable => {
+				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
+				await this.removeMessages(key);
+			})
+		);
+
+	dispatchEvent = async (event: InAppMessagingEvent): Promise<void> => {
+		const messages: InAppMessage[][] = await Promise.all<InAppMessage[]>(
+			this.pluggables.map(async pluggable => {
+				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
+				const messages = await this.getMessages(key);
+				return pluggable.processInAppMessages(messages, event);
+			})
+		);
+
+		const flattenedMessages = flatten(messages);
+
+		if (flattenedMessages.length) {
+			notifyEventListeners(
+				InAppMessageInteractionEvent.MESSAGE_RECEIVED,
+				this.conflictHandler(flattenedMessages)
+			);
+		}
+	};
+
+	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> =>
+		Promise.all<void>(
+			this.pluggables.map(async pluggable => {
+				try {
+					await pluggable.identifyUser(userId, userInfo);
+				} catch (err) {
+					logger.error('Failed to identify user', err);
+					throw err;
+				}
+			})
+		);
+
+	onMessageReceived = (
+		handler: OnMessageInteractionEventHandler
+	): EventListener<OnMessageInteractionEventHandler> =>
+		addEventListener(InAppMessageInteractionEvent.MESSAGE_RECEIVED, handler);
+
+	onMessageDisplayed = (
+		handler: OnMessageInteractionEventHandler
+	): EventListener<OnMessageInteractionEventHandler> =>
+		addEventListener(InAppMessageInteractionEvent.MESSAGE_DISPLAYED, handler);
+
+	onMessageDismissed = (
+		handler: OnMessageInteractionEventHandler
+	): EventListener<OnMessageInteractionEventHandler> =>
+		addEventListener(InAppMessageInteractionEvent.MESSAGE_DISMISSED, handler);
+
+	onMessageActionTaken = (
+		handler: OnMessageInteractionEventHandler
+	): EventListener<OnMessageInteractionEventHandler> =>
+		addEventListener(
+			InAppMessageInteractionEvent.MESSAGE_ACTION_TAKEN,
+			handler
+		);
+
+	notifyMessageInteraction = (
+		message: InAppMessage,
+		type: InAppMessageInteractionEvent
+	): void => {
+		notifyEventListeners(type, message);
+	};
+
+	setConflictHandler = (handler: InAppMessageConflictHandler): void => {
+		this.conflictHandler = handler;
+	};
+
+	private analyticsListener: HubCallback = ({ payload }: HubCapsule) => {
+		const { event, data } = payload;
+		switch (event) {
+			case 'record': {
+				this.dispatchEvent(data);
+				break;
+			}
+			default:
+				break;
+		}
+	};
+
+	private syncStorage = async (): Promise<void> => {
+		const { storage } = this.config;
+		try {
+			// Only run sync() if it's available (i.e. React Native)
+			if (typeof storage.sync === 'function') {
+				await storage.sync();
+			}
+			this.storageSynced = true;
+		} catch (err) {
+			logger.error('Failed to sync storage', err);
+		}
+	};
+
+	private getMessages = async (key: string): Promise<any> => {
+		try {
+			if (!this.storageSynced) {
+				await this.syncStorage();
+			}
+			const { storage } = this.config;
+			const storedMessages = storage.getItem(key);
+			return storedMessages ? JSON.parse(storedMessages) : [];
+		} catch (err) {
+			logger.error('Failed to retrieve in-app messages from storage', err);
+		}
+	};
+
+	private setMessages = async (
+		key: string,
+		messages: InAppMessage[]
+	): Promise<void> => {
+		if (!messages) {
+			return;
+		}
+
+		try {
+			if (!this.storageSynced) {
+				await this.syncStorage();
+			}
+			const { storage } = this.config;
+			storage.setItem(key, JSON.stringify(messages));
+		} catch (err) {
+			logger.error('Failed to store in-app messages', err);
+		}
+	};
+
+	private removeMessages = async (key: string): Promise<void> => {
+		try {
+			if (!this.storageSynced) {
+				await this.syncStorage();
+			}
+			const { storage } = this.config;
+			storage.removeItem(key);
+		} catch (err) {
+			logger.error('Failed to remove in-app messages from storage', err);
+		}
+	};
+
+	private defaultConflictHandler = (messages: InAppMessage[]): InAppMessage => {
+		// default behavior is to return the message closest to expiry
+		// this function assumes that messages processed by providers already filters out expired messages
+		const sorted = messages.sort((a, b) => {
+			const endDateA = a.metadata?.endDate;
+			const endDateB = b.metadata?.endDate;
+			// if both message end dates are falsy or have the same date string, treat them as equal
+			if (endDateA === endDateB) {
+				return 0;
+			}
+			// if only message A has an end date, treat it as closer to expiry
+			if (endDateA && !endDateB) {
+				return -1;
+			}
+			// if only message B has an end date, treat it as closer to expiry
+			if (!endDateA && endDateB) {
+				return 1;
+			}
+			// otherwise, compare them
+			return new Date(endDateA) < new Date(endDateB) ? -1 : 1;
+		});
+		// always return the top sorted
+		return sorted[0];
+	};
+}

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -9,6 +9,7 @@ import {
 	Hub,
 	StorageHelper,
 	CustomUserAgentDetails,
+	InAppMessagingAction,
 } from '@aws-amplify/core';
 import flatten from 'lodash/flatten';
 
@@ -31,6 +32,7 @@ import {
 	InternalNotifcationsSubCategory,
 	NotificationsSubCategory,
 } from '../types';
+import { getUserAgentValue } from './utils';
 
 const STORAGE_KEY_SUFFIX = '_inAppMessages';
 
@@ -147,7 +149,12 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 		return Promise.all<void>(
 			this.pluggables.map(async pluggable => {
 				try {
-					const messages = await pluggable.getInAppMessages();
+					const messages = await pluggable.getInAppMessages(
+						getUserAgentValue(
+							InAppMessagingAction.SyncMesssages,
+							customUserAgentDetails
+						)
+					);
 					const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
 					await this.setMessages(key, messages);
 				} catch (err) {

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -165,9 +165,7 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 		);
 	}
 
-	public clearMessages(
-		customUserAgentDetails?: CustomUserAgentDetails
-	): Promise<void[]> {
+	public clearMessages(): Promise<void[]> {
 		return Promise.all<void>(
 			this.pluggables.map(async pluggable => {
 				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
@@ -176,10 +174,7 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 		);
 	}
 
-	public async dispatchEvent(
-		event: InAppMessagingEvent,
-		customUserAgentDetails?: CustomUserAgentDetails
-	): Promise<void> {
+	public async dispatchEvent(event: InAppMessagingEvent): Promise<void> {
 		const messages: InAppMessage[][] = await Promise.all<InAppMessage[]>(
 			this.pluggables.map(async pluggable => {
 				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-	Amplify,
 	ConsoleLogger as Logger,
 	HubCallback,
 	HubCapsule,
@@ -345,6 +344,3 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 		return sorted[0];
 	};
 }
-
-const InternalInAppMessaging = new InternalInAppMessagingClass();
-Amplify.register(InternalInAppMessaging);

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -201,7 +201,14 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 		return Promise.all<void>(
 			this.pluggables.map(async pluggable => {
 				try {
-					await pluggable.identifyUser(userId, userInfo);
+					await pluggable.identifyUser(
+						userId,
+						userInfo,
+						getUserAgentValue(
+							InAppMessagingAction.IdentifyUser,
+							customUserAgentDetails
+						)
+					);
 				} catch (err) {
 					logger.error('Failed to identify user', err);
 					throw err;

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -7,6 +7,7 @@ import {
 	HubCapsule,
 	Hub,
 	StorageHelper,
+	CustomUserAgentDetails,
 } from '@aws-amplify/core';
 import flatten from 'lodash/flatten';
 
@@ -14,9 +15,9 @@ import {
 	addEventListener,
 	EventListener,
 	notifyEventListeners,
-} from '../common';
-import { UserInfo } from '../types';
-import { AWSPinpointProvider } from './Providers';
+} from '../../common';
+import { UserInfo } from '../../types';
+import { AWSPinpointProvider } from '../Providers';
 import {
 	InAppMessage,
 	InAppMessageInteractionEvent,
@@ -25,15 +26,15 @@ import {
 	InAppMessageConflictHandler,
 	InAppMessagingEvent,
 	InAppMessagingProvider,
-	NotificationsSubCategory,
 	OnMessageInteractionEventHandler,
-} from './types';
+	InternalNotifcationsSubCategory,
+} from '../types';
 
 const STORAGE_KEY_SUFFIX = '_inAppMessages';
 
 const logger = new Logger('Notifications.InAppMessaging');
 
-export default class InAppMessaging implements InAppMessagingInterface {
+export default class InternalInAppMessaging implements InAppMessagingInterface {
 	private config: Record<string, any> = {};
 	private conflictHandler: InAppMessageConflictHandler;
 	private listeningForAnalyticEvents = false;
@@ -77,8 +78,8 @@ export default class InAppMessaging implements InAppMessagingInterface {
 	 * Get the name of this module
 	 * @returns {string} name of this module
 	 */
-	getModuleName(): NotificationsSubCategory {
-		return 'InAppMessaging';
+	getModuleName(): InternalNotifcationsSubCategory {
+		return 'InternalInAppMessaging';
 	}
 
 	/**
@@ -138,7 +139,9 @@ export default class InAppMessaging implements InAppMessagingInterface {
 	 * @param {string} provider
 	 * @returns - Array of available map resources
 	 */
-	syncMessages = (): Promise<void[]> =>
+	syncMessages = (
+		customUserAgentDetails?: CustomUserAgentDetails
+	): Promise<void[]> =>
 		Promise.all<void>(
 			this.pluggables.map(async pluggable => {
 				try {
@@ -152,7 +155,9 @@ export default class InAppMessaging implements InAppMessagingInterface {
 			})
 		);
 
-	clearMessages = (): Promise<void[]> =>
+	clearMessages = (
+		customUserAgentDetails?: CustomUserAgentDetails
+	): Promise<void[]> =>
 		Promise.all<void>(
 			this.pluggables.map(async pluggable => {
 				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
@@ -160,7 +165,10 @@ export default class InAppMessaging implements InAppMessagingInterface {
 			})
 		);
 
-	dispatchEvent = async (event: InAppMessagingEvent): Promise<void> => {
+	dispatchEvent = async (
+		event: InAppMessagingEvent,
+		customUserAgentDetails?: CustomUserAgentDetails
+	): Promise<void> => {
 		const messages: InAppMessage[][] = await Promise.all<InAppMessage[]>(
 			this.pluggables.map(async pluggable => {
 				const key = `${pluggable.getProviderName()}${STORAGE_KEY_SUFFIX}`;
@@ -179,7 +187,11 @@ export default class InAppMessaging implements InAppMessagingInterface {
 		}
 	};
 
-	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> =>
+	identifyUser = (
+		userId: string,
+		userInfo: UserInfo,
+		customUserAgentDetails?: CustomUserAgentDetails
+	): Promise<void[]> =>
 		Promise.all<void>(
 			this.pluggables.map(async pluggable => {
 				try {

--- a/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
+++ b/packages/notifications/src/InAppMessaging/internals/InternalInAppMessaging.ts
@@ -151,7 +151,7 @@ export class InternalInAppMessagingClass implements InAppMessagingInterface {
 				try {
 					const messages = await pluggable.getInAppMessages(
 						getUserAgentValue(
-							InAppMessagingAction.SyncMesssages,
+							InAppMessagingAction.SyncMessages,
 							customUserAgentDetails
 						)
 					);

--- a/packages/notifications/src/InAppMessaging/internals/index.ts
+++ b/packages/notifications/src/InAppMessaging/internals/index.ts
@@ -1,0 +1,3 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+export { InternalInAppMessagingClass } from './InternalInAppMessaging';

--- a/packages/notifications/src/InAppMessaging/internals/utils.ts
+++ b/packages/notifications/src/InAppMessaging/internals/utils.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	Category,
+	CustomUserAgentDetails,
+	getAmplifyUserAgent,
+	InAppMessagingAction,
+} from '@aws-amplify/core';
+
+export const getUserAgentValue = (
+	action: InAppMessagingAction,
+	customUserAgentDetails?: CustomUserAgentDetails
+) => {
+	return getAmplifyUserAgent({
+		category: Category.InAppMessaging,
+		action,
+		...customUserAgentDetails,
+	});
+};

--- a/packages/notifications/src/InAppMessaging/types.ts
+++ b/packages/notifications/src/InAppMessaging/types.ts
@@ -51,7 +51,7 @@ export interface InAppMessagingProvider extends NotificationsProvider {
 	getSubCategory(): NotificationsSubCategory;
 
 	// get in-app messages from provider
-	getInAppMessages(): Promise<any>;
+	getInAppMessages(userAgentValue?: string): Promise<any>;
 
 	// filters in-app messages based on event input and provider logic
 	processInAppMessages(

--- a/packages/notifications/src/InAppMessaging/types.ts
+++ b/packages/notifications/src/InAppMessaging/types.ts
@@ -13,10 +13,13 @@ export type NotificationsSubCategory = Extract<
 	NotificationsSubCategories,
 	'InAppMessaging'
 >;
+export type InternalNotifcationsSubCategory = 'InternalInAppMessaging';
 
 export interface InAppMessagingInterface {
 	configure: (config: InAppMessagingConfig) => InAppMessagingConfig;
-	getModuleName: () => NotificationsSubCategory;
+	getModuleName: () =>
+		| NotificationsSubCategory
+		| InternalNotifcationsSubCategory;
 	getPluggable: (providerName: string) => InAppMessagingProvider;
 	addPluggable: (pluggable: InAppMessagingProvider) => void;
 	removePluggable: (providerName: string) => void;

--- a/packages/notifications/src/Notifications.ts
+++ b/packages/notifications/src/Notifications.ts
@@ -3,11 +3,7 @@
 
 import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
 
-import InAppMessagingClass from './InAppMessaging';
-import PushNotificationClass from './PushNotification';
-import { InAppMessagingInterface as InAppMessaging } from './InAppMessaging/types';
-import { PushNotificationInterface as PushNotification } from './PushNotification/types';
-import { NotificationsCategory, NotificationsConfig, UserInfo } from './types';
+import { NotificationsCategory } from './types';
 import { InternalNotificationsClass } from './internals/InternalNotifications';
 
 const logger = new Logger('Notifications');

--- a/packages/notifications/src/Notifications.ts
+++ b/packages/notifications/src/Notifications.ts
@@ -8,16 +8,13 @@ import PushNotificationClass from './PushNotification';
 import { InAppMessagingInterface as InAppMessaging } from './InAppMessaging/types';
 import { PushNotificationInterface as PushNotification } from './PushNotification/types';
 import { NotificationsCategory, NotificationsConfig, UserInfo } from './types';
+import { InternalNotificationsClass } from './internals/InternalNotifications';
 
 const logger = new Logger('Notifications');
 
-class NotificationsClass {
-	private config: Record<string, any> = {};
-	private inAppMessaging: InAppMessaging;
-	private pushNotification?: PushNotification;
-
+class NotificationsClass extends InternalNotificationsClass {
 	constructor() {
-		this.inAppMessaging = new InAppMessagingClass();
+		super(false);
 	}
 
 	/**
@@ -27,61 +24,6 @@ class NotificationsClass {
 	getModuleName(): NotificationsCategory {
 		return 'Notifications';
 	}
-
-	/**
-	 * Configure Notifications
-	 * @param {Object} config - Notifications configuration object
-	 */
-	configure = ({ Notifications: config }: NotificationsConfig = {}) => {
-		this.config = { ...this.config, ...config };
-
-		logger.debug('configure Notifications', config);
-
-		// Configure sub-categories
-		this.inAppMessaging.configure(this.config.InAppMessaging);
-
-		if (this.config.Push) {
-			try {
-				// only instantiate once
-				if (!this.pushNotification) {
-					this.pushNotification = new PushNotificationClass();
-				}
-				this.pushNotification.configure(this.config.Push);
-			} catch (err) {
-				logger.error(err);
-			}
-		}
-
-		return this.config;
-	};
-
-	get InAppMessaging(): InAppMessaging {
-		return this.inAppMessaging;
-	}
-
-	get Push(): PushNotification {
-		return this.pushNotification ?? ({} as PushNotification);
-	}
-
-	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> => {
-		const identifyFunctions: Function[] = [];
-		if (this.inAppMessaging) {
-			identifyFunctions.push(this.inAppMessaging.identifyUser);
-		}
-		if (this.pushNotification) {
-			identifyFunctions.push(this.pushNotification.identifyUser);
-		}
-		return Promise.all<void>(
-			identifyFunctions.map(async identifyFunction => {
-				try {
-					await identifyFunction(userId, userInfo);
-				} catch (err) {
-					logger.error('Failed to identify user', err);
-					throw err;
-				}
-			})
-		);
-	};
 }
 
 const Notifications = new NotificationsClass();

--- a/packages/notifications/src/PushNotification/types.ts
+++ b/packages/notifications/src/PushNotification/types.ts
@@ -23,7 +23,7 @@ export interface PushNotificationInterface {
 	enable: () => void;
 	identifyUser: (userId: string, userInfo: UserInfo) => Promise<void[]>;
 	getLaunchNotification: () => Promise<PushNotificationMessage>;
-	getBadgeCount: () => Promise<number>;
+	getBadgeCount: () => Promise<number | null>;
 	setBadgeCount: (count: number) => void;
 	getPermissionStatus: () => Promise<PushNotificationPermissionStatus>;
 	requestPermissions: (

--- a/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
+++ b/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
@@ -77,12 +77,16 @@ export default abstract class AWSPinpointProviderCommon
 		return this.config;
 	}
 
-	identifyUser = async (userId: string, userInfo: UserInfo): Promise<void> => {
+	identifyUser = async (
+		userId: string,
+		userInfo: UserInfo,
+		userAgentValue?: string
+	): Promise<void> => {
 		if (!this.initialized) {
 			await this.init();
 		}
 		try {
-			await this.updateEndpoint(userId, userInfo);
+			await this.updateEndpoint(userId, userInfo, userAgentValue);
 		} catch (err) {
 			this.logger.error('Error identifying user', err);
 			throw err;
@@ -161,7 +165,8 @@ export default abstract class AWSPinpointProviderCommon
 
 	protected updateEndpoint = async (
 		userId: string = null,
-		userInfo: AWSPinpointUserInfo = null
+		userInfo: AWSPinpointUserInfo = null,
+		userAgentValue?: string
 	): Promise<void> => {
 		const credentials = await this.getCredentials();
 		// Shallow compare to determine if credentials stored here are outdated
@@ -230,7 +235,11 @@ export default abstract class AWSPinpointProviderCommon
 			};
 			this.logger.debug('updating endpoint');
 			await updateEndpoint(
-				{ credentials, region, userAgentValue: this.getUserAgentValue() },
+				{
+					credentials,
+					region,
+					userAgentValue: userAgentValue || this.getUserAgentValue(),
+				},
 				input
 			);
 			this.endpointInitialized = true;

--- a/packages/notifications/src/internals/InternalNotifications
+++ b/packages/notifications/src/internals/InternalNotifications
@@ -1,0 +1,90 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
+
+import InAppMessagingClass from './InAppMessaging';
+import PushNotificationClass from './PushNotification';
+import { InAppMessagingInterface as InAppMessaging } from './InAppMessaging/types';
+import { PushNotificationInterface as PushNotification } from './PushNotification/types';
+import { NotificationsCategory, NotificationsConfig, UserInfo } from './types';
+
+const logger = new Logger('Notifications');
+
+class NotificationsClass {
+	private config: Record<string, any> = {};
+	private inAppMessaging: InAppMessaging;
+	private pushNotification?: PushNotification;
+
+	constructor() {
+		this.inAppMessaging = new InAppMessagingClass();
+	}
+
+	/**
+	 * Get the name of the module category
+	 * @returns {string} name of the module category
+	 */
+	getModuleName(): NotificationsCategory {
+		return 'Notifications';
+	}
+
+	/**
+	 * Configure Notifications
+	 * @param {Object} config - Notifications configuration object
+	 */
+	configure = ({ Notifications: config }: NotificationsConfig = {}) => {
+		this.config = { ...this.config, ...config };
+
+		logger.debug('configure Notifications', config);
+
+		// Configure sub-categories
+		this.inAppMessaging.configure(this.config.InAppMessaging);
+
+		if (this.config.Push) {
+			try {
+				// only instantiate once
+				if (!this.pushNotification) {
+					this.pushNotification = new PushNotificationClass();
+				}
+				this.pushNotification.configure(this.config.Push);
+			} catch (err) {
+				logger.error(err);
+			}
+		}
+
+		return this.config;
+	};
+
+	get InAppMessaging(): InAppMessaging {
+		return this.inAppMessaging;
+	}
+
+	get Push(): PushNotification {
+		return this.pushNotification ?? ({} as PushNotification);
+	}
+
+	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> => {
+		const identifyFunctions: Function[] = [];
+		if (this.inAppMessaging) {
+			identifyFunctions.push(this.inAppMessaging.identifyUser);
+		}
+		if (this.pushNotification) {
+			identifyFunctions.push(this.pushNotification.identifyUser);
+		}
+		return Promise.all<void>(
+			identifyFunctions.map(async identifyFunction => {
+				try {
+					await identifyFunction(userId, userInfo);
+				} catch (err) {
+					logger.error('Failed to identify user', err);
+					throw err;
+				}
+			})
+		);
+	};
+}
+
+const Notifications = new NotificationsClass();
+
+export default Notifications;
+Amplify.register(Notifications);

--- a/packages/notifications/src/internals/InternalNotifications.ts
+++ b/packages/notifications/src/internals/InternalNotifications.ts
@@ -3,29 +3,33 @@
 
 import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
 
-import InAppMessagingClass from './InAppMessaging';
-import PushNotificationClass from './PushNotification';
-import { InAppMessagingInterface as InAppMessaging } from './InAppMessaging/types';
-import { PushNotificationInterface as PushNotification } from './PushNotification/types';
-import { NotificationsCategory, NotificationsConfig, UserInfo } from './types';
+import { InternalInAppMessagingClass } from '../InAppMessaging/internals';
+import PushNotificationClass from '../PushNotification';
+import { InAppMessagingInterface as InAppMessaging } from '../InAppMessaging/types';
+import { PushNotificationInterface as PushNotification } from '../PushNotification/types';
+import {
+	InternalNotificationsCategory,
+	NotificationsConfig,
+	UserInfo,
+} from '../types';
 
 const logger = new Logger('Notifications');
 
-class NotificationsClass {
+class InternalNotificationsClass {
 	private config: Record<string, any> = {};
-	private inAppMessaging: InAppMessaging;
+	private internalInAppMessaging: InAppMessaging;
 	private pushNotification?: PushNotification;
 
 	constructor() {
-		this.inAppMessaging = new InAppMessagingClass();
+		this.internalInAppMessaging = new InternalInAppMessagingClass();
 	}
 
 	/**
 	 * Get the name of the module category
 	 * @returns {string} name of the module category
 	 */
-	getModuleName(): NotificationsCategory {
-		return 'Notifications';
+	getModuleName(): InternalNotificationsCategory {
+		return 'InternalNotifications';
 	}
 
 	/**
@@ -38,7 +42,7 @@ class NotificationsClass {
 		logger.debug('configure Notifications', config);
 
 		// Configure sub-categories
-		this.inAppMessaging.configure(this.config.InAppMessaging);
+		this.internalInAppMessaging.configure(this.config.InAppMessaging);
 
 		if (this.config.Push) {
 			try {
@@ -56,7 +60,7 @@ class NotificationsClass {
 	};
 
 	get InAppMessaging(): InAppMessaging {
-		return this.inAppMessaging;
+		return this.internalInAppMessaging;
 	}
 
 	get Push(): PushNotification {
@@ -65,8 +69,8 @@ class NotificationsClass {
 
 	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> => {
 		const identifyFunctions: Function[] = [];
-		if (this.inAppMessaging) {
-			identifyFunctions.push(this.inAppMessaging.identifyUser);
+		if (this.internalInAppMessaging) {
+			identifyFunctions.push(this.internalInAppMessaging.identifyUser);
 		}
 		if (this.pushNotification) {
 			identifyFunctions.push(this.pushNotification.identifyUser);
@@ -84,7 +88,7 @@ class NotificationsClass {
 	};
 }
 
-const Notifications = new NotificationsClass();
+const InternalNotifications = new InternalNotificationsClass();
 
-export default Notifications;
-Amplify.register(Notifications);
+export default InternalNotifications;
+Amplify.register(InternalNotifications);

--- a/packages/notifications/src/internals/InternalNotifications.ts
+++ b/packages/notifications/src/internals/InternalNotifications.ts
@@ -92,7 +92,5 @@ export class InternalNotificationsClass {
 	};
 }
 
-const InternalNotifications = new InternalNotificationsClass();
-
-export default InternalNotifications;
+export const InternalNotifications = new InternalNotificationsClass();
 Amplify.register(InternalNotifications);

--- a/packages/notifications/src/internals/InternalNotifications.ts
+++ b/packages/notifications/src/internals/InternalNotifications.ts
@@ -3,32 +3,36 @@
 
 import { Amplify, ConsoleLogger as Logger } from '@aws-amplify/core';
 
+import InAppMessagingClass from '../InAppMessaging';
 import { InternalInAppMessagingClass } from '../InAppMessaging/internals';
 import PushNotificationClass from '../PushNotification';
 import { InAppMessagingInterface as InAppMessaging } from '../InAppMessaging/types';
 import { PushNotificationInterface as PushNotification } from '../PushNotification/types';
 import {
 	InternalNotificationsCategory,
+	NotificationsCategory,
 	NotificationsConfig,
 	UserInfo,
 } from '../types';
 
 const logger = new Logger('Notifications');
 
-class InternalNotificationsClass {
+export class InternalNotificationsClass {
 	private config: Record<string, any> = {};
-	private internalInAppMessaging: InAppMessaging;
+	private inAppMessaging: InAppMessaging;
 	private pushNotification?: PushNotification;
 
-	constructor() {
-		this.internalInAppMessaging = new InternalInAppMessagingClass();
+	constructor(isInternal = true) {
+		this.inAppMessaging = isInternal
+			? new InternalInAppMessagingClass()
+			: new InAppMessagingClass();
 	}
 
 	/**
 	 * Get the name of the module category
 	 * @returns {string} name of the module category
 	 */
-	getModuleName(): InternalNotificationsCategory {
+	getModuleName(): InternalNotificationsCategory | NotificationsCategory {
 		return 'InternalNotifications';
 	}
 
@@ -42,7 +46,7 @@ class InternalNotificationsClass {
 		logger.debug('configure Notifications', config);
 
 		// Configure sub-categories
-		this.internalInAppMessaging.configure(this.config.InAppMessaging);
+		this.inAppMessaging.configure(this.config.InAppMessaging);
 
 		if (this.config.Push) {
 			try {
@@ -60,7 +64,7 @@ class InternalNotificationsClass {
 	};
 
 	get InAppMessaging(): InAppMessaging {
-		return this.internalInAppMessaging;
+		return this.inAppMessaging;
 	}
 
 	get Push(): PushNotification {
@@ -69,8 +73,8 @@ class InternalNotificationsClass {
 
 	identifyUser = (userId: string, userInfo: UserInfo): Promise<void[]> => {
 		const identifyFunctions: Function[] = [];
-		if (this.internalInAppMessaging) {
-			identifyFunctions.push(this.internalInAppMessaging.identifyUser);
+		if (this.inAppMessaging) {
+			identifyFunctions.push(this.inAppMessaging.identifyUser);
 		}
 		if (this.pushNotification) {
 			identifyFunctions.push(this.pushNotification.identifyUser);

--- a/packages/notifications/src/internals/index.ts
+++ b/packages/notifications/src/internals/index.ts
@@ -1,0 +1,3 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+export { InternalNotifications } from './InternalNotifications';

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -22,7 +22,11 @@ export interface NotificationsProvider {
 	getProviderName(): string;
 
 	// identify the current user with the provider
-	identifyUser(userId: string, userInfo: UserInfo): Promise<void>;
+	identifyUser(
+		userId: string,
+		userInfo: UserInfo,
+		userAgentValue?: string
+	): Promise<void>;
 }
 
 export interface NotificationsConfig {

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -5,18 +5,20 @@ import { InAppMessagingConfig } from './InAppMessaging/types';
 import { PushNotificationConfig } from './PushNotification/types';
 
 export type NotificationsCategory = 'Notifications';
+export type InternalNotificationsCategory = 'InternalNotifications';
 
 export type NotificationsSubCategory = 'InAppMessaging' | 'PushNotification';
+export type InternalNotificationsSubCategory = 'InternalInAppMessaging';
 
 export interface NotificationsProvider {
 	// configure provider
 	configure(config: object): object;
 
 	// return category ('Notifications')
-	getCategory(): NotificationsCategory;
+	getCategory(): NotificationsCategory | InternalNotificationsCategory;
 
 	// return sub-category
-	getSubCategory(): NotificationsSubCategory;
+	getSubCategory(): NotificationsSubCategory | InternalNotificationsCategory;
 
 	// return the name of you provider
 	getProviderName(): string;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Creates InternalInAppMessaging class with added customUserAgentDetails parameter on public API's that result in service calls
- Sends received customUserAgentDetails through to storage service calls
- Creates and exports InternalNotifications class from @aws-amplify/notifications/internals with InternalInAppMessaging as inAppMessaging

NOTES
- This is the second of two options for InternalInAppMessaging: option 1 lives in [this PR](https://github.com/aws-amplify/amplify-js/pull/11630)
- To see the changes to InternalInAppMessaging after moving the code over from InAppMessaging, see [this comparison](https://github.com/erinleigh90/amplify-js/compare/e7229f15ad6e700412bab91891172b46e332422a...3355311d37533717736dad62e85e55557ce4aded#diff-eaa168799ccf04080fe2ca3fdb0f6fcec87a64264d789c1905e653628b6912ec)
- To see the changes to InternalNotifications after moving the code over from Notifications, see [this comparison](https://github.com/erinleigh90/amplify-js/compare/90ace2431b2418dafd73c03e4f23d6550eb5ef0a...59ab4478363fb65c9e00aa3eb5876cb1ee17f556#diff-e55ec7f6eb4c1fca94d24828cd71a2f14a8eaa9e11920b5d8d78a2c87df90912)


#### Description of how you validated changes
yarn tests pass


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x]  Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
