### PR TITLE
chore: fix canary failure with incompatible NPM

### DIFF
--- a/.github/actions/node-and-build/action.yml
+++ b/.github/actions/node-and-build/action.yml
@@ -4,13 +4,16 @@ inputs:
   is-prebuild:
     required: false
     default: false
+  node-version:
+    required: false
+    default: 16 # TODO: Update to 18 when we validate with the staging repo.
 runs:
   using: 'composite'
   steps:
-    - name: Setup Node.js 16
+    - name: Setup Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0 https://github.com/actions/setup-node/commit/64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
       with:
-        node-version: 16
+        node-version: ${{ inputs.node-version }}
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
     - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1

--- a/.github/workflows/callable-canary-sampleapp-tests.yml
+++ b/.github/workflows/callable-canary-sampleapp-tests.yml
@@ -17,6 +17,9 @@ env:
 jobs:
   build_apps:
     name: Build Sample App Tests
+    strategy:
+      matrix:
+        node-version: [18, 20]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -31,6 +34,8 @@ jobs:
           GH_TOKEN_STAGING_READ: ${{ secrets.GH_TOKEN_STAGING_READ }}
       - name: Setup node and build the repository
         uses: ./amplify-js/.github/actions/node-and-build
+        with:
+          node-version: ${{ matrix.node-version }}
 
         # React
       - name: Create react application

--- a/.github/workflows/callable-canary-sampleapp-tests.yml
+++ b/.github/workflows/callable-canary-sampleapp-tests.yml
@@ -88,7 +88,6 @@ jobs:
         working-directory: amplify-js-samples-staging/samples/angular/interactions/new-angular-app
       - name: Install amplify
         run: |
-          npm install -g npm@latest
           npm install aws-amplify -legacy-peer-deps
         working-directory: amplify-js-samples-staging/samples/angular/interactions/new-angular-app
       - name: Start application and run test
@@ -126,7 +125,6 @@ jobs:
         working-directory: amplify-js-samples-staging/samples/next/auth/new-next-app
       - name: Install amplify
         run: |
-          npm install -g npm@latest
           npm install aws-amplify -legacy-peer-deps
         working-directory: amplify-js-samples-staging/samples/next/auth/new-next-app
       - name: Start application and run test
@@ -158,7 +156,6 @@ jobs:
         working-directory: amplify-js-samples-staging/cypress/integration/auth
       - name: Install amplify
         run: |
-          npm install -g npm@latest
           npm install aws-amplify -legacy-peer-deps
         working-directory: amplify-js-samples-staging/samples/vue/auth/new-vue-app
       - name: Install dependencies
@@ -186,7 +183,6 @@ jobs:
         working-directory: amplify-js-samples-staging/samples/javascript/auth
       - name: Install amplify
         run: |
-          npm install -g npm@latest
           npm install aws-amplify -legacy-peer-deps
         working-directory: amplify-js-samples-staging/samples/javascript/auth/new-javascript-app
       - name: Remove existing src folder

--- a/.github/workflows/on-schedule-canary-test.yml
+++ b/.github/workflows/on-schedule-canary-test.yml
@@ -1,8 +1,10 @@
 on:
   # Tests scheduled at 4pm(UTC) / 9am(PDT) everyday
   # default supported timezone is UTC
-  schedule:
-    - cron: '0 16 * * *'
+  pull_request:
+    branches: [fix-canary-engine-failure]
+  push:
+    branches: [fix-canary-engine-failure]
 
 jobs:
   canaries:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Remove the repetative npm@latest installation that causes the failure. The NPM installation already happend other tasks:
https://github.com/aws-amplify/amplify-js/blob/dd3dea1c341b1873f2e53fa0f430aa13fd12d09a/.github/workflows/callable-canary-sampleapp-tests.yml#L32

#### Issue #, if available
Example failure: https://github.com/aws-amplify/amplify-js/actions/runs/6238043024/job/16934343712



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
