### PR TITLE
fix(adapter-nextjs): getAmplifyConfig may not return config in the pages router

### DIFF
--- a/packages/adapter-nextjs/__tests__/utils/getAmplifyConfig.test.ts
+++ b/packages/adapter-nextjs/__tests__/utils/getAmplifyConfig.test.ts
@@ -1,32 +1,52 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { NextConfig } from 'next';
+import getConfig from 'next/config';
 import { getAmplifyConfig } from '../../src/utils/getAmplifyConfig';
+import { AmplifyError } from '@aws-amplify/core/internals/utils';
+
+jest.mock('next/config');
+
+const mockGetConfig = getConfig as jest.Mock;
 
 describe('getAmplifyConfig', () => {
+	const mockAmplifyConfig = {
+		Auth: {
+			identityPoolId: '123',
+			userPoolId: 'abc',
+			userPoolWebClientId: 'def',
+		},
+		Storage: {
+			bucket: 'bucket',
+			region: 'us-east-1',
+		},
+	};
+
 	beforeEach(() => {
+		mockGetConfig.mockReturnValue({});
 		delete process.env.amplifyConfig;
 	});
 
 	it('should return amplifyConfig from env vars', () => {
-		const mockAmplifyConfig = {
-			Auth: {
-				identityPoolId: '123',
-				userPoolId: 'abc',
-				userPoolWebClientId: 'def',
-			},
-			Storage: {
-				bucket: 'bucket',
-				region: 'us-east-1',
-			},
-		};
 		process.env.amplifyConfig = JSON.stringify(mockAmplifyConfig);
 
 		const result = getAmplifyConfig();
 		expect(result).toEqual(mockAmplifyConfig);
 	});
 
+	it('should attempt to get amplifyConfig via getConfig provided by Next.js as a fallback', () => {
+		mockGetConfig.mockReturnValueOnce({
+			serverRuntimeConfig: {
+				amplifyConfig: JSON.stringify(mockAmplifyConfig),
+			},
+		});
+
+		const result = getAmplifyConfig();
+		expect(result).toEqual(mockAmplifyConfig);
+	});
+
 	it('should throw error when amplifyConfig is not found from env vars', () => {
-		expect(() => getAmplifyConfig()).toThrowError();
+		expect(() => getAmplifyConfig()).toThrow(AmplifyError);
 	});
 });

--- a/packages/adapter-nextjs/__tests__/withAmplify.test.ts
+++ b/packages/adapter-nextjs/__tests__/withAmplify.test.ts
@@ -29,6 +29,9 @@ describe('withAmplify', () => {
 			env: {
 				amplifyConfig: JSON.stringify(mockAmplifyConfig),
 			},
+			serverRuntimeConfig: {
+				amplifyConfig: JSON.stringify(mockAmplifyConfig),
+			},
 		});
 	});
 
@@ -37,12 +40,19 @@ describe('withAmplify', () => {
 			env: {
 				existingKey: '123',
 			},
+			serverRuntimeConfig: {
+				myKey: 'myValue',
+			},
 		};
 		const result = withAmplify(nextConfig, mockAmplifyConfig);
 
 		expect(result).toEqual({
 			env: {
 				existingKey: '123',
+				amplifyConfig: JSON.stringify(mockAmplifyConfig),
+			},
+			serverRuntimeConfig: {
+				myKey: 'myValue',
 				amplifyConfig: JSON.stringify(mockAmplifyConfig),
 			},
 		});

--- a/packages/adapter-nextjs/src/utils/getAmplifyConfig.ts
+++ b/packages/adapter-nextjs/src/utils/getAmplifyConfig.ts
@@ -3,9 +3,19 @@
 
 import { ResourcesConfig } from 'aws-amplify';
 import { AmplifyServerContextError } from '@aws-amplify/core/internals/adapter-core';
+import getConfig from 'next/config';
 
 export const getAmplifyConfig = (): ResourcesConfig => {
-	const configStr = process.env.amplifyConfig;
+	let configStr = process.env.amplifyConfig;
+
+	// With a Next.js app that uses the Pages Router, the key-value pairs
+	// listed under the `env` field in the `next.config.js` is not accessible
+	// via process.env.<key> at some occasion. Using the following as a fallback
+	// See: https://github.com/vercel/next.js/issues/39299
+	if (!configStr) {
+		const { serverRuntimeConfig } = getConfig();
+		configStr = serverRuntimeConfig?.amplifyConfig;
+	}
 
 	if (!configStr) {
 		throw new AmplifyServerContextError({

--- a/packages/adapter-nextjs/src/withAmplify.ts
+++ b/packages/adapter-nextjs/src/withAmplify.ts
@@ -31,9 +31,15 @@ export const withAmplify = (
 	nextConfig: NextConfig,
 	amplifyConfig: ResourcesConfig
 ) => {
+	const configStr = JSON.stringify(amplifyConfig);
 	nextConfig.env = {
 		...nextConfig.env,
-		amplifyConfig: JSON.stringify(amplifyConfig),
+		amplifyConfig: configStr,
+	};
+
+	nextConfig.serverRuntimeConfig = {
+		...nextConfig.serverRuntimeConfig,
+		amplifyConfig: configStr,
 	};
 
 	return nextConfig;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Added a fallback in the `getAmplifyConfig` function to ensure get the amplify config in the Next.js Pages Router.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* Local testing with a Next.js sample app using the Pages Router

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
