### PR TITLE
chore(auth): adding missing type exports

### DIFF
--- a/packages/auth/src/providers/cognito/types/index.ts
+++ b/packages/auth/src/providers/cognito/types/index.ts
@@ -6,6 +6,7 @@ export {
 	ValidationData,
 	AuthFlowType,
 	CognitoUserAttributeKey,
+	MFAPreference,
 } from './models';
 
 export {
@@ -17,7 +18,7 @@ export {
 	CognitoConfirmSignUpOptions,
 	CognitoConfirmSignInOptions,
 	CognitoUpdateUserAttributesOptions,
-	CogntioVerifyTOTPSetupOptions
+	CogntioVerifyTOTPSetupOptions,
 } from './options';
 
 export { UpdateMFAPreferenceRequest } from './requests';

--- a/packages/auth/src/types/index.ts
+++ b/packages/auth/src/types/index.ts
@@ -4,7 +4,12 @@
 // TODO: Remove "./Auth" export
 export * from './Auth';
 
-export { AuthSignUpStep, AuthResetPasswordStep, AuthSignInStep } from './enums';
+export {
+	AuthSignUpStep,
+	AuthResetPasswordStep,
+	AuthSignInStep,
+	AuthUpdateAttributeStep,
+} from './enums';
 
 export {
 	AdditionalInfo,
@@ -20,7 +25,8 @@ export {
 	AuthNextUpdateAttributeStep,
 	MFAType,
 	AllowedMFATypes,
-	AuthUser
+	AuthUser,
+	TOTPSetupDetails,
 } from './models';
 
 export { AuthServiceOptions, AuthSignUpOptions } from './options';
@@ -36,7 +42,8 @@ export {
 	UpdatePasswordRequest,
 	UpdateUserAttributesRequest,
 	GetCurrentUserRequest,
-	ConfirmUserAttributeRequest
+	ConfirmUserAttributeRequest,
+	VerifyTOTPSetupRequest,
 } from './requests';
 
 export {

--- a/packages/auth/src/types/models.ts
+++ b/packages/auth/src/types/models.ts
@@ -140,12 +140,13 @@ export type AuthUserAttributeKey = AuthStandardAttributeKey | AnyAttribute;
 /**
  * Data encapsulating the next step in the Sign Up process
  */
-export type AuthNextSignUpStep<UserAttributeKey extends AuthUserAttributeKey> =
-	{
-		signUpStep?: AuthSignUpStep;
-		additionalInfo?: AdditionalInfo;
-		codeDeliveryDetails?: AuthCodeDeliveryDetails<UserAttributeKey>;
-	};
+export type AuthNextSignUpStep<
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
+> = {
+	signUpStep?: AuthSignUpStep;
+	additionalInfo?: AdditionalInfo;
+	codeDeliveryDetails?: AuthCodeDeliveryDetails<UserAttributeKey>;
+};
 
 export type ConfirmAttributeWithCodeAttributeStep<
 	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey

--- a/packages/auth/src/types/models.ts
+++ b/packages/auth/src/types/models.ts
@@ -32,7 +32,7 @@ export type AuthCodeDeliveryDetails<
 };
 
 export type AuthNextResetPasswordStep<
-	UserAttributeKey extends AuthUserAttributeKey
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
 > = {
 	resetPasswordStep: AuthResetPasswordStep;
 	additionalInfo?: AdditionalInfo;
@@ -67,7 +67,7 @@ export type ConfirmSignInWithCustomChallenge = {
 };
 
 export type ConfirmSignInWithNewPasswordRequired<
-	UserAttributeKey extends AuthUserAttributeKey
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
 > = {
 	signInStep: AuthSignInStep.CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED;
 	missingAttributes?: UserAttributeKey[];
@@ -90,7 +90,9 @@ export type DoneSignInStep = {
 	signInStep: AuthSignInStep.DONE;
 };
 
-export type AuthNextSignInStep<UserAttributeKey extends AuthUserAttributeKey> =
+export type AuthNextSignInStep<
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
+> =
 	| ConfirmSignInWithCustomChallenge
 	| ContinueSignInWithMFASelection
 	| ConfirmSignInWithNewPasswordRequired<UserAttributeKey>

--- a/packages/auth/src/types/requests.ts
+++ b/packages/auth/src/types/requests.ts
@@ -5,7 +5,7 @@ import { AuthUserAttribute, AuthUserAttributeKey } from './models';
 import { AuthServiceOptions, AuthSignUpOptions } from './options';
 
 export type ConfirmResetPasswordRequest<
-	ServiceOptions extends AuthServiceOptions
+	ServiceOptions extends AuthServiceOptions = AuthServiceOptions
 > = {
 	username: string;
 	newPassword: string;
@@ -28,7 +28,9 @@ export type ResendSignUpCodeRequest<
 	options?: { serviceOptions?: ServiceOptions };
 };
 
-export type ResetPasswordRequest<ServiceOptions extends AuthServiceOptions> = {
+export type ResetPasswordRequest<
+	ServiceOptions extends AuthServiceOptions = AuthServiceOptions
+> = {
 	username: string;
 	options?: {
 		serviceOptions?: ServiceOptions;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR adds missing type exports

**Other changes**
- It adds default generic parameters to requests and models. This will help to import and use these types without passing any generic type parameters.
 ```typescript
 import {AuthNextSignInStep} from 'aws-amplify/auth'

 // before
const signInStep:AuthNextSignInStep // --> Typescript will yell it needs a generic type param

// after
const signInStep:AuthNextSignInStep // --> Typescript is happy
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

yarn build & yarn test works

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
