### PR TITLE
fix: Fix regression in InternalGraphQL client & broken tests

### DIFF
--- a/packages/api-graphql/__tests__/utils/expects.ts
+++ b/packages/api-graphql/__tests__/utils/expects.ts
@@ -12,6 +12,7 @@ export function expectMutation(
 	item: Record<string, any>
 ) {
 	expect(spy).toHaveBeenCalledWith({
+		abortController: expect.any(AbortController),
 		url: new URL('https://localhost/graphql'),
 		options: expect.objectContaining({
 			headers: expect.objectContaining({ 'X-Api-Key': 'FAKE-KEY' }),
@@ -41,6 +42,7 @@ export function expectGet(
 	item: Record<string, any>
 ) {
 	expect(spy).toHaveBeenCalledWith({
+		abortController: expect.any(AbortController),
 		url: new URL('https://localhost/graphql'),
 		options: expect.objectContaining({
 			headers: expect.objectContaining({ 'X-Api-Key': 'FAKE-KEY' }),
@@ -66,6 +68,7 @@ export function expectList(
 	item: Record<string, any>
 ) {
 	expect(spy).toHaveBeenCalledWith({
+		abortController: expect.any(AbortController),
 		url: new URL('https://localhost/graphql'),
 		options: expect.objectContaining({
 			headers: expect.objectContaining({ 'X-Api-Key': 'FAKE-KEY' }),

--- a/packages/api-graphql/src/internals/InternalGraphQLAPI.ts
+++ b/packages/api-graphql/src/internals/InternalGraphQLAPI.ts
@@ -264,7 +264,7 @@ export class InternalGraphQLAPIClass {
 				abortController,
 			});
 
-			const result = { data: await responseBody.json() };
+			const result = await responseBody.json();
 
 			response = result;
 		} catch (err) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes a regression in InternalGraphQL client introduced in #12142 & fixes unit tests to support abort controller.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
