### PR TITLE
feat(analytics): add record API for service provider kinesis firehose

### DIFF
--- a/packages/analytics/__tests__/providers/kinesis-firehose/apis/record.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis-firehose/apis/record.test.ts
@@ -1,25 +1,25 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getEventBuffer } from '../../../../src/providers/kinesis/utils/getEventBuffer';
-import { resolveConfig } from '../../../../src/providers/kinesis/utils/resolveConfig';
+import {
+	getEventBuffer,
+	resolveConfig,
+} from '../../../../src/providers/kinesis-firehose/utils';
 import { resolveCredentials } from '../../../../src/utils';
 import {
 	mockConfig,
 	mockCredentialConfig,
 } from '../../../testUtils/mockConstants.test';
-import { record } from '../../../../src/providers/kinesis';
+import { record } from '../../../../src/providers/kinesis-firehose';
 import { ConsoleLogger as Logger } from '@aws-amplify/core/lib/Logger';
-import { RecordInput as KinesisRecordInput } from '../../../../src/providers/kinesis/types';
+import { RecordInput as KinesisFirehoseRecordInput } from '../../../../src/providers/kinesis-firehose/types';
 
 jest.mock('../../../../src/utils');
-jest.mock('../../../../src/providers/kinesis/utils/resolveConfig');
-jest.mock('../../../../src/providers/kinesis/utils/getEventBuffer');
+jest.mock('../../../../src/providers/kinesis-firehose/utils');
 
-describe('Analytics Kinesis API: record', () => {
-	const mockEvent: KinesisRecordInput = {
+describe('Analytics KinesisFirehose API: record', () => {
+	const mockEvent: KinesisFirehoseRecordInput = {
 		streamName: 'stream0',
-		partitionKey: 'partition0',
 		data: new Uint8Array([0x01, 0x02, 0xff]),
 	};
 
@@ -54,7 +54,6 @@ describe('Analytics Kinesis API: record', () => {
 			expect.objectContaining({
 				region: mockConfig.region,
 				streamName: mockEvent.streamName,
-				partitionKey: mockEvent.partitionKey,
 				event: mockEvent.data,
 				retryCount: 0,
 			})

--- a/packages/analytics/__tests__/providers/kinesis-firehose/utils/getEventBuffer.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis-firehose/utils/getEventBuffer.test.ts
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getEventBuffer } from '../../../../src/providers/kinesis-firehose/utils';
+import { EventBuffer } from '../../../../src/utils';
+import {
+	mockBufferConfig,
+	mockConfig,
+	mockCredentialConfig,
+} from '../../../testUtils/mockConstants.test';
+
+jest.mock('../../../../src/utils');
+
+describe('KinesisFirehose Provider Util: getEventBuffer', () => {
+	const mockEventBuffer = EventBuffer as jest.Mock;
+
+	afterEach(() => {
+		mockEventBuffer.mockReset();
+	});
+
+	it("create a buffer if one doesn't exist", () => {
+		const testBuffer = getEventBuffer({
+			...mockConfig,
+			...mockCredentialConfig,
+		});
+
+		expect(mockEventBuffer).toBeCalledWith(
+			mockBufferConfig,
+			expect.any(Function)
+		);
+		expect(testBuffer).toBeInstanceOf(EventBuffer);
+	});
+
+	it('returns an existing buffer instance', () => {
+		const testBuffer1 = getEventBuffer({
+			...mockConfig,
+			...mockCredentialConfig,
+		});
+		const testBuffer2 = getEventBuffer({
+			...mockConfig,
+			...mockCredentialConfig,
+		});
+		expect(testBuffer1).toBe(testBuffer2);
+	});
+
+	it('release other buffers & creates a new one if credential has changed', () => {
+		const testBuffer1 = getEventBuffer({
+			...mockConfig,
+			...mockCredentialConfig,
+		});
+		const testBuffer2 = getEventBuffer({
+			...mockConfig,
+			...mockCredentialConfig,
+			identityId: 'identityId2',
+		});
+
+		expect(testBuffer1.release).toHaveBeenCalledTimes(1);
+		expect(testBuffer1).not.toBe(testBuffer2);
+	});
+});

--- a/packages/analytics/__tests__/providers/kinesis-firehose/utils/resolveConfig.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis-firehose/utils/resolveConfig.test.ts
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+import { resolveConfig } from '../../../../src/providers/kinesis-firehose/utils';
+import { DEFAULT_KINESIS_FIREHOSE_CONFIG } from '../../../../src/providers/kinesis-firehose/utils/constants';
+
+describe('Analytics KinesisFirehose Provider Util: resolveConfig', () => {
+	const providedConfig = {
+		region: 'us-east-1',
+		bufferSize: 100,
+		flushSize: 10,
+		flushInterval: 1000,
+		resendLimit: 3,
+	};
+
+	const getConfigSpy = jest.spyOn(Amplify, 'getConfig');
+
+	beforeEach(() => {
+		getConfigSpy.mockReset();
+	});
+
+	it('returns required config', () => {
+		getConfigSpy.mockReturnValue({
+			Analytics: { KinesisFirehose: providedConfig },
+		});
+
+		expect(resolveConfig()).toStrictEqual(providedConfig);
+	});
+
+	it('use default config for optional fields', () => {
+		const requiredFields = {
+			region: 'us-east-1',
+			bufferSize: undefined,
+			resendLimit: undefined,
+		};
+		getConfigSpy.mockReturnValue({
+			Analytics: { KinesisFirehose: requiredFields },
+		});
+
+		expect(resolveConfig()).toStrictEqual({
+			...DEFAULT_KINESIS_FIREHOSE_CONFIG,
+			region: requiredFields.region,
+			resendLimit: requiredFields.resendLimit,
+		});
+	});
+
+	it('throws if region is missing', () => {
+		getConfigSpy.mockReturnValue({
+			Analytics: { KinesisFirehose: { ...providedConfig, region: undefined } },
+		});
+
+		expect(resolveConfig).toThrow();
+	});
+
+	it('throws if flushSize is larger than bufferSize', () => {
+		getConfigSpy.mockReturnValue({
+			Analytics: {
+				KinesisFirehose: {
+					...providedConfig,
+					flushSize: providedConfig.bufferSize + 1,
+				},
+			},
+		});
+
+		expect(resolveConfig).toThrow();
+	});
+});

--- a/packages/analytics/__tests__/providers/kinesis/apis/record.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis/apis/record.test.ts
@@ -3,13 +3,13 @@
 
 import { getEventBuffer } from '../../../../src/providers/kinesis/utils/getEventBuffer';
 import { resolveConfig } from '../../../../src/providers/kinesis/utils/resolveConfig';
-import { resolveCredentials } from '../../../../src/utils';
+import { isAnalyticsEnabled, resolveCredentials } from '../../../../src/utils';
 import {
 	mockConfig,
 	mockCredentialConfig,
 } from '../../../testUtils/mockConstants.test';
 import { record } from '../../../../src/providers/kinesis';
-import { ConsoleLogger as Logger } from '@aws-amplify/core/lib/Logger';
+import { ConsoleLogger as Logger } from '@aws-amplify/core/internals/utils';
 import { RecordInput as KinesisRecordInput } from '../../../../src/providers/kinesis/types';
 
 jest.mock('../../../../src/utils');
@@ -17,7 +17,7 @@ jest.mock('../../../../src/providers/kinesis/utils/resolveConfig');
 jest.mock('../../../../src/providers/kinesis/utils/getEventBuffer');
 
 describe('Analytics Kinesis API: record', () => {
-	const mockEvent: KinesisRecordInput = {
+	const mockRecordInput: KinesisRecordInput = {
 		streamName: 'stream0',
 		partitionKey: 'partition0',
 		data: new Uint8Array([0x01, 0x02, 0xff]),
@@ -26,10 +26,13 @@ describe('Analytics Kinesis API: record', () => {
 	const mockResolveConfig = resolveConfig as jest.Mock;
 	const mockResolveCredentials = resolveCredentials as jest.Mock;
 	const mockGetEventBuffer = getEventBuffer as jest.Mock;
+	const mockIsAnalyticsEnabled = isAnalyticsEnabled as jest.Mock;
 	const mockAppend = jest.fn();
 	const loggerWarnSpy = jest.spyOn(Logger.prototype, 'warn');
+	const loggerDebugSpy = jest.spyOn(Logger.prototype, 'debug');
 
 	beforeEach(() => {
+		mockIsAnalyticsEnabled.mockReturnValue(true);
 		mockResolveConfig.mockReturnValue(mockConfig);
 		mockResolveCredentials.mockReturnValue(
 			Promise.resolve(mockCredentialConfig)
@@ -44,18 +47,19 @@ describe('Analytics Kinesis API: record', () => {
 		mockResolveCredentials.mockReset();
 		mockAppend.mockReset();
 		mockGetEventBuffer.mockReset();
+		mockIsAnalyticsEnabled.mockReset();
 	});
 
 	it('append to event buffer if record provided', async () => {
-		record(mockEvent);
+		record(mockRecordInput);
 		await new Promise(process.nextTick);
 		expect(mockGetEventBuffer).toHaveBeenCalledTimes(1);
 		expect(mockAppend).toBeCalledWith(
 			expect.objectContaining({
 				region: mockConfig.region,
-				streamName: mockEvent.streamName,
-				partitionKey: mockEvent.partitionKey,
-				event: mockEvent.data,
+				streamName: mockRecordInput.streamName,
+				partitionKey: mockRecordInput.partitionKey,
+				event: mockRecordInput.data,
 				retryCount: 0,
 			})
 		);
@@ -64,9 +68,18 @@ describe('Analytics Kinesis API: record', () => {
 	it('logs an error when credentials can not be fetched', async () => {
 		mockResolveCredentials.mockRejectedValue(new Error('Mock Error'));
 
-		record(mockEvent);
+		record(mockRecordInput);
 
 		await new Promise(process.nextTick);
 		expect(loggerWarnSpy).toBeCalledWith(expect.any(String), expect.any(Error));
+	});
+
+	it('logs and skip the event recoding if Analytics plugin is not enabled', async () => {
+		mockIsAnalyticsEnabled.mockReturnValue(false);
+		record(mockRecordInput);
+		await new Promise(process.nextTick);
+		expect(loggerDebugSpy).toBeCalledWith(expect.any(String));
+		expect(mockGetEventBuffer).not.toBeCalled();
+		expect(mockAppend).not.toBeCalled();
 	});
 });

--- a/packages/analytics/src/providers/kinesis-firehose/apis/record.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/apis/record.ts
@@ -2,7 +2,39 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { RecordInput } from '../types';
+import { getEventBuffer, resolveConfig } from '../utils';
+import { resolveCredentials } from '../../../utils';
+import { fromUtf8 } from '@smithy/util-utf8';
+import { ConsoleLogger as Logger } from '@aws-amplify/core/lib/Logger';
 
-export const record = (input: RecordInput): void => {
-	throw new Error('Not Yet Implemented');
+const logger = new Logger('KinesisFirehose');
+
+export const record = ({ streamName, data }: RecordInput): void => {
+	const timestamp = Date.now();
+	const { region, bufferSize, flushSize, flushInterval, resendLimit } =
+		resolveConfig();
+
+	resolveCredentials()
+		.then(({ credentials, identityId }) => {
+			const buffer = getEventBuffer({
+				region,
+				credentials,
+				identityId,
+				bufferSize,
+				flushSize,
+				flushInterval,
+				resendLimit,
+			});
+
+			buffer.append({
+				region,
+				streamName,
+				event: ArrayBuffer.isView(data) ? data : fromUtf8(JSON.stringify(data)),
+				timestamp,
+				retryCount: 0,
+			});
+		})
+		.catch(e => {
+			logger.warn('Failed to record event.', e);
+		});
 };

--- a/packages/analytics/src/providers/kinesis-firehose/apis/record.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/apis/record.ts
@@ -3,13 +3,18 @@
 
 import { RecordInput } from '../types';
 import { getEventBuffer, resolveConfig } from '../utils';
-import { resolveCredentials } from '../../../utils';
+import { isAnalyticsEnabled, resolveCredentials } from '../../../utils';
 import { fromUtf8 } from '@smithy/util-utf8';
-import { ConsoleLogger as Logger } from '@aws-amplify/core/lib/Logger';
+import { ConsoleLogger as Logger } from '@aws-amplify/core/internals/utils';
 
 const logger = new Logger('KinesisFirehose');
 
 export const record = ({ streamName, data }: RecordInput): void => {
+	if (!isAnalyticsEnabled()) {
+		logger.debug('Analytics is disabled, event will not be recorded.');
+		return;
+	}
+
 	const timestamp = Date.now();
 	const { region, bufferSize, flushSize, flushInterval, resendLimit } =
 		resolveConfig();

--- a/packages/analytics/src/providers/kinesis-firehose/types/buffer.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/types/buffer.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { EventBufferConfig } from '../../../utils';
+import { KinesisStream } from '../../../types';
+import { Credentials } from '@aws-sdk/types';
+
+export type KinesisFirehoseBufferEvent = KinesisStream & {
+	event: Uint8Array;
+	retryCount: number;
+	timestamp: number;
+};
+
+export type KinesisFirehoseEventBufferConfig = EventBufferConfig & {
+	region: string;
+	credentials: Credentials;
+	identityId?: string;
+	resendLimit?: number;
+	userAgentValue?: string;
+};

--- a/packages/analytics/src/providers/kinesis-firehose/types/index.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/types/index.ts
@@ -2,3 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { RecordInput } from './inputs';
+
+export {
+	KinesisFirehoseBufferEvent,
+	KinesisFirehoseEventBufferConfig,
+} from './buffer';

--- a/packages/analytics/src/providers/kinesis-firehose/types/inputs.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/types/inputs.ts
@@ -1,4 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export type RecordInput = {};
+import { KinesisEventData } from '../../../types';
+
+export type RecordInput = {
+	streamName: string;
+	data: KinesisEventData;
+};

--- a/packages/analytics/src/providers/kinesis-firehose/utils/constants.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/utils/constants.ts
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const DEFAULT_KINESIS_FIREHOSE_CONFIG = {
+	bufferSize: 1_000,
+	flushSize: 100,
+	flushInterval: 5_000,
+	resendLimit: 5,
+};

--- a/packages/analytics/src/providers/kinesis-firehose/utils/getEventBuffer.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/utils/getEventBuffer.ts
@@ -11,6 +11,14 @@ import {
 	KinesisFirehoseEventBufferConfig,
 } from '../types';
 
+/**
+ * These Records hold cached event buffers and AWS clients.
+ * The hash key is determined by the region and session,
+ * consisting of a combined value comprising [region, sessionToken, identityId].
+ *
+ * Only one active session should exist at any given moment.
+ * When a new session is initiated, the previous ones should be released.
+ * */
 const eventBufferMap: Record<
 	string,
 	EventBuffer<KinesisFirehoseBufferEvent>

--- a/packages/analytics/src/providers/kinesis-firehose/utils/getEventBuffer.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/utils/getEventBuffer.ts
@@ -1,0 +1,108 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { EventBuffer, groupBy, IAnalyticsClient } from '../../../utils';
+import {
+	FirehoseClient,
+	PutRecordBatchCommand,
+} from '@aws-sdk/client-firehose';
+import {
+	KinesisFirehoseBufferEvent,
+	KinesisFirehoseEventBufferConfig,
+} from '../types';
+
+const eventBufferMap: Record<
+	string,
+	EventBuffer<KinesisFirehoseBufferEvent>
+> = {};
+const cachedClients: Record<string, FirehoseClient> = {};
+
+const createPutRecordsBatchCommand = (
+	streamName: string,
+	events: KinesisFirehoseBufferEvent[]
+): PutRecordBatchCommand =>
+	new PutRecordBatchCommand({
+		DeliveryStreamName: streamName,
+		Records: events.map(event => ({
+			Data: event.event,
+		})),
+	});
+
+const submitEvents = async (
+	events: KinesisFirehoseBufferEvent[],
+	client: FirehoseClient,
+	resendLimit?: number
+): Promise<KinesisFirehoseBufferEvent[]> => {
+	const groupedByStreamName = Object.entries(
+		groupBy(event => event.streamName, events)
+	);
+
+	const requests = groupedByStreamName
+		.map(([streamName, events]) =>
+			createPutRecordsBatchCommand(streamName, events)
+		)
+		.map(command => client.send(command));
+
+	const responses = await Promise.allSettled(requests);
+	const failedEvents = responses
+		.map((response, i) =>
+			response.status === 'rejected' ? groupedByStreamName[i][1] : []
+		)
+		.flat();
+	return resendLimit
+		? failedEvents
+				.filter(event => event.retryCount < resendLimit)
+				.map(event => ({ ...event, retryCount: event.retryCount + 1 }))
+				.sort((a, b) => a.timestamp - b.timestamp)
+		: [];
+};
+
+export const getEventBuffer = ({
+	region,
+	credentials,
+	identityId,
+	bufferSize,
+	flushSize,
+	flushInterval,
+	resendLimit,
+}: KinesisFirehoseEventBufferConfig): EventBuffer<KinesisFirehoseBufferEvent> => {
+	const { sessionToken } = credentials;
+	const sessionIdentityKey = [region, sessionToken, identityId]
+		.filter(id => !!id)
+		.join('-');
+
+	if (!eventBufferMap[sessionIdentityKey]) {
+		const getClient = (): IAnalyticsClient<KinesisFirehoseBufferEvent> => {
+			if (!cachedClients[sessionIdentityKey]) {
+				cachedClients[sessionIdentityKey] = new FirehoseClient({
+					region,
+					credentials,
+				});
+			}
+
+			const firehoseClient = cachedClients[sessionIdentityKey];
+			return events => submitEvents(events, firehoseClient, resendLimit);
+		};
+
+		eventBufferMap[sessionIdentityKey] =
+			new EventBuffer<KinesisFirehoseBufferEvent>(
+				{
+					bufferSize,
+					flushSize,
+					flushInterval,
+				},
+				getClient
+			);
+
+		const releaseSessionKeys = Object.keys(eventBufferMap).filter(
+			key => key !== sessionIdentityKey
+		);
+		for (const releaseSessionKey of releaseSessionKeys) {
+			eventBufferMap[releaseSessionKey].release();
+			delete eventBufferMap[releaseSessionKey];
+			delete cachedClients[releaseSessionKey];
+		}
+	}
+
+	return eventBufferMap[sessionIdentityKey];
+};

--- a/packages/analytics/src/providers/kinesis-firehose/utils/index.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/utils/index.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { getEventBuffer } from './getEventBuffer';
+export { resolveConfig } from './resolveConfig';

--- a/packages/analytics/src/providers/kinesis-firehose/utils/resolveConfig.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/utils/resolveConfig.ts
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+import {
+	AnalyticsValidationErrorCode,
+	assertValidationError,
+} from '../../../errors';
+import { DEFAULT_KINESIS_FIREHOSE_CONFIG } from './constants';
+
+export const resolveConfig = () => {
+	const config = Amplify.getConfig().Analytics?.KinesisFirehose;
+	const {
+		region,
+		bufferSize = DEFAULT_KINESIS_FIREHOSE_CONFIG.bufferSize,
+		flushSize = DEFAULT_KINESIS_FIREHOSE_CONFIG.flushSize,
+		flushInterval = DEFAULT_KINESIS_FIREHOSE_CONFIG.flushInterval,
+		resendLimit,
+	} = {
+		...DEFAULT_KINESIS_FIREHOSE_CONFIG,
+		...config,
+	};
+
+	assertValidationError(!!region, AnalyticsValidationErrorCode.NoRegion);
+	assertValidationError(
+		flushSize < bufferSize,
+		AnalyticsValidationErrorCode.InvalidFlushSize
+	);
+	return {
+		region,
+		bufferSize,
+		flushSize,
+		flushInterval,
+		resendLimit,
+	};
+};

--- a/packages/analytics/src/providers/kinesis/apis/record.ts
+++ b/packages/analytics/src/providers/kinesis/apis/record.ts
@@ -4,9 +4,9 @@
 import { RecordInput } from '../types';
 import { getEventBuffer } from '../utils/getEventBuffer';
 import { resolveConfig } from '../utils/resolveConfig';
-import { resolveCredentials } from '../../../utils';
+import { isAnalyticsEnabled, resolveCredentials } from '../../../utils';
 import { fromUtf8 } from '@smithy/util-utf8';
-import { ConsoleLogger } from '@aws-amplify/core/lib/Logger';
+import { ConsoleLogger } from '@aws-amplify/core/internals/utils';
 
 const logger = new ConsoleLogger('Kinesis');
 
@@ -15,6 +15,11 @@ export const record = ({
 	partitionKey,
 	data,
 }: RecordInput): void => {
+	if (!isAnalyticsEnabled()) {
+		logger.debug('Analytics is disabled, event will not be recorded.');
+		return;
+	}
+
 	const timestamp = Date.now();
 	const { region, bufferSize, flushSize, flushInterval, resendLimit } =
 		resolveConfig();

--- a/packages/analytics/src/providers/kinesis/types/index.ts
+++ b/packages/analytics/src/providers/kinesis/types/index.ts
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export { RecordInput, KinesisEvent } from './inputs';
+export { RecordInput } from './inputs';
 export { KinesisBufferEvent, KinesisEventBufferConfig } from './buffer';

--- a/packages/analytics/src/providers/kinesis/types/inputs.ts
+++ b/packages/analytics/src/providers/kinesis/types/inputs.ts
@@ -3,10 +3,8 @@
 
 import { KinesisEventData } from '../../../types';
 
-export type KinesisEvent = {
+export type RecordInput = {
 	streamName: string;
 	partitionKey: string;
 	data: KinesisEventData;
 };
-
-export type RecordInput = KinesisEvent;

--- a/packages/analytics/src/utils/eventBuffer/EventBuffer.ts
+++ b/packages/analytics/src/utils/eventBuffer/EventBuffer.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ConsoleLogger } from '@aws-amplify/core/lib/Logger';
+import { ConsoleLogger } from '@aws-amplify/core/internals/utils';
 import { EventBufferConfig, IAnalyticsClient } from './';
 
 const logger = new ConsoleLogger('EventBuffer');

--- a/packages/aws-amplify/__tests__/exports.test.ts
+++ b/packages/aws-amplify/__tests__/exports.test.ts
@@ -8,6 +8,7 @@ import * as authCognitoExports from '../src/auth/cognito';
 import * as analyticsTopLevelExports from '../src/analytics';
 import * as analyticsPinpointExports from '../src/analytics/pinpoint';
 import * as analyticsKinesisExports from '../src/analytics/kinesis';
+import * as analyticsKinesisFirehoseExports from '../src/analytics/kinesis-firehose';
 import * as storageTopLevelExports from '../src/storage';
 import * as storageS3Exports from '../src/storage/s3';
 
@@ -62,6 +63,15 @@ describe('aws-amplify Exports', () => {
 
 		it('should only export expected symbols from the Kinesis provider', () => {
 			expect(Object.keys(analyticsKinesisExports)).toMatchInlineSnapshot(`
+			Array [
+			  "record",
+			]
+			`);
+		});
+
+		it('should only export expected symbols from the Kinesis Firehose provider', () => {
+			expect(Object.keys(analyticsKinesisFirehoseExports))
+				.toMatchInlineSnapshot(`
 			Array [
 			  "record",
 			]

--- a/packages/core/src/providers/kinesis-firehose/types/index.ts
+++ b/packages/core/src/providers/kinesis-firehose/types/index.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { KinesisFirehoseProviderConfig } from './kinesis-firehose';

--- a/packages/core/src/providers/kinesis-firehose/types/kinesis-firehose.ts
+++ b/packages/core/src/providers/kinesis-firehose/types/kinesis-firehose.ts
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export type KinesisFirehoseProviderConfig = {
+	KinesisFirehose?: {
+		region: string;
+		bufferSize?: number;
+		flushSize?: number;
+		flushInterval?: number;
+		resendLimit?: number;
+	};
+};

--- a/packages/core/src/singleton/Analytics/types.ts
+++ b/packages/core/src/singleton/Analytics/types.ts
@@ -3,5 +3,8 @@
 
 import { PinpointProviderConfig } from '../../providers/pinpoint/types';
 import { KinesisProviderConfig } from '../../providers/kinesis/types';
+import { KinesisFirehoseProviderConfig } from '../../providers/kinesis-firehose/types';
 
-export type AnalyticsConfig = PinpointProviderConfig & KinesisProviderConfig;
+export type AnalyticsConfig = PinpointProviderConfig &
+	KinesisProviderConfig &
+	KinesisFirehoseProviderConfig;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Add `record` API for Analytics service provider Kinesis Data Firehose.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
