### PR TITLE
chore: remove smithy resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,7 @@
 	"resolutions": {
 		"@types/babel__traverse": "7.20.0",
 		"path-scurry": "1.10.0",
-		"**/glob/minipass": "6.0.2",
-		"@smithy/types": "1.1.0"
+		"**/glob/minipass": "6.0.2"
 	},
 	"jest": {
 		"resetMocks": true,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR removes the smithy type resolution that was causing the build process to fail. The AWS-SDK has released a new version of the aws-sdk/types which fixes the previous issue.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
