### PR TITLE
chore: Disable RSC test for firefox

### DIFF
--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -584,7 +584,7 @@ tests:
     category: auth
     sample_name: [auth-rsc]
     spec: auth-rsc
-    browser: *minimal_browser_list
+    browser: [chrome]
     timeout_minutes: 45
     retry_count: 10
   - test_name: integ_next_auth_nextjs_auth_custom_implementation_with_ssr


### PR DESCRIPTION
#### Description of changes
Disabling the Auth Next RSC test in Firefox.

https://github.com/aws-amplify/amplify-js/actions/runs/5754429667

The test is passing in circle and passes in Chrome. Locally, I see Firefox failures when running a dev build, but it passes for a production app build. It appears that somewhere between versions of Cypress and Firefox we are seeing issues specific to this test that don't occur for me when manually stepping through the test actions.

Recommend we disable the test on firefox pending further research.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
