### PR TITLE
refactor: move generateClient core to api-graphql, add surface tests

### DIFF
--- a/packages/api-graphql/__tests__/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/generateClient.test.ts
@@ -1,0 +1,126 @@
+import * as raw from '../src';
+import { AmplifyClassV6 } from '@aws-amplify/core';
+import { generateClient } from '../src/internals';
+
+const serverManagedFields = {
+	id: 'some-id',
+	owner: 'wirejobviously',
+	createdAt: new Date().toISOString(),
+	updatedAt: new Date().toISOString(),
+};
+
+describe('generateClient', () => {
+	test('can produce a client bound to an arbitrary amplify object for getConfig()', async () => {
+		// TS lies: We don't care what `amplify` is or does. We want want to make sure
+		// it shows up in the client in the right spot.
+
+		const fetchAuthSession = jest.fn().mockReturnValue({});
+		const getConfig = jest.fn().mockReturnValue({
+			API: {
+				GraphQL: {
+					apiKey: 'apikey',
+					customEndpoint: undefined,
+					customEndpointRegion: undefined,
+					defaultAuthMode: 'apiKey',
+					endpoint: 'https://0.0.0.0/graphql',
+					region: 'us-east-1',
+				},
+			},
+		});
+
+		const apiSpy = jest
+			.spyOn((raw.GraphQLAPI as any)._api, 'post')
+			.mockReturnValue({
+				body: {
+					json: () => ({
+						data: {
+							getWidget: {
+								__typename: 'Widget',
+								...serverManagedFields,
+								someField: 'some value',
+							},
+						},
+					}),
+				},
+			});
+
+		const amplify = {
+			Auth: {
+				fetchAuthSession,
+			},
+			getConfig,
+		} as unknown as AmplifyClassV6;
+
+		const client = generateClient({ amplify });
+		const result = (await client.graphql({
+			query: `query Q {
+				getWidget {
+					__typename id owner createdAt updatedAt someField
+				}
+			}`,
+		})) as any;
+
+		// shouldn't fetch auth for apiKey auth
+		expect(fetchAuthSession).not.toHaveBeenCalled();
+
+		expect(getConfig).toHaveBeenCalled();
+		expect(apiSpy).toHaveBeenCalled();
+	});
+
+	test('can produce a client bound to an arbitrary amplify object for fetchAuthSession()', async () => {
+		// TS lies: We don't care what `amplify` is or does. We want want to make sure
+		// it shows up in the client in the right spot.
+
+		const fetchAuthSession = jest.fn().mockReturnValue({ credentials: {} });
+		const getConfig = jest.fn().mockReturnValue({
+			API: {
+				GraphQL: {
+					apiKey: undefined,
+					customEndpoint: undefined,
+					customEndpointRegion: undefined,
+					defaultAuthMode: 'iam',
+					endpoint: 'https://0.0.0.0/graphql',
+					region: 'us-east-1',
+				},
+			},
+		});
+
+		const apiSpy = jest
+			.spyOn((raw.GraphQLAPI as any)._api, 'post')
+			.mockReturnValue({
+				body: {
+					json: () => ({
+						data: {
+							getWidget: {
+								__typename: 'Widget',
+								...serverManagedFields,
+								someField: 'some value',
+							},
+						},
+					}),
+				},
+			});
+
+		const amplify = {
+			Auth: {
+				fetchAuthSession,
+			},
+			getConfig,
+		} as unknown as AmplifyClassV6;
+
+		const client = generateClient({ amplify });
+		const result = await client.graphql({
+			query: `query Q {
+				getWidget {
+					__typename id owner createdAt updatedAt someField
+				}
+			}`,
+		});
+
+		// should fetch auth for iam
+		expect(fetchAuthSession).toHaveBeenCalled();
+
+		expect(getConfig).toHaveBeenCalled();
+		expect(apiSpy).toHaveBeenCalled();
+	});
+});

--- a/packages/api-graphql/src/internals/generateClient.ts
+++ b/packages/api-graphql/src/internals/generateClient.ts
@@ -1,0 +1,25 @@
+import { AmplifyClassV6 } from '@aws-amplify/core';
+import { graphql, cancel, isCancelError } from './v6';
+import { V6Client, __amplify } from '../types';
+
+type ClientGenerationParams = {
+	amplify: AmplifyClassV6;
+};
+
+/**
+ * @private
+ *
+ * Creates a client that can be used to make GraphQL requests, using a provided `AmplifyClassV6`
+ * compatible context object for config and auth fetching.
+ *
+ * @param params
+ * @returns
+ */
+export function generateClient(params: ClientGenerationParams): V6Client {
+	return {
+		[__amplify]: params.amplify,
+		graphql,
+		cancel,
+		isCancelError,
+	};
+}

--- a/packages/api-graphql/src/internals/index.ts
+++ b/packages/api-graphql/src/internals/index.ts
@@ -6,3 +6,4 @@ export {
 } from './InternalGraphQLAPI';
 
 export { graphql, cancel, isCancelError } from './v6';
+export { generateClient } from './generateClient';

--- a/packages/api/__tests__/API.test.ts
+++ b/packages/api/__tests__/API.test.ts
@@ -1,8 +1,22 @@
+import { ResourcesConfig } from 'aws-amplify';
 import { InternalGraphQLAPIClass } from '@aws-amplify/api-graphql/internals';
-import { generateClient } from 'aws-amplify/api';
+import { generateClient } from '@aws-amplify/api';
+import { generateClient as generateClientSSR } from '@aws-amplify/api/server';
+import { runWithAmplifyServerContext } from 'aws-amplify/internals/adapter-core';
+
+const serverManagedFields = {
+	id: 'some-id',
+	owner: 'wirejobviously',
+	createdAt: new Date().toISOString(),
+	updatedAt: new Date().toISOString(),
+};
 
 describe('API generateClient', () => {
-	test('client.graphql', async () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('client-side client.graphql', async () => {
 		const spy = jest
 			.spyOn(InternalGraphQLAPIClass.prototype, 'graphql')
 			.mockResolvedValue('grapqhqlResponse' as any);
@@ -11,6 +25,44 @@ describe('API generateClient', () => {
 		expect(spy).toBeCalledWith(
 			{ Auth: {}, libraryOptions: {}, resourcesConfig: {} },
 			{ query: 'query' },
+			undefined
+		);
+	});
+
+	test('server-side client.graphql', async () => {
+		const config: ResourcesConfig = {
+			API: {
+				GraphQL: {
+					apiKey: 'adsf',
+					customEndpoint: undefined,
+					customEndpointRegion: undefined,
+					defaultAuthMode: 'apiKey',
+					endpoint: 'https://0.0.0.0/graphql',
+					region: 'us-east-1',
+				},
+			},
+		};
+
+		const query = `query Q {
+			getWidget {
+				__typename id owner createdAt updatedAt someField
+			}
+		}`;
+
+		const spy = jest
+			.spyOn(InternalGraphQLAPIClass.prototype, 'graphql')
+			.mockResolvedValue('grapqhqlResponse' as any);
+
+		await runWithAmplifyServerContext(config, {}, ctx => {
+			const client = generateClientSSR(ctx);
+			return client.graphql({ query }) as any;
+		});
+
+		expect(spy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				resourcesConfig: config,
+			}),
+			{ query },
 			undefined
 		);
 	});

--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -1,11 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { __amplify, V6Client } from '@aws-amplify/api-graphql';
-import {
-	graphql as v6graphql,
-	cancel as v6cancel,
-	isCancelError as v6isCancelError,
-} from '@aws-amplify/api-graphql/internals';
+import { V6Client } from '@aws-amplify/api-graphql';
+import { generateClient as internalGenerateClient } from '@aws-amplify/api-graphql/internals';
 import { Amplify } from '@aws-amplify/core';
 
 /**
@@ -14,10 +10,5 @@ import { Amplify } from '@aws-amplify/core';
 export function generateClient<
 	T extends Record<any, any> = never
 >(): V6Client<T> {
-	return {
-		[__amplify]: Amplify,
-		graphql: v6graphql,
-		cancel: v6cancel,
-		isCancelError: v6isCancelError,
-	};
+	return internalGenerateClient({ amplify: Amplify });
 }

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -2,17 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { GraphQLQuery, GraphQLSubscription } from './types';
-import {
-	graphql,
-	cancel,
-	isCancelError,
-} from '@aws-amplify/api-graphql/internals';
+import { generateClient as internalGenerateClient } from '@aws-amplify/api-graphql/internals';
 import {
 	AmplifyServer,
 	getAmplifyServerContext,
 } from '@aws-amplify/core/internals/adapter-core';
 
-import { __amplify, V6Client } from '@aws-amplify/api-graphql';
+import { V6Client } from '@aws-amplify/api-graphql';
 
 export type {
 	GraphQLResult,
@@ -25,12 +21,9 @@ export type {
 export function generateClient<T extends Record<any, any> = never>(
 	contextSpec: AmplifyServer.ContextSpec
 ): V6Client<T> {
-	return {
-		[__amplify]: getAmplifyServerContext(contextSpec).amplify,
-		graphql,
-		cancel,
-		isCancelError,
-	};
+	return internalGenerateClient({
+		amplify: getAmplifyServerContext(contextSpec).amplify,
+	});
 }
 
 export {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Moves core `generateClient` assembly to `api-graphql` in preparation for re-adding `.models` property generation in `api-graphql` category.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
