### PR TITLE
fix(auth): guest credentials obtained only if isMandatorySignIn is false

### DIFF
--- a/packages/core/src/singleton/Auth/index.ts
+++ b/packages/core/src/singleton/Auth/index.ts
@@ -57,15 +57,17 @@ export class AuthClass {
 		let tokens: AuthTokens | undefined;
 		let credentialsAndIdentityId: AWSCredentialsAndIdentityId | undefined;
 
-		// Get tokens will throw if session cannot be refreshed (network or service error) or return null if not available
-		tokens =
-			(await this.authOptions?.tokenProvider?.getTokens(options)) ?? undefined;
 		asserts(!!this.authConfig, {
 			name: AUTH_CONFING_EXCEPTION,
 			message: 'AuthConfig is required',
 			recoverySuggestion:
 				'call Amplify.configure in your app with a valid AuthConfig',
 		});
+
+		// Get tokens will throw if session cannot be refreshed (network or service error) or return null if not available
+		tokens =
+			(await this.authOptions?.tokenProvider?.getTokens(options)) ?? undefined;
+
 		if (tokens) {
 			// getCredentialsAndIdentityId will throw if cannot get credentials (network or service error)
 			credentialsAndIdentityId =
@@ -77,7 +79,7 @@ export class AuthClass {
 						forceRefresh: options.forceRefresh,
 					}
 				);
-		} else {
+		} else if (!this.authConfig.isMandatorySignInEnabled) {
 			// getCredentialsAndIdentityId will throw if cannot get credentials (network or service error)
 			credentialsAndIdentityId =
 				await this.authOptions?.credentialsProvider?.getCredentialsAndIdentityId(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

guest credentials obtained only if isMandatorySignIn is false
#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
