### PR TITLE
chore: api-graphql enable jest diagnostics, fixed ignore paths

### DIFF
--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -69,7 +69,9 @@
 	"jest": {
 		"globals": {
 			"ts-jest": {
-				"diagnostics": false,
+				"diagnostics": {
+					"pathRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$"
+				},
 				"tsConfig": {
 					"lib": [
 						"es5",
@@ -79,7 +81,8 @@
 						"es2017.object"
 					],
 					"allowJs": true,
-					"noEmitOnError": false
+					"noEmitOnError": false,
+					"types": ["@types/jest"]
 				}
 			}
 		},
@@ -88,8 +91,8 @@
 		},
 		"testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
 		"testPathIgnorePatterns": [
-			"__tests__/fixtures/",
-			"__tests__/utils/"
+			"<rootDir>/__tests__/fixtures/",
+			"<rootDir>/__tests__/utils/"
 		],
 		"moduleFileExtensions": [
 			"ts",

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -112,10 +112,11 @@
 			}
 		},
 		"coveragePathIgnorePatterns": [
-			"/node_modules/",
-			"dist",
-			"lib",
-			"lib-esm"
+			"<rootDir>/node_modules/",
+			"<rootDir>/dist",
+			"<rootDir>/lib",
+			"<rootDir>/lib-esm",
+			"<rootDir>/__tests__"
 		]
 	}
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

1. Re-enabled jest diagnostics.
1. Updated the `testPathIgnorePatterns` to include `<rootDir>/`.
1. Added `<rootDir>/__tests__` to coverage ignore paths.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

1. Added a type mismatch and ensured `jest` gave a TS error.
1. Removed the type mismatch and watched tests pass again.
1. Confirmed with eyeballs that code coverage now shows in my working copy that lives under a `.../lib/...` path. (Previously not working.)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
