### PR TITLE
chore: Upgrade to UUID v9

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -78,7 +78,7 @@
 		"@aws-sdk/util-utf8-browser": "3.259.0",
 		"lodash": "^4.17.20",
 		"tslib": "^2.5.0",
-		"uuid": "^3.2.1"
+		"uuid": "^9.0.0"
 	},
 	"peerDependencies": {
 		"@aws-amplify/core": "^6.0.0"

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -53,7 +53,7 @@
     "@aws-amplify/pubsub": "6.0.0",
     "graphql": "15.8.0",
     "tslib": "^2.5.0",
-    "uuid": "^3.2.1",
+    "uuid": "^9.0.0",
     "zen-observable-ts": "0.8.19"
   },
   "peerDependencies": {

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -54,8 +54,8 @@
 		"amazon-cognito-identity-js": "6.4.0",
 		"idb": "5.0.6",
 		"immer": "9.0.6",
-		"ulid": "2.3.0",
-		"uuid": "9.0.0",
+		"ulid": "^2.3.0",
+		"uuid": "^9.0.0",
 		"zen-observable-ts": "0.8.19",
 		"zen-push": "0.2.1"
 	},

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -55,7 +55,7 @@
 		"idb": "5.0.6",
 		"immer": "9.0.6",
 		"ulid": "2.3.0",
-		"uuid": "3.4.0",
+		"uuid": "9.0.0",
 		"zen-observable-ts": "0.8.19",
 		"zen-push": "0.2.1"
 	},
@@ -65,7 +65,7 @@
 	"devDependencies": {
 		"@aws-amplify/core": "6.0.0",
 		"@react-native-community/netinfo": "4.7.0",
-		"@types/uuid": "3.4.6",
+		"@types/uuid": "^9.0.0",
 		"@types/uuid-validate": "^0.0.1",
 		"dexie": "3.2.2",
 		"dexie-export-import": "1.0.3",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -52,7 +52,7 @@
 	"dependencies": {
 		"@aws-amplify/rtn-push-notification": "1.2.0",
 		"lodash": "^4.17.21",
-		"uuid": "^3.2.1"
+		"uuid": "^9.0.0"
 	},
 	"peerDependencies": {
 		"@aws-amplify/core": "^6.0.0"

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -56,7 +56,7 @@
 		"@aws-sdk/util-utf8-node": "3.6.1",
 		"buffer": "4.9.2",
 		"tslib": "^2.5.0",
-		"uuid": "^3.2.1"
+		"uuid": "^9.0.0"
 	},
 	"peerDependencies": {
 		"@aws-amplify/core": "^6.0.0"

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -51,7 +51,7 @@
     "graphql": "15.8.0",
     "tslib": "^2.5.0",
     "url": "0.11.0",
-    "uuid": "^3.2.1",
+    "uuid": "^9.0.0",
     "zen-observable-ts": "0.8.19"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change upgrades us to UUID v9. This upgrade will require that customers install the `react-native-random-values` polyfill, which is being tracked with our overall RN v6 story. This change will also resolve one of Amplify's long standing deprecation warnings:

```
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Unit tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
