### PR TITLE
chore: Rebuild yarn.lock - release pr to main - one generic PAT and an env scoped write PAT

### DIFF
--- a/.github/actions/node-and-build/action.yml
+++ b/.github/actions/node-and-build/action.yml
@@ -14,10 +14,22 @@ runs:
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
     - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-      id: cache-build-artifacts
+      id: cache-yarn-artifacts
       with:
         path: |
           **/node_modules
+        key: ${{ runner.os }}-yarn-artifacts-${{ hashFiles('./amplify-js/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-artifacts-
+    - name: Install
+      if: steps.cache-yarn-artifacts.outputs.cache-hit != 'true'
+      run: yarn
+      shell: bash
+      working-directory: ./amplify-js
+    - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      id: cache-build-artifacts
+      with:
+        path: |
           **/dist
           **/lib
           **/lib-esm/
@@ -25,19 +37,13 @@ runs:
           **/esm/
           **/cjs/
           **/packages/core/src/Platform/version.ts
-        key: ${{ runner.os }}-build-artifacts-${{ github.sha }}
+        key: ${{ runner.os }}-build-artifacts-${{ hashFiles('./amplify-js/packages/*/src/**', './amplify-js/packages/*/*.json', './amplify-js/packages/*/*.js') }}
         restore-keys: |
           ${{ runner.os }}-build-artifacts-
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
-    # TODO We should be able to skip yarn / bootstrap if we cache enough things. Leaving because skipping causes issues.
-    - name: Install
-      if: inputs.is-prebuild != 'true' || steps.cache-build-artifacts.outputs.cache-hit != 'true'
-      run: yarn
-      shell: bash
-      working-directory: ./amplify-js
     - name: Bootstrap
-      if: inputs.is-prebuild != 'true' || steps.cache-build-artifacts.outputs.cache-hit != 'true'
+      if: steps.cache-build-artifacts.outputs.cache-hit != 'true'
       run: yarn bootstrap
       shell: bash
       working-directory: ./amplify-js

--- a/.github/actions/setup-samples-staging/action.yml
+++ b/.github/actions/setup-samples-staging/action.yml
@@ -2,7 +2,7 @@ name: Setup Amplify Integration Test Package
 description: Checks out "amplify-js-samples-staging" and builds the package with caching
 
 inputs:
-  GH_TOKEN_STAGING_READ:
+  GH_TOKEN_AMPLIFY_JS_AUTOMATION:
     description: The token that grants read access to the sample staging repo
     required: true
 
@@ -24,7 +24,7 @@ runs:
       with:
         repository: ${{ github.repository_owner }}/amplify-js-samples-staging
         path: amplify-js-samples-staging
-        token: ${{ inputs.GH_TOKEN_STAGING_READ }}
+        token: ${{ inputs.GH_TOKEN_AMPLIFY_JS_AUTOMATION }}
 
     # We test on the staging branch that corresponds to the amplify-js branch
     #   when it exists and test on the default branch `main` otherwise

--- a/.github/workflows/callable-canary-e2e-tests.yml
+++ b/.github/workflows/callable-canary-e2e-tests.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup samples staging repository
         uses: ./amplify-js/.github/actions/setup-samples-staging
         with:
-          GH_TOKEN_STAGING_READ: ${{ secrets.GH_TOKEN_STAGING_READ }}
+          GH_TOKEN_AMPLIFY_JS_AUTOMATION: ${{ secrets.GH_TOKEN_AMPLIFY_JS_AUTOMATION }}
       - name: Modify package.json to run against aws-amplify latest
         env:
           E2E_FRAMEWORK: ${{ inputs.framework }}

--- a/.github/workflows/callable-canary-sampleapp-tests.yml
+++ b/.github/workflows/callable-canary-sampleapp-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup samples staging repository
         uses: ./amplify-js/.github/actions/setup-samples-staging
         with:
-          GH_TOKEN_STAGING_READ: ${{ secrets.GH_TOKEN_STAGING_READ }}
+          GH_TOKEN_AMPLIFY_JS_AUTOMATION: ${{ secrets.GH_TOKEN_AMPLIFY_JS_AUTOMATION }}
       - name: Setup node and build the repository
         uses: ./amplify-js/.github/actions/node-and-build
 

--- a/.github/workflows/callable-e2e-test-detox.yml
+++ b/.github/workflows/callable-e2e-test-detox.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup samples staging repository
         uses: ./amplify-js/.github/actions/setup-samples-staging
         with:
-          GH_TOKEN_STAGING_READ: ${{ secrets.GH_TOKEN_STAGING_READ }}
+          GH_TOKEN_AMPLIFY_JS_AUTOMATION: ${{ secrets.GH_TOKEN_AMPLIFY_JS_AUTOMATION }}
       - name: Load Verdaccio with AmplifyJs
         uses: ./amplify-js/.github/actions/load-verdaccio-with-amplify-js
       - name: Yarn Install

--- a/.github/workflows/callable-e2e-test-headless.yml
+++ b/.github/workflows/callable-e2e-test-headless.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup samples staging repository
         uses: ./amplify-js/.github/actions/setup-samples-staging
         with:
-          GH_TOKEN_STAGING_READ: ${{ secrets.GH_TOKEN_STAGING_READ }}
+          GH_TOKEN_AMPLIFY_JS_AUTOMATION: ${{ secrets.GH_TOKEN_AMPLIFY_JS_AUTOMATION }}
 
       - name: Change directory into build and run link
         run: |

--- a/.github/workflows/callable-e2e-test.yml
+++ b/.github/workflows/callable-e2e-test.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup samples staging repository
         uses: ./amplify-js/.github/actions/setup-samples-staging
         with:
-          GH_TOKEN_STAGING_READ: ${{ secrets.GH_TOKEN_STAGING_READ }}
+          GH_TOKEN_AMPLIFY_JS_AUTOMATION: ${{ secrets.GH_TOKEN_AMPLIFY_JS_AUTOMATION }}
       - name: Load Verdaccio with AmplifyJs
         uses: ./amplify-js/.github/actions/load-verdaccio-with-amplify-js
       - name: Run cypress tests for ${{ inputs.test_name }} dev

--- a/.github/workflows/callable-npm-publish-release.yml
+++ b/.github/workflows/callable-npm-publish-release.yml
@@ -1,4 +1,4 @@
-name: Release to npm and update repository
+name: Release to npm and update repository # NOTE: Name must align with `./run-after-push-latest-releast.yml`
 
 on: workflow_call
 
@@ -11,7 +11,6 @@ jobs:
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
         with:
           path: amplify-js
-          token: ${{ secrets.GH_TOKEN_AMPLIFY_JS_WRITE }}
 
       - name: Setup node and build the repository
         uses: ./amplify-js/.github/actions/node-and-build
@@ -40,16 +39,7 @@ jobs:
           RELEASE_COMMIT_MESSAGE=$(git log -n 1 --skip 1 --pretty=oneline)
           if [[ $RELEASE_COMMIT_MESSAGE = *release\(required\)* ]]; then git tag -f required-release $PUBLISH_COMMIT_HASH; fi
 
-      - name: Update API documentation
-        working-directory: ./amplify-js
-        run: |
-          yarn run docs
-          git add ./docs/api/
-          git commit -m "chore(release): update API docs [ci skip]"
-
       - name: Push post release changes
         working-directory: ./amplify-js
         run: |
           git push origin release
-          git push -f origin required-release
-          git push --force-with-lease origin release:main

--- a/.github/workflows/callable-npm-publish-release.yml
+++ b/.github/workflows/callable-npm-publish-release.yml
@@ -6,11 +6,13 @@ jobs:
   deploy:
     name: Publish to Amplify Package
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout repository
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
         with:
           path: amplify-js
+          token: ${{ secrets.GH_TOKEN_AMPLIFY_JS_WRITE }}
 
       - name: Setup node and build the repository
         uses: ./amplify-js/.github/actions/node-and-build

--- a/.github/workflows/callable-npm-publish-release.yml
+++ b/.github/workflows/callable-npm-publish-release.yml
@@ -43,3 +43,4 @@ jobs:
         working-directory: ./amplify-js
         run: |
           git push origin release
+          git push -f origin required-release

--- a/.github/workflows/callable-prebuild-samples-staging.yml
+++ b/.github/workflows/callable-prebuild-samples-staging.yml
@@ -3,7 +3,7 @@ name: Prebuild AmplifyJsSamplesStaging
 on:
   workflow_call:
     secrets:
-      GH_TOKEN_STAGING_READ:
+      GH_TOKEN_AMPLIFY_JS_AUTOMATION:
         required: true
 jobs:
   pre-staging:
@@ -17,4 +17,4 @@ jobs:
       - name: Setup samples staging
         uses: ./amplify-js/.github/actions/setup-samples-staging
         with:
-          GH_TOKEN_STAGING_READ: ${{ secrets.GH_TOKEN_STAGING_READ }}
+          GH_TOKEN_AMPLIFY_JS_AUTOMATION: ${{ secrets.GH_TOKEN_AMPLIFY_JS_AUTOMATION }}

--- a/.github/workflows/on-schedule-canary-test.yml
+++ b/.github/workflows/on-schedule-canary-test.yml
@@ -6,5 +6,6 @@ on:
 
 jobs:
   canaries:
+    if: github.repository == 'aws-amplify/amplify-js'
     secrets: inherit
     uses: ./.github/workflows/callable-canary-e2e.yml

--- a/.github/workflows/on-schedule-update-yarn-lock.yml
+++ b/.github/workflows/on-schedule-update-yarn-lock.yml
@@ -1,0 +1,50 @@
+name: Update yarn.lock
+
+on:
+  push:
+    branches: ['01-yarnlock']
+  schedule:
+    - cron: '0 8 * * 0' # run weekly on Sunday at 8am GMT
+
+permissions:
+  contents: write
+
+jobs:
+  yarn-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date
+        id: current-date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        with:
+          ref: main
+      - name: Set github commit user
+        shell: bash
+        env:
+          GITHUB_EMAIL: ${{ vars.GH_EMAIL }}
+          GITHUB_USER: ${{ vars.GH_USER }}
+        run: |
+          git config --global user.email $GITHUB_EMAIL
+          git config --global user.name $GITHUB_USER
+      - name: Update yarn.lock on a branch
+        env:
+          BRANCH: update-yarnlock/${{ steps.current-date.outputs.date }}
+        run: |
+          git fetch origin
+          git checkout -b $BRANCH
+          rm yarn.lock
+          yarn || true
+          git add yarn.lock
+          git commit -am "chore: update yarn.lock"
+          git push origin HEAD
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_AMPLIFY_JS_AUTOMATION }}
+          BRANCH: update-yarnlock/${{ steps.current-date.outputs.date }}
+        run: |
+          gh pr create \
+          --title "chore: update yarn.lock" \
+          --body "Update the yarn.lock file" \
+          --head $BRANCH \
+          --base main

--- a/.github/workflows/on-schedule-update-yarn-lock.yml
+++ b/.github/workflows/on-schedule-update-yarn-lock.yml
@@ -47,8 +47,7 @@ jobs:
           --title "chore: update yarn.lock" \
           --body "Update the yarn.lock file" \
           --head $BRANCH \
-          --base main) && export PR_URL
-          curl -X POST -H "Content-Type: application/json" --data '{ \
-            "PR_URL": "$PR_URL", \
-            "PR_DESC": "yarn.lock file update" \
-          }' $WEBHOOK_URL
+          --base main)
+          curl -X POST -H "Content-Type: application/json" \
+            --data '{"PR_URL":"'$PR_URL'","PR_DESC":"yarn.lock file update"}' \
+            $WEBHOOK_URL

--- a/.github/workflows/on-schedule-update-yarn-lock.yml
+++ b/.github/workflows/on-schedule-update-yarn-lock.yml
@@ -41,9 +41,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_AMPLIFY_JS_AUTOMATION }}
           BRANCH: update-yarnlock/${{ steps.current-date.outputs.date }}
+          WEBHOOK_URL: ${{ secrets.SLACK_PR_WEBHOOK_URL }}
         run: |
-          gh pr create \
+          PR_URL=$(gh pr create \
           --title "chore: update yarn.lock" \
           --body "Update the yarn.lock file" \
           --head $BRANCH \
-          --base main
+          --base main) && export PR_URL
+          curl -X POST -H "Content-Type: application/json" --data '{ \
+            "PR_URL": "$PR_URL", \
+            "PR_DESC": "yarn.lock file update" \
+          }' $WEBHOOK_URL

--- a/.github/workflows/on-schedule-update-yarn-lock.yml
+++ b/.github/workflows/on-schedule-update-yarn-lock.yml
@@ -1,8 +1,6 @@
 name: Update yarn.lock
 
 on:
-  push:
-    branches: ['01-yarnlock']
   schedule:
     - cron: '0 8 * * 0' # run weekly on Sunday at 8am GMT
 
@@ -11,6 +9,7 @@ permissions:
 
 jobs:
   yarn-update:
+    if: github.repository == 'aws-amplify/amplify-js'
     runs-on: ubuntu-latest
     steps:
       - name: Get current date

--- a/.github/workflows/on-schedule-update-yarn-lock.yml
+++ b/.github/workflows/on-schedule-update-yarn-lock.yml
@@ -37,7 +37,7 @@ jobs:
           git add yarn.lock
           git commit -am "chore: update yarn.lock"
           git push origin HEAD
-      - name: Create Pull Request
+      - name: Create Pull Request and post to slack
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_AMPLIFY_JS_AUTOMATION }}
           BRANCH: update-yarnlock/${{ steps.current-date.outputs.date }}

--- a/.github/workflows/push-latest-release.yml
+++ b/.github/workflows/push-latest-release.yml
@@ -5,6 +5,9 @@ concurrency:
   group: push-release-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:
@@ -17,7 +20,5 @@ jobs:
   release:
     needs:
       - e2e
-    permissions:
-      contents: write
     secrets: inherit
     uses: ./.github/workflows/callable-npm-publish-release.yml

--- a/.github/workflows/run-after-push-latest-release.yml
+++ b/.github/workflows/run-after-push-latest-release.yml
@@ -64,8 +64,7 @@ jobs:
           --title "chore: Merge release back to main" \
           --body "Merge version updates and docs changes from release back to main." \
           --head $BRANCH \
-          --base main) && export PR_URL
-          curl -X POST -H "Content-Type: application/json" --data '{ \
-            "PR_URL": "$PR_URL", \
-            "PR_DESC": "Post-release merge to main" \
-          }' $WEBHOOK_URL
+          --base main)
+          curl -X POST -H "Content-Type: application/json" \
+            --data '{"PR_URL":"'$PR_URL'","PR_DESC":"Post-release merge to main"}' \
+            $WEBHOOK_URL

--- a/.github/workflows/run-after-push-latest-release.yml
+++ b/.github/workflows/run-after-push-latest-release.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   pr-release-to-main:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Create branch name

--- a/.github/workflows/run-after-push-latest-release.yml
+++ b/.github/workflows/run-after-push-latest-release.yml
@@ -53,7 +53,7 @@ jobs:
           git fetch origin
           git checkout -b $BRANCH
           git push origin HEAD
-      - name: Create Pull Request
+      - name: Create Pull Request and post to slack
         working-directory: ./amplify-js
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_AMPLIFY_JS_AUTOMATION }}

--- a/.github/workflows/run-after-push-latest-release.yml
+++ b/.github/workflows/run-after-push-latest-release.yml
@@ -1,0 +1,65 @@
+name: After release - Merge from release back to main
+
+on:
+  workflow_run:
+    workflows:
+      - Push - release from release to latest
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  pr-release-to-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create branch name
+        env:
+          GH_SHA: ${{ github.sha }}
+        id: branch-name
+        run: |
+          export SHORT_SHA=$(echo $GH_SHA | cut -c -7)
+          echo "name=merge-release-to-main/$SHORT_SHA" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        with:
+          ref: release
+          fetch-depth: 0
+          path: amplify-js
+
+      - name: Setup node and build the repository
+        uses: ./amplify-js/.github/actions/node-and-build
+
+      - name: Set github commit user
+        shell: bash
+        env:
+          GITHUB_EMAIL: ${{ vars.GH_EMAIL }}
+          GITHUB_USER: ${{ vars.GH_USER }}
+        run: |
+          git config --global user.email $GITHUB_EMAIL
+          git config --global user.name $GITHUB_USER
+      - name: Update API documentation
+        working-directory: ./amplify-js
+        run: |
+          yarn run docs
+          git add ./docs/api/
+          git commit -m "chore: update API docs"
+      - name:
+        working-directory: ./amplify-js
+        env:
+          BRANCH: ${{ steps.branch-name.outputs.name }}
+        run: |
+          git fetch origin
+          git checkout -b $BRANCH
+          git push origin HEAD
+      - name: Create Pull Request
+        working-directory: ./amplify-js
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_AMPLIFY_JS_AUTOMATION }}
+          BRANCH: ${{ steps.branch-name.outputs.name }}
+        run: |
+          gh pr create \
+          --title "chore: Merge release back to main" \
+          --body "Merge version updates and docs changes from release back to main." \
+          --head $BRANCH \
+          --base main

--- a/.github/workflows/run-after-push-latest-release.yml
+++ b/.github/workflows/run-after-push-latest-release.yml
@@ -58,9 +58,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_AMPLIFY_JS_AUTOMATION }}
           BRANCH: ${{ steps.branch-name.outputs.name }}
+          WEBHOOK_URL: ${{ secrets.SLACK_PR_WEBHOOK_URL }}
         run: |
-          gh pr create \
+          PR_URL=$(gh pr create \
           --title "chore: Merge release back to main" \
           --body "Merge version updates and docs changes from release back to main." \
           --head $BRANCH \
-          --base main
+          --base main) && export PR_URL
+          curl -X POST -H "Content-Type: application/json" --data '{ \
+            "PR_URL": "$PR_URL", \
+            "PR_DESC": "Post-release merge to main" \
+          }' $WEBHOOK_URL


### PR DESCRIPTION
#### Description of changes
Two big changes:
- A scheduled job to post a PR to update the `yarn.lock` file
- Revise the release process to use a PR to merge from `release` back to `main`

Smaller changes:
- Add owner protection for canaries and yarn.lock (keep these from running on forks)
- Migrate to using a single Personal Access Token (PR and Staging only, eliminate the write token)
- Cache `yarn` separately from `build` files so we can go back to invalidating the cache less frequently

#### Description of how you validated changes
Tested by running on my fork.
- [Release](https://github.com/stocaaro/amplify-js/actions/runs/6053723498) ***Without e2e tests***
- [Post release merge to main workflow](https://github.com/stocaaro/amplify-js/actions/runs/6053726955)
- [PR created](https://github.com/stocaaro/amplify-js/pull/80)
- [Triggers validation](https://github.com/stocaaro/amplify-js/actions/runs/6053737196)


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
