### PR TITLE
feat(adapter-nextjs): let withAmplify read the aws-exports content

### DIFF
--- a/packages/adapter-nextjs/__tests__/withAmplify.test.ts
+++ b/packages/adapter-nextjs/__tests__/withAmplify.test.ts
@@ -1,9 +1,43 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ResourcesConfig } from 'aws-amplify';
+import * as fs from 'fs';
+import * as path from 'path';
+import { ResourcesConfig, parseAmplifyConfig } from 'aws-amplify';
 import { withAmplify } from '../src/withAmplify';
+import { AmplifyError } from '@aws-amplify/core/internals/utils';
 
+jest.mock('fs');
+jest.mock('path');
+jest.mock('aws-amplify');
+
+const legacyAmplifyConfig = {
+	aws_project_region: 'us-west-2',
+	aws_cognito_identity_pool_id: 'aws_cognito_identity_pool_id',
+	aws_cognito_region: 'us-west-2',
+	aws_user_pools_id: 'aws_user_pools_id',
+	aws_user_pools_web_client_id: 'aws_user_pools_web_client_id',
+	aws_cognito_username_attributes: [],
+	aws_cognito_social_providers: [],
+	aws_cognito_signup_attributes: [],
+	aws_cognito_mfa_configuration: 'OFF',
+	aws_cognito_mfa_types: ['SMS'],
+	aws_cognito_password_protection_settings: {
+		passwordPolicyMinLength: 8,
+		passwordPolicyCharacters: [],
+	},
+	aws_cognito_verification_mechanisms: ['PHONE_NUMBER'],
+	aws_user_files_s3_bucket: 'aws_user_files_s3_bucket',
+	aws_user_files_s3_bucket_region: 'us-west-2',
+	aws_mobile_analytics_app_id: 'aws_mobile_analytics_app_id',
+	aws_mobile_analytics_app_region: 'us-west-2',
+	Analytics: {
+		AWSPinpoint: {
+			appId: 'aws_mobile_analytics_app_id',
+			region: 'us-west-2',
+		},
+	},
+};
 const mockAmplifyConfig: ResourcesConfig = {
 	Auth: {
 		Cognito: {
@@ -19,42 +53,141 @@ const mockAmplifyConfig: ResourcesConfig = {
 		},
 	},
 };
+const mockLegacyConfigFileContent = `
+const awsmobile = ${JSON.stringify(legacyAmplifyConfig, null, 2)};
+
+export default awsmobile;
+`;
+const mockConfigPath = './src/aws-exports.js';
+const mockCommandRoot = '/User/Developer/next-js-project';
+const mockResolvedPath = `${mockCommandRoot}/${mockConfigPath}`;
+const mockParseAmplifyConfig = parseAmplifyConfig as jest.Mock;
+const mockCWD = jest.fn();
+const mockPathResolve = path.resolve as jest.Mock;
+const mockFSReadFileSync = fs.readFileSync as jest.Mock;
 
 describe('withAmplify', () => {
-	it('should add amplifyConfig to nextConfig.env', () => {
-		const nextConfig = {};
-		const result = withAmplify(nextConfig, mockAmplifyConfig);
+	let originalCWD;
+	let originalProcessArgv;
 
-		expect(result).toEqual({
-			env: {
-				amplifyConfig: JSON.stringify(mockAmplifyConfig),
-			},
-			serverRuntimeConfig: {
-				amplifyConfig: JSON.stringify(mockAmplifyConfig),
-			},
+	beforeAll(() => {
+		originalCWD = process.cwd;
+		process.cwd = mockCWD;
+	});
+
+	afterAll(() => {
+		process.cwd = originalCWD;
+	});
+
+	beforeEach(() => {
+		mockCWD.mockReturnValue(mockCommandRoot);
+		mockPathResolve.mockReturnValue(mockResolvedPath);
+		mockFSReadFileSync.mockReturnValue(mockLegacyConfigFileContent);
+		originalProcessArgv = process.argv;
+		process.argv = ['node', '.bin/next', 'build'];
+	});
+
+	afterEach(() => {
+		process.argv = originalProcessArgv;
+	});
+
+	describe('reading config file', () => {
+		it('should read the file content specified by the `configPath` parameter', () => {
+			withAmplify({}, mockConfigPath);
+
+			expect(mockCWD).toHaveBeenCalled();
+			expect(mockPathResolve).toHaveBeenCalledWith(
+				mockCommandRoot,
+				'',
+				mockConfigPath
+			);
+
+			expect(mockFSReadFileSync).toHaveBeenCalledWith(mockResolvedPath, 'utf8');
+		});
+
+		it('should resolve the path with next command `dir` option', () => {
+			const mockDirArg = 'subDir';
+			const mockResolvedPathWithSubDir = `${mockCommandRoot}/${mockDirArg}/${mockConfigPath}`;
+			mockPathResolve.mockReturnValueOnce(mockResolvedPathWithSubDir);
+			process.argv = ['node', '.bin/next', 'build', mockDirArg];
+
+			withAmplify({}, mockConfigPath);
+
+			expect(mockPathResolve).toHaveBeenCalledWith(
+				mockCommandRoot,
+				mockDirArg,
+				mockConfigPath
+			);
+
+			expect(mockFSReadFileSync).toHaveBeenCalledWith(
+				mockResolvedPathWithSubDir,
+				'utf8'
+			);
+		});
+
+		it('should throw exception if no config found in the config file', () => {
+			mockFSReadFileSync.mockReturnValueOnce('empty file');
+
+			expect(() => withAmplify({}, mockConfigPath)).toThrow(AmplifyError);
+		});
+
+		it('should throw an AmplifyServerContextError if reading file content filed', () => {
+			mockFSReadFileSync.mockImplementation(() => {
+				throw new Error('File does not exist');
+			});
+
+			expect(() => withAmplify({}, mockConfigPath)).toThrow(AmplifyError);
 		});
 	});
 
-	it('should merge amplifyConfig to nextConfig.env (if this key has already defined)', () => {
-		const nextConfig = {
-			env: {
-				existingKey: '123',
-			},
-			serverRuntimeConfig: {
-				myKey: 'myValue',
-			},
-		};
-		const result = withAmplify(nextConfig, mockAmplifyConfig);
+	describe('return the config', () => {
+		beforeEach(() => {
+			mockParseAmplifyConfig.mockReset();
+			mockParseAmplifyConfig.mockReturnValue(mockAmplifyConfig);
+		});
 
-		expect(result).toEqual({
-			env: {
-				existingKey: '123',
-				amplifyConfig: JSON.stringify(mockAmplifyConfig),
-			},
-			serverRuntimeConfig: {
-				myKey: 'myValue',
-				amplifyConfig: JSON.stringify(mockAmplifyConfig),
-			},
+		it('should invoke the parseAmplifyConfig function to transform the legacy config object', () => {
+			mockParseAmplifyConfig.mockReturnValueOnce(mockAmplifyConfig);
+			withAmplify({}, mockConfigPath);
+
+			expect(mockParseAmplifyConfig).toHaveBeenCalledWith(legacyAmplifyConfig);
+		});
+
+		it('should add amplifyConfig to nextConfig.env', () => {
+			const nextConfig = {};
+			const result = withAmplify(nextConfig, mockConfigPath);
+
+			expect(result).toEqual({
+				env: {
+					amplifyConfig: JSON.stringify(mockAmplifyConfig),
+				},
+				serverRuntimeConfig: {
+					amplifyConfig: JSON.stringify(mockAmplifyConfig),
+				},
+			});
+		});
+
+		it('should merge amplifyConfig to nextConfig.env (if this key has already defined)', () => {
+			const nextConfig = {
+				env: {
+					existingKey: '123',
+				},
+				serverRuntimeConfig: {
+					myKey: 'myValue',
+				},
+			};
+			const result = withAmplify(nextConfig, mockConfigPath);
+
+			expect(result).toEqual({
+				env: {
+					existingKey: '123',
+					amplifyConfig: JSON.stringify(mockAmplifyConfig),
+				},
+				serverRuntimeConfig: {
+					myKey: 'myValue',
+					amplifyConfig: JSON.stringify(mockAmplifyConfig),
+				},
+			});
 		});
 	});
 });

--- a/packages/adapter-nextjs/src/withAmplify.ts
+++ b/packages/adapter-nextjs/src/withAmplify.ts
@@ -1,8 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ResourcesConfig, parseAmplifyConfig } from 'aws-amplify';
+import * as path from 'path';
+import * as fs from 'fs';
+import { parseAmplifyConfig } from 'aws-amplify';
 import { NextConfig } from 'next';
+import { AmplifyServerContextError } from '@aws-amplify/core/internals/adapter-core';
+
+const configTextRegex = /const awsmobile = ({.*});/s;
+const nextCommands = ['build', 'dev', 'export', 'start'];
 
 // NOTE: this function is exported from the subpath `/with-amplify`.
 // The reason is that this function is called in the `next.config.js` which
@@ -12,26 +18,22 @@ import { NextConfig } from 'next';
  * Merges the `amplifyConfig` into the `nextConfig.env`.
  *
  * @param nextConfig The next config for a Next.js app.
- * @param amplifyConfig The Amplify configuration.
+ * @param configPath The relative path of the `aws-exports.js` file
  *
- *   **NOTE**: If you are using Amplify CLI to generate the `aws-exports.js`
- *   file, you need to use {@link parseAmplifyConfig} to reformat the configuration.
- *   E.g.
- *   ```javascript
- *   const { parseAmplifyConfig } = require('aws-amplify');
- *   const { withAmplify } = require('@aws-amplify/adapter-nextjs/with-amplify');
- *   const config = require('./src/aws-exports');
- *
- *   const nextConfig = {};
- *   module.exports = withAmplify(nextConfig, parseAmplifyConfig(config));
- *   ```
  * @returns The updated `nextConfig`.
+ *
+ * @example
+ * const { withAmplify } = require('@aws-amplify/adapter-nextjs/with-amplify');
+ * const nextConfig = {
+ *   experimental: {
+ *     serverActions: true,
+ *   },
+ * }
+ * module.exports = withAmplify(nextConfig, './src/aws-exports.js');
  */
-export const withAmplify = (
-	nextConfig: NextConfig,
-	amplifyConfig: ResourcesConfig
-) => {
-	const configStr = JSON.stringify(amplifyConfig);
+export const withAmplify = (nextConfig: NextConfig, configPath: string) => {
+	const configStr = JSON.stringify(getAmplifyConfig(configPath));
+
 	nextConfig.env = {
 		...nextConfig.env,
 		amplifyConfig: configStr,
@@ -44,3 +46,36 @@ export const withAmplify = (
 
 	return nextConfig;
 };
+
+const getAmplifyConfig = (configPath: string) => {
+	try {
+		const projectRoot = process.cwd();
+		const resolvedPath = path.resolve(projectRoot, getDirArg(), configPath);
+		const fileContent = fs.readFileSync(resolvedPath, 'utf8');
+		const match = configTextRegex.exec(fileContent);
+
+		if (match && match[1]) {
+			// TODO(HuiSF): add handling when parseAmplifyConfig is not needed.
+			const configObject = parseAmplifyConfig(JSON.parse(match[1]));
+
+			return configObject;
+		} else {
+			throw new AmplifyServerContextError({
+				message: 'The `awsmobile` object not found in the file.',
+				recoverySuggestion:
+					'Ensure the path parameter points to a correct aws-exports file.',
+			});
+		}
+	} catch (error) {
+		throw new AmplifyServerContextError({
+			message: 'Cannot read or parse the `awsmobile` object.',
+			recoverySuggestion:
+				'Ensure the path parameter points to a correct aws-exports file.',
+		});
+	}
+};
+
+function getDirArg() {
+	const lastArg = process.argv[process.argv.length - 1];
+	return nextCommands.includes(lastArg) ? '' : lastArg;
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* `withAmplify` now reads the content of `aws-exports.js` instead of relying on letting developers to import and pass the object

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

- Unit tests
- Local testing with sample Next.js app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
