### PR TITLE
fix(web-browser): pass callbackURLScheme to auth session

### DIFF
--- a/packages/rtn-web-browser/ios/AmplifyRTNWebBrowser.m
+++ b/packages/rtn-web-browser/ios/AmplifyRTNWebBrowser.m
@@ -6,6 +6,7 @@
 @interface RCT_EXTERN_MODULE(AmplifyRTNWebBrowser, NSObject)
 
 RCT_EXTERN_METHOD(openAuthSessionAsync:(NSString*)url
+                  redirectUrlStr:(NSString*)redirectUrlStr
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/packages/rtn-web-browser/ios/AmplifyRTNWebBrowser.swift
+++ b/packages/rtn-web-browser/ios/AmplifyRTNWebBrowser.swift
@@ -22,10 +22,16 @@ class AmplifyRTNWebBrowser: NSObject {
     
     @objc
     func openAuthSessionAsync(_ urlStr: String,
+                              redirectUrlStr: String,
                               resolve: @escaping RCTPromiseResolveBlock,
                               reject: @escaping RCTPromiseRejectBlock) {
         guard let url = URL(string: urlStr) else {
             reject("ERROR", "provided url is invalid", nil)
+            return
+        }
+        
+        guard let redirectUrl = URL(string: redirectUrlStr) else {
+            reject("ERROR", "provided redirectUrl is invalid", nil)
             return
         }
         
@@ -36,7 +42,7 @@ class AmplifyRTNWebBrowser: NSObject {
         
         let authSession = ASWebAuthenticationSession(
             url: url,
-            callbackURLScheme: nil,
+            callbackURLScheme: redirectUrl.scheme,
             completionHandler: { url, error in
                 if (error as? ASWebAuthenticationSessionError)?.code == .canceledLogin {
                     resolve(nil)

--- a/packages/rtn-web-browser/src/types.ts
+++ b/packages/rtn-web-browser/src/types.ts
@@ -2,5 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export type WebBrowserNativeModule = {
-	openAuthSessionAsync: (url: string) => Promise<string | null>;
+	openAuthSessionAsync: (
+		url: string,
+		redirectUrl?: string
+	) => Promise<string | null>;
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR fixes an issue in iOS where deeplinking back to the app is blocked when a redirect scheme is not matched.

#### Description of how you validated changes
* `yarn test`
* Tested in a React Native app on iOS and Android
* Tested in an Expo app on iOS and Android (*not* Expo Go)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
