### PR TITLE
fix(auth): deleteUser client resp parsing

### DIFF
--- a/packages/auth/src/providers/cognito/apis/deleteUser.ts
+++ b/packages/auth/src/providers/cognito/apis/deleteUser.ts
@@ -24,25 +24,12 @@ export async function deleteUser(): Promise<void> {
 	const { tokens } = await fetchAuthSession();
 	assertAuthTokens(tokens);
 
-	try {
-		await serviceDeleteUser(
-			{ region: getRegion(authConfig.userPoolId) },
-			{
-				AccessToken: tokens.accessToken.toString(),
-			}
-		);
-	} catch (error) {
-		if (
-			error instanceof SyntaxError &&
-			error.message === 'Unexpected end of JSON input'
-		) {
-			// TODO: fix this error and remove try/catch block
-			// this error is caused when parsing empty client response.
-			// Swallow error as a workaround
-		} else {
-			throw error;
+	await serviceDeleteUser(
+		{ region: getRegion(authConfig.userPoolId) },
+		{
+			AccessToken: tokens.accessToken.toString(),
 		}
-	}
+	);
 	await signOut();
 	await tokenOrchestrator.clearDeviceMetadata();
 }

--- a/packages/auth/src/providers/cognito/utils/clients/CognitoIdentityProvider/index.ts
+++ b/packages/auth/src/providers/cognito/utils/clients/CognitoIdentityProvider/index.ts
@@ -118,6 +118,20 @@ const buildUserPoolDeserializer = <Output>(): ((
 	};
 };
 
+const buildDeleteDeserializer = <Output>(): ((
+	response: HttpResponse
+) => Promise<Output>) => {
+	return async (response: HttpResponse): Promise<Output> => {
+		if (response.statusCode >= 300) {
+			const error = await parseJsonError(response);
+			assertServiceError(error);
+			throw new AuthError({ name: error.name, message: error.message });
+		} else {
+			return undefined as any;
+		}
+	};
+};
+
 export const initiateAuth = composeServiceApi(
 	cognitoUserPoolTransferHandler,
 	buildUserPoolSerializer<InitiateAuthInput>('InitiateAuth'),
@@ -216,11 +230,10 @@ export const forgetDevice = composeServiceApi(
 	buildUserPoolDeserializer<ForgetDeviceOutput>(),
 	defaultConfig
 );
-
 export const deleteUser = composeServiceApi(
 	cognitoUserPoolTransferHandler,
 	buildUserPoolSerializer<DeleteUserInput>('DeleteUser'),
-	buildUserPoolDeserializer<DeleteUserOutput>(),
+	buildDeleteDeserializer<DeleteUserOutput>(),
 	defaultConfig
 );
 export const getUserAttributeVerificationCode = composeServiceApi(


### PR DESCRIPTION
#### Description of changes
The DELETE rest API call does not contain a body in the response. Parsing it will cause a `SyntaxError: Unexpected end of JSON input`. Create a separate Deserializer for handling this scenario  

#### Description of how you validated changes
- Success case: calling deleteUser should 
  - Should NOT throw a `SyntaxError: Unexpected end of JSON input` on sampleApp
  - delete the user on cognito console
  - clear deviceToken on `localStore`
  - sign-out successfully, fetchAuthSession() to make sure there aren't any access tokens
- Fail case: provide invalid access token to make sure errors are not swallowed  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
