### PR TITLE
fix(adapter-nextjs): remove usage of node http

### DIFF
--- a/packages/adapter-nextjs/__tests__/utils/createCookieStorageAdapterFromNextServerContext.test.ts
+++ b/packages/adapter-nextjs/__tests__/utils/createCookieStorageAdapterFromNextServerContext.test.ts
@@ -224,7 +224,7 @@ describe('createCookieStorageAdapterFromNextServerContext', () => {
 	it('should throw error when no cookie storage adapter is created from the context', () => {
 		expect(() =>
 			createCookieStorageAdapterFromNextServerContext({
-				request: {} as any,
+				request: undefined,
 				response: new ServerResponse({} as any),
 			} as any)
 		).toThrowError();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Remove the usage of `http`, it was used to detect the input instances. 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* Build with the sample Next.js app
* Running the sample Next.js app manually

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
