### PR TITLE
feat(auth): make a subset of auth apis runnable with the server context

### DIFF
--- a/packages/auth/__tests__/providers/cognito/fetchUserAttributes.test.ts
+++ b/packages/auth/__tests__/providers/cognito/fetchUserAttributes.test.ts
@@ -1,17 +1,21 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyV6 as Amplify } from 'aws-amplify';
+import { decodeJWT, fetchAuthSession } from '@aws-amplify/core/internals/utils';
 import * as getUserClient from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider';
 import { AuthError } from '../../../src/errors/AuthError';
 import { GetUserException } from '../../../src/providers/cognito/types/errors';
 import { GetUserCommandOutput } from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider/types';
 import { fetchTransferHandler } from '@aws-amplify/core/internals/aws-client-utils';
 import { buildMockErrorResponse, mockJsonResponse } from './testUtils/data';
-import { AmplifyV6 as Amplify } from 'aws-amplify';
-import { decodeJWT } from '@aws-amplify/core/internals/utils';
-import * as authUtils from '../../../src';
 import { fetchUserAttributes } from '../../../src/providers/cognito/apis/fetchUserAttributes';
+
 jest.mock('@aws-amplify/core/lib/clients/handlers/fetch');
+jest.mock('@aws-amplify/core/internals/utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/utils'),
+	fetchAuthSession: jest.fn(),
+}));
 
 Amplify.configure({
 	Auth: {
@@ -22,23 +26,17 @@ Amplify.configure({
 });
 const mockedAccessToken =
 	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+const mockFetchAuthSession = fetchAuthSession as jest.Mock;
 
 describe('fetchUserAttributes Happy Path Cases:', () => {
 	let getUserClientSpy;
-	let fetchAuthSessionsSpy;
 
 	beforeEach(() => {
-		fetchAuthSessionsSpy = jest
-			.spyOn(authUtils, 'fetchAuthSession')
-			.mockImplementationOnce(
-				async (): Promise<{ tokens: { accessToken: any } }> => {
-					return {
-						tokens: {
-							accessToken: decodeJWT(mockedAccessToken),
-						},
-					};
-				}
-			);
+		mockFetchAuthSession.mockResolvedValue({
+			tokens: {
+				accessToken: decodeJWT(mockedAccessToken),
+			},
+		});
 		getUserClientSpy = jest
 			.spyOn(getUserClient, 'getUser')
 			.mockImplementationOnce(async (): Promise<GetUserCommandOutput> => {
@@ -56,7 +54,7 @@ describe('fetchUserAttributes Happy Path Cases:', () => {
 	});
 	afterEach(() => {
 		getUserClientSpy.mockClear();
-		fetchAuthSessionsSpy.mockClear();
+		mockFetchAuthSession.mockClear();
 	});
 
 	test('fetchUserAttributes should return the current user attributes into a map format', async () => {
@@ -83,17 +81,12 @@ describe('fetchUserAttributes Error Path Cases:', () => {
 				buildMockErrorResponse(GetUserException.InvalidParameterException)
 			)
 		);
-		jest
-			.spyOn(authUtils, 'fetchAuthSession')
-			.mockImplementationOnce(
-				async (): Promise<{ tokens: { accessToken: any } }> => {
-					return {
-						tokens: {
-							accessToken: decodeJWT(mockedAccessToken),
-						},
-					};
-				}
-			);
+		mockFetchAuthSession.mockResolvedValueOnce({
+			tokens: {
+				accessToken: decodeJWT(mockedAccessToken),
+			},
+		});
+
 		try {
 			await fetchUserAttributes();
 		} catch (error) {

--- a/packages/auth/__tests__/providers/cognito/getCurrentUser.test.ts
+++ b/packages/auth/__tests__/providers/cognito/getCurrentUser.test.ts
@@ -1,15 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyV6 as Amplify } from 'aws-amplify';
+import { decodeJWT, fetchAuthSession } from '@aws-amplify/core/internals/utils';
 import { AuthError } from '../../../src/errors/AuthError';
 import { getCurrentUser } from '../../../src/providers/cognito';
 import { InitiateAuthException } from '../../../src/providers/cognito/types/errors';
-import { AmplifyV6 as Amplify } from 'aws-amplify';
-import { decodeJWT } from '@aws-amplify/core/internals/utils';
-import * as authUtils from '../../../src';
 import { fetchTransferHandler } from '@aws-amplify/core/internals/aws-client-utils';
 import { buildMockErrorResponse, mockJsonResponse } from './testUtils/data';
+
 jest.mock('@aws-amplify/core/lib/clients/handlers/fetch');
+jest.mock('@aws-amplify/core/internals/utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/utils'),
+	fetchAuthSession: jest.fn(),
+}));
 
 Amplify.configure({
 	Auth: {
@@ -20,33 +24,27 @@ Amplify.configure({
 });
 const mockedAccessToken =
 	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-
+const mockFetchAuthSession = fetchAuthSession as jest.Mock;
 const mockedSub = 'mockedSub';
 const mockedUsername = 'XXXXXXXXXXXXXX';
+
 describe('getUser API happy path cases', () => {
-	let fetchAuthSessionsSpy;
 	beforeEach(() => {
-		fetchAuthSessionsSpy = jest
-			.spyOn(authUtils, 'fetchAuthSession')
-			.mockImplementationOnce(
-				async (): Promise<{ tokens: { accessToken: any; idToken: any } }> => {
-					return {
-						tokens: {
-							accessToken: decodeJWT(mockedAccessToken),
-							idToken: {
-								payload: {
-									sub: mockedSub,
-									'cognito:username': mockedUsername,
-								},
-							},
-						},
-					};
-				}
-			);
+		mockFetchAuthSession.mockResolvedValue({
+			tokens: {
+				accessToken: decodeJWT(mockedAccessToken),
+				idToken: {
+					payload: {
+						sub: mockedSub,
+						'cognito:username': mockedUsername,
+					},
+				},
+			},
+		});
 	});
 
 	afterEach(() => {
-		fetchAuthSessionsSpy.mockClear();
+		mockFetchAuthSession.mockClear();
 	});
 
 	test('get current user', async () => {
@@ -58,14 +56,12 @@ describe('getUser API happy path cases', () => {
 describe('getUser API error path cases:', () => {
 	test('getUser API should raise service error', async () => {
 		expect.assertions(2);
-		jest
-			.spyOn(authUtils, 'fetchAuthSession')
-			.mockImplementationOnce(async () => {
-				throw new AuthError({
-					name: InitiateAuthException.InternalErrorException,
-					message: 'error at fetchAuthSession',
-				});
+		mockFetchAuthSession.mockImplementationOnce(async () => {
+			throw new AuthError({
+				name: InitiateAuthException.InternalErrorException,
+				message: 'error at fetchAuthSession',
 			});
+		});
 		(fetchTransferHandler as jest.Mock).mockResolvedValue(
 			mockJsonResponse(
 				buildMockErrorResponse(InitiateAuthException.InternalErrorException)

--- a/packages/auth/src/providers/cognito/apis/fetchUserAttributes.ts
+++ b/packages/auth/src/providers/cognito/apis/fetchUserAttributes.ts
@@ -2,17 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AmplifyV6 } from '@aws-amplify/core';
-import { assertTokenProviderConfig } from '@aws-amplify/core/internals/utils';
-import { getUser } from '../utils/clients/CognitoIdentityProvider';
-import {
-	GetUserException,
-	InitiateAuthException,
-} from '../../cognito/types/errors';
-import { AuthUserAttribute, fetchAuthSession } from '../../../';
-import { getRegion } from '../utils/clients/CognitoIdentityProvider/utils';
-import { assertAuthTokens } from '../utils/types';
+import { AuthUserAttribute } from '../../../types';
 import { CognitoUserAttributeKey } from '../types';
-import { toAuthUserAttribute } from '../utils/apiHelpers';
+import { fetchUserAttributes as fetchUserAttributesInternal } from './internal/fetchUserAttributes';
 
 /**
  * Fetches the current user attributes while authenticated.
@@ -21,22 +13,8 @@ import { toAuthUserAttribute } from '../utils/apiHelpers';
  *
  * @throws AuthTokenConfigException - Thrown when the token provider config is invalid.
  */
-export const fetchUserAttributes = async (): Promise<
+export const fetchUserAttributes = (): Promise<
 	AuthUserAttribute<CognitoUserAttributeKey>
 > => {
-	const authConfig = AmplifyV6.getConfig().Auth;
-	assertTokenProviderConfig(authConfig);
-	const { tokens } = await fetchAuthSession({
-		forceRefresh: false,
-	});
-	assertAuthTokens(tokens);
-
-	const { UserAttributes } = await getUser(
-		{ region: getRegion(authConfig.userPoolId) },
-		{
-			AccessToken: tokens.accessToken.toString(),
-		}
-	);
-
-	return toAuthUserAttribute(UserAttributes);
+	return fetchUserAttributesInternal(AmplifyV6);
 };

--- a/packages/auth/src/providers/cognito/apis/internal/fetchUserAttributes.ts
+++ b/packages/auth/src/providers/cognito/apis/internal/fetchUserAttributes.ts
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AmplifyClassV6 } from '@aws-amplify/core';
+import {
+	assertTokenProviderConfig,
+	fetchAuthSession,
+} from '@aws-amplify/core/internals/utils';
+import { getUser } from '../../utils/clients/CognitoIdentityProvider';
+import { AuthUserAttribute } from '../../../..';
+import { getRegion } from '../../utils/clients/CognitoIdentityProvider/utils';
+import { assertAuthTokens } from '../../utils/types';
+import { CognitoUserAttributeKey } from '../../types';
+import { toAuthUserAttribute } from '../../utils/apiHelpers';
+
+export const fetchUserAttributes = async (
+	amplify: AmplifyClassV6
+): Promise<AuthUserAttribute<CognitoUserAttributeKey>> => {
+	const authConfig = amplify.getConfig().Auth;
+	assertTokenProviderConfig(authConfig);
+	const { tokens } = await fetchAuthSession(amplify, {
+		forceRefresh: false,
+	});
+	assertAuthTokens(tokens);
+
+	const { UserAttributes } = await getUser(
+		{ region: getRegion(authConfig.userPoolId) },
+		{
+			AccessToken: tokens.accessToken.toString(),
+		}
+	);
+
+	return toAuthUserAttribute(UserAttributes);
+};

--- a/packages/auth/src/providers/cognito/apis/internal/getCurrentUser.ts
+++ b/packages/auth/src/providers/cognito/apis/internal/getCurrentUser.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AmplifyClassV6 } from '@aws-amplify/core';
+import {
+	assertTokenProviderConfig,
+	fetchAuthSession,
+} from '@aws-amplify/core/internals/utils';
+import { GetCurrentUserRequest, AuthUser } from '../../../../types';
+import { assertAuthTokens } from '../../utils/types';
+
+export const getCurrentUser = async (
+	amplify: AmplifyClassV6,
+	getCurrentUserRequest?: GetCurrentUserRequest
+): Promise<AuthUser> => {
+	const authConfig = amplify.getConfig().Auth;
+	assertTokenProviderConfig(authConfig);
+	const { tokens } = await fetchAuthSession(amplify, {
+		forceRefresh: getCurrentUserRequest?.recache ?? false,
+	});
+	assertAuthTokens(tokens);
+	const { payload } = tokens.idToken;
+
+	return {
+		username: payload['cognito:username'] as string,
+		userId: payload['sub'] as string,
+	};
+};

--- a/packages/auth/src/providers/cognito/apis/server/fetchUserAttributes.ts
+++ b/packages/auth/src/providers/cognito/apis/server/fetchUserAttributes.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+import { AuthUserAttribute } from '../../../../types';
+import { CognitoUserAttributeKey } from '../../types';
+import { fetchUserAttributes as fetchUserAttributesInternal } from '../internal/fetchUserAttributes';
+
+export const fetchUserAttributes = (
+	contextSpec: AmplifyServer.ContextSpec
+): Promise<AuthUserAttribute<CognitoUserAttributeKey>> => {
+	return fetchUserAttributesInternal(
+		getAmplifyServerContext(contextSpec).amplify
+	);
+};

--- a/packages/auth/src/providers/cognito/apis/server/getCurrentUser.ts
+++ b/packages/auth/src/providers/cognito/apis/server/getCurrentUser.ts
@@ -1,9 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyV6 } from '@aws-amplify/core';
-import { AuthUser, GetCurrentUserRequest } from '../../../types';
-import { getCurrentUser as getCurrentUserInternal } from './internal/getCurrentUser';
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+import { AuthUser, GetCurrentUserRequest } from '../../../../types';
+import { getCurrentUser as getCurrentUserInternal } from '../internal/getCurrentUser';
 
 /**
  * Gets the current user from the idToken.
@@ -17,7 +20,11 @@ import { getCurrentUser as getCurrentUserInternal } from './internal/getCurrentU
  * @returns AuthUser
  */
 export const getCurrentUser = async (
+	contextSpec: AmplifyServer.ContextSpec,
 	getCurrentUserRequest?: GetCurrentUserRequest
 ): Promise<AuthUser> => {
-	return getCurrentUserInternal(AmplifyV6, getCurrentUserRequest);
+	return getCurrentUserInternal(
+		getAmplifyServerContext(contextSpec).amplify,
+		getCurrentUserRequest
+	);
 };

--- a/packages/auth/src/providers/cognito/apis/server/index.ts
+++ b/packages/auth/src/providers/cognito/apis/server/index.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { fetchUserAttributes } from './fetchUserAttributes';
+export { getCurrentUser } from './getCurrentUser';

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from '@aws-amplify/core/server';
+export * from './providers/cognito/apis/server';

--- a/packages/core/src/libraryUtils.ts
+++ b/packages/core/src/libraryUtils.ts
@@ -98,3 +98,4 @@ export {
 	INTERNAL_AWS_APPSYNC_REALTIME_PUBSUB_PROVIDER,
 	USER_AGENT_HEADER,
 } from './Util/Constants';
+export { fetchAuthSession } from './singleton/apis/internal/fetchAuthSession';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
### `@amplify/core`
* Removed `**/package.json` from the `files` field in the `package.json`
* Now export the low level `fetchAuthSession` from the `/internals` subpath

### `@amplify/auth`
Made the following APIs to be callable with Amplify server context.
* `getCurrentUser`
* `fetchUserAttributes`
* Updated relevant unit tests


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* Unit tests
* Making API call in Next.js server.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
