### PR TITLE
fix(core): decode encoded cookie name while creating universal storage

### DIFF
--- a/packages/core/__tests__/UniversalStorage-browser-test.ts
+++ b/packages/core/__tests__/UniversalStorage-browser-test.ts
@@ -44,6 +44,23 @@ describe(UniversalStorage.name, () => {
 				const universalStorage = new UniversalStorage();
 				expect(universalStorage.store).toMatchObject({ bar: 'barz' });
 			});
+
+			test('decodes encoded cookie name', () => {
+				const expectedCookieName = 'CognitoUserPool.test@email.com.idToken';
+				const cookieValue = '123';
+				const encodedCookieName = encodeURIComponent(expectedCookieName);
+				const mockCookieHeaderValue = `${encodedCookieName}=${cookieValue}`;
+				const expectedCookieHeaderValue = `${expectedCookieName}=${cookieValue}`;
+				new UniversalStorage({
+					req: {
+						headers: {
+							cookie: mockCookieHeaderValue,
+						},
+					},
+				});
+				console.log(mockCookies.mock.calls);
+				expect(mockCookies).toHaveBeenCalledWith(expectedCookieHeaderValue);
+			});
 		});
 
 		describe('setItem', () => {

--- a/packages/core/src/UniversalStorage/index.ts
+++ b/packages/core/src/UniversalStorage/index.ts
@@ -18,7 +18,7 @@ export class UniversalStorage implements Storage {
 
 	constructor(context: Context = {}) {
 		this.cookies = context.req
-			? new Cookies(context.req.headers.cookie)
+			? new Cookies(decodeURIComponent(context.req.headers.cookie))
 			: new Cookies();
 
 		Object.assign(this.store, this.cookies.getAll());


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-js/issues/11945

#### Description of how you validated changes

* Decode the cookie header before using the value to create a cookie store

**Context**

When `Amplify.configure({ ssr: true })`, the Cognito auth tokens will be stored in cookie store. This is handled by the package `amazon-cognito-identity-js` using `js-cookie` under the hood.

Per RFC 6265 [section 4.1.1](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1) and RFC 2616 [section 2.2](https://datatracker.ietf.org/doc/html/rfc2616#section-2.2), a cookie name must be a `token` that doesn't contain any separators. 

In the situation described in the linked issue, the cookie name contains `'@'` as a part of user email address, hence, `js-cookie` encodes it following above the aforementioned standard. However, the `UniversalStorage` creates a cookie store instance using the cookie header value directly, without decoding it, this further caused the issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
