### PR TITLE
feat: send customUserAgent from core Credentials to Auth

### DIFF
--- a/packages/aws-amplify/src/withSSRContext.ts
+++ b/packages/aws-amplify/src/withSSRContext.ts
@@ -11,8 +11,8 @@ import { DataStore } from '@aws-amplify/datastore';
 import { Amplify } from './index';
 
 const requiredModules = [
-	// API cannot function without Auth
-	Auth,
+	// API cannot function without InternalAuth
+	InternalAuth,
 	// Auth cannot function without Credentials
 	Credentials,
 ];
@@ -29,7 +29,6 @@ export function withSSRContext(context: Context = {}) {
 	const { modules = defaultModules, req } = context;
 	if (modules.includes(DataStore)) {
 		modules.push(InternalAPI);
-		modules.push(InternalAuth);
 	}
 	const previousConfig = Amplify.configure();
 	const amplify = new AmplifyClass();

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -66,7 +66,7 @@
 			"name": "Notifications (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Notifications }",
-			"limit": "30.67 kB"
+			"limit": "30.72 kB"
 		},
 		{
 			"name": "Notifications (with Analytics)",

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -81,7 +81,7 @@
 			"name": "Predictions (Interpret provider)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Predictions, AmazonAIInterpretPredictionsProvider }",
-			"limit": "43.77 kB"
+			"limit": "43.82 kB"
 		}
 	],
 	"jest": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Send user agent information received by Credentials.get() to InternalAuth calls.



#### Description of how you validated changes
Added checks in unit test and tests passing



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
