### PR TITLE
feat: add ability to set ephemeral session

### DIFF
--- a/packages/auth/__tests__/providers/cognito/signOut.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signOut.test.ts
@@ -265,9 +265,10 @@ describe('signOut tests with oauth', () => {
 		);
 		oauthStoreSpy = jest
 			.spyOn(DefaultOAuthStore.prototype, 'loadOAuthSignIn')
-			.mockImplementation(async () => {
-				return true;
-			});
+			.mockImplementation(async () => ({
+				isOAuthSignIn: true,
+				preferPrivateSession: false,
+			}));
 
 		revokeTokenSpy = jest
 			.spyOn(clients, 'revokeToken')
@@ -316,7 +317,8 @@ describe('signOut tests with oauth', () => {
 		expect(tokenStoreSpy).toBeCalled();
 		expect(mockOpenAuthSession).toBeCalledWith(
 			'https://https://amazonaws.com/logout?client_id=111111-aaaaa-42d8-891d-ee81a1549398&logout_uri=http%3A%2F%2Flocalhost%3A3000%2F',
-			['http://localhost:3000/']
+			['http://localhost:3000/'],
+			false
 		);
 		expect(clearCredentialsSpy).toBeCalled();
 	});
@@ -337,7 +339,8 @@ describe('signOut tests with oauth', () => {
 		expect(tokenStoreSpy).toBeCalled();
 		expect(mockOpenAuthSession).toBeCalledWith(
 			'https://https://amazonaws.com/logout?client_id=111111-aaaaa-42d8-891d-ee81a1549398&logout_uri=http%3A%2F%2Flocalhost%3A3000%2F',
-			['http://localhost:3000/']
+			['http://localhost:3000/'],
+			false
 		);
 		expect(clearCredentialsSpy).toBeCalled();
 	});

--- a/packages/auth/src/providers/cognito/apis/signOut.ts
+++ b/packages/auth/src/providers/cognito/apis/signOut.ts
@@ -107,15 +107,19 @@ async function handleOAuthSignOut(cognitoConfig: CognitoUserPoolConfig) {
 
 	const oauthStore = new DefaultOAuthStore(defaultStorage);
 	oauthStore.setAuthConfig(cognitoConfig);
-	const isOAuthSignIn = await oauthStore.loadOAuthSignIn();
+	const { isOAuthSignIn, preferPrivateSession } =
+		await oauthStore.loadOAuthSignIn();
 	await oauthStore.clearOAuthData();
 
 	if (isOAuthSignIn) {
-		oAuthSignOutRedirect(cognitoConfig);
+		oAuthSignOutRedirect(cognitoConfig, preferPrivateSession);
 	}
 }
 
-async function oAuthSignOutRedirect(authConfig: CognitoUserPoolConfig) {
+async function oAuthSignOutRedirect(
+	authConfig: CognitoUserPoolConfig,
+	preferPrivateSession: boolean
+) {
 	assertOAuthConfig(authConfig);
 
 	const { loginWith, userPoolClientId } = authConfig;
@@ -135,7 +139,11 @@ async function oAuthSignOutRedirect(authConfig: CognitoUserPoolConfig) {
 	// );
 	// logger.debug(`Signing out from ${oAuthLogoutEndpoint}`);
 
-	await openAuthSession(oAuthLogoutEndpoint, redirectSignOut);
+	await openAuthSession(
+		oAuthLogoutEndpoint,
+		redirectSignOut,
+		preferPrivateSession
+	);
 }
 
 function isSessionRevocable(token: JWT) {

--- a/packages/auth/src/providers/cognito/utils/signInWithRedirectStore.ts
+++ b/packages/auth/src/providers/cognito/utils/signInWithRedirectStore.ts
@@ -124,7 +124,10 @@ export class DefaultOAuthStore implements OAuthStore {
 		);
 	}
 
-	async loadOAuthSignIn(): Promise<boolean> {
+	async loadOAuthSignIn(): Promise<{
+		isOAuthSignIn: boolean;
+		preferPrivateSession: boolean;
+	}> {
 		assertTokenProviderConfig(this.cognitoConfig);
 
 		const name = 'Cognito'; // TODO(v6): update after API review for Amplify.configure
@@ -134,14 +137,20 @@ export class DefaultOAuthStore implements OAuthStore {
 			this.cognitoConfig.userPoolClientId
 		);
 
-		const isOAuthSignIn = await this.keyValueStorage.getItem(
-			authKeys.oauthSignIn
-		);
+		const [isOAuthSignIn, preferPrivateSession] =
+			(await this.keyValueStorage.getItem(authKeys.oauthSignIn))?.split(',') ??
+			[];
 
-		return isOAuthSignIn === 'true';
+		return {
+			isOAuthSignIn: isOAuthSignIn === 'true',
+			preferPrivateSession: preferPrivateSession === 'true',
+		};
 	}
 
-	async storeOAuthSignIn(oauthSignIn: boolean): Promise<void> {
+	async storeOAuthSignIn(
+		oauthSignIn: boolean,
+		preferPrivateSession: boolean = false
+	): Promise<void> {
 		assertTokenProviderConfig(this.cognitoConfig);
 
 		const name = 'Cognito'; // TODO(v6): update after API review for Amplify.configure
@@ -153,7 +162,7 @@ export class DefaultOAuthStore implements OAuthStore {
 
 		return await this.keyValueStorage.setItem(
 			authKeys.oauthSignIn,
-			`${oauthSignIn}`
+			`${oauthSignIn},${preferPrivateSession}`
 		);
 	}
 }

--- a/packages/auth/src/providers/cognito/utils/types.ts
+++ b/packages/auth/src/providers/cognito/utils/types.ts
@@ -98,8 +98,14 @@ export interface OAuthStore {
 	setAuthConfig(authConfigParam: CognitoUserPoolConfig): void;
 	loadOAuthInFlight(): Promise<boolean>;
 	storeOAuthInFlight(inflight: boolean): Promise<void>;
-	loadOAuthSignIn(): Promise<boolean>;
-	storeOAuthSignIn(oauthSignIn: boolean): Promise<void>;
+	loadOAuthSignIn(): Promise<{
+		isOAuthSignIn: boolean;
+		preferPrivateSession: boolean;
+	}>;
+	storeOAuthSignIn(
+		oauthSignIn: boolean,
+		preferPrivateSession: boolean
+	): Promise<void>;
 	loadOAuthState(): Promise<string | null>;
 	storeOAuthState(state: string): Promise<void>;
 	loadPKCE(): Promise<string | null>;

--- a/packages/auth/src/types/inputs.ts
+++ b/packages/auth/src/types/inputs.ts
@@ -58,6 +58,18 @@ export type AuthProvider = 'Amazon' | 'Apple' | 'Facebook' | 'Google';
 export type AuthSignInWithRedirectInput = {
 	provider?: AuthProvider | { custom: string };
 	customState?: string;
+	options?: {
+		/**
+		 * On iOS devices, setting this to true requests that the browser not share cookies or other browsing data between
+		 * the authentication session and the user’s normal browser session. This will bypass the permissions dialog that
+		 * is displayed your user during sign-in and sign-out but also prevents reuse of existing sessions from the user's
+		 * browser, requiring them to re-enter their credentials even if they are already externally logged in on their
+		 * browser.
+		 *
+		 * On all other platforms, this flag is ignored.
+		 */
+		preferPrivateSession?: boolean;
+	};
 };
 
 /**

--- a/packages/auth/src/utils/openAuthSession.native.ts
+++ b/packages/auth/src/utils/openAuthSession.native.ts
@@ -22,12 +22,14 @@ try {
 
 export const openAuthSession: OpenAuthSession = async (
 	url: string,
-	redirectSchemes: string[]
+	redirectUrls: string[],
+	prefersEphemeralSession?: boolean
 ): Promise<OpenAuthSessionResult> => {
 	try {
 		const redirectUrl = await webBrowser.openAuthSessionAsync(
 			url,
-			redirectSchemes
+			redirectUrls,
+			prefersEphemeralSession
 		);
 		if (!redirectUrl) {
 			return { type: 'canceled' };

--- a/packages/auth/src/utils/openAuthSession.ts
+++ b/packages/auth/src/utils/openAuthSession.ts
@@ -3,7 +3,7 @@
 
 import { OpenAuthSession } from './types';
 
-export const openAuthSession: OpenAuthSession = (url: string) => {
+export const openAuthSession: OpenAuthSession = async (url: string) => {
 	if (!window?.location) {
 		return;
 	}

--- a/packages/auth/src/utils/types.ts
+++ b/packages/auth/src/utils/types.ts
@@ -3,8 +3,9 @@
 
 export type OpenAuthSession = (
 	url: string,
-	redirectSchemes: string[]
-) => Promise<OpenAuthSessionResult> | void;
+	redirectUrls: string[],
+	preferPrivateSession?: boolean
+) => Promise<OpenAuthSessionResult | void>;
 
 type OpenAuthSessionResultType = 'canceled' | 'success' | 'error';
 
@@ -17,6 +18,7 @@ export type OpenAuthSessionResult = {
 export type AmplifyWebBrowser = {
 	openAuthSessionAsync: (
 		url: string,
-		redirectSchemes: string[]
+		redirectUrls: string[],
+		prefersEphemeralSession?: boolean
 	) => Promise<string | null>;
 };

--- a/packages/rtn-web-browser/ios/AmplifyRTNWebBrowser.m
+++ b/packages/rtn-web-browser/ios/AmplifyRTNWebBrowser.m
@@ -7,6 +7,7 @@
 
 RCT_EXTERN_METHOD(openAuthSessionAsync:(NSString*)url
                   redirectUrlStr:(NSString*)redirectUrlStr
+                  prefersEphemeralSession:(BOOL)prefersEphemeralSession
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/packages/rtn-web-browser/ios/AmplifyRTNWebBrowser.swift
+++ b/packages/rtn-web-browser/ios/AmplifyRTNWebBrowser.swift
@@ -23,6 +23,7 @@ class AmplifyRTNWebBrowser: NSObject {
     @objc
     func openAuthSessionAsync(_ urlStr: String,
                               redirectUrlStr: String,
+                              prefersEphemeralSession: Bool,
                               resolve: @escaping RCTPromiseResolveBlock,
                               reject: @escaping RCTPromiseRejectBlock) {
         guard let url = URL(string: urlStr) else {
@@ -56,7 +57,7 @@ class AmplifyRTNWebBrowser: NSObject {
             })
         webBrowserAuthSession = authSession
         authSession.presentationContextProvider = presentationContextProvider
-        authSession.prefersEphemeralWebBrowserSession = true
+        authSession.prefersEphemeralWebBrowserSession = prefersEphemeralSession
         
         DispatchQueue.main.async {
             authSession.start()

--- a/packages/rtn-web-browser/src/apis/openAuthSessionAsync.ts
+++ b/packages/rtn-web-browser/src/apis/openAuthSessionAsync.ts
@@ -14,12 +14,13 @@ let redirectListener: NativeEventSubscription | undefined;
 
 export const openAuthSessionAsync = async (
 	url: string,
-	redirectUrls: string[]
+	redirectUrls: string[],
+	prefersEphemeralSession?: boolean
 ) => {
 	// enforce HTTPS
 	const httpsUrl = url.replace('http://', 'https://');
 	if (Platform.OS === 'ios') {
-		return openAuthSessionIOS(httpsUrl, redirectUrls);
+		return openAuthSessionIOS(httpsUrl, redirectUrls, prefersEphemeralSession);
 	}
 
 	if (Platform.OS === 'android') {
@@ -27,12 +28,20 @@ export const openAuthSessionAsync = async (
 	}
 };
 
-const openAuthSessionIOS = async (url: string, redirectUrls: string[]) => {
+const openAuthSessionIOS = async (
+	url: string,
+	redirectUrls: string[],
+	prefersEphemeralSession: boolean = false
+) => {
 	const redirectUrl = redirectUrls.find(
 		// take the first non-web url as the deeplink
 		item => !item.startsWith('https://') && !item.startsWith('http://')
 	);
-	return nativeModule.openAuthSessionAsync(url, redirectUrl);
+	return nativeModule.openAuthSessionAsync(
+		url,
+		redirectUrl,
+		prefersEphemeralSession
+	);
 };
 
 const openAuthSessionAndroid = async (url: string, redirectUrls: string[]) => {

--- a/packages/rtn-web-browser/src/types.ts
+++ b/packages/rtn-web-browser/src/types.ts
@@ -4,6 +4,7 @@
 export type WebBrowserNativeModule = {
 	openAuthSessionAsync: (
 		url: string,
-		redirectUrl?: string
+		redirectUrl?: string,
+		prefersEphemeralSession?: boolean
 	) => Promise<string | null>;
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR adds ~~prop drilling~~ an option `preferPrivateSession` which adds the ability to toggle the underlying `prefersEphemeralSession` flag when opening an ASWebAuthenticationSession on iOS during `signInWithRedirect`.

#### Description of how you validated changes
* Tested against React Native app on iOS
* `yarn test`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
