### PR TITLE
V6 predictions integration

### DIFF
--- a/packages/core/src/singleton/Predictions/types.ts
+++ b/packages/core/src/singleton/Predictions/types.ts
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+type ConvertConfig = {
+	speechGenerator?: {
+		region: string;
+		proxy: boolean;
+		defaults: { VoiceId: string };
+	};
+	translateText?: {
+		region?: string;
+		proxy?: boolean;
+		defaults?: {
+			sourceLanguage?: string;
+			targetLanguage?: string;
+		};
+	};
+};
+
+type IdentifyConfig = {
+	identifyEntities?: {
+		region?: string;
+		proxy?: boolean;
+		celebrityDetectionEnabled?: boolean;
+		defaults?: {
+			collectionId?: string;
+			maxEntities?: number;
+		};
+	};
+};
+
+type InterpretConfig = {
+	interpretText?: {
+		region?: string;
+		proxy?: boolean;
+		defaults?: {
+			type?: string;
+		};
+	};
+};
+
+export type PredictionsConfig = {
+	convert?: ConvertConfig;
+	identify?: IdentifyConfig;
+	interpret?: InterpretConfig;
+};

--- a/packages/core/src/singleton/types.ts
+++ b/packages/core/src/singleton/types.ts
@@ -11,6 +11,7 @@ import {
 	GetCredentialsOptions,
 	CognitoIdentityPoolConfig,
 } from './Auth/types';
+import { PredictionsConfig } from './Predictions/types';
 import {
 	LibraryStorageOptions,
 	StorageAccessLevel,
@@ -26,7 +27,7 @@ export type ResourcesConfig = {
 	// I18n?: I18nOptions;
 	// Interactions?: {};
 	// Notifications?: {};
-	// Predictions?: {};
+	predictions?: PredictionsConfig;
 	Storage?: StorageConfig;
 	ssr?: boolean;
 };

--- a/packages/predictions/src/Predictions.ts
+++ b/packages/predictions/src/Predictions.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import {
-	PredictionsOptions,
 	TranslateTextInput,
 	TranslateTextOutput,
 	TextToSpeechInput,

--- a/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
@@ -15,14 +15,15 @@ import {
 	SpeechToTextOutput,
 	isBytesSource,
 } from '../types';
+import { Amplify } from '@aws-amplify/core';
 import {
-	Credentials,
 	ConsoleLogger as Logger,
 	Signer,
 	getAmplifyUserAgentObject,
 	Category,
 	PredictionsAction,
-} from '@aws-amplify/core';
+} from '@aws-amplify/core/internals/utils';
+
 import {
 	EventStreamMarshaller,
 	MessageHeaderValue,
@@ -61,7 +62,7 @@ export class AmazonAIConvertPredictionsProvider extends AbstractConvertPredictio
 			return Promise.reject('region not configured for transcription');
 		}
 
-		const credentials = await Credentials.get();
+		const { credentials } = await Amplify.Auth.fetchAuthSession();
 		if (!credentials) {
 			return Promise.reject('No credentials');
 		}
@@ -100,7 +101,7 @@ export class AmazonAIConvertPredictionsProvider extends AbstractConvertPredictio
 	protected async convertTextToSpeech(
 		input: TextToSpeechInput
 	): Promise<TextToSpeechOutput> {
-		const credentials = await Credentials.get();
+		const { credentials } = await Amplify.Auth.fetchAuthSession();
 		if (!credentials) {
 			return Promise.reject('No credentials');
 		}
@@ -161,7 +162,7 @@ export class AmazonAIConvertPredictionsProvider extends AbstractConvertPredictio
 	): Promise<SpeechToTextOutput> {
 		try {
 			logger.debug('starting transcription..');
-			const credentials = await Credentials.get();
+			const { credentials } = await Amplify.Auth.fetchAuthSession();
 			if (!credentials) {
 				return Promise.reject('No credentials');
 			}

--- a/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { Amplify } from '@aws-amplify/core';
 import {
 	Category,
-	Credentials,
 	ConsoleLogger as Logger,
 	PredictionsAction,
 	getAmplifyUserAgentObject,
-} from '@aws-amplify/core';
+} from '@aws-amplify/core/internals/utils';
 import { Storage } from '@aws-amplify/storage';
 import { AbstractIdentifyPredictionsProvider } from '../types/Providers';
 import {
@@ -131,7 +131,7 @@ export class AmazonAIIdentifyPredictionsProvider extends AbstractIdentifyPredict
 	protected async identifyText(
 		input: IdentifyTextInput
 	): Promise<IdentifyTextOutput> {
-		const credentials = await Credentials.get();
+		const { credentials } = await Amplify.Auth.fetchAuthSession();
 		if (!credentials) return Promise.reject('No credentials');
 		const {
 			identifyText: {
@@ -233,7 +233,7 @@ export class AmazonAIIdentifyPredictionsProvider extends AbstractIdentifyPredict
 		input: IdentifyLabelsInput
 	): Promise<IdentifyLabelsOutput> {
 		try {
-			const credentials = await Credentials.get();
+			const { credentials } = await Amplify.Auth.fetchAuthSession();
 			if (!credentials) return Promise.reject('No credentials');
 			const {
 				identifyLabels: {
@@ -346,7 +346,7 @@ export class AmazonAIIdentifyPredictionsProvider extends AbstractIdentifyPredict
 	protected async identifyEntities(
 		input: IdentifyEntitiesInput
 	): Promise<IdentifyEntitiesOutput> {
-		const credentials = await Credentials.get();
+		const { credentials } = await Amplify.Auth.fetchAuthSession();
 		if (!credentials) return Promise.reject('No credentials');
 		const {
 			identifyEntities: {

--- a/packages/predictions/src/Providers/AmazonAIInterpretPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIInterpretPredictionsProvider.ts
@@ -1,11 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { Amplify } from '@aws-amplify/core';
 import {
 	Category,
-	Credentials,
 	PredictionsAction,
 	getAmplifyUserAgentObject,
-} from '@aws-amplify/core';
+} from '@aws-amplify/core/internals/utils';
 import { AbstractInterpretPredictionsProvider } from '../types/Providers';
 
 import {
@@ -39,7 +39,7 @@ export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredi
 
 	interpretText(input: InterpretTextInput): Promise<InterpretTextOutput> {
 		return new Promise(async (res, rej) => {
-			const credentials = await Credentials.get();
+			const { credentials } = await Amplify.Auth.fetchAuthSession();
 			if (!credentials) return rej('No credentials');
 			const {
 				interpretText: {

--- a/packages/predictions/src/types/Providers/AbstractPredictionsProvider.ts
+++ b/packages/predictions/src/types/Providers/AbstractPredictionsProvider.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { PredictionsOptions } from '..';
-import { ConsoleLogger as Logger } from '@aws-amplify/core';
+import { ConsoleLogger as Logger } from '@aws-amplify/core/internals/utils';
 
 const logger = new Logger('Amplify');
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Integrate Predictions with new Singleton and Auth structure.
- Remove configuration from constructor
- Remove configure method
- Configure plugins as they are added using the singleton configuration
- Get credentials from singleton AuthSession.credentials (NOTE: I double-checked the expected values in aws-sdk api docs and the types should line up)


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
- [ ] unit tests passing
- [ ] integ tests passing locally
- [ ] sample app functioning as expected with authentication requirements



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
