### PR TITLE
fix(auth): clear device metadata when sign out

### DIFF
--- a/packages/auth/__tests__/providers/cognito/signOut.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signOut.test.ts
@@ -15,9 +15,10 @@ const mockRefreshToken = 'abcdefghijk';
 
 describe('signOut tests no oauth happy path', () => {
 	let tokenStoreSpy;
-	let tokenOrchestratorSpy;
+	let clearTokensSpy;
 	let globalSignOutSpy;
 	let revokeTokenSpy;
+	let clearDeviceMetadataSpy;
 
 	beforeEach(() => {
 		Amplify.configure(
@@ -53,8 +54,12 @@ describe('signOut tests no oauth happy path', () => {
 				};
 			});
 
-		tokenOrchestratorSpy = jest
+		clearTokensSpy = jest
 			.spyOn(TokenProvider.tokenOrchestrator, 'clearTokens')
+			.mockImplementation(async () => {});
+
+		clearDeviceMetadataSpy = jest
+			.spyOn(TokenProvider.tokenOrchestrator, 'clearDeviceMetadata')
 			.mockImplementation(async () => {});
 
 		globalSignOutSpy = jest
@@ -78,7 +83,8 @@ describe('signOut tests no oauth happy path', () => {
 			}
 		);
 		expect(globalSignOutSpy).not.toHaveBeenCalled();
-		expect(tokenOrchestratorSpy).toBeCalled();
+		expect(clearTokensSpy).toBeCalled();
+		expect(clearDeviceMetadataSpy).toBeCalled();
 		expect(tokenStoreSpy).toBeCalled();
 	});
 
@@ -94,7 +100,8 @@ describe('signOut tests no oauth happy path', () => {
 			}
 		);
 
-		expect(tokenOrchestratorSpy).toBeCalled();
+		expect(clearTokensSpy).toBeCalled();
+		expect(clearDeviceMetadataSpy).toBeCalled();
 		expect(tokenStoreSpy).toBeCalled();
 	});
 

--- a/packages/auth/src/providers/cognito/apis/signOut.ts
+++ b/packages/auth/src/providers/cognito/apis/signOut.ts
@@ -70,6 +70,7 @@ async function clientSignOut(cognitoConfig: CognitoUserPoolConfig) {
 		// TODO(v6): add logger message
 	} finally {
 		tokenOrchestrator.clearTokens();
+		tokenOrchestrator.clearDeviceMetadata();
 		await clearCredentials();
 	}
 }
@@ -93,6 +94,7 @@ async function globalSignOut(cognitoConfig: CognitoUserPoolConfig) {
 		// TODO(v6): add logger
 	} finally {
 		tokenOrchestrator.clearTokens();
+		tokenOrchestrator.clearDeviceMetadata();
 		await clearCredentials();
 	}
 }


### PR DESCRIPTION
- This caused an issue: after signing out a user who has associated device metadata, when signing in a different user [ResourceNotFoundException: Device does not exist.] would be thrown

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Added call of `clearDeviceMetadata` within the `signOut` flows.

This caused an issue: after signing out a user who has associated device metadata, when signing in a different user [ResourceNotFoundException: Device does not exist.] would be thrown.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* Local testing with a react-native sample app.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
