### PR TITLE
fix(storage):  assertion for maxUrlExpiration in getUrl api

### DIFF
--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -12,7 +12,6 @@ import { resolveS3ConfigAndInput } from '../../utils';
 import { assertValidationError } from '../../../../errors/utils/assertValidationError';
 
 const DEFAULT_PRESIGN_EXPIRATION = 900;
-const MAX_URL_EXPIRATION = 7 * 24 * 60 * 60 * 1000;
 
 export const getUrl = async function (
 	amplify: AmplifyClassV6,
@@ -37,9 +36,8 @@ export const getUrl = async function (
 		);
 		urlExpirationInSec = Math.min(awsCredExpirationInSec, urlExpirationInSec);
 	}
-
 	assertValidationError(
-		urlExpirationInSec < MAX_URL_EXPIRATION,
+		!(urlExpirationInSec > DEFAULT_PRESIGN_EXPIRATION),
 		StorageValidationErrorCode.UrlExpirationMaxLimitExceed
 	);
 

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -40,7 +40,7 @@ export const getUrl = async function (
 	}
 	const maxUrlExpirationInSec = MAX_URL_EXPIRATION / 1000;
 	assertValidationError(
-		urlExpirationInSec < maxUrlExpirationInSec,
+		urlExpirationInSec <= maxUrlExpirationInSec,
 		StorageValidationErrorCode.UrlExpirationMaxLimitExceed
 	);
 

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -40,7 +40,7 @@ export const getUrl = async function (
 	}
 	const maxUrlExpirationInSec = MAX_URL_EXPIRATION / 1000;
 	assertValidationError(
-		!(urlExpirationInSec > maxUrlExpirationInSec),
+		urlExpirationInSec < maxUrlExpirationInSec,
 		StorageValidationErrorCode.UrlExpirationMaxLimitExceed
 	);
 

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -10,9 +10,10 @@ import { getPresignedGetObjectUrl } from '../../utils/client';
 import { getProperties } from './getProperties';
 import { resolveS3ConfigAndInput } from '../../utils';
 import { assertValidationError } from '../../../../errors/utils/assertValidationError';
-
-const DEFAULT_PRESIGN_EXPIRATION = 900;
-const MAX_URL_EXPIRATION = 900;
+import {
+	DEFAULT_PRESIGN_EXPIRATION,
+	MAX_URL_EXPIRATION,
+} from '../../utils/constants';
 
 export const getUrl = async function (
 	amplify: AmplifyClassV6,
@@ -37,8 +38,9 @@ export const getUrl = async function (
 		);
 		urlExpirationInSec = Math.min(awsCredExpirationInSec, urlExpirationInSec);
 	}
+	const maxUrlExpirationInSec = MAX_URL_EXPIRATION / 1000;
 	assertValidationError(
-		!(urlExpirationInSec > MAX_URL_EXPIRATION),
+		!(urlExpirationInSec > maxUrlExpirationInSec),
 		StorageValidationErrorCode.UrlExpirationMaxLimitExceed
 	);
 

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -12,6 +12,7 @@ import { resolveS3ConfigAndInput } from '../../utils';
 import { assertValidationError } from '../../../../errors/utils/assertValidationError';
 
 const DEFAULT_PRESIGN_EXPIRATION = 900;
+const MAX_URL_EXPIRATION = 900;
 
 export const getUrl = async function (
 	amplify: AmplifyClassV6,
@@ -37,7 +38,7 @@ export const getUrl = async function (
 		urlExpirationInSec = Math.min(awsCredExpirationInSec, urlExpirationInSec);
 	}
 	assertValidationError(
-		!(urlExpirationInSec > DEFAULT_PRESIGN_EXPIRATION),
+		!(urlExpirationInSec > MAX_URL_EXPIRATION),
 		StorageValidationErrorCode.UrlExpirationMaxLimitExceed
 	);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fix assertion for maxUrlExpiration in getUrl api

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
