### PR TITLE
Fixes _generateState() to sample characters uniformly

### DIFF
--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -302,8 +302,9 @@ export default class OAuth {
 		let i = length;
 		const chars =
 			'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-		for (; i > 0; --i)
-			result += chars[Math.floor(Math.random() * chars.length)];
+		for (; i > 0; --i) {
+			result += chars[(Math.random() * chars.length) | 0];
+		}
 		return result;
 	}
 

--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -303,7 +303,7 @@ export default class OAuth {
 		const chars =
 			'0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 		for (; i > 0; --i)
-			result += chars[Math.round(Math.random() * (chars.length - 1))];
+			result += chars[Math.floor(Math.random() * chars.length)];
 		return result;
 	}
 


### PR DESCRIPTION
#### Description of changes
The previous code that used `Math.round(Math.random() * (chars.length - 1))` sampled the first and last characters half as often as the other characters. The new code that uses `(Math.random() * chars.length) | 0` samples all characters equally and aligns better with the sampling code used in [`_generateRandom()`](https://github.com/aws-amplify/amplify-js/blob/main/packages/auth/src/OAuth/OAuth.ts#L333).

#### Description of how you validated changes
Tested locally.

#### Checklist
- [x] PR description included
- [ ] `yarn test` passes
The 6 tests passed, but the 11 test suites did not. Here are the results I get when running `yarn test` from `amplify-js/packages/auth`, and I was getting these same results both before and after the making change in this PR, so the change didn't seem to affect the results:
```
-----------|----------|----------|----------|----------|-------------------|
File       |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-----------|----------|----------|----------|----------|-------------------|
All files  |     59.6 |    50.62 |    47.37 |    61.36 |                   |
 OAuth     |    54.55 |    50.72 |    51.85 |    54.81 |                   |
  OAuth.ts |    54.55 |    50.72 |    51.85 |    54.81 |... 43,344,345,347 |
 types     |    77.27 |       50 |    36.36 |    82.93 |                   |
  Auth.ts  |    77.27 |       50 |    36.36 |    82.93 |... 2,83,90,91,216 |
-----------|----------|----------|----------|----------|-------------------|
Test Suites: 9 failed, 2 passed, 11 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        5.931s
```
(Let me know if you want me to post the full test results).
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
