### PR TITLE
chore(repo): use single AMPLIFY_SYMBOL definition

### DIFF
--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -16,15 +16,10 @@ import {
 	ConsoleLogger as Logger,
 	urlSafeEncode,
 	USER_AGENT_HEADER,
+	AMPLIFY_SYMBOL,
 } from '@aws-amplify/core/internals/utils';
 
 import { Sha256 } from '@aws-crypto/sha256-js';
-
-const AMPLIFY_SYMBOL = (
-	typeof Symbol !== 'undefined' && typeof Symbol.for === 'function'
-		? Symbol.for('amplify_default')
-		: '@@amplify_default'
-) as Symbol;
 
 const dispatchAuthEvent = payload => {
 	Hub.dispatch('auth', payload, 'Auth', AMPLIFY_SYMBOL);

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -10,19 +10,13 @@ import { ICredentials } from './types';
 import { Amplify } from './Amplify';
 import { getId, getCredentialsForIdentity } from './AwsClients/CognitoIdentity';
 import { parseAWSExports } from './parseAWSExports';
-import { Hub } from './Hub';
+import { Hub, AMPLIFY_SYMBOL } from './Hub';
 
 const logger = new Logger('Credentials');
 
 const CREDENTIALS_TTL = 50 * 60 * 1000; // 50 min, can be modified on config if required in the future
 
 const COGNITO_IDENTITY_KEY_PREFIX = 'CognitoIdentityId-';
-
-const AMPLIFY_SYMBOL = (
-	typeof Symbol !== 'undefined' && typeof Symbol.for === 'function'
-		? Symbol.for('amplify_default')
-		: '@@amplify_default'
-) as Symbol;
 
 const dispatchCredentialsEvent = (
 	event: string,

--- a/packages/core/src/libraryUtils.ts
+++ b/packages/core/src/libraryUtils.ts
@@ -99,3 +99,4 @@ export {
 	USER_AGENT_HEADER,
 } from './Util/Constants';
 export { fetchAuthSession } from './singleton/apis/internal/fetchAuthSession';
+export { AMPLIFY_SYMBOL } from './Hub';

--- a/packages/core/src/singleton/Amplify.ts
+++ b/packages/core/src/singleton/Amplify.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { AuthClass } from './Auth';
-import { Hub } from '../Hub';
+import { Hub, AMPLIFY_SYMBOL } from '../Hub';
 import { LibraryOptions, ResourcesConfig } from './types';
 
 // TODO(v6): add default AuthTokenStore for each platform
@@ -54,7 +54,8 @@ export class AmplifyClass {
 				event: 'configure',
 				data: resourcesConfig,
 			},
-			'Configure'
+			'Configure',
+			AMPLIFY_SYMBOL
 		);
 	}
 

--- a/packages/pubsub/src/Providers/constants.ts
+++ b/packages/pubsub/src/Providers/constants.ts
@@ -1,5 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+export { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
+
 export const MAX_DELAY_MS = 5000;
 
 export const NON_RETRYABLE_CODES = [400, 401, 403];
@@ -70,12 +72,6 @@ export enum SOCKET_STATUS {
 	READY,
 	CONNECTING,
 }
-
-export const AMPLIFY_SYMBOL = (
-	typeof Symbol !== 'undefined' && typeof Symbol.for === 'function'
-		? Symbol.for('amplify_default')
-		: '@@amplify_default'
-) as Symbol;
 
 export const AWS_APPSYNC_REALTIME_HEADERS = {
 	accept: 'application/json, text/javascript',

--- a/packages/storage/src/common/StorageConstants.ts
+++ b/packages/storage/src/common/StorageConstants.ts
@@ -1,10 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-export const AMPLIFY_SYMBOL = (
-	typeof Symbol !== 'undefined' && typeof Symbol.for === 'function'
-		? Symbol.for('amplify_default')
-		: '@@amplify_default'
-) as Symbol;
+
+export { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
 
 export const localTestingStorageEndpoint = 'http://localhost:20005';
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Removed the external usage warning from Hub caused by the Amplify singleton `configure`
* Export `AMPLIFY_SYMBOL` from the `@aws-amplify/core/internals/utils` subpath and use across packages


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
