### PR TITLE
fix(core): parse empty oauth param

### DIFF
--- a/packages/core/src/parseAWSExports.ts
+++ b/packages/core/src/parseAWSExports.ts
@@ -49,7 +49,10 @@ export const parseAWSExports = (
 				signUpVerificationMethod: aws_cognito_sign_up_verification_method,
 				userPoolClientId: aws_user_pools_web_client_id,
 				userPoolId: aws_user_pools_id,
-				...(oauth && { loginWith: getOAuthConfig(oauth) }),
+				...(oauth &&
+					Object.keys(oauth).length > 0 && {
+						loginWith: getOAuthConfig(oauth),
+					}),
 			},
 		};
 	}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The default configuration starts with an empty oauth object, however the parse logic only checks for oauth to be undefined. This is a tiny fix to not proceed if there the oauth object is empty.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
```
const awsmobile = {
  ...
  oauth: {},
  ...
};
Amplify.configure(awsmobile) // does not error out
```


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
