### PR TITLE
feat(storage): make storage apis runnable with the server context

### DIFF
--- a/packages/storage/__tests__/providers/s3/downloadData.test.ts
+++ b/packages/storage/__tests__/providers/s3/downloadData.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Credentials } from '@aws-sdk/types';
-import { AmplifyV6, fetchAuthSession } from '@aws-amplify/core';
+import { AmplifyV6 } from '@aws-amplify/core';
 import { getObject } from '../../../src/AwsClients/S3';
 import { downloadData } from '../../../src/providers/s3';
 import { createDownloadTask } from '../../../src/utils/transferTask';
@@ -16,6 +16,10 @@ jest.mock('@aws-amplify/core', () => {
 		AmplifyV6: {
 			...core.AmplifyV6,
 			getConfig: jest.fn(),
+			Auth: {
+				...core.AmplifyV6.Auth,
+				fetchAuthSession: jest.fn(),
+			},
 		},
 		fetchAuthSession: jest.fn(),
 	};
@@ -26,14 +30,15 @@ const credentials: Credentials = {
 	secretAccessKey: 'secretAccessKey',
 };
 const identityId = 'identityId';
-const mockFetchAuthSession = fetchAuthSession as jest.Mock;
+const mockAmplifySingletonAuthFetchAuthSession = AmplifyV6.Auth
+	.fetchAuthSession as jest.Mock;
 const mockCreateDownloadTask = createDownloadTask as jest.Mock;
 
 // TODO: test validation errors
 // TODO: test downloadData from guest, private, protected access level respectively.
 describe('downloadData', () => {
 	beforeAll(() => {
-		mockFetchAuthSession.mockResolvedValue({
+		mockAmplifySingletonAuthFetchAuthSession.mockResolvedValue({
 			credentials,
 			identityId,
 		});

--- a/packages/storage/__tests__/providers/s3/getProperties.test.ts
+++ b/packages/storage/__tests__/providers/s3/getProperties.test.ts
@@ -4,7 +4,7 @@
 import { headObject } from '../../../src/AwsClients/S3';
 import { getProperties } from '../../../src/providers/s3';
 import { Credentials } from '@aws-sdk/types';
-import { AmplifyV6, fetchAuthSession } from '@aws-amplify/core';
+import { AmplifyV6 } from '@aws-amplify/core';
 
 jest.mock('../../../src/AwsClients/S3');
 const mockHeadObject = headObject as jest.Mock;
@@ -17,6 +17,10 @@ jest.mock('@aws-amplify/core', () => {
 		AmplifyV6: {
 			...core.AmplifyV6,
 			getConfig: jest.fn(),
+			Auth: {
+				...core.AmplifyV6.Auth,
+				fetchAuthSession: jest.fn(),
+			},
 		},
 	};
 });
@@ -34,11 +38,11 @@ describe('getProperties test', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
-
-	(fetchAuthSession as jest.Mock).mockResolvedValue({
+	(AmplifyV6.Auth.fetchAuthSession as jest.Mock).mockResolvedValue({
 		credentials,
 		identityId: targetIdentityId,
 	});
+
 	(AmplifyV6.getConfig as jest.Mock).mockReturnValue({
 		Storage: {
 			bucket,

--- a/packages/storage/__tests__/providers/s3/getUrl.test.ts
+++ b/packages/storage/__tests__/providers/s3/getUrl.test.ts
@@ -1,6 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { getProperties, getUrl } from '../../../src/providers/s3/apis';
 import { Credentials } from '@aws-sdk/types';
-import { AmplifyV6, fetchAuthSession } from '@aws-amplify/core';
+import { AmplifyV6 } from '@aws-amplify/core';
 import {
 	getPresignedGetObjectUrl,
 	headObject,
@@ -17,6 +20,10 @@ jest.mock('@aws-amplify/core', () => {
 		AmplifyV6: {
 			...core.AmplifyV6,
 			getConfig: jest.fn(),
+			Auth: {
+				...core.AmplifyV6.Auth,
+				fetchAuthSession: jest.fn(),
+			},
 		},
 	};
 });
@@ -35,10 +42,11 @@ describe('getProperties test', () => {
 		jest.clearAllMocks();
 	});
 
-	(fetchAuthSession as jest.Mock).mockResolvedValue({
+	(AmplifyV6.Auth.fetchAuthSession as jest.Mock).mockResolvedValue({
 		credentials,
 		identityId: targetIdentityId,
 	});
+
 	(AmplifyV6.getConfig as jest.Mock).mockReturnValue({
 		Storage: {
 			bucket,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -67,7 +67,8 @@
     "lib",
     "lib-esm",
     "src",
-    "internals"
+    "internals",
+    "server"
   ],
   "dependencies": {
     "@aws-sdk/md5-js": "3.6.1",
@@ -76,6 +77,24 @@
     "events": "^3.1.0",
     "fast-xml-parser": "^4.2.5",
     "tslib": "^2.5.0"
+  },
+  "exports": {
+    ".": {
+			"types": "./lib-esm/index.d.ts",
+			"import": "./lib-esm/index.js",
+			"require": "./lib/index.js"
+		},
+		"./server": {
+			"types": "./lib-esm/server.d.ts",
+			"import": "./lib-esm/server.js",
+			"require": "./lib/server.js"
+		},
+		"./internals": {
+			"types": "./lib-esm/lib-esm/internals/index.d.ts",
+			"import": "./lib-esm/internals/index.js",
+			"require": "./lib/internals/index.js"
+		},
+		"./package.json": "./package.json"
   },
   "peerDependencies": {
     "@aws-amplify/core": "^6.0.0"

--- a/packages/storage/server/package.json
+++ b/packages/storage/server/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@aws-amplify/storage/server",
+	"types": "../lib-esm/server.d.ts",
+	"main": "../lib/server.js",
+	"module": "../lib-esm/server.js",
+	"react-native": "../lib-esm/server.js",
+	"sideEffects": false
+}

--- a/packages/storage/src/providers/s3/apis/copy.ts
+++ b/packages/storage/src/providers/s3/apis/copy.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyV6 } from '@aws-amplify/core';
 import { S3Exception, S3CopyResult } from '../types';
 import { CopyRequest } from '../../../types';
 import {
@@ -26,8 +27,9 @@ import { assertValidationError } from '../../../errors/utils/assertValidationErr
  */
 export const copy = async (copyRequest: CopyRequest): Promise<S3CopyResult> => {
 	const { identityId: defaultIdentityId, credentials } =
-		await resolveCredentials();
-	const { defaultAccessLevel, bucket, region } = resolveStorageConfig();
+		await resolveCredentials(AmplifyV6);
+	const { defaultAccessLevel, bucket, region } =
+		resolveStorageConfig(AmplifyV6);
 	const {
 		source: {
 			key: sourceKey,
@@ -45,7 +47,7 @@ export const copy = async (copyRequest: CopyRequest): Promise<S3CopyResult> => {
 		StorageValidationErrorCode.NoDestinationKey
 	);
 
-	const sourceFinalKey = `${bucket}/${getKeyWithPrefix({
+	const sourceFinalKey = `${bucket}/${getKeyWithPrefix(AmplifyV6, {
 		accessLevel: sourceAccessLevel,
 		targetIdentityId:
 			copyRequest.source.accessLevel === 'protected'
@@ -54,7 +56,7 @@ export const copy = async (copyRequest: CopyRequest): Promise<S3CopyResult> => {
 		key: sourceKey,
 	})}`;
 
-	const destinationFinalKey = getKeyWithPrefix({
+	const destinationFinalKey = getKeyWithPrefix(AmplifyV6, {
 		accessLevel: destinationAccessLevel,
 		targetIdentityId: defaultIdentityId,
 		key: destinationKey,

--- a/packages/storage/src/providers/s3/apis/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/downloadData.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyV6 as Amplify } from '@aws-amplify/core';
 import { StorageDownloadDataRequest, DownloadTask } from '../../../types';
 import { S3TransferOptions, S3DownloadDataResult } from '../types';
 import {
@@ -49,8 +50,9 @@ const downloadDataJob =
 	async () => {
 		// TODO[AllanZhengYP]: refactor this to reduce duplication
 		const options = downloadDataRequest?.options ?? {};
-		const { credentials, identityId } = await resolveCredentials();
-		const { defaultAccessLevel, bucket, region } = resolveStorageConfig();
+		const { credentials, identityId } = await resolveCredentials(Amplify);
+		const { defaultAccessLevel, bucket, region } =
+			resolveStorageConfig(Amplify);
 		const {
 			key,
 			options: {
@@ -61,7 +63,7 @@ const downloadDataJob =
 		} = downloadDataRequest;
 		assertValidationError(!!key, StorageValidationErrorCode.NoKey);
 
-		const finalKey = getKeyWithPrefix({
+		const finalKey = getKeyWithPrefix(Amplify, {
 			accessLevel,
 			targetIdentityId:
 				options.accessLevel === 'protected'

--- a/packages/storage/src/providers/s3/apis/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/getProperties.ts
@@ -1,16 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { headObject } from '../../../AwsClients/S3';
-import { StorageOptions, StorageOperationRequest } from '../../../types';
-import { assertValidationError } from '../../../errors/utils/assertValidationError';
-import { StorageValidationErrorCode } from '../../../errors/types/validation';
-import { S3Exception, S3GetPropertiesResult } from '../types';
-import {
-	resolveStorageConfig,
-	getKeyWithPrefix,
-	resolveCredentials,
-} from '../utils';
+import { AmplifyV6 } from '@aws-amplify/core';
+import { StorageOperationRequest, StorageOptions } from '../../..';
+import { S3GetPropertiesResult } from '../types';
+import { getProperties as getPropertiesInternal } from './internal/getProperties';
 
 /**
  * Gets the properties of a file. The properties include S3 system metadata and
@@ -21,42 +15,8 @@ import {
  * @throws A {@link S3Exception} when the underlying S3 service returned error.
  * @throws A {@link StorageValidationErrorCode} when API call parameters are invalid.
  */
-export const getProperties = async function (
+export const getProperties = (
 	req: StorageOperationRequest<StorageOptions>
-): Promise<S3GetPropertiesResult> {
-	const { defaultAccessLevel, bucket, region } = resolveStorageConfig();
-	const { identityId, credentials } = await resolveCredentials();
-	const { key, options = {} } = req;
-	const { accessLevel = defaultAccessLevel } = options;
-
-	assertValidationError(!!key, StorageValidationErrorCode.NoKey);
-	// TODO[AllanZhengYP]: refactor this to reduce duplication
-	const finalKey = getKeyWithPrefix({
-		accessLevel,
-		targetIdentityId:
-			options.accessLevel === 'protected'
-				? options.targetIdentityId
-				: identityId,
-		key,
-	});
-
-	const response = await headObject(
-		{
-			region,
-			credentials,
-		},
-		{
-			Bucket: bucket,
-			Key: finalKey,
-		}
-	);
-	return {
-		key,
-		contentType: response.ContentType,
-		size: response.ContentLength,
-		eTag: response.ETag,
-		lastModified: response.LastModified,
-		metadata: response.Metadata,
-		versionId: response.VersionId,
-	};
+): Promise<S3GetPropertiesResult> => {
+	return getPropertiesInternal(AmplifyV6, req);
 };

--- a/packages/storage/src/providers/s3/apis/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/getUrl.ts
@@ -1,25 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { StorageDownloadDataRequest } from '../../../types';
+import { AmplifyV6 } from '@aws-amplify/core';
+import { StorageDownloadDataRequest } from '../../..';
 import { S3GetUrlOptions, S3GetUrlResult } from '../types';
-import { StorageValidationErrorCode } from '../../../errors/types/validation';
-import {
-	SERVICE_NAME as S3_SERVICE_NAME,
-	GetObjectInput,
-	getPresignedGetObjectUrl,
-} from '../../../AwsClients/S3';
-import { getProperties } from './getProperties';
-import { S3Exception } from '../types/errors';
-import {
-	getKeyWithPrefix,
-	resolveCredentials,
-	resolveStorageConfig,
-} from '../utils';
-import { assertValidationError } from '../../../errors/utils/assertValidationError';
-
-const DEFAULT_PRESIGN_EXPIRATION = 900;
-const MAX_URL_EXPIRATION = 7 * 24 * 60 * 60 * 1000;
+import { getUrl as getUrlInternal } from './internal/getUrl';
 
 /**
  * Get Presigned url of the object
@@ -33,55 +18,8 @@ const MAX_URL_EXPIRATION = 7 * 24 * 60 * 60 * 1000;
  * TODO: add config errors
  *
  */
-export const getUrl = async function (
+export const getUrl = (
 	req: StorageDownloadDataRequest<S3GetUrlOptions>
-): Promise<S3GetUrlResult> {
-	const options = req?.options ?? {};
-	const { credentials, identityId } = await resolveCredentials();
-	const { defaultAccessLevel, bucket, region } = resolveStorageConfig();
-	const { key, options: { accessLevel = defaultAccessLevel } = {} } = req;
-	assertValidationError(!!key, StorageValidationErrorCode.NoKey);
-	if (options?.validateObjectExistence) {
-		await getProperties({ key });
-	}
-
-	// TODO[AllanZhengYP]: refactor this to reduce duplication
-	const finalKey = getKeyWithPrefix({
-		accessLevel,
-		targetIdentityId:
-			options.accessLevel === 'protected'
-				? options.targetIdentityId
-				: identityId,
-		key,
-	});
-	const getUrlParams: GetObjectInput = {
-		Bucket: bucket,
-		Key: finalKey,
-	};
-	let urlExpirationInSec = options?.expiresIn ?? DEFAULT_PRESIGN_EXPIRATION;
-	const getUrlOptions = {
-		accessLevel,
-		credentials,
-		expiration: urlExpirationInSec,
-		signingRegion: region,
-		region,
-		signingService: S3_SERVICE_NAME,
-	};
-	const awsCredExpiration = credentials?.expiration;
-	if (awsCredExpiration) {
-		const awsCredExpirationInSec = Math.floor(
-			(awsCredExpiration.getTime() - Date.now()) / 1000
-		);
-		urlExpirationInSec = Math.min(awsCredExpirationInSec, urlExpirationInSec);
-	}
-
-	assertValidationError(
-		urlExpirationInSec < MAX_URL_EXPIRATION,
-		StorageValidationErrorCode.UrlExpirationMaxLimitExceed
-	);
-	// expiresAt is the minimum of credential expiration and url expiration
-	return {
-		url: await getPresignedGetObjectUrl(getUrlOptions, getUrlParams),
-		expiresAt: new Date(Date.now() + urlExpirationInSec * 1000),
-	};
+): Promise<S3GetUrlResult> => {
+	return getUrlInternal(AmplifyV6, req);
 };

--- a/packages/storage/src/providers/s3/apis/internal/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getProperties.ts
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { headObject } from '../../../../AwsClients/S3';
+import { StorageOptions, StorageOperationRequest } from '../../../../types';
+import { assertValidationError } from '../../../../errors/utils/assertValidationError';
+import { StorageValidationErrorCode } from '../../../../errors/types/validation';
+import { S3Exception, S3GetPropertiesResult } from '../../types';
+import {
+	resolveStorageConfig,
+	getKeyWithPrefix,
+	resolveCredentials,
+} from '../../utils';
+import { AmplifyClassV6 } from '@aws-amplify/core';
+
+export const getProperties = async function (
+	amplify: AmplifyClassV6,
+	req: StorageOperationRequest<StorageOptions>
+): Promise<S3GetPropertiesResult> {
+	const { defaultAccessLevel, bucket, region } = resolveStorageConfig(amplify);
+	const { identityId, credentials } = await resolveCredentials(amplify);
+	const { key, options = {} } = req;
+	const { accessLevel = defaultAccessLevel } = options;
+
+	assertValidationError(!!key, StorageValidationErrorCode.NoKey);
+	// TODO[AllanZhengYP]: refactor this to reduce duplication
+	const finalKey = getKeyWithPrefix(amplify, {
+		accessLevel,
+		targetIdentityId:
+			options.accessLevel === 'protected'
+				? options.targetIdentityId
+				: identityId,
+		key,
+	});
+
+	const response = await headObject(
+		{
+			region,
+			credentials,
+		},
+		{
+			Bucket: bucket,
+			Key: finalKey,
+		}
+	);
+	return {
+		key,
+		contentType: response.ContentType,
+		size: response.ContentLength,
+		eTag: response.ETag,
+		lastModified: response.LastModified,
+		metadata: response.Metadata,
+		versionId: response.VersionId,
+	};
+};

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AmplifyClassV6 } from '@aws-amplify/core';
+import { StorageDownloadDataRequest } from '../../../../types';
+import { S3GetUrlOptions, S3GetUrlResult } from '../../types';
+import { StorageValidationErrorCode } from '../../../../errors/types/validation';
+import {
+	SERVICE_NAME as S3_SERVICE_NAME,
+	GetObjectInput,
+	getPresignedGetObjectUrl,
+} from '../../../../AwsClients/S3';
+import { getProperties } from './getProperties';
+import { S3Exception } from '../../types/errors';
+import {
+	getKeyWithPrefix,
+	resolveCredentials,
+	resolveStorageConfig,
+} from '../../utils';
+import { assertValidationError } from '../../../../errors/utils/assertValidationError';
+
+const DEFAULT_PRESIGN_EXPIRATION = 900;
+const MAX_URL_EXPIRATION = 7 * 24 * 60 * 60 * 1000;
+
+export const getUrl = async function (
+	amplify: AmplifyClassV6,
+	req: StorageDownloadDataRequest<S3GetUrlOptions>
+): Promise<S3GetUrlResult> {
+	const options = req?.options ?? {};
+	const { credentials, identityId } = await resolveCredentials(amplify);
+	const { defaultAccessLevel, bucket, region } = resolveStorageConfig(amplify);
+	const { key, options: { accessLevel = defaultAccessLevel } = {} } = req;
+	assertValidationError(!!key, StorageValidationErrorCode.NoKey);
+	if (options?.validateObjectExistence) {
+		await getProperties(amplify, { key });
+	}
+
+	// TODO[AllanZhengYP]: refactor this to reduce duplication
+	const finalKey = getKeyWithPrefix(amplify, {
+		accessLevel,
+		targetIdentityId:
+			options.accessLevel === 'protected'
+				? options.targetIdentityId
+				: identityId,
+		key,
+	});
+	const getUrlParams: GetObjectInput = {
+		Bucket: bucket,
+		Key: finalKey,
+	};
+	let urlExpirationInSec = options?.expiresIn ?? DEFAULT_PRESIGN_EXPIRATION;
+	const getUrlOptions = {
+		accessLevel,
+		credentials,
+		expiration: urlExpirationInSec,
+		signingRegion: region,
+		region,
+		signingService: S3_SERVICE_NAME,
+	};
+	const awsCredExpiration = credentials?.expiration;
+	if (awsCredExpiration) {
+		const awsCredExpirationInSec = Math.floor(
+			(awsCredExpiration.getTime() - Date.now()) / 1000
+		);
+		urlExpirationInSec = Math.min(awsCredExpirationInSec, urlExpirationInSec);
+	}
+
+	assertValidationError(
+		urlExpirationInSec < MAX_URL_EXPIRATION,
+		StorageValidationErrorCode.UrlExpirationMaxLimitExceed
+	);
+
+	// expiresAt is the minimum of credential expiration and url expiration
+	return {
+		url: await getPresignedGetObjectUrl(getUrlOptions, getUrlParams),
+		expiresAt: new Date(Date.now() + urlExpirationInSec * 1000),
+	};
+};

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -1,0 +1,117 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	ListObjectsV2Input,
+	ListObjectsV2Output,
+	listObjectsV2,
+} from '../../../../AwsClients/S3';
+import {
+	StorageConfig,
+	StorageListRequest,
+	StorageListAllOptions,
+	StorageListPaginateOptions,
+} from '../../../../types';
+import {
+	S3ListOutputItem,
+	S3Exception,
+	S3ListAllResult,
+	S3ListPaginateResult,
+} from '../../types';
+import {
+	resolveStorageConfig,
+	getKeyWithPrefix,
+	resolveCredentials,
+} from '../../utils';
+import { StorageValidationErrorCode } from '../../../../errors/types/validation';
+import { AmplifyClassV6 } from '@aws-amplify/core';
+
+const MAX_PAGE_SIZE = 1000;
+
+// TODO(ashwinkumar6) add unit test for list API
+export const list = async (
+	amplify: AmplifyClassV6,
+	req:
+		| StorageListRequest<StorageListAllOptions>
+		| StorageListRequest<StorageListPaginateOptions>
+): Promise<S3ListAllResult | S3ListPaginateResult> => {
+	const { identityId, credentials } = await resolveCredentials(amplify);
+	const { defaultAccessLevel, bucket, region } = resolveStorageConfig(amplify);
+	const { path = '', options = {} } = req;
+	const { accessLevel = defaultAccessLevel, listAll } = options;
+
+	// TODO(ashwinkumar6) V6-logger: check if this can be refactored
+	const finalPath = getKeyWithPrefix(amplify, {
+		accessLevel,
+		targetIdentityId:
+			options.accessLevel === 'protected'
+				? options.targetIdentityId
+				: identityId,
+		key: path,
+	});
+
+	const listConfig = {
+		region,
+		credentials,
+	};
+	const listParams = {
+		Bucket: bucket,
+		Prefix: finalPath,
+		MaxKeys: options?.listAll ? undefined : options?.pageSize,
+		ContinuationToken: options?.listAll ? undefined : options?.nextToken,
+	};
+	return listAll
+		? await _listAll(listConfig, listParams)
+		: await _list(listConfig, listParams);
+};
+
+const _listAll = async (
+	listConfig: StorageConfig,
+	listParams: ListObjectsV2Input
+): Promise<S3ListAllResult> => {
+	// TODO(ashwinkumar6) V6-logger: pageSize and nextToken aren't required when listing all items
+	const listResult: S3ListOutputItem[] = [];
+	let continuationToken = listParams.ContinuationToken;
+	do {
+		const { items: pageResults, nextToken: pageNextToken } = await _list(
+			listConfig,
+			{
+				...listParams,
+				ContinuationToken: continuationToken,
+				MaxKeys: MAX_PAGE_SIZE,
+			}
+		);
+		listResult.push(...pageResults);
+		continuationToken = pageNextToken;
+	} while (continuationToken);
+
+	return {
+		items: listResult,
+	};
+};
+
+const _list = async (
+	listConfig: StorageConfig,
+	listParams: ListObjectsV2Input
+): Promise<S3ListPaginateResult> => {
+	const listParamsClone = { ...listParams };
+	if (!listParamsClone.MaxKeys || listParamsClone.MaxKeys > MAX_PAGE_SIZE) {
+		listParamsClone.MaxKeys = MAX_PAGE_SIZE;
+		// TODO(ashwinkumar6) V6-logger: defaulting pageSize to ${MAX_PAGE_SIZE}.
+	}
+
+	const response: ListObjectsV2Output = await listObjectsV2(
+		listConfig,
+		listParamsClone
+	);
+	const listResult = response!.Contents!.map(item => ({
+		key: item.Key!.substring(listParamsClone.Prefix!.length),
+		eTag: item.ETag,
+		lastModified: item.LastModified,
+		size: item.Size,
+	}));
+	return {
+		items: listResult,
+		nextToken: response.NextContinuationToken,
+	};
+};

--- a/packages/storage/src/providers/s3/apis/internal/remove.ts
+++ b/packages/storage/src/providers/s3/apis/internal/remove.ts
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { S3Exception } from '../../types';
+import {
+	StorageOperationRequest,
+	StorageRemoveOptions,
+	StorageRemoveResult,
+} from '../../../../types';
+import {
+	resolveStorageConfig,
+	getKeyWithPrefix,
+	resolveCredentials,
+} from '../../utils';
+import { deleteObject, DeleteObjectInput } from '../../../../AwsClients/S3';
+import { StorageValidationErrorCode } from '../../../../errors/types/validation';
+import { assertValidationError } from '../../../../errors/utils/assertValidationError';
+import { AmplifyClassV6 } from '@aws-amplify/core';
+
+// TODO(ashwinkumar6) add unit test for remove API
+
+export const remove = async (
+	amplify: AmplifyClassV6,
+	req: StorageOperationRequest<StorageRemoveOptions>
+): Promise<StorageRemoveResult> => {
+	const { identityId, credentials } = await resolveCredentials(amplify);
+	const { defaultAccessLevel, bucket, region } = resolveStorageConfig(amplify);
+	const { key, options = {} } = req;
+	const { accessLevel = defaultAccessLevel } = options;
+
+	assertValidationError(!!key, StorageValidationErrorCode.NoKey);
+	// TODO(ashwinkumar6) can we refactor getKeyWithPrefix to avoid duplication
+	const finalKey = getKeyWithPrefix(amplify, {
+		accessLevel,
+		targetIdentityId:
+			options.accessLevel === 'protected'
+				? options.targetIdentityId
+				: identityId,
+		key,
+	});
+
+	// TODO(ashwinkumar6) V6-logger: debug `remove ${key} from ${finalKey}`
+	await deleteObject(
+		{
+			region,
+			credentials,
+		},
+		{
+			Bucket: bucket,
+			Key: finalKey,
+		}
+	);
+	return {
+		key,
+	};
+};

--- a/packages/storage/src/providers/s3/apis/remove.ts
+++ b/packages/storage/src/providers/s3/apis/remove.ts
@@ -1,22 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { S3Exception } from '../types';
+import { AmplifyV6 } from '@aws-amplify/core';
 import {
 	StorageOperationRequest,
 	StorageRemoveOptions,
 	StorageRemoveResult,
-} from '../../../types';
-import {
-	resolveStorageConfig,
-	getKeyWithPrefix,
-	resolveCredentials,
-} from '../utils';
-import { deleteObject, DeleteObjectInput } from '../../../AwsClients/S3';
-import { StorageValidationErrorCode } from '../../../errors/types/validation';
-import { assertValidationError } from '../../../errors/utils/assertValidationError';
-
-// TODO(ashwinkumar6) add unit test for remove API
+} from '../../..';
+import { remove as removeInternal } from './internal/remove';
 
 /**
  * Remove the object that is specified by the `req`.
@@ -25,37 +16,8 @@ import { assertValidationError } from '../../../errors/utils/assertValidationErr
  * @throws service: {@link S3Exception} - S3 service errors thrown while getting properties
  * @throws validation: {@link StorageValidationErrorCode } - Validation errors thrown
  */
-export const remove = async (
+export const remove = (
 	req: StorageOperationRequest<StorageRemoveOptions>
 ): Promise<StorageRemoveResult> => {
-	const { identityId, credentials } = await resolveCredentials();
-	const { defaultAccessLevel, bucket, region } = resolveStorageConfig();
-	const { key, options = {} } = req;
-	const { accessLevel = defaultAccessLevel } = options;
-
-	assertValidationError(!!key, StorageValidationErrorCode.NoKey);
-	// TODO(ashwinkumar6) can we refactor getKeyWithPrefix to avoid duplication
-	const finalKey = getKeyWithPrefix({
-		accessLevel,
-		targetIdentityId:
-			options.accessLevel === 'protected'
-				? options.targetIdentityId
-				: identityId,
-		key,
-	});
-
-	// TODO(ashwinkumar6) V6-logger: debug `remove ${key} from ${finalKey}`
-	await deleteObject(
-		{
-			region,
-			credentials,
-		},
-		{
-			Bucket: bucket,
-			Key: finalKey,
-		}
-	);
-	return {
-		key,
-	};
+	return removeInternal(AmplifyV6, req);
 };

--- a/packages/storage/src/providers/s3/apis/server/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/server/getProperties.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+import { StorageOperationRequest, StorageOptions } from '../../../..';
+import { S3GetPropertiesResult } from '../../types';
+import { getProperties as getPropertiesInternal } from '../internal/getProperties';
+
+export const getProperties = (
+	contextSpec: AmplifyServer.ContextSpec,
+	req: StorageOperationRequest<StorageOptions>
+): Promise<S3GetPropertiesResult> => {
+	return getPropertiesInternal(
+		getAmplifyServerContext(contextSpec).amplify,
+		req
+	);
+};

--- a/packages/storage/src/providers/s3/apis/server/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/server/getUrl.ts
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+import { StorageDownloadDataRequest } from '../../../..';
+import { S3GetUrlOptions, S3GetUrlResult } from '../../types';
+import { getUrl as getUrlInternal } from '../internal/getUrl';
+
+export const getUrl = async (
+	contextSpec: AmplifyServer.ContextSpec,
+	req: StorageDownloadDataRequest<S3GetUrlOptions>
+): Promise<S3GetUrlResult> => {
+	return getUrlInternal(getAmplifyServerContext(contextSpec).amplify, req);
+};

--- a/packages/storage/src/providers/s3/apis/server/index.ts
+++ b/packages/storage/src/providers/s3/apis/server/index.ts
@@ -1,0 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { getProperties } from './getProperties';
+export { getUrl } from './getUrl';
+export { list } from './list';
+export { remove } from './remove';

--- a/packages/storage/src/providers/s3/apis/server/list.ts
+++ b/packages/storage/src/providers/s3/apis/server/list.ts
@@ -1,14 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6, AmplifyV6 } from '@aws-amplify/core';
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
 import {
 	StorageListAllOptions,
 	StorageListPaginateOptions,
 	StorageListRequest,
-} from '../../..';
-import { S3ListAllResult, S3ListPaginateResult } from '../types';
-import { list as listInternal } from './internal/list';
+} from '../../../..';
+import { S3ListAllResult, S3ListPaginateResult } from '../../types';
+import { list as listInternal } from '../internal/list';
 
 type S3ListApi = {
 	/**
@@ -18,7 +21,10 @@ type S3ListApi = {
 	 * @throws service: {@link S3Exception} - S3 service errors thrown while getting properties
 	 * @throws validation: {@link StorageValidationErrorCode } - Validation errors thrown
 	 */
-	(req: StorageListRequest<StorageListAllOptions>): Promise<S3ListAllResult>;
+	(
+		contextSpec: AmplifyServer.ContextSpec,
+		req: StorageListRequest<StorageListAllOptions>
+	): Promise<S3ListAllResult>;
 	/**
 	 * List bucket objects with pagination
 	 * @param {StorageListRequest<StorageListPaginateOptions>} req - The request object
@@ -28,12 +34,11 @@ type S3ListApi = {
 	 * @throws validation: {@link StorageValidationErrorCode } - Validation errors thrown
 	 */
 	(
+		contextSpec: AmplifyServer.ContextSpec,
 		req: StorageListRequest<StorageListPaginateOptions>
 	): Promise<S3ListPaginateResult>;
 };
 
-export const list: S3ListApi = (
-	req
-): Promise<S3ListAllResult | S3ListPaginateResult> => {
-	return listInternal(AmplifyV6, req);
+export const list: S3ListApi = (contextSpec, req) => {
+	return listInternal(getAmplifyServerContext(contextSpec).amplify, req);
 };

--- a/packages/storage/src/providers/s3/apis/server/remove.ts
+++ b/packages/storage/src/providers/s3/apis/server/remove.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+import {
+	StorageOperationRequest,
+	StorageRemoveOptions,
+	StorageRemoveResult,
+} from '../../../../';
+import { remove as removeInternal } from '../internal/remove';
+
+export const remove = (
+	contextSpec: AmplifyServer.ContextSpec,
+	req: StorageOperationRequest<StorageRemoveOptions>
+): Promise<StorageRemoveResult> => {
+	return removeInternal(getAmplifyServerContext(contextSpec).amplify, req);
+};

--- a/packages/storage/src/providers/s3/utils/getKeyWithPrefix.ts
+++ b/packages/storage/src/providers/s3/utils/getKeyWithPrefix.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyV6, StorageAccessLevel } from '@aws-amplify/core';
+import { AmplifyClassV6, StorageAccessLevel } from '@aws-amplify/core';
 import { prefixResolver as defaultPrefixResolver } from '../../../utils/prefixResolver';
 
 type GetKeyWithPrefixOptions = {
@@ -10,13 +10,12 @@ type GetKeyWithPrefixOptions = {
 	key: string;
 };
 
-export const getKeyWithPrefix = ({
-	accessLevel,
-	targetIdentityId,
-	key,
-}: GetKeyWithPrefixOptions) => {
+export const getKeyWithPrefix = (
+	amplify: AmplifyClassV6,
+	{ accessLevel, targetIdentityId, key }: GetKeyWithPrefixOptions
+) => {
 	const { prefixResolver = defaultPrefixResolver } =
-		AmplifyV6.libraryOptions?.Storage ?? {};
+		amplify.libraryOptions?.Storage ?? {};
 	return (
 		prefixResolver({
 			accessLevel,

--- a/packages/storage/src/providers/s3/utils/resolveCredentials.ts
+++ b/packages/storage/src/providers/s3/utils/resolveCredentials.ts
@@ -1,14 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyClassV6 } from '@aws-amplify/core';
+
 import { assertValidationError } from '../../../errors/utils/assertValidationError';
 import { StorageValidationErrorCode } from '../../../errors/types/validation';
-import { fetchAuthSession } from '@aws-amplify/core';
 
-export const resolveCredentials = async () => {
-	const { identityId, credentials } = await fetchAuthSession({
-		forceRefresh: false,
-	});
+export const resolveCredentials = async (amplify: AmplifyClassV6) => {
+	const { identityId, credentials } = await amplify.Auth.fetchAuthSession();
 	assertValidationError(
 		!!credentials,
 		StorageValidationErrorCode.NoCredentials

--- a/packages/storage/src/providers/s3/utils/resolveStorageConfig.ts
+++ b/packages/storage/src/providers/s3/utils/resolveStorageConfig.ts
@@ -1,18 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyV6 } from '@aws-amplify/core';
+import { AmplifyClassV6 } from '@aws-amplify/core';
 import { assertValidationError } from '../../../errors/utils/assertValidationError';
 import { StorageValidationErrorCode } from '../../../errors/types/validation';
 
 const DEFAULT_ACCESS_LEVEL = 'guest';
 
-export function resolveStorageConfig() {
-	const { bucket, region } = AmplifyV6.getConfig()?.Storage ?? {};
+export function resolveStorageConfig(amplify: AmplifyClassV6) {
+	const { bucket, region } = amplify.getConfig()?.Storage ?? {};
 	assertValidationError(!!bucket, StorageValidationErrorCode.NoBucket);
 	assertValidationError(!!region, StorageValidationErrorCode.NoRegion);
 	const { defaultAccessLevel = DEFAULT_ACCESS_LEVEL } =
-		AmplifyV6.libraryOptions?.Storage ?? {};
+		amplify.libraryOptions?.Storage ?? {};
 	return {
 		defaultAccessLevel,
 		bucket,

--- a/packages/storage/src/server.ts
+++ b/packages/storage/src/server.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './providers/s3/apis/server';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- Moved the original APIs implementation into `/internal` with adding a positional parameter `amplify: AmplifyClassV6`
- Added the APIs that are supposed to run on the client side with the original function signatures
- Added the APIs that are supposed to run on the server side, with adding a positional parameter `contextSpect: AmplifyServer.Context`
- Updated util functions allow injecting an `AmplifyClassV6` instance instead of hardcoding the look up of the Amplify singleton
- Exported the server side APIs via `@aws-amplify/storage/server` subpath
- ~~Fixed the expiration assertion for the getUrl API~~ got the fix after rebasing


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
