### PR TITLE
feature: Add script for supporting pre-release IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
 		"lint:license": "license-check-and-add add -f license_config.json",
 		"link-all": "yarn unlink-all && lerna exec --no-bail --parallel yarn link",
 		"unlink-all": "lerna exec --no-bail --parallel -- yarn unlink; exit 0",
-		"publish:main": "lerna publish --canary --force-publish \"*\" --yes --dist-tag=unstable --preid=unstable${PREID_HASH_SUFFIX} --exact --no-verify-access",		
-		"publish:release": "lerna publish --conventional-commits --yes --message 'chore(release): Publish [ci skip]' --no-verify-access",
-		"publish:verdaccio": "lerna publish --no-push --canary minor --dist-tag=unstable --preid=unstable --exact --force-publish --yes --no-verify-access",
-		"ts-coverage": "lerna run ts-coverage"
+		"publish:main": "lerna publish --canary --force-publish --dist-tag=unstable --preid=unstable${PREID_HASH_SUFFIX} --yes",	
+		"publish:release": "lerna publish --conventional-commits --message 'chore(release): Publish [ci skip]' --yes",
+		"publish:verdaccio": "lerna publish --canary --force-publish --no-push --dist-tag=unstable --preid=unstable --yes",	
+		"ts-coverage": "lerna run ts-coverage",
+		"prepare": "./scripts/set-preid-versions.sh"
 	},
 	"husky": {
 		"hooks": {

--- a/scripts/set-preid-versions.sh
+++ b/scripts/set-preid-versions.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# This script sets the `@aws-amplify/core` peer dependency version when the library is being published with a 
+# `preid` version.
+#
+# By design, Lerna does not update peer dependencies on packages vended by the monorepo as it would defeat the efficacy
+# of having peer dependencies in the first place (which indicate a range of compatible versions). This script enables
+# us to effectively test the library by pinning the peer dependency version of `@aws-amplify/core` across the library
+# to the version being published. This script will not be executed for production releases, which do not specify a
+# `preid`.
+#
+# @remarks
+# This script is to be executed after versions have been set but before publication to NPM, e.g. the NPM `prepare`
+# life-cycle script which Lerna will invoke.
+#
+# @remarks
+# This script requires `jq` which is installed by default on Linux. On OSX use `brew install jq`.
+
+PACKAGE_DIR=packages
+UMBRELLA_PACKAGE_JSON=${PACKAGE_DIR}/aws-amplify/package.json
+CORE_PACKAGE_JSON=${PACKAGE_DIR}/core/package.json
+LOG_PREFIX="[preid preparation]"
+PRE_ID_REGEX='.*-(.*)\.'
+
+# Step 1: Grab the version of `aws-amplify` & determine if a pre-release ID is in use
+libraryVersion=$(jq '.version' $UMBRELLA_PACKAGE_JSON | tr -d \")
+
+echo "$LOG_PREFIX aws-amplify version: $libraryVersion"
+
+if [[ $libraryVersion =~ $PRE_ID_REGEX ]]; then
+	echo "$LOG_PREFIX Pre-release ID in use: ${BASH_REMATCH[1]}"
+else 
+	echo "$LOG_PREFIX Pre-release ID NOT in use, exiting."
+	exit 0;
+fi
+
+# Step 2: Grab the version of `@aws-amplify/core`
+coreVersion=$(jq '.version' $CORE_PACKAGE_JSON | tr -d \")
+echo "$LOG_PREFIX @aws-amplify/core version: $coreVersion"
+
+# Step 3: Set the peer dependency version across the library ahead of publication
+for packageFile in $PACKAGE_DIR/*/package.json; do
+	peerDepExistsInFile=$(jq '.peerDependencies | has("@aws-amplify/core")' $packageFile)
+
+	# Skip private packages as they won't be published
+	privateFlag=$(jq '.private' $packageFile)
+	[[ "$privateFlag" == "true" ]] && packageIsPrivate=true || packageIsPrivate=false
+  
+	if [ $packageIsPrivate != true ] && [ $peerDepExistsInFile == true ]
+	then
+		jq --arg version "$coreVersion" '.peerDependencies."@aws-amplify/core" = $version' $packageFile > $packageFile.tmp && mv $packageFile.tmp $packageFile
+
+		echo "$LOG_PREFIX Set peer dependency version in: ${packageFile}"
+	fi
+done 
+
+echo "$LOG_PREFIX ✅ Completed successfully!"

--- a/scripts/set-preid-versions.sh
+++ b/scripts/set-preid-versions.sh
@@ -11,7 +11,8 @@
 #
 # @remarks
 # This script is to be executed after versions have been set but before publication to NPM, e.g. the NPM `prepare`
-# life-cycle script which Lerna will invoke.
+# life-cycle script which Lerna will invoke. It will set the peer-dependency in each category's package.json file 
+# before it gets packaged up and sent to NPM.
 #
 # @remarks
 # This script requires `jq` which is installed by default on Linux. On OSX use `brew install jq`.
@@ -48,6 +49,7 @@ for packageFile in $PACKAGE_DIR/*/package.json; do
   
 	if [ $packageIsPrivate != true ] && [ $peerDepExistsInFile == true ]
 	then
+		# Set the peer dependency & write back to the package's package.json file
 		jq --arg version "$coreVersion" '.peerDependencies."@aws-amplify/core" = $version' $packageFile > $packageFile.tmp && mv $packageFile.tmp $packageFile
 
 		echo "$LOG_PREFIX Set peer dependency version in: ${packageFile}"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change introduces a script to enable reliable pre-release testing with the new `peerDependencies` configuration. When publishing a release that specifies a pre-release ID, the peer dependencies on `@aws-amplify/core` across the library will be updated to point to the version of `@aws-amplify/core` being published. If a pre-release ID is not specified (such as during our production releases), this process will be skipped. The process is triggered automatically via the NPM `prepare` lifecycle hook, which Lerna will invoke when required.

This script requires that `jq` be installed. This is available by default on Linux hosts and via `brew install jq` for OSX. This script was already required for other ops processes including our roll-back procedure.

Other changes:
- Removed unneeded arguments from the `publish:main` & `publish:release` commands & standardized argument ordering.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Tested a variety of scenarios with Verdaccio & smoke-tested in a sample app.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
