### PR TITLE
chore(storage): remove File type from uploadInput type

### DIFF
--- a/packages/storage/src/providers/s3/apis/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/index.ts
@@ -26,7 +26,7 @@ import { getMultipartUploadHandlers } from './multipart';
  *
  * @example
  * ```ts
- * // Upload a data to s3 bucket
+ * // Upload data to s3 bucket
  * await uploadData({ key, data, options: {
  *   onProgress, // Optional progress callback.
  * } }).result;

--- a/packages/storage/src/providers/s3/apis/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/index.ts
@@ -26,15 +26,15 @@ import { getMultipartUploadHandlers } from './multipart';
  *
  * @example
  * ```ts
- * // Upload a file to s3 bucket
- * await uploadData({ key, data: file, options: {
+ * // Upload a data to s3 bucket
+ * await uploadData({ key, data, options: {
  *   onProgress, // Optional progress callback.
  * } }).result;
  * ```
  * @example
  * ```ts
  * // Cancel a task
- * const uploadTask = uploadData({ key, data: file });
+ * const uploadTask = uploadData({ key, data });
  * //...
  * uploadTask.cancel();
  * try {
@@ -49,7 +49,7 @@ import { getMultipartUploadHandlers } from './multipart';
  * @example
  * ```ts
  * // Pause and resume a task
- * const uploadTask = uploadData({ key, data: file });
+ * const uploadTask = uploadData({ key, data });
  * //...
  * uploadTask.pause();
  * //...

--- a/packages/storage/src/types/inputs.ts
+++ b/packages/storage/src/types/inputs.ts
@@ -49,4 +49,4 @@ export type StorageCopyInput<
 /**
  * The data payload type for upload operation.
  */
-export type StorageUploadDataPayload = Blob | BufferSource | string | File;
+export type StorageUploadDataPayload = Blob | BufferSource | string;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change involves removing `File` type from `uploadData` api input.

Some Observation while uploading to S3 in WEB (Time take in milliseconds):

Before [Having File Type]
4 MB (Small):  977 ms
100 MB (Medium):   10,265 ms
1 GB (Large):  55,633 ms
10 GB (Very Large):   5,99,674 ms


After [Removing File type]
4 MB (Small):   744 ms
100 MB (Medium):   9,316 ms
1 GB (Large): 54,393 ms
10 GB (Very Large):   6,02,375 ms

 #### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
