### PR TITLE
feat: make Amplify.configure accept both new and legacy config objects

### DIFF
--- a/packages/adapter-nextjs/__tests__/utils/getAmplifyConfig.test.ts
+++ b/packages/adapter-nextjs/__tests__/utils/getAmplifyConfig.test.ts
@@ -1,25 +1,51 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { NextConfig } from 'next';
 import getConfig from 'next/config';
+import { parseAWSExports } from '@aws-amplify/core/internals/utils';
 import { getAmplifyConfig } from '../../src/utils/getAmplifyConfig';
 import { AmplifyError } from '@aws-amplify/core/internals/utils';
 
 jest.mock('next/config');
+jest.mock('@aws-amplify/core/internals/utils');
 
 const mockGetConfig = getConfig as jest.Mock;
+const mockParseAWSExports = parseAWSExports as jest.Mock;
 
 describe('getAmplifyConfig', () => {
+	const mockLegacyConfig = {
+		aws_project_region: 'us-west-2',
+		aws_cognito_identity_pool_id: '123',
+		aws_cognito_region: 'aws_cognito_region',
+		aws_user_pools_id: 'abc',
+		aws_user_pools_web_client_id: 'def',
+		oauth: {},
+		aws_cognito_username_attributes: [],
+		aws_cognito_social_providers: [],
+		aws_cognito_signup_attributes: [],
+		aws_cognito_mfa_configuration: 'OFF',
+		aws_cognito_mfa_types: ['SMS'],
+		aws_cognito_password_protection_settings: {
+			passwordPolicyMinLength: 8,
+			passwordPolicyCharacters: [],
+		},
+		aws_cognito_verification_mechanisms: ['PHONE_NUMBER'],
+		aws_user_files_s3_bucket: 'bucket',
+		aws_user_files_s3_bucket_region: 'us-east-1',
+	};
 	const mockAmplifyConfig = {
 		Auth: {
-			identityPoolId: '123',
-			userPoolId: 'abc',
-			userPoolWebClientId: 'def',
+			Cognito: {
+				identityPoolId: '123',
+				userPoolId: 'abc',
+				userPoolClientId: 'def',
+			},
 		},
 		Storage: {
-			bucket: 'bucket',
-			region: 'us-east-1',
+			S3: {
+				bucket: 'bucket',
+				region: 'us-east-1',
+			},
 		},
 	};
 
@@ -33,6 +59,13 @@ describe('getAmplifyConfig', () => {
 
 		const result = getAmplifyConfig();
 		expect(result).toEqual(mockAmplifyConfig);
+	});
+
+	it('should invoke parseAWSConfig when using the legacy shaped config', () => {
+		process.env.amplifyConfig = JSON.stringify(mockLegacyConfig);
+
+		getAmplifyConfig();
+		expect(mockParseAWSExports).toHaveBeenCalledWith(mockLegacyConfig);
 	});
 
 	it('should attempt to get amplifyConfig via getConfig provided by Next.js as a fallback', () => {

--- a/packages/adapter-nextjs/__tests__/withAmplify.test.ts
+++ b/packages/adapter-nextjs/__tests__/withAmplify.test.ts
@@ -19,6 +19,24 @@ const mockAmplifyConfig: ResourcesConfig = {
 		},
 	},
 };
+const mockLegacyConfig = {
+	aws_project_region: 'us-west-2',
+	aws_cognito_identity_pool_id: 'aws_cognito_identity_pool_id',
+	aws_cognito_region: 'aws_cognito_region',
+	aws_user_pools_id: 'aws_user_pools_id',
+	aws_user_pools_web_client_id: 'aws_user_pools_web_client_id',
+	oauth: {},
+	aws_cognito_username_attributes: [],
+	aws_cognito_social_providers: [],
+	aws_cognito_signup_attributes: [],
+	aws_cognito_mfa_configuration: 'OFF',
+	aws_cognito_mfa_types: ['SMS'],
+	aws_cognito_password_protection_settings: {
+		passwordPolicyMinLength: 8,
+		passwordPolicyCharacters: [],
+	},
+	aws_cognito_verification_mechanisms: ['PHONE_NUMBER'],
+};
 
 describe('withAmplify', () => {
 	it('should add amplifyConfig to nextConfig.env', () => {
@@ -31,6 +49,20 @@ describe('withAmplify', () => {
 			},
 			serverRuntimeConfig: {
 				amplifyConfig: JSON.stringify(mockAmplifyConfig),
+			},
+		});
+	});
+
+	it('should add amplifyConfig (legacy CLI shaped) to nextConfig.env', () => {
+		const nextConfig = {};
+		const result = withAmplify(nextConfig, mockLegacyConfig);
+
+		expect(result).toEqual({
+			env: {
+				amplifyConfig: JSON.stringify(mockLegacyConfig),
+			},
+			serverRuntimeConfig: {
+				amplifyConfig: JSON.stringify(mockLegacyConfig),
 			},
 		});
 	});

--- a/packages/adapter-nextjs/src/utils/getAmplifyConfig.ts
+++ b/packages/adapter-nextjs/src/utils/getAmplifyConfig.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ResourcesConfig } from 'aws-amplify';
+import { parseAWSExports } from '@aws-amplify/core/internals/utils';
 import { AmplifyServerContextError } from '@aws-amplify/core/internals/adapter-core';
 import getConfig from 'next/config';
 
@@ -28,5 +29,7 @@ export const getAmplifyConfig = (): ResourcesConfig => {
 	const configObject = JSON.parse(configStr);
 
 	// TODO(HuiSF): adds ResourcesConfig validation when it has one.
-	return configObject;
+	return Object.keys(configObject).some(key => key.startsWith('aws_'))
+		? parseAWSExports(configObject)
+		: configObject;
 };

--- a/packages/adapter-nextjs/src/withAmplify.ts
+++ b/packages/adapter-nextjs/src/withAmplify.ts
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ResourcesConfig, parseAmplifyConfig } from 'aws-amplify';
+import { ResourcesConfig } from 'aws-amplify';
+import { LegacyConfig } from 'aws-amplify/internals/adapter-core';
 import { NextConfig } from 'next';
 
 // NOTE: this function is exported from the subpath `/with-amplify`.
@@ -14,22 +15,11 @@ import { NextConfig } from 'next';
  * @param nextConfig The next config for a Next.js app.
  * @param amplifyConfig The Amplify configuration.
  *
- *   **NOTE**: If you are using Amplify CLI to generate the `aws-exports.js`
- *   file, you need to use {@link parseAmplifyConfig} to reformat the configuration.
- *   E.g.
- *   ```javascript
- *   const { parseAmplifyConfig } = require('aws-amplify');
- *   const { withAmplify } = require('@aws-amplify/adapter-nextjs/with-amplify');
- *   const config = require('./src/aws-exports');
- *
- *   const nextConfig = {};
- *   module.exports = withAmplify(nextConfig, parseAmplifyConfig(config));
- *   ```
  * @returns The updated `nextConfig`.
  */
 export const withAmplify = (
 	nextConfig: NextConfig,
-	amplifyConfig: ResourcesConfig
+	amplifyConfig: ResourcesConfig | LegacyConfig
 ) => {
 	const configStr = JSON.stringify(amplifyConfig);
 	nextConfig.env = {

--- a/packages/aws-amplify/__tests__/exports.test.ts
+++ b/packages/aws-amplify/__tests__/exports.test.ts
@@ -9,7 +9,6 @@ describe('aws-amplify', () => {
 			expect(Object.keys(exported)).toMatchInlineSnapshot(`
 			Array [
 			  "Amplify",
-			  "parseAmplifyConfig",
 			]
 		`);
 		});

--- a/packages/aws-amplify/__tests__/initSingleton.test.ts
+++ b/packages/aws-amplify/__tests__/initSingleton.test.ts
@@ -65,6 +65,43 @@ describe('initSingleton (DefaultAmplify)', () => {
 	});
 
 	describe('DefaultAmplify.configure()', () => {
+		it('should take the legacy CLI shaped config object for configuring the underlying Amplify Singleton', () => {
+			const mockLegacyConfig = {
+				aws_project_region: 'us-west-2',
+				aws_cognito_identity_pool_id: 'aws_cognito_identity_pool_id',
+				aws_cognito_region: 'aws_cognito_region',
+				aws_user_pools_id: 'aws_user_pools_id',
+				aws_user_pools_web_client_id: 'aws_user_pools_web_client_id',
+				oauth: {},
+				aws_cognito_username_attributes: [],
+				aws_cognito_social_providers: [],
+				aws_cognito_signup_attributes: [],
+				aws_cognito_mfa_configuration: 'OFF',
+				aws_cognito_mfa_types: ['SMS'],
+				aws_cognito_password_protection_settings: {
+					passwordPolicyMinLength: 8,
+					passwordPolicyCharacters: [],
+				},
+				aws_cognito_verification_mechanisms: ['PHONE_NUMBER'],
+			};
+
+			Amplify.configure(mockLegacyConfig);
+
+			expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
+				{
+					Auth: {
+						Cognito: {
+							allowGuestAccess: true,
+							identityPoolId: 'aws_cognito_identity_pool_id',
+							userPoolClientId: 'aws_user_pools_web_client_id',
+							userPoolId: 'aws_user_pools_id',
+						},
+					},
+				},
+				expect.anything()
+			);
+		});
+
 		describe('when ResourcesConfig.Auth is defined', () => {
 			describe('when libraryOptions.Auth is undefined', () => {
 				it('should invoke AmplifySingleton.configure with the default auth providers', () => {

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -258,19 +258,19 @@
 			"name": "[Auth] getCurrentUser (Cognito)",
 			"path": "./lib-esm/auth/index.js",
 			"import": "{ getCurrentUser }",
-			"limit": "4.18 kB"
+			"limit": "4.52 kB"
 		},
 		{
 			"name": "[Auth] confirmUserAttribute (Cognito)",
 			"path": "./lib-esm/auth/index.js",
 			"import": "{ confirmUserAttribute }",
-			"limit": "10.49 kB"
+			"limit": "10.50 kB"
 		},
 		{
 			"name": "[Auth] signInWithRedirect (Cognito)",
 			"path": "./lib-esm/auth/index.js",
 			"import": "{ signInWithRedirect }",
-			"limit": "19.78 kB"
+			"limit": "20.00 kB"
 		},
 		{
 			"name": "[Auth] fetchUserAttributes (Cognito)",
@@ -288,49 +288,49 @@
 			"name": "[Auth] OAuth Auth Flow (Cognito)",
 			"path": "./lib-esm/auth/index.js",
 			"import": "{ signInWithRedirect, signOut, fetchAuthSession }",
-			"limit": "20.22 kB"
+			"limit": "20.45 kB"
 		},
 		{
 			"name": "[Storage] copy (S3)",
 			"path": "./lib-esm/storage/index.js",
 			"import": "{ copy }",
-			"limit": "16.41 kB"
+			"limit": "16.70 kB"
 		},
 		{
 			"name": "[Storage] downloadData (S3)",
 			"path": "./lib-esm/storage/index.js",
 			"import": "{ downloadData }",
-			"limit": "17.21 kB"
+			"limit": "17.50 kB"
 		},
 		{
 			"name": "[Storage] getProperties (S3)",
 			"path": "./lib-esm/storage/index.js",
 			"import": "{ getProperties }",
-			"limit": "16.43 kB"
+			"limit": "16.70 kB"
 		},
 		{
 			"name": "[Storage] getUrl (S3)",
 			"path": "./lib-esm/storage/index.js",
 			"import": "{ getUrl }",
-			"limit": "17.81 kB"
+			"limit": "18.2 kB"
 		},
 		{
 			"name": "[Storage] list (S3)",
 			"path": "./lib-esm/storage/index.js",
 			"import": "{ list }",
-			"limit": "16.99 kB"
+			"limit": "17.4 kB"
 		},
 		{
 			"name": "[Storage] remove (S3)",
 			"path": "./lib-esm/storage/index.js",
 			"import": "{ remove }",
-			"limit": "16.28 kB"
+			"limit": "16.6 kB"
 		},
 		{
 			"name": "[Storage] uploadData (S3)",
 			"path": "./lib-esm/storage/index.js",
 			"import": "{ uploadData }",
-			"limit": "23.05 kB"
+			"limit": "23.3 kB"
 		}
 	],
 	"jest": {

--- a/packages/aws-amplify/src/adapterCore/index.ts
+++ b/packages/aws-amplify/src/adapterCore/index.ts
@@ -7,3 +7,4 @@ export {
 	createAWSCredentialsAndIdentityIdProvider,
 	createUserPoolsTokenProvider,
 } from './authProvidersFactories/cognito';
+export { LegacyConfig } from '@aws-amplify/core/internals/utils';

--- a/packages/aws-amplify/src/index.ts
+++ b/packages/aws-amplify/src/index.ts
@@ -5,7 +5,4 @@
 This file maps top-level exports from `aws-amplify`.
 */
 export { DefaultAmplify as Amplify } from './initSingleton';
-export {
-	parseAWSExports as parseAmplifyConfig,
-	ResourcesConfig,
-} from '@aws-amplify/core';
+export { ResourcesConfig } from '@aws-amplify/core';

--- a/packages/core/__tests__/singleton/Singleton.test.ts
+++ b/packages/core/__tests__/singleton/Singleton.test.ts
@@ -9,9 +9,43 @@ type ArgumentTypes<F extends Function> = F extends (...args: infer A) => any
 	? A
 	: never;
 
-describe('Amplify config test', () => {
-	test('Happy path Set and Get config', () => {
-		expect.assertions(1);
+describe('Amplify.configure() and Amplify.getConfig()', () => {
+	it('should take the legacy CLI shaped config object for configuring and return it from getConfig()', () => {
+		const mockLegacyConfig = {
+			aws_project_region: 'us-west-2',
+			aws_cognito_identity_pool_id: 'aws_cognito_identity_pool_id',
+			aws_cognito_region: 'aws_cognito_region',
+			aws_user_pools_id: 'aws_user_pools_id',
+			aws_user_pools_web_client_id: 'aws_user_pools_web_client_id',
+			oauth: {},
+			aws_cognito_username_attributes: [],
+			aws_cognito_social_providers: [],
+			aws_cognito_signup_attributes: [],
+			aws_cognito_mfa_configuration: 'OFF',
+			aws_cognito_mfa_types: ['SMS'],
+			aws_cognito_password_protection_settings: {
+				passwordPolicyMinLength: 8,
+				passwordPolicyCharacters: [],
+			},
+			aws_cognito_verification_mechanisms: ['PHONE_NUMBER'],
+		};
+
+		Amplify.configure(mockLegacyConfig);
+		const result = Amplify.getConfig();
+
+		expect(result).toEqual({
+			Auth: {
+				Cognito: {
+					allowGuestAccess: true,
+					identityPoolId: 'aws_cognito_identity_pool_id',
+					userPoolClientId: 'aws_user_pools_web_client_id',
+					userPoolId: 'aws_user_pools_id',
+				},
+			},
+		});
+	});
+
+	it('should take the v6 shaped config object for configuring and return it from getConfig()', () => {
 		const config: ArgumentTypes<typeof Amplify.configure>[0] = {
 			Auth: {
 				Cognito: {
@@ -28,8 +62,7 @@ describe('Amplify config test', () => {
 		expect(result).toEqual(config);
 	});
 
-	test('Replace Cognito configuration set and get config', () => {
-		expect.assertions(1);
+	it('should replace Cognito configuration set and get config', () => {
 		const config1: ArgumentTypes<typeof Amplify.configure>[0] = {
 			Auth: {
 				Cognito: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,5 +67,3 @@ export { BrowserStorageCache as Cache }; // Maintain interoperability with React
 
 // Internationalization utilities
 export { I18n } from './I18n';
-
-export { parseAWSExports } from './parseAWSExports';

--- a/packages/core/src/libraryUtils.ts
+++ b/packages/core/src/libraryUtils.ts
@@ -20,7 +20,8 @@ export {
 	transferKeyToLowerCase,
 	transferKeyToUpperCase,
 } from './Util/JS';
-
+export { parseAWSExports } from './parseAWSExports';
+export { LegacyConfig } from './singleton/types';
 export {
 	JWT,
 	StrictUnion,

--- a/packages/core/src/singleton/Amplify.ts
+++ b/packages/core/src/singleton/Amplify.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { AuthClass } from './Auth';
 import { Hub, AMPLIFY_SYMBOL } from '../Hub';
-import { LibraryOptions, ResourcesConfig } from './types';
+import { LegacyConfig, LibraryOptions, ResourcesConfig } from './types';
+import { parseAWSExports } from '../parseAWSExports';
 
 // TODO(v6): add default AuthTokenStore for each platform
 
@@ -33,12 +34,20 @@ export class AmplifyClass {
 	 * @param libraryOptions - Additional options for customizing the behavior of the library.
 	 */
 	configure(
-		resourcesConfig: ResourcesConfig,
+		resourcesConfig: ResourcesConfig | LegacyConfig,
 		libraryOptions: LibraryOptions = {}
 	): void {
+		let resolvedResourceConfig: ResourcesConfig;
+
+		if (Object.keys(resourcesConfig).some(key => key.startsWith('aws_'))) {
+			resolvedResourceConfig = parseAWSExports(resourcesConfig);
+		} else {
+			resolvedResourceConfig = resourcesConfig as ResourcesConfig;
+		}
+
 		this.resourcesConfig = mergeResourceConfig(
 			this.resourcesConfig,
-			resourcesConfig
+			resolvedResourceConfig
 		);
 
 		this.libraryOptions = mergeLibraryOptions(

--- a/packages/core/src/singleton/types.ts
+++ b/packages/core/src/singleton/types.ts
@@ -17,6 +17,13 @@ import {
 	StorageConfig,
 } from './Storage/types';
 
+export type LegacyConfig = {
+	/**
+	 * @deprecated The field should not be used.
+	 */
+	aws_project_region?: string;
+};
+
 export type ResourcesConfig = {
 	// API?: {};
 	Analytics?: AnalyticsConfig;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Made the `Amplify.configure` function accept both legacy config object and the config object with the new shape.
* Removed the need of calling `parseAmplifyConfig` function.
* Now export `parseAWSExports` function from the `internals/util` subpath from the core package.
* Updated relevant implementation of `adapter-nextjs`


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* Unit tests
* Manual integration tests with the Next.js sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
