### PR TITLE
fix: avoid federated signin redirect loop

### DIFF
--- a/packages/auth/src/internals/InternalAuth.ts
+++ b/packages/auth/src/internals/InternalAuth.ts
@@ -261,7 +261,7 @@ export class InternalAuthClass {
 			// See https://github.com/aws-amplify/amplify-js/issues/4388
 			const usedResponseUrls = {};
 			// Only register urlListener once
-			if (this.getModuleName() === 'InternalAuth') {
+			if (this.getModuleName() === 'Auth') {
 				urlListener(({ url }) => {
 					if (usedResponseUrls[url]) {
 						return;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Made sure urlListener is registered on Auth instance so the oAuthFlowInProgress refers to the Auth instance that customers are using.
- NOTE: this will be an issue for UI team when they start using InternalAuth, so a more robust solution will need to be found going forward.


#### Issue #, if available
https://github.com/aws-amplify/amplify-js/issues/11846



#### Description of how you validated changes
Reproduced issue in sample app, validated changes using yarn linking.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
