### PR TITLE
feat: Added support for specifying a custom endpoint for identity pools: issue 11275

### DIFF
--- a/packages/core/__tests__/AwsClients/CognitoIdentity/getCredentialsForIdentity-test.ts
+++ b/packages/core/__tests__/AwsClients/CognitoIdentity/getCredentialsForIdentity-test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../src/AwsClients/CognitoIdentity';
 import {
 	cognitoIdentityHandlerOptions,
+	cognitoIdentityHandlerOptions2,
 	mockCredentials,
 	mockIdentityId,
 	mockJsonResponse,
@@ -49,6 +50,59 @@ describe('CognitoIdentity - getCredentialsForIdentity', () => {
 		};
 		const expectedRequest = {
 			url: new URL('https://cognito-identity.us-east-1.amazonaws.com/'),
+			method: 'POST',
+			headers: expect.objectContaining({
+				'cache-control': 'no-store',
+				'content-type': 'application/x-amz-json-1.1',
+				'x-amz-target': 'AWSCognitoIdentityService.GetCredentialsForIdentity',
+				'x-amz-user-agent': expect.stringContaining('aws-amplify'),
+			}),
+			body: JSON.stringify({
+				IdentityId: mockIdentityId,
+			}),
+		};
+
+		(fetchTransferHandler as jest.Mock).mockResolvedValue(
+			mockJsonResponse(succeedResponse)
+		);
+		const response = await getCredentialsForIdentity(
+			cognitoIdentityHandlerOptions2,
+			params
+		);
+		expect(response).toEqual(expectedOutput);
+		expect(fetchTransferHandler).toBeCalledWith(
+			expectedRequest,
+			expect.anything()
+		);
+	});
+
+	test('happy case(new)', async () => {
+		const succeedResponse = {
+			status: 200,
+			headers: {
+				'x-amzn-requestid': mockRequestId,
+			},
+			body: {
+				Credentials: mockCredentials,
+				IdentityId: mockIdentityId,
+			},
+		};
+		const expectedOutput: GetCredentialsForIdentityOutput = {
+			Credentials: {
+				...mockCredentials,
+				Expiration: new Date(mockCredentials.Expiration * 1000),
+			},
+			IdentityId: mockIdentityId,
+			$metadata: expect.objectContaining({
+				attempts: 1,
+				requestId: mockRequestId,
+				httpStatusCode: 200,
+			}),
+		};
+		const expectedRequest = {
+			url: new URL(
+				'https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/example/'
+			),
 			method: 'POST',
 			headers: expect.objectContaining({
 				'cache-control': 'no-store',

--- a/packages/core/__tests__/AwsClients/CognitoIdentity/getId-test.ts
+++ b/packages/core/__tests__/AwsClients/CognitoIdentity/getId-test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../src/AwsClients/CognitoIdentity';
 import {
 	cognitoIdentityHandlerOptions,
+	cognitoIdentityHandlerOptions2,
 	mockIdentityId,
 	mockJsonResponse,
 	mockRequestId,
@@ -62,6 +63,51 @@ describe('CognitoIdentity - getId', () => {
 			mockJsonResponse(succeedResponse)
 		);
 		const response = await getId(cognitoIdentityHandlerOptions, params);
+		expect(response).toEqual(expectedOutput);
+		expect(fetchTransferHandler).toBeCalledWith(
+			expectedRequest,
+			expect.anything()
+		);
+	});
+
+	test('happy case(new)', async () => {
+		const expectedRequest = {
+			url: new URL(
+				'https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/example/'
+			),
+			method: 'POST',
+			headers: expect.objectContaining({
+				'cache-control': 'no-store',
+				'content-type': 'application/x-amz-json-1.1',
+				'x-amz-target': 'AWSCognitoIdentityService.GetId',
+				'x-amz-user-agent': expect.stringContaining('aws-amplify'),
+			}),
+			body: JSON.stringify({
+				IdentityPoolId: IDENTITY_POOL_ID,
+				AccountId: ACCOUNT_ID,
+			}),
+		};
+		const succeedResponse = {
+			status: 200,
+			headers: {
+				'x-amzn-requestid': mockRequestId,
+			},
+			body: {
+				IdentityId: mockIdentityId,
+			},
+		};
+		const expectedOutput: GetIdOutput = {
+			IdentityId: mockIdentityId,
+			$metadata: expect.objectContaining({
+				attempts: 1,
+				requestId: mockRequestId,
+				httpStatusCode: 200,
+			}),
+		};
+		(fetchTransferHandler as jest.Mock).mockResolvedValue(
+			mockJsonResponse(succeedResponse)
+		);
+		const response = await getId(cognitoIdentityHandlerOptions2, params);
 		expect(response).toEqual(expectedOutput);
 		expect(fetchTransferHandler).toBeCalledWith(
 			expectedRequest,

--- a/packages/core/__tests__/AwsClients/testUtils/data.ts
+++ b/packages/core/__tests__/AwsClients/testUtils/data.ts
@@ -5,6 +5,8 @@ import { HttpResponse } from '../../../src/clients/types';
 
 // Common
 const region = 'us-east-1';
+const endpoint =
+	'https://xxxxxxxxxx.execute-api.us-east-2.amazonaws.com/example/';
 
 export const mockJsonResponse = ({
 	status,
@@ -41,6 +43,10 @@ export const mockIdentityId = 'us-east-1:88859bc9-0149-4183-bf10-39e36EXAMPLE';
 
 export const cognitoIdentityHandlerOptions = {
 	region,
+};
+export const cognitoIdentityHandlerOptions2 = {
+	region,
+	endpoint,
 };
 
 // Pinpoint

--- a/packages/core/src/AwsClients/CognitoIdentity/base.ts
+++ b/packages/core/src/AwsClients/CognitoIdentity/base.ts
@@ -28,9 +28,22 @@ const SERVICE_NAME = 'cognito-identity';
 /**
  * The endpoint resolver function that returns the endpoint URL for a given region.
  */
-const endpointResolver = ({ region }: EndpointResolverOptions) => ({
-	url: new URL(`https://cognito-identity.${region}.${getDnsSuffix(region)}`),
-});
+const endpointResolver = ({
+	region,
+	customEndpoint,
+}: EndpointResolverOptions) => {
+	if (customEndpoint) {
+		return {
+			url: new URL(customEndpoint),
+		};
+	} else {
+		return {
+			url: new URL(
+				`https://cognito-identity.${region}.${getDnsSuffix(region)}`
+			),
+		};
+	}
+};
 
 /**
  * A Cognito Identity-specific middleware that disables caching for all requests.

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -257,6 +257,7 @@ export class CredentialsClass {
 		}
 		const { identityPoolId, region, mandatorySignIn, identityPoolRegion } =
 			this._config;
+		const endpoint: string = this._config.Auth?.endpoint;
 
 		if (mandatorySignIn) {
 			return Promise.reject(
@@ -282,7 +283,10 @@ export class CredentialsClass {
 
 		const identityId = (this._identityId = await this._getGuestIdentityId());
 
-		const cognitoConfig = { region: identityPoolRegion ?? region };
+		const cognitoConfig = {
+			region: identityPoolRegion ?? region,
+			customEndpoint: endpoint,
+		};
 
 		const guestCredentialsProvider = async () => {
 			if (!identityId) {
@@ -372,6 +376,8 @@ export class CredentialsClass {
 		logins[domain] = token;
 
 		const { identityPoolId, region, identityPoolRegion } = this._config;
+		const endpoint: string = this._config.Auth?.endpoint;
+
 		if (!identityPoolId) {
 			logger.debug('No Cognito Federated Identity pool provided');
 			return Promise.reject('No Cognito Federated Identity pool provided');
@@ -383,7 +389,10 @@ export class CredentialsClass {
 			);
 		}
 
-		const cognitoConfig = { region: identityPoolRegion ?? region };
+		const cognitoConfig = {
+			region: identityPoolRegion ?? region,
+			customEndpoint: endpoint,
+		};
 
 		const authenticatedCredentialsProvider = async () => {
 			if (!identity_id) {
@@ -418,6 +427,8 @@ export class CredentialsClass {
 		const idToken = session.getIdToken().getJwtToken();
 		const { region, userPoolId, identityPoolId, identityPoolRegion } =
 			this._config;
+		const endpoint: string = this._config.Auth?.endpoint;
+
 		if (!identityPoolId) {
 			logger.debug('No Cognito Federated Identity pool provided');
 			return Promise.reject('No Cognito Federated Identity pool provided');
@@ -432,7 +443,10 @@ export class CredentialsClass {
 		const logins = {};
 		logins[key] = idToken;
 
-		const cognitoConfig = { region: identityPoolRegion ?? region };
+		const cognitoConfig = {
+			region: identityPoolRegion ?? region,
+			customEndpoint: endpoint,
+		};
 
 		/* 
 			Retreiving identityId with GetIdCommand to mimic the behavior in the following code in aws-sdk-v3:

--- a/packages/core/src/clients/types/aws.ts
+++ b/packages/core/src/clients/types/aws.ts
@@ -12,10 +12,14 @@ export type SourceData = string | ArrayBuffer | ArrayBufferView;
 /**
  * Basic option type for endpoint resolvers. It contains region only.
  */
-export type EndpointResolverOptions = { region: string };
+export type EndpointResolverOptions = {
+	region: string;
+	customEndpoint?: string;
+};
 
 export interface ServiceClientOptions {
 	region: string;
+	customEndpoint?: string;
 	endpointResolver: (options: EndpointResolverOptions, input?: any) => Endpoint;
 }
 


### PR DESCRIPTION
#### Description of changes
It is possible to specify a custom endpoint for a Cognito user pool through settings, but we were unable to specify a custom endpoint for identity pools. We have implemented a solution to enable custom endpoints for identity pools using the same settings as the user pool's custom endpoint.


#### Issue #, if available
#11275



#### Description of how you validated changes
I have built a custom app using Amplify and confirmed that it can access the AWS API Gateway URL specified for the custom endpoint.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
