### PR TITLE
chore(storage): update accessLevel tests

### DIFF
--- a/packages/storage/__tests__/providers/s3/apis/copy.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/copy.test.ts
@@ -44,27 +44,6 @@ const copyObjectClientBaseParams = {
 	MetadataDirective: 'COPY',
 };
 
-// /**
-//  * bucket is appended at start if it's a sourceKey
-//  * guest: public/${key}`
-//  * private: private/${targetIdentityId}/${key}`
-//  * protected: protected/${targetIdentityId}/${key}`
-//  */
-// const buildClientRequestKey = (
-// 	key: string,
-// 	KeyType: 'source' | 'destination',
-// 	accessLevel: StorageAccessLevel
-// ) => {
-// 	const targetIdentityId = 'targetIdentityId';
-// 	const bucket = 'bucket';
-// 	const finalAccessLevel = accessLevel == 'guest' ? 'public' : accessLevel;
-// 	let finalKey = KeyType == 'source' ? `${bucket}/` : '';
-// 	finalKey += `${finalAccessLevel}/`;
-// 	finalKey += finalAccessLevel != 'public' ? `${targetIdentityId}/` : '';
-// 	finalKey += `${key}`;
-// 	return finalKey;
-// };
-
 describe('copy API', () => {
 	beforeAll(() => {
 		mockFetchAuthSession.mockResolvedValue({

--- a/packages/storage/__tests__/providers/s3/apis/downloadData.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/downloadData.test.ts
@@ -16,7 +16,6 @@ jest.mock('@aws-amplify/core', () => ({
 			fetchAuthSession: jest.fn(),
 		},
 	},
-	fetchAuthSession: jest.fn(),
 }));
 const credentials: Credentials = {
 	accessKeyId: 'accessKeyId',

--- a/packages/storage/__tests__/providers/s3/apis/getProperties.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/getProperties.test.ts
@@ -5,10 +5,10 @@ import { headObject } from '../../../../src/providers/s3/utils/client';
 import { getProperties } from '../../../../src/providers/s3';
 import { Credentials } from '@aws-sdk/types';
 import { Amplify } from '@aws-amplify/core';
+import { StorageOptions } from '../../../../src/types';
 
 jest.mock('../../../../src/providers/s3/utils/client');
 jest.mock('@aws-amplify/core', () => ({
-	fetchAuthSession: jest.fn(),
 	Amplify: {
 		getConfig: jest.fn(),
 		Auth: {
@@ -28,87 +28,119 @@ const credentials: Credentials = {
 	secretAccessKey: 'secretAccessKey',
 };
 const targetIdentityId = 'targetIdentityId';
+const defaultIdentityId = 'defaultIdentityId';
 
-describe('getProperties test', () => {
-	beforeEach(() => {
-		jest.clearAllMocks();
-	});
-	mockFetchAuthSession.mockResolvedValue({
-		credentials,
-		identityId: targetIdentityId,
-	});
-	mockGetConfig.mockReturnValue({
-		Storage: {
-			S3: {
-				bucket,
-				region,
-			},
-		},
-	});
-	it('getProperties happy path case with private check', async () => {
-		expect.assertions(3);
-		mockHeadObject.mockReturnValueOnce({
-			ContentLength: '100',
-			ContentType: 'text/plain',
-			ETag: 'etag',
-			LastModified: 'last-modified',
-			Metadata: { key: 'value' },
-			VersionId: 'version-id',
+describe('getProperties api', () => {
+	beforeAll(() => {
+		mockFetchAuthSession.mockResolvedValue({
+			credentials,
+			identityId: defaultIdentityId,
 		});
-		const metadata = { key: 'value' };
-		expect(
-			await getProperties({
-				key: 'key',
-				options: {
-					targetIdentityId: 'targetIdentityId',
-					accessLevel: 'protected',
+		mockGetConfig.mockReturnValue({
+			Storage: {
+				S3: {
+					bucket,
+					region,
 				},
-			})
-		).toEqual({
+			},
+		});
+	});
+	describe('getProperties happy path ', () => {
+		const expected = {
 			key: 'key',
 			size: '100',
 			contentType: 'text/plain',
 			eTag: 'etag',
-			metadata,
+			metadata: { key: 'value' },
 			lastModified: 'last-modified',
 			versionId: 'version-id',
+		};
+		const config = {
+			credentials,
+			region: 'region',
+		};
+		const key = 'key';
+		beforeEach(() => {
+			mockHeadObject.mockReturnValueOnce({
+				ContentLength: '100',
+				ContentType: 'text/plain',
+				ETag: 'etag',
+				LastModified: 'last-modified',
+				Metadata: { key: 'value' },
+				VersionId: 'version-id',
+			});
 		});
-		expect(headObject).toBeCalledTimes(1);
-		expect(headObject).toHaveBeenCalledWith(
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+		it.each([
 			{
-				credentials,
-				region: 'region',
+				expectedKey: `public/${key}`,
 			},
 			{
-				Bucket: 'bucket',
-				Key: 'protected/targetIdentityId/key',
+				options: { accessLevel: 'guest' },
+				expectedKey: `public/${key}`,
+			},
+			{
+				options: { accessLevel: 'private' },
+				expectedKey: `private/${defaultIdentityId}/${key}`,
+			},
+			{
+				options: { accessLevel: 'protected', targetIdentityId },
+				expectedKey: `protected/${targetIdentityId}/${key}`,
+			},
+			{
+				options: { accessLevel: 'protected' },
+				expectedKey: `protected/${defaultIdentityId}/${key}`,
+			},
+		])(
+			'getProperties api with $options.accessLevel',
+			async ({ options, expectedKey }) => {
+				const headObjectOptions = {
+					Bucket: 'bucket',
+					Key: expectedKey,
+				};
+				expect.assertions(3);
+				expect(
+					await getProperties({
+						key,
+						options: options as StorageOptions,
+					})
+				).toEqual(expected);
+				expect(headObject).toBeCalledTimes(1);
+				expect(headObject).toHaveBeenCalledWith(config, headObjectOptions);
 			}
 		);
 	});
 
-	it('getProperties should return a not found error', async () => {
-		mockHeadObject.mockRejectedValueOnce(
-			Object.assign(new Error(), {
-				$metadata: { httpStatusCode: 404 },
-				name: 'NotFound',
-			})
-		);
-		try {
-			await getProperties({ key: 'keyed' });
-		} catch (error) {
-			expect.assertions(3);
-			expect(headObject).toBeCalledTimes(1);
-			expect(headObject).toHaveBeenCalledWith(
-				{
-					credentials,
-					region: 'region',
-				},
-				{
-					Bucket: 'bucket',
-					Key: 'public/keyed',
-				}
+	describe('getProperties error path', () => {
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+		it('getProperties should return a not found error', async () => {
+			mockHeadObject.mockRejectedValueOnce(
+				Object.assign(new Error(), {
+					$metadata: { httpStatusCode: 404 },
+					name: 'NotFound',
+				})
 			);
-			expect(error.$metadata.httpStatusCode).toBe(404);
-		}
+			try {
+				await getProperties({ key: 'keyed' });
+			} catch (error) {
+				expect.assertions(3);
+				expect(headObject).toBeCalledTimes(1);
+				expect(headObject).toHaveBeenCalledWith(
+					{
+						credentials,
+						region: 'region',
+					},
+					{
+						Bucket: 'bucket',
+						Key: 'public/keyed',
+					}
+				);
+				expect(error.$metadata.httpStatusCode).toBe(404);
+			}
+		});
 	});
 });

--- a/packages/storage/__tests__/providers/s3/apis/getProperties.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/getProperties.test.ts
@@ -147,7 +147,3 @@ describe('getProperties api', () => {
 		});
 	});
 });
-
-// [].forEach(({ options, expectedKey }) => {
-// 	it(`getProperties api with ${options.accessLevel}`, async () => {});
-// });

--- a/packages/storage/__tests__/providers/s3/apis/getProperties.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/getProperties.test.ts
@@ -73,7 +73,7 @@ describe('getProperties api', () => {
 		afterEach(() => {
 			jest.clearAllMocks();
 		});
-		it.each([
+		[
 			{
 				expectedKey: `public/${key}`,
 			},
@@ -86,16 +86,19 @@ describe('getProperties api', () => {
 				expectedKey: `private/${defaultIdentityId}/${key}`,
 			},
 			{
-				options: { accessLevel: 'protected', targetIdentityId },
-				expectedKey: `protected/${targetIdentityId}/${key}`,
-			},
-			{
 				options: { accessLevel: 'protected' },
 				expectedKey: `protected/${defaultIdentityId}/${key}`,
 			},
-		])(
-			'getProperties api with $options.accessLevel',
-			async ({ options, expectedKey }) => {
+			{
+				options: { accessLevel: 'protected', targetIdentityId },
+				expectedKey: `protected/${targetIdentityId}/${key}`,
+			},
+		].forEach(({ options, expectedKey }) => {
+			const accessLevelMsg = options?.accessLevel ?? 'default';
+			const targetIdentityIdMsg = options?.targetIdentityId
+				? `and targetIdentityId`
+				: '';
+			it(`getProperties api with ${accessLevelMsg} accessLevel ${targetIdentityIdMsg}`, async () => {
 				const headObjectOptions = {
 					Bucket: 'bucket',
 					Key: expectedKey,
@@ -109,8 +112,8 @@ describe('getProperties api', () => {
 				).toEqual(expected);
 				expect(headObject).toBeCalledTimes(1);
 				expect(headObject).toHaveBeenCalledWith(config, headObjectOptions);
-			}
-		);
+			});
+		});
 	});
 
 	describe('getProperties error path', () => {
@@ -144,3 +147,7 @@ describe('getProperties api', () => {
 		});
 	});
 });
+
+// [].forEach(({ options, expectedKey }) => {
+// 	it(`getProperties api with ${options.accessLevel}`, async () => {});
+// });

--- a/packages/storage/__tests__/providers/s3/apis/getUrl.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/getUrl.test.ts
@@ -47,6 +47,7 @@ describe('getUrl test', () => {
 			},
 		});
 	});
+
 	describe('getUrl happy path', () => {
 		const config = {
 			credentials,
@@ -71,7 +72,7 @@ describe('getUrl test', () => {
 		afterEach(() => {
 			jest.clearAllMocks();
 		});
-		it.each([
+		[
 			{
 				expectedKey: `public/${key}`,
 			},
@@ -84,16 +85,19 @@ describe('getUrl test', () => {
 				expectedKey: `private/${defaultIdentityId}/${key}`,
 			},
 			{
-				options: { accessLevel: 'protected', targetIdentityId },
-				expectedKey: `protected/${targetIdentityId}/${key}`,
-			},
-			{
 				options: { accessLevel: 'protected' },
 				expectedKey: `protected/${defaultIdentityId}/${key}`,
 			},
-		])(
-			'should getUrl with $options.accessLevel',
-			async ({ options, expectedKey }) => {
+			{
+				options: { accessLevel: 'protected', targetIdentityId },
+				expectedKey: `protected/${targetIdentityId}/${key}`,
+			},
+		].forEach(({ options, expectedKey }) => {
+			const accessLevelMsg = options?.accessLevel ?? 'default';
+			const targetIdentityIdMsg = options?.targetIdentityId
+				? `and targetIdentityId`
+				: '';
+			it(`should getUrl with ${accessLevelMsg} accessLevel ${targetIdentityIdMsg}`, async () => {
 				const headObjectOptions = {
 					Bucket: bucket,
 					Key: expectedKey,
@@ -110,8 +114,8 @@ describe('getUrl test', () => {
 				expect(result.url).toEqual({
 					url: new URL('https://google.com'),
 				});
-			}
-		);
+			});
+		});
 	});
 	describe('getUrl error path', () => {
 		afterAll(() => {

--- a/packages/storage/__tests__/providers/s3/apis/getUrl.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/getUrl.test.ts
@@ -8,10 +8,10 @@ import {
 	getPresignedGetObjectUrl,
 	headObject,
 } from '../../../../src/providers/s3/utils/client';
+import { StorageOptions } from '../../../../src/types';
 
 jest.mock('../../../../src/providers/s3/utils/client');
 jest.mock('@aws-amplify/core', () => ({
-	fetchAuthSession: jest.fn(),
 	Amplify: {
 		getConfig: jest.fn(),
 		Auth: {
@@ -30,60 +30,110 @@ const credentials: Credentials = {
 	secretAccessKey: 'secretAccessKey',
 };
 const targetIdentityId = 'targetIdentityId';
+const defaultIdentityId = 'defaultIdentityId';
 
-describe('getProperties test', () => {
-	beforeEach(() => {
-		jest.clearAllMocks();
-	});
-	mockFetchAuthSession.mockResolvedValue({
-		credentials,
-		identityId: targetIdentityId,
-	});
-	mockGetConfig.mockReturnValue({
-		Storage: {
-			S3: {
-				bucket,
-				region,
+describe('getUrl test', () => {
+	beforeAll(() => {
+		mockFetchAuthSession.mockResolvedValue({
+			credentials,
+			identityId: defaultIdentityId,
+		});
+		mockGetConfig.mockReturnValue({
+			Storage: {
+				S3: {
+					bucket,
+					region,
+				},
 			},
-		},
-	});
-	it('get presigned url happy case', async () => {
-		expect.assertions(2);
-		(headObject as jest.Mock).mockImplementation(() => {
-			return {
-				Key: 'key',
-				ContentLength: '100',
-				ContentType: 'text/plain',
-				ETag: 'etag',
-				LastModified: 'last-modified',
-				Metadata: { key: 'value' },
-			};
-		});
-		(getPresignedGetObjectUrl as jest.Mock).mockReturnValueOnce({
-			url: new URL('https://google.com'),
-		});
-		const result = await getUrl({ key: 'key' });
-		expect(getPresignedGetObjectUrl).toBeCalledTimes(1);
-		expect(result.url).toEqual({
-			url: new URL('https://google.com'),
 		});
 	});
-	test('Should return not found error when the object is not found', async () => {
-		(headObject as jest.Mock).mockImplementation(() =>
-			Object.assign(new Error(), {
-				$metadata: { httpStatusCode: 404 },
-				name: 'NotFound',
-			})
-		);
-		try {
-			await getUrl({
-				key: 'invalid_key',
-				options: { validateObjectExistence: true },
+	describe('getUrl happy path', () => {
+		const config = {
+			credentials,
+			region,
+		};
+		const key = 'key';
+		beforeEach(() => {
+			(headObject as jest.Mock).mockImplementation(() => {
+				return {
+					Key: 'key',
+					ContentLength: '100',
+					ContentType: 'text/plain',
+					ETag: 'etag',
+					LastModified: 'last-modified',
+					Metadata: { key: 'value' },
+				};
 			});
-		} catch (error) {
-			expect.assertions(2);
-			expect(headObject).toBeCalledTimes(1);
-			expect(error.$metadata?.httpStatusCode).toBe(404);
-		}
+			(getPresignedGetObjectUrl as jest.Mock).mockReturnValueOnce({
+				url: new URL('https://google.com'),
+			});
+		});
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+		it.each([
+			{
+				expectedKey: `public/${key}`,
+			},
+			{
+				options: { accessLevel: 'guest' },
+				expectedKey: `public/${key}`,
+			},
+			{
+				options: { accessLevel: 'private' },
+				expectedKey: `private/${defaultIdentityId}/${key}`,
+			},
+			{
+				options: { accessLevel: 'protected', targetIdentityId },
+				expectedKey: `protected/${targetIdentityId}/${key}`,
+			},
+			{
+				options: { accessLevel: 'protected' },
+				expectedKey: `protected/${defaultIdentityId}/${key}`,
+			},
+		])(
+			'should getUrl with $options.accessLevel',
+			async ({ options, expectedKey }) => {
+				const headObjectOptions = {
+					Bucket: bucket,
+					Key: expectedKey,
+				};
+				const optionsVal = { ...options, validateObjectExistence: true };
+				expect.assertions(4);
+				const result = await getUrl({
+					key,
+					options: optionsVal as StorageOptions,
+				});
+				expect(getPresignedGetObjectUrl).toBeCalledTimes(1);
+				expect(headObject).toBeCalledTimes(1);
+				expect(headObject).toHaveBeenCalledWith(config, headObjectOptions);
+				expect(result.url).toEqual({
+					url: new URL('https://google.com'),
+				});
+			}
+		);
+	});
+	describe('getUrl error path', () => {
+		afterAll(() => {
+			jest.clearAllMocks();
+		});
+		it('Should return not found error when the object is not found', async () => {
+			(headObject as jest.Mock).mockImplementation(() =>
+				Object.assign(new Error(), {
+					$metadata: { httpStatusCode: 404 },
+					name: 'NotFound',
+				})
+			);
+			try {
+				await getUrl({
+					key: 'invalid_key',
+					options: { validateObjectExistence: true },
+				});
+			} catch (error) {
+				expect.assertions(2);
+				expect(headObject).toBeCalledTimes(1);
+				expect(error.$metadata?.httpStatusCode).toBe(404);
+			}
+		});
 	});
 });

--- a/packages/storage/__tests__/providers/s3/apis/list.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/list.test.ts
@@ -205,7 +205,7 @@ describe('list API', () => {
 		it.each(accessLevelTests)(
 			'Should list all objects successfully having three pages from $options.accessLevel accessLevel',
 			async ({ path, options, expectedPath }) => {
-				// expect.assertions(5);
+				expect.assertions(5);
 				mockListObjectsV2ApiWithPages(3);
 
 				const result = await list({

--- a/packages/storage/__tests__/providers/s3/apis/list.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/list.test.ts
@@ -107,19 +107,23 @@ describe('list API', () => {
 			},
 			{
 				path,
-				options: { accessLevel: 'protected', targetIdentityId },
-				expectedPath: `protected/${targetIdentityId}/${path}`,
-			},
-			{
-				path,
 				options: { accessLevel: 'protected' },
 				expectedPath: `protected/${defaultIdentityId}/${path}`,
 			},
+			{
+				path,
+				options: { accessLevel: 'protected', targetIdentityId },
+				expectedPath: `protected/${targetIdentityId}/${path}`,
+			},
 		];
 
-		it.each(accessLevelTests)(
-			'Should list objects with pagination using default pageSize and $options.accessLevel accessLevel',
-			async ({ path, options, expectedPath }) => {
+		accessLevelTests.forEach(({ path, options, expectedPath }) => {
+			const pathMsg = path ? 'custom' : 'default';
+			const accessLevelMsg = options?.accessLevel ?? 'default';
+			const targetIdentityIdMsg = options?.targetIdentityId
+				? `with targetIdentityId`
+				: '';
+			it(`Should list objects with pagination, default pageSize, ${pathMsg} path, ${accessLevelMsg} accessLevel ${targetIdentityIdMsg}`, async () => {
 				mockListObject.mockImplementationOnce(() => {
 					return {
 						Contents: [
@@ -128,7 +132,6 @@ describe('list API', () => {
 						NextContinuationToken: nextToken,
 					};
 				});
-
 				expect.assertions(4);
 				let response = await list({ path, options: options as StorageOptions });
 				expect(response.items).toEqual([
@@ -141,12 +144,16 @@ describe('list API', () => {
 					MaxKeys: 1000,
 					Prefix: expectedPath,
 				});
-			}
-		);
+			});
+		});
 
-		it.each(accessLevelTests)(
-			'Should list objects with pagination using pageSize, nextToken and $options.accessLevel accessLevel',
-			async ({ path, options, expectedPath }) => {
+		accessLevelTests.forEach(({ path, options, expectedPath }) => {
+			const pathMsg = path ? 'custom' : 'default';
+			const accessLevelMsg = options?.accessLevel ?? 'default';
+			const targetIdentityIdMsg = options?.targetIdentityId
+				? `with targetIdentityId`
+				: '';
+			it(`Should list objects with pagination using pageSize, nextToken, ${pathMsg} path, ${accessLevelMsg} accessLevel ${targetIdentityIdMsg}`, async () => {
 				mockListObject.mockImplementationOnce(() => {
 					return {
 						Contents: [
@@ -155,7 +162,6 @@ describe('list API', () => {
 						NextContinuationToken: nextToken,
 					};
 				});
-
 				expect.assertions(4);
 				const customPageSize = 5;
 				const response = await list({
@@ -177,16 +183,19 @@ describe('list API', () => {
 					ContinuationToken: nextToken,
 					MaxKeys: customPageSize,
 				});
-			}
-		);
+			});
+		});
 
-		it.each(accessLevelTests)(
-			'Should list objects with zero results from $options.accessLevel accessLevel',
-			async ({ path, options, expectedPath }) => {
+		accessLevelTests.forEach(({ path, options, expectedPath }) => {
+			const pathMsg = path ? 'custom' : 'default';
+			const accessLevelMsg = options?.accessLevel ?? 'default';
+			const targetIdentityIdMsg = options?.targetIdentityId
+				? `with targetIdentityId`
+				: '';
+			it(`Should list objects with zero results with ${pathMsg} path, ${accessLevelMsg} accessLevel ${targetIdentityIdMsg}`, async () => {
 				mockListObject.mockImplementationOnce(() => {
 					return {};
 				});
-
 				expect.assertions(3);
 				let response = await list({
 					path,
@@ -199,15 +208,18 @@ describe('list API', () => {
 					MaxKeys: 1000,
 					Prefix: expectedPath,
 				});
-			}
-		);
+			});
+		});
 
-		it.each(accessLevelTests)(
-			'Should list all objects successfully having three pages from $options.accessLevel accessLevel',
-			async ({ path, options, expectedPath }) => {
+		accessLevelTests.forEach(({ path, options, expectedPath }) => {
+			const pathMsg = path ? 'custom' : 'default';
+			const accessLevelMsg = options?.accessLevel ?? 'default';
+			const targetIdentityIdMsg = options?.targetIdentityId
+				? `with targetIdentityId`
+				: '';
+			it(`Should list all objects having three pages with ${pathMsg} path, ${accessLevelMsg} accessLevel ${targetIdentityIdMsg}`, async () => {
 				expect.assertions(5);
 				mockListObjectsV2ApiWithPages(3);
-
 				const result = await list({
 					path,
 					options: { ...(options as StorageOptions), listAll: true },
@@ -242,8 +254,8 @@ describe('list API', () => {
 						ContinuationToken: nextToken,
 					}
 				);
-			}
-		);
+			});
+		});
 	});
 
 	describe('Error Cases:', () => {

--- a/packages/storage/__tests__/providers/s3/apis/remove.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/remove.test.ts
@@ -85,7 +85,6 @@ describe('remove API', () => {
 			'Should remove object with $options.accessLevel accessLevel',
 			async ({ options, expectedKey }) => {
 				expect.assertions(3);
-				console.log('options', options);
 				expect(
 					await remove({ key, options: options as StorageOptions })
 				).toEqual(removeResult);
@@ -109,7 +108,7 @@ describe('remove API', () => {
 					name: 'NotFound',
 				})
 			);
-			// expect.assertions(3);
+			expect.assertions(3);
 			const key = 'wrongKey';
 			try {
 				await remove({ key });

--- a/packages/storage/__tests__/providers/s3/apis/remove.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/remove.test.ts
@@ -22,7 +22,6 @@ const mockGetConfig = Amplify.getConfig as jest.Mock;
 const key = 'key';
 const bucket = 'bucket';
 const region = 'region';
-const targetIdentityId = 'targetIdentityId';
 const defaultIdentityId = 'defaultIdentityId';
 const removeResult = { key };
 const credentials: Credentials = {
@@ -61,7 +60,7 @@ describe('remove API', () => {
 		afterEach(() => {
 			jest.clearAllMocks();
 		});
-		it.each([
+		[
 			{
 				expectedKey: `public/${key}`,
 			},
@@ -74,16 +73,13 @@ describe('remove API', () => {
 				expectedKey: `private/${defaultIdentityId}/${key}`,
 			},
 			{
-				options: { accessLevel: 'protected', targetIdentityId },
-				expectedKey: `protected/${targetIdentityId}/${key}`,
-			},
-			{
 				options: { accessLevel: 'protected' },
 				expectedKey: `protected/${defaultIdentityId}/${key}`,
 			},
-		])(
-			'Should remove object with $options.accessLevel accessLevel',
-			async ({ options, expectedKey }) => {
+		].forEach(({ options, expectedKey }) => {
+			const accessLevel = options?.accessLevel ?? 'default';
+
+			it(`Should remove object with ${accessLevel} accessLevel`, async () => {
 				expect.assertions(3);
 				expect(
 					await remove({ key, options: options as StorageOptions })
@@ -93,8 +89,8 @@ describe('remove API', () => {
 					Bucket: bucket,
 					Key: expectedKey,
 				});
-			}
-		);
+			});
+		});
 	});
 
 	describe('Error Path Cases:', () => {


### PR DESCRIPTION
#### Description of changes
- Cleanup old `fetchAuthSession: jest.fn()`
- Add additional test case, use default options to getProperties, getUrl
- Test across all accessLevels for list, remove, copy
- ~~Use "it.each"~~. Use `Array.foreach` for now as a workaround. We currently use Jest [v24.x](https://archive.jestjs.io/docs/en/24.x/api#testeachtablename-fn-timeout) Latest is .[v29.x](https://jestjs.io/docs/api#testeachtablename-fn-timeout). 
  - v24.x does not support dynamic test names from an array of objects. We can switch back to "it.each" once we update jest.

1. **getUrl**
![Screenshot 2023-09-07 at 6 45 16 PM](https://github.com/aws-amplify/amplify-js/assets/22762119/2e56c7be-55fd-42e5-815c-79bac998087a)
2. **getProperties**
![Screenshot 2023-09-07 at 6 47 14 PM](https://github.com/aws-amplify/amplify-js/assets/22762119/f29f5c24-90dd-4fb2-a0ab-222a19862ac0)
3. **remove**
![Screenshot 2023-09-07 at 6 47 54 PM](https://github.com/aws-amplify/amplify-js/assets/22762119/0f859927-b012-4b0c-a600-4a2bd220e085)
4. **copy**
![Screenshot 2023-09-07 at 6 48 36 PM](https://github.com/aws-amplify/amplify-js/assets/22762119/47afcb5f-9e4a-4e08-9ff6-2bbb3e65fb4c)
5. **list**
![Screenshot 2023-09-07 at 6 49 12 PM](https://github.com/aws-amplify/amplify-js/assets/22762119/c4581fac-d65d-42ef-99d7-ee40fdeaf1fa)

Please feel free to add comments if there are 
- missed test cases
- redundant tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
