### PR TITLE
fix: device metadata for multiple users on single device

### DIFF
--- a/packages/auth/__tests__/providers/cognito/tokenProvider.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider.test.ts
@@ -89,27 +89,27 @@ describe('Loading tokens', () => {
 
 		memoryStorage.setItem(
 			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub1Encoded}.deviceKey`,
-			'device-key'
+			'user1-device-key'
 		);
 		memoryStorage.setItem(
 			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub1Encoded}.deviceGroupKey`,
-			'device-group-key'
+			'user1-device-group-key'
 		);
 		memoryStorage.setItem(
 			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub1Encoded}.randomPasswordKey`,
-			'random-password'
+			'user1-random-password'
 		);
 		memoryStorage.setItem(
 			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub2}.deviceKey`,
-			'device-key'
+			'user2-device-key'
 		);
 		memoryStorage.setItem(
 			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub2}.deviceGroupKey`,
-			'device-group-key'
+			'user2-device-group-key'
 		);
 		memoryStorage.setItem(
 			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub2}.randomPasswordKey`,
-			'random-password'
+			'user2-random-password'
 		);
 
 		tokenStore.setKeyValueStorage(memoryStorage);
@@ -120,14 +120,14 @@ describe('Loading tokens', () => {
 			},
 		});
 		const user1DeviceMetadata = await tokenStore.getDeviceMetadata(userSub1);
-		expect(user1DeviceMetadata?.randomPassword).toBe('random-password');
-		expect(user1DeviceMetadata?.deviceGroupKey).toBe('device-group-key');
-		expect(user1DeviceMetadata?.deviceKey).toBe('device-key');
+		expect(user1DeviceMetadata?.randomPassword).toBe('user1-random-password');
+		expect(user1DeviceMetadata?.deviceGroupKey).toBe('user1-device-group-key');
+		expect(user1DeviceMetadata?.deviceKey).toBe('user1-device-key');
 
 		const user2DeviceMetadata = await tokenStore.getDeviceMetadata(userSub2);
-		expect(user2DeviceMetadata?.randomPassword).toBe('random-password');
-		expect(user2DeviceMetadata?.deviceGroupKey).toBe('device-group-key');
-		expect(user2DeviceMetadata?.deviceKey).toBe('device-key');
+		expect(user2DeviceMetadata?.randomPassword).toBe('user2-random-password');
+		expect(user2DeviceMetadata?.deviceGroupKey).toBe('user2-device-group-key');
+		expect(user2DeviceMetadata?.deviceKey).toBe('user2-device-key');
 	});
 });
 

--- a/packages/auth/__tests__/providers/cognito/tokenProvider.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider.test.ts
@@ -78,6 +78,57 @@ describe('Loading tokens', () => {
 		expect(result?.deviceMetadata?.randomPassword).toBe('random-password');
 		expect(result?.deviceMetadata?.deviceKey).toBe('device-key');
 	});
+
+	test('load device tokens from store', async () => {
+		const tokenStore = new DefaultTokenStore();
+		const memoryStorage = new MemoryStorage();
+		const userPoolClientId = 'userPoolClientId';
+		const userSub1 = 'user1@email.com';
+		const userSub1Encoded = 'user1%40email.com';
+		const userSub2 = 'user2@email.com';
+
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub1Encoded}.deviceKey`,
+			'device-key'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub1Encoded}.deviceGroupKey`,
+			'device-group-key'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub1Encoded}.randomPasswordKey`,
+			'random-password'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub2}.deviceKey`,
+			'device-key'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub2}.deviceGroupKey`,
+			'device-group-key'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub2}.randomPasswordKey`,
+			'random-password'
+		);
+
+		tokenStore.setKeyValueStorage(memoryStorage);
+		tokenStore.setAuthConfig({
+			Cognito: {
+				userPoolId: 'us-east-1:1111111',
+				userPoolClientId,
+			},
+		});
+		const user1DeviceMetadata = await tokenStore.getDeviceMetadata(userSub1);
+		expect(user1DeviceMetadata?.randomPassword).toBe('random-password');
+		expect(user1DeviceMetadata?.deviceGroupKey).toBe('device-group-key');
+		expect(user1DeviceMetadata?.deviceKey).toBe('device-key');
+
+		const user2DeviceMetadata = await tokenStore.getDeviceMetadata(userSub2);
+		expect(user2DeviceMetadata?.randomPassword).toBe('random-password');
+		expect(user2DeviceMetadata?.deviceGroupKey).toBe('device-group-key');
+		expect(user2DeviceMetadata?.deviceKey).toBe('device-key');
+	});
 });
 
 describe('saving tokens', () => {

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -150,10 +150,10 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 		return this.getTokenStore().clearTokens();
 	}
 
-	getDeviceMetadata(): Promise<DeviceMetadata | null> {
-		return this.getTokenStore().getDeviceMetadata();
+	getDeviceMetadata(username?: string): Promise<DeviceMetadata | null> {
+		return this.getTokenStore().getDeviceMetadata(username);
 	}
-	clearDeviceMetadata(): Promise<void> {
-		return this.getTokenStore().clearDeviceMetadata();
+	clearDeviceMetadata(username?: string): Promise<void> {
+		return this.getTokenStore().clearDeviceMetadata(username);
 	}
 }

--- a/packages/auth/src/providers/cognito/tokenProvider/types.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/types.ts
@@ -36,8 +36,8 @@ export interface AuthTokenStore {
 	storeTokens(tokens: CognitoAuthTokens): Promise<void>;
 	clearTokens(): Promise<void>;
 	setKeyValueStorage(keyValueStorage: KeyValueStorageInterface): void;
-	getDeviceMetadata(): Promise<DeviceMetadata | null>;
-	clearDeviceMetadata(): Promise<void>;
+	getDeviceMetadata(username?: string): Promise<DeviceMetadata | null>;
+	clearDeviceMetadata(username?: string): Promise<void>;
 }
 
 export interface AuthTokenOrchestrator {
@@ -46,8 +46,8 @@ export interface AuthTokenOrchestrator {
 	getTokens: (options?: FetchAuthSessionOptions) => Promise<AuthTokens | null>;
 	setTokens: ({ tokens }: { tokens: CognitoAuthTokens }) => Promise<void>;
 	clearTokens: () => Promise<void>;
-	getDeviceMetadata(): Promise<DeviceMetadata | null>;
-	clearDeviceMetadata(): Promise<void>;
+	getDeviceMetadata(username?: string): Promise<DeviceMetadata | null>;
+	clearDeviceMetadata(username?: string): Promise<void>;
 }
 
 export interface CognitoUserPoolTokenProviderType extends TokenProvider {

--- a/packages/auth/src/providers/cognito/utils/signInHelpers.ts
+++ b/packages/auth/src/providers/cognito/utils/signInHelpers.ts
@@ -91,7 +91,7 @@ export async function handleCustomChallenge({
 		ANSWER: challengeResponse,
 	};
 
-	const deviceMetadata = await tokenOrchestrator?.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator?.getDeviceMetadata(username);
 	if (deviceMetadata && deviceMetadata.deviceKey) {
 		challengeResponses['DEVICE_KEY'] = deviceMetadata.deviceKey;
 	}
@@ -267,7 +267,7 @@ export async function handleUserPasswordAuthFlow(
 		USERNAME: username,
 		PASSWORD: password,
 	};
-	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata(username);
 
 	if (deviceMetadata && deviceMetadata.deviceKey) {
 		authParameters['DEVICE_KEY'] = deviceMetadata.deviceKey;
@@ -310,7 +310,7 @@ export async function handleUserSRPAuthFlow(
 		USERNAME: username,
 		SRP_A: authenticationHelper.A.toString(16),
 	};
-	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata(username);
 
 	if (deviceMetadata && deviceMetadata.deviceKey) {
 		authParameters['DEVICE_KEY'] = deviceMetadata.deviceKey;
@@ -346,7 +346,7 @@ export async function handleCustomAuthFlowWithoutSRP(
 	const authParameters: Record<string, string> = {
 		USERNAME: username,
 	};
-	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata(username);
 
 	if (deviceMetadata && deviceMetadata.deviceKey) {
 		authParameters['DEVICE_KEY'] = deviceMetadata.deviceKey;
@@ -386,7 +386,7 @@ export async function handleCustomSRPAuthFlow(
 	const userPoolName = userPoolId?.split('_')[1] || '';
 	const authenticationHelper = await getAuthenticationHelper(userPoolName);
 
-	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata(username);
 
 	const authParameters: Record<string, string> = {
 		USERNAME: username,
@@ -427,7 +427,7 @@ async function handleDeviceSRPAuth({
 }: HandleDeviceSRPInput): Promise<RespondToAuthChallengeCommandOutput> {
 	const userPoolId = config.userPoolId;
 	const clientId = config.userPoolClientId;
-	const deviceMetadata = await tokenOrchestrator?.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator?.getDeviceMetadata(username);
 	assertDeviceMetadata(deviceMetadata);
 	const authenticationHelper = await getAuthenticationHelper(
 		deviceMetadata.deviceGroupKey
@@ -470,7 +470,7 @@ async function handleDevicePasswordVerifier(
 	{ userPoolId, userPoolClientId }: CognitoUserPoolConfig,
 	tokenOrchestrator?: AuthTokenOrchestrator
 ): Promise<RespondToAuthChallengeCommandOutput> {
-	const deviceMetadata = await tokenOrchestrator?.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator?.getDeviceMetadata(username);
 	assertDeviceMetadata(deviceMetadata);
 
 	const serverBValue = new BigInteger(challengeParameters?.SRP_B, 16);
@@ -554,7 +554,7 @@ export async function handlePasswordVerifierChallenge(
 		}),
 	} as { [key: string]: string };
 
-	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata(username);
 	if (deviceMetadata && deviceMetadata.deviceKey) {
 		challengeResponses['DEVICE_KEY'] = deviceMetadata.deviceKey;
 	}


### PR DESCRIPTION
### Description of changes
device metadata for multiple users on single device

### Description of how you validated changes
user1 (has encoded username)
user2 (has not encoded username)

user1 -> signIn -> confirmSignIn() -> rememberdevice()
user1 -> signIn (bypass MFA )
user1 -> signOut

user2 -> signIn -> confirmSignIn() -> rememberdevice()
user2 -> signIn (bypass MFA)
user2 -> signOut

user1 -> signIn (bypass MFA) -> signOut
user2 -> signIn (bypass MFA) -> signOut
user1 -> signIn (bypass MFA) -> signOut
user2 -> signIn (bypass MFA) -> signOut
confirmed localStore deviceMetadata for both users co-exist   


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
