### PR TITLE
Disable datastore cpk canary

### DIFF
--- a/.github/canary-config/canary-all.yml
+++ b/.github/canary-config/canary-all.yml
@@ -75,15 +75,15 @@ tests:
     browser: *minimal_browser_list
     timeout_minutes: 45
     retry_count: 10
-  - test_name: integ_react_datastore_cpk_related_models
-    desc: 'DataStore - Custom Primary Key + Related Models'
-    framework: react
-    category: datastore
-    sample_name: [v2/related-models]
-    spec: cpk-related-models
-    browser: *minimal_browser_list
-    timeout_minutes: 45
-    retry_count: 10
+  # - test_name: integ_react_datastore_cpk_related_models
+  #   desc: 'DataStore - Custom Primary Key + Related Models'
+  #   framework: react
+  #   category: datastore
+  #   sample_name: [v2/related-models]
+  #   spec: cpk-related-models
+  #   browser: *minimal_browser_list
+  #   timeout_minutes: 45
+  #   retry_count: 10
   - test_name: integ_react_datastore_selective_sync
     desc: 'DataStore - Selective Sync'
     framework: react

--- a/.github/canary-config/canary-all.yml
+++ b/.github/canary-config/canary-all.yml
@@ -66,15 +66,15 @@ tests:
     spec: background-process-manager
     browser: *extended_browser_list
   # TODO: remove when updated CPK + related models tests are added
-  - test_name: integ_react_datastore_related_models
-    desc: 'DataStore - Related Models'
-    framework: react
-    category: datastore
-    sample_name: [related-models]
-    spec: related-models
-    browser: *minimal_browser_list
-    timeout_minutes: 45
-    retry_count: 10
+  # - test_name: integ_react_datastore_related_models
+  #   desc: 'DataStore - Related Models'
+  #   framework: react
+  #   category: datastore
+  #   sample_name: [related-models]
+  #   spec: related-models
+  #   browser: *minimal_browser_list
+  #   timeout_minutes: 45
+  #   retry_count: 10
   # - test_name: integ_react_datastore_cpk_related_models
   #   desc: 'DataStore - Custom Primary Key + Related Models'
   #   framework: react


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Temporary disable CPK tests that are timing out. And related model tests that are missing on the samples repo



#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
