### PR TITLE
chore: Set up missing exports & `typesVersions` specification

### DIFF
--- a/packages/auth/cognito/server/package.json
+++ b/packages/auth/cognito/server/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "@aws-amplify/auth/cognito/server",
+	"main": "../../lib/providers/cognito/apis/server/index.js",
+	"browser": "../../lib-esm/providers/cognito/apis/server/index.js",
+	"module": "../../lib-esm/providers/cognito/apis/server/index.js",
+	"typings": "../../lib-esm/providers/cognito/apis/server/index.d.ts"
+}

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -34,6 +34,15 @@
 			],
 			"cognito": [
 				"./lib-esm/providers/cognito/index.d.ts"
+			],
+			"cognito/server": [
+				"./lib-esm/providers/cognito/apis/server/index.d.ts"
+			],
+			"server": [
+				"./lib-esm/server.d.ts"
+			],
+			"internals": [
+				"./lib-esm/lib-esm/internals/index.d.ts"
 			]
 		}
 	},
@@ -47,6 +56,11 @@
 			"types": "./lib-esm/providers/cognito/index.d.ts",
 			"import": "./lib-esm/providers/cognito/index.js",
 			"require": "./lib/providers/cognito/index.js"
+		},
+		"./cognito/server": {
+			"types": "./lib-esm/providers/cognito/apis/server/index.d.ts",
+			"import": "./lib-esm/providers/cognito/apis/server/index.js",
+			"require": "./lib/providers/cognito/apis/server/index.js"
 		},
 		"./server": {
 			"types": "./lib-esm/server.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -88,7 +88,9 @@
 		"lib",
 		"lib-esm",
 		"src",
-		"internals"
+		"internals",
+		"cognito",
+		"server"
 	],
 	"dependencies": {
 		"@smithy/util-base64": "2.0.0",

--- a/packages/aws-amplify/auth/cognito/server/package.json
+++ b/packages/aws-amplify/auth/cognito/server/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "aws-amplify/auth/cognito/server",
+	"main": "../../../lib/auth/cognito/server/index.js",
+	"browser": "../../../lib-esm/auth/cognito/server/index.js",
+	"module": "../../../lib-esm/auth/cognito/server/index.js",
+	"typings": "../../../lib-esm/auth/cognito/server/index.d.ts"
+}

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -88,6 +88,12 @@
 			"auth/cognito": [
 				"./lib-esm/auth/cognito/index.d.ts"
 			],
+			"auth/cognito/server": [
+				"./lib-esm/auth/cognito/server/index.d.ts"
+			],
+			"auth/server": [
+				"./lib-esm/auth/server.d.ts"
+			],
 			"analytics": [
 				"./lib-esm/analytics/index.d.ts"
 			],
@@ -99,6 +105,15 @@
 			],
 			"storage/s3": [
 				"./lib-esm/storage/s3/index.d.ts"
+			],
+			"storage/server": [
+				"./lib-esm/storage/server.d.ts"
+			],
+			"storage/s3/server": [
+				"./lib-esm/storage/s3/server.d.ts"
+			],
+			"internals/adapter-core": [
+				"./lib-esm/adapterCore/index.d.ts"
 			]
 		}
 	},

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -27,6 +27,11 @@
 			"import": "./lib-esm/auth/cognito/index.js",
 			"require": "./lib/auth/cognito/index.js"
 		},
+		"./auth/cognito/server": {
+			"types": "./lib-esm/auth/cognito/server/index.d.ts",
+			"import": "./lib-esm/auth/cognito/server/index.js",
+			"require": "./lib/auth/cognito/server/index.js"
+		},
 		"./auth/server": {
 			"types": "./lib-esm/auth/server.d.ts",
 			"import": "./lib-esm/auth/server.js",

--- a/packages/aws-amplify/src/auth/cognito/server/index.ts
+++ b/packages/aws-amplify/src/auth/cognito/server/index.ts
@@ -1,0 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+This file maps exports from `aws-amplify/auth/cognito/server`. It provides access to server-enabled Cognito APIs.
+*/
+export * from '@aws-amplify/auth/cognito/server';

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -33,6 +33,15 @@
 			],
 			"s3": [
 				"./lib-esm/providers/s3/index.d.ts"
+			],
+			"server": [
+				"./lib-esm/server.d.ts"
+			],
+			"internals": [
+				"./lib-esm/lib-esm/internals/index.d.ts"
+			],
+			"s3/server": [
+				"./lib-esm/providers/s3/server.d.ts"
 			]
 		}
 	},


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change adds missing export path for `aws-amplify/auth/cognito/server` as well as some missing `typesVersions` configurations which were missed.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Tested in Verdaccio

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
