### PR TITLE
fix: adds InternalAuth to requiredModules for SSR

### DIFF
--- a/packages/aws-amplify/src/withSSRContext.ts
+++ b/packages/aws-amplify/src/withSSRContext.ts
@@ -11,8 +11,10 @@ import { DataStore } from '@aws-amplify/datastore';
 import { Amplify } from './index';
 
 const requiredModules = [
-	// API cannot function without Auth
+	// Credentials cannot function without Auth
 	Auth,
+	// API cannot function without InternalAuth
+	InternalAuth,
 	// Auth cannot function without Credentials
 	Credentials,
 ];
@@ -29,8 +31,8 @@ export function withSSRContext(context: Context = {}) {
 	const { modules = defaultModules, req } = context;
 	if (modules.includes(DataStore)) {
 		modules.push(InternalAPI);
-		modules.push(InternalAuth);
 	}
+
 	const previousConfig = Amplify.configure();
 	const amplify = new AmplifyClass();
 	const storage = new UniversalStorage({ req });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes issue where InternalAuth missing from withSSRContext when only the API module is included.
- Adds InternalAuth as a requiredModule - it will be used for DataStore, API, and eventually Credentials.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Tested in a sample app where I was able to verify there was an issue and fix with the included code.



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
