### PR TITLE
fix(storage): react-native picks up wrong utils/client/runtime

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -4,6 +4,7 @@
 	"description": "Storage category of aws-amplify",
 	"main": "./lib/index.js",
 	"module": "./lib-esm/index.js",
+	"react-native": "./lib-esm/index.js",
 	"typings": "./lib-esm/index.d.ts",
 	"browser": {
 		"./lib-esm/lib-esm/providers/s3/utils/client/runtime/index": "./lib-esm/providers/s3/utils/client/runtime/index.browser.js"

--- a/packages/storage/src/providers/s3/utils/client/runtime/package.json
+++ b/packages/storage/src/providers/s3/utils/client/runtime/package.json
@@ -1,8 +1,13 @@
 {
 	"name": "@aws-amplify/storage/src/providers/s3/utils/client/runtime",
 	"main": "../../../../../../lib/providers/s3/utils/client/runtime/index.js",
+	"react-native": {
+		"./": "../../../../../../lib-esm/providers/s3/utils/client/runtime/index.native.js",
+		"fast-xml-parser": "fast-xml-parser",
+		"buffer": "buffer"
+	},
 	"browser": {
-		"./index.js": "../../../../../../lib-esm/providers/s3/utils/client/runtime/index.browser.js",
+		"./": "../../../../../../lib-esm/providers/s3/utils/client/runtime/index.browser.js",
 		"fast-xml-parser": false,
 		"buffer": false
 	},


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Added appropriate `react-native` root fields to ensure the module resolution picks up correct code path of `packages/storage` in a react-native app.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
