### PR TITLE
fix(core): fail to clean up framework observers

### DIFF
--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -65,7 +65,7 @@
       "name": "API (GraphQL client)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, GraphQLAPI }",
-      "limit": "89.51 kB"
+      "limit": "89.52 kB"
     }
   ],
   "jest": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -67,7 +67,7 @@
 			"name": "API (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, API }",
-			"limit": "90.27 kB"
+			"limit": "90.28 kB"
 		}
 	],
 	"jest": {

--- a/packages/core/src/Platform/detectFramework.ts
+++ b/packages/core/src/Platform/detectFramework.ts
@@ -7,7 +7,7 @@ import { detect } from './detection';
 // We want to cache detection since the framework won't change
 let frameworkCache: Framework | undefined;
 
-const frameworkChangeObservers: (() => void)[] = [];
+export const frameworkChangeObservers: (() => void)[] = [];
 
 // Setup the detection reset tracking / timeout delays
 let resetTriggered = false;
@@ -19,8 +19,19 @@ export const detectFramework = (): Framework => {
 	if (!frameworkCache) {
 		frameworkCache = detect();
 
-		// Everytime we update the cache, call each observer function
-		frameworkChangeObservers.forEach(fcn => fcn());
+		if (resetTriggered) {
+			// The final run of detectFramework:
+			// Starting from this point, the `frameworkCache` becomes "final".
+			// So we don't need to notify the observers again so the observer
+			// can be removed after the final notice.
+			while (frameworkChangeObservers.length) {
+				frameworkChangeObservers.pop()();
+			}
+		} else {
+			// The first run of detectFramework:
+			// Every time we update the cache, call each observer function
+			frameworkChangeObservers.forEach(fcn => fcn());
+		}
 
 		// Retry once for either Unknown type after a delay (explained below)
 		resetTimeout(Framework.ServerSideUnknown, SSR_RESET_TIMEOUT);
@@ -33,6 +44,12 @@ export const detectFramework = (): Framework => {
  * @internal Setup observer callback that will be called everytime the framework changes
  */
 export const observeFrameworkChanges = (fcn: () => void) => {
+	// When the `frameworkCache` won't be updated again, we ignore all incoming
+	// observers.
+	if (resetTriggered) {
+		return;
+	}
+
 	frameworkChangeObservers.push(fcn);
 };
 

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -58,7 +58,7 @@
 			"name": "Geo (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Geo }",
-			"limit": "52.1 kB"
+			"limit": "52.12 kB"
 		}
 	],
 	"jest": {

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -59,7 +59,7 @@
 			"name": "Interactions (top-level class with Lex v2)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Interactions, AWSLexV2Provider }",
-			"limit": "76 kB"
+			"limit": "76.02 kB"
 		}
 	],
 	"jest": {

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -75,7 +75,7 @@
 			"name": "Predictions (Identify provider)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Predictions, AmazonAIIdentifyPredictionsProvider }",
-			"limit": "73.55 kB"
+			"limit": "73.57 kB"
 		},
 		{
 			"name": "Predictions (Interpret provider)",

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -65,13 +65,13 @@
       "name": "PubSub (IoT provider)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, PubSub, AWSIoTProvider }",
-      "limit": "81.37 kB"
+      "limit": "81.39 kB"
     },
     {
       "name": "PubSub (Mqtt provider)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, PubSub, MqttOverWSProvider }",
-      "limit": "81.24 kB"
+      "limit": "81.26 kB"
     }
   ],
   "jest": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -60,7 +60,7 @@
       "name": "Storage (top-level class)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, Storage }",
-      "limit": "38.95 kB"
+      "limit": "38.96 kB"
     }
   ],
   "jest": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Added logic to clean up the Framework detection observers, and ignore new incoming observers after the detection completes.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-js/issues/11770

#### Description of how you validated changes

Unit tests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
