### PR TITLE
chore(aws-amplify): change deafult sameSite value to 'lax'

### DIFF
--- a/packages/aws-amplify/__tests__/initSingleton.test.ts
+++ b/packages/aws-amplify/__tests__/initSingleton.test.ts
@@ -180,7 +180,7 @@ describe('initSingleton (DefaultAmplify)', () => {
 					Amplify.configure(mockResourceConfig, { ssr: true });
 
 					expect(MockCookieStorage).toHaveBeenCalledWith({
-						sameSite: 'strict',
+						sameSite: 'lax',
 					});
 					expect(
 						mockCognitoUserPoolsTokenProviderSetKeyValueStorage

--- a/packages/aws-amplify/src/adapterCore/storageFactories/createKeyValueStorageFromCookieStorageAdapter.ts
+++ b/packages/aws-amplify/src/adapterCore/storageFactories/createKeyValueStorageFromCookieStorageAdapter.ts
@@ -5,8 +5,8 @@ import { KeyValueStorageInterface } from '@aws-amplify/core';
 import { CookieStorage } from '@aws-amplify/core/internals/adapter-core';
 
 export const defaultSetCookieOptions: CookieStorage.SetCookieOptions = {
-	sameSite: 'strict',
-	secure: true,
+	// TODO: allow configure with a public interface
+	sameSite: 'lax',
 };
 const ONE_YEAR_IN_MS = 365 * 24 * 60 * 60 * 1000;
 

--- a/packages/aws-amplify/src/initSingleton.ts
+++ b/packages/aws-amplify/src/initSingleton.ts
@@ -44,8 +44,9 @@ export const DefaultAmplify = {
 
 			CognitoUserPoolsTokenProvider.setKeyValueStorage(
 				libraryOptions?.ssr
-					? new CookieStorage({
-							sameSite: 'strict',
+					? // TODO: allow configure with a public interface
+					  new CookieStorage({
+							sameSite: 'lax',
 					  })
 					: defaultStorage
 			);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Context:

Currently we don't provide an interface to configure the sameSite values when Amplify.configure(config, { ssr: true })  on both client and server sides

We are planning to provide an interface to do so post GA.

Considering to support most of use cases of cookies, we decided to change this default value. This is aligned with how browsers handle cookies with sameSite unset.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
