### PR TITLE
fix(storage): rename list request path to prefix

### DIFF
--- a/packages/storage/__tests__/providers/s3/apis/list.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/list.test.ts
@@ -125,7 +125,7 @@ describe('list API', () => {
 			expect.assertions(4);
 			const customPageSize = 5;
 			const response = await list({
-				path: 'listWithTokenResultsPath',
+				prefix: 'listWithTokenResultsPath',
 				options: {
 					accessLevel: 'guest',
 					pageSize: customPageSize,
@@ -148,7 +148,7 @@ describe('list API', () => {
 			mockListObjectsV2ApiWithPages(3);
 
 			const result = await list({
-				path: 'listALLResultsPath',
+				prefix: 'listALLResultsPath',
 				options: { accessLevel: 'guest', listAll: true },
 			});
 
@@ -185,7 +185,7 @@ describe('list API', () => {
 
 			expect.assertions(3);
 			let response = await list({
-				path: 'emptyListResultsPath',
+				prefix: 'emptyListResultsPath',
 				options: {
 					accessLevel: 'guest',
 				},

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -34,7 +34,7 @@ export const list = async (
 		| StorageListRequest<StorageListAllOptions>
 		| StorageListRequest<StorageListPaginateOptions>
 ): Promise<S3ListAllResult | S3ListPaginateResult> => {
-	const { options = {}, path = '' } = listRequest ?? {};
+	const { options = {}, prefix: path = '' } = listRequest ?? {};
 	const {
 		s3Config,
 		bucket,

--- a/packages/storage/src/types/requests.ts
+++ b/packages/storage/src/types/requests.ts
@@ -18,7 +18,7 @@ export type StorageOperationRequest<Options extends StorageOptions> = {
 export type StorageListRequest<
 	Options extends StorageListAllOptions | StorageListPaginateOptions
 > = {
-	path?: string;
+	prefix?: string;
 	options?: Options;
 };
 


### PR DESCRIPTION
#### Description of changes
- Storage `list` request would expose `prefix` instead of `path`. 
- No change in the behavior of the API

**DX**
From
```
await list({ path: "photo" });
```
To
```
await list({ prefix: "photo" });
```
#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
- updated unit tests
- validated on sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
