### PR TITLE
Bugfix for #11071: Auth.currentUserCredentials() doesn't throw an exc…

### DIFF
--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -1964,7 +1964,9 @@ export class AuthClass {
 				})
 				.catch(() => {
 					logger.debug('getting guest credentials');
-					return this.Credentials.set(null, 'guest');
+					return this.Credentials.set(null, 'guest').catch(error => {
+						throw error;
+					});
 				});
 		}
 	}

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -347,7 +347,7 @@ export class CredentialsClass {
 
 					return this._loadCredentials(credentials, 'guest', false, null);
 				} else {
-					return e;
+					throw e;
 				}
 			});
 	}


### PR DESCRIPTION
…eption on error

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Issue was: Auth.currentUserCredentials() with an incorrect IdentityPoolId in amplify's config did not throw an error, it only returned the error as an object which did not trigger any catch statements in the frontend. This PR should fix that, so that, for the given case of an incorrect IdentityPoolId, the function now throws an error which can be catched.

#### Issue #, if available
https://github.com/aws-amplify/amplify-js/issues/11071


#### Description of how you validated changes
Tested in a test React-Project; tested with: 

 async function toTest() {
    try {
      const credentials = await Auth.currentUserCredentials();
      console.log(credentials);
    } catch (error) {
      console.log("exception:");
      console.error({ error });
    }
  }
...where the catch statement was reached correctly.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] PR description included
- [x ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)
(comment: There was no reference in the docs how this should be catched/what should be returned or at least I have not found anything)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
