### PR TITLE
feat(adapter-nextjs): initial implementation and relevant changes to support its functionalities

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,8 @@
 		"packages/auth",
 		"packages/analytics",
 		"packages/storage",
-		"packages/aws-amplify"
+		"packages/aws-amplify",
+		"packages/adapter-nextjs"
 	],
 	"exact": true,
 	"version": "independent",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
 			"packages/auth",
 			"packages/analytics",
 			"packages/storage",
-			"packages/aws-amplify"
+			"packages/aws-amplify",
+			"packages/adapter-nextjs"
 		],
 		"nohoist": [
 			"**/@types/react-native",

--- a/packages/adapter-nextjs/CHANGELOG.md
+++ b/packages/adapter-nextjs/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.0.1
+
+The initial implementation of the adapter supporting using Amplify in Next.js.

--- a/packages/adapter-nextjs/LICENSE
+++ b/packages/adapter-nextjs/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 - 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/adapter-nextjs/__tests__/runWithAmplifyServerContext.test.ts
+++ b/packages/adapter-nextjs/__tests__/runWithAmplifyServerContext.test.ts
@@ -1,0 +1,123 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ResourcesConfig, MemoryKeyValueStorage } from '@aws-amplify/core';
+import {
+	createAWSCredentialsAndIdentityIdProvider,
+	createKeyValueStorageFromCookieStorageAdapter,
+	createUserPoolsTokenProvider,
+	runWithAmplifyServerContext as runWithAmplifyServerContextCore,
+} from 'aws-amplify/internals/adapter-core';
+import { runWithAmplifyServerContext } from '../src';
+import { getAmplifyConfig } from '../src/utils';
+import { NextServer } from '../src/types';
+
+const mockAmplifyConfig: ResourcesConfig = {
+	Auth: {
+		identityPoolId: '123',
+		userPoolId: 'abc',
+		userPoolWebClientId: 'def',
+	},
+	Storage: {
+		bucket: 'bucket',
+		region: 'us-east-1',
+	},
+};
+
+jest.mock('../src/utils', () => ({
+	getAmplifyConfig: jest.fn(() => mockAmplifyConfig),
+	createCookieStorageAdapterFromNextServerContext: jest.fn(),
+}));
+jest.mock('aws-amplify/internals/adapter-core');
+
+const mockGetAmplifyConfig = getAmplifyConfig as jest.Mock;
+const mockRunWithAmplifyServerContextCore =
+	runWithAmplifyServerContextCore as jest.Mock;
+const mockCreateAWSCredentialsAndIdentityIdProvider =
+	createAWSCredentialsAndIdentityIdProvider as jest.Mock;
+const mockCreateKeyValueStorageFromCookieStorageAdapter =
+	createKeyValueStorageFromCookieStorageAdapter as jest.Mock;
+const mockCreateUserPoolsTokenProvider =
+	createUserPoolsTokenProvider as jest.Mock;
+
+describe('runWithAmplifyServerContext', () => {
+	it('should call getAmlifyConfig', async () => {
+		const operation = jest.fn();
+		await runWithAmplifyServerContext({ operation, nextServerContext: null });
+		expect(mockGetAmplifyConfig).toHaveBeenCalled();
+	});
+
+	describe('when amplifyConfig.Auth is not defined', () => {
+		it('should call runWithAmplifyServerContextCore without Auth library options', () => {
+			const mockAmplifyConfig: ResourcesConfig = {
+				API: {
+					endpoint: 'https://example.com',
+					apiKey: '123',
+				},
+			};
+			mockGetAmplifyConfig.mockReturnValueOnce(mockAmplifyConfig);
+			const operation = jest.fn();
+			runWithAmplifyServerContext({ operation, nextServerContext: null });
+			expect(mockRunWithAmplifyServerContextCore).toHaveBeenCalledWith(
+				mockAmplifyConfig,
+				{},
+				operation
+			);
+		});
+	});
+
+	describe('when amplifyConfig.Auth is defined', () => {
+		describe('when nextServerContext is null (opt-in unauthenticated role)', () => {
+			it('should create auth providers with MemoryKeyValueStorage', () => {
+				const operation = jest.fn();
+				runWithAmplifyServerContext({ operation, nextServerContext: null });
+				expect(
+					mockCreateAWSCredentialsAndIdentityIdProvider
+				).toHaveBeenCalledWith(mockAmplifyConfig.Auth, MemoryKeyValueStorage);
+				expect(mockCreateUserPoolsTokenProvider).toHaveBeenCalledWith(
+					mockAmplifyConfig.Auth,
+					MemoryKeyValueStorage
+				);
+			});
+		});
+
+		describe('when nextServerContext is not null', () => {
+			it('should create auth providers with cookie storage adapter', () => {
+				const operation = jest.fn();
+				const mockCookieStorageAdapter = {
+					get: jest.fn(),
+					set: jest.fn(),
+					remove: jest.fn(),
+				};
+				mockCreateKeyValueStorageFromCookieStorageAdapter.mockReturnValueOnce(
+					mockCookieStorageAdapter
+				);
+				const mockNextServerContext = {
+					req: {
+						headers: {
+							cookie: 'cookie',
+						},
+					},
+					res: {
+						setHeader: jest.fn(),
+					},
+				};
+				runWithAmplifyServerContext({
+					operation,
+					nextServerContext:
+						mockNextServerContext as unknown as NextServer.Context,
+				});
+				expect(
+					mockCreateAWSCredentialsAndIdentityIdProvider
+				).toHaveBeenCalledWith(
+					mockAmplifyConfig.Auth,
+					mockCookieStorageAdapter
+				);
+				expect(mockCreateUserPoolsTokenProvider).toHaveBeenCalledWith(
+					mockAmplifyConfig.Auth,
+					mockCookieStorageAdapter
+				);
+			});
+		});
+	});
+});

--- a/packages/adapter-nextjs/__tests__/utils/createCookieStorageAdapterFromNextServerContext.test.ts
+++ b/packages/adapter-nextjs/__tests__/utils/createCookieStorageAdapterFromNextServerContext.test.ts
@@ -1,0 +1,232 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { enableFetchMocks } from 'jest-fetch-mock';
+
+// Make global Request available during test
+enableFetchMocks();
+
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { createCookieStorageAdapterFromNextServerContext } from '../../src/utils';
+import { DATE_IN_THE_PAST } from '../../src/utils/createCookieStorageAdapterFromNextServerContext';
+import { IncomingMessage, ServerResponse } from 'http';
+import { Socket } from 'net';
+
+jest.mock('next/headers', () => ({
+	cookies: jest.fn(),
+}));
+
+const mockNextCookiesFunc = cookies as jest.Mock;
+
+describe('createCookieStorageAdapterFromNextServerContext', () => {
+	const mockGetFunc = jest.fn();
+	const mockGetAllFunc = jest.fn();
+	const mockSetFunc = jest.fn();
+	const mockDeleteFunc = jest.fn();
+	const mockAppend = jest.fn();
+	const mockNextCookiesFuncReturn = {
+		get: jest.fn(),
+		getAll: jest.fn(),
+		set: jest.fn(),
+		delete: jest.fn(),
+	};
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('it should return cookieStorageAdapter from NextRequest and NextResponse', () => {
+		const request = new NextRequest(new URL('https://example.com'));
+		const response = NextResponse.next();
+
+		jest.spyOn(request, 'cookies', 'get').mockImplementation(
+			() =>
+				({
+					get: mockGetFunc,
+					getAll: mockGetAllFunc,
+				} as any)
+		);
+
+		jest.spyOn(response, 'cookies', 'get').mockImplementation(() => ({
+			set: mockSetFunc,
+			delete: mockDeleteFunc,
+			get: jest.fn(),
+			getAll: jest.fn(),
+			has: jest.fn(),
+		}));
+
+		const mockContext = {
+			request,
+			response,
+		} as any;
+
+		const result = createCookieStorageAdapterFromNextServerContext(mockContext);
+		const mockKey = 'key';
+		const mockValue = 'cookieName=value';
+		result.get(mockKey);
+		expect(mockGetFunc).toHaveBeenCalledWith(mockKey);
+
+		result.getAll();
+		expect(mockGetAllFunc).toHaveBeenCalled();
+
+		result.set(mockKey, mockValue);
+		expect(mockSetFunc).toHaveBeenCalledWith(mockKey, mockValue);
+
+		result.delete(mockKey);
+		expect(mockDeleteFunc).toHaveBeenCalledWith(mockKey);
+	});
+
+	it('should return cookieStorageAdapter from NextRequest and Response', () => {
+		const request = new NextRequest(new URL('https://example.com'));
+		const response = new Response();
+
+		jest.spyOn(request, 'cookies', 'get').mockImplementation(
+			() =>
+				({
+					get: mockGetFunc,
+					getAll: mockGetAllFunc,
+				} as any)
+		);
+		jest.spyOn(response, 'headers', 'get').mockImplementation(
+			() =>
+				({
+					append: mockAppend,
+				} as any)
+		);
+
+		const mockContext = {
+			request,
+			response,
+		} as any;
+
+		const result = createCookieStorageAdapterFromNextServerContext(mockContext);
+		const mockKey = 'key';
+		const mockValue = '123';
+
+		result.get(mockKey);
+		expect(mockGetFunc).toHaveBeenCalledWith(mockKey);
+
+		result.getAll();
+		expect(mockGetAllFunc).toHaveBeenCalled();
+
+		const mockSerializeOptions = {
+			domain: 'example.com',
+			expires: new Date('2023-08-22'),
+			sameSite: 'strict' as any,
+			httpOnly: true,
+			secure: true,
+		};
+		result.set(mockKey, mockValue, mockSerializeOptions);
+		expect(mockAppend).toHaveBeenCalledWith(
+			'Set-Cookie',
+			`${mockKey}=${mockValue};Domain=${
+				mockSerializeOptions.domain
+			};Expires=${mockSerializeOptions.expires.toUTCString()};HttpOnly;SameSite=${
+				mockSerializeOptions.sameSite
+			};Secure`
+		);
+
+		result.set(mockKey, mockValue, undefined);
+		expect(mockAppend).toHaveBeenCalledWith(
+			'Set-Cookie',
+			`${mockKey}=${mockValue};`
+		);
+
+		result.set(mockKey, mockValue, {
+			httpOnly: false,
+			sameSite: false,
+			secure: false,
+		});
+		expect(mockAppend).toHaveBeenCalledWith(
+			'Set-Cookie',
+			`${mockKey}=${mockValue};`
+		);
+
+		result.delete(mockKey);
+		expect(mockAppend).toHaveBeenCalledWith(
+			'Set-Cookie',
+			`${mockKey}=;Expires=${DATE_IN_THE_PAST.toUTCString()}`
+		);
+	});
+
+	it('should return cookieStorageAdapter from Next cookies function', () => {
+		mockNextCookiesFunc.mockReturnValueOnce(mockNextCookiesFuncReturn);
+
+		const result = createCookieStorageAdapterFromNextServerContext({ cookies });
+
+		const mockKey = 'key';
+		const mockValue = '123';
+
+		result.get(mockKey);
+		expect(mockNextCookiesFuncReturn.get).toHaveBeenCalledWith(mockKey);
+
+		result.getAll();
+		expect(mockNextCookiesFuncReturn.getAll).toHaveBeenCalled();
+
+		result.set(mockKey, mockValue);
+		expect(mockNextCookiesFuncReturn.set).toHaveBeenCalledWith(
+			mockKey,
+			mockValue,
+			undefined
+		);
+
+		result.delete(mockKey);
+		expect(mockNextCookiesFuncReturn.delete).toHaveBeenCalledWith(mockKey);
+	});
+
+	it('should return cookieStorageAdapter from IncomingMessage and ServerResponse as the Pages Router context', () => {
+		const mockCookies = {
+			key1: 'value1',
+			key2: 'value2',
+		};
+
+		const request = new IncomingMessage(new Socket());
+		const response = new ServerResponse(request);
+		const setHeaderSpy = jest.spyOn(response, 'setHeader');
+
+		Object.defineProperty(request, 'cookies', {
+			get() {
+				return mockCookies;
+			},
+		});
+
+		const result = createCookieStorageAdapterFromNextServerContext({
+			request: request as any,
+			response,
+		});
+
+		expect(result.get('key1')).toEqual({ name: 'key1', value: 'value1' });
+		expect(result.get('non-exist')).toBeUndefined();
+		expect(result.getAll()).toEqual([
+			{ name: 'key1', value: 'value1' },
+			{ name: 'key2', value: 'value2' },
+		]);
+
+		result.set('key3', 'value3');
+		expect(setHeaderSpy).toHaveBeenCalledWith('Set-Cookie', 'key3=value3;');
+
+		result.set('key4', 'value4', {
+			httpOnly: true,
+		});
+		expect(setHeaderSpy).toHaveBeenCalledWith(
+			'Set-Cookie',
+			'key4=value4;HttpOnly'
+		);
+
+		result.delete('key3');
+		expect(setHeaderSpy).toHaveBeenCalledWith(
+			'Set-Cookie',
+			`key3=;Expires=${DATE_IN_THE_PAST.toUTCString()}`
+		);
+	});
+
+	it('should throw error when no cookie storage adapter is created from the context', () => {
+		expect(() =>
+			createCookieStorageAdapterFromNextServerContext({
+				request: {} as any,
+				response: new ServerResponse({} as any),
+			} as any)
+		).toThrowError();
+	});
+});

--- a/packages/adapter-nextjs/__tests__/utils/getAmplifyConfig.test.ts
+++ b/packages/adapter-nextjs/__tests__/utils/getAmplifyConfig.test.ts
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getAmplifyConfig } from '../../src/utils/getAmplifyConfig';
+
+describe('getAmplifyConfig', () => {
+	beforeEach(() => {
+		delete process.env.amplifyConfig;
+	});
+
+	it('should return amplifyConfig from env vars', () => {
+		const mockAmplifyConfig = {
+			Auth: {
+				identityPoolId: '123',
+				userPoolId: 'abc',
+				userPoolWebClientId: 'def',
+			},
+			Storage: {
+				bucket: 'bucket',
+				region: 'us-east-1',
+			},
+		};
+		process.env.amplifyConfig = JSON.stringify(mockAmplifyConfig);
+
+		const result = getAmplifyConfig();
+		expect(result).toEqual(mockAmplifyConfig);
+	});
+
+	it('should throw error when amplifyConfig is not found from env vars', () => {
+		expect(() => getAmplifyConfig()).toThrowError();
+	});
+});

--- a/packages/adapter-nextjs/__tests__/withAmplify.test.ts
+++ b/packages/adapter-nextjs/__tests__/withAmplify.test.ts
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ResourcesConfig } from '@aws-amplify/core';
+import { withAmplify } from '../src/withAmplify';
+
+const mockAmplifyConfig: ResourcesConfig = {
+	Auth: {
+		identityPoolId: '123',
+		userPoolId: 'abc',
+		userPoolWebClientId: 'def',
+	},
+	Storage: {
+		bucket: 'bucket',
+		region: 'us-east-1',
+	},
+};
+
+describe('withAmplify', () => {
+	it('should add amplifyConfig to nextConfig.env', () => {
+		const nextConfig = {};
+		const result = withAmplify(nextConfig, mockAmplifyConfig);
+
+		expect(result).toEqual({
+			env: {
+				amplifyConfig: JSON.stringify(mockAmplifyConfig),
+			},
+		});
+	});
+
+	it('should merge amplifyConfig to nextConfig.env (if this key has already defined)', () => {
+		const nextConfig = {
+			env: {
+				existingKey: '123',
+			},
+		};
+		const result = withAmplify(nextConfig, mockAmplifyConfig);
+
+		expect(result).toEqual({
+			env: {
+				existingKey: '123',
+				amplifyConfig: JSON.stringify(mockAmplifyConfig),
+			},
+		});
+	});
+});

--- a/packages/adapter-nextjs/package.json
+++ b/packages/adapter-nextjs/package.json
@@ -1,0 +1,117 @@
+{
+  "author": "Amazon Web Services",
+  "name": "@aws-amplify/adapter-nextjs",
+  "description": "The adapter for the supporting of using Amplify APIs in Next.js.",
+  
+  "peerDependencies": {
+    "aws-amplify": "^6.0.0",
+    "next": ">=13.4.0 <14.0.0"
+  },
+  "dependencies": {
+    "cookie": "0.5.0",
+    "server-only": "^0.0.1"
+  },
+  "devDependencies": {
+    "@types/cookie": "0.5.1",
+    "@types/node": "^20.3.1",
+    "@types/react": "^18.2.13",
+    "@types/react-dom": "^18.2.6",
+    "aws-amplify": "6.0.0",
+    "jest-fetch-mock": "3.0.3",
+    "next": ">= 13.4.0 < 14.0.0",
+    "typescript": "5.1.6"
+  },
+  "bugs": {
+    "url": "https://github.com/aws/aws-amplify/issues"
+  },
+  "exports": {
+    ".": {
+      "types": "./lib-esm/index.d.ts",
+      "import": "./lib-esm/index.js",
+      "require": "./lib/index.js"
+    },
+    "./with-amplify": {
+      "types": "./lib-esm/withAmplify.d.ts",
+      "import": "./lib-esm/withAmplify.js",
+      "require": "./lib/withAmplify.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "lib",
+    "lib-esm",
+    "src",
+    "withAmplify"
+  ],
+  "homepage": "https://aws-amplify.github.io/",
+  "jest": {
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "dist",
+      "lib",
+      "lib-esm"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
+      }
+    },
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+          "pathRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$"
+        },
+        "tsConfig": false
+      }
+    },
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "json",
+      "jsx"
+    ],
+    "testEnvironment": "node",
+    "testPathIgnorePatterns": [
+      "xmlParser-fixture.ts",
+      "testUtils",
+      "cases"
+    ],
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+    "testURL": "http://localhost/",
+    "transform": {
+      "^.+\\.(js|jsx|ts|tsx)$": "ts-jest"
+    }
+  },
+  "license": "Apache-2.0",
+  "main": "./lib/index.js",
+  "module": "./lib-esm/index.js",
+  "scripts": {
+    "build": "npm run clean && npm run build:esm && npm run build:cjs",
+    "build-with-test": "npm test && npm run build",
+    "build:cjs": "rimraf lib && tsc -m commonjs --outDir lib",
+    "build:cjs:watch": "rimraf lib && tsc -m commonjs --outDir lib --watch",
+    "build:esm": "rimraf lib-esm && tsc -m esnext --outDir lib-esm",
+    "build:esm:watch": "rimraf lib-esm && tsc -m esnext --outDir lib-esm --watch",
+    "clean": "npm run clean:size && rimraf lib-esm lib",
+    "clean:size": "rimraf dual-publish-tmp tmp*",
+    "format": "echo \"Not implemented\"",
+    "lint": "tslint 'src/**/*.ts'  && npm run ts-coverage",
+    "test": "npm run lint && jest -w 1 --coverage",
+    "test:size": "size-limit",
+    "ts-coverage": "typescript-coverage-report -p ./tsconfig.build.json -t 90.31"
+  },
+  "size-limit": [
+    {
+      "name": "Adapter Next.js",
+      "path": "./lib-esm/index.js",
+      "import": "{ runWithAmplifyServerContext }",
+      "limit": "1.5 kB"
+    }
+  ],
+  "typings": "./lib-esm/index.d.ts",
+  "version": "0.0.1"
+}

--- a/packages/adapter-nextjs/src/index.ts
+++ b/packages/adapter-nextjs/src/index.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { runWithAmplifyServerContext } from './runWithAmplifyServerContext';

--- a/packages/adapter-nextjs/src/runWithAmplifyServerContext.ts
+++ b/packages/adapter-nextjs/src/runWithAmplifyServerContext.ts
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NextServer } from './types';
+import {
+	createCookieStorageAdapterFromNextServerContext,
+	getAmplifyConfig,
+} from './utils';
+import { MemoryKeyValueStorage } from '@aws-amplify/core';
+import {
+	createAWSCredentialsAndIdentityIdProvider,
+	createKeyValueStorageFromCookieStorageAdapter,
+	createUserPoolsTokenProvider,
+	runWithAmplifyServerContext as runWithAmplifyServerContextCore,
+} from 'aws-amplify/internals/adapter-core';
+
+export const runWithAmplifyServerContext: NextServer.RunOperationWithContext =
+	async ({ nextServerContext, operation }) => {
+		// 1. get amplify config from env vars
+		// 2. create key-value storage from nextServerContext
+		// 3. create credentials provider
+		// 4. create token provider
+		// 5. call low level runWithAmplifyServerContext
+		const amplifyConfig = getAmplifyConfig();
+
+		// When the Auth config is presented, attempt to create a Amplify server
+		// context with token and credentials provider.
+		if (amplifyConfig.Auth) {
+			const keyValueStorage =
+				nextServerContext === null
+					? // When `null` is passed as the value of `nextServerContext`, opt-in
+					  // unauthenticated role (primarily for static rendering). It's
+					  // safe to use the singleton `MemoryKeyValueStorage` here, as the
+					  // static rendering uses the same unauthenticated role cross-sever.
+					  MemoryKeyValueStorage
+					: createKeyValueStorageFromCookieStorageAdapter(
+							createCookieStorageAdapterFromNextServerContext(nextServerContext)
+					  );
+			const credentialsProvider = createAWSCredentialsAndIdentityIdProvider(
+				amplifyConfig.Auth,
+				keyValueStorage
+			);
+			const tokenProvider = createUserPoolsTokenProvider(
+				amplifyConfig.Auth,
+				keyValueStorage
+			);
+
+			return runWithAmplifyServerContextCore(
+				amplifyConfig,
+				{
+					Auth: { credentialsProvider, tokenProvider },
+				},
+				operation
+			);
+		}
+
+		// Otherwise it may be the case that auth is not used, e.g. API key.
+		// Omitting the `Auth` in the second parameter.
+		return runWithAmplifyServerContextCore(amplifyConfig, {}, operation);
+	};

--- a/packages/adapter-nextjs/src/types/NextServer.ts
+++ b/packages/adapter-nextjs/src/types/NextServer.ts
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { GetServerSidePropsContext as NextGetServerSidePropsContext } from 'next';
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { AmplifyServer } from '@aws-amplify/core/internals/adapter-core';
+
+export namespace NextServer {
+	/**
+	 * This context is normally available in the following:
+	 *   - Next App Router [middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware)
+	 *   - Next App Router [route handler](https://nextjs.org/docs/app/building-your-application/routing/route-handlers)
+	 *     when using `NextResponse` to create the response of the route handler
+	 */
+	export type NextRequestAndNextResponseContext = {
+		request: NextRequest;
+		response: NextResponse;
+	};
+
+	/**
+	 * This context is normally available in the following:
+	 *   - Next App Router [route handler](https://nextjs.org/docs/app/building-your-application/routing/route-handlers)
+	 *     when using the Web API [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
+	 *     to create the response of the route handler
+	 */
+	export type NextRequestAndResponseContext = {
+		request: NextRequest;
+		response: Response;
+	};
+
+	/**
+	 * This context is normally available in the following:
+	 *   - Next [Server Component](https://nextjs.org/docs/getting-started/react-essentials#server-components)
+	 *     where the [`cookies`](https://nextjs.org/docs/app/api-reference/functions/cookies)
+	 *     function can be imported and called
+	 */
+	export type ServerComponentContext = {
+		cookies: typeof cookies;
+	};
+
+	export type ServerActionContext = ServerComponentContext;
+
+	/**
+	 * This context is normally available in the
+	 * [`getServerSideProps`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props)
+	 * function of the Next Pages Router.
+	 */
+	export type GetServerSidePropsContext = {
+		request: NextGetServerSidePropsContext['req'];
+		response: NextGetServerSidePropsContext['res'];
+	};
+
+	export type Context =
+		| NextRequestAndNextResponseContext
+		| NextRequestAndResponseContext
+		| ServerComponentContext
+		| GetServerSidePropsContext;
+
+	export interface RunWithContextInput<OperationResult> {
+		nextServerContext: Context | null;
+		operation: (
+			contextSpec: AmplifyServer.ContextSpec
+		) => OperationResult | void | Promise<OperationResult | void>;
+	}
+
+	export interface RunOperationWithContext {
+		<OperationResult>(
+			input: RunWithContextInput<OperationResult>
+		): Promise<OperationResult | void>;
+	}
+}

--- a/packages/adapter-nextjs/src/types/NextServer.ts
+++ b/packages/adapter-nextjs/src/types/NextServer.ts
@@ -61,12 +61,12 @@ export namespace NextServer {
 		nextServerContext: Context | null;
 		operation: (
 			contextSpec: AmplifyServer.ContextSpec
-		) => OperationResult | void | Promise<OperationResult | void>;
+		) => OperationResult | Promise<OperationResult>;
 	}
 
 	export interface RunOperationWithContext {
 		<OperationResult>(
 			input: RunWithContextInput<OperationResult>
-		): Promise<OperationResult | void>;
+		): Promise<OperationResult>;
 	}
 }

--- a/packages/adapter-nextjs/src/types/index.ts
+++ b/packages/adapter-nextjs/src/types/index.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { NextServer } from './NextServer';

--- a/packages/adapter-nextjs/src/utils/createCookieStorageAdapterFromNextServerContext.ts
+++ b/packages/adapter-nextjs/src/utils/createCookieStorageAdapterFromNextServerContext.ts
@@ -1,0 +1,202 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NextRequest, NextResponse } from 'next/server';
+import { NextServer } from '../types';
+import {
+	AmplifyServerContextError,
+	CookieStorage,
+} from '@aws-amplify/core/internals/adapter-core';
+import { IncomingMessage, ServerResponse } from 'http';
+
+export const DATE_IN_THE_PAST = new Date(0);
+
+export const createCookieStorageAdapterFromNextServerContext = (
+	context: NextServer.Context
+): CookieStorage.Adapter => {
+	const { request, response } = context as
+		| NextServer.NextRequestAndNextResponseContext
+		| NextServer.NextRequestAndResponseContext;
+
+	if (request instanceof NextRequest && response) {
+		if (response instanceof NextResponse) {
+			return createCookieStorageAdapterFromNextRequestAndNextResponse(
+				request,
+				response
+			);
+		} else {
+			return createCookieStorageAdapterFromNextRequestAndHttpResponse(
+				request,
+				response
+			);
+		}
+	}
+
+	const { cookies } = context as
+		| NextServer.ServerComponentContext
+		| NextServer.ServerActionContext;
+
+	if (typeof cookies === 'function') {
+		return createCookieStorageAdapterFromNextCookies(cookies);
+	}
+
+	const { request: req, response: res } =
+		context as NextServer.GetServerSidePropsContext;
+
+	if (req instanceof IncomingMessage && res instanceof ServerResponse) {
+		return createCookieStorageAdapterFromGetServerSidePropsContext(req, res);
+	}
+
+	// This should not happen normally.
+	throw new AmplifyServerContextError({
+		message:
+			'Attempted to create cookie storage adapter from an unsupported Next.js server context.',
+	});
+};
+
+const createCookieStorageAdapterFromNextRequestAndNextResponse = (
+	request: NextRequest,
+	response: NextResponse
+): CookieStorage.Adapter => {
+	const readonlyCookieStore = request.cookies;
+	const mutableCookieStore = response.cookies;
+
+	return {
+		get: readonlyCookieStore.get.bind(readonlyCookieStore),
+		getAll: readonlyCookieStore.getAll.bind(readonlyCookieStore),
+		set: mutableCookieStore.set.bind(mutableCookieStore),
+		delete: mutableCookieStore.delete.bind(mutableCookieStore),
+	};
+};
+
+const createCookieStorageAdapterFromNextRequestAndHttpResponse = (
+	request: NextRequest,
+	response: Response
+): CookieStorage.Adapter => {
+	const readonlyCookieStore = request.cookies;
+	const mutableCookieStore = createMutableCookieStoreFromHeaders(
+		response.headers
+	);
+
+	return {
+		get: readonlyCookieStore.get.bind(readonlyCookieStore),
+		getAll: readonlyCookieStore.getAll.bind(readonlyCookieStore),
+		...mutableCookieStore,
+	};
+};
+
+const createCookieStorageAdapterFromNextCookies = (
+	cookies: NextServer.ServerComponentContext['cookies']
+): CookieStorage.Adapter => {
+	const cookieStore = cookies();
+
+	// When Next cookies() is called in a server component, it returns a readonly
+	// cookie store. Hence calling set and delete throws an error. However,
+	// cookies() returns a mutable cookie store when called in a server action.
+	// We have no way to detect which one is returned, so we try to call set and delete
+	// and safely ignore the error if it is thrown.
+	const setFunc: CookieStorage.Adapter['set'] = (name, value, options) => {
+		try {
+			cookieStore.set(name, value, options);
+		} catch {
+			// no-op
+		}
+	};
+
+	const deleteFunc: CookieStorage.Adapter['delete'] = name => {
+		try {
+			cookieStore.delete(name);
+		} catch {
+			// no-op
+		}
+	};
+
+	return {
+		get: cookieStore.get.bind(cookieStore),
+		getAll: cookieStore.getAll.bind(cookieStore),
+		set: setFunc,
+		delete: deleteFunc,
+	};
+};
+
+const createCookieStorageAdapterFromGetServerSidePropsContext = (
+	request: NextServer.GetServerSidePropsContext['request'],
+	response: NextServer.GetServerSidePropsContext['response']
+): CookieStorage.Adapter => {
+	const cookiesMap = { ...request.cookies };
+	const allCookies = Object.entries(cookiesMap).map(([name, value]) => ({
+		name,
+		value,
+	}));
+
+	return {
+		get(name) {
+			const value = cookiesMap[name];
+			return value
+				? {
+						name,
+						value,
+				  }
+				: undefined;
+		},
+		getAll() {
+			return allCookies;
+		},
+		set(name, value, options) {
+			response.setHeader(
+				'Set-Cookie',
+				`${name}=${value};${options ? serializeSetCookieOptions(options) : ''}`
+			);
+		},
+		delete(name) {
+			response.setHeader(
+				'Set-Cookie',
+				`${name}=;Expires=${DATE_IN_THE_PAST.toUTCString()}`
+			);
+		},
+	};
+};
+
+const createMutableCookieStoreFromHeaders = (
+	headers: Headers
+): Pick<CookieStorage.Adapter, 'set' | 'delete'> => {
+	const setFunc: CookieStorage.Adapter['set'] = (name, value, options) => {
+		headers.append(
+			'Set-Cookie',
+			`${name}=${value};${options ? serializeSetCookieOptions(options) : ''}`
+		);
+	};
+	const deleteFunc: CookieStorage.Adapter['delete'] = name => {
+		headers.append(
+			'Set-Cookie',
+			`${name}=;Expires=${DATE_IN_THE_PAST.toUTCString()}`
+		);
+	};
+	return {
+		set: setFunc,
+		delete: deleteFunc,
+	};
+};
+
+const serializeSetCookieOptions = (
+	options: CookieStorage.SetCookieOptions
+): string => {
+	const { expires, maxAge, domain, httpOnly, sameSite, secure } = options;
+	const serializedOptions: string[] = [];
+	if (domain) {
+		serializedOptions.push(`Domain=${domain}`);
+	}
+	if (expires) {
+		serializedOptions.push(`Expires=${expires.toUTCString()}`);
+	}
+	if (httpOnly) {
+		serializedOptions.push(`HttpOnly`);
+	}
+	if (sameSite) {
+		serializedOptions.push(`SameSite=${sameSite}`);
+	}
+	if (secure) {
+		serializedOptions.push(`Secure`);
+	}
+	return serializedOptions.join(';');
+};

--- a/packages/adapter-nextjs/src/utils/getAmplifyConfig.ts
+++ b/packages/adapter-nextjs/src/utils/getAmplifyConfig.ts
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ResourcesConfig } from '@aws-amplify/core';
+import { AmplifyServerContextError } from '@aws-amplify/core/internals/adapter-core';
+
+export const getAmplifyConfig = (): ResourcesConfig => {
+	const configStr = process.env.amplifyConfig;
+
+	if (!configStr) {
+		throw new AmplifyServerContextError({
+			message: 'Amplify configuration is missing from `process.env`.',
+			recoverySuggestion:
+				'Ensure to use `withAmplify` function in your `next.config.js`.',
+		});
+	}
+
+	const configObject = JSON.parse(configStr);
+
+	// TODO(HuiSF): adds ResourcesConfig validation when it has one.
+	return configObject;
+};

--- a/packages/adapter-nextjs/src/utils/index.ts
+++ b/packages/adapter-nextjs/src/utils/index.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { getAmplifyConfig } from './getAmplifyConfig';
+export { createCookieStorageAdapterFromNextServerContext } from './createCookieStorageAdapterFromNextServerContext';

--- a/packages/adapter-nextjs/src/withAmplify.ts
+++ b/packages/adapter-nextjs/src/withAmplify.ts
@@ -19,7 +19,7 @@ export const withAmplify = (
 	amplifyConfig: ResourcesConfig
 ) => {
 	nextConfig.env = {
-		...(nextConfig.env ?? {}),
+		...nextConfig.env,
 		// TODO(Hui): follow up the validation of the amplifyConfig.
 		amplifyConfig: JSON.stringify(amplifyConfig),
 	};

--- a/packages/adapter-nextjs/src/withAmplify.ts
+++ b/packages/adapter-nextjs/src/withAmplify.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ResourcesConfig } from '@aws-amplify/core';
+import { NextConfig } from 'next';
+
+// NOTE: this function is exported from the subpath `/with-amplify`.
+// The reason is that this function is called in the `next.config.js` which
+// is not being transpiled by Next.js.
+
+/**
+ * Merges the `amplifyConfig` into the `nextConfig.env`.
+ * @param nextConfig The next config for a Next.js app.
+ * @param amplifyConfig
+ * @returns The updated `nextConfig`.
+ */
+export const withAmplify = (
+	nextConfig: NextConfig,
+	amplifyConfig: ResourcesConfig
+) => {
+	nextConfig.env = {
+		...(nextConfig.env ?? {}),
+		// TODO(Hui): follow up the validation of the amplifyConfig.
+		amplifyConfig: JSON.stringify(amplifyConfig),
+	};
+
+	return nextConfig;
+};

--- a/packages/adapter-nextjs/tsconfig.build.json
+++ b/packages/adapter-nextjs/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+	"extends": "../tsconfig.base.json",
+	"compilerOptions": {},
+	"include": ["lib*/**/*.ts", "src"]
+}

--- a/packages/adapter-nextjs/tsconfig.json
+++ b/packages/adapter-nextjs/tsconfig.json
@@ -1,0 +1,23 @@
+//WARNING: If you are manually specifying files to compile then the tsconfig.json is completely ignored, you must use command line flags
+{
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"outDir": "./lib/",
+		"target": "es5",
+		"noImplicitAny": false,
+		"lib": ["dom", "es2019", "esnext.asynciterable"],
+		"sourceMap": true,
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"allowJs": false,
+		"declaration": true,
+		"typeRoots": ["./node_modules/@types", "../../node_modules/@types"],
+		"types": ["node"],
+		"esModuleInterop": true,
+		"resolveJsonModule": true,
+		"strict": true,
+		"alwaysStrict": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["src/setupTests.ts"]
+}

--- a/packages/adapter-nextjs/tslint.json
+++ b/packages/adapter-nextjs/tslint.json
@@ -1,0 +1,50 @@
+{
+	"defaultSeverity": "error",
+	"plugins": ["prettier"],
+	"extends": [],
+	"jsRules": {},
+	"rules": {
+		"prefer-const": true,
+		"max-line-length": [true, 120],
+		"no-empty-interface": true,
+		"no-var-keyword": true,
+		"object-literal-shorthand": true,
+		"no-eval": true,
+		"space-before-function-paren": [
+			true,
+			{
+				"anonymous": "never",
+				"named": "never"
+			}
+		],
+		"no-parameter-reassignment": true,
+		"align": [true, "parameters"],
+		"no-duplicate-imports": true,
+		"one-variable-per-declaration": [false, "ignore-for-loop"],
+		"triple-equals": [true, "allow-null-check"],
+		"comment-format": [true, "check-space"],
+		"indent": [false],
+		"whitespace": [
+			false,
+			"check-branch",
+			"check-decl",
+			"check-operator",
+			"check-preblock"
+		],
+		"eofline": true,
+		"variable-name": [
+			true,
+			"check-format",
+			"allow-pascal-case",
+			"allow-snake-case",
+			"allow-leading-underscore"
+		],
+		"semicolon": [
+			true,
+			"always",
+			"ignore-interfaces",
+			"ignore-bound-class-methods"
+		]
+	},
+	"rulesDirectory": []
+}

--- a/packages/adapter-nextjs/with-amplify/package.json
+++ b/packages/adapter-nextjs/with-amplify/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "@aws-amplify/adapter-nextjs/with-amplify",
+	"main": "../lib/withAmplify.js",
+	"browser": "../lib-esm/withAmplify.js",
+	"module": "../lib-esm/withAmplify.js",
+	"typings": "../lib-esm/withAmplify.js"
+}

--- a/packages/auth/__tests__/providers/cognito/confirmSignInHappyCases.test.ts
+++ b/packages/auth/__tests__/providers/cognito/confirmSignInHappyCases.test.ts
@@ -8,6 +8,8 @@ import * as signInHelpers from '../../../src/providers/cognito/utils/signInHelpe
 import { AuthSignInStep } from '../../../src/types';
 import { confirmSignIn } from '../../../src/providers/cognito/apis/confirmSignIn';
 import { RespondToAuthChallengeCommandOutput } from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider/types';
+import { cognitoCredentialsProvider } from '../../../src/providers/cognito/credentialsProvider';
+import { CognitoUserPoolsTokenProvider } from '../../../src/providers/cognito/tokenProvider';
 
 const authConfig = {
 	userPoolWebClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
@@ -50,6 +52,8 @@ describe('confirmSignIn API happy path cases', () => {
 	});
 
 	test(`confirmSignIn test SMS_MFA ChallengeName.`, async () => {
+		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+		cognitoCredentialsProvider.setAuthConfig(authConfig);
 		Amplify.configure({
 			Auth: authConfig,
 		});
@@ -98,6 +102,8 @@ describe('confirmSignIn API happy path cases', () => {
 	});
 
 	test(`confirmSignIn tests MFA_SETUP challengeName`, async () => {
+		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+		cognitoCredentialsProvider.setAuthConfig(authConfig);
 		Amplify.configure({
 			Auth: authConfig,
 		});
@@ -138,6 +144,8 @@ describe('confirmSignIn API happy path cases', () => {
 	});
 
 	test(`confirmSignIn tests SELECT_MFA_TYPE challengeName `, async () => {
+		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+		cognitoCredentialsProvider.setAuthConfig(authConfig);
 		Amplify.configure({
 			Auth: authConfig,
 		});
@@ -202,6 +210,8 @@ describe('confirmSignIn API happy path cases', () => {
 	});
 
 	test('handleChallengeName should be called with clientMetadata from request', async () => {
+		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+		cognitoCredentialsProvider.setAuthConfig(authConfig);
 		Amplify.configure({
 			Auth: authConfig,
 		});
@@ -242,6 +252,8 @@ describe('confirmSignIn API happy path cases', () => {
 	});
 
 	test('handleChallengeName should be called with clientMetadata from config', async () => {
+		CognitoUserPoolsTokenProvider.setAuthConfig(authConfigWithMetadata);
+		cognitoCredentialsProvider.setAuthConfig(authConfigWithMetadata);
 		Amplify.configure({
 			Auth: authConfigWithMetadata,
 		});

--- a/packages/auth/__tests__/providers/cognito/confirmSignInHappyCases.test.ts
+++ b/packages/auth/__tests__/providers/cognito/confirmSignInHappyCases.test.ts
@@ -26,7 +26,10 @@ describe('confirmSignIn API happy path cases', () => {
 	let handleChallengeNameSpy;
 	const username = authAPITestParams.user1.username;
 	const password = authAPITestParams.user1.password;
+
 	beforeEach(async () => {
+		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+		cognitoCredentialsProvider.setAuthConfig(authConfig);
 		handleChallengeNameSpy = jest
 			.spyOn(signInHelpers, 'handleChallengeName')
 			.mockImplementation(
@@ -52,8 +55,6 @@ describe('confirmSignIn API happy path cases', () => {
 	});
 
 	test(`confirmSignIn test SMS_MFA ChallengeName.`, async () => {
-		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
-		cognitoCredentialsProvider.setAuthConfig(authConfig);
 		Amplify.configure({
 			Auth: authConfig,
 		});
@@ -102,8 +103,6 @@ describe('confirmSignIn API happy path cases', () => {
 	});
 
 	test(`confirmSignIn tests MFA_SETUP challengeName`, async () => {
-		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
-		cognitoCredentialsProvider.setAuthConfig(authConfig);
 		Amplify.configure({
 			Auth: authConfig,
 		});
@@ -144,8 +143,6 @@ describe('confirmSignIn API happy path cases', () => {
 	});
 
 	test(`confirmSignIn tests SELECT_MFA_TYPE challengeName `, async () => {
-		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
-		cognitoCredentialsProvider.setAuthConfig(authConfig);
 		Amplify.configure({
 			Auth: authConfig,
 		});
@@ -210,8 +207,6 @@ describe('confirmSignIn API happy path cases', () => {
 	});
 
 	test('handleChallengeName should be called with clientMetadata from request', async () => {
-		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
-		cognitoCredentialsProvider.setAuthConfig(authConfig);
 		Amplify.configure({
 			Auth: authConfig,
 		});

--- a/packages/auth/__tests__/providers/cognito/credentialsProvider.test.ts
+++ b/packages/auth/__tests__/providers/cognito/credentialsProvider.test.ts
@@ -54,6 +54,7 @@ const credentialsForidentityIdSpy = jest.spyOn(
 const configSpy = jest.spyOn(cogId.AmplifyV6, 'getConfig');
 
 describe('Guest Credentials', () => {
+	cognitoCredentialsProvider.setAuthConfig(validAuthConfig.Auth!);
 	describe('Happy Path Cases:', () => {
 		beforeEach(() => {
 			credentialsForidentityIdSpy.mockImplementationOnce(

--- a/packages/auth/__tests__/providers/cognito/signInStateManagement.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInStateManagement.test.ts
@@ -15,6 +15,16 @@ describe('local sign-in state management tests', () => {
 	const challengeName = 'SMS_MFA';
 	const username = authAPITestParams.user1.username;
 	const password = authAPITestParams.user1.password;
+	const authConfig = {
+		userPoolWebClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
+		userPoolId: 'us-west-2_zzzzz',
+	};
+
+	beforeEach(() => {
+		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+		cognitoCredentialsProvider.setAuthConfig(authConfig);
+	});
+
 	test('local state management should return state after signIn returns a ChallengeName', async () => {
 		const handleUserSRPAuthflowSpy = jest
 			.spyOn(signInHelpers, 'handleUserSRPAuthFlow')
@@ -29,12 +39,7 @@ describe('local sign-in state management tests', () => {
 					},
 				})
 			);
-		const authConfig = {
-			userPoolWebClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
-			userPoolId: 'us-west-2_zzzzz',
-		};
-		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
-		cognitoCredentialsProvider.setAuthConfig(authConfig);
+
 		AmplifyV6.configure({
 			Auth: authConfig,
 		});
@@ -62,12 +67,7 @@ describe('local sign-in state management tests', () => {
 				async (): Promise<RespondToAuthChallengeCommandOutput> =>
 					authAPITestParams.RespondToAuthChallengeCommandOutput
 			);
-		const authConfig = {
-			userPoolWebClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
-			userPoolId: 'us-west-2_zzzzz',
-		};
-		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
-		cognitoCredentialsProvider.setAuthConfig(authConfig);
+
 		AmplifyV6.configure({
 			Auth: authConfig,
 		});

--- a/packages/auth/__tests__/providers/cognito/signInStateManagement.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInStateManagement.test.ts
@@ -7,6 +7,8 @@ import * as signInHelpers from '../../../src/providers/cognito/utils/signInHelpe
 import { signInStore } from '../../../src/providers/cognito/utils/signInStore';
 import { AmplifyV6 } from '@aws-amplify/core';
 import { RespondToAuthChallengeCommandOutput } from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider/types';
+import { cognitoCredentialsProvider } from '../../../src/providers/cognito/credentialsProvider';
+import { CognitoUserPoolsTokenProvider } from '../../../src/providers/cognito/tokenProvider';
 
 describe('local sign-in state management tests', () => {
 	const session = '1234234232';
@@ -27,11 +29,14 @@ describe('local sign-in state management tests', () => {
 					},
 				})
 			);
+		const authConfig = {
+			userPoolWebClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
+			userPoolId: 'us-west-2_zzzzz',
+		};
+		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+		cognitoCredentialsProvider.setAuthConfig(authConfig);
 		AmplifyV6.configure({
-			Auth: {
-				userPoolWebClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
-				userPoolId: 'us-west-2_zzzzz',
-			},
+			Auth: authConfig,
 		});
 		await signIn({
 			username,
@@ -57,11 +62,14 @@ describe('local sign-in state management tests', () => {
 				async (): Promise<RespondToAuthChallengeCommandOutput> =>
 					authAPITestParams.RespondToAuthChallengeCommandOutput
 			);
+		const authConfig = {
+			userPoolWebClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
+			userPoolId: 'us-west-2_zzzzz',
+		};
+		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+		cognitoCredentialsProvider.setAuthConfig(authConfig);
 		AmplifyV6.configure({
-			Auth: {
-				userPoolWebClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
-				userPoolId: 'us-west-2_zzzzz',
-			},
+			Auth: authConfig,
 		});
 		await signIn({
 			username,

--- a/packages/auth/__tests__/providers/cognito/signInWithSRP.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithSRP.test.ts
@@ -14,6 +14,8 @@ import { RespondToAuthChallengeCommandOutput } from '../../../src/providers/cogn
 import { AmplifyV6 as Amplify } from 'aws-amplify';
 import { fetchTransferHandler } from '@aws-amplify/core/internals/aws-client-utils';
 import { buildMockErrorResponse, mockJsonResponse } from './testUtils/data';
+import { cognitoCredentialsProvider } from '../../../src/providers/cognito/credentialsProvider';
+import { CognitoUserPoolsTokenProvider } from '../../../src/providers/cognito/tokenProvider';
 jest.mock('@aws-amplify/core/lib/clients/handlers/fetch');
 
 const authConfig = {
@@ -25,6 +27,8 @@ const authConfigWithClientmetadata = {
 	userPoolId: 'us-west-2_zzzzz',
 	...authAPITestParams.configWithClientMetadata,
 };
+cognitoCredentialsProvider.setAuthConfig(authConfig);
+CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
 Amplify.configure({
 	Auth: authConfig,
 });
@@ -96,12 +100,15 @@ describe('signIn API happy path cases', () => {
 	});
 
 	test('handleUserSRPFlow should be called with clientMetada from config', async () => {
+		const authConfig = {
+			userPoolWebClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
+			userPoolId: 'us-west-2_zzzzz',
+			...authAPITestParams.configWithClientMetadata,
+		};
+		cognitoCredentialsProvider.setAuthConfig(authConfig);
+		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
 		Amplify.configure({
-			Auth: {
-				userPoolWebClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
-				userPoolId: 'us-west-2_zzzzz',
-				...authAPITestParams.configWithClientMetadata,
-			},
+			Auth: authConfig,
 		});
 		const username = authAPITestParams.user1.username;
 		const password = authAPITestParams.user1.password;

--- a/packages/auth/__tests__/providers/cognito/signInWithUserPassword.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithUserPassword.test.ts
@@ -12,6 +12,8 @@ import { RespondToAuthChallengeCommandOutput } from '../../../src/providers/cogn
 import { AmplifyV6 as Amplify } from 'aws-amplify';
 import { fetchTransferHandler } from '@aws-amplify/core/internals/aws-client-utils';
 import { buildMockErrorResponse, mockJsonResponse } from './testUtils/data';
+import { cognitoCredentialsProvider } from '../../../src/providers/cognito/credentialsProvider';
+import { CognitoUserPoolsTokenProvider } from '../../../src/providers/cognito/tokenProvider';
 jest.mock('@aws-amplify/core/lib/clients/handlers/fetch');
 
 const authConfig = {
@@ -23,6 +25,8 @@ const authConfigWithClientmetadata = {
 	userPoolId: 'us-west-2_zzzzz',
 	...authAPITestParams.configWithClientMetadata,
 };
+cognitoCredentialsProvider.setAuthConfig(authConfig);
+CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
 Amplify.configure({
 	Auth: authConfig,
 });
@@ -77,6 +81,13 @@ describe('signIn API happy path cases', () => {
 	test('handleUserPasswordAuthFlow should be called with clientMetada from config', async () => {
 		const username = authAPITestParams.user1.username;
 		const password = authAPITestParams.user1.password;
+		const authConfig = {
+			...authAPITestParams.configWithClientMetadata,
+			userPoolWebClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
+			userPoolId: 'us-west-2_zzzzz',
+		};
+		cognitoCredentialsProvider.setAuthConfig(authConfig);
+		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
 		Amplify.configure({
 			Auth: {
 				...authAPITestParams.configWithClientMetadata,
@@ -98,7 +109,6 @@ describe('signIn API happy path cases', () => {
 });
 
 describe('signIn API error path cases:', () => {
-
 	test('signIn API should throw a validation AuthError when username is empty', async () => {
 		expect.assertions(2);
 		try {
@@ -126,5 +136,4 @@ describe('signIn API error path cases:', () => {
 			expect(error.name).toBe(InitiateAuthException.InvalidParameterException);
 		}
 	});
-
 });

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -51,6 +51,16 @@
 			"import": "./lib-esm/providers/cognito/index.js",
 			"require": "./lib/providers/cognito/index.js"
 		},
+		"./server": {
+			"types": "./lib-esm/server.d.ts",
+			"import": "./lib-esm/server.js",
+			"require": "./lib/server.js"
+		},
+		"./internals": {
+			"types": "./lib-esm/lib-esm/internals/index.d.ts",
+			"import": "./lib-esm/internals/index.js",
+			"require": "./lib/internals/index.js"
+		},
 		"./package.json": "./package.json"
 	},
 	"repository": {

--- a/packages/auth/server/package.json
+++ b/packages/auth/server/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@aws-amplify/auth/server",
+	"types": "../lib-esm/server.d.ts",
+	"main": "../lib/server.js",
+	"module": "../lib-esm/server.js",
+	"react-native": "../lib-esm/server.js",
+	"sideEffects": false
+}

--- a/packages/auth/src/providers/cognito/credentialsProvider/IdentityIdProvider.ts
+++ b/packages/auth/src/providers/cognito/credentialsProvider/IdentityIdProvider.ts
@@ -41,7 +41,7 @@ export async function cognitoIdentityIdProvider({
 			return identityId.id;
 		} else {
 			const logins = tokens.idToken
-				? formLoginsMap(tokens.idToken.toString(), 'COGNITO')
+				? formLoginsMap(tokens.idToken.toString(), 'COGNITO', authConfig)
 				: {};
 			// TODO(V6): reuse previous guest idenityId if present
 			const generatedIdentityId = await generateIdentityId(logins, authConfig);

--- a/packages/auth/src/providers/cognito/credentialsProvider/credentialsProvider.ts
+++ b/packages/auth/src/providers/cognito/credentialsProvider/credentialsProvider.ts
@@ -49,6 +49,7 @@ export class CognitoAWSCredentialsAndIdentityIdProvider
 	): Promise<AWSCredentialsAndIdentityId> {
 		const isAuthenticated = getCredentialsOptions.authenticated;
 		const tokens = getCredentialsOptions.tokens;
+		// TODO: refactor use the this._authConfig
 		const authConfig =
 			getCredentialsOptions.authConfig as UserPoolConfigAndIdentityPoolConfig;
 		const forceRefresh = getCredentialsOptions.forceRefresh;

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import {
-	AmplifyV6,
 	AuthTokens,
 	FetchAuthSessionOptions,
+	AuthConfig,
 } from '@aws-amplify/core';
 import { isTokenExpired } from '@aws-amplify/core/internals/utils';
 import {
@@ -14,10 +14,15 @@ import {
 } from './types';
 
 export class TokenOrchestrator implements AuthTokenOrchestrator {
+	private authConfig: AuthConfig;
+
 	tokenStore: AuthTokenStore;
 	tokenRefresher: TokenRefresher;
 	waitForInflightOAuth: () => Promise<void> = async () => {};
 
+	setAuthConfig(authConfig: AuthConfig) {
+		this.authConfig = authConfig;
+	}
 	setTokenRefresher(tokenRefresher: TokenRefresher) {
 		this.tokenRefresher = tokenRefresher;
 	}
@@ -72,11 +77,9 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 		tokens: CognitoAuthTokens;
 	}): Promise<CognitoAuthTokens | null> {
 		try {
-			const authConfig = AmplifyV6.getConfig().Auth;
-
 			const newTokens = await this.tokenRefresher({
 				tokens,
-				authConfig,
+				authConfig: this.authConfig,
 			});
 
 			this.setTokens({ tokens: newTokens });

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
@@ -1,14 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import {
-	AmplifyV6,
-	KeyValueStorageInterface
-} from '@aws-amplify/core';
-import {
-	assertTokenProviderConfig,
-	asserts,
-	decodeJWT,
-} from '@aws-amplify/core/internals/utils';
+import { AuthConfig, KeyValueStorageInterface } from '@aws-amplify/core';
+import { asserts, decodeJWT } from '@aws-amplify/core/internals/utils';
 import {
 	AuthKeys,
 	AuthTokenStorageKeys,
@@ -17,8 +10,12 @@ import {
 } from './types';
 
 export class DefaultTokenStore implements AuthTokenStore {
-	constructor() {}
+	private authConfig: AuthConfig;
 	keyValueStorage: KeyValueStorageInterface;
+
+	setAuthConfig(authConfig: AuthConfig) {
+		this.authConfig = authConfig;
+	}
 
 	setKeyValueStorage(keyValueStorage: KeyValueStorageInterface) {
 		this.keyValueStorage = keyValueStorage;
@@ -26,13 +23,6 @@ export class DefaultTokenStore implements AuthTokenStore {
 	}
 
 	async loadTokens(): Promise<CognitoAuthTokens | null> {
-		const authConfig = AmplifyV6.getConfig().Auth;
-		try {
-			assertTokenProviderConfig(authConfig);
-		} catch (err) {
-			return null;
-		}
-
 		// TODO(v6): migration logic should be here
 		// Reading V5 tokens old format
 
@@ -41,7 +31,7 @@ export class DefaultTokenStore implements AuthTokenStore {
 			const name = 'Cognito'; // TODO(v6): update after API review for Amplify.configure
 			const authKeys = createKeysForAuthStorage(
 				name,
-				authConfig.userPoolWebClientId
+				this.authConfig.userPoolWebClientId
 			);
 
 			const accessTokenString = await this.keyValueStorage.getItem(
@@ -79,8 +69,6 @@ export class DefaultTokenStore implements AuthTokenStore {
 		}
 	}
 	async storeTokens(tokens: CognitoAuthTokens): Promise<void> {
-		const authConfig = AmplifyV6.getConfig().Auth;
-		assertTokenProviderConfig(authConfig);
 		asserts(!(tokens === undefined), {
 			message: 'Invalid tokens',
 			name: 'InvalidAuthTokens',
@@ -90,7 +78,7 @@ export class DefaultTokenStore implements AuthTokenStore {
 		const name = 'Cognito'; // TODO(v6): update after API review for Amplify.configure
 		const authKeys = createKeysForAuthStorage(
 			name,
-			authConfig.userPoolWebClientId
+			this.authConfig.userPoolWebClientId
 		);
 
 		this.keyValueStorage.setItem(
@@ -117,13 +105,10 @@ export class DefaultTokenStore implements AuthTokenStore {
 	}
 
 	async clearTokens(): Promise<void> {
-		const authConfig = AmplifyV6.getConfig().Auth;
-		assertTokenProviderConfig(authConfig);
-
 		const name = 'Cognito'; // TODO(v6): update after API review for Amplify.configure
 		const authKeys = createKeysForAuthStorage(
 			name,
-			authConfig.userPoolWebClientId
+			this.authConfig.userPoolWebClientId
 		);
 
 		// Not calling clear because it can remove data that is not managed by AuthTokenStore

--- a/packages/auth/src/providers/cognito/tokenProvider/index.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/index.ts
@@ -5,6 +5,7 @@ import {
 	KeyValueStorageInterface,
 	FetchAuthSessionOptions,
 	LocalStorage,
+	AuthConfig,
 } from '@aws-amplify/core';
 import { DefaultTokenStore } from './TokenStore';
 import { TokenOrchestrator } from './TokenOrchestrator';
@@ -34,6 +35,10 @@ class CognitoUserPoolsTokenProviderClass
 	}
 	setWaitForInflightOAuth(waitForInflightOAuth: () => Promise<void>): void {
 		this.tokenOrchestrator.setWaitForInflightOAuth(waitForInflightOAuth);
+	}
+	setAuthConfig(authConfig: AuthConfig) {
+		this.authTokenStore.setAuthConfig(authConfig);
+		this.tokenOrchestrator.setAuthConfig(authConfig);
 	}
 }
 

--- a/packages/auth/src/providers/cognito/tokenProvider/types.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/types.ts
@@ -46,6 +46,7 @@ export interface AuthTokenOrchestrator {
 
 export interface CognitoUserPoolTokenProviderType extends TokenProvider {
 	setKeyValueStorage: (keyValueStorage: KeyValueStorageInterface) => void;
+	setAuthConfig: (authConfig: AuthConfig) => void;
 }
 
 export type CognitoAuthTokens = AuthTokens & {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from '@aws-amplify/core/server';

--- a/packages/aws-amplify/__tests__/adapterCore/authProvidersFactories/cognito/createUserPoolsTokenProvider.test.ts
+++ b/packages/aws-amplify/__tests__/adapterCore/authProvidersFactories/cognito/createUserPoolsTokenProvider.test.ts
@@ -7,7 +7,7 @@ import {
 	CognitoUserPoolTokenRefresher,
 } from '@aws-amplify/auth/cognito';
 
-import { KeyValueStorageInterface } from '@aws-amplify/core';
+import { AuthConfig, KeyValueStorageInterface } from '@aws-amplify/core';
 import { createUserPoolsTokenProvider } from '../../../../src/adapterCore';
 
 jest.mock('@aws-amplify/auth/cognito');
@@ -17,6 +17,11 @@ const mockKeyValueStorage: KeyValueStorageInterface = {
 	getItem: jest.fn(),
 	removeItem: jest.fn(),
 	clear: jest.fn(),
+};
+const mockAuthConfig: AuthConfig = {
+	identityPoolId: '123',
+	userPoolId: 'abc',
+	userPoolWebClientId: 'def',
 };
 const MockDefaultTokenStore = DefaultTokenStore as jest.Mock;
 const MockTokenOrchestrator = TokenOrchestrator as jest.Mock;
@@ -29,10 +34,16 @@ describe('createUserPoolsTokenProvider', () => {
 	});
 
 	it('should create a token provider with underlying dependencies', () => {
-		const tokenProvider = createUserPoolsTokenProvider(mockKeyValueStorage);
+		const tokenProvider = createUserPoolsTokenProvider(
+			mockAuthConfig,
+			mockKeyValueStorage
+		);
 
 		expect(MockDefaultTokenStore).toHaveBeenCalledTimes(1);
 		const mockTokenStoreInstance = MockDefaultTokenStore.mock.instances[0];
+		expect(mockTokenStoreInstance.setAuthConfig).toHaveBeenCalledWith(
+			mockAuthConfig
+		);
 		expect(mockTokenStoreInstance.setKeyValueStorage).toHaveBeenCalledWith(
 			mockKeyValueStorage
 		);
@@ -40,6 +51,9 @@ describe('createUserPoolsTokenProvider', () => {
 		expect(MockTokenOrchestrator).toHaveBeenCalledTimes(1);
 		const mockTokenOrchestratorInstance =
 			MockTokenOrchestrator.mock.instances[0];
+		expect(mockTokenOrchestratorInstance.setAuthConfig).toHaveBeenCalledWith(
+			mockAuthConfig
+		);
 		expect(
 			mockTokenOrchestratorInstance.setAuthTokenStore
 		).toHaveBeenCalledWith(mockTokenStoreInstance);
@@ -51,7 +65,10 @@ describe('createUserPoolsTokenProvider', () => {
 	});
 
 	it('should call TokenOrchestrator.getTokens method with the default forceRefresh value', async () => {
-		const tokenProvider = createUserPoolsTokenProvider(mockKeyValueStorage);
+		const tokenProvider = createUserPoolsTokenProvider(
+			mockAuthConfig,
+			mockKeyValueStorage
+		);
 		const mockTokenOrchestratorInstance =
 			MockTokenOrchestrator.mock.instances[0];
 
@@ -63,7 +80,10 @@ describe('createUserPoolsTokenProvider', () => {
 	});
 
 	it('should call TokenOrchestrator.getTokens method with the specified forceRefresh value', async () => {
-		const tokenProvider = createUserPoolsTokenProvider(mockKeyValueStorage);
+		const tokenProvider = createUserPoolsTokenProvider(
+			mockAuthConfig,
+			mockKeyValueStorage
+		);
 		const mockTokenOrchestratorInstance =
 			MockTokenOrchestrator.mock.instances[0];
 

--- a/packages/aws-amplify/__tests__/adapterCore/storageFactories/createKeyValueStorageFromCookieStorageAdapter.ts
+++ b/packages/aws-amplify/__tests__/adapterCore/storageFactories/createKeyValueStorageFromCookieStorageAdapter.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createKeyValueStorageFromCookieStorageAdapter } from '../../../src/adapterCore';
+import { defaultSetCookieOptions } from '../../../src/adapterCore/storageFactories/createKeyValueStorageFromCookieStorageAdapter';
 
 const mockCookiesStorageAdapter = {
 	getAll: jest.fn(),
@@ -32,30 +33,24 @@ describe('keyValueStorage', () => {
 				expect(mockCookiesStorageAdapter.set).toBeCalledWith(
 					testKey,
 					testValue,
-					{}
+					{
+						...defaultSetCookieOptions,
+						expires: expect.any(Date),
+					}
 				);
 			});
 
 			it('should set item with options', async () => {
 				const testKey = 'testKey';
 				const testValue = 'testValue';
-				const testOptions = {
-					domain: 'testDomain',
-					expires: new Date(),
-					httpOnly: true,
-					maxAge: 100,
-					sameSite: 'strict',
-				};
-				mockCookiesStorageAdapter.get.mockReturnValueOnce({
-					name: testKey,
-					value: testValue,
-					...testOptions,
-				});
 				keyValueStorage.setItem(testKey, testValue);
 				expect(mockCookiesStorageAdapter.set).toBeCalledWith(
 					testKey,
 					testValue,
-					testOptions
+					{
+						...defaultSetCookieOptions,
+						expires: expect.any(Date),
+					}
 				);
 			});
 
@@ -71,8 +66,7 @@ describe('keyValueStorage', () => {
 			});
 
 			it('should get null if item not found', async () => {
-				const testKey = 'testKey';
-				const testValue = 'testValue';
+				const testKey = 'nonExisting';
 				const value = await keyValueStorage.getItem(testKey);
 				expect(value).toBeNull();
 			});

--- a/packages/aws-amplify/auth/server/package.json
+++ b/packages/aws-amplify/auth/server/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "aws-amplify/auth/server",
+	"main": "../../lib/auth/server.js",
+	"browser": "../../lib-esm/auth/server.js",
+	"module": "../../lib-esm/auth/server.js",
+	"typings": "../../lib-esm/auth/server.d.ts"
+}

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -27,6 +27,11 @@
       "import": "./lib-esm/auth/cognito/index.js",
       "require": "./lib/auth/cognito/index.js"
     },
+    "./auth/server": {
+      "types": "./lib-esm/auth/server.d.ts",
+      "import": "./lib-esm/auth/server.js",
+      "require": "./lib/auth/server.js"
+    },
     "./analytics": {
       "types": "./lib-esm/analytics/index.d.ts",
       "import": "./lib-esm/analytics/index.js",

--- a/packages/aws-amplify/src/adapterCore/authProvidersFactories/cognito/createAWSCredentialsAndIdentityIdProvider.ts
+++ b/packages/aws-amplify/src/adapterCore/authProvidersFactories/cognito/createAWSCredentialsAndIdentityIdProvider.ts
@@ -7,19 +7,24 @@ import {
 } from '@aws-amplify/auth/cognito';
 import {
 	AWSCredentialsAndIdentityIdProvider,
+	AuthConfig,
 	KeyValueStorageInterface,
 } from '@aws-amplify/core';
 
 /**
  * Creates a instance of {@link CognitoAWSCredentialsAndIdentityIdProvider} using
  * the provided `keyValueStorage`.
+ * @param authConfig The Auth config that the credentials provider needs to function.
  * @param keyValueStorage An object that implements the {@link KeyValueStorageInterface}.
  * @returns An instance of {@link CognitoAWSCredentialsAndIdentityIdProvider}.
  */
 export const createAWSCredentialsAndIdentityIdProvider = (
+	authConfig: AuthConfig,
 	keyValueStorage: KeyValueStorageInterface
 ): AWSCredentialsAndIdentityIdProvider => {
-	return new CognitoAWSCredentialsAndIdentityIdProvider(
+	const credentialsProvider = new CognitoAWSCredentialsAndIdentityIdProvider(
 		new DefaultIdentityIdStore(keyValueStorage)
 	);
+	credentialsProvider.setAuthConfig(authConfig);
+	return credentialsProvider;
 };

--- a/packages/aws-amplify/src/adapterCore/authProvidersFactories/cognito/createUserPoolsTokenProvider.ts
+++ b/packages/aws-amplify/src/adapterCore/authProvidersFactories/cognito/createUserPoolsTokenProvider.ts
@@ -6,19 +6,27 @@ import {
 	TokenOrchestrator,
 	CognitoUserPoolTokenRefresher,
 } from '@aws-amplify/auth/cognito';
-import { KeyValueStorageInterface, TokenProvider } from '@aws-amplify/core';
+import {
+	AuthConfig,
+	KeyValueStorageInterface,
+	TokenProvider,
+} from '@aws-amplify/core';
 
 /**
  * Creates an object that implements {@link TokenProvider}.
+ * @param authConfig The Auth config that the credentials provider needs to function.
  * @param keyValueStorage An object that implements the {@link KeyValueStorageInterface}.
  * @returns An object that implements {@link TokenProvider}.
  */
 export const createUserPoolsTokenProvider = (
+	authConfig: AuthConfig,
 	keyValueStorage: KeyValueStorageInterface
 ): TokenProvider => {
 	const authTokenStore = new DefaultTokenStore();
+	authTokenStore.setAuthConfig(authConfig);
 	authTokenStore.setKeyValueStorage(keyValueStorage);
 	const tokenOrchestrator = new TokenOrchestrator();
+	tokenOrchestrator.setAuthConfig(authConfig);
 	tokenOrchestrator.setAuthTokenStore(authTokenStore);
 	tokenOrchestrator.setTokenRefresher(CognitoUserPoolTokenRefresher);
 

--- a/packages/aws-amplify/src/adapterCore/storageFactories/createKeyValueStorageFromCookieStorageAdapter.ts
+++ b/packages/aws-amplify/src/adapterCore/storageFactories/createKeyValueStorageFromCookieStorageAdapter.ts
@@ -4,6 +4,12 @@
 import { KeyValueStorageInterface } from '@aws-amplify/core';
 import { CookieStorage } from '@aws-amplify/core/internals/adapter-core';
 
+export const defaultSetCookieOptions: CookieStorage.SetCookieOptions = {
+	sameSite: 'strict',
+	secure: true,
+};
+const ONE_YEAR_IN_MS = 365 * 24 * 60 * 60 * 1000;
+
 /**
  * Creates a Key Value storage interface using the `cookieStorageAdapter` as the
  * underlying storage.
@@ -16,9 +22,9 @@ export const createKeyValueStorageFromCookieStorageAdapter = (
 	return {
 		setItem(key, value) {
 			// TODO(HuiSF): follow up the default CookieSerializeOptions values
-			const originalCookie = cookieStorageAdapter.get(key) ?? {};
 			cookieStorageAdapter.set(key, value, {
-				...extractSerializeOptions(originalCookie),
+				...defaultSetCookieOptions,
+				expires: new Date(Date.now() + ONE_YEAR_IN_MS),
 			});
 			return Promise.resolve();
 		},
@@ -36,13 +42,3 @@ export const createKeyValueStorageFromCookieStorageAdapter = (
 		},
 	};
 };
-
-const extractSerializeOptions = (
-	cookie: Partial<CookieStorage.Cookie>
-): CookieStorage.SetCookieOptions => ({
-	domain: cookie.domain,
-	expires: cookie.expires,
-	httpOnly: cookie.httpOnly,
-	maxAge: cookie.maxAge,
-	sameSite: cookie.sameSite,
-});

--- a/packages/aws-amplify/src/auth/server.ts
+++ b/packages/aws-amplify/src/auth/server.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from '@aws-amplify/auth/server';

--- a/packages/aws-amplify/src/initSingleton.ts
+++ b/packages/aws-amplify/src/initSingleton.ts
@@ -13,6 +13,8 @@ import {
 
 export const DefaultAmplifyV6 = {
 	configure(resourceConfig: ResourcesConfig, libraryOptions?: LibraryOptions) {
+		CognitoUserPoolsTokenProvider.setAuthConfig(resourceConfig.Auth);
+		cognitoCredentialsProvider.setAuthConfig(resourceConfig.Auth);
 		const defaultLibraryOptions: LibraryOptions = {
 			Auth: {
 				tokenProvider: CognitoUserPoolsTokenProvider,

--- a/packages/aws-amplify/src/initSingleton.ts
+++ b/packages/aws-amplify/src/initSingleton.ts
@@ -5,6 +5,7 @@ import {
 	ResourcesConfig,
 	AmplifyV6,
 	LocalStorage,
+	CookieStorage,
 } from '@aws-amplify/core';
 import {
 	CognitoUserPoolsTokenProvider,
@@ -27,7 +28,13 @@ export const DefaultAmplifyV6 = {
 		if (libraryOptions !== undefined) {
 			updatedLibraryOptions = libraryOptions;
 		} else {
-			CognitoUserPoolsTokenProvider.setKeyValueStorage(LocalStorage);
+			CognitoUserPoolsTokenProvider.setKeyValueStorage(
+				resourceConfig.ssr
+					? new CookieStorage({
+							sameSite: 'strict',
+					  })
+					: LocalStorage
+			);
 			updatedLibraryOptions = defaultLibraryOptions;
 		}
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,8 @@
 		"src",
 		"typings.d.ts",
 		"internals",
-		"polyfills"
+		"polyfills",
+		"**/package.json"
 	],
 	"dependencies": {
 		"@aws-crypto/sha256-js": "1.2.2",

--- a/packages/core/server/package.json
+++ b/packages/core/server/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@aws-amplify/core/server",
+	"types": "../lib-esm/server.d.ts",
+	"main": "../lib/server.js",
+	"module": "../lib-esm/server.js",
+	"react-native": "../lib-esm/server.js",
+	"sideEffects": false
+}

--- a/packages/core/src/adapterCore/error/AmplifyServerContextError.ts
+++ b/packages/core/src/adapterCore/error/AmplifyServerContextError.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AmplifyError } from '../../libraryUtils';
+
+export class AmplifyServerContextError extends AmplifyError {
+	constructor({
+		message,
+		recoverySuggestion,
+		underlyingError,
+	}: {
+		message: string;
+		recoverySuggestion?: string;
+		underlyingError?: Error;
+	}) {
+		super({
+			name: 'AmplifyServerContextError',
+			message,
+			recoverySuggestion,
+			underlyingError,
+		});
+	}
+}

--- a/packages/core/src/adapterCore/error/index.ts
+++ b/packages/core/src/adapterCore/error/index.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { AmplifyServerContextError } from './AmplifyServerContextError';

--- a/packages/core/src/adapterCore/index.ts
+++ b/packages/core/src/adapterCore/index.ts
@@ -8,3 +8,4 @@ export {
 	AmplifyServer,
 	CookieStorage,
 } from './serverContext';
+export { AmplifyServerContextError } from './error';

--- a/packages/core/src/adapterCore/serverContext/types/amplifyServer.ts
+++ b/packages/core/src/adapterCore/serverContext/types/amplifyServer.ts
@@ -23,7 +23,7 @@ export namespace AmplifyServer {
 			libraryOptions: LibraryOptions,
 			operation: (
 				contextSpec: AmplifyServer.ContextSpec
-			) => Result | void | Promise<Result | void>
-		): Promise<Result | void>;
+			) => Result | Promise<Result>
+		): Promise<Result>;
 	}
 }

--- a/packages/core/src/adapterCore/serverContext/types/cookieStorage.ts
+++ b/packages/core/src/adapterCore/serverContext/types/cookieStorage.ts
@@ -6,7 +6,7 @@ import { CookieSerializeOptions } from 'cookie';
 export namespace CookieStorage {
 	export type SetCookieOptions = Pick<
 		CookieSerializeOptions,
-		'expires' | 'maxAge' | 'httpOnly' | 'domain' | 'sameSite'
+		'domain' | 'expires' | 'httpOnly' | 'maxAge' | 'sameSite' | 'secure'
 	>;
 
 	export type Cookie = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,11 @@ export {
 	ResourcesConfig,
 	LibraryOptions,
 } from './singleton/types';
-export { AmplifyV6, fetchAuthSession } from './singleton';
+export {
+	AmplifyV6,
+	fetchAuthSession,
+	AmplifyClass as AmplifyClassV6,
+} from './singleton';
 
 // AWSClients exports
 export {

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { fetchAuthSession } from './singleton/apis/server/fetchAuthSession';

--- a/packages/core/src/singleton/Amplify.ts
+++ b/packages/core/src/singleton/Amplify.ts
@@ -87,12 +87,14 @@ function mergeResourceConfig(
 		resultConfig[category] = existingConfig[category as keyof ResourcesConfig];
 	}
 
-	for (const category of Object.keys(newConfig)) {
-		resultConfig[category] = {
-			...resultConfig[category],
-			...newConfig[category as keyof ResourcesConfig],
+	for (const key of Object.keys(newConfig).filter(key => key !== 'ssr')) {
+		resultConfig[key] = {
+			...resultConfig[key],
+			...newConfig[key as Exclude<keyof ResourcesConfig, 'ssr'>],
 		};
 	}
+
+	resultConfig.ssr = newConfig.ssr;
 
 	return resultConfig;
 }

--- a/packages/core/src/singleton/types.ts
+++ b/packages/core/src/singleton/types.ts
@@ -14,9 +14,7 @@ import {
 	StorageAccessLevel,
 	StorageConfig,
 } from './Storage/types';
-import {
-	CacheConfig
-} from '../Cache/types';
+import { CacheConfig } from '../Cache/types';
 import { I18nOptions } from '../I18n/types';
 
 export type ResourcesConfig = {
@@ -30,6 +28,7 @@ export type ResourcesConfig = {
 	Notifications?: {};
 	Predictions?: {};
 	Storage?: StorageConfig;
+	ssr?: boolean;
 };
 
 export type LibraryOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2324,6 +2324,56 @@
     write-pkg "4.0.0"
     yargs "16.2.0"
 
+"@next/env@13.4.19":
+  version "13.4.19"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-13.4.19.tgz#46905b4e6f62da825b040343cbc233144e9578d3"
+  integrity sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ==
+
+"@next/swc-darwin-arm64@13.4.19":
+  version "13.4.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz#77ad462b5ced4efdc26cb5a0053968d2c7dac1b6"
+  integrity sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==
+
+"@next/swc-darwin-x64@13.4.19":
+  version "13.4.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.19.tgz#aebe38713a4ce536ee5f2a291673e14b715e633a"
+  integrity sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==
+
+"@next/swc-linux-arm64-gnu@13.4.19":
+  version "13.4.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz#ec54db65b587939c7b94f9a84800f003a380f5a6"
+  integrity sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==
+
+"@next/swc-linux-arm64-musl@13.4.19":
+  version "13.4.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz#1f5e2c1ea6941e7d530d9f185d5d64be04279d86"
+  integrity sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==
+
+"@next/swc-linux-x64-gnu@13.4.19":
+  version "13.4.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz#96b0882492a2f7ffcce747846d3680730f69f4d1"
+  integrity sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==
+
+"@next/swc-linux-x64-musl@13.4.19":
+  version "13.4.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz#f276b618afa321d2f7b17c81fc83f429fb0fd9d8"
+  integrity sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==
+
+"@next/swc-win32-arm64-msvc@13.4.19":
+  version "13.4.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz#1599ae0d401da5ffca0947823dac577697cce577"
+  integrity sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==
+
+"@next/swc-win32-ia32-msvc@13.4.19":
+  version "13.4.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz#55cdd7da90818f03e4da16d976f0cb22045d16fd"
+  integrity sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==
+
+"@next/swc-win32-x64-msvc@13.4.19":
+  version "13.4.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz#648f79c4e09279212ac90d871646ae12d80cdfce"
+  integrity sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==
+
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz#323d72dd25103d0c4fbdce89dadf574a787b1f9b"
@@ -3181,6 +3231,13 @@
   dependencies:
     "@statoscope/types" "5.22.0"
 
+"@swc/helpers@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.1.tgz#e9031491aa3f26bfcc974a67f48bd456c8a5357a"
+  integrity sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -3241,6 +3298,11 @@
   integrity sha512-TBOjqAGf0hmaqRwpii5LLkJLg7c6OMm4nHLmpsUxwk9bBHtoTC6dAHdVWdGv4TBxj2CZOZY8Xfq8WmfoVi7n4Q==
   dependencies:
     "@babel/types" "^7.20.7"
+
+"@types/cookie@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.5.1.tgz#b29aa1f91a59f35e29ff8f7cb24faf1a3a750554"
+  integrity sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==
 
 "@types/cookie@^0.3.3":
   version "0.3.3"
@@ -3365,6 +3427,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.3.tgz#fa52c147f405d56b2f1dd8780d840aa87ddff629"
   integrity sha512-ITI7rbWczR8a/S6qjAW7DMqxqFMjjTo61qZVWJ1ubPvbIQsL5D/TvwjYEalM8Kthpe3hTzOGrF2TGbAu2uyqeA==
 
+"@types/node@^20.3.1":
+  version "20.5.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.3.tgz#fa52c147f405d56b2f1dd8780d840aa87ddff629"
+  integrity sha512-ITI7rbWczR8a/S6qjAW7DMqxqFMjjTo61qZVWJ1ubPvbIQsL5D/TvwjYEalM8Kthpe3hTzOGrF2TGbAu2uyqeA==
+
 "@types/node@^8.9.5":
   version "8.10.66"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.66.tgz#dd035d409df322acc83dff62a602f12a5783bbb3"
@@ -3385,6 +3452,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/prop-types@*":
+  version "15.7.5"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
+  integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
 "@types/puppeteer@1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-1.3.0.tgz#dbee1fa65e24b6ad628e4a35867ad389faf81a5b"
@@ -3393,12 +3465,33 @@
     "@types/events" "*"
     "@types/node" "*"
 
+"@types/react-dom@^18.2.6":
+  version "18.2.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.7.tgz#67222a08c0a6ae0a0da33c3532348277c70abb63"
+  integrity sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^18.2.13":
+  version "18.2.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.21.tgz#774c37fd01b522d0b91aed04811b58e4e0514ed9"
+  integrity sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/resolve@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
+
+"@types/scheduler@*":
+  version "0.16.3"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
+  integrity sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==
 
 "@types/semver@^7.3.10":
   version "7.5.0"
@@ -4425,6 +4518,13 @@ builtins@^5.0.0:
   dependencies:
     semver "^7.0.0"
 
+busboy@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
+
 byte-size@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-7.0.0.tgz#36528cd1ca87d39bd9abd51f5715dc93b6ceb032"
@@ -4557,6 +4657,11 @@ camelcase@^6.0.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
+
+caniuse-lite@^1.0.30001406:
+  version "1.0.30001522"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz#44b87a406c901269adcdb834713e23582dd71856"
+  integrity sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==
 
 caniuse-lite@^1.0.30001517:
   version "1.0.30001522"
@@ -4735,6 +4840,11 @@ cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
+client-only@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
+  integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
 cliui@^3.2.0:
   version "3.2.0"
@@ -5132,6 +5242,11 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.7.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
 
+cookie@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
+  integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
 cookie@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
@@ -5179,6 +5294,13 @@ cosmiconfig@^5.0.5, cosmiconfig@^5.1.0, cosmiconfig@^5.2.1:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
+
+cross-fetch@^3.0.4:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
+  dependencies:
+    node-fetch "^2.6.12"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -5235,6 +5357,11 @@ cssstyle@^1.0.0:
   integrity sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==
   dependencies:
     cssom "0.3.x"
+
+csstype@^3.0.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
+  integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
 dargs@^7.0.0:
   version "7.0.0"
@@ -7817,6 +7944,14 @@ jest-environment-node@^24.8.0, jest-environment-node@^24.9.0:
     jest-mock "^24.9.0"
     jest-util "^24.9.0"
 
+jest-fetch-mock@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^24.8.0, jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
@@ -9479,7 +9614,7 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
   integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
 
-nanoid@^3.3.6:
+nanoid@^3.3.4, nanoid@^3.3.6:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
@@ -9528,6 +9663,30 @@ neo-async@^2.5.0, neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
+"next@>= 13.4.0 < 14.0.0":
+  version "13.4.19"
+  resolved "https://registry.yarnpkg.com/next/-/next-13.4.19.tgz#2326e02aeedee2c693d4f37b90e4f0ed6882b35f"
+  integrity sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==
+  dependencies:
+    "@next/env" "13.4.19"
+    "@swc/helpers" "0.5.1"
+    busboy "1.6.0"
+    caniuse-lite "^1.0.30001406"
+    postcss "8.4.14"
+    styled-jsx "5.1.1"
+    watchpack "2.4.0"
+    zod "3.21.4"
+  optionalDependencies:
+    "@next/swc-darwin-arm64" "13.4.19"
+    "@next/swc-darwin-x64" "13.4.19"
+    "@next/swc-linux-arm64-gnu" "13.4.19"
+    "@next/swc-linux-arm64-musl" "13.4.19"
+    "@next/swc-linux-x64-gnu" "13.4.19"
+    "@next/swc-linux-x64-musl" "13.4.19"
+    "@next/swc-win32-arm64-msvc" "13.4.19"
+    "@next/swc-win32-ia32-msvc" "13.4.19"
+    "@next/swc-win32-x64-msvc" "13.4.19"
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -9557,7 +9716,7 @@ node-fetch@2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7:
   version "2.6.13"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.13.tgz#a20acbbec73c2e09f9007de5cda17104122e0010"
   integrity sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==
@@ -10552,6 +10711,15 @@ postcss-selector-parser@^6.0.10:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
+postcss@8.4.14:
+  version "8.4.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
+  integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -10642,6 +10810,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==
+
+promise-polyfill@^8.1.3:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.3.0.tgz#9284810268138d103807b11f4e23d5e945a4db63"
+  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
 
 promise-retry@^2.0.1:
   version "2.0.1"
@@ -11658,6 +11831,11 @@ serve-static@^1.13.1:
     parseurl "~1.3.3"
     send "0.18.0"
 
+server-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
+  integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -11883,7 +12061,7 @@ sort-keys@^2.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-map-js@^1.0.1:
+source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
@@ -12089,6 +12267,11 @@ stream-events@^1.0.5:
   dependencies:
     stubs "^3.0.0"
 
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -12261,6 +12444,13 @@ stubs@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
   integrity sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==
+
+styled-jsx@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.1.1.tgz#839a1c3aaacc4e735fed0781b8619ea5d0009d1f"
+  integrity sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==
+  dependencies:
+    client-only "0.0.1"
 
 sudo-prompt@^9.0.0:
   version "9.2.1"
@@ -12871,6 +13061,11 @@ typescript@5.0.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
   integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
+typescript@5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
+  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
+
 "typescript@^3 || ^4":
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
@@ -13202,7 +13397,7 @@ warning@^4.0.2, warning@^4.0.3:
   dependencies:
     loose-envify "^1.0.0"
 
-watchpack@^2.4.0:
+watchpack@2.4.0, watchpack@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
   integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
@@ -13814,3 +14009,8 @@ zen-observable@^0.8.0:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
+
+zod@3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

### `@aws-amplify/auth` Auth Providers

* Added capability to allow `setAuthConfig` rather than always looking up from the Amplify singleton to make the implementation reusable
* Fixed an issue in the `IdentityIdStore` that may wipe out entire cookie store/local storage.

### `@aws-amplify/core`

* Enable the `ssr` flag with calling `Amplify.configure()` on the client side
* Added `AmplifyServerContextError`

### `aws-amplify`
* Adjusted implementation of the auth provider and key-value store factories functions

### `@aws-amplify/adapter-nextjs`
* Set up the package
* Added initial implementation

### Subpaths
* Set up `/server` subpaths for `@aws-amplify/core` `@aws-amplify/auth` and `aws-amplify` packages to export relevant APIs 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
