### PR TITLE
fix(core): allow credentials to be called without token provider and no guest mode

### DIFF
--- a/packages/core/__tests__/singleton/Singleton.test.ts
+++ b/packages/core/__tests__/singleton/Singleton.test.ts
@@ -3,6 +3,7 @@ import { AuthClass as Auth } from '../../src/singleton/Auth';
 import { decodeJWT } from '../../src/singleton/Auth/utils';
 import { AWSCredentialsAndIdentityId } from '../../src/singleton/Auth/types';
 import { TextEncoder, TextDecoder } from 'util';
+import { fetchAuthSession } from '../../src';
 Object.assign(global, { TextDecoder, TextEncoder });
 type ArgumentTypes<F extends Function> = F extends (...args: infer A) => any
 	? A
@@ -84,6 +85,32 @@ describe('Session tests', () => {
 
 		expect(session.tokens).toBe(undefined);
 		expect(session.credentials).toBe(undefined);
+	});
+
+	test('fetchAuthSession with credentials provider only', async () => {
+		const mockCredentials = {
+			accessKeyId: 'accessKeyValue',
+			secretAccessKey: 'secreatAccessKeyValue',
+		};
+		Amplify.configure(
+			{},
+			{
+				Auth: {
+					credentialsProvider: {
+						getCredentialsAndIdentityId: async () => {
+							return {
+								credentials: mockCredentials,
+							};
+						},
+						clearCredentialsAndIdentityId: () => {},
+					},
+				},
+			}
+		);
+
+		const session = await fetchAuthSession();
+
+		expect(session.credentials).toBe(mockCredentials);
 	});
 
 	test('fetch user after no credentials', async () => {

--- a/packages/core/src/singleton/Auth/index.ts
+++ b/packages/core/src/singleton/Auth/index.ts
@@ -8,8 +8,6 @@ import {
 	FetchAuthSessionOptions,
 	LibraryAuthOptions,
 } from './types';
-import { asserts } from '../../Util/errors/AssertError';
-import { AUTH_CONFING_EXCEPTION } from '../../Util/Constants';
 
 export function isTokenExpired({
 	expiresAt,
@@ -53,13 +51,6 @@ export class AuthClass {
 		let credentialsAndIdentityId: AWSCredentialsAndIdentityId | undefined;
 		let userSub: string | undefined;
 
-		asserts(!!this.authConfig, {
-			name: AUTH_CONFING_EXCEPTION,
-			message: 'AuthConfig is required',
-			recoverySuggestion:
-				'call Amplify.configure in your app with a valid AuthConfig',
-		});
-
 		// Get tokens will throw if session cannot be refreshed (network or service error) or return null if not available
 		tokens =
 			(await this.authOptions?.tokenProvider?.getTokens(options)) ?? undefined;
@@ -77,7 +68,7 @@ export class AuthClass {
 						forceRefresh: options.forceRefresh,
 					}
 				);
-		} else if (this.authConfig.Cognito.allowGuestAccess) {
+		} else {
 			// getCredentialsAndIdentityId will throw if cannot get credentials (network or service error)
 			credentialsAndIdentityId =
 				await this.authOptions?.credentialsProvider?.getCredentialsAndIdentityId(

--- a/packages/core/src/singleton/Auth/types.ts
+++ b/packages/core/src/singleton/Auth/types.ts
@@ -152,14 +152,14 @@ export type GetCredentialsOptions =
 type GetCredentialsAuthenticatedUser = {
 	authenticated: true;
 	forceRefresh?: boolean;
-	authConfig: AuthConfig;
+	authConfig: AuthConfig | undefined;
 	tokens: AuthTokens;
 };
 
 type GetCredentialsUnauthenticatedUser = {
 	authenticated: false;
 	forceRefresh?: boolean;
-	authConfig: AuthConfig;
+	authConfig: AuthConfig | undefined;
 	tokens?: never;
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Disable check for `allowGuestAccess: true` in order to call `credentialsProvider` when no tokens are present

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
