### PR TITLE
chore: Turn on integ tests on next/main

### DIFF
--- a/.github/workflows/push-integ-test.yml
+++ b/.github/workflows/push-integ-test.yml
@@ -8,7 +8,7 @@ concurrency:
 on:
   push:
     branches:
-      - feat/example-integ-test-branch/main
+      - next/main
 
 jobs:
   e2e:

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -288,7 +288,7 @@
 			"name": "[API] REST API handlers",
 			"path": "./lib-esm/api/index.js",
 			"import": "{ get, post, put, del, patch, head, isCancelError }",
-			"limit": "13.63 kB"
+			"limit": "13.8 kB"
 		},
 		{
 			"name": "[Auth] signUp (Cognito)",
@@ -312,7 +312,7 @@
 			"name": "[Auth] signIn (Cognito)",
 			"path": "./lib-esm/auth/index.js",
 			"import": "{ signIn }",
-			"limit": "28.30 kB"
+			"limit": "29.0 kB"
 		},
 		{
 			"name": "[Auth] resendSignUpCode (Cognito)",
@@ -330,7 +330,7 @@
 			"name": "[Auth] confirmSignIn (Cognito)",
 			"path": "./lib-esm/auth/index.js",
 			"import": "{ confirmSignIn }",
-			"limit": "28.20 kB"
+			"limit": "28.80 kB"
 		},
 		{
 			"name": "[Auth] updateMFAPreference (Cognito)",
@@ -384,7 +384,7 @@
 			"name": "[Auth] signInWithRedirect (Cognito)",
 			"path": "./lib-esm/auth/index.js",
 			"import": "{ signInWithRedirect }",
-			"limit": "21.50 kB"
+			"limit": "22.50 kB"
 		},
 		{
 			"name": "[Auth] fetchUserAttributes (Cognito)",
@@ -396,13 +396,13 @@
 			"name": "[Auth] Basic Auth Flow (Cognito)",
 			"path": "./lib-esm/auth/index.js",
 			"import": "{ signIn, signOut, fetchAuthSession, confirmSignIn }",
-			"limit": "30.30 kB"
+			"limit": "31.10 kB"
 		},
 		{
 			"name": "[Auth] OAuth Auth Flow (Cognito)",
 			"path": "./lib-esm/auth/index.js",
 			"import": "{ signInWithRedirect, signOut, fetchAuthSession }",
-			"limit": "22.00 kB"
+			"limit": "22.80 kB"
 		},
 		{
 			"name": "[Storage] copy (S3)",


### PR DESCRIPTION
#### Description of changes
Turn on integ test execution for `next/main`


#### Description of how you validated changes
I've run this locally. It's not [currently passing](https://github.com/stocaaro/amplify-js/actions/runs/6421070921).  This won't block anything, just an opportunity for signal on our changes while we're building towards GA.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
