### PR TITLE
chore(storage): more specific Jest ignore path

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -133,9 +133,9 @@
 			"cases"
 		],
 		"modulePathIgnorePatterns": [
-			"dist",
-			"lib",
-			"lib-esm"
+			"<rootDir>/dist",
+			"<rootDir>/lib",
+			"<rootDir>/lib-esm"
 		],
 		"moduleFileExtensions": [
 			"ts",


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Previously the overly broad jest test ignore path pattern may cause the jest test to fail if the developers' workspace path name includes 'dist', 'lib', or 'lib-esm'.



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
