### PR TITLE
fix(auth): wrongly throwing when allowGuestAccess is set to true

### DIFF
--- a/packages/auth/src/providers/cognito/credentialsProvider/credentialsProvider.ts
+++ b/packages/auth/src/providers/cognito/credentialsProvider/credentialsProvider.ts
@@ -75,20 +75,22 @@ export class CognitoAWSCredentialsAndIdentityIdProvider
 		// - if there is error fetching tokens
 		// - if user is not signed in
 		if (!isAuthenticated) {
-			// Check if mandatory sign-in is enabled
+			// Check if guest access is allowed (get credentials for the unauthenticated role)
 			if (authConfig.Cognito.allowGuestAccess) {
-				// TODO(V6): confirm if this needs to throw or log
-				throw new AuthError({
-					name: 'AuthConfigException',
-					message:
-						'Cannot get guest credentials when mandatory signin is enabled',
-					recoverySuggestion: 'Make sure mandatory signin is disabled.',
-				});
+				return this.getGuestCredentials(identityId, authConfig);
 			}
-			return await this.getGuestCredentials(identityId, authConfig);
+
+			// This needs to throw, otherwise the category APIs would throw the "Credentials is absent" error.
+			throw new AuthError({
+				name: 'AuthConfigException',
+				message:
+					'Cannot get guest credentials when guest access is not allowed.',
+				recoverySuggestion:
+					'Ensure guest access (unauthenticated access) is enabled.',
+			});
 		} else {
 			// Tokens will always be present if getCredentialsOptions.authenticated is true as dictated by the type
-			return await this.credsForOIDCTokens(authConfig, tokens!, identityId);
+			return this.credsForOIDCTokens(authConfig, tokens!, identityId);
 		}
 	}
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Fixed when setting the `allowGuestAccess` to true, `getCredentialsAndIdentityId` would throw wrong error
* Updated the `credentialsProvider.test.ts`

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* Unit tests
* Storage unauthenticated access manual testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
