### PR TITLE
chore(storage): align api types names

### DIFF
--- a/packages/storage/src/providers/s3/apis/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/downloadData.ts
@@ -3,17 +3,17 @@
 
 import { Amplify } from '@aws-amplify/core';
 
-import { S3TransferOptions, S3DownloadDataResult } from '../types';
+import { S3DownloadDataOptions, S3DownloadDataResult } from '../types';
 import { resolveS3ConfigAndInput } from '../utils/resolveS3ConfigAndInput';
 import { StorageValidationErrorCode } from '../../../errors/types/validation';
-import { StorageDownloadDataRequest, DownloadTask } from '../../../types';
+import { DownloadDataRequest, DownloadTask } from '../../../types';
 import { createDownloadTask } from '../utils';
 import { getObject } from '../utils/client';
 
 /**
  * Download S3 object data to memory
  *
- * @param {StorageDownloadDataRequest<S3TransferOptions>} downloadDataRequest The parameters that are passed to the
+ * @param {DownloadDataRequest<S3DownloadDataOptions>} downloadDataRequest The parameters that are passed to the
  * 	downloadData operation.
  * @returns {DownloadTask<S3DownloadDataResult>} Cancelable task exposing result promise from `result` property.
  * @throws service: {@link S3Exception} - thrown when checking for existence of the object
@@ -42,7 +42,7 @@ import { getObject } from '../utils/client';
  *```
  */
 export const downloadData = (
-	downloadDataRequest: StorageDownloadDataRequest<S3TransferOptions>
+	downloadDataRequest: DownloadDataRequest<S3DownloadDataOptions>
 ): DownloadTask<S3DownloadDataResult> => {
 	const abortController = new AbortController();
 
@@ -60,7 +60,7 @@ const downloadDataJob =
 		{
 			options: downloadDataOptions,
 			key,
-		}: StorageDownloadDataRequest<S3TransferOptions>,
+		}: DownloadDataRequest<S3DownloadDataOptions>,
 		abortSignal: AbortSignal
 	) =>
 	async () => {

--- a/packages/storage/src/providers/s3/apis/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/getProperties.ts
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Amplify } from '@aws-amplify/core';
-import { StorageOperationRequest, StorageOptions } from '../../../types';
-import { S3GetPropertiesResult } from '../types';
+import { GetPropertiesRequest } from '../../../types';
+import { S3GetPropertiesOptions, S3GetPropertiesResult } from '../types';
 import { getProperties as getPropertiesInternal } from './internal/getProperties';
 
 /**
  * Gets the properties of a file. The properties include S3 system metadata and
  * the user metadata that was provided when uploading the file.
  *
- * @param {StorageOperationRequest} req The request to make an API call.
+ * @param {GetPropertiesRequest<S3GetPropertiesOptions>} req The request to make an API call.
  * @returns {Promise<S3GetPropertiesResult>} A promise that resolves the properties.
  * @throws A {@link S3Exception} when the underlying S3 service returned error.
  * @throws A {@link StorageValidationErrorCode} when API call parameters are invalid.
  */
 export const getProperties = (
-	req: StorageOperationRequest<StorageOptions>
+	getPropertiesRequest: GetPropertiesRequest<S3GetPropertiesOptions>
 ): Promise<S3GetPropertiesResult> => {
-	return getPropertiesInternal(Amplify, req);
+	return getPropertiesInternal(Amplify, getPropertiesRequest);
 };

--- a/packages/storage/src/providers/s3/apis/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/getUrl.ts
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Amplify } from '@aws-amplify/core';
-import { StorageDownloadDataRequest } from '../../../types';
+import { GetUrlRequest } from '../../../types';
 import { S3GetUrlOptions, S3GetUrlResult } from '../types';
 import { getUrl as getUrlInternal } from './internal/getUrl';
 
 /**
  * Get Presigned url of the object
  *
- * @param {StorageDownloadDataRequest<S3GetUrlOptions>} The request object
+ * @param {GetUrlRequest<S3GetUrlOptions>} The request object
  * @return {Promise<S3GetUrlResult>} url of the object
  * @throws service: {@link S3Exception} - thrown when checking for existence of the object
  * @throws validation: {@link StorageValidationErrorCode } - Validation errors
@@ -19,7 +19,7 @@ import { getUrl as getUrlInternal } from './internal/getUrl';
  *
  */
 export const getUrl = (
-	req: StorageDownloadDataRequest<S3GetUrlOptions>
+	getUrlRequest: GetUrlRequest<S3GetUrlOptions>
 ): Promise<S3GetUrlResult> => {
-	return getUrlInternal(Amplify, req);
+	return getUrlInternal(Amplify, getUrlRequest);
 };

--- a/packages/storage/src/providers/s3/apis/internal/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getProperties.ts
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AmplifyClassV6 } from '@aws-amplify/core';
-import { StorageOptions, StorageOperationRequest } from '../../../../types';
-import { S3GetPropertiesResult } from '../../types';
+import { GetPropertiesRequest } from '../../../../types';
+import { S3GetPropertiesOptions, S3GetPropertiesResult } from '../../types';
 import { resolveS3ConfigAndInput } from '../../utils';
 import { headObject } from '../../utils/client';
 
 export const getProperties = async function (
 	amplify: AmplifyClassV6,
-	getPropertiesRequest: StorageOperationRequest<StorageOptions>
+	getPropertiesRequest: GetPropertiesRequest<S3GetPropertiesOptions>
 ): Promise<S3GetPropertiesResult> {
 	const { key, options } = getPropertiesRequest;
 	const { s3Config, bucket, keyPrefix } = await resolveS3ConfigAndInput(

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -3,7 +3,7 @@
 
 import { AmplifyClassV6 } from '@aws-amplify/core';
 
-import { StorageDownloadDataRequest } from '../../../../types';
+import { GetUrlRequest } from '../../../../types';
 import { S3GetUrlOptions, S3GetUrlResult } from '../../types';
 import { StorageValidationErrorCode } from '../../../../errors/types/validation';
 import { getPresignedGetObjectUrl } from '../../utils/client';
@@ -16,7 +16,7 @@ const MAX_URL_EXPIRATION = 7 * 24 * 60 * 60 * 1000;
 
 export const getUrl = async function (
 	amplify: AmplifyClassV6,
-	getUrlRequest: StorageDownloadDataRequest<S3GetUrlOptions>
+	getUrlRequest: GetUrlRequest<S3GetUrlOptions>
 ): Promise<S3GetUrlResult> {
 	const { key, options } = getUrlRequest;
 

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AmplifyClassV6 } from '@aws-amplify/core';
-import {
-	StorageListRequest,
-	StorageListAllOptions,
-	StorageListPaginateOptions,
-} from '../../../../types';
+import { ListRequest } from '../../../../types';
 import {
 	S3ListOutputItem,
+	S3ListAllOptions,
+	S3ListPaginateOptions,
 	S3ListAllResult,
 	S3ListPaginateResult,
 } from '../../types';
@@ -31,8 +29,8 @@ type ListRequestArgs = {
 export const list = async (
 	amplify: AmplifyClassV6,
 	listRequest?:
-		| StorageListRequest<StorageListAllOptions>
-		| StorageListRequest<StorageListPaginateOptions>
+		| ListRequest<S3ListAllOptions>
+		| ListRequest<S3ListPaginateOptions>
 ): Promise<S3ListAllResult | S3ListPaginateResult> => {
 	const { options = {}, path = '' } = listRequest ?? {};
 	const {

--- a/packages/storage/src/providers/s3/apis/internal/remove.ts
+++ b/packages/storage/src/providers/s3/apis/internal/remove.ts
@@ -2,19 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AmplifyClassV6 } from '@aws-amplify/core';
-
-import {
-	StorageOperationRequest,
-	StorageRemoveOptions,
-	StorageRemoveResult,
-} from '../../../../types';
+import { RemoveRequest } from '../../../../types';
+import { S3RemoveOptions, S3RemoveResult } from '../../types';
 import { resolveS3ConfigAndInput } from '../../utils';
 import { deleteObject } from '../../utils/client';
 
 export const remove = async (
 	amplify: AmplifyClassV6,
-	removeRequest: StorageOperationRequest<StorageRemoveOptions>
-): Promise<StorageRemoveResult> => {
+	removeRequest: RemoveRequest<S3RemoveOptions>
+): Promise<S3RemoveResult> => {
 	const { key, options = {} } = removeRequest;
 	const { s3Config, keyPrefix, bucket } = await resolveS3ConfigAndInput(
 		amplify,

--- a/packages/storage/src/providers/s3/apis/list.ts
+++ b/packages/storage/src/providers/s3/apis/list.ts
@@ -2,38 +2,41 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Amplify } from '@aws-amplify/core';
+import { ListRequest } from '../../../types';
 import {
-	StorageListAllOptions,
-	StorageListPaginateOptions,
-	StorageListRequest,
-} from '../../../types';
-import { S3ListAllResult, S3ListPaginateResult } from '../types';
+	S3ListAllOptions,
+	S3ListPaginateOptions,
+	S3ListAllResult,
+	S3ListPaginateResult,
+} from '../types';
 import { list as listInternal } from './internal/list';
 
 type S3ListApi = {
 	/**
 	 * Lists bucket objects with pagination.
-	 * @param {StorageListRequest<StorageListPaginateOptions>} req - The request object
+	 * @param {ListRequest<S3ListPaginateOptions>} listRequest - The request object
 	 * @return {Promise<S3ListPaginateResult>} - Promise resolves to list of keys and metadata with
 	 * pageSize defaulting to 1000. Additionally the result will include a nextToken if there are more items to retrieve
 	 * @throws service: {@link S3Exception} - S3 service errors thrown when checking for existence of bucket
 	 * @throws validation: {@link StorageValidationErrorCode } - thrown when there are issues with credentials
 	 */
 	(
-		req?: StorageListRequest<StorageListPaginateOptions>
+		listRequest?: ListRequest<S3ListPaginateOptions>
 	): Promise<S3ListPaginateResult>;
 	/**
 	 * Lists all bucket objects.
-	 * @param {StorageListRequest<StorageListAllOptions>} req - The request object
+	 * @param {ListRequest<S3ListAllOptions>} listRequest - The request object
 	 * @return {Promise<S3ListAllResult>} - Promise resolves to list of keys and metadata for all objects in path
 	 * @throws service: {@link S3Exception} - S3 service errors thrown when checking for existence of bucket
 	 * @throws validation: {@link StorageValidationErrorCode } - thrown when there are issues with credentials
 	 */
-	(req?: StorageListRequest<StorageListAllOptions>): Promise<S3ListAllResult>;
+	(listRequest?: ListRequest<S3ListAllOptions>): Promise<S3ListAllResult>;
 };
 
 export const list: S3ListApi = (
-	req
+	listRequest?:
+		| ListRequest<S3ListAllOptions>
+		| ListRequest<S3ListPaginateOptions>
 ): Promise<S3ListAllResult | S3ListPaginateResult> => {
-	return listInternal(Amplify, req ?? {});
+	return listInternal(Amplify, listRequest ?? {});
 };

--- a/packages/storage/src/providers/s3/apis/remove.ts
+++ b/packages/storage/src/providers/s3/apis/remove.ts
@@ -2,22 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Amplify } from '@aws-amplify/core';
-import {
-	StorageOperationRequest,
-	StorageRemoveOptions,
-	StorageRemoveResult,
-} from '../../../types';
+import { RemoveRequest } from '../../../types';
+import { S3RemoveOptions, S3RemoveResult } from '../types';
 import { remove as removeInternal } from './internal/remove';
 
 /**
  * Remove the object that is specified by the `req`.
- * @param {StorageOperationRequest<StorageRemoveOptions>} req - The request object
- * @return {Promise<StorageRemoveResult>} - Promise resolves upon successful removal of the object
+ * @param {RemoveRequest<S3RemoveOptions>} removeRequest - The request object
+ * @return {Promise<S3RemoveResult>} - Promise resolves upon successful removal of the object
  * @throws service: {@link S3Exception} - S3 service errors thrown while getting properties
  * @throws validation: {@link StorageValidationErrorCode } - Validation errors thrown
  */
 export const remove = (
-	req: StorageOperationRequest<StorageRemoveOptions>
-): Promise<StorageRemoveResult> => {
-	return removeInternal(Amplify, req);
+	removeRequest: RemoveRequest<S3RemoveOptions>
+): Promise<S3RemoveResult> => {
+	return removeInternal(Amplify, removeRequest);
 };

--- a/packages/storage/src/providers/s3/apis/server/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/server/getProperties.ts
@@ -5,16 +5,16 @@ import {
 	AmplifyServer,
 	getAmplifyServerContext,
 } from '@aws-amplify/core/internals/adapter-core';
-import { StorageOperationRequest, StorageOptions } from '../../../../types';
-import { S3GetPropertiesResult } from '../../types';
+import { GetPropertiesRequest } from '../../../../types';
+import { S3GetPropertiesOptions, S3GetPropertiesResult } from '../../types';
 import { getProperties as getPropertiesInternal } from '../internal/getProperties';
 
 export const getProperties = (
 	contextSpec: AmplifyServer.ContextSpec,
-	req: StorageOperationRequest<StorageOptions>
+	getPropertiesRequest: GetPropertiesRequest<S3GetPropertiesOptions>
 ): Promise<S3GetPropertiesResult> => {
 	return getPropertiesInternal(
 		getAmplifyServerContext(contextSpec).amplify,
-		req
+		getPropertiesRequest
 	);
 };

--- a/packages/storage/src/providers/s3/apis/server/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/server/getUrl.ts
@@ -5,13 +5,16 @@ import {
 	AmplifyServer,
 	getAmplifyServerContext,
 } from '@aws-amplify/core/internals/adapter-core';
-import { StorageDownloadDataRequest } from '../../../../types';
+import { GetUrlRequest } from '../../../../types';
 import { S3GetUrlOptions, S3GetUrlResult } from '../../types';
 import { getUrl as getUrlInternal } from '../internal/getUrl';
 
 export const getUrl = async (
 	contextSpec: AmplifyServer.ContextSpec,
-	req: StorageDownloadDataRequest<S3GetUrlOptions>
+	getUrlRequest: GetUrlRequest<S3GetUrlOptions>
 ): Promise<S3GetUrlResult> => {
-	return getUrlInternal(getAmplifyServerContext(contextSpec).amplify, req);
+	return getUrlInternal(
+		getAmplifyServerContext(contextSpec).amplify,
+		getUrlRequest
+	);
 };

--- a/packages/storage/src/providers/s3/apis/server/list.ts
+++ b/packages/storage/src/providers/s3/apis/server/list.ts
@@ -5,18 +5,19 @@ import {
 	AmplifyServer,
 	getAmplifyServerContext,
 } from '@aws-amplify/core/internals/adapter-core';
+import { ListRequest } from '../../../../types';
 import {
-	StorageListAllOptions,
-	StorageListPaginateOptions,
-	StorageListRequest,
-} from '../../../../types';
-import { S3ListAllResult, S3ListPaginateResult } from '../../types';
+	S3ListAllOptions,
+	S3ListPaginateOptions,
+	S3ListAllResult,
+	S3ListPaginateResult,
+} from '../../types';
 import { list as listInternal } from '../internal/list';
 
 type S3ListApi = {
 	/**
 	 * Lists bucket objects with pagination.
-	 * @param {StorageListRequest<StorageListPaginateOptions>} req - The request object
+	 * @param {ListRequest<S3ListPaginateOptions>} listRequest - The request object
 	 * @return {Promise<S3ListPaginateResult>} - Promise resolves to list of keys and metadata with
 	 * pageSize defaulting to 1000. Additionally the result will include a nextToken if there are more items to retrieve
 	 * @throws service: {@link S3Exception} - S3 service errors thrown when checking for existence of bucket
@@ -24,21 +25,29 @@ type S3ListApi = {
 	 */
 	(
 		contextSpec: AmplifyServer.ContextSpec,
-		req?: StorageListRequest<StorageListPaginateOptions>
+		listRequest?: ListRequest<S3ListPaginateOptions>
 	): Promise<S3ListPaginateResult>;
 	/**
 	 * Lists all bucket objects.
-	 * @param {StorageListRequest<StorageListAllOptions>} req - The request object
+	 * @param {ListRequest<S3ListAllOptions>} listRequest - The request object
 	 * @return {Promise<S3ListAllResult>} - Promise resolves to list of keys and metadata for all objects in path
 	 * @throws service: {@link S3Exception} - S3 service errors thrown when checking for existence of bucket
 	 * @throws validation: {@link StorageValidationErrorCode } - thrown when there are issues with credentials
 	 */
 	(
 		contextSpec: AmplifyServer.ContextSpec,
-		req?: StorageListRequest<StorageListAllOptions>
+		listRequest?: ListRequest<S3ListAllOptions>
 	): Promise<S3ListAllResult>;
 };
 
-export const list: S3ListApi = (contextSpec, req) => {
-	return listInternal(getAmplifyServerContext(contextSpec).amplify, req ?? {});
+export const list: S3ListApi = (
+	contextSpec: AmplifyServer.ContextSpec,
+	listRequest?:
+		| ListRequest<S3ListAllOptions>
+		| ListRequest<S3ListPaginateOptions>
+) => {
+	return listInternal(
+		getAmplifyServerContext(contextSpec).amplify,
+		listRequest ?? {}
+	);
 };

--- a/packages/storage/src/providers/s3/apis/server/remove.ts
+++ b/packages/storage/src/providers/s3/apis/server/remove.ts
@@ -5,16 +5,16 @@ import {
 	AmplifyServer,
 	getAmplifyServerContext,
 } from '@aws-amplify/core/internals/adapter-core';
-import {
-	StorageOperationRequest,
-	StorageRemoveOptions,
-	StorageRemoveResult,
-} from '../../../../types';
+import { RemoveRequest } from '../../../../types';
+import { S3RemoveOptions, S3RemoveResult } from '../../types';
 import { remove as removeInternal } from '../internal/remove';
 
 export const remove = (
 	contextSpec: AmplifyServer.ContextSpec,
-	req: StorageOperationRequest<StorageRemoveOptions>
-): Promise<StorageRemoveResult> => {
-	return removeInternal(getAmplifyServerContext(contextSpec).amplify, req);
+	removeRequest: RemoveRequest<S3RemoveOptions>
+): Promise<S3RemoveResult> => {
+	return removeInternal(
+		getAmplifyServerContext(contextSpec).amplify,
+		removeRequest
+	);
 };

--- a/packages/storage/src/providers/s3/apis/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/index.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { S3UploadDataResult, S3UploadOptions } from '../../types';
+import { S3UploadDataResult, S3UploadDataOptions } from '../../types';
 import { createUploadTask } from '../../utils';
-import { StorageUploadDataRequest, UploadTask } from '../../../../types';
+import { UploadDataRequest, UploadTask } from '../../../../types';
 import { assertValidationError } from '../../../../errors/utils/assertValidationError';
 import { StorageValidationErrorCode } from '../../../../errors/types/validation';
 import { DEFAULT_PART_SIZE, MAX_OBJECT_SIZE } from '../../utils/constants';
@@ -19,7 +19,7 @@ import { getMultipartUploadHandlers } from './multipart';
  * * Maximum object size is 5TB.
  * * Maximum object size if the size cannot be determined before upload is 50GB.
  *
- * @param {StorageUploadDataRequest<S3UploadOptions>} uploadDataRequest The parameters that are passed to the
+ * @param {UploadDataRequest<S3UploadDataOptions>} uploadDataRequest The parameters that are passed to the
  * 	uploadData operation.
  * @returns {UploadTask<S3UploadDataResult>} Cancelable and Resumable task exposing result promise from `result`
  * 	property.
@@ -61,7 +61,7 @@ import { getMultipartUploadHandlers } from './multipart';
  * ```
  */
 export const uploadData = (
-	uploadDataRequest: StorageUploadDataRequest<S3UploadOptions>
+	uploadDataRequest: UploadDataRequest<S3UploadDataOptions>
 ): UploadTask<S3UploadDataResult> => {
 	const { data } = uploadDataRequest;
 

--- a/packages/storage/src/providers/s3/apis/uploadData/multipart/getDataChunker.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/multipart/getDataChunker.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { StorageUploadSourceOptions } from '../../../../../types';
+import { UploadDataPayload } from '../../../../../types';
 import {
 	StorageValidationErrorCode,
 	validationErrorMap,
@@ -15,10 +15,7 @@ export type PartToUpload = {
 	size: number;
 };
 
-export const getDataChunker = (
-	data: StorageUploadSourceOptions,
-	totalSize?: number
-) => {
+export const getDataChunker = (data: UploadDataPayload, totalSize?: number) => {
 	const partSize = calculatePartSize(totalSize);
 
 	if (data instanceof Blob) {

--- a/packages/storage/src/providers/s3/apis/uploadData/multipart/initialUpload.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/multipart/initialUpload.ts
@@ -9,12 +9,12 @@ import {
 	getUploadsCacheKey,
 } from './uploadCache';
 import { ResolvedS3Config } from '../../../types/options';
-import { StorageUploadSourceOptions } from '../../../../../types';
+import { UploadDataPayload } from '../../../../../types';
 import { Part, createMultipartUpload } from '../../../utils/client';
 
 type LoadOrCreateMultipartUploadOptions = {
 	s3Config: ResolvedS3Config;
-	data: StorageUploadSourceOptions;
+	data: UploadDataPayload;
 	bucket: string;
 	accessLevel: StorageAccessLevel;
 	keyPrefix: string;

--- a/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
@@ -4,9 +4,9 @@
 import { Amplify, StorageAccessLevel } from '@aws-amplify/core';
 
 import { getDataChunker } from './getDataChunker';
-import { S3UploadOptions } from '../../../types';
+import { S3UploadDataOptions } from '../../../types';
 import { resolveS3ConfigAndInput } from '../../../utils';
-import { StorageUploadDataRequest } from '../../../../../types';
+import { UploadDataRequest } from '../../../../../types';
 import { S3Item } from '../../../types/results';
 import {
 	DEFAULT_ACCESS_LEVEL,
@@ -37,7 +37,7 @@ export const getMultipartUploadHandlers = (
 		options: uploadDataOptions,
 		key,
 		data,
-	}: StorageUploadDataRequest<S3UploadOptions>,
+	}: UploadDataRequest<S3UploadDataOptions>,
 	size?: number
 ) => {
 	let resolveCallback: ((value: S3Item) => void) | undefined;

--- a/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
@@ -3,9 +3,9 @@
 
 import { Amplify } from '@aws-amplify/core';
 
-import { S3UploadOptions } from '../../types';
+import { S3UploadDataOptions } from '../../types';
 import { calculateContentMd5, resolveS3ConfigAndInput } from '../../utils';
-import { StorageUploadDataRequest } from '../../../../types';
+import { UploadDataRequest } from '../../../../types';
 import { S3Item } from '../../types/results';
 import { putObject } from '../../utils/client';
 
@@ -20,7 +20,7 @@ export const putObjectJob =
 			options: uploadDataOptions,
 			key,
 			data,
-		}: StorageUploadDataRequest<S3UploadOptions>,
+		}: UploadDataRequest<S3UploadDataOptions>,
 		abortSignal: AbortSignal,
 		totalLength?: number
 	) =>

--- a/packages/storage/src/providers/s3/types/index.ts
+++ b/packages/storage/src/providers/s3/types/index.ts
@@ -3,9 +3,13 @@
 
 export {
 	S3Options,
-	S3TransferOptions,
 	S3GetUrlOptions,
-	S3UploadOptions,
+	S3UploadDataOptions,
+	S3GetPropertiesOptions,
+	S3ListAllOptions,
+	S3ListPaginateOptions,
+	S3RemoveOptions,
+	S3DownloadDataOptions,
 } from './options';
 export {
 	S3DownloadDataResult,
@@ -17,5 +21,6 @@ export {
 	S3ListPaginateResult,
 	S3GetPropertiesResult,
 	S3CopyResult,
+	S3RemoveResult,
 } from './results';
 export { S3Exception } from './errors';

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -5,7 +5,11 @@
 import { Credentials } from '@aws-sdk/types';
 
 import { TransferProgressEvent } from '../../../types';
-import { StorageOptions } from '../../../types/options';
+import {
+	StorageOptions,
+	StorageListAllOptions,
+	StorageListPaginateOptions,
+} from '../../../types/options';
 
 /**
  * Request options type for S3 Storage operations.
@@ -19,15 +23,33 @@ export type S3Options = StorageOptions & {
 };
 
 /**
- * Request options type for S3 downloadData, uploadData APIs.
+ * Request options type for S3 getProperties API.
  */
-export type S3TransferOptions = S3Options & {
-	/**
-	 * Callback function tracking the upload/download progress.
-	 */
-	onProgress?: (event: TransferProgressEvent) => void;
-};
+export type S3GetPropertiesOptions = S3Options;
 
+/**
+ * Request options type for S3 getProperties API.
+ */
+export type S3RemoveOptions = S3Options;
+
+/**
+ * Request options type for S3 list API.
+ */
+export type S3ListAllOptions = StorageListAllOptions;
+
+/**
+ * Request options type for S3 list API.
+ */
+export type S3ListPaginateOptions = StorageListPaginateOptions;
+
+/**
+ * Request options type for S3 downloadData API.
+ */
+export type S3DownloadDataOptions = S3TransferOptions;
+
+/**
+ * Request options type for S3 getUrl API.
+ */
 export type S3GetUrlOptions = S3Options & {
 	/**
 	 * Whether to head object to make sure the object existence before downloading.
@@ -41,7 +63,7 @@ export type S3GetUrlOptions = S3Options & {
 	expiresIn?: number;
 };
 
-export type S3UploadOptions = S3TransferOptions & {
+export type S3UploadDataOptions = S3TransferOptions & {
 	/**
 	 * The default content-disposition header value of the file when downloading it.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
@@ -75,4 +97,13 @@ export type ResolvedS3Config = {
 	customEndpoint?: string;
 	forcePathStyle?: boolean;
 	useAccelerateEndpoint?: boolean;
+};
+/**
+ * Request options type for S3 downloadData, uploadData APIs.
+ */
+type S3TransferOptions = S3Options & {
+	/**
+	 * Callback function tracking the upload/download progress.
+	 */
+	onProgress?: (event: TransferProgressEvent) => void;
 };

--- a/packages/storage/src/providers/s3/types/results.ts
+++ b/packages/storage/src/providers/s3/types/results.ts
@@ -5,7 +5,6 @@ import {
 	StorageDownloadDataResult,
 	StorageGetUrlResult,
 	StorageItem,
-	StorageUploadResult,
 	StorageListResult,
 } from '../../../types';
 
@@ -39,4 +38,5 @@ export type S3ListPaginateResult = StorageListResult<S3Item> & {
 };
 
 // TODO: expose more properties if required
-export type S3CopyResult = Required<Pick<S3Item, 'key'>>;
+export type S3CopyResult = Pick<S3Item, 'key'>;
+export type S3RemoveResult = Pick<S3Item, 'key'>;

--- a/packages/storage/src/types/index.ts
+++ b/packages/storage/src/types/index.ts
@@ -3,11 +3,15 @@
 
 export { DownloadTask, TransferProgressEvent, UploadTask } from './common';
 export {
-	StorageListRequest,
-	StorageOperationRequest,
-	StorageDownloadDataRequest,
-	StorageUploadDataRequest,
+	OperationRequest,
+	ListRequest,
+	GetPropertiesRequest,
+	RemoveRequest,
+	DownloadDataRequest,
+	UploadDataRequest,
 	CopyRequest,
+	GetUrlRequest,
+	UploadDataPayload,
 } from './requests';
 export {
 	StorageOptions,
@@ -16,7 +20,6 @@ export {
 	StorageListPaginateOptions,
 	StorageCopySourceOptions,
 	StorageCopyDestinationOptions,
-	StorageUploadSourceOptions,
 } from './options';
 export {
 	StorageItem,
@@ -24,5 +27,4 @@ export {
 	StorageDownloadDataResult,
 	StorageGetUrlResult,
 	StorageUploadResult,
-	StorageRemoveResult,
 } from './results';

--- a/packages/storage/src/types/options.ts
+++ b/packages/storage/src/types/options.ts
@@ -10,11 +10,6 @@ export type StorageOptions =
 			targetIdentityId?: string;
 	  };
 
-/**
- * The data payload type for upload operation.
- */
-export type StorageUploadSourceOptions = Blob | BufferSource | string | File;
-
 export type StorageListAllOptions = StorageOptions & {
 	listAll: true;
 };

--- a/packages/storage/src/types/requests.ts
+++ b/packages/storage/src/types/requests.ts
@@ -3,34 +3,47 @@
 
 import {
 	StorageOptions,
-	StorageUploadSourceOptions,
 	StorageListAllOptions,
 	StorageListPaginateOptions,
 	StorageCopySourceOptions,
 	StorageCopyDestinationOptions,
 } from './options';
 
-export type StorageOperationRequest<Options extends StorageOptions> = {
+export type OperationRequest<Options extends StorageOptions> = {
 	key: string;
 	options?: Options;
 };
 
-export type StorageListRequest<
+export type GetPropertiesRequest<Options extends StorageOptions> =
+	OperationRequest<Options>;
+
+export type RemoveRequest<Options extends StorageOptions> =
+	OperationRequest<Options>;
+
+export type ListRequest<
 	Options extends StorageListAllOptions | StorageListPaginateOptions
 > = {
 	path?: string;
 	options?: Options;
 };
 
-export type StorageDownloadDataRequest<Options extends StorageOptions> =
-	StorageOperationRequest<Options>;
+export type GetUrlRequest<Options extends StorageOptions> =
+	OperationRequest<Options>;
 
-export type StorageUploadDataRequest<Options extends StorageOptions> =
-	StorageOperationRequest<Options> & {
-		data: StorageUploadSourceOptions;
+export type DownloadDataRequest<Options extends StorageOptions> =
+	OperationRequest<Options>;
+
+export type UploadDataRequest<Options extends StorageOptions> =
+	OperationRequest<Options> & {
+		data: UploadDataPayload;
 	};
 
 export type CopyRequest = {
 	source: StorageCopySourceOptions;
 	destination: StorageCopyDestinationOptions;
 };
+
+/**
+ * The data payload type for upload operation.
+ */
+export type UploadDataPayload = Blob | BufferSource | string | File;

--- a/packages/storage/src/types/results.ts
+++ b/packages/storage/src/types/results.ts
@@ -7,7 +7,7 @@ export type StorageItem = {
 	/**
 	 * Key of the object
 	 */
-	key?: string;
+	key: string;
 	/**
 	 * Creation date of the object.
 	 */
@@ -44,10 +44,6 @@ export type StorageGetUrlResult = {
 };
 
 export type StorageUploadResult<Item extends StorageItem> = Item;
-
-export type StorageRemoveResult = {
-	key: string;
-};
 
 export type StorageListResult<Item extends StorageItem> = {
 	items: Item[];


### PR DESCRIPTION
#### Description of changes
Use naming for all API as follows
export const`api` = (
`api`Request: `Api`Request<`Provider` `Api`Options>
): Promise<`Provider` `Api`Result> => {

Example:
FROM
> export const getProperties = (
> 	getPropertiesRequest: StorageOperationRequest<**_StorageOptions_**>
> ): Promise<**_StorageGetPropertiesResult_**> => {
> 

TO (proposal)
> export const getProperties = (
> 	getPropertiesRequest: GetPropertiesRequest<**_S3GetPropertiesOptions_**>
> ): Promise<**_S3GetPropertiesResult_**> => {
> 

We can do this by
- Alias category level options on provider level options ([example](https://github.com/aws-amplify/amplify-js/pull/11960/files#diff-380e33ff82765e24f6b3c2872d359ee7946bf0109f3f1f96af5def4cf374170bR13-R24))
- Alias category level results on provider level results ([example](https://github.com/aws-amplify/amplify-js/blob/b6801630cb7e46c1ecd7fd9593db749c199d5983/packages/storage/src/providers/s3/types/results.ts#L31))

#### Checklist
- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
