### PR TITLE
feat(auth): add `customOAuthState` missing hub event

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -270,7 +270,7 @@
 			"name": "[Auth] signInWithRedirect (Cognito)",
 			"path": "./lib-esm/auth/index.js",
 			"import": "{ signInWithRedirect }",
-			"limit": "20.00 kB"
+			"limit": "20.07 kB"
 		},
 		{
 			"name": "[Auth] fetchUserAttributes (Cognito)",
@@ -288,7 +288,7 @@
 			"name": "[Auth] OAuth Auth Flow (Cognito)",
 			"path": "./lib-esm/auth/index.js",
 			"import": "{ signInWithRedirect, signOut, fetchAuthSession }",
-			"limit": "20.45 kB"
+			"limit": "20.50 kB"
 		},
 		{
 			"name": "[Storage] copy (S3)",

--- a/packages/core/src/Hub/types/AuthTypes.ts
+++ b/packages/core/src/Hub/types/AuthTypes.ts
@@ -9,4 +9,6 @@ export type AuthHubEventData =
 	/** Dispatched when auth tokens are successfully refreshed.*/
 	| { event: 'tokenRefresh' }
 	/** Dispatched when there is an error in the refresh of tokens.*/
-	| { event: 'tokenRefresh_failure' };
+	| { event: 'tokenRefresh_failure' }
+	/** Dispatched when there is a customState passed in the options of the `signInWithRedirect` API.*/
+	| { event: 'customOAuthState'; data: string };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Dispatches the `customOAuthState` hub event when `customState` is passed in the `signInRequest` and when the state has been validated.

**Other changes:**

Increase bundle size for `signInWithRedirect` API as it is using a util function to decode the oauth state.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

Listened for this hub event in a sample app using the `implicit` and `code` oauth flows.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
