### PR TITLE
fix(notifications): add notifications as dependency to aws-amplify

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -15,6 +15,7 @@
 		"packages/datastore",
 		"packages/rtn-web-browser",
 		"packages/notifications",
+		"packages/rtn-push-notification",
 		"packages/react-native",
 		"packages/react-native/example",
 		"scripts/tsc-compliance-test"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"publish:main": "lerna publish --canary --force-publish --dist-tag=unstable --preid=unstable${PREID_HASH_SUFFIX} --yes",
 		"publish:release": "lerna publish --conventional-commits --message 'chore(release): Publish [ci skip]' --yes",
 		"publish:verdaccio": "lerna publish --canary --force-publish --no-push --dist-tag=unstable --preid=unstable --yes",
+		"unpublish:verdaccio": "lerna exec -- npm unpublish --force",
 		"ts-coverage": "lerna run ts-coverage",
 		"prepare": "./scripts/set-preid-versions.sh"
 	},
@@ -52,6 +53,7 @@
 			"packages/api",
 			"packages/datastore",
 			"packages/notifications",
+			"packages/rtn-push-notification",
 			"packages/aws-amplify",
 			"packages/rtn-web-browser",
 			"packages/react-native",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 		"publish:main": "lerna publish --canary --force-publish --dist-tag=unstable --preid=unstable${PREID_HASH_SUFFIX} --yes",
 		"publish:release": "lerna publish --conventional-commits --message 'chore(release): Publish [ci skip]' --yes",
 		"publish:verdaccio": "lerna publish --canary --force-publish --no-push --dist-tag=unstable --preid=unstable --yes",
-		"unpublish:verdaccio": "lerna exec -- npm unpublish --force",
 		"ts-coverage": "lerna run ts-coverage",
 		"prepare": "./scripts/set-preid-versions.sh"
 	},

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -222,7 +222,9 @@
 		"auth",
 		"internals",
 		"storage",
-		"datastore"
+		"datastore",
+		"in-app-messaging",
+		"push-notifications"
 	],
 	"dependencies": {
 		"@aws-amplify/api": "6.0.0",
@@ -231,6 +233,7 @@
 		"@aws-amplify/core": "6.0.0",
 		"@aws-amplify/storage": "6.0.0",
 		"@aws-amplify/datastore": "5.0.0",
+		"@aws-amplify/notifications": "2.0.0",
 		"tslib": "^2.5.0"
 	},
 	"devDependencies": {

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -5,10 +5,7 @@
 	"main": "./lib/index.js",
 	"module": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
-	"sideEffects": [
-		"./lib/Notifications.js",
-		"./lib-esm/Notifications.js"
-	],
+	"sideEffects": false,
 	"publishConfig": {
 		"access": "public"
 	},
@@ -96,7 +93,6 @@
 		"src"
 	],
 	"dependencies": {
-		"@aws-amplify/rtn-push-notification": "1.1.7",
 		"lodash": "^4.17.21",
 		"uuid": "^9.0.0"
 	},

--- a/packages/rtn-push-notification/package.json
+++ b/packages/rtn-push-notification/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@aws-amplify/rtn-push-notification",
 	"version": "1.2.0",
-	"private": true,
 	"description": "React Native module for aws-amplify push notifications",
 	"main": "./lib/index.js",
 	"module": "./lib-esm/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,11 +10,6 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-amplify/rtn-push-notification@1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/rtn-push-notification/-/rtn-push-notification-1.1.7.tgz#90593b613db4ee935ff5208c012cc7b6524be2fc"
-  integrity sha512-P3Gj0o5g6DZoSdN3DXDweOU2on8eZKr/KzbX1beCaNgBnjqGW0pIkMvD+SMdffXeRD0Lbawk9FHvQM7o0BwR8g==
-
 "@aws-crypto/crc32@3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-3.0.0.tgz#07300eca214409c33e3ff769cd5697b57fdd38fa"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes the absent notifications dependency to aws-amplify this allows the notifications packages to show up in the scoped `@aws-amplify` package in the final publish

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

- setup verdaccio 
- install on a sample app
- can access notifications APIs


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
