### PR TITLE
fix: avoid duplicate instances in Auth/InternalAuth

### DIFF
--- a/packages/auth/__tests__/auth-attribute-test.ts
+++ b/packages/auth/__tests__/auth-attribute-test.ts
@@ -1,4 +1,6 @@
 import { AuthClass as Auth } from '../src/Auth';
+import { InternalAuthClass } from '../src/internals/InternalAuth';
+import { AuthOptions } from '../src/types';
 
 import {
 	CognitoUserPool,
@@ -13,9 +15,6 @@ import {
 	InternalCognitoUser,
 } from 'amazon-cognito-identity-js/internals';
 
-import { AuthOptions } from '../src/types';
-import { InternalAuthClass } from '../src/internals/InternalAuth';
-
 const authOptions: AuthOptions = {
 	userPoolId: 'us-west-2_0xxxxxxxx',
 	userPoolWebClientId: 'awsUserPoolsWebClientId',
@@ -27,7 +26,7 @@ const authOptions: AuthOptions = {
 describe('User-Attribute-validation', () => {
 	it('Check-non-verified-attributes', async () => {
 		const spyonAuthUserAttributes = jest
-			.spyOn(InternalAuthClass.prototype as any, '_userAttributes')
+			.spyOn(InternalAuthClass.prototype, 'userAttributes')
 			.mockImplementation((user: CognitoUser) => {
 				const emailAttribute = new CognitoUserAttribute({
 					Name: 'email',
@@ -51,7 +50,7 @@ describe('User-Attribute-validation', () => {
 				});
 			});
 
-		const auth = new Auth(authOptions);
+		const auth = new Auth(new InternalAuthClass(authOptions));
 
 		const verified = await auth.verifiedContact(
 			new CognitoUser({
@@ -76,7 +75,7 @@ describe('User-Attribute-validation', () => {
 	});
 
 	it('Checking not coerced values after sign in', async () => {
-		const auth = new Auth(authOptions);
+		const auth = new Auth(new InternalAuthClass(authOptions));
 
 		const spyUserPoolCurrentUser = jest
 			.spyOn(InternalCognitoUserPool.prototype, 'getCurrentUser')

--- a/packages/auth/__tests__/auth-configure-test.ts
+++ b/packages/auth/__tests__/auth-configure-test.ts
@@ -1,4 +1,5 @@
 import { AuthClass as Auth } from '../src/Auth';
+import { InternalAuthClass } from '../src/internals/InternalAuth';
 import { Credentials } from '@aws-amplify/core';
 
 describe('configure test', () => {
@@ -11,7 +12,7 @@ describe('configure test', () => {
 			mandatorySignIn: false,
 			storage: {},
 		};
-		const auth = new Auth(null);
+		const auth = new Auth(new InternalAuthClass());
 		expect.assertions(1);
 		try {
 			auth.configure(opts);
@@ -31,7 +32,7 @@ describe('configure test', () => {
 
 		const spyOn = jest.spyOn(Credentials, 'configure');
 
-		const auth = new Auth(null);
+		const auth = new Auth(new InternalAuthClass());
 		expect.assertions(1);
 
 		auth.configure(opts);

--- a/packages/auth/__tests__/auth-creds-test.ts
+++ b/packages/auth/__tests__/auth-creds-test.ts
@@ -1,4 +1,5 @@
 import { AuthClass as Auth } from '../src/Auth';
+import { InternalAuthClass } from '../src/internals/InternalAuth';
 import { Credentials } from '@aws-amplify/core';
 import { AuthOptions } from '../src/types';
 import {
@@ -22,7 +23,7 @@ const authOptions: AuthOptions = {
 
 describe('credentials syncing tests', () => {
 	it('BypassCache clear credentials', async () => {
-		const auth = new Auth(authOptions);
+		const auth = new Auth(new InternalAuthClass(authOptions));
 
 		jest
 			.spyOn(InternalCognitoUser.prototype, 'authenticateUser')

--- a/packages/auth/__tests__/auth-federation-unit-tests.ts
+++ b/packages/auth/__tests__/auth-federation-unit-tests.ts
@@ -258,6 +258,7 @@ const DEFAULT_RETRY_TIMEOUT = 60000;
 
 import { AuthOptions } from '../src/types';
 import { AuthClass as Auth } from '../src/Auth';
+import { InternalAuthClass } from '../src/internals/InternalAuth';
 import {
 	Credentials,
 	StorageHelper,
@@ -319,7 +320,7 @@ describe('auth federation unit test', () => {
 						return Promise.resolve('cred');
 					});
 
-				const auth = new Auth(authOptions);
+				const auth = new Auth(new InternalAuthClass(authOptions));
 
 				expect.assertions(2);
 				expect(await auth.currentUserCredentials()).toBe('cred');
@@ -370,7 +371,7 @@ describe('auth federation unit test', () => {
 						return Promise.resolve('cred');
 					});
 
-				const auth = new Auth(authOptions);
+				const auth = new Auth(new InternalAuthClass(authOptions));
 
 				expect.assertions(2);
 				expect(await auth.currentUserCredentials()).toBe('cred');
@@ -414,7 +415,7 @@ describe('auth federation unit test', () => {
 				.spyOn(Credentials, 'clear')
 				.mockImplementation();
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			try {
 				await auth.currentUserCredentials();
@@ -461,7 +462,7 @@ describe('auth federation unit test', () => {
 				.spyOn(Credentials, 'clear')
 				.mockImplementation();
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			try {
 				await auth.currentUserCredentials();

--- a/packages/auth/__tests__/auth-refresh-token-test.ts
+++ b/packages/auth/__tests__/auth-refresh-token-test.ts
@@ -1,4 +1,6 @@
 import { AuthClass as Auth } from '../src/Auth';
+import { InternalAuthClass } from '../src/internals/InternalAuth';
+import { AuthOptions } from '../src/types';
 
 import {
 	CognitoUser,
@@ -11,8 +13,6 @@ import {
 	InternalCognitoUser,
 	InternalCognitoUserPool,
 } from 'amazon-cognito-identity-js/internals';
-
-import { AuthOptions } from '../src/types';
 
 const clientMetadata = {
 	test: 'i need to be send for token refresh',
@@ -30,7 +30,7 @@ const authOptions: AuthOptions = {
 describe('Refresh token', () => {
 	it('currentUserPoolUser  user.getSession using ClientMetadata from config', async () => {
 		// configure with client metadata
-		const auth = new Auth(authOptions);
+		const auth = new Auth(new InternalAuthClass(authOptions));
 
 		expect.assertions(1);
 
@@ -69,7 +69,7 @@ describe('Refresh token', () => {
 
 	it('userSession  user.getSession using ClientMetadata from config', async () => {
 		// configure with client metadata
-		const auth = new Auth(authOptions);
+		const auth = new Auth(new InternalAuthClass(authOptions));
 
 		expect.assertions(2);
 
@@ -110,7 +110,8 @@ describe('Refresh token', () => {
 
 	it('cognitoIdentitySignOut user.getSession using ClientMetadata from config', async () => {
 		// configure with client metadata
-		const auth = new Auth(authOptions);
+		const internalAuth = new InternalAuthClass(authOptions);
+		const auth = new Auth(internalAuth);
 
 		expect.assertions(2);
 
@@ -150,13 +151,12 @@ describe('Refresh token', () => {
 			});
 		const user = await auth.currentUserPoolUser();
 
-		// @ts-ignore
-		await auth.cognitoIdentitySignOut({ global: true }, user);
+		await (internalAuth as any).cognitoIdentitySignOut({ global: true }, user);
 	});
 
 	it('currentUserPoolUser user.getUserData using ClientMetadata from config', async () => {
 		// configure with client metadata
-		const auth = new Auth(authOptions);
+		const auth = new Auth(new InternalAuthClass(authOptions));
 
 		expect.assertions(1);
 
@@ -208,7 +208,7 @@ describe('Refresh token', () => {
 
 	it('getPreferredMFA user.getUserData using ClientMetadata from config', async () => {
 		// configure with client metadata
-		const auth = new Auth(authOptions);
+		const auth = new Auth(new InternalAuthClass(authOptions));
 
 		expect.assertions(2);
 
@@ -262,7 +262,7 @@ describe('Refresh token', () => {
 
 	it('setPreferredMFA user.getUserData using ClientMetadata from config', async () => {
 		// configure with client metadata
-		const auth = new Auth(authOptions);
+		const auth = new Auth(new InternalAuthClass(authOptions));
 
 		expect.assertions(3);
 

--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -405,7 +405,7 @@ describe('auth unit test', () => {
 	describe('signUp', () => {
 		test('happy case with object attr', async () => {
 			const spyon = jest.spyOn(InternalCognitoUserPool.prototype, 'signUp');
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const attrs = {
 				username: 'username',
@@ -423,7 +423,9 @@ describe('auth unit test', () => {
 
 		test('happy case clientMetadata default', async () => {
 			const spyon = jest.spyOn(InternalCognitoUserPool.prototype, 'signUp');
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 
 			const attrs = {
 				username: 'username',
@@ -454,7 +456,9 @@ describe('auth unit test', () => {
 
 		test('happy case clientMetadata parameter', async () => {
 			const spyon = jest.spyOn(InternalCognitoUserPool.prototype, 'signUp');
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 
 			const attrs = {
 				username: 'username',
@@ -487,7 +491,7 @@ describe('auth unit test', () => {
 		});
 
 		test('object attr with null username', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const attrs = {
 				username: null,
@@ -517,7 +521,7 @@ describe('auth unit test', () => {
 					}
 				);
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			try {
@@ -539,7 +543,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no config', async () => {
-			const auth = new Auth(undefined);
+			const auth = new Auth(new InternalAuthClass());
 			const errorMessage = new NoUserPoolError(AuthErrorTypes.NoConfig);
 
 			expect.assertions(2);
@@ -552,7 +556,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no user pool in config', async () => {
-			const auth = new Auth(authOptionsWithNoUserPoolId);
+			const auth = new Auth(new InternalAuthClass(authOptionsWithNoUserPoolId));
 			const errorMessage = new NoUserPoolError(
 				AuthErrorTypes.MissingAuthConfig
 			);
@@ -567,7 +571,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no username', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			expect.assertions(1);
 			expect(
 				auth.signUp(null, 'password', 'email', 'phone').then()
@@ -575,7 +579,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no password', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const errorMessage = new AuthError(AuthErrorTypes.EmptyPassword);
 
 			expect.assertions(2);
@@ -588,7 +592,7 @@ describe('auth unit test', () => {
 		});
 
 		test('only username', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const errorMessage = new AuthError(AuthErrorTypes.EmptyPassword);
 
 			expect.assertions(2);
@@ -617,7 +621,7 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'authenticateUser'
 			);
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const attrs = {
 				username: 'username',
 				password: 'password',
@@ -644,7 +648,7 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'authenticateUser'
 			);
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const attrs = {
 				username: 'username',
 				password: 'password',
@@ -670,7 +674,7 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'authenticateUser'
 			);
-			const auth = new Auth(authOptionConfirmationLink);
+			const auth = new Auth(new InternalAuthClass(authOptionConfirmationLink));
 			const attrs = {
 				username: 'username',
 				password: 'password',
@@ -701,7 +705,7 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'authenticateUser'
 			);
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const attrs = {
 				username: 'username',
 				password: 'password',
@@ -731,7 +735,7 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'confirmRegistration'
 			);
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			expect(await auth.confirmSignUp('username', 'code')).toBe('Success');
@@ -744,7 +748,7 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'confirmRegistration'
 			);
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			expect(
@@ -761,7 +765,9 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'confirmRegistration'
 			);
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 			const code = 'code';
 
 			await auth.confirmSignUp('username', code);
@@ -785,7 +791,9 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'confirmRegistration'
 			);
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 			const code = 'code';
 
 			await auth.confirmSignUp('username', code, {
@@ -815,7 +823,7 @@ describe('auth unit test', () => {
 					}
 				);
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			try {
@@ -828,7 +836,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no user pool in config', async () => {
-			const auth = new Auth(authOptionsWithNoUserPoolId);
+			const auth = new Auth(new InternalAuthClass(authOptionsWithNoUserPoolId));
 			const errorMessage = new NoUserPoolError(
 				AuthErrorTypes.MissingAuthConfig
 			);
@@ -843,7 +851,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no user name', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const errorMessage = new AuthError(AuthErrorTypes.EmptyUsername);
 
 			expect.assertions(2);
@@ -856,7 +864,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no code', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const errorMessage = new AuthError(AuthErrorTypes.EmptyCode);
 
 			expect.assertions(2);
@@ -875,7 +883,7 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'resendConfirmationCode'
 			);
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			expect(await auth.resendSignUp('username')).toMatchObject({
@@ -894,7 +902,9 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'resendConfirmationCode'
 			);
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 
 			await auth.resendSignUp('username');
 
@@ -913,7 +923,9 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'resendConfirmationCode'
 			);
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 
 			await auth.resendSignUp('username', { custom: 'value' });
 
@@ -934,7 +946,7 @@ describe('auth unit test', () => {
 					callback(new Error('err'), null);
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			try {
@@ -947,7 +959,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no user pool in config', async () => {
-			const auth = new Auth(authOptionsWithNoUserPoolId);
+			const auth = new Auth(new InternalAuthClass(authOptionsWithNoUserPoolId));
 			const errorMessage = new NoUserPoolError(
 				AuthErrorTypes.MissingAuthConfig
 			);
@@ -962,7 +974,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no username', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const errorMessage = new AuthError(AuthErrorTypes.EmptyUsername);
 
 			expect.assertions(2);
@@ -976,7 +988,7 @@ describe('auth unit test', () => {
 			expect.assertions(2);
 
 			// calling the `wrappedCallback` (a node callback) manually lets us trigger hub events
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const callback: NodeCallback.Any = (error, result) => {};
 			const wrappedCallback = auth.wrapRefreshSessionCallback(callback);
 
@@ -1030,14 +1042,14 @@ describe('auth unit test', () => {
 					callback.onSuccess(session);
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return Promise.resolve(user);
 				});
@@ -1055,7 +1067,9 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'authenticateUser'
 			);
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 
 			await auth.signIn('username', 'password');
 
@@ -1080,7 +1094,9 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'authenticateUser'
 			);
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 
 			await auth.signIn('username', 'password', { custom: 'value' });
 
@@ -1102,7 +1118,9 @@ describe('auth unit test', () => {
 
 		test('happy case validationData parameter', async () => {
 			const spyon = jest.spyOn(InternalCognitoUserPool.prototype, 'signUp');
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 
 			const attrs: SignUpParams = {
 				username: 'username',
@@ -1148,14 +1166,14 @@ describe('auth unit test', () => {
 					callback.onSuccess(session);
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return Promise.reject('User is disabled.');
 				});
@@ -1178,10 +1196,12 @@ describe('auth unit test', () => {
 					callback.onSuccess(session);
 				});
 
-			const auth = new Auth({
-				...authOptions,
-				cookieStorage: { domain: '.example.com' },
-			});
+			const auth = new Auth(
+				new InternalAuthClass({
+					...authOptions,
+					cookieStorage: { domain: '.example.com' },
+				})
+			);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1189,7 +1209,7 @@ describe('auth unit test', () => {
 			});
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return Promise.resolve(user);
 				});
@@ -1208,7 +1228,7 @@ describe('auth unit test', () => {
 					callback.onFailure('err');
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			try {
@@ -1226,7 +1246,7 @@ describe('auth unit test', () => {
 				.mockImplementationOnce((authenticationDetails, callback) => {
 					callback.mfaRequired('SELECT_MFA_TYPE', 'challengeParam');
 				});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1250,7 +1270,7 @@ describe('auth unit test', () => {
 				.mockImplementationOnce((authenticationDetails, callback) => {
 					callback.mfaSetup('MFA_SETUP', 'challengeParam');
 				});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1274,7 +1294,7 @@ describe('auth unit test', () => {
 				.mockImplementationOnce((authenticationDetails, callback) => {
 					callback.totpRequired('SOFTWARE_TOKEN_MFA', 'challengeParam');
 				});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1298,7 +1318,7 @@ describe('auth unit test', () => {
 				.mockImplementationOnce((authenticationDetails, callback) => {
 					callback.selectMFAType('SELECT_MFA_TYPE', 'challengeParam');
 				});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1322,7 +1342,7 @@ describe('auth unit test', () => {
 				.mockImplementationOnce((authenticationDetails, callback) => {
 					callback.newPasswordRequired('userAttributes', 'requiredAttributes');
 				});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1355,7 +1375,7 @@ describe('auth unit test', () => {
 					'setAuthenticationFlowType'
 				)
 				.mockImplementationOnce(type => {});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1380,7 +1400,7 @@ describe('auth unit test', () => {
 			);
 
 			// @ts-ignore
-			const auth = new Auth(authOptionsWithNoUserPoolId);
+			const auth = new Auth(new InternalAuthClass(authOptionsWithNoUserPoolId));
 
 			expect.assertions(1);
 			try {
@@ -1397,7 +1417,7 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'authenticateUser'
 			);
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			try {
@@ -1417,7 +1437,7 @@ describe('auth unit test', () => {
 				.mockImplementationOnce((code, callback) => {
 					callback.onSuccess(session);
 				});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1436,7 +1456,7 @@ describe('auth unit test', () => {
 					callback.onSuccess(session);
 				});
 			const hubSpy = jest.spyOn(Hub, 'dispatch');
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1459,7 +1479,9 @@ describe('auth unit test', () => {
 
 		test('happy case clientMetadata default', async () => {
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'sendMFACode');
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1483,7 +1505,9 @@ describe('auth unit test', () => {
 
 		test('happy case clientMetadata parameter', async () => {
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'sendMFACode');
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1506,7 +1530,7 @@ describe('auth unit test', () => {
 		});
 
 		test('currentUserPoolUser fails but hub event still dispatches', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const spyon = jest
 				.spyOn(InternalCognitoUser.prototype, 'sendMFACode')
 				.mockImplementationOnce((code, callback) => {
@@ -1514,7 +1538,7 @@ describe('auth unit test', () => {
 				});
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return Promise.reject('Could not get current user.');
 				});
@@ -1544,7 +1568,7 @@ describe('auth unit test', () => {
 				.mockImplementationOnce((code, callback) => {
 					callback.onFailure('err');
 				});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1561,7 +1585,7 @@ describe('auth unit test', () => {
 
 		test('no code', async () => {
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'sendMFACode');
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const user = new InternalCognitoUser({
 				Username: 'username',
@@ -1587,7 +1611,7 @@ describe('auth unit test', () => {
 					callback.onSuccess(session);
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1606,7 +1630,9 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'completeNewPasswordChallenge'
 			);
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1637,7 +1663,9 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'completeNewPasswordChallenge'
 			);
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1670,7 +1698,7 @@ describe('auth unit test', () => {
 					callback.onFailure('err');
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1693,7 +1721,7 @@ describe('auth unit test', () => {
 					callback.mfaRequired('SMS_MFA', 'challengeParam');
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1712,7 +1740,7 @@ describe('auth unit test', () => {
 					callback.mfaSetup('MFA_SETUP', 'challengeParam');
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1725,7 +1753,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no password', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1746,7 +1774,7 @@ describe('auth unit test', () => {
 	describe('userAttributes', () => {
 		test('happy case', async () => {
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_userSession')
+				.spyOn(InternalAuthClass.prototype, 'userSession')
 				.mockImplementationOnce(user => {
 					return new Promise((res: any, rej) => {
 						res('session');
@@ -1758,7 +1786,7 @@ describe('auth unit test', () => {
 				'getUserAttributes'
 			);
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1773,7 +1801,7 @@ describe('auth unit test', () => {
 
 		test('get userattributes failed', async () => {
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_userSession')
+				.spyOn(InternalAuthClass.prototype, 'userSession')
 				.mockImplementationOnce(user => {
 					return new Promise((res: any, rej) => {
 						res('session');
@@ -1786,7 +1814,7 @@ describe('auth unit test', () => {
 					callback(new Error('err'));
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1810,20 +1838,20 @@ describe('auth unit test', () => {
 			jest.useRealTimers();
 		});
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
 
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return Promise.resolve(user);
 				});
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_userSession')
+				.spyOn(InternalAuthClass.prototype, 'userSession')
 				.mockImplementationOnce(() => {
 					return new Promise((res, rej) => {
 						res(session);
@@ -1837,7 +1865,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no current session', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const user = new InternalCognitoUser({
 				Username: 'username',
@@ -1845,13 +1873,13 @@ describe('auth unit test', () => {
 			});
 
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return Promise.resolve(user);
 				});
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_userSession')
+				.spyOn(InternalAuthClass.prototype, 'userSession')
 				.mockImplementationOnce(() => {
 					return Promise.reject('cannot get the session');
 				});
@@ -1868,10 +1896,10 @@ describe('auth unit test', () => {
 		});
 
 		test('no current user', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return Promise.reject('no current user');
 				});
@@ -1887,13 +1915,15 @@ describe('auth unit test', () => {
 		});
 
 		test('no UserPool', async () => {
-			const auth = new Auth({
-				userPoolId: undefined,
-				userPoolWebClientId: 'awsUserPoolsWebClientId',
-				region: 'region',
-				identityPoolId: 'awsCognitoIdentityPoolId',
-				mandatorySignIn: false,
-			});
+			const auth = new Auth(
+				new InternalAuthClass({
+					userPoolId: undefined,
+					userPoolWebClientId: 'awsUserPoolsWebClientId',
+					region: 'region',
+					identityPoolId: 'awsCognitoIdentityPoolId',
+					mandatorySignIn: false,
+				})
+			);
 
 			const noUserPoolError = Error('No User Pool in the configuration.');
 
@@ -1905,14 +1935,14 @@ describe('auth unit test', () => {
 
 	describe('currentAuthenticatedUser', () => {
 		test('happy case with source userpool', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
 
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return new Promise((res, rej) => {
 						res(user);
@@ -1942,7 +1972,7 @@ describe('auth unit test', () => {
 					};
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1966,7 +1996,7 @@ describe('auth unit test', () => {
 					callback(null, session);
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -1986,13 +2016,13 @@ describe('auth unit test', () => {
 				.mockImplementationOnce(
 					// prettier-ignore
 					function(callback: any) {
-					this.signInUserSession = session;
-					callback(null, session);
-				}
+						this.signInUserSession = session;
+						callback(null, session);
+					}
 				);
 			expect.assertions(2 * concurrency + 1);
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const promiseArr = Array.from({ length: concurrency }, async () => {
 				const user = new InternalCognitoUser({
@@ -2012,7 +2042,7 @@ describe('auth unit test', () => {
 		});
 
 		test('callback error', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -2035,7 +2065,7 @@ describe('auth unit test', () => {
 		});
 
 		test('debounce callback error', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
 				.spyOn(InternalCognitoUser.prototype, 'getSession')
@@ -2061,7 +2091,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no user', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = null;
 
 			expect.assertions(1);
@@ -2073,7 +2103,7 @@ describe('auth unit test', () => {
 		});
 
 		test('refresh token revoked case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -2107,7 +2137,7 @@ describe('auth unit test', () => {
 		});
 
 		test('debounce refresh token revoked case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const credentialsClearSpy = jest.spyOn(Credentials, 'clear');
 			const hubSpy = jest.spyOn(Hub, 'dispatch');
 			let user: InternalCognitoUser | null = null;
@@ -2164,7 +2194,7 @@ describe('auth unit test', () => {
 					};
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon2 = jest
 				.spyOn(Credentials, 'refreshFederatedToken')
@@ -2191,10 +2221,10 @@ describe('auth unit test', () => {
 						removeItem() {},
 					};
 				});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentSession')
+				.spyOn(InternalAuthClass.prototype, 'currentSession')
 				.mockImplementationOnce(() => {
 					return Promise.resolve('session' as any);
 				});
@@ -2225,10 +2255,10 @@ describe('auth unit test', () => {
 						removeItem() {},
 					};
 				});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentSession')
+				.spyOn(InternalAuthClass.prototype, 'currentSession')
 				.mockImplementationOnce(() => {
 					return Promise.reject('err' as any);
 				});
@@ -2259,10 +2289,10 @@ describe('auth unit test', () => {
 						removeItem() {},
 					};
 				});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentSession')
+				.spyOn(InternalAuthClass.prototype, 'currentSession')
 				.mockImplementationOnce(() => {
 					return Promise.resolve('session') as any;
 				});
@@ -2287,7 +2317,7 @@ describe('auth unit test', () => {
 			return;
 		});
 
-		const auth = new Auth(authOptions);
+		const auth = new Auth(new InternalAuthClass(authOptions));
 
 		auth.currentCredentials();
 		expect(spyon).toBeCalled();
@@ -2301,7 +2331,7 @@ describe('auth unit test', () => {
 				'getAttributeVerificationCode'
 			);
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -2321,7 +2351,7 @@ describe('auth unit test', () => {
 					callback.onFailure('err' as any);
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -2345,7 +2375,7 @@ describe('auth unit test', () => {
 				'verifyAttribute'
 			);
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -2366,7 +2396,7 @@ describe('auth unit test', () => {
 					callback.onFailure('err' as any);
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -2383,7 +2413,7 @@ describe('auth unit test', () => {
 		});
 
 		test('code empty', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -2402,14 +2432,14 @@ describe('auth unit test', () => {
 
 	describe('verifyCurrentUserAttribute test', () => {
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
 
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return new Promise((res, rej) => {
 						res(user);
@@ -2417,7 +2447,7 @@ describe('auth unit test', () => {
 				});
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_verifyUserAttribute')
+				.spyOn(InternalAuthClass.prototype, 'verifyUserAttribute')
 				.mockImplementationOnce(() => {
 					return new Promise((res, rej) => {
 						res();
@@ -2446,14 +2476,14 @@ describe('auth unit test', () => {
 
 	describe('verifyCurrentUserAttributeSubmit test', () => {
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
 
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return new Promise((res, rej) => {
 						res(user);
@@ -2461,7 +2491,7 @@ describe('auth unit test', () => {
 				});
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_verifyUserAttributeSubmit')
+				.spyOn(InternalAuthClass.prototype, 'verifyUserAttributeSubmit')
 				.mockImplementationOnce(() => {
 					return new Promise((res, rej) => {
 						res();
@@ -2501,7 +2531,7 @@ describe('auth unit test', () => {
 		});
 
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const user = new InternalCognitoUser({
 				Username: 'username',
@@ -2530,13 +2560,14 @@ describe('auth unit test', () => {
 		});
 
 		test('happy case for source userpool', async () => {
-			const auth = new Auth(authOptions);
+			const internalAuth = new InternalAuthClass(authOptions);
+			const auth = new Auth(internalAuth);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
-			auth['credentials_source'] = 'aws';
-			auth['credentials'] = {
+			internalAuth['credentials_source'] = 'aws';
+			internalAuth['credentials'] = {
 				IdentityPoolId: 'identityPoolId',
 			};
 
@@ -2566,7 +2597,7 @@ describe('auth unit test', () => {
 		});
 
 		test('happy case for globalSignOut', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -2596,13 +2627,13 @@ describe('auth unit test', () => {
 
 		test('happy case for no userpool', async () => {
 			// @ts-ignore
-			const auth = new Auth(authOptionsWithNoUserPoolId);
+			const auth = new Auth(new InternalAuthClass(authOptionsWithNoUserPoolId));
 
 			expect(await auth.signOut()).toBeUndefined();
 		});
 
 		test('no User in userpool', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
 				.spyOn(InternalCognitoUserPool.prototype, 'getCurrentUser')
@@ -2615,7 +2646,7 @@ describe('auth unit test', () => {
 		});
 
 		test('get guest credentials failed', async () => {
-			const auth = new Auth(authOptionsWithNoUserPoolId);
+			const auth = new Auth(new InternalAuthClass(authOptionsWithNoUserPoolId));
 
 			expect(await auth.signOut()).toBeUndefined();
 		});
@@ -2623,7 +2654,7 @@ describe('auth unit test', () => {
 
 	describe('changePassword', () => {
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -2632,7 +2663,7 @@ describe('auth unit test', () => {
 			const newPassword = 'newPassword1.';
 
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_userSession')
+				.spyOn(InternalAuthClass.prototype, 'userSession')
 				.mockImplementationOnce(() => {
 					return new Promise((res, rej) => {
 						res(session);
@@ -2649,7 +2680,9 @@ describe('auth unit test', () => {
 
 		test('happy case clientMetadata default', async () => {
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'changePassword');
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -2673,7 +2706,9 @@ describe('auth unit test', () => {
 
 		test('happy case clientMetadata parameter', async () => {
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'changePassword');
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -2702,7 +2737,7 @@ describe('auth unit test', () => {
 		test('happy case', async () => {
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'forgotPassword');
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			expect(await auth.forgotPassword('username')).toBeUndefined();
@@ -2712,7 +2747,9 @@ describe('auth unit test', () => {
 
 		test('happy case clientMetadata default', async () => {
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'forgotPassword');
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 
 			await auth.forgotPassword('username');
 
@@ -2730,7 +2767,9 @@ describe('auth unit test', () => {
 
 		test('happy case clientMetadata parameter', async () => {
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'forgotPassword');
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 
 			await auth.forgotPassword('username', { custom: 'value' });
 
@@ -2753,7 +2792,7 @@ describe('auth unit test', () => {
 					callback.onFailure(new Error('err'));
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			try {
@@ -2772,7 +2811,7 @@ describe('auth unit test', () => {
 					callback.inputVerificationCode('data');
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			expect(await auth.forgotPassword('username')).toBe('data');
@@ -2783,7 +2822,7 @@ describe('auth unit test', () => {
 		test('no user pool id', async () => {
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'forgotPassword');
 
-			const auth = new Auth(authOptionsWithNoUserPoolId);
+			const auth = new Auth(new InternalAuthClass(authOptionsWithNoUserPoolId));
 			const errorMessage = new NoUserPoolError(
 				AuthErrorTypes.MissingAuthConfig
 			);
@@ -2802,7 +2841,7 @@ describe('auth unit test', () => {
 		test('no username', async () => {
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'forgotPassword');
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			try {
@@ -2821,7 +2860,7 @@ describe('auth unit test', () => {
 				'confirmPassword'
 			);
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			expect(
@@ -2837,7 +2876,7 @@ describe('auth unit test', () => {
 				'confirmPassword'
 			);
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			expect(await auth.forgotPassword('username')).toBeUndefined();
@@ -2847,7 +2886,9 @@ describe('auth unit test', () => {
 
 		test('happy case clientMetadata default', async () => {
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'forgotPassword');
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 			const username = 'username';
 			const code = 'code';
 			const password = 'password';
@@ -2871,7 +2912,9 @@ describe('auth unit test', () => {
 
 		test('happy case clientMetadata parameter', async () => {
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'forgotPassword');
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 			const username = 'username';
 			const code = 'code';
 			const password = 'password';
@@ -2902,7 +2945,7 @@ describe('auth unit test', () => {
 					callback.onFailure(new Error('err'));
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect.assertions(1);
 			try {
@@ -2915,7 +2958,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no user pool in config', async () => {
-			const auth = new Auth(authOptionsWithNoUserPoolId);
+			const auth = new Auth(new InternalAuthClass(authOptionsWithNoUserPoolId));
 			const errorMessage = new NoUserPoolError(
 				AuthErrorTypes.MissingAuthConfig
 			);
@@ -2930,7 +2973,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no username', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const errorMessage = new AuthError(AuthErrorTypes.EmptyUsername);
 
 			expect.assertions(2);
@@ -2943,7 +2986,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no code', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const errorMessage = new AuthError(AuthErrorTypes.EmptyCode);
 
 			expect.assertions(2);
@@ -2956,7 +2999,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no password', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const errorMessage = new AuthError(AuthErrorTypes.EmptyPassword);
 
 			expect.assertions(2);
@@ -2971,14 +3014,15 @@ describe('auth unit test', () => {
 
 	describe('currentUserInfo test', () => {
 		test('happy case with aws or userpool source', async () => {
-			const auth = new Auth(authOptions);
+			const internalAuth = new InternalAuthClass(authOptions);
+			const auth = new Auth(internalAuth);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
 
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return new Promise((res, rej) => {
 						res(user);
@@ -2986,13 +3030,13 @@ describe('auth unit test', () => {
 				});
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_userAttributes')
+				.spyOn(InternalAuthClass.prototype, 'userAttributes')
 				.mockImplementationOnce(() => {
-					auth['credentials'] = {
+					internalAuth['credentials'] = {
 						IdentityPoolId: 'identityPoolId',
 						IdentityId: 'identityId',
 					};
-					auth['credentials']['identityId'] = 'identityId';
+					internalAuth['credentials']['identityId'] = 'identityId';
 					return new Promise((res: any, rej) => {
 						res([
 							{ Name: 'email', Value: 'email' },
@@ -3005,8 +3049,9 @@ describe('auth unit test', () => {
 				});
 
 			const spyon3 = jest
-				.spyOn(auth, 'currentCredentials')
+				.spyOn(internalAuth, 'currentCredentials')
 				.mockImplementationOnce(() => {
+					console.log(6);
 					return Promise.resolve({
 						identityId: 'identityId',
 					} as any);
@@ -3015,10 +3060,12 @@ describe('auth unit test', () => {
 			const spyon4 = jest
 				.spyOn(Credentials, 'getCredSource')
 				.mockImplementationOnce(() => {
+					console.log(7);
 					return 'aws';
 				});
 
-			expect.assertions(1);
+			expect.assertions(2);
+			expect(spyon3).toBeCalled();
 			expect(await auth.currentUserInfo()).toEqual({
 				username: 'username',
 				id: 'identityId',
@@ -3038,14 +3085,14 @@ describe('auth unit test', () => {
 		});
 
 		test('return empty object if error happens', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
 
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return new Promise((res, rej) => {
 						res({
@@ -3055,7 +3102,7 @@ describe('auth unit test', () => {
 				});
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_userAttributes')
+				.spyOn(InternalAuthClass.prototype, 'userAttributes')
 				.mockImplementationOnce(() => {
 					return new Promise((res, rej) => {
 						rej('err');
@@ -3087,15 +3134,16 @@ describe('auth unit test', () => {
 		});
 
 		test('no current userpool user', async () => {
-			const auth = new Auth(authOptions);
+			const internalAuth = new InternalAuthClass(authOptions);
+			const auth = new Auth(internalAuth);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
-			auth['credentials_source'] = 'aws';
+			internalAuth['credentials_source'] = 'aws';
 
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return new Promise((res, rej) => {
 						res(null);
@@ -3116,12 +3164,13 @@ describe('auth unit test', () => {
 		});
 
 		test('federated user', async () => {
-			const auth = new Auth(authOptions);
+			const internalAuth = new InternalAuthClass(authOptions);
+			const auth = new Auth(internalAuth);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
-			auth['user'] = 'federated_user';
+			internalAuth['user'] = 'federated_user';
 
 			const spyon = jest
 				.spyOn(Credentials, 'getCredSource')
@@ -3138,7 +3187,7 @@ describe('auth unit test', () => {
 
 	describe('updateUserAttributes test', () => {
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const user = new InternalCognitoUser({
 				Username: 'username',
@@ -3152,7 +3201,7 @@ describe('auth unit test', () => {
 			};
 
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_userSession')
+				.spyOn(InternalAuthClass.prototype, 'userSession')
 				.mockImplementationOnce(() => {
 					return new Promise((res, rej) => {
 						res(session);
@@ -3170,7 +3219,9 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'updateAttributes'
 			);
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -3194,7 +3245,9 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'updateAttributes'
 			);
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -3221,7 +3274,7 @@ describe('auth unit test', () => {
 					callback(new Error('Error'), null, null);
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const user = new InternalCognitoUser({
 				Username: 'username',
@@ -3270,7 +3323,7 @@ describe('auth unit test', () => {
 				.mockImplementationOnce((attrs, callback: any) => {
 					callback(null, 'SUCCESS', codeDeliverDetailsResult);
 				});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const user = new InternalCognitoUser({
 				Username: 'username',
@@ -3314,7 +3367,7 @@ describe('auth unit test', () => {
 
 	describe('deleteUserAttributes test', () => {
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const user = new InternalCognitoUser({
 				Username: 'username',
@@ -3324,7 +3377,7 @@ describe('auth unit test', () => {
 			const attributeNames = ['email', 'phone_number'];
 
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_userSession')
+				.spyOn(InternalAuthClass.prototype, 'userSession')
 				.mockImplementationOnce(() => {
 					return new Promise(res => {
 						res(session);
@@ -3344,7 +3397,9 @@ describe('auth unit test', () => {
 				InternalCognitoUser.prototype,
 				'deleteAttributes'
 			);
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -3369,7 +3424,7 @@ describe('auth unit test', () => {
 		let userPool = null;
 		beforeEach(() => {
 			jest.clearAllMocks();
-			auth = new Auth(authOptions);
+			auth = new Auth(new InternalAuthClass(authOptions));
 			user = new InternalCognitoUser({
 				Username: 'raz',
 				Pool: userPool,
@@ -3400,7 +3455,9 @@ describe('auth unit test', () => {
 		});
 
 		test('no user pool should throw error', async () => {
-			const noUserPoolAuth = new Auth(authOptionsWithNoUserPoolId);
+			const noUserPoolAuth = new Auth(
+				new InternalAuthClass(authOptionsWithNoUserPoolId)
+			);
 			try {
 				await noUserPoolAuth.deleteUser();
 			} catch (error) {
@@ -3501,7 +3558,7 @@ describe('auth unit test', () => {
 		test('No Identity Pool and No User Pool', async () => {
 			const options: AuthOptions = {};
 
-			const auth = new Auth(options);
+			const auth = new Auth(new InternalAuthClass(options));
 
 			let error;
 			try {
@@ -3524,7 +3581,7 @@ describe('auth unit test', () => {
 		test('No User Pool', async () => {
 			const options: AuthOptions = {};
 
-			const auth = new Auth(options);
+			const auth = new Auth(new InternalAuthClass(options));
 
 			let error;
 			try {
@@ -3546,7 +3603,7 @@ describe('auth unit test', () => {
 				identityPoolId: 'awsCognitoIdentityPoolId',
 			};
 
-			const auth = new Auth(options);
+			const auth = new Auth(new InternalAuthClass(options));
 
 			let error;
 			try {
@@ -3568,7 +3625,7 @@ describe('auth unit test', () => {
 				identityPoolId: 'awsCognitoIdentityPoolId',
 			};
 
-			const auth = new Auth(options);
+			const auth = new Auth(new InternalAuthClass(options));
 			let user = null;
 			const spyon = jest
 				.spyOn(Credentials, 'set')
@@ -3577,7 +3634,7 @@ describe('auth unit test', () => {
 					return Promise.resolve('cred' as any);
 				});
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentAuthenticatedUser')
+				.spyOn(InternalAuthClass.prototype, 'currentAuthenticatedUser')
 				.mockImplementation(() => {
 					if (!user) return Promise.reject('error');
 					else return Promise.resolve(user);
@@ -3611,7 +3668,7 @@ describe('auth unit test', () => {
 				},
 			};
 
-			const auth = new Auth(options);
+			const auth = new Auth(new InternalAuthClass(options));
 
 			const spyon3 = jest.spyOn(OAuth.prototype, 'oauthSignIn');
 
@@ -3639,7 +3696,7 @@ describe('auth unit test', () => {
 				},
 			};
 
-			const auth = new Auth(options);
+			const auth = new Auth(new InternalAuthClass(options));
 
 			const spyon3 = jest.spyOn(OAuth.prototype, 'oauthSignIn');
 
@@ -3651,7 +3708,7 @@ describe('auth unit test', () => {
 					return Promise.resolve('cred' as any);
 				});
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentAuthenticatedUser')
+				.spyOn(InternalAuthClass.prototype, 'currentAuthenticatedUser')
 				.mockImplementation(() => {
 					if (!user) return Promise.reject('error');
 					else return Promise.resolve(user);
@@ -3697,8 +3754,8 @@ describe('auth unit test', () => {
 					responseType: 'code',
 				},
 			};
-
-			const auth = new Auth(options);
+			const internalAuth = new InternalAuthClass(options);
+			const auth = new Auth(internalAuth);
 
 			const handleAuthResponseSpy = jest
 				.spyOn(OAuth.prototype, 'handleAuthResponse')
@@ -3707,7 +3764,7 @@ describe('auth unit test', () => {
 				.spyOn(CognitoUserSession.prototype, 'getIdToken')
 				.mockReturnValueOnce({ decodePayload: () => ({}) } as any);
 			jest.spyOn(Credentials, 'set').mockImplementationOnce(c => c);
-			(auth as any).createCognitoUser = jest.fn(() => ({
+			(internalAuth as any).createCognitoUser = jest.fn(() => ({
 				getUsername: jest.fn(),
 				setSignInUserSession: jest.fn(),
 			}));
@@ -3739,7 +3796,7 @@ describe('auth unit test', () => {
 			}?code=${code}&state=${state}`;
 
 			(oauthStorage.getState as jest.Mock<any>).mockReturnValueOnce(state);
-			await (auth as any)._handleAuthResponse(url);
+			await (internalAuth as any)._handleAuthResponse(url);
 
 			expect(handleAuthResponseSpy).toHaveBeenCalledWith(url, undefined);
 			expect(replaceStateSpy).toHaveBeenCalledWith(
@@ -3781,7 +3838,8 @@ describe('auth unit test', () => {
 				},
 			};
 
-			const auth = new Auth(options);
+			const internalAuth = new InternalAuthClass(options);
+			const auth = new Auth(internalAuth);
 
 			const handleAuthResponseSpy = jest
 				.spyOn(OAuth.prototype, 'handleAuthResponse')
@@ -3804,7 +3862,7 @@ describe('auth unit test', () => {
 				(options.oauth as AwsCognitoOAuthOpts).redirectSignIn
 			}#access_token=${token}&state=${state}`;
 
-			await (auth as any)._handleAuthResponse(url);
+			await (internalAuth as any)._handleAuthResponse(url);
 
 			expect(handleAuthResponseSpy).toHaveBeenCalledWith(url, undefined);
 			expect(replaceStateSpy).toHaveBeenCalledWith(
@@ -3819,11 +3877,12 @@ describe('auth unit test', () => {
 
 			const options: AuthOptions = {};
 
-			const auth = new Auth(options);
+			const internalAuth = new InternalAuthClass(options);
+			const auth = new Auth(internalAuth);
 
 			let error;
 			try {
-				await (auth as any)._handleAuthResponse(' ');
+				await (internalAuth as any)._handleAuthResponse(' ');
 			} catch (e) {
 				error = e;
 			}
@@ -3847,7 +3906,8 @@ describe('auth unit test', () => {
 				identityPoolId: 'awsCognitoIdentityPoolId',
 			};
 
-			const auth = new Auth(options);
+			const internalAuth = new InternalAuthClass(options);
+			const auth = new Auth(internalAuth);
 
 			const handleAuthResponseSpy = jest
 				.spyOn(OAuth.prototype, 'handleAuthResponse')
@@ -3868,7 +3928,7 @@ describe('auth unit test', () => {
 			const url = `${
 				(options.oauth as AwsCognitoOAuthOpts).redirectSignIn
 			}?code=${code}`;
-			await (auth as any)._handleAuthResponse(url);
+			await (internalAuth as any)._handleAuthResponse(url);
 
 			expect(handleAuthResponseSpy).toHaveBeenCalledWith(url, undefined);
 			expect(replaceStateSpy).toHaveBeenCalledWith(
@@ -3882,7 +3942,7 @@ describe('auth unit test', () => {
 	describe('verifiedContact test', () => {
 		test('happy case with unverified', async () => {
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_userAttributes')
+				.spyOn(InternalAuthClass.prototype, 'userAttributes')
 				.mockImplementationOnce(() => {
 					return new Promise((res: any, rej) => {
 						res([
@@ -3898,7 +3958,7 @@ describe('auth unit test', () => {
 					});
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -3914,7 +3974,7 @@ describe('auth unit test', () => {
 
 		test('happy case with verified', async () => {
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_userAttributes')
+				.spyOn(InternalAuthClass.prototype, 'userAttributes')
 				.mockImplementationOnce(() => {
 					return new Promise((res: any, rej) => {
 						res([
@@ -3938,7 +3998,7 @@ describe('auth unit test', () => {
 					});
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -3954,7 +4014,7 @@ describe('auth unit test', () => {
 
 		test('happy case with verified as strings', async () => {
 			const spyon = jest
-				.spyOn(InternalAuthClass.prototype as any, '_userAttributes')
+				.spyOn(InternalAuthClass.prototype, 'userAttributes')
 				.mockImplementationOnce(() => {
 					return new Promise((res: any, rej) => {
 						res([
@@ -3978,7 +4038,7 @@ describe('auth unit test', () => {
 					});
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -3999,7 +4059,7 @@ describe('auth unit test', () => {
 		});
 
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4050,7 +4110,7 @@ describe('auth unit test', () => {
 		});
 
 		test('no current user', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4072,7 +4132,7 @@ describe('auth unit test', () => {
 		});
 
 		test('No userPool in config', async () => {
-			const auth = new Auth(authOptionsWithNoUserPoolId);
+			const auth = new Auth(new InternalAuthClass(authOptionsWithNoUserPoolId));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4089,7 +4149,7 @@ describe('auth unit test', () => {
 		});
 
 		test('get session error', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4118,7 +4178,7 @@ describe('auth unit test', () => {
 		});
 
 		test('get session error - refresh token revoked should signout user', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4157,7 +4217,7 @@ describe('auth unit test', () => {
 				.spyOn(StorageHelper.prototype, 'getStorage')
 				.mockImplementation(createMockLocalStorage);
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4219,7 +4279,9 @@ describe('auth unit test', () => {
 				return {} as Window;
 			});
 
-			const auth = new Auth(authOptionsWithHostedUIConfig);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithHostedUIConfig)
+			);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4263,7 +4325,7 @@ describe('auth unit test', () => {
 		});
 
 		test('bypass the error if the user is not deleted or disabled', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4308,7 +4370,7 @@ describe('auth unit test', () => {
 		});
 
 		test('directly return the user if no permission(scope) to get the user data', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4360,7 +4422,7 @@ describe('auth unit test', () => {
 				.mockImplementationOnce((challengeResponses, callback) => {
 					callback.onSuccess(session);
 				});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4377,7 +4439,7 @@ describe('auth unit test', () => {
 			);
 
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return Promise.resolve(user);
 				});
@@ -4395,14 +4457,16 @@ describe('auth unit test', () => {
 		});
 
 		test('happy case clientMetadata default', async () => {
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 
 			const spyon = jest.spyOn(
 				InternalCognitoUser.prototype,
 				'sendCustomChallengeAnswer'
 			);
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return Promise.resolve(user);
 				});
@@ -4425,14 +4489,16 @@ describe('auth unit test', () => {
 		});
 
 		test('happy case clientMetadata parameter', async () => {
-			const auth = new Auth(authOptionsWithClientMetadata);
+			const auth = new Auth(
+				new InternalAuthClass(authOptionsWithClientMetadata)
+			);
 
 			const spyon = jest.spyOn(
 				InternalCognitoUser.prototype,
 				'sendCustomChallengeAnswer'
 			);
 			const spyon2 = jest
-				.spyOn(InternalAuthClass.prototype as any, '_currentUserPoolUser')
+				.spyOn(InternalAuthClass.prototype, 'currentUserPoolUser')
 				.mockImplementationOnce(() => {
 					return Promise.resolve(user);
 				});
@@ -4460,7 +4526,7 @@ describe('auth unit test', () => {
 				.mockImplementationOnce((challengeResponses, callback) => {
 					callback.customChallenge('challengeParam');
 				});
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4494,7 +4560,7 @@ describe('auth unit test', () => {
 					callback.onFailure('err');
 				});
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const userAfterCustomChallengeAnswer = Object.assign(
 				new InternalCognitoUser({
 					Username: 'username',
@@ -4525,7 +4591,7 @@ describe('auth unit test', () => {
 				'sendCustomChallengeAnswer'
 			);
 
-			const auth = new Auth(authOptionsWithNoUserPoolId);
+			const auth = new Auth(new InternalAuthClass(authOptionsWithNoUserPoolId));
 			const userAfterCustomChallengeAnswer = Object.assign(
 				new InternalCognitoUser({
 					Username: 'username',
@@ -4565,7 +4631,7 @@ describe('auth unit test', () => {
 
 	describe('Device Tracking', () => {
 		test('remember device happy path', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
 				.spyOn(CognitoUserSession.prototype, 'getAccessToken')
@@ -4599,7 +4665,7 @@ describe('auth unit test', () => {
 		});
 
 		test('forget device happy path', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
 				.spyOn(CognitoUserSession.prototype, 'getAccessToken')
@@ -4634,7 +4700,7 @@ describe('auth unit test', () => {
 		});
 
 		test('list devices with no devices from Cognito happy path', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
 				.spyOn(CognitoUserSession.prototype, 'getAccessToken')
@@ -4673,7 +4739,7 @@ describe('auth unit test', () => {
 		});
 
 		test('list devices with mock devices from Cognito happy path', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
 				.spyOn(CognitoUserSession.prototype, 'getAccessToken')
@@ -4728,7 +4794,7 @@ describe('auth unit test', () => {
 		});
 
 		test('happy path', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4747,7 +4813,7 @@ describe('auth unit test', () => {
 		});
 
 		test('should allow bypassCache', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4772,7 +4838,7 @@ describe('auth unit test', () => {
 		});
 
 		test('get user data error because user is deleted, disabled or token has been revoked', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			console.log('mock class definition', InternalCognitoUser);
 			console.log('auth class def', Auth);
 			const user = new InternalCognitoUser({
@@ -4827,7 +4893,7 @@ describe('auth unit test', () => {
 		});
 
 		it('happy path', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -4861,7 +4927,7 @@ describe('auth unit test', () => {
 		});
 
 		test('get user data error because user is deleted, disabled or token has been revoked', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,

--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -3064,8 +3064,7 @@ describe('auth unit test', () => {
 					return 'aws';
 				});
 
-			expect.assertions(2);
-			expect(spyon3).toBeCalled();
+			expect.assertions(1);
 			expect(await auth.currentUserInfo()).toEqual({
 				username: 'username',
 				id: 'identityId',
@@ -3085,7 +3084,8 @@ describe('auth unit test', () => {
 		});
 
 		test('return empty object if error happens', async () => {
-			const auth = new Auth(new InternalAuthClass(authOptions));
+			const internalAuth = new InternalAuthClass(authOptions);
+			const auth = new Auth(internalAuth);
 			const user = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
@@ -3110,7 +3110,7 @@ describe('auth unit test', () => {
 				});
 
 			const spyon3 = jest
-				.spyOn(InternalAuthClass.prototype, 'currentCredentials')
+				.spyOn(internalAuth, 'currentCredentials')
 				.mockImplementationOnce(() => {
 					return Promise.resolve({
 						IdentityPoolId: 'identityPoolId',

--- a/packages/auth/__tests__/hosted-ui.test.ts
+++ b/packages/auth/__tests__/hosted-ui.test.ts
@@ -1,13 +1,137 @@
 import {
-	CognitoUser,
 	CognitoUserSession,
 	CognitoAccessToken,
 	CognitoIdToken,
 } from 'amazon-cognito-identity-js';
 
-import { InternalCognitoUserPool } from 'amazon-cognito-identity-js/internals';
+import {
+	InternalCognitoUser,
+	InternalCognitoUserPool,
+} from 'amazon-cognito-identity-js/internals';
 
 jest.mock('amazon-cognito-identity-js/internals', () => {
+	const InternalCognitoUser = () => {};
+
+	InternalCognitoUser.prototype.InternalCognitoUser = options => {
+		InternalCognitoUser.prototype.options = options;
+		return InternalCognitoUser;
+	};
+
+	InternalCognitoUser.prototype.getSession = callback => {
+		callback(null, 'session');
+	};
+
+	InternalCognitoUser.prototype.getUserAttributes = callback => {
+		callback(null, 'attributes');
+	};
+
+	InternalCognitoUser.prototype.getAttributeVerificationCode = (
+		attr,
+		callback
+	) => {
+		callback.onSuccess('success');
+	};
+
+	InternalCognitoUser.prototype.verifyAttribute = (attr, code, callback) => {
+		callback.onSuccess('success');
+	};
+
+	InternalCognitoUser.prototype.authenticateUser = (
+		authenticationDetails,
+		callback
+	) => {
+		callback.onSuccess('session');
+	};
+
+	InternalCognitoUser.prototype.sendMFACode = (code, callback) => {
+		callback.onSuccess('session');
+	};
+
+	InternalCognitoUser.prototype.resendConfirmationCode = callback => {
+		callback(null, 'result');
+	};
+
+	InternalCognitoUser.prototype.changePassword = (
+		oldPassword,
+		newPassword,
+		callback
+	) => {
+		callback(null, 'SUCCESS');
+	};
+
+	InternalCognitoUser.prototype.forgotPassword = callback => {
+		callback.onSuccess();
+	};
+
+	InternalCognitoUser.prototype.confirmPassword = (
+		code,
+		password,
+		callback
+	) => {
+		callback.onSuccess();
+	};
+
+	InternalCognitoUser.prototype.signOut = callback => {
+		if (callback && typeof callback === 'function') {
+			callback();
+		}
+	};
+
+	InternalCognitoUser.prototype.globalSignOut = callback => {
+		callback.onSuccess();
+	};
+
+	InternalCognitoUser.prototype.confirmRegistration = (
+		confirmationCode,
+		forceAliasCreation,
+		callback
+	) => {
+		callback(null, 'Success');
+	};
+
+	InternalCognitoUser.prototype.completeNewPasswordChallenge = (
+		password,
+		requiredAttributes,
+		callback
+	) => {
+		callback.onSuccess('session');
+	};
+
+	InternalCognitoUser.prototype.updateAttributes = (
+		attributeList,
+		callback
+	) => {
+		callback(null, 'SUCCESS');
+	};
+
+	InternalCognitoUser.prototype.setAuthenticationFlowType = type => {};
+
+	InternalCognitoUser.prototype.initiateAuth = (
+		authenticationDetails,
+		callback
+	) => {
+		callback.customChallenge('challengeParam');
+	};
+
+	InternalCognitoUser.prototype.sendCustomChallengeAnswer = (
+		challengeAnswer,
+		callback
+	) => {
+		callback.onSuccess('session');
+	};
+
+	InternalCognitoUser.prototype.refreshSession = (refreshToken, callback) => {
+		callback(null, 'session');
+	};
+
+	InternalCognitoUser.prototype.getUsername = () => {
+		return 'username';
+	};
+
+	InternalCognitoUser.prototype.getUserData = callback => {
+		callback(null, 'data');
+	};
+
 	const InternalCognitoUserPool = () => {};
 
 	InternalCognitoUserPool.prototype.InternalCognitoUserPool = options => {
@@ -44,121 +168,9 @@ jest.mock('amazon-cognito-identity-js/internals', () => {
 
 	return {
 		...jest.requireActual('amazon-cognito-identity-js/internals'),
+		InternalCognitoUser,
 		InternalCognitoUserPool,
 	};
-});
-
-jest.mock('amazon-cognito-identity-js/lib/CognitoUser', () => {
-	const CognitoUser = () => {};
-
-	CognitoUser.prototype.CognitoUser = options => {
-		CognitoUser.prototype.options = options;
-		return CognitoUser;
-	};
-
-	CognitoUser.prototype.getSession = callback => {
-		callback(null, 'session');
-	};
-
-	CognitoUser.prototype.getUserAttributes = callback => {
-		callback(null, 'attributes');
-	};
-
-	CognitoUser.prototype.getAttributeVerificationCode = (attr, callback) => {
-		callback.onSuccess('success');
-	};
-
-	CognitoUser.prototype.verifyAttribute = (attr, code, callback) => {
-		callback.onSuccess('success');
-	};
-
-	CognitoUser.prototype.authenticateUser = (
-		authenticationDetails,
-		callback
-	) => {
-		callback.onSuccess('session');
-	};
-
-	CognitoUser.prototype.sendMFACode = (code, callback) => {
-		callback.onSuccess('session');
-	};
-
-	CognitoUser.prototype.resendConfirmationCode = callback => {
-		callback(null, 'result');
-	};
-
-	CognitoUser.prototype.changePassword = (
-		oldPassword,
-		newPassword,
-		callback
-	) => {
-		callback(null, 'SUCCESS');
-	};
-
-	CognitoUser.prototype.forgotPassword = callback => {
-		callback.onSuccess();
-	};
-
-	CognitoUser.prototype.confirmPassword = (code, password, callback) => {
-		callback.onSuccess();
-	};
-
-	CognitoUser.prototype.signOut = callback => {
-		if (callback && typeof callback === 'function') {
-			callback();
-		}
-	};
-
-	CognitoUser.prototype.globalSignOut = callback => {
-		callback.onSuccess();
-	};
-
-	CognitoUser.prototype.confirmRegistration = (
-		confirmationCode,
-		forceAliasCreation,
-		callback
-	) => {
-		callback(null, 'Success');
-	};
-
-	CognitoUser.prototype.completeNewPasswordChallenge = (
-		password,
-		requiredAttributes,
-		callback
-	) => {
-		callback.onSuccess('session');
-	};
-
-	CognitoUser.prototype.updateAttributes = (attributeList, callback) => {
-		callback(null, 'SUCCESS');
-	};
-
-	CognitoUser.prototype.setAuthenticationFlowType = type => {};
-
-	CognitoUser.prototype.initiateAuth = (authenticationDetails, callback) => {
-		callback.customChallenge('challengeParam');
-	};
-
-	CognitoUser.prototype.sendCustomChallengeAnswer = (
-		challengeAnswer,
-		callback
-	) => {
-		callback.onSuccess('session');
-	};
-
-	CognitoUser.prototype.refreshSession = (refreshToken, callback) => {
-		callback(null, 'session');
-	};
-
-	CognitoUser.prototype.getUsername = () => {
-		return 'username';
-	};
-
-	CognitoUser.prototype.getUserData = callback => {
-		callback(null, 'data');
-	};
-
-	return CognitoUser;
 });
 
 import * as AmplifyCore from '@aws-amplify/core';
@@ -198,6 +210,7 @@ const session = new CognitoUserSession({
 });
 
 import { AuthClass as Auth } from '../src/Auth';
+import { InternalAuthClass } from '../src/internals/InternalAuth';
 import { AuthOptions } from '../src/types';
 
 describe('Hosted UI tests', () => {
@@ -207,8 +220,9 @@ describe('Hosted UI tests', () => {
 	});
 
 	test('hosted UI in progress, signIn success', done => {
-		const auth = new Auth(authOptionsWithOAuth);
-		const user = new CognitoUser({
+		const internalAuth = new InternalAuthClass(authOptionsWithOAuth);
+		const auth = new Auth(internalAuth);
+		const user = new InternalCognitoUser({
 			Username: 'username',
 			Pool: userPool,
 		});
@@ -218,13 +232,13 @@ describe('Hosted UI tests', () => {
 				return user;
 			});
 		jest
-			.spyOn(CognitoUser.prototype, 'getSession')
+			.spyOn(InternalCognitoUser.prototype, 'getSession')
 			.mockImplementation((callback: any) => {
 				return callback(null, session);
 			});
 
 		jest
-			.spyOn(CognitoUser.prototype, 'getUserData')
+			.spyOn(InternalCognitoUser.prototype, 'getUserData')
 			.mockImplementationOnce((callback: any) => {
 				const data = {
 					PreferredMfaSetting: 'SMS',
@@ -247,7 +261,7 @@ describe('Hosted UI tests', () => {
 
 		expect.assertions(2);
 
-		(auth as any).oAuthFlowInProgress = true;
+		(internalAuth as any).oAuthFlowInProgress = true;
 
 		auth.currentUserPoolUser().then(resUser => {
 			expect(resUser).toEqual(user);
@@ -278,9 +292,10 @@ describe('Hosted UI tests', () => {
 			isNode: false,
 		}));
 
-		const auth = new Auth(authOptionsWithOAuth);
+		const internalAuth = new InternalAuthClass(authOptionsWithOAuth);
+		const auth = new Auth(internalAuth);
 
-		const user = new CognitoUser({
+		const user = new InternalCognitoUser({
 			Username: 'username',
 			Pool: userPool,
 		});
@@ -296,12 +311,12 @@ describe('Hosted UI tests', () => {
 			});
 
 		const spyGlobalSignOut = jest
-			.spyOn(CognitoUser.prototype, 'globalSignOut')
+			.spyOn(InternalCognitoUser.prototype, 'globalSignOut')
 			.mockImplementation(({ onSuccess }) => {
 				onSuccess('success');
 			});
 
-		(auth as any)._oAuthHandler = {
+		(internalAuth as any)._oAuthHandler = {
 			signOut: () => {
 				// testing timeout
 				return new Promise(() => {});
@@ -332,9 +347,10 @@ describe('Hosted UI tests', () => {
 			isNode: true,
 		}));
 
-		const auth = new Auth(authOptionsWithOAuth);
+		const internalAuth = new InternalAuthClass(authOptionsWithOAuth);
+		const auth = new Auth(internalAuth);
 
-		const user = new CognitoUser({
+		const user = new InternalCognitoUser({
 			Username: 'username',
 			Pool: userPool,
 		});
@@ -350,12 +366,12 @@ describe('Hosted UI tests', () => {
 			});
 
 		const spyGlobalSignOut = jest
-			.spyOn(CognitoUser.prototype, 'globalSignOut')
+			.spyOn(InternalCognitoUser.prototype, 'globalSignOut')
 			.mockImplementation(({ onSuccess }) => {
 				onSuccess('success');
 			});
 
-		(auth as any)._oAuthHandler = {
+		(internalAuth as any)._oAuthHandler = {
 			signOut: () => {
 				// testing timeout
 				return new Promise(() => {});
@@ -386,9 +402,10 @@ describe('Hosted UI tests', () => {
 			isNode: true,
 		}));
 
-		const auth = new Auth(authOptionsWithOAuth);
+		const internalAuth = new InternalAuthClass(authOptionsWithOAuth);
+		const auth = new Auth(internalAuth);
 
-		const user = new CognitoUser({
+		const user = new InternalCognitoUser({
 			Username: 'username',
 			Pool: userPool,
 		});
@@ -403,7 +420,7 @@ describe('Hosted UI tests', () => {
 				return user;
 			});
 
-		(auth as any)._oAuthHandler = {
+		(internalAuth as any)._oAuthHandler = {
 			signOut: () => {
 				// testing timeout
 				return new Promise(() => {});
@@ -432,9 +449,10 @@ describe('Hosted UI tests', () => {
 			isNode: false,
 		}));
 
-		const auth = new Auth(authOptionsWithOAuth);
+		const internalAuth = new InternalAuthClass(authOptionsWithOAuth);
+		const auth = new Auth(internalAuth);
 
-		const user = new CognitoUser({
+		const user = new InternalCognitoUser({
 			Username: 'username',
 			Pool: userPool,
 		});
@@ -449,7 +467,7 @@ describe('Hosted UI tests', () => {
 				return user;
 			});
 
-		(auth as any)._oAuthHandler = {
+		(internalAuth as any)._oAuthHandler = {
 			signOut: () => {
 				// testing timeout
 				return new Promise(() => {});
@@ -492,9 +510,9 @@ describe('Hosted UI tests', () => {
 		};
 		options.oauth.urlOpener = urlOpener;
 
-		const auth = new Auth(options);
+		const auth = new Auth(new InternalAuthClass(options));
 
-		const user = new CognitoUser({
+		const user = new InternalCognitoUser({
 			Username: 'username',
 			Pool: userPool,
 		});
@@ -539,9 +557,9 @@ describe('Hosted UI tests', () => {
 		};
 		options.oauth.urlOpener = urlOpener;
 
-		const auth = new Auth(options);
+		const auth = new Auth(new InternalAuthClass(options));
 
-		const user = new CognitoUser({
+		const user = new InternalCognitoUser({
 			Username: 'username',
 			Pool: userPool,
 		});

--- a/packages/auth/__tests__/totp-unit-test.ts
+++ b/packages/auth/__tests__/totp-unit-test.ts
@@ -198,7 +198,6 @@ jest.mock('amazon-cognito-identity-js/internals', () => {
 
 import { AuthClass as Auth } from '../src/Auth';
 import {
-	CognitoUser,
 	CognitoUserSession,
 	CognitoIdToken,
 	CognitoAccessToken,
@@ -241,7 +240,7 @@ const session = new CognitoUserSession({
 	AccessToken: accessToken,
 });
 
-const user = new CognitoUser({
+const user = new InternalCognitoUser({
 	Username: 'username',
 	Pool: userPool,
 });
@@ -249,7 +248,7 @@ const user = new CognitoUser({
 describe('auth unit test', () => {
 	describe('getMFAOptions test', () => {
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'getMFAOptions');
 			expect(await auth.getMFAOptions(user)).toBe('mfaOptions');
@@ -259,7 +258,7 @@ describe('auth unit test', () => {
 		});
 
 		test('err case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
 				.spyOn(InternalCognitoUser.prototype, 'getMFAOptions')
@@ -278,7 +277,7 @@ describe('auth unit test', () => {
 
 	describe('disableMFA test', () => {
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'disableMFA');
 			expect(await auth.disableSMS(user)).toBe('Success');
 			expect(spyon).toBeCalled();
@@ -287,7 +286,7 @@ describe('auth unit test', () => {
 		});
 
 		test('err case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
 				.spyOn(InternalCognitoUser.prototype, 'disableMFA')
@@ -306,7 +305,7 @@ describe('auth unit test', () => {
 
 	describe('enableMFA test', () => {
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest.spyOn(InternalCognitoUser.prototype, 'enableMFA');
 			expect(await auth.enableSMS(user)).toBe('Success');
@@ -316,7 +315,7 @@ describe('auth unit test', () => {
 		});
 
 		test('err case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
 				.spyOn(InternalCognitoUser.prototype, 'enableMFA')
@@ -335,7 +334,7 @@ describe('auth unit test', () => {
 
 	describe('setupTOTP test', () => {
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest.spyOn(
 				InternalCognitoUser.prototype,
@@ -348,7 +347,7 @@ describe('auth unit test', () => {
 		});
 
 		test('err case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
 				.spyOn(InternalCognitoUser.prototype, 'associateSoftwareToken')
@@ -367,10 +366,10 @@ describe('auth unit test', () => {
 
 	describe('verifyTotpToken test', () => {
 		test('happy case during sign-in', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			jest.clearAllMocks(); // clear hub calls
 
-			const happyCaseUser = new CognitoUser({
+			const happyCaseUser = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
@@ -396,10 +395,10 @@ describe('auth unit test', () => {
 		});
 
 		test('happy case signedin user', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			jest.clearAllMocks(); // clear hub calls
 
-			const happyCaseUser = new CognitoUser({
+			const happyCaseUser = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
@@ -423,13 +422,13 @@ describe('auth unit test', () => {
 		});
 
 		test('err case user during sign in', async () => {
-			const errCaseUser = new CognitoUser({
+			const errCaseUser = new InternalCognitoUser({
 				Username: 'username',
 				Pool: userPool,
 			});
 			errCaseUser.getSignInUserSession = () => null;
 
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
 				.spyOn(InternalCognitoUser.prototype, 'verifySoftwareToken')
@@ -448,7 +447,7 @@ describe('auth unit test', () => {
 
 	describe('setPreferredMFA test', () => {
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest.spyOn(
 				InternalCognitoUser.prototype,
@@ -469,7 +468,7 @@ describe('auth unit test', () => {
 		('User has not verified software token mfa');
 
 		test('totp not setup but TOTP chosed', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
 				.spyOn(InternalCognitoUser.prototype, 'setUserMfaPreference')
@@ -497,7 +496,7 @@ describe('auth unit test', () => {
 		});
 
 		test('incorrect mfa type', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 			try {
 				// using <any> to allow us to pass an incorrect value
 				await auth.setPreferredMFA(user, 'incorrect mfa type' as any);
@@ -509,13 +508,13 @@ describe('auth unit test', () => {
 
 	describe('getPreferredMFA test', () => {
 		test('happy case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			expect(await auth.getPreferredMFA(user)).toBe('SMS_MFA');
 		});
 
 		test('error case', async () => {
-			const auth = new Auth(authOptions);
+			const auth = new Auth(new InternalAuthClass(authOptions));
 
 			const spyon = jest
 				.spyOn(InternalCognitoUser.prototype, 'getUserData')

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -23,19 +23,38 @@ import {
 	MFAOption,
 	CognitoUserSession,
 	CognitoUserAttribute,
+	NodeCallback,
 } from 'amazon-cognito-identity-js';
 
 import { AuthError } from './Errors';
 import { IAuthDevice } from './types/Auth';
-import { InternalAuthClass } from './internals/InternalAuth';
+import { InternalAuth, InternalAuthClass } from './internals/InternalAuth';
 
 /**
  * Provide authentication steps
  */
-export class AuthClass extends InternalAuthClass {
+export class AuthClass {
+	private InternalAuth: InternalAuthClass;
+
+	/**
+	 * Initialize Auth with AWS configurations
+	 * @param {Object} config - Configuration of the Auth
+	 */
+	constructor(InteralAuthInstance: InternalAuthClass) {
+		this.InternalAuth = InteralAuthInstance;
+	}
+
 	public getModuleName() {
 		return 'Auth';
 	}
+
+	configure(config?) {
+		return this.InternalAuth.configure(config);
+	}
+
+	wrapRefreshSessionCallback = (callback: NodeCallback.Any) => {
+		return this.InternalAuth.wrapRefreshSessionCallback(callback);
+	};
 
 	/**
 	 * Sign up with username, password and other attributes like phone, email
@@ -47,7 +66,7 @@ export class AuthClass extends InternalAuthClass {
 		params: string | SignUpParams,
 		...restOfAttrs: string[]
 	): Promise<ISignUpResult> {
-		return super.signUp(params, restOfAttrs);
+		return this.InternalAuth.signUp(params, restOfAttrs);
 	}
 
 	/**
@@ -62,7 +81,7 @@ export class AuthClass extends InternalAuthClass {
 		code: string,
 		options?: ConfirmSignUpOptions
 	): Promise<any> {
-		return super.confirmSignUp(username, code, options);
+		return this.InternalAuth.confirmSignUp(username, code, options);
 	}
 
 	/**
@@ -75,7 +94,7 @@ export class AuthClass extends InternalAuthClass {
 		username: string,
 		clientMetadata?: ClientMetaData
 	): Promise<any> {
-		return super.resendSignUp(username, clientMetadata);
+		return this.InternalAuth.resendSignUp(username, clientMetadata);
 	}
 
 	/**
@@ -90,7 +109,7 @@ export class AuthClass extends InternalAuthClass {
 		pw?: string,
 		clientMetadata?: ClientMetaData
 	): Promise<CognitoUser | any> {
-		return super.signIn(usernameOrSignInOpts, pw, clientMetadata);
+		return this.InternalAuth.signIn(usernameOrSignInOpts, pw, clientMetadata);
 	}
 
 	/**
@@ -102,7 +121,7 @@ export class AuthClass extends InternalAuthClass {
 	 * @return - A promise resolves the current preferred mfa option if success
 	 */
 	public getMFAOptions(user: CognitoUser | any): Promise<MFAOption[]> {
-		return super.getMFAOptions(user);
+		return this.InternalAuth.getMFAOptions(user);
 	}
 
 	/**
@@ -114,7 +133,7 @@ export class AuthClass extends InternalAuthClass {
 		user: CognitoUser | any,
 		params?: GetPreferredMFAOpts
 	): Promise<string> {
-		return super.getPreferredMFA(user, params);
+		return this.InternalAuth.getPreferredMFA(user, params);
 	}
 
 	/**
@@ -127,7 +146,7 @@ export class AuthClass extends InternalAuthClass {
 		user: CognitoUser | any,
 		mfaMethod: 'TOTP' | 'SMS' | 'NOMFA' | 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA'
 	): Promise<string> {
-		return super.setPreferredMFA(user, mfaMethod);
+		return this.InternalAuth.setPreferredMFA(user, mfaMethod);
 	}
 
 	/**
@@ -137,7 +156,7 @@ export class AuthClass extends InternalAuthClass {
 	 * @return - A promise resolves is success
 	 */
 	public disableSMS(user: CognitoUser): Promise<string> {
-		return super.disableSMS(user);
+		return this.InternalAuth.disableSMS(user);
 	}
 
 	/**
@@ -147,7 +166,7 @@ export class AuthClass extends InternalAuthClass {
 	 * @return - A promise resolves is success
 	 */
 	public enableSMS(user: CognitoUser): Promise<string> {
-		return super.enableSMS(user);
+		return this.InternalAuth.enableSMS(user);
 	}
 
 	/**
@@ -156,7 +175,7 @@ export class AuthClass extends InternalAuthClass {
 	 * @return - A promise resolves with the secret code if success
 	 */
 	public setupTOTP(user: CognitoUser | any): Promise<string> {
-		return super.setupTOTP(user);
+		return this.InternalAuth.setupTOTP(user);
 	}
 
 	/**
@@ -169,7 +188,7 @@ export class AuthClass extends InternalAuthClass {
 		user: CognitoUser | any,
 		challengeAnswer: string
 	): Promise<CognitoUserSession> {
-		return super.verifyTotpToken(user, challengeAnswer);
+		return this.InternalAuth.verifyTotpToken(user, challengeAnswer);
 	}
 
 	/**
@@ -183,7 +202,7 @@ export class AuthClass extends InternalAuthClass {
 		mfaType?: 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA' | null,
 		clientMetadata?: ClientMetaData
 	): Promise<CognitoUser | any> {
-		return super.confirmSignIn(user, code, mfaType, clientMetadata);
+		return this.InternalAuth.confirmSignIn(user, code, mfaType, clientMetadata);
 	}
 
 	public completeNewPassword(
@@ -192,7 +211,7 @@ export class AuthClass extends InternalAuthClass {
 		requiredAttributes: any = {},
 		clientMetadata?: ClientMetaData
 	): Promise<CognitoUser | any> {
-		return super.completeNewPassword(
+		return this.InternalAuth.completeNewPassword(
 			user,
 			password,
 			requiredAttributes,
@@ -210,7 +229,7 @@ export class AuthClass extends InternalAuthClass {
 		challengeResponses: string,
 		clientMetadata?: ClientMetaData
 	): Promise<CognitoUser | any> {
-		return super.sendCustomChallengeAnswer(
+		return this.InternalAuth.sendCustomChallengeAnswer(
 			user,
 			challengeResponses,
 			clientMetadata
@@ -226,7 +245,7 @@ export class AuthClass extends InternalAuthClass {
 		user: CognitoUser | any,
 		attributeNames: string[]
 	) {
-		return super.deleteUserAttributes(user, attributeNames);
+		return this.InternalAuth.deleteUserAttributes(user, attributeNames);
 	}
 
 	/**
@@ -235,7 +254,7 @@ export class AuthClass extends InternalAuthClass {
 	 **/
 	// TODO: Check return type void
 	public deleteUser(): Promise<string | void> {
-		return super.deleteUser();
+		return this.InternalAuth.deleteUser();
 	}
 
 	/**
@@ -248,7 +267,11 @@ export class AuthClass extends InternalAuthClass {
 		attributes: object,
 		clientMetadata?: ClientMetaData
 	): Promise<string> {
-		return super.updateUserAttributes(user, attributes, clientMetadata);
+		return this.InternalAuth.updateUserAttributes(
+			user,
+			attributes,
+			clientMetadata
+		);
 	}
 
 	/**
@@ -259,11 +282,11 @@ export class AuthClass extends InternalAuthClass {
 	public userAttributes(
 		user: CognitoUser | any
 	): Promise<CognitoUserAttribute[]> {
-		return super.userAttributes(user);
+		return this.InternalAuth.userAttributes(user);
 	}
 
 	public verifiedContact(user: CognitoUser | any) {
-		return super.verifiedContact(user);
+		return this.InternalAuth.verifiedContact(user);
 	}
 
 	/**
@@ -273,7 +296,7 @@ export class AuthClass extends InternalAuthClass {
 	public currentUserPoolUser(
 		params?: CurrentUserOpts
 	): Promise<CognitoUser | any> {
-		return super.currentUserPoolUser(params);
+		return this.InternalAuth.currentUserPoolUser(params);
 	}
 
 	/**
@@ -284,7 +307,7 @@ export class AuthClass extends InternalAuthClass {
 	public currentAuthenticatedUser(
 		params?: CurrentUserOpts
 	): Promise<CognitoUser | any> {
-		return super.currentAuthenticatedUser(params);
+		return this.InternalAuth.currentAuthenticatedUser(params);
 	}
 
 	/**
@@ -292,7 +315,7 @@ export class AuthClass extends InternalAuthClass {
 	 * @return - A promise resolves to session object if success
 	 */
 	public currentSession(): Promise<CognitoUserSession> {
-		return super.currentSession();
+		return this.InternalAuth.currentSession();
 	}
 
 	/**
@@ -301,7 +324,7 @@ export class AuthClass extends InternalAuthClass {
 	 * @return - A promise resolves to the session
 	 */
 	public userSession(user): Promise<CognitoUserSession> {
-		return super.userSession(user);
+		return this.InternalAuth.userSession(user);
 	}
 
 	/**
@@ -309,11 +332,11 @@ export class AuthClass extends InternalAuthClass {
 	 * @return - A promise resolves to be current user's credentials
 	 */
 	public currentUserCredentials(): Promise<ICredentials> {
-		return super.currentUserCredentials();
+		return this.InternalAuth.currentUserCredentials();
 	}
 
 	public currentCredentials(): Promise<ICredentials> {
-		return super.currentCredentials();
+		return this.InternalAuth.currentCredentials();
 	}
 
 	/**
@@ -327,7 +350,7 @@ export class AuthClass extends InternalAuthClass {
 		attr: string,
 		clientMetadata?: ClientMetaData
 	): Promise<void> {
-		return super.verifyUserAttribute(user, attr, clientMetadata);
+		return this.InternalAuth.verifyUserAttribute(user, attr, clientMetadata);
 	}
 
 	/**
@@ -342,11 +365,11 @@ export class AuthClass extends InternalAuthClass {
 		attr: string,
 		code: string
 	): Promise<string> {
-		return super.verifyUserAttributeSubmit(user, attr, code);
+		return this.InternalAuth.verifyUserAttributeSubmit(user, attr, code);
 	}
 
 	public verifyCurrentUserAttribute(attr: string): Promise<void> {
-		return super.verifyCurrentUserAttribute(attr);
+		return this.InternalAuth.verifyCurrentUserAttribute(attr);
 	}
 
 	/**
@@ -359,7 +382,7 @@ export class AuthClass extends InternalAuthClass {
 		attr: string,
 		code: string
 	): Promise<string> {
-		return super.verifyCurrentUserAttributeSubmit(attr, code);
+		return this.InternalAuth.verifyCurrentUserAttributeSubmit(attr, code);
 	}
 
 	/**
@@ -368,7 +391,7 @@ export class AuthClass extends InternalAuthClass {
 	 * @return - A promise resolved if success
 	 */
 	public signOut(opts?: SignOutOpts): Promise<any> {
-		return super.signOut(opts);
+		return this.InternalAuth.signOut(opts);
 	}
 
 	/**
@@ -384,7 +407,12 @@ export class AuthClass extends InternalAuthClass {
 		newPassword: string,
 		clientMetadata?: ClientMetaData
 	): Promise<'SUCCESS'> {
-		return super.changePassword(user, oldPassword, newPassword, clientMetadata);
+		return this.InternalAuth.changePassword(
+			user,
+			oldPassword,
+			newPassword,
+			clientMetadata
+		);
 	}
 
 	/**
@@ -396,7 +424,7 @@ export class AuthClass extends InternalAuthClass {
 		username: string,
 		clientMetadata?: ClientMetaData
 	): Promise<any> {
-		return super.forgotPassword(username, clientMetadata);
+		return this.InternalAuth.forgotPassword(username, clientMetadata);
 	}
 
 	/**
@@ -412,7 +440,12 @@ export class AuthClass extends InternalAuthClass {
 		password: string,
 		clientMetadata?: ClientMetaData
 	): Promise<string> {
-		return super.forgotPasswordSubmit(username, code, password, clientMetadata);
+		return this.InternalAuth.forgotPasswordSubmit(
+			username,
+			code,
+			password,
+			clientMetadata
+		);
 	}
 
 	/**
@@ -421,7 +454,7 @@ export class AuthClass extends InternalAuthClass {
 	 * @return {Object }- current User's information
 	 */
 	public currentUserInfo() {
-		return super.currentUserInfo();
+		return this.InternalAuth.currentUserInfo();
 	}
 
 	public federatedSignIn(
@@ -443,7 +476,7 @@ export class AuthClass extends InternalAuthClass {
 		response?: FederatedResponse,
 		user?: FederatedUser
 	): Promise<ICredentials> {
-		return super.federatedSignIn(providerOrOptions, response, user);
+		return this.InternalAuth.federatedSignIn(providerOrOptions, response, user);
 	}
 
 	/**
@@ -452,21 +485,21 @@ export class AuthClass extends InternalAuthClass {
 	 * @return {Object} - Credentials
 	 */
 	public essentialCredentials(credentials): ICredentials {
-		return super.essentialCredentials(credentials);
+		return this.InternalAuth.essentialCredentials(credentials);
 	}
 
 	public rememberDevice(): Promise<string | AuthError> {
-		return super.rememberDevice();
+		return this.InternalAuth.rememberDevice();
 	}
 
 	public forgetDevice(): Promise<void> {
-		return super.forgetDevice();
+		return this.InternalAuth.forgetDevice();
 	}
 
 	public fetchDevices(): Promise<IAuthDevice[]> {
-		return super.fetchDevices();
+		return this.InternalAuth.fetchDevices();
 	}
 }
 
-export const Auth = new AuthClass(null);
+export const Auth = new AuthClass(InternalAuth);
 Amplify.register(Auth);

--- a/packages/auth/src/internals/InternalAuth.ts
+++ b/packages/auth/src/internals/InternalAuth.ts
@@ -123,7 +123,7 @@ export class InternalAuthClass {
 	 * Initialize Auth with AWS configurations
 	 * @param {Object} config - Configuration of the Auth
 	 */
-	constructor(config: AuthOptions) {
+	constructor(config?: AuthOptions) {
 		this.configure(config);
 		this.currentCredentials = this.currentCredentials.bind(this);
 		this.currentUserCredentials = this.currentUserCredentials.bind(this);
@@ -3266,5 +3266,4 @@ export class InternalAuthClass {
 	}
 }
 
-export const InternalAuth = new InternalAuthClass(null);
-Amplify.register(InternalAuth);
+export const InternalAuth = new InternalAuthClass();

--- a/packages/auth/src/internals/index.ts
+++ b/packages/auth/src/internals/index.ts
@@ -1,3 +1,4 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-export { InternalAuth } from './InternalAuth';
+export { InternalAuth, InternalAuthClass } from './InternalAuth';
+export { AuthClass } from '../Auth';

--- a/packages/aws-amplify/__tests__/withSSRContext-test.ts
+++ b/packages/aws-amplify/__tests__/withSSRContext-test.ts
@@ -55,13 +55,17 @@ describe('withSSRContext', () => {
 		});
 
 		it('should be created with UniversalStorage', () => {
-			expect(withSSRContext().Auth._storage).toBeInstanceOf(UniversalStorage);
+			expect(withSSRContext().InternalAuth._storage).toBeInstanceOf(
+				UniversalStorage
+			);
 		});
 
 		it('should use different Credentials than Amplify', () => {
 			const amplify = withSSRContext();
 
-			expect(Amplify.Auth.Credentials).not.toBe(amplify.Auth.Credentials);
+			expect(Amplify.InternalAuth.Credentials).not.toBe(
+				amplify.InternalAuth.Credentials
+			);
 		});
 	});
 
@@ -71,7 +75,7 @@ describe('withSSRContext', () => {
 		});
 
 		it('should use Amplify components from the ssr context', () => {
-			const { Auth, DataStore, InternalAPI, InternalAuth } = withSSRContext();
+			const { DataStore, InternalAPI, InternalAuth } = withSSRContext();
 
 			expect(DataStore.InternalAPI).toBe(InternalAPI);
 			expect(DataStore.InternalAPI).not.toBe(Amplify.InternalAPI);

--- a/packages/aws-amplify/__tests__/withSSRContext-test.ts
+++ b/packages/aws-amplify/__tests__/withSSRContext-test.ts
@@ -29,7 +29,7 @@ describe('withSSRContext', () => {
 	});
 
 	describe('API', () => {
-		it('should be a different instance than Amplify.Auth', () => {
+		it('should be a different instance than Amplify.API', () => {
 			expect(withSSRContext().API).not.toBe(Amplify.API);
 		});
 
@@ -53,7 +53,9 @@ describe('withSSRContext', () => {
 		it('should be a different instance than Amplify.Auth', () => {
 			expect(withSSRContext().Auth).not.toBe(Amplify.Auth);
 		});
+	});
 
+	describe('InternalAuth', () => {
 		it('should be created with UniversalStorage', () => {
 			expect(withSSRContext().InternalAuth._storage).toBeInstanceOf(
 				UniversalStorage
@@ -61,10 +63,8 @@ describe('withSSRContext', () => {
 		});
 
 		it('should use different Credentials than Amplify', () => {
-			const amplify = withSSRContext();
-
-			expect(Amplify.InternalAuth.Credentials).not.toBe(
-				amplify.InternalAuth.Credentials
+			expect(withSSRContext().InternalAuth.Credentials).not.toBe(
+				Amplify.Credentials
 			);
 		});
 	});

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -66,7 +66,7 @@
 			"name": "Notifications (top-level class)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Notifications }",
-			"limit": "30.67 kB"
+			"limit": "30.72 kB"
 		},
 		{
 			"name": "Notifications (with Analytics)",

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -81,7 +81,7 @@
 			"name": "Predictions (Interpret provider)",
 			"path": "./lib-esm/index.js",
 			"import": "{ Amplify, Predictions, AmazonAIInterpretPredictionsProvider }",
-			"limit": "43.77 kB"
+			"limit": "43.82 kB"
 		}
 	],
 	"jest": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Updated AuthClass to not extend InternalAuth, but to call InternalAuth methods. This accomplishes the following:
1. Configure is only being called on a single instance (InternalAuth) through Auth, avoiding duplicate listeners, etc
2. InternalAuth instance is the keeper of all private properties and methods: "this" will always refer to InternalAuth

Because withSSRContext needs to create fresh instances of Auth and InternalAuth, I altered the constructor of AuthClass to accept an instance of InternalAuth that will be used. 

We could potentially use the form of dependency injection used elsewhere (via Amplify._modules), however there is a risk that Auth will not function or be configured without InternalAuth defined first, and this may introduce problems related to race conditions client-side.


#### Issue #, if available




#### Description of how you validated changes
- [x] unit tests pass
- [ ] integ tests pass
- [ ] test in sample app with yarn linking



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
