### PR TITLE
chore: Exported `AWSCredentials` for internal use

### DIFF
--- a/packages/analytics/src/providers/kinesis-firehose/types/buffer.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/types/buffer.ts
@@ -3,7 +3,7 @@
 
 import { EventBufferConfig } from '../../../utils';
 import { KinesisStream } from '../../../types';
-import { Credentials } from '@aws-sdk/types';
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 
 export type KinesisFirehoseBufferEvent = KinesisStream & {
 	event: Uint8Array;
@@ -13,7 +13,7 @@ export type KinesisFirehoseBufferEvent = KinesisStream & {
 
 export type KinesisFirehoseEventBufferConfig = EventBufferConfig & {
 	region: string;
-	credentials: Credentials;
+	credentials: AWSCredentials;
 	identityId?: string;
 	resendLimit?: number;
 	userAgentValue?: string;

--- a/packages/analytics/src/providers/kinesis/types/buffer.ts
+++ b/packages/analytics/src/providers/kinesis/types/buffer.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 import { EventBufferConfig } from '../../../utils';
-import { Credentials } from '@aws-sdk/types';
 import { KinesisShard } from '../../../types';
 
 export type KinesisBufferEvent = KinesisShard & {
@@ -13,7 +13,7 @@ export type KinesisBufferEvent = KinesisShard & {
 
 export type KinesisEventBufferConfig = EventBufferConfig & {
 	region: string;
-	credentials: Credentials;
+	credentials: AWSCredentials;
 	identityId?: string;
 	resendLimit?: number;
 	userAgentValue?: string;

--- a/packages/analytics/src/providers/personalize/types/buffer.ts
+++ b/packages/analytics/src/providers/personalize/types/buffer.ts
@@ -3,7 +3,7 @@
 
 import { PersonalizeEvent } from './';
 import { EventBufferConfig } from '../../../utils';
-import { Credentials } from '@aws-sdk/types';
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 
 export type PersonalizeBufferEvent = {
 	trackingId: string;
@@ -15,7 +15,7 @@ export type PersonalizeBufferEvent = {
 
 export type PersonalizeBufferConfig = EventBufferConfig & {
 	region: string;
-	credentials: Credentials;
+	credentials: AWSCredentials;
 	identityId?: string;
 	userAgentValue?: string;
 };

--- a/packages/core/src/libraryUtils.ts
+++ b/packages/core/src/libraryUtils.ts
@@ -38,6 +38,7 @@ export {
 	JwtPayload,
 	AuthStandardAttributeKey,
 	AuthVerifiableAttributeKey,
+	AWSCredentials
 } from './singleton/Auth/types';
 
 // Logging utilities

--- a/packages/core/src/providers/pinpoint/apis/flushEvents.ts
+++ b/packages/core/src/providers/pinpoint/apis/flushEvents.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Credentials } from '@aws-sdk/types';
+import { AWSCredentials } from '../../../libraryUtils';
 import { getEventBuffer } from '../utils/getEventBuffer';
 import {
 	BUFFER_SIZE,
@@ -13,7 +13,7 @@ import {
 export const flushEvents = (
 	appId: string,
 	region: string,
-	credentials: Credentials,
+	credentials: AWSCredentials,
 	identityId?: string,
 	userAgentValue?: string
 ) => {

--- a/packages/core/src/singleton/Auth/types.ts
+++ b/packages/core/src/singleton/Auth/types.ts
@@ -217,7 +217,7 @@ export type AWSCredentialsAndIdentityId = {
 	identityId?: string;
 };
 
-type AWSCredentials = {
+export type AWSCredentials = {
 	accessKeyId: string;
 	secretAccessKey: string;
 	sessionToken?: string;

--- a/packages/storage/__tests__/providers/s3/apis/copy.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/copy.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Credentials } from '@aws-sdk/types';
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 import { Amplify } from '@aws-amplify/core';
 import { copyObject } from '../../../../src/providers/s3/utils/client';
 import { copy } from '../../../../src/providers/s3/apis';
@@ -30,7 +30,7 @@ const region = 'region';
 const targetIdentityId = 'targetIdentityId';
 const defaultIdentityId = 'defaultIdentityId';
 const copyResult = { key: destinationKey };
-const credentials: Credentials = {
+const credentials: AWSCredentials = {
 	accessKeyId: 'accessKeyId',
 	sessionToken: 'sessionToken',
 	secretAccessKey: 'secretAccessKey',

--- a/packages/storage/__tests__/providers/s3/apis/downloadData.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/downloadData.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Credentials } from '@aws-sdk/types';
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 import { Amplify } from '@aws-amplify/core';
 import { getObject } from '../../../../src/providers/s3/utils/client';
 import { downloadData } from '../../../../src/providers/s3';
@@ -18,7 +18,7 @@ jest.mock('@aws-amplify/core', () => ({
 		},
 	},
 }));
-const credentials: Credentials = {
+const credentials: AWSCredentials = {
 	accessKeyId: 'accessKeyId',
 	sessionToken: 'sessionToken',
 	secretAccessKey: 'secretAccessKey',

--- a/packages/storage/__tests__/providers/s3/apis/getProperties.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/getProperties.test.ts
@@ -3,7 +3,7 @@
 
 import { headObject } from '../../../../src/providers/s3/utils/client';
 import { getProperties } from '../../../../src/providers/s3';
-import { Credentials } from '@aws-sdk/types';
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 import { Amplify } from '@aws-amplify/core';
 import { GetPropertiesOptions } from '../../../../src/providers/s3/types';
 
@@ -22,7 +22,7 @@ const mockGetConfig = Amplify.getConfig as jest.Mock;
 
 const bucket = 'bucket';
 const region = 'region';
-const credentials: Credentials = {
+const credentials: AWSCredentials = {
 	accessKeyId: 'accessKeyId',
 	sessionToken: 'sessionToken',
 	secretAccessKey: 'secretAccessKey',

--- a/packages/storage/__tests__/providers/s3/apis/getUrl.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/getUrl.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getUrl } from '../../../../src/providers/s3/apis';
-import { Credentials } from '@aws-sdk/types';
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 import { Amplify } from '@aws-amplify/core';
 import {
 	getPresignedGetObjectUrl,
@@ -24,7 +24,7 @@ const bucket = 'bucket';
 const region = 'region';
 const mockFetchAuthSession = Amplify.Auth.fetchAuthSession as jest.Mock;
 const mockGetConfig = Amplify.getConfig as jest.Mock;
-const credentials: Credentials = {
+const credentials: AWSCredentials = {
 	accessKeyId: 'accessKeyId',
 	sessionToken: 'sessionToken',
 	secretAccessKey: 'secretAccessKey',

--- a/packages/storage/__tests__/providers/s3/apis/list.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/list.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Credentials } from '@aws-sdk/types';
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 import { Amplify } from '@aws-amplify/core';
 import { listObjectsV2 } from '../../../../src/providers/s3/utils/client';
 import { list } from '../../../../src/providers/s3';
@@ -32,7 +32,7 @@ const defaultIdentityId = 'defaultIdentityId';
 const eTag = 'eTag';
 const lastModified = 'lastModified';
 const size = 'size';
-const credentials: Credentials = {
+const credentials: AWSCredentials = {
 	accessKeyId: 'accessKeyId',
 	sessionToken: 'sessionToken',
 	secretAccessKey: 'secretAccessKey',

--- a/packages/storage/__tests__/providers/s3/apis/remove.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/remove.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Credentials } from '@aws-sdk/types';
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 import { Amplify } from '@aws-amplify/core';
 import { deleteObject } from '../../../../src/providers/s3/utils/client';
 import { remove } from '../../../../src/providers/s3/apis';
@@ -24,7 +24,7 @@ const bucket = 'bucket';
 const region = 'region';
 const defaultIdentityId = 'defaultIdentityId';
 const removeResult = { key };
-const credentials: Credentials = {
+const credentials: AWSCredentials = {
 	accessKeyId: 'accessKeyId',
 	sessionToken: 'sessionToken',
 	secretAccessKey: 'secretAccessKey',

--- a/packages/storage/__tests__/providers/s3/apis/uploadData/multipartHandlers.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/uploadData/multipartHandlers.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Credentials } from '@aws-sdk/types';
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 import { Amplify, defaultStorage } from '@aws-amplify/core';
 import {
 	createMultipartUpload,
@@ -24,7 +24,7 @@ import { StorageOptions } from '../../../../../src/types';
 jest.mock('@aws-amplify/core');
 jest.mock('../../../../../src/providers/s3/utils/client');
 
-const credentials: Credentials = {
+const credentials: AWSCredentials = {
 	accessKeyId: 'accessKeyId',
 	sessionToken: 'sessionToken',
 	secretAccessKey: 'secretAccessKey',

--- a/packages/storage/__tests__/providers/s3/apis/uploadData/putObjectJob.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/uploadData/putObjectJob.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Credentials } from '@aws-sdk/types';
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 import { Amplify } from '@aws-amplify/core';
 import { putObject } from '../../../../../src/providers/s3/utils/client';
 import { calculateContentMd5 } from '../../../../../src/providers/s3/utils';
@@ -24,7 +24,7 @@ jest.mock('@aws-amplify/core', () => ({
 		},
 	},
 }));
-const credentials: Credentials = {
+const credentials: AWSCredentials = {
 	accessKeyId: 'accessKeyId',
 	sessionToken: 'sessionToken',
 	secretAccessKey: 'secretAccessKey',

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { StorageAccessLevel } from '@aws-amplify/core';
-// TODO(ashwinkumar6) this uses V5 Credentials, update to V6.
-import { Credentials } from '@aws-sdk/types';
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 
 import { TransferProgressEvent } from '../../../types';
 import {
@@ -123,7 +122,7 @@ export type CopyDestinationOptions = WriteOptions & {
  */
 export type ResolvedS3Config = {
 	region: string;
-	credentials: Credentials;
+	credentials: AWSCredentials;
 	customEndpoint?: string;
 	forcePathStyle?: boolean;
 	useAccelerateEndpoint?: boolean;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Exports `AWSCredentials` type for internal uses and updates references to the AWS SDK credentials type to use this instead.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
