### PR TITLE
fix(storage): CanceledError not a StorageError; cannot cancel paused task

### DIFF
--- a/packages/storage/__tests__/AwsClients/xhrTransferHandler-util-test.ts
+++ b/packages/storage/__tests__/AwsClients/xhrTransferHandler-util-test.ts
@@ -1,10 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-	xhrTransferHandler,
-	isCancelError,
-} from '../../src/AwsClients/S3/runtime/xhrTransferHandler';
+import { xhrTransferHandler } from '../../src/AwsClients/S3/runtime/xhrTransferHandler';
+import { isCancelError } from '../../src/errors/CanceledError';
 import {
 	spyOnXhr,
 	mockXhrResponse,

--- a/packages/storage/__tests__/providers/s3/uploadData/multipartHandlers.test.ts
+++ b/packages/storage/__tests__/providers/s3/uploadData/multipartHandlers.test.ts
@@ -20,6 +20,7 @@ import {
 import { UPLOADS_STORAGE_KEY } from '../../../../src/common/StorageConstants';
 import { getKvStorage } from '../../../../src/providers/s3/apis/uploadData/multipart/uploadCache/kvStorage';
 import { byteLength } from '../../../../src/providers/s3/apis/uploadData/byteLength';
+import { CanceledError } from '../../../../src/errors/CanceledError';
 
 jest.mock('../../../../src/AwsClients/S3');
 
@@ -523,8 +524,8 @@ describe('getMultipartUploadHandlers', () => {
 				await multipartUploadJob();
 				fail('should throw error');
 			} catch (error) {
-				expect(error).toBeInstanceOf(Error);
-				expect(error.message).toBe('AbortError');
+				expect(error).toBeInstanceOf(CanceledError);
+				expect(error.message).toBe('Upload is canceled by user');
 			}
 			expect(mockAbortMultipartUpload).toBeCalledTimes(1);
 			expect(mockUploadPart).toBeCalledTimes(2);

--- a/packages/storage/src/AwsClients/S3/runtime/index.browser.ts
+++ b/packages/storage/src/AwsClients/S3/runtime/index.browser.ts
@@ -10,5 +10,4 @@ export {
 } from './constants';
 export { s3TransferHandler } from './s3TransferHandler/xhr';
 export { parser } from './xmlParser/dom';
-export { isCancelError } from './xhrTransferHandler';
 export { toBase64, utf8Encode } from './base64/index.browser';

--- a/packages/storage/src/AwsClients/S3/runtime/index.native.ts
+++ b/packages/storage/src/AwsClients/S3/runtime/index.native.ts
@@ -10,5 +10,4 @@ export {
 } from './constants';
 export { s3TransferHandler } from './s3TransferHandler/xhr';
 export { parser } from './xmlParser/pureJs';
-export { isCancelError } from './xhrTransferHandler';
 export { toBase64, utf8Encode } from './base64/index.native';

--- a/packages/storage/src/AwsClients/S3/runtime/index.ts
+++ b/packages/storage/src/AwsClients/S3/runtime/index.ts
@@ -11,8 +11,6 @@ export {
 } from './constants';
 export { s3TransferHandler } from './s3TransferHandler/fetch';
 export { parser } from './xmlParser/pureJs';
-// TODO[AllanZhengYP]: support isCancelError in Node.js with node-fetch
-export { isCancelError } from './xhrTransferHandler';
 export { toBase64, utf8Encode } from './index.native';
 
 // Make sure package.json is included in the TypeScript build output.

--- a/packages/storage/src/AwsClients/S3/runtime/xhrTransferHandler.ts
+++ b/packages/storage/src/AwsClients/S3/runtime/xhrTransferHandler.ts
@@ -18,16 +18,9 @@ import {
 	NETWORK_ERROR_MESSAGE,
 } from './constants';
 import { TransferProgressEvent } from '../../../types/common';
+import { CanceledError } from '../../../errors/CanceledError';
 
 const logger = new Logger('xhr-http-handler');
-
-/**
- * Internal type for CanceledError thrown by handler when AbortController is called
- * with out overwriting.
- */
-interface CanceledError extends Error {
-	__CANCEL__: true;
-}
 
 /**
  * @internal
@@ -165,10 +158,10 @@ export const xhrTransferHandler: TransferHandler<
 				if (!xhr) {
 					return;
 				}
-				const canceledError = Object.assign(
-					buildHandlerError(CANCELED_ERROR_MESSAGE, CANCELED_ERROR_CODE),
-					{ __CANCEL__: true }
-				);
+				const canceledError = new CanceledError({
+					name: CANCELED_ERROR_CODE,
+					message: CANCELED_ERROR_MESSAGE,
+				});
 				reject(canceledError);
 				xhr.abort();
 				xhr = null;
@@ -203,8 +196,6 @@ const buildHandlerError = (message: string, name: string): Error => {
 	return error;
 };
 
-export const isCancelError = (error: unknown): boolean =>
-	!!error && (error as CanceledError).__CANCEL__ === true;
 /**
  * Convert xhr.getAllResponseHeaders() string to a Record<string, string>. Note that modern browser already returns
  * header names in lowercase.

--- a/packages/storage/src/AwsClients/S3/utils/index.ts
+++ b/packages/storage/src/AwsClients/S3/utils/index.ts
@@ -7,7 +7,6 @@ export {
 	SEND_UPLOAD_PROGRESS_EVENT,
 	s3TransferHandler,
 	CANCELED_ERROR_MESSAGE,
-	isCancelError,
 	CONTENT_SHA256_HEADER,
 	toBase64,
 	utf8Encode,

--- a/packages/storage/src/errors/CanceledError.ts
+++ b/packages/storage/src/errors/CanceledError.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ErrorParams } from '@aws-amplify/core/internals/utils';
+import { StorageError } from './StorageError';
+
+/**
+ * Internal-only class for CanceledError thrown by XHR handler or multipart upload when cancellation is invoked
+ * without overwriting behavior.
+ *
+ * @internal
+ */
+export class CanceledError extends StorageError {
+	constructor(params: ErrorParams) {
+		super(params);
+
+		// TODO: Delete the following 2 lines after we change the build target to >= es2015
+		this.constructor = CanceledError;
+		Object.setPrototypeOf(this, CanceledError.prototype);
+	}
+}
+
+/**
+ * Check if an error is caused by user calling `cancel()` on a upload/download task. If an overwriting error is
+ * supplied to `task.cancel(errorOverwrite)`, this function will return `false`.
+ */
+export const isCancelError = (error: unknown): boolean =>
+	!!error && error instanceof CanceledError;

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -9,6 +9,7 @@ export {
 	getProperties,
 	copy,
 	getUrl,
-	isCancelError,
 } from './providers/s3';
 export * from './types';
+// TODO[AllanZhengYP]: support isCancelError in Node.js with node-fetch
+export { isCancelError } from './errors/CanceledError';

--- a/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadCache/index.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadCache/index.ts
@@ -47,16 +47,21 @@ export const findCachedUploadParts = async ({
 
 	await kvStorage.setItem(UPLOADS_STORAGE_KEY, JSON.stringify(cachedUploads));
 
-	const { Parts = [] } = await listParts(s3Config, {
-		Bucket: bucket,
-		Key: finalKey,
-		UploadId: cachedUpload.uploadId,
-	});
-
-	return {
-		parts: Parts,
-		uploadId: cachedUpload.uploadId,
-	};
+	try {
+		const { Parts = [] } = await listParts(s3Config, {
+			Bucket: bucket,
+			Key: finalKey,
+			UploadId: cachedUpload.uploadId,
+		});
+		return {
+			parts: Parts,
+			uploadId: cachedUpload.uploadId,
+		};
+	} catch (e) {
+		// TODO: debug message: failed to list parts. The cached upload will be removed.
+		await removeCachedUpload(cacheKey);
+		return null;
+	}
 };
 
 type FileMetadata = {

--- a/packages/storage/src/providers/s3/index.ts
+++ b/packages/storage/src/providers/s3/index.ts
@@ -10,4 +10,3 @@ export {
 	copy,
 	getUrl,
 } from './apis';
-export { isCancelError } from '../../AwsClients/S3/runtime';

--- a/packages/storage/src/providers/s3/utils/transferTask.ts
+++ b/packages/storage/src/providers/s3/utils/transferTask.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isCancelError } from '../../../AwsClients/S3/runtime';
+import { isCancelError } from '../../../errors/CanceledError';
 import {
 	DownloadTask,
 	TransferTaskState,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This issue mainly fixes the following issues:
1. An error thrown by canceling a task should be an instance of  `StorageError`
2. Fixed an error that a task cannot be canceled if it's paused.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
* Unit test
* Integration test



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
