### PR TITLE
chore: pin @smtihy/types to 1.1.0 to prevent build failure in TS3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
 	"resolutions": {
 		"@types/babel__traverse": "7.20.0",
 		"path-scurry": "1.10.0",
-		"**/glob/minipass": "6.0.2"
+		"**/glob/minipass": "6.0.2",
+		"@smithy/types": "1.1.0"
 	},
 	"jest": {
 		"resetMocks": true,


### PR DESCRIPTION
This is ok because the AWS SDK and crypto dependencies have been pinned already

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Unblock the main branch if underlying issue is not resolved in smithy-typescript repo.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Related to: https://github.com/awslabs/smithy-typescript/issues/845


#### Description of how you validated changes
build passes


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
