### PR TITLE
feat: add basic models type support

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
 	"resolutions": {
 		"@types/babel__traverse": "7.20.0",
 		"path-scurry": "1.10.0",
-		"**/glob/minipass": "6.0.2"
+		"**/glob/minipass": "6.0.2",
+		"@smithy/types": "1.1.0"
 	},
 	"jest": {
 		"resetMocks": true,

--- a/packages/api/index.v3.d.ts
+++ b/packages/api/index.v3.d.ts
@@ -1,8 +1,8 @@
 // the original ts3.7 version declaration file, used by "typesVersions" field in package.json
 // https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#file-redirects
 // can consider using third-party tool like downlevel-dts in the build process to automate this.
-import { API } from './lib-esm/API';
-export { API, APIClass } from './lib-esm/API';
+import { API } from './lib-esm/API.v3';
+export { API, APIClass } from './lib-esm/API.v3';
 export {
 	graphqlOperation,
 	GraphQLAuthError,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,9 +6,9 @@
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
 	"typesVersions": {
-		"<3.8": {
+		"<5": {
 			"lib-esm/index.d.ts": [
-				"index.v37.d.ts"
+				"index.v3.d.ts"
 			]
 		}
 	},
@@ -26,16 +26,16 @@
 		"test": "npm run lint && jest -w 1 --coverage",
 		"test:size": "size-limit",
 		"build-with-test": "npm test && npm run build",
-		"build:cjs": "node ./build es5 && webpack && webpack --config ./webpack.config.dev.js",
-		"build:esm": "node ./build es6",
-		"build:cjs:watch": "node ./build es5 --watch",
-		"build:esm:watch": "node ./build es6 --watch",
+		"build:cjs": "rimraf lib && tsc -p ./tsconfig.build.json -m commonjs --outDir lib && webpack && webpack --config ./webpack.config.dev.js",
+		"build:esm": "rimraf lib-esm && tsc -p ./tsconfig.build.json -m esnext --outDir lib-esm",
+		"build:cjs:watch": "rimraf lib && tsc -m commonjs --outDir lib --watch",
+		"build:esm:watch": "rimraf lib-esm && tsc -m esnext --outDir lib-esm --watch",
 		"build": "npm run clean && npm run build:esm && npm run build:cjs",
 		"clean": "npm run clean:size && rimraf lib-esm lib dist",
 		"clean:size": "rimraf dual-publish-tmp tmp*",
 		"format": "echo \"Not implemented\"",
 		"lint": "tslint 'src/**/*.ts' && npm run ts-coverage",
-		"ts-coverage": "typescript-coverage-report -p ./tsconfig.build.json -t 91.14"
+		"ts-coverage": "typescript-coverage-report -p ./tsconfig.build.json -t 91.14 -i \"src/API.v3.ts\""
 	},
 	"repository": {
 		"type": "git",
@@ -48,7 +48,8 @@
 	},
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
-		"@types/zen-observable": "^0.8.0"
+		"@types/zen-observable": "^0.8.0",
+		"typescript": "5.1.6"
 	},
 	"files": [
 		"lib",
@@ -60,7 +61,7 @@
 	"dependencies": {
 		"@aws-amplify/api-graphql": "3.4.5",
 		"@aws-amplify/api-rest": "3.4.0",
-		"tslib": "^1.8.0"
+		"tslib": "^2.6.0"
 	},
 	"size-limit": [
 		{

--- a/packages/api/src/API.v3.ts
+++ b/packages/api/src/API.v3.ts
@@ -260,25 +260,13 @@ type GraphQLResponse<QueryKey extends string, ResponseType> = Prettify<{
 	};
 }>;
 
-/* tslint:disable semicolon */
 // If no T is passed, ExcludeNeverFields removes "models" from the client
-declare type V6Client<T = never> = ExcludeNeverFields<{
+type V6Client<T = never> = ExcludeNeverFields<{
 	graphql: typeof v6graphql;
 	models: {
-		[K in keyof T]: K extends string
-			? {
-					create: (post: T[K]) => Promise<GraphQLResponse<`create${K}`, T[K]>>;
-					update: (
-						post: Prettify<{ id: string } & Partial<T[K]>>
-					) => Promise<GraphQLResponse<`update${K}`, T[K]>>;
-					delete: (id: string) => Promise<GraphQLResponse<`delete${K}`, T[K]>>;
-					get: (id: string) => Promise<GraphQLResponse<`get${K}`, T[K]>>;
-					list: () => Promise<
-						GraphQLResponse<`list${K}s`, { items: Array<T[K]> }>
-					>;
-					type: T[K];
-			  }
-			: never;
+		[K in keyof T]: {
+			[K in OperationPrefix]: (...args: any[]) => Promise<any>;
+		};
 	};
 }>;
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Adds new V6 client types. These depends on TS@5, so also adding a fallback API.v3.ts which is compatible with older version of TS, e.g. what DataStore uses. It's a duplicate of API.ts except with the V6 client type return values any'd.
* Changes api/package.json build script to use `tsc` instead of the custom build script. This allows API category to utilize the TS version listed in the package.json devDep. Same pattern as what's currently used in core.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
