### PR TITLE
fix(datastore): unexpected nulls in creates on undefined fields

### DIFF
--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -776,9 +776,14 @@ const initializeInstance = <T extends PersistentModel>(
 	const modelValidator = validateModelFields(modelDefinition);
 	Object.entries(init).forEach(([k, v]) => {
 		const parsedValue = castInstanceType(modelDefinition, k, v);
-
 		modelValidator(k, parsedValue);
-		(<any>draft)[k] = parsedValue;
+
+		// so that explicitly-set undefined fields aren't part of the draft
+		// and therefore sent to appsync as explicit null's. AppSync doesn't like explicit null's
+		// on [most?] optional fields.
+		if (parsedValue !== undefined) {
+			(<any>draft)[k] = parsedValue;
+		}
 	});
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fixes an issue where DataStore would send explicit `{field: null}` values in graphql `create` operations when models were initialized with explicit `{field: undefined}`. E.g. in a model where `description` is optional, a DataStore save like this,

```js
await DataStore.save(new Model({
  title: 'some title',
  description: undefined
}));
```

Would result in a graphql create like this:

```json
{
  id: "123...",
  title: "some title",
  description: null
}
```

AppSync then rejects this operation.

This PR updates DataStore to ignore `undefined` fields in updates, regardless of whether they're implicit (omitted from the `new Model()` initialization) or explicit as above. The new graphql operation will attempt to save this:

```json
{
  id: "123...",
  title: "some title"
}
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

1. Repro'd manually
1. Added a test that replicates the manual repro
1. Made the test pass
1. Validated manually (pending)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
