### PR TITLE
fix(core): change userPoolClientId to userPoolId in assertion

### DIFF
--- a/packages/core/src/singleton/Auth/utils/index.ts
+++ b/packages/core/src/singleton/Auth/utils/index.ts
@@ -28,7 +28,7 @@ export function assertTokenProviderConfig(
 		assertionValid = false;
 	} else {
 		assertionValid =
-			!!cognitoConfig.userPoolClientId && !!cognitoConfig.userPoolClientId;
+			!!cognitoConfig.userPoolId && !!cognitoConfig.userPoolClientId;
 	}
 
 	return assert(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This is a small change in assertion value changing from `cognitoConfig.userPoolClientId`  to `cognitoConfig.userPoolId` to avoid duplicacy in checking.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
