### PR TITLE
chore: Move Storage TS dependency to `devDependencies`

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -51,8 +51,7 @@
     "@aws-sdk/types": "3.6.1",
     "events": "^3.1.0",
     "fast-xml-parser": "^4.2.5",
-    "tslib": "^1.8.0",
-    "typescript": "5.0.2"
+    "tslib": "^1.8.0"
   },
   "size-limit": [
     {
@@ -105,6 +104,7 @@
     ]
   },
   "devDependencies": {
-    "@types/sinon": "^7.5.1"
+    "@types/sinon": "^7.5.1",
+    "typescript": "5.0.2"
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Moves the `typescript` dependency in Storage to dev dependencies to avoid installing it in consuming apps.

The `tsconfig.tsbuildinfo` confirms that the package is being built with `5.0.2`:
```
{"program": { ... }, ..., "version":"5.0.2"}
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
