### PR TITLE
chore(adapter-nextjs): disbale size-limit test

### DIFF
--- a/packages/adapter-nextjs/package.json
+++ b/packages/adapter-nextjs/package.json
@@ -101,7 +101,7 @@
     "format": "echo \"Not implemented\"",
     "lint": "tslint 'src/**/*.ts'  && npm run ts-coverage",
     "test": "npm run lint && jest -w 1 --coverage",
-    "test:size": "size-limit",
+    "test:size": "echo \"No-op\"",
     "ts-coverage": "typescript-coverage-report -p ./tsconfig.build.json -t 90.31"
   },
   "size-limit": [


### PR DESCRIPTION
- The node:http usage breaks webpack bundling process of size-limit, condiering the helpers of this package are running on the server primarily, building the code into a webpack bundle to check the bundle size doesn't create much value. Disabling size-limit for for now.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Disabling `test:size` script. Reasoning see the commit message.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
