### PR TITLE
feat(storage): make the copy API runnable with server context

### DIFF
--- a/packages/storage/src/providers/s3/apis/copy.ts
+++ b/packages/storage/src/providers/s3/apis/copy.ts
@@ -2,18 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AmplifyV6 } from '@aws-amplify/core';
-import { S3Exception, S3CopyResult } from '../types';
 import { CopyRequest } from '../../../types';
-import {
-	resolveStorageConfig,
-	getKeyWithPrefix,
-	resolveCredentials,
-} from '../utils';
-import { copyObject, CopyObjectOutput } from '../../../AwsClients/S3';
-import { StorageValidationErrorCode } from '../../../errors/types/validation';
-import { assertValidationError } from '../../../errors/utils/assertValidationError';
+import { S3CopyResult } from '../types';
+import { copy as copyInternal } from './internal/copy';
 
-// TODO(ashwinkumar6) add unit test for copy API
 /**
  * Copy an object from a source object to a new object within the same bucket. Can optionally copy files across
  * different level or identityId (if source object's level is 'protected').
@@ -26,58 +18,5 @@ import { assertValidationError } from '../../../errors/utils/assertValidationErr
  * source or destination key are not defined.
  */
 export const copy = async (copyRequest: CopyRequest): Promise<S3CopyResult> => {
-	const { identityId: defaultIdentityId, credentials } =
-		await resolveCredentials(AmplifyV6);
-	const { defaultAccessLevel, bucket, region } =
-		resolveStorageConfig(AmplifyV6);
-	const {
-		source: {
-			key: sourceKey,
-			accessLevel: sourceAccessLevel = defaultAccessLevel,
-		},
-		destination: {
-			key: destinationKey,
-			accessLevel: destinationAccessLevel = defaultAccessLevel,
-		},
-	} = copyRequest;
-
-	assertValidationError(!!sourceKey, StorageValidationErrorCode.NoSourceKey);
-	assertValidationError(
-		!!destinationKey,
-		StorageValidationErrorCode.NoDestinationKey
-	);
-
-	const sourceFinalKey = `${bucket}/${getKeyWithPrefix(AmplifyV6, {
-		accessLevel: sourceAccessLevel,
-		targetIdentityId:
-			copyRequest.source.accessLevel === 'protected'
-				? copyRequest.source.targetIdentityId
-				: defaultIdentityId,
-		key: sourceKey,
-	})}`;
-
-	const destinationFinalKey = getKeyWithPrefix(AmplifyV6, {
-		accessLevel: destinationAccessLevel,
-		targetIdentityId: defaultIdentityId,
-		key: destinationKey,
-	});
-
-	// TODO(ashwinkumar6) V6-logger: warn `You may copy files from another user if the source level is "protected", currently it's ${srcLevel}`
-	// TODO(ashwinkumar6) V6-logger: debug `copying ${finalSrcKey} to ${finalDestKey}`
-	const response: CopyObjectOutput = await copyObject(
-		{
-			region,
-			credentials,
-		},
-		{
-			Bucket: bucket,
-			CopySource: sourceFinalKey,
-			Key: destinationFinalKey,
-			MetadataDirective: 'COPY', // Copies over metadata like contentType as well
-		}
-	);
-
-	return {
-		key: destinationKey,
-	};
+	return copyInternal(AmplifyV6, copyRequest);
 };

--- a/packages/storage/src/providers/s3/apis/internal/copy.ts
+++ b/packages/storage/src/providers/s3/apis/internal/copy.ts
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AmplifyClassV6 } from '@aws-amplify/core';
+import { S3CopyResult } from '../../types';
+import { CopyRequest } from '../../../../types';
+import {
+	resolveStorageConfig,
+	getKeyWithPrefix,
+	resolveCredentials,
+} from '../../utils';
+import { copyObject, CopyObjectOutput } from '../../../../AwsClients/S3';
+import { StorageValidationErrorCode } from '../../../../errors/types/validation';
+import { assertValidationError } from '../../../../errors/utils/assertValidationError';
+
+// TODO(ashwinkumar6) add unit test for copy API
+export const copy = async (
+	amplify: AmplifyClassV6,
+	copyRequest: CopyRequest
+): Promise<S3CopyResult> => {
+	const { identityId: defaultIdentityId, credentials } =
+		await resolveCredentials(amplify);
+	const { defaultAccessLevel, bucket, region } = resolveStorageConfig(amplify);
+	const {
+		source: {
+			key: sourceKey,
+			accessLevel: sourceAccessLevel = defaultAccessLevel,
+		},
+		destination: {
+			key: destinationKey,
+			accessLevel: destinationAccessLevel = defaultAccessLevel,
+		},
+	} = copyRequest;
+
+	assertValidationError(!!sourceKey, StorageValidationErrorCode.NoSourceKey);
+	assertValidationError(
+		!!destinationKey,
+		StorageValidationErrorCode.NoDestinationKey
+	);
+
+	const sourceFinalKey = `${bucket}/${getKeyWithPrefix(amplify, {
+		accessLevel: sourceAccessLevel,
+		targetIdentityId:
+			copyRequest.source.accessLevel === 'protected'
+				? copyRequest.source.targetIdentityId
+				: defaultIdentityId,
+		key: sourceKey,
+	})}`;
+
+	const destinationFinalKey = getKeyWithPrefix(amplify, {
+		accessLevel: destinationAccessLevel,
+		targetIdentityId: defaultIdentityId,
+		key: destinationKey,
+	});
+
+	// TODO(ashwinkumar6) V6-logger: warn `You may copy files from another user if the source level is "protected", currently it's ${srcLevel}`
+	// TODO(ashwinkumar6) V6-logger: debug `copying ${finalSrcKey} to ${finalDestKey}`
+	const response: CopyObjectOutput = await copyObject(
+		{
+			region,
+			credentials,
+		},
+		{
+			Bucket: bucket,
+			CopySource: sourceFinalKey,
+			Key: destinationFinalKey,
+			MetadataDirective: 'COPY', // Copies over metadata like contentType as well
+		}
+	);
+
+	return {
+		key: destinationKey,
+	};
+};

--- a/packages/storage/src/providers/s3/apis/internal/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getProperties.ts
@@ -5,7 +5,7 @@ import { headObject } from '../../../../AwsClients/S3';
 import { StorageOptions, StorageOperationRequest } from '../../../../types';
 import { assertValidationError } from '../../../../errors/utils/assertValidationError';
 import { StorageValidationErrorCode } from '../../../../errors/types/validation';
-import { S3Exception, S3GetPropertiesResult } from '../../types';
+import { S3GetPropertiesResult } from '../../types';
 import {
 	resolveStorageConfig,
 	getKeyWithPrefix,

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -11,7 +11,6 @@ import {
 	getPresignedGetObjectUrl,
 } from '../../../../AwsClients/S3';
 import { getProperties } from './getProperties';
-import { S3Exception } from '../../types/errors';
 import {
 	getKeyWithPrefix,
 	resolveCredentials,

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -13,7 +13,6 @@ import {
 } from '../../../../types';
 import {
 	S3ListOutputItem,
-	S3Exception,
 	S3ListAllResult,
 	S3ListPaginateResult,
 } from '../../types';

--- a/packages/storage/src/providers/s3/apis/internal/remove.ts
+++ b/packages/storage/src/providers/s3/apis/internal/remove.ts
@@ -12,7 +12,7 @@ import {
 	getKeyWithPrefix,
 	resolveCredentials,
 } from '../../utils';
-import { deleteObject, DeleteObjectInput } from '../../../../AwsClients/S3';
+import { deleteObject } from '../../../../AwsClients/S3';
 import { StorageValidationErrorCode } from '../../../../errors/types/validation';
 import { assertValidationError } from '../../../../errors/utils/assertValidationError';
 import { AmplifyClassV6 } from '@aws-amplify/core';

--- a/packages/storage/src/providers/s3/apis/server/copy.ts
+++ b/packages/storage/src/providers/s3/apis/server/copy.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+import { CopyRequest } from '../../../../types';
+import { S3CopyResult } from '../../types';
+import { copy as copyInternal } from '../internal/copy';
+
+export const copy = async (
+	contextSpec: AmplifyServer.ContextSpec,
+	copyRequest: CopyRequest
+): Promise<S3CopyResult> => {
+	return copyInternal(
+		getAmplifyServerContext(contextSpec).amplify,
+		copyRequest
+	);
+};

--- a/packages/storage/src/providers/s3/apis/server/index.ts
+++ b/packages/storage/src/providers/s3/apis/server/index.ts
@@ -5,3 +5,4 @@ export { getProperties } from './getProperties';
 export { getUrl } from './getUrl';
 export { list } from './list';
 export { remove } from './remove';
+export { copy } from './copy';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Make the storage `copy` API runnable with the server context.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
