### PR TITLE
chore: Upgrade `url` dependency

### DIFF
--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "axios": "0.26.0",
     "tslib": "^2.5.0",
-    "url": "0.11.0"
+    "url": "^0.11.1"
   },
   "peerDependencies": {
     "@aws-amplify/core": "^6.0.0"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -70,7 +70,7 @@
 	"dependencies": {
 		"amazon-cognito-identity-js": "6.4.0",
 		"tslib": "^2.5.0",
-		"url": "0.11.0",
+		"url": "^0.11.1",
 		"typescript": "5.0.2"
 	},
 	"peerDependencies": {

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -50,8 +50,8 @@
     "@aws-amplify/auth": "6.0.0",
     "graphql": "15.8.0",
     "tslib": "^2.5.0",
-    "url": "0.11.0",
-    "uuid": "^3.2.1",
+    "url": "^0.11.1",
+    "uuid": "^9.0.0",
     "zen-observable-ts": "0.8.19"
   },
   "peerDependencies": {

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -51,7 +51,7 @@
     "graphql": "15.8.0",
     "tslib": "^2.5.0",
     "url": "^0.11.1",
-    "uuid": "^9.0.0",
+    "uuid": "^3.2.1",
     "zen-observable-ts": "0.8.19"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change upgrades direct dependencies on `url` throughout the library. This will partially resolve the deprecation warning on `querystring`:

```
npm WARN deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
```

The deprecation warning will be completely resolved when we:
- Upgrade `@aws-sdk/client-cloudwatch-logs` (required for dev preview)
- Upgrade the AWS SDK clients in Predictions (GA)

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Local build & test.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
