### PR TITLE
feat(analytics): add record API for Analytics service provider Personalize

### DIFF
--- a/packages/analytics/__tests__/providers/kinesis-firehose/apis/record.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis-firehose/apis/record.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../../src/providers/kinesis-firehose/utils';
 import { isAnalyticsEnabled, resolveCredentials } from '../../../../src/utils';
 import {
-	mockConfig,
+	mockKinesisConfig,
 	mockCredentialConfig,
 } from '../../../testUtils/mockConstants.test';
 import { record } from '../../../../src/providers/kinesis-firehose';
@@ -33,7 +33,7 @@ describe('Analytics KinesisFirehose API: record', () => {
 
 	beforeEach(() => {
 		mockIsAnalyticsEnabled.mockReturnValue(true);
-		mockResolveConfig.mockReturnValue(mockConfig);
+		mockResolveConfig.mockReturnValue(mockKinesisConfig);
 		mockResolveCredentials.mockReturnValue(
 			Promise.resolve(mockCredentialConfig)
 		);
@@ -56,7 +56,7 @@ describe('Analytics KinesisFirehose API: record', () => {
 		expect(mockGetEventBuffer).toHaveBeenCalledTimes(1);
 		expect(mockAppend).toBeCalledWith(
 			expect.objectContaining({
-				region: mockConfig.region,
+				region: mockKinesisConfig.region,
 				streamName: mockRecordInput.streamName,
 				event: mockRecordInput.data,
 				retryCount: 0,

--- a/packages/analytics/__tests__/providers/kinesis/apis/record.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis/apis/record.test.ts
@@ -5,7 +5,7 @@ import { getEventBuffer } from '../../../../src/providers/kinesis/utils/getEvent
 import { resolveConfig } from '../../../../src/providers/kinesis/utils/resolveConfig';
 import { isAnalyticsEnabled, resolveCredentials } from '../../../../src/utils';
 import {
-	mockConfig,
+	mockKinesisConfig,
 	mockCredentialConfig,
 } from '../../../testUtils/mockConstants.test';
 import { record } from '../../../../src/providers/kinesis';
@@ -33,7 +33,7 @@ describe('Analytics Kinesis API: record', () => {
 
 	beforeEach(() => {
 		mockIsAnalyticsEnabled.mockReturnValue(true);
-		mockResolveConfig.mockReturnValue(mockConfig);
+		mockResolveConfig.mockReturnValue(mockKinesisConfig);
 		mockResolveCredentials.mockReturnValue(
 			Promise.resolve(mockCredentialConfig)
 		);
@@ -56,7 +56,7 @@ describe('Analytics Kinesis API: record', () => {
 		expect(mockGetEventBuffer).toHaveBeenCalledTimes(1);
 		expect(mockAppend).toBeCalledWith(
 			expect.objectContaining({
-				region: mockConfig.region,
+				region: mockKinesisConfig.region,
 				streamName: mockRecordInput.streamName,
 				partitionKey: mockRecordInput.partitionKey,
 				event: mockRecordInput.data,

--- a/packages/analytics/__tests__/providers/kinesis/utils/getEventBuffer.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis/utils/getEventBuffer.test.ts
@@ -5,7 +5,7 @@ import { getEventBuffer } from '../../../../src/providers/kinesis/utils/getEvent
 import { EventBuffer } from '../../../../src/utils';
 import {
 	mockBufferConfig,
-	mockConfig,
+	mockKinesisConfig,
 	mockCredentialConfig,
 } from '../../../testUtils/mockConstants.test';
 
@@ -20,7 +20,7 @@ describe('Kinesis Provider Util: getEventBuffer', () => {
 
 	it("create a buffer if one doesn't exist", () => {
 		const testBuffer = getEventBuffer({
-			...mockConfig,
+			...mockKinesisConfig,
 			...mockCredentialConfig,
 		});
 
@@ -33,11 +33,11 @@ describe('Kinesis Provider Util: getEventBuffer', () => {
 
 	it('returns an existing buffer instance', () => {
 		const testBuffer1 = getEventBuffer({
-			...mockConfig,
+			...mockKinesisConfig,
 			...mockCredentialConfig,
 		});
 		const testBuffer2 = getEventBuffer({
-			...mockConfig,
+			...mockKinesisConfig,
 			...mockCredentialConfig,
 		});
 		expect(testBuffer1).toBe(testBuffer2);
@@ -45,11 +45,11 @@ describe('Kinesis Provider Util: getEventBuffer', () => {
 
 	it('release other buffers & creates a new one if credential has changed', () => {
 		const testBuffer1 = getEventBuffer({
-			...mockConfig,
+			...mockKinesisConfig,
 			...mockCredentialConfig,
 		});
 		const testBuffer2 = getEventBuffer({
-			...mockConfig,
+			...mockKinesisConfig,
 			...mockCredentialConfig,
 			identityId: 'identityId2',
 		});

--- a/packages/analytics/__tests__/providers/personalize/apis/record.test.ts
+++ b/packages/analytics/__tests__/providers/personalize/apis/record.test.ts
@@ -1,0 +1,218 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import {
+	autoTrackMedia,
+	getEventBuffer,
+	resolveCachedSession,
+	resolveConfig,
+	updateCachedSession,
+} from '../../../../src/providers/personalize/utils';
+import { isAnalyticsEnabled, resolveCredentials } from '../../../../src/utils';
+import {
+	mockCredentialConfig,
+	mockPersonalizeConfig,
+} from '../../../testUtils/mockConstants.test';
+import { record } from '../../../../src/providers/personalize';
+import { ConsoleLogger as Logger } from '@aws-amplify/core/internals/utils';
+import { RecordInput as PersonalizeRecordInput } from '../../../../src/providers/personalize/types';
+import {
+	IDENTIFY_EVENT_TYPE,
+	MEDIA_AUTO_TRACK_EVENT_TYPE,
+} from '../../../../src/providers/personalize/utils/constants';
+
+jest.mock('../../../../src/utils');
+jest.mock('../../../../src/providers/personalize/utils');
+
+describe('Analytics Personalize API: record', () => {
+	const mockRecordInput: PersonalizeRecordInput = {
+		eventType: 'eventType0',
+		properties: {
+			property0: 0,
+			property1: '1',
+		},
+	};
+
+	const mockCachedSession = {
+		sessionId: 'sessionId0',
+		userId: 'userId0',
+	};
+
+	const mockResolveConfig = resolveConfig as jest.Mock;
+	const mockResolveCredentials = resolveCredentials as jest.Mock;
+	const mockIsAnalyticsEnabled = isAnalyticsEnabled as jest.Mock;
+	const mockResolveCachedSession = resolveCachedSession as jest.Mock;
+	const mockUpdateCachedSession = updateCachedSession as jest.Mock;
+	const mockAutoTrackMedia = autoTrackMedia as jest.Mock;
+	const mockGetEventBuffer = getEventBuffer as jest.Mock;
+	const mockAppend = jest.fn();
+	const loggerWarnSpy = jest.spyOn(Logger.prototype, 'warn');
+	const loggerDebugSpy = jest.spyOn(Logger.prototype, 'debug');
+	const mockEventBuffer = {
+		append: mockAppend,
+	};
+	beforeEach(() => {
+		mockIsAnalyticsEnabled.mockReturnValue(true);
+		mockResolveConfig.mockReturnValue(mockPersonalizeConfig);
+		mockResolveCachedSession.mockReturnValue(mockCachedSession);
+		mockResolveCredentials.mockReturnValue(
+			Promise.resolve(mockCredentialConfig)
+		);
+		mockGetEventBuffer.mockImplementation(() => mockEventBuffer);
+	});
+
+	afterEach(() => {
+		mockResolveConfig.mockReset();
+		mockResolveCredentials.mockReset();
+		mockResolveCachedSession.mockReset();
+		mockUpdateCachedSession.mockReset();
+		mockAutoTrackMedia.mockReset();
+		mockAppend.mockReset();
+		mockGetEventBuffer.mockReset();
+		mockIsAnalyticsEnabled.mockReset();
+	});
+
+	it('append to event buffer if record provided', async () => {
+		record(mockRecordInput);
+		await new Promise(process.nextTick);
+		expect(mockGetEventBuffer).toHaveBeenCalledTimes(1);
+		expect(mockAppend).toBeCalledWith(
+			expect.objectContaining({
+				trackingId: mockPersonalizeConfig.trackingId,
+				...mockCachedSession,
+				event: mockRecordInput,
+			})
+		);
+	});
+
+	it('triggers updateCachedSession if eventType is identity event', async () => {
+		const newSession = {
+			sessionId: 'sessionId1',
+			userId: 'userId1',
+		};
+		mockResolveCachedSession
+			.mockReturnValueOnce(mockCachedSession)
+			.mockReturnValueOnce(newSession);
+
+		const updatedMockRecordInput = {
+			...mockRecordInput,
+			eventType: IDENTIFY_EVENT_TYPE,
+			properties: {
+				...mockRecordInput.properties,
+				userId: newSession.userId,
+			},
+		};
+		record(updatedMockRecordInput);
+
+		await new Promise(process.nextTick);
+		expect(mockGetEventBuffer).toHaveBeenCalledTimes(1);
+		expect(mockUpdateCachedSession).toBeCalledWith(
+			newSession.userId,
+			mockCachedSession.sessionId,
+			mockCachedSession.userId
+		);
+		expect(mockAppend).toBeCalledWith(
+			expect.objectContaining({
+				trackingId: mockPersonalizeConfig.trackingId,
+				...newSession,
+				event: updatedMockRecordInput,
+			})
+		);
+	});
+
+	it('triggers updateCachedSession if userId is non-empty in RecordInput', async () => {
+		const newSession = {
+			sessionId: 'sessionId1',
+			userId: 'userId1',
+		};
+		mockResolveCachedSession
+			.mockReturnValueOnce(mockCachedSession)
+			.mockReturnValueOnce(newSession);
+
+		const updatedMockRecordInput = {
+			...mockRecordInput,
+			userId: newSession.userId,
+		};
+		record(updatedMockRecordInput);
+
+		await new Promise(process.nextTick);
+		expect(mockGetEventBuffer).toHaveBeenCalledTimes(1);
+		expect(mockUpdateCachedSession).toBeCalledWith(
+			newSession.userId,
+			mockCachedSession.sessionId,
+			mockCachedSession.userId
+		);
+		expect(mockAppend).toBeCalledWith(
+			expect.objectContaining({
+				trackingId: mockPersonalizeConfig.trackingId,
+				...newSession,
+				event: mockRecordInput,
+			})
+		);
+	});
+
+	it(`triggers autoTrackMedia if eventType is ${MEDIA_AUTO_TRACK_EVENT_TYPE}`, async () => {
+		const updatedMockRecordInput = {
+			...mockRecordInput,
+			eventType: MEDIA_AUTO_TRACK_EVENT_TYPE,
+		};
+		record(updatedMockRecordInput);
+
+		await new Promise(process.nextTick);
+		expect(mockGetEventBuffer).toHaveBeenCalledTimes(1);
+		expect(mockAutoTrackMedia).toBeCalledWith(
+			{
+				trackingId: mockPersonalizeConfig.trackingId,
+				...mockCachedSession,
+				event: updatedMockRecordInput,
+			},
+			mockEventBuffer
+		);
+		expect(mockAppend).not.toBeCalled();
+	});
+
+	it('flushEvents when buffer size is full', async () => {
+		const mockFlushAll = jest.fn();
+		const mockGetLength = jest.fn();
+		const updatedMockEventBuffer = {
+			...mockEventBuffer,
+			flushAll: mockFlushAll,
+		};
+		Object.defineProperty(updatedMockEventBuffer, 'length', {
+			get: mockGetLength,
+		});
+
+		mockGetLength.mockReturnValue(mockPersonalizeConfig.flushSize + 1);
+		mockGetEventBuffer.mockImplementation(() => updatedMockEventBuffer);
+
+		record(mockRecordInput);
+		await new Promise(process.nextTick);
+		expect(mockGetEventBuffer).toHaveBeenCalledTimes(1);
+		expect(mockAppend).toBeCalledWith(
+			expect.objectContaining({
+				trackingId: mockPersonalizeConfig.trackingId,
+				...mockCachedSession,
+				event: mockRecordInput,
+			})
+		);
+		expect(mockGetLength).toHaveBeenCalledTimes(1);
+		expect(mockFlushAll).toHaveBeenCalledTimes(1);
+	});
+
+	it('logs an error when credentials can not be fetched', async () => {
+		mockResolveCredentials.mockRejectedValue(new Error('Mock Error'));
+
+		record(mockRecordInput);
+
+		await new Promise(process.nextTick);
+		expect(loggerWarnSpy).toBeCalledWith(expect.any(String), expect.any(Error));
+	});
+
+	it('logs and skip the event recoding if Analytics plugin is not enabled', async () => {
+		mockIsAnalyticsEnabled.mockReturnValue(false);
+		record(mockRecordInput);
+		await new Promise(process.nextTick);
+		expect(loggerDebugSpy).toBeCalledWith(expect.any(String));
+		expect(mockGetEventBuffer).not.toBeCalled();
+		expect(mockAppend).not.toBeCalled();
+	});
+});

--- a/packages/analytics/__tests__/providers/personalize/utils/cachedSession.test.ts
+++ b/packages/analytics/__tests__/providers/personalize/utils/cachedSession.test.ts
@@ -1,0 +1,115 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Cache, BrowserStorageCache } from '@aws-amplify/core';
+import { isBrowser } from '@aws-amplify/core/internals/utils';
+import {
+	resolveCachedSession,
+	updateCachedSession,
+} from '../../../../src/providers/personalize/utils';
+
+jest.mock('@aws-amplify/core');
+jest.mock('@aws-amplify/core/internals/utils');
+
+describe('Analytics service provider Personalize utils: cachedSession', () => {
+	const sessionIdCacheKey = '_awsct_sid.personalize';
+	const userIdCacheKey = '_awsct_uid.personalize';
+	const mockCache = Cache as jest.Mocked<typeof BrowserStorageCache>;
+	const mockIsBrowser = isBrowser as jest.Mock;
+
+	const mockSession = {
+		sessionId: 'sessionId0',
+		userId: 'userId0',
+	};
+
+	const mockCachedStorage = {
+		[userIdCacheKey]: mockSession.userId,
+		[sessionIdCacheKey]: mockSession.sessionId,
+	};
+
+	beforeEach(() => {
+		mockCache.getItem.mockImplementation(key => mockCachedStorage[key]);
+		mockIsBrowser.mockReturnValue(false);
+	});
+
+	afterEach(() => {
+		mockIsBrowser.mockReset();
+		mockCache.getItem.mockReset();
+		mockCache.setItem.mockReset();
+	});
+
+	it('resolve cached session from Cache', () => {
+		const result = resolveCachedSession('trackingId0');
+		expect(result).toStrictEqual(mockSession);
+	});
+
+	it('create a new session if there is no cache', () => {
+		mockCache.getItem.mockImplementation(() => undefined);
+		const result = resolveCachedSession('trackingId0');
+		expect(result.sessionId).not.toBe(mockSession.sessionId);
+		expect(result.sessionId.length).toBeGreaterThan(0);
+		expect(result.userId).toBe(undefined);
+	});
+
+	it('updateCachedSession create a new session if user has changed', () => {
+		updateCachedSession('newUserId', mockSession.sessionId, mockSession.userId);
+		expect(mockCache.setItem).toBeCalledTimes(2);
+		expect(mockCache.setItem).toHaveBeenNthCalledWith(
+			1,
+			sessionIdCacheKey,
+			expect.any(String),
+			expect.any(Object)
+		);
+		expect(mockCache.setItem).toHaveBeenNthCalledWith(
+			2,
+			userIdCacheKey,
+			'newUserId',
+			expect.any(Object)
+		);
+	});
+
+	it('updateCachedSession create a new session if user is signed out', () => {
+		updateCachedSession(undefined, mockSession.sessionId, undefined);
+		expect(mockCache.setItem).toBeCalledTimes(2);
+		expect(mockCache.setItem).toHaveBeenNthCalledWith(
+			1,
+			sessionIdCacheKey,
+			expect.any(String),
+			expect.any(Object)
+		);
+		expect(mockCache.setItem).toHaveBeenNthCalledWith(
+			2,
+			userIdCacheKey,
+			undefined,
+			expect.any(Object)
+		);
+	});
+
+	it('updateCachedSession create a new session if no cached session', () => {
+		updateCachedSession('newUserId', undefined, mockSession.userId);
+		expect(mockCache.setItem).toBeCalledTimes(2);
+		expect(mockCache.setItem).toHaveBeenNthCalledWith(
+			1,
+			sessionIdCacheKey,
+			expect.any(String),
+			expect.any(Object)
+		);
+		expect(mockCache.setItem).toHaveBeenNthCalledWith(
+			2,
+			userIdCacheKey,
+			'newUserId',
+			expect.any(Object)
+		);
+	});
+
+	it('updateCachedSession only updates userId if cached sessionId but no cached userId', () => {
+		updateCachedSession('newUserId', mockSession.sessionId, undefined);
+		expect(mockCache.setItem).toBeCalledTimes(1);
+		expect(mockCache.setItem).toHaveBeenNthCalledWith(
+			1,
+			userIdCacheKey,
+			'newUserId',
+			expect.any(Object)
+		);
+	});
+});

--- a/packages/analytics/__tests__/providers/personalize/utils/getEventBuffer.test.ts
+++ b/packages/analytics/__tests__/providers/personalize/utils/getEventBuffer.test.ts
@@ -1,16 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getEventBuffer } from '../../../../src/providers/kinesis-firehose/utils';
 import { EventBuffer } from '../../../../src/utils';
 import {
 	mockBufferConfig,
-	mockCredentialConfig, mockKinesisConfig,
+	mockKinesisConfig,
+	mockCredentialConfig,
 } from '../../../testUtils/mockConstants.test';
+import { getEventBuffer } from '../../../../src/providers/personalize/utils';
 
 jest.mock('../../../../src/utils');
 
-describe('KinesisFirehose Provider Util: getEventBuffer', () => {
+describe('Personalize Provider Util: getEventBuffer', () => {
 	const mockEventBuffer = EventBuffer as jest.Mock;
 
 	afterEach(() => {

--- a/packages/analytics/__tests__/providers/personalize/utils/resolveConfig.test.ts
+++ b/packages/analytics/__tests__/providers/personalize/utils/resolveConfig.test.ts
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+import { resolveConfig } from '../../../../src/providers/personalize/utils';
+import {
+	DEFAULT_PERSONALIZE_CONFIG,
+	PERSONALIZE_FLUSH_SIZE_MAX,
+} from '../../../../src/providers/personalize/utils';
+
+describe('Analytics Personalize Provider Util: resolveConfig', () => {
+	const providedConfig = {
+		region: 'us-east-1',
+		trackingId: 'trackingId0',
+		flushSize: 10,
+		flushInterval: 1000,
+	};
+
+	const getConfigSpy = jest.spyOn(Amplify, 'getConfig');
+
+	beforeEach(() => {
+		getConfigSpy.mockReset();
+	});
+
+	it('returns required config', () => {
+		getConfigSpy.mockReturnValue({
+			Analytics: { Personalize: providedConfig },
+		});
+
+		expect(resolveConfig()).toStrictEqual({
+			...providedConfig,
+			bufferSize: providedConfig.flushSize + 1,
+		});
+	});
+
+	it('use default config for optional fields', () => {
+		const requiredFields = {
+			region: 'us-east-1',
+			trackingId: 'trackingId1',
+		};
+		getConfigSpy.mockReturnValue({
+			Analytics: { Personalize: requiredFields },
+		});
+
+		expect(resolveConfig()).toStrictEqual({
+			...DEFAULT_PERSONALIZE_CONFIG,
+			region: requiredFields.region,
+			trackingId: requiredFields.trackingId,
+			bufferSize: DEFAULT_PERSONALIZE_CONFIG.flushSize + 1,
+		});
+	});
+
+	it('throws if region is missing', () => {
+		getConfigSpy.mockReturnValue({
+			Analytics: { Personalize: { ...providedConfig, region: undefined } },
+		});
+
+		expect(resolveConfig).toThrow();
+	});
+
+	it('throws if flushSize is larger than max', () => {
+		getConfigSpy.mockReturnValue({
+			Analytics: {
+				Personalize: {
+					...providedConfig,
+					flushSize: PERSONALIZE_FLUSH_SIZE_MAX + 1,
+				},
+			},
+		});
+
+		expect(resolveConfig).toThrow();
+	});
+});

--- a/packages/analytics/__tests__/testUtils/mockConstants.test.ts
+++ b/packages/analytics/__tests__/testUtils/mockConstants.test.ts
@@ -7,9 +7,16 @@ export const mockBufferConfig = {
 	flushInterval: 50,
 };
 
-export const mockConfig = {
+export const mockKinesisConfig = {
 	...mockBufferConfig,
 	region: 'us-east-1',
+};
+
+export const mockPersonalizeConfig = {
+	...mockBufferConfig,
+	bufferSize: mockBufferConfig.flushSize + 1,
+	region: 'us-east-1',
+	trackingId: 'trackingId0',
 };
 
 export const mockCredentialConfig = {

--- a/packages/analytics/src/errors/assertValidationError.ts
+++ b/packages/analytics/src/errors/assertValidationError.ts
@@ -9,11 +9,17 @@ import { AnalyticsValidationErrorCode, validationErrorMap } from './validation';
  */
 export function assertValidationError(
 	assertion: boolean,
-	name: AnalyticsValidationErrorCode
+	name: AnalyticsValidationErrorCode,
+	message?: string
 ): asserts assertion {
-	const { message, recoverySuggestion } = validationErrorMap[name];
+	const { message: defaultMessage, recoverySuggestion } =
+		validationErrorMap[name];
 
 	if (!assertion) {
-		throw new AnalyticsError({ name, message, recoverySuggestion });
+		throw new AnalyticsError({
+			name,
+			message: message ?? defaultMessage,
+			recoverySuggestion,
+		});
 	}
 }

--- a/packages/analytics/src/errors/validation.ts
+++ b/packages/analytics/src/errors/validation.ts
@@ -8,6 +8,7 @@ export enum AnalyticsValidationErrorCode {
 	NoCredentials = 'NoCredentials',
 	NoEventName = 'NoEventName',
 	NoRegion = 'NoRegion',
+	NoTrackingId = 'NoTrackingId',
 	InvalidFlushSize = 'InvalidFlushSize',
 }
 
@@ -26,6 +27,10 @@ export const validationErrorMap: AmplifyErrorMap<AnalyticsValidationErrorCode> =
 			message: 'Missing region.',
 		},
 		[AnalyticsValidationErrorCode.InvalidFlushSize]: {
-			message: 'Invalid FlushSize, it should smaller than BufferSize',
+			message: 'Invalid FlushSize, it should be smaller than BufferSize',
+		},
+		[AnalyticsValidationErrorCode.NoTrackingId]: {
+			message:
+				'a trackingId field is required for using AmazonPersonalize provider',
 		},
 	};

--- a/packages/analytics/src/errors/validation.ts
+++ b/packages/analytics/src/errors/validation.ts
@@ -30,7 +30,6 @@ export const validationErrorMap: AmplifyErrorMap<AnalyticsValidationErrorCode> =
 			message: 'Invalid FlushSize, it should be smaller than BufferSize',
 		},
 		[AnalyticsValidationErrorCode.NoTrackingId]: {
-			message:
-				'a trackingId field is required for using AmazonPersonalize provider',
+			message: 'A trackingId is required to use Amazon Personalize',
 		},
 	};

--- a/packages/analytics/src/providers/personalize/apis/record.ts
+++ b/packages/analytics/src/providers/personalize/apis/record.ts
@@ -3,17 +3,18 @@
 
 import { RecordInput } from '../types';
 import {
+	autoTrackMedia,
 	getEventBuffer,
 	resolveCachedSession,
 	resolveConfig,
 	updateCachedSession,
 } from '../utils';
-import { resolveCredentials } from '../../../utils';
-import { ConsoleLogger } from '@aws-amplify/core/lib/Logger';
-import { autoTrackMedia } from '../utils/autoTrackMedia';
-
-const IDENTIFY_EVENT_TYPE = 'Identify';
-const MEDIA_AUTO_TRACK_EVENT_TYPE = 'MediaAutoTrack';
+import { isAnalyticsEnabled, resolveCredentials } from '../../../utils';
+import { ConsoleLogger } from '@aws-amplify/core/internals/utils';
+import {
+	IDENTIFY_EVENT_TYPE,
+	MEDIA_AUTO_TRACK_EVENT_TYPE,
+} from '../utils/constants';
 
 const logger = new ConsoleLogger('Personalize');
 
@@ -23,6 +24,11 @@ export const record = ({
 	eventType,
 	properties,
 }: RecordInput): void => {
+	if (!isAnalyticsEnabled()) {
+		logger.debug('Analytics is disabled, event will not be recorded.');
+		return;
+	}
+
 	const { region, trackingId, bufferSize, flushSize, flushInterval } =
 		resolveConfig();
 	resolveCredentials()

--- a/packages/analytics/src/providers/personalize/apis/record.ts
+++ b/packages/analytics/src/providers/personalize/apis/record.ts
@@ -2,7 +2,89 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { RecordInput } from '../types';
+import {
+	getEventBuffer,
+	resolveCachedSession,
+	resolveConfig,
+	updateCachedSession,
+} from '../utils';
+import { resolveCredentials } from '../../../utils';
+import { ConsoleLogger } from '@aws-amplify/core/lib/Logger';
+import { autoTrackMedia } from '../utils/autoTrackMedia';
 
-export const record = (input: RecordInput): void => {
-	throw new Error('Not Yet Implemented');
+const IDENTIFY_EVENT_TYPE = 'Identify';
+const MEDIA_AUTO_TRACK_EVENT_TYPE = 'MediaAutoTrack';
+
+const logger = new ConsoleLogger('Personalize');
+
+export const record = ({
+	userId,
+	eventId,
+	eventType,
+	properties,
+}: RecordInput): void => {
+	const { region, trackingId, bufferSize, flushSize, flushInterval } =
+		resolveConfig();
+	resolveCredentials()
+		.then(({ credentials, identityId }) => {
+			const timestamp = Date.now();
+			const { sessionId: cachedSessionId, userId: cachedUserId } =
+				resolveCachedSession(trackingId);
+			if (eventType === IDENTIFY_EVENT_TYPE) {
+				updateCachedSession(
+					typeof properties.userId === 'string' ? properties.userId : '',
+					cachedSessionId,
+					cachedUserId
+				);
+			} else if (!!userId) {
+				updateCachedSession(userId, cachedSessionId, cachedUserId);
+			}
+
+			const { sessionId: updatedSessionId, userId: updatedUserId } =
+				resolveCachedSession(trackingId);
+
+			const eventBuffer = getEventBuffer({
+				region,
+				flushSize,
+				flushInterval,
+				bufferSize,
+				credentials,
+				identityId,
+			});
+
+			if (eventType === MEDIA_AUTO_TRACK_EVENT_TYPE) {
+				autoTrackMedia(
+					{
+						trackingId,
+						sessionId: updatedSessionId,
+						userId: updatedUserId,
+						event: {
+							eventId,
+							eventType,
+							properties,
+						},
+					},
+					eventBuffer
+				);
+			} else {
+				eventBuffer.append({
+					trackingId,
+					sessionId: updatedSessionId,
+					userId: updatedUserId,
+					event: {
+						eventId,
+						eventType,
+						properties,
+					},
+					timestamp,
+				});
+			}
+
+			if (eventBuffer.length >= bufferSize) {
+				eventBuffer.flushAll();
+			}
+		})
+		.catch(e => {
+			logger.warn('Failed to record event.', e);
+		});
 };

--- a/packages/analytics/src/providers/personalize/types/buffer.ts
+++ b/packages/analytics/src/providers/personalize/types/buffer.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PersonalizeEvent } from './';
+import { EventBufferConfig } from '../../../utils/eventBuffer';
+import { AuthSession } from '@aws-amplify/core/src/singleton/Auth/types';
+
+export type PersonalizeBufferEvent = {
+	trackingId: string;
+	sessionId?: string;
+	userId?: string;
+	event: PersonalizeEvent;
+	timestamp: number;
+};
+
+export type PersonalizeBufferConfig = EventBufferConfig & {
+	region: string;
+	credentials: Required<AuthSession>['credentials'];
+	identityId: AuthSession['identityId'];
+};

--- a/packages/analytics/src/providers/personalize/types/index.ts
+++ b/packages/analytics/src/providers/personalize/types/index.ts
@@ -1,4 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export { RecordInput } from './inputs';
+export { RecordInput, PersonalizeEvent } from './inputs';
+export { PersonalizeBufferEvent, PersonalizeBufferConfig } from './buffer';

--- a/packages/analytics/src/providers/personalize/types/inputs.ts
+++ b/packages/analytics/src/providers/personalize/types/inputs.ts
@@ -1,4 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export type RecordInput = {};
+export type PersonalizeEvent = {
+	userId?: string;
+	eventId?: string;
+	eventType: string;
+	properties: Record<string, unknown>;
+};
+
+export type RecordInput = PersonalizeEvent;

--- a/packages/analytics/src/providers/personalize/utils/autoTrackMedia.ts
+++ b/packages/analytics/src/providers/personalize/utils/autoTrackMedia.ts
@@ -3,8 +3,7 @@
 
 import { EventBuffer } from '../../../utils';
 import { PersonalizeBufferEvent, PersonalizeEvent } from '../types';
-import { isBrowser } from '@aws-amplify/core/lib/utils';
-import { ConsoleLogger } from '@aws-amplify/core/lib/Logger';
+import { ConsoleLogger, isBrowser } from '@aws-amplify/core/internals/utils';
 
 enum HTML5_MEDIA_EVENT {
 	'PLAY' = 'play',

--- a/packages/analytics/src/providers/personalize/utils/autoTrackMedia.ts
+++ b/packages/analytics/src/providers/personalize/utils/autoTrackMedia.ts
@@ -1,0 +1,228 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { EventBuffer } from '../../../utils';
+import { PersonalizeBufferEvent, PersonalizeEvent } from '../types';
+import { isBrowser } from '@aws-amplify/core/lib/utils';
+import { ConsoleLogger } from '@aws-amplify/core/lib/Logger';
+
+enum HTML5_MEDIA_EVENT {
+	'PLAY' = 'play',
+	'PAUSE' = 'pause',
+	'ENDED' = 'Ended',
+}
+
+enum MEDIA_TYPE {
+	'IFRAME' = 'IFRAME',
+	'VIDEO' = 'VIDEO',
+	'AUDIO' = 'AUDIO',
+}
+
+enum EVENT_TYPE {
+	'PLAY' = 'Play',
+	'ENDED' = 'Ended',
+	'PAUSE' = 'Pause',
+	'TIME_WATCHED' = 'TimeWatched',
+}
+
+interface IRecordEvent {
+	(eventType: string, properties: Record<string, unknown>): void;
+}
+
+type MediaAutoTrackConfig = {
+	trackingId: string;
+	sessionId: string;
+	userId?: string;
+	event: PersonalizeEvent;
+};
+
+const logger = new ConsoleLogger('MediaAutoTrack');
+
+const startIframeAutoTracking = (
+	element: HTMLElement,
+	recordEvent: IRecordEvent
+) => {
+	let isPlaying = false;
+	let player: any;
+	const mediaProperties = (): Record<string, unknown> => {
+		const duration = Number(parseFloat(player.getDuration()).toFixed(4));
+		const currentTime = Number(parseFloat(player.getCurrentTime()).toFixed(4));
+		return {
+			duration,
+			eventValue: Number((currentTime / duration).toFixed(4)),
+		};
+	};
+
+	const scriptElement = document.createElement('script');
+	scriptElement.type = 'text/javascript';
+	scriptElement.src = 'https://www.youtube.com/iframe_api';
+	document.body.append(scriptElement);
+
+	setInterval(() => {
+		if (isPlaying && player) {
+			recordEvent(EVENT_TYPE.TIME_WATCHED, mediaProperties());
+		}
+	}, 3_000);
+
+	// @ts-ignore
+	window.onYouTubeIframeAPIReady = () => {
+		// @ts-ignore
+		delete window.onYouTubeIframeAPIReady;
+
+		// @ts-ignore
+		player = new window.YT.Player(element.id, {
+			events: {
+				onStateChange: (event: any) => {
+					const iframeEventMapping = {
+						0: EVENT_TYPE.ENDED,
+						1: EVENT_TYPE.PLAY,
+						2: EVENT_TYPE.PAUSE,
+					};
+					// @ts-ignore
+					const eventType = iframeEventMapping[event.data];
+					switch (eventType) {
+						case EVENT_TYPE.ENDED:
+						case EVENT_TYPE.PAUSE:
+							isPlaying = false;
+							break;
+						case EVENT_TYPE.PLAY:
+							isPlaying = true;
+							break;
+					}
+
+					if (eventType) {
+						recordEvent(eventType, mediaProperties());
+					}
+				},
+			},
+		});
+	};
+};
+
+const startHTMLMediaAutoTracking = (
+	element: HTMLMediaElement,
+	recordEvent: IRecordEvent
+) => {
+	let isPlaying = false;
+	const mediaProperties = (): Record<string, unknown> => ({
+		duration: element.duration,
+		eventValue: Number((element.currentTime / element.duration).toFixed(4)),
+	});
+
+	// TODO: don't we need to clear the interval here?
+	setInterval(() => {
+		if (isPlaying) {
+			recordEvent(EVENT_TYPE.TIME_WATCHED, mediaProperties());
+		}
+	}, 3_000);
+	element.addEventListener(HTML5_MEDIA_EVENT.PLAY, () => {
+		isPlaying = true;
+		recordEvent(EVENT_TYPE.PLAY, mediaProperties());
+	});
+
+	element.addEventListener(HTML5_MEDIA_EVENT.PAUSE, () => {
+		isPlaying = false;
+		recordEvent(EVENT_TYPE.PAUSE, mediaProperties());
+	});
+
+	element.addEventListener(HTML5_MEDIA_EVENT.ENDED, () => {
+		isPlaying = false;
+		recordEvent(EVENT_TYPE.ENDED, mediaProperties());
+	});
+};
+
+const checkElementLoaded = (interval: number, maxTries: number) => {
+	let retryCount = 0;
+	const wait = () => new Promise(r => setTimeout(r, interval));
+	const check = async (elementId: string): Promise<boolean> => {
+		if (retryCount >= maxTries) {
+			return false;
+		}
+
+		const domElement = document.getElementById(elementId);
+		if (domElement && domElement.clientHeight) {
+			return true;
+		} else {
+			retryCount += 1;
+			await wait();
+			return await check(elementId);
+		}
+	};
+	return check;
+};
+
+const recordEvent =
+	(
+		config: MediaAutoTrackConfig,
+		eventBuffer: EventBuffer<PersonalizeBufferEvent>
+	): IRecordEvent =>
+	(eventType: string, properties: Record<string, unknown>) => {
+		// override eventType and merge properties
+		eventBuffer.append({
+			...config,
+			event: {
+				...config.event,
+				eventType,
+				properties: {
+					...config.event.properties,
+					...properties,
+				},
+			},
+			timestamp: Date.now(),
+		});
+	};
+
+export const autoTrackMedia = async (
+	config: MediaAutoTrackConfig,
+	eventBuffer: EventBuffer<PersonalizeBufferEvent>
+) => {
+	const { eventType, properties } = config.event;
+	const { domElementId, ...otherProperties } = properties;
+	if (!isBrowser()) {
+		logger.debug(`${eventType} only for browser`);
+		return;
+	}
+
+	if (typeof domElementId === 'string' && !domElementId) {
+		logger.debug(
+			"Missing domElementId field in 'properties' for MediaAutoTrack event type."
+		);
+		return;
+	}
+
+	const elementId = domElementId as string;
+	const isElementLoaded = await checkElementLoaded(500, 5)(elementId);
+	if (isElementLoaded) {
+		const autoTrackConfigWithoutDomElementId = {
+			...config,
+			event: {
+				...config.event,
+				properties: otherProperties,
+			},
+		};
+
+		const element = document.getElementById(elementId);
+		switch (element?.tagName) {
+			case MEDIA_TYPE.IFRAME:
+				startIframeAutoTracking(
+					element,
+					recordEvent(autoTrackConfigWithoutDomElementId, eventBuffer)
+				);
+				break;
+			case MEDIA_TYPE.VIDEO:
+			case MEDIA_TYPE.AUDIO:
+				if (element instanceof HTMLMediaElement) {
+					startHTMLMediaAutoTracking(
+						element,
+						recordEvent(autoTrackConfigWithoutDomElementId, eventBuffer)
+					);
+				}
+				break;
+			default:
+				logger.debug(`Unsupported DOM element tag: ${element?.tagName}`);
+				break;
+		}
+	} else {
+		logger.debug('Cannot find the media element.');
+	}
+};

--- a/packages/analytics/src/providers/personalize/utils/autoTrackMedia.ts
+++ b/packages/analytics/src/providers/personalize/utils/autoTrackMedia.ts
@@ -57,11 +57,13 @@ const startIframeAutoTracking = (
 	scriptElement.src = 'https://www.youtube.com/iframe_api';
 	document.body.append(scriptElement);
 
-	setInterval(() => {
+	const timer = setInterval(() => {
 		if (isPlaying && player) {
 			recordEvent(EVENT_TYPE.TIME_WATCHED, mediaProperties());
 		}
 	}, 3_000);
+
+	element.addEventListener('unload', () => clearInterval(timer));
 
 	// @ts-ignore
 	window.onYouTubeIframeAPIReady = () => {
@@ -108,12 +110,14 @@ const startHTMLMediaAutoTracking = (
 		eventValue: Number((element.currentTime / element.duration).toFixed(4)),
 	});
 
-	// TODO: don't we need to clear the interval here?
-	setInterval(() => {
+	const timer = setInterval(() => {
 		if (isPlaying) {
 			recordEvent(EVENT_TYPE.TIME_WATCHED, mediaProperties());
 		}
 	}, 3_000);
+
+	element.addEventListener('unload', () => clearInterval(timer));
+
 	element.addEventListener(HTML5_MEDIA_EVENT.PLAY, () => {
 		isPlaying = true;
 		recordEvent(EVENT_TYPE.PLAY, mediaProperties());

--- a/packages/analytics/src/providers/personalize/utils/cachedSession.ts
+++ b/packages/analytics/src/providers/personalize/utils/cachedSession.ts
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Cache } from '@aws-amplify/core';
+import { isBrowser } from '@aws-amplify/core/lib/utils';
+import { v4 as uuid } from 'uuid';
+
+const PERSONALIZE_CACHE = '_awsct';
+const PERSONALIZE_CACHE_USERID = '_awsct_uid';
+const PERSONALIZE_CACHE_SESSIONID = '_awsct_sid';
+const DEFAULT_CACHE_PREFIX = 'personalize';
+const TIMER_INTERVAL = 30 * 1000;
+const DELIMITER = '.';
+const CACHE_EXPIRY_IN_DAYS = 7;
+
+const cachePrefix = (key: string): string =>
+	isBrowser() ? key + DELIMITER + window.location.host : DEFAULT_CACHE_PREFIX;
+
+const getCache = (key: string) => Cache.getItem(cachePrefix(key));
+
+const setCache = (key: string, value: unknown) => {
+	const expiredAt = new Date(
+		Date.now() + 3_600_000 * 24 * CACHE_EXPIRY_IN_DAYS
+	);
+	Cache.setItem(cachePrefix(key), value, {
+		expires: expiredAt.getTime(),
+	});
+};
+
+export const resolveCachedSession = (trackingId: string) => {
+	let sessionId: string | undefined = getCache(PERSONALIZE_CACHE_SESSIONID);
+	if (!sessionId) {
+		sessionId = uuid();
+		setCache(PERSONALIZE_CACHE_SESSIONID, sessionId);
+	}
+
+	const userId: string | undefined = getCache(PERSONALIZE_CACHE_USERID);
+
+	return {
+		sessionId,
+		userId,
+	};
+};
+
+export const updateCachedSession = (
+	newUserId: string,
+	currentSessionId: string,
+	currentUserId?: string
+) => {
+	const isNoCachedSession = !currentSessionId;
+	const isSignOutCase = !newUserId && !currentUserId;
+	const isSwitchUserCase =
+		!!newUserId && !!currentUserId && newUserId !== currentUserId;
+
+	const isRequireNewSession =
+		isNoCachedSession || isSignOutCase || isSwitchUserCase;
+	const isRequireUpdateSession =
+		!!currentSessionId && !currentUserId && !!newUserId;
+
+	if (isRequireNewSession) {
+		const newSessionId = uuid();
+		setCache(PERSONALIZE_CACHE_SESSIONID, newSessionId);
+		setCache(PERSONALIZE_CACHE_USERID, newUserId);
+	} else if (isRequireUpdateSession) {
+		setCache(PERSONALIZE_CACHE_USERID, newUserId);
+	}
+};

--- a/packages/analytics/src/providers/personalize/utils/cachedSession.ts
+++ b/packages/analytics/src/providers/personalize/utils/cachedSession.ts
@@ -2,27 +2,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Cache } from '@aws-amplify/core';
-import { isBrowser } from '@aws-amplify/core/lib/utils';
+import { isBrowser } from '@aws-amplify/core/internals/utils';
 import { v4 as uuid } from 'uuid';
 
-const PERSONALIZE_CACHE = '_awsct';
 const PERSONALIZE_CACHE_USERID = '_awsct_uid';
 const PERSONALIZE_CACHE_SESSIONID = '_awsct_sid';
 const DEFAULT_CACHE_PREFIX = 'personalize';
-const TIMER_INTERVAL = 30 * 1000;
 const DELIMITER = '.';
 const CACHE_EXPIRY_IN_DAYS = 7;
 
-const cachePrefix = (key: string): string =>
-	isBrowser() ? key + DELIMITER + window.location.host : DEFAULT_CACHE_PREFIX;
+const normalize = (key: string): string =>
+	[key, isBrowser() ? window.location.host : DEFAULT_CACHE_PREFIX].join(
+		DELIMITER
+	);
 
-const getCache = (key: string) => Cache.getItem(cachePrefix(key));
+const getCache = (key: string) => Cache.getItem(normalize(key));
 
 const setCache = (key: string, value: unknown) => {
 	const expiredAt = new Date(
 		Date.now() + 3_600_000 * 24 * CACHE_EXPIRY_IN_DAYS
 	);
-	Cache.setItem(cachePrefix(key), value, {
+	Cache.setItem(normalize(key), value, {
 		expires: expiredAt.getTime(),
 	});
 };
@@ -43,8 +43,8 @@ export const resolveCachedSession = (trackingId: string) => {
 };
 
 export const updateCachedSession = (
-	newUserId: string,
-	currentSessionId: string,
+	newUserId?: string,
+	currentSessionId?: string,
 	currentUserId?: string
 ) => {
 	const isNoCachedSession = !currentSessionId;

--- a/packages/analytics/src/providers/personalize/utils/constants.ts
+++ b/packages/analytics/src/providers/personalize/utils/constants.ts
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const DEFAULT_PERSONALIZE_CONFIG = {
+	flushSize: 5,
+	flushInterval: 5_000,
+};
+
+export const PERSONALIZE_FLUSH_SIZE_MAX = 10;

--- a/packages/analytics/src/providers/personalize/utils/constants.ts
+++ b/packages/analytics/src/providers/personalize/utils/constants.ts
@@ -7,3 +7,6 @@ export const DEFAULT_PERSONALIZE_CONFIG = {
 };
 
 export const PERSONALIZE_FLUSH_SIZE_MAX = 10;
+
+export const IDENTIFY_EVENT_TYPE = 'Identify';
+export const MEDIA_AUTO_TRACK_EVENT_TYPE = 'MediaAutoTrack';

--- a/packages/analytics/src/providers/personalize/utils/getEventBuffer.ts
+++ b/packages/analytics/src/providers/personalize/utils/getEventBuffer.ts
@@ -1,0 +1,101 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { EventBuffer, groupBy, IAnalyticsClient } from '../../../utils';
+import { PersonalizeBufferConfig, PersonalizeBufferEvent } from '../types';
+import {
+	PersonalizeEventsClient,
+	PutEventsCommand,
+} from '@aws-sdk/client-personalize-events';
+
+const eventBufferMap: Record<string, EventBuffer<PersonalizeBufferEvent>> = {};
+const cachedClients: Record<string, PersonalizeEventsClient> = {};
+
+const DELIMITER = '#';
+
+const createPutEventsCommand = (
+	ids: string,
+	events: PersonalizeBufferEvent[]
+): PutEventsCommand => {
+	const [trackingId, sessionId, userId] = ids.split(DELIMITER);
+	return new PutEventsCommand({
+		trackingId,
+		sessionId,
+		userId,
+		eventList: events.map(event => ({
+			eventId: event.event.eventId,
+			eventType: event.event.eventType,
+			properties: JSON.stringify(event.event.properties),
+			sentAt: new Date(event.timestamp),
+		})),
+	});
+};
+
+const submitEvents = async (
+	events: PersonalizeBufferEvent[],
+	client: PersonalizeEventsClient
+): Promise<PersonalizeBufferEvent[]> => {
+	const groupedByIds = Object.entries(
+		groupBy(
+			event =>
+				[event.trackingId, event.sessionId, event.userId]
+					.filter(id => !!id)
+					.join(DELIMITER),
+			events
+		)
+	);
+
+	const requests = groupedByIds
+		.map(([ids, events]) => createPutEventsCommand(ids, events))
+		.map(command => client.send(command));
+
+	await Promise.allSettled(requests);
+	return Promise.resolve([]);
+};
+
+export const getEventBuffer = ({
+	region,
+	flushSize,
+	flushInterval,
+	bufferSize,
+	credentials,
+	identityId,
+}: PersonalizeBufferConfig): EventBuffer<PersonalizeBufferEvent> => {
+	const { sessionToken } = credentials;
+	const sessionIdentityKey = [region, sessionToken, identityId]
+		.filter(x => !!x)
+		.join('-');
+
+	if (!eventBufferMap[sessionIdentityKey]) {
+		const getClient = (): IAnalyticsClient<PersonalizeBufferEvent> => {
+			if (!cachedClients[sessionIdentityKey]) {
+				cachedClients[sessionIdentityKey] = new PersonalizeEventsClient({
+					region,
+					credentials,
+				});
+			}
+			return events => submitEvents(events, cachedClients[sessionIdentityKey]);
+		};
+
+		eventBufferMap[sessionIdentityKey] =
+			new EventBuffer<PersonalizeBufferEvent>(
+				{
+					bufferSize,
+					flushSize,
+					flushInterval,
+				},
+				getClient
+			);
+
+		const releaseSessionKeys = Object.keys(eventBufferMap).filter(
+			key => key !== sessionIdentityKey
+		);
+		for (const releaseSessionKey of releaseSessionKeys) {
+			eventBufferMap[releaseSessionKey].release();
+			delete eventBufferMap[releaseSessionKey];
+			delete cachedClients[releaseSessionKey];
+		}
+	}
+
+	return eventBufferMap[sessionIdentityKey];
+};

--- a/packages/analytics/src/providers/personalize/utils/getEventBuffer.ts
+++ b/packages/analytics/src/providers/personalize/utils/getEventBuffer.ts
@@ -8,6 +8,14 @@ import {
 	PutEventsCommand,
 } from '@aws-sdk/client-personalize-events';
 
+/**
+ * These Records hold cached event buffers and AWS clients.
+ * The hash key is determined by the region and session,
+ * consisting of a combined value comprising [region, sessionToken, identityId].
+ *
+ * Only one active session should exist at any given moment.
+ * When a new session is initiated, the previous ones should be released.
+ * */
 const eventBufferMap: Record<string, EventBuffer<PersonalizeBufferEvent>> = {};
 const cachedClients: Record<string, PersonalizeEventsClient> = {};
 

--- a/packages/analytics/src/providers/personalize/utils/index.ts
+++ b/packages/analytics/src/providers/personalize/utils/index.ts
@@ -3,6 +3,7 @@
 
 export { getEventBuffer } from './getEventBuffer';
 export { resolveConfig } from './resolveConfig';
+export { autoTrackMedia } from './autoTrackMedia';
 export { resolveCachedSession, updateCachedSession } from './cachedSession';
 export {
 	DEFAULT_PERSONALIZE_CONFIG,

--- a/packages/analytics/src/providers/personalize/utils/index.ts
+++ b/packages/analytics/src/providers/personalize/utils/index.ts
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { getEventBuffer } from './getEventBuffer';
+export { resolveConfig } from './resolveConfig';
+export { resolveCachedSession, updateCachedSession } from './cachedSession';
+export {
+	DEFAULT_PERSONALIZE_CONFIG,
+	PERSONALIZE_FLUSH_SIZE_MAX,
+} from './constants';

--- a/packages/analytics/src/providers/personalize/utils/resolveConfig.ts
+++ b/packages/analytics/src/providers/personalize/utils/resolveConfig.ts
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+import {
+	AnalyticsValidationErrorCode,
+	assertValidationError,
+} from '../../../errors';
+import { DEFAULT_PERSONALIZE_CONFIG, PERSONALIZE_FLUSH_SIZE_MAX } from './';
+
+export const resolveConfig = () => {
+	const config = Amplify.getConfig().Analytics?.Personalize;
+	const {
+		region,
+		trackingId,
+		flushSize = DEFAULT_PERSONALIZE_CONFIG.flushSize,
+		flushInterval = DEFAULT_PERSONALIZE_CONFIG.flushInterval,
+	} = {
+		...DEFAULT_PERSONALIZE_CONFIG,
+		...config,
+	};
+
+	assertValidationError(!!region, AnalyticsValidationErrorCode.NoRegion);
+	assertValidationError(
+		!!trackingId,
+		AnalyticsValidationErrorCode.NoTrackingId
+	);
+	assertValidationError(
+		flushSize <= PERSONALIZE_FLUSH_SIZE_MAX,
+		AnalyticsValidationErrorCode.InvalidFlushSize,
+		`FlushSize for Personalize should be less or equal than ${PERSONALIZE_FLUSH_SIZE_MAX}`
+	);
+
+	return {
+		region,
+		trackingId,
+		bufferSize: flushSize + 1,
+		flushSize,
+		flushInterval,
+	};
+};

--- a/packages/analytics/src/utils/eventBuffer/EventBuffer.ts
+++ b/packages/analytics/src/utils/eventBuffer/EventBuffer.ts
@@ -46,6 +46,10 @@ export class EventBuffer<T> {
 		}
 	}
 
+	public get length() {
+		return this.list.length;
+	}
+
 	private head(count: number) {
 		return this.list.splice(0, count);
 	}

--- a/packages/aws-amplify/__tests__/exports.test.ts
+++ b/packages/aws-amplify/__tests__/exports.test.ts
@@ -9,6 +9,7 @@ import * as analyticsTopLevelExports from '../src/analytics';
 import * as analyticsPinpointExports from '../src/analytics/pinpoint';
 import * as analyticsKinesisExports from '../src/analytics/kinesis';
 import * as analyticsKinesisFirehoseExports from '../src/analytics/kinesis-firehose';
+import * as analyticsPersonalizeExports from '../src/analytics/personalize';
 import * as storageTopLevelExports from '../src/storage';
 import * as storageS3Exports from '../src/storage/s3';
 
@@ -72,6 +73,14 @@ describe('aws-amplify Exports', () => {
 		it('should only export expected symbols from the Kinesis Firehose provider', () => {
 			expect(Object.keys(analyticsKinesisFirehoseExports))
 				.toMatchInlineSnapshot(`
+			Array [
+				"record",
+				]
+			`);
+		});
+
+		it('should only export expected symbols from the Personalize provider', () => {
+			expect(Object.keys(analyticsPersonalizeExports)).toMatchInlineSnapshot(`
 			Array [
 			  "record",
 			]

--- a/packages/aws-amplify/__tests__/exports.test.ts
+++ b/packages/aws-amplify/__tests__/exports.test.ts
@@ -74,8 +74,8 @@ describe('aws-amplify Exports', () => {
 			expect(Object.keys(analyticsKinesisFirehoseExports))
 				.toMatchInlineSnapshot(`
 			Array [
-				"record",
-				]
+			  "record",
+			]
 			`);
 		});
 

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -62,6 +62,11 @@
 			"import": "./lib-esm/analytics/kinesis-firehose/index.js",
 			"require": "./lib/analytics/kinesis-firehose/index.js"
 		},
+		"./analytics/personalize": {
+			"types": "./lib-esm/analytics/personalize/index.d.ts",
+			"import": "./lib-esm/analytics/personalize/index.js",
+			"require": "./lib/analytics/personalize/index.js"
+		},
 		"./storage": {
 			"types": "./lib-esm/storage/index.d.ts",
 			"import": "./lib-esm/storage/index.js",
@@ -138,8 +143,14 @@
 			"analytics/pinpoint": [
 				"./lib-esm/analytics/pinpoint/index.d.ts"
 			],
+			"analytics/kinesis": [
+				"./lib-esm/analytics/kinesis/index.d.ts"
+			],
 			"analytics/kinesis-firehose": [
 				"./lib-esm/analytics/kinesis-firehose/index.d.ts"
+			],
+			"analytics/personalize": [
+				"./lib-esm/analytics/personalize/index.d.ts"
 			],
 			"storage": [
 				"./lib-esm/storage/index.d.ts"

--- a/packages/core/src/providers/personalize/types/index.ts
+++ b/packages/core/src/providers/personalize/types/index.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { PersonalizeProviderConfig } from './personalize';

--- a/packages/core/src/providers/personalize/types/personalize.ts
+++ b/packages/core/src/providers/personalize/types/personalize.ts
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export type PersonalizeProviderConfig = {
+	Personalize?: {
+		trackingId: string;
+		region: string;
+		flushSize?: number;
+		flushInterval?: number;
+	};
+};

--- a/packages/core/src/singleton/Analytics/types.ts
+++ b/packages/core/src/singleton/Analytics/types.ts
@@ -7,5 +7,6 @@ import { KinesisFirehoseProviderConfig } from '../../providers/kinesis-firehose/
 import { PersonalizeProviderConfig } from '../../providers/personalize/types';
 
 export type AnalyticsConfig = PinpointProviderConfig &
-	KinesisProviderConfig & KinesisFirehoseProviderConfig &
+	KinesisProviderConfig &
+	KinesisFirehoseProviderConfig &
 	PersonalizeProviderConfig;

--- a/packages/core/src/singleton/Analytics/types.ts
+++ b/packages/core/src/singleton/Analytics/types.ts
@@ -4,7 +4,8 @@
 import { PinpointProviderConfig } from '../../providers/pinpoint/types';
 import { KinesisProviderConfig } from '../../providers/kinesis/types';
 import { KinesisFirehoseProviderConfig } from '../../providers/kinesis-firehose/types';
+import { PersonalizeProviderConfig } from '../../providers/personalize/types';
 
 export type AnalyticsConfig = PinpointProviderConfig &
-	KinesisProviderConfig &
-	KinesisFirehoseProviderConfig;
+	KinesisProviderConfig & KinesisFirehoseProviderConfig &
+	PersonalizeProviderConfig;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- add `record` API for Analytics service provider Amazon Personalize.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
