### PR TITLE
fix(adapter-nextjs): align with js-cookie on the client handling double encoded cookie names

### DIFF
--- a/packages/adapter-nextjs/__tests__/utils/createCookieStorageAdapterFromNextServerContext.test.ts
+++ b/packages/adapter-nextjs/__tests__/utils/createCookieStorageAdapterFromNextServerContext.test.ts
@@ -32,11 +32,15 @@ describe('createCookieStorageAdapterFromNextServerContext', () => {
 		delete: jest.fn(),
 	};
 
+	const mockKey = 'key';
+	const mockKeyWithEncoding = 'test%40email.com';
+	const mockValue = 'fabCookie';
+
 	beforeEach(() => {
 		jest.resetAllMocks();
 	});
 
-	it('it should return cookieStorageAdapter from NextRequest and NextResponse', () => {
+	describe('cookieStorageAdapter created from NextRequest and NextResponse', () => {
 		const request = new NextRequest(new URL('https://example.com'));
 		const response = NextResponse.next();
 
@@ -62,22 +66,56 @@ describe('createCookieStorageAdapterFromNextServerContext', () => {
 		} as any;
 
 		const result = createCookieStorageAdapterFromNextServerContext(mockContext);
-		const mockKey = 'key';
-		const mockValue = 'cookieName=value';
-		result.get(mockKey);
-		expect(mockGetFunc).toHaveBeenCalledWith(mockKey);
 
-		result.getAll();
-		expect(mockGetAllFunc).toHaveBeenCalled();
+		it('gets cookie by calling `get` method of the underlying cookie store', () => {
+			result.get(mockKey);
+			expect(mockGetFunc).toHaveBeenCalledWith(mockKey);
+		});
 
-		result.set(mockKey, mockValue);
-		expect(mockSetFunc).toHaveBeenCalledWith(mockKey, mockValue);
+		it('gets cookie by calling `get` method of the underlying cookie store with a encoded cookie name', () => {
+			result.get(mockKeyWithEncoding);
+			expect(mockGetFunc).toHaveBeenCalledWith(
+				encodeURIComponent(mockKeyWithEncoding)
+			);
+		});
 
-		result.delete(mockKey);
-		expect(mockDeleteFunc).toHaveBeenCalledWith(mockKey);
+		it('gets all cookies by calling `getAll` method of the underlying cookie store', () => {
+			result.getAll();
+			expect(mockGetAllFunc).toHaveBeenCalled();
+		});
+
+		it('sets cookie by calling the `set` method of the underlying cookie store', () => {
+			result.set(mockKey, mockValue);
+			expect(mockSetFunc).toHaveBeenCalledWith(
+				mockKey,
+				mockValue,
+				undefined /* didn't specify the options param in the call */
+			);
+		});
+
+		it('sets cookie by calling the `set` method of the underlying cookie store with a encoded cookie name', () => {
+			result.set(mockKeyWithEncoding, mockValue, { sameSite: 'lax' });
+			expect(mockSetFunc).toHaveBeenCalledWith(
+				encodeURIComponent(mockKeyWithEncoding),
+				mockValue,
+				{ sameSite: 'lax' }
+			);
+		});
+
+		it('deletes cookie by calling  the `delete` method of the underlying cookie store', () => {
+			result.delete(mockKey);
+			expect(mockDeleteFunc).toHaveBeenCalledWith(mockKey);
+		});
+
+		it('deletes cookie by calling  the `delete` method of the underlying cookie store with a encoded cookie name', () => {
+			result.delete(mockKeyWithEncoding);
+			expect(mockDeleteFunc).toHaveBeenCalledWith(
+				encodeURIComponent(mockKeyWithEncoding)
+			);
+		});
 	});
 
-	it('should return cookieStorageAdapter from NextRequest and Response', () => {
+	describe('cookieStorageAdapter created from NextRequest and Response', () => {
 		const request = new NextRequest(new URL('https://example.com'));
 		const response = new Response();
 
@@ -100,16 +138,6 @@ describe('createCookieStorageAdapterFromNextServerContext', () => {
 			response,
 		} as any;
 
-		const result = createCookieStorageAdapterFromNextServerContext(mockContext);
-		const mockKey = 'key';
-		const mockValue = '123';
-
-		result.get(mockKey);
-		expect(mockGetFunc).toHaveBeenCalledWith(mockKey);
-
-		result.getAll();
-		expect(mockGetAllFunc).toHaveBeenCalled();
-
 		const mockSerializeOptions = {
 			domain: 'example.com',
 			expires: new Date('2023-08-22'),
@@ -117,108 +145,250 @@ describe('createCookieStorageAdapterFromNextServerContext', () => {
 			httpOnly: true,
 			secure: true,
 		};
-		result.set(mockKey, mockValue, mockSerializeOptions);
-		expect(mockAppend).toHaveBeenCalledWith(
-			'Set-Cookie',
-			`${mockKey}=${mockValue};Domain=${
-				mockSerializeOptions.domain
-			};Expires=${mockSerializeOptions.expires.toUTCString()};HttpOnly;SameSite=${
-				mockSerializeOptions.sameSite
-			};Secure`
-		);
 
-		result.set(mockKey, mockValue, undefined);
-		expect(mockAppend).toHaveBeenCalledWith(
-			'Set-Cookie',
-			`${mockKey}=${mockValue};`
-		);
+		const result = createCookieStorageAdapterFromNextServerContext(mockContext);
 
-		result.set(mockKey, mockValue, {
-			httpOnly: false,
-			sameSite: false,
-			secure: false,
+		it('gets cookie by calling `get` method of the underlying cookie store', () => {
+			result.get(mockKey);
+			expect(mockGetFunc).toHaveBeenCalledWith(mockKey);
 		});
-		expect(mockAppend).toHaveBeenCalledWith(
-			'Set-Cookie',
-			`${mockKey}=${mockValue};`
-		);
 
-		result.delete(mockKey);
-		expect(mockAppend).toHaveBeenCalledWith(
-			'Set-Cookie',
-			`${mockKey}=;Expires=${DATE_IN_THE_PAST.toUTCString()}`
-		);
+		it('gets cookie by calling `get` method of the underlying cookie store with a encoded cookie name', () => {
+			result.get(mockKeyWithEncoding);
+			expect(mockGetFunc).toHaveBeenCalledWith(
+				encodeURIComponent(mockKeyWithEncoding)
+			);
+		});
+
+		it('gets all cookies by calling `getAll` method of the underlying cookie store', () => {
+			result.getAll();
+			expect(mockGetAllFunc).toHaveBeenCalled();
+		});
+
+		it('sets cookie by calling the `set` method of the underlying cookie store with options', () => {
+			result.set(mockKey, mockValue, mockSerializeOptions);
+			expect(mockAppend).toHaveBeenCalledWith(
+				'Set-Cookie',
+				`${mockKey}=${mockValue};Domain=${
+					mockSerializeOptions.domain
+				};Expires=${mockSerializeOptions.expires.toUTCString()};HttpOnly;SameSite=${
+					mockSerializeOptions.sameSite
+				};Secure`
+			);
+		});
+
+		it('sets cookie by calling the `set` method of the underlying cookie store with options and a encoded cookie name', () => {
+			result.set(mockKeyWithEncoding, mockValue, mockSerializeOptions);
+			expect(mockAppend).toHaveBeenCalledWith(
+				'Set-Cookie',
+				`${encodeURIComponent(mockKeyWithEncoding)}=${mockValue};Domain=${
+					mockSerializeOptions.domain
+				};Expires=${mockSerializeOptions.expires.toUTCString()};HttpOnly;SameSite=${
+					mockSerializeOptions.sameSite
+				};Secure`
+			);
+		});
+
+		it('sets cookie by calling the `set` method of the underlying cookie store without options', () => {
+			result.set(mockKey, mockValue, undefined);
+			expect(mockAppend).toHaveBeenCalledWith(
+				'Set-Cookie',
+				`${mockKey}=${mockValue};`
+			);
+		});
+
+		it('sets cookie by calling the `set` method of the underlying cookie store with options that do not need to be serialized', () => {
+			result.set(mockKey, mockValue, {
+				httpOnly: false,
+				sameSite: false,
+				secure: false,
+			});
+			expect(mockAppend).toHaveBeenCalledWith(
+				'Set-Cookie',
+				`${mockKey}=${mockValue};`
+			);
+		});
+
+		it('deletes cookie by calling  the `delete` method of the underlying cookie store', () => {
+			result.delete(mockKey);
+			expect(mockAppend).toHaveBeenCalledWith(
+				'Set-Cookie',
+				`${mockKey}=;Expires=${DATE_IN_THE_PAST.toUTCString()}`
+			);
+		});
+
+		it('deletes cookie by calling  the `delete` method of the underlying cookie store with a encoded cookie name', () => {
+			result.delete(mockKeyWithEncoding);
+			expect(mockAppend).toHaveBeenCalledWith(
+				'Set-Cookie',
+				`${encodeURIComponent(
+					mockKeyWithEncoding
+				)}=;Expires=${DATE_IN_THE_PAST.toUTCString()}`
+			);
+		});
 	});
 
-	it('should return cookieStorageAdapter from Next cookies function', () => {
+	describe('cookieStorageAdapter created from Next cookies function', () => {
 		mockNextCookiesFunc.mockReturnValueOnce(mockNextCookiesFuncReturn);
 
 		const result = createCookieStorageAdapterFromNextServerContext({ cookies });
 
-		const mockKey = 'key';
-		const mockValue = '123';
+		it('gets cookie by calling `get` method of the underlying cookie store', () => {
+			result.get(mockKey);
+			expect(mockNextCookiesFuncReturn.get).toHaveBeenCalledWith(mockKey);
+		});
 
-		result.get(mockKey);
-		expect(mockNextCookiesFuncReturn.get).toHaveBeenCalledWith(mockKey);
+		it('gets cookie by calling `get` method of the underlying cookie store with a encoded cookie name', () => {
+			result.get(mockKeyWithEncoding);
+			expect(mockNextCookiesFuncReturn.get).toHaveBeenCalledWith(
+				encodeURIComponent(mockKeyWithEncoding)
+			);
+		});
 
-		result.getAll();
-		expect(mockNextCookiesFuncReturn.getAll).toHaveBeenCalled();
+		it('gets all cookies by calling `getAll` method of the underlying cookie store', () => {
+			result.getAll();
+			expect(mockNextCookiesFuncReturn.getAll).toHaveBeenCalled();
+		});
 
-		result.set(mockKey, mockValue);
-		expect(mockNextCookiesFuncReturn.set).toHaveBeenCalledWith(
-			mockKey,
-			mockValue,
-			undefined
-		);
+		it('sets cookie by calling the `set` method of the underlying cookie store', () => {
+			result.set(mockKey, mockValue);
+			expect(mockNextCookiesFuncReturn.set).toHaveBeenCalledWith(
+				mockKey,
+				mockValue,
+				undefined
+			);
+		});
 
-		result.delete(mockKey);
-		expect(mockNextCookiesFuncReturn.delete).toHaveBeenCalledWith(mockKey);
+		it('sets cookie by calling the `set` method of the underlying cookie store with a encoded cookie name', () => {
+			result.set(mockKeyWithEncoding, mockValue);
+			expect(mockNextCookiesFuncReturn.set).toHaveBeenCalledWith(
+				encodeURIComponent(mockKeyWithEncoding),
+				mockValue,
+				undefined
+			);
+		});
+
+		it('deletes cookie by calling  the `delete` method of the underlying cookie store', () => {
+			result.delete(mockKey);
+			expect(mockNextCookiesFuncReturn.delete).toHaveBeenCalledWith(mockKey);
+		});
+
+		it('deletes cookie by calling  the `delete` method of the underlying cookie store with a encoded cookie name', () => {
+			result.delete(mockKeyWithEncoding);
+			expect(mockNextCookiesFuncReturn.delete).toHaveBeenCalledWith(
+				encodeURIComponent(mockKeyWithEncoding)
+			);
+		});
 	});
 
-	it('should return cookieStorageAdapter from IncomingMessage and ServerResponse as the Pages Router context', () => {
-		const mockCookies = {
-			key1: 'value1',
-			key2: 'value2',
-		};
+	describe('cookieStorageAdapter created from IncomingMessage and ServerResponse as the Pages Router context', () => {
+		it('operates with the underlying cookie store', () => {
+			const mockCookies = {
+				key1: 'value1',
+				key2: 'value2',
+			};
 
-		const request = new IncomingMessage(new Socket());
-		const response = new ServerResponse(request);
-		const setHeaderSpy = jest.spyOn(response, 'setHeader');
+			const request = new IncomingMessage(new Socket());
+			const response = new ServerResponse(request);
+			const setHeaderSpy = jest.spyOn(response, 'setHeader');
 
-		Object.defineProperty(request, 'cookies', {
-			get() {
-				return mockCookies;
-			},
+			Object.defineProperty(request, 'cookies', {
+				get() {
+					return mockCookies;
+				},
+			});
+
+			const result = createCookieStorageAdapterFromNextServerContext({
+				request: request as any,
+				response,
+			});
+
+			expect(result.get('key1')).toEqual({ name: 'key1', value: 'value1' });
+			expect(result.get('non-exist')).toBeUndefined();
+			expect(result.getAll()).toEqual([
+				{ name: 'key1', value: 'value1' },
+				{ name: 'key2', value: 'value2' },
+			]);
+
+			result.set('key3', 'value3');
+			expect(setHeaderSpy).toHaveBeenCalledWith('Set-Cookie', 'key3=value3;');
+
+			result.set('key4', 'value4', {
+				httpOnly: true,
+			});
+			expect(setHeaderSpy).toHaveBeenCalledWith(
+				'Set-Cookie',
+				'key4=value4;HttpOnly'
+			);
+
+			result.delete('key3');
+			expect(setHeaderSpy).toHaveBeenCalledWith(
+				'Set-Cookie',
+				`key3=;Expires=${DATE_IN_THE_PAST.toUTCString()}`
+			);
 		});
 
-		const result = createCookieStorageAdapterFromNextServerContext({
-			request: request as any,
-			response,
+		it('operates with the underlying cookie store with encoded cookie names', () => {
+			// these the auth keys generated by Amplify
+			const encodedCookieName1 = encodeURIComponent('test@email.com.idToken');
+			const encodedCookieName2 = encodeURIComponent(
+				'test@email.com.refreshToken'
+			);
+
+			const mockCookies = {
+				// these keys are generate by js-cookie used on the client side
+				[encodeURIComponent(encodedCookieName1)]: 'value1',
+				[encodeURIComponent(encodedCookieName2)]: 'value2',
+			};
+
+			const request = new IncomingMessage(new Socket());
+			const response = new ServerResponse(request);
+			const setHeaderSpy = jest.spyOn(response, 'setHeader');
+
+			Object.defineProperty(request, 'cookies', {
+				get() {
+					return mockCookies;
+				},
+			});
+
+			const result = createCookieStorageAdapterFromNextServerContext({
+				request: request as any,
+				response,
+			});
+
+			expect(result.get(encodedCookieName1)).toEqual({
+				name: encodedCookieName1,
+				value: 'value1',
+			});
+			expect(result.get('non-exist')).toBeUndefined();
+			expect(result.getAll()).toEqual([
+				// these keys are generate by js-cookie used on the client side
+				{ name: encodeURIComponent(encodedCookieName1), value: 'value1' },
+				{ name: encodeURIComponent(encodedCookieName2), value: 'value2' },
+			]);
+
+			result.set('key3', 'value3');
+			expect(setHeaderSpy).toHaveBeenCalledWith('Set-Cookie', 'key3=value3;');
+
+			result.set('key4', 'value4', {
+				httpOnly: true,
+			});
+
+			const encodedCookieName = encodeURIComponent(
+				'test@email.com.somethingElse'
+			);
+			result.set(encodeURIComponent('test@email.com.somethingElse'), 'value5');
+			expect(setHeaderSpy).toHaveBeenCalledWith(
+				'Set-Cookie',
+				`${encodeURIComponent(encodedCookieName)}=value5;`
+			);
+
+			result.delete('key3');
+			expect(setHeaderSpy).toHaveBeenCalledWith(
+				'Set-Cookie',
+				`key3=;Expires=${DATE_IN_THE_PAST.toUTCString()}`
+			);
 		});
-
-		expect(result.get('key1')).toEqual({ name: 'key1', value: 'value1' });
-		expect(result.get('non-exist')).toBeUndefined();
-		expect(result.getAll()).toEqual([
-			{ name: 'key1', value: 'value1' },
-			{ name: 'key2', value: 'value2' },
-		]);
-
-		result.set('key3', 'value3');
-		expect(setHeaderSpy).toHaveBeenCalledWith('Set-Cookie', 'key3=value3;');
-
-		result.set('key4', 'value4', {
-			httpOnly: true,
-		});
-		expect(setHeaderSpy).toHaveBeenCalledWith(
-			'Set-Cookie',
-			'key4=value4;HttpOnly'
-		);
-
-		result.delete('key3');
-		expect(setHeaderSpy).toHaveBeenCalledWith(
-			'Set-Cookie',
-			`key3=;Expires=${DATE_IN_THE_PAST.toUTCString()}`
-		);
 	});
 
 	it('should throw error when no cookie storage adapter is created from the context', () => {

--- a/packages/adapter-nextjs/tsconfig.json
+++ b/packages/adapter-nextjs/tsconfig.json
@@ -9,7 +9,7 @@
 		"sourceMap": true,
 		"module": "commonjs",
 		"moduleResolution": "node",
-		"allowJs": false,
+		"allowJs": true,
 		"declaration": true,
 		"typeRoots": ["./node_modules/@types", "../../node_modules/@types"],
 		"types": ["node"],

--- a/packages/core/__tests__/storage/CookieStorage.test.ts
+++ b/packages/core/__tests__/storage/CookieStorage.test.ts
@@ -54,6 +54,14 @@ describe('CookieStorage', () => {
 				expect(await cookieStore.getItem('testKey')).toBe('testValue');
 			});
 
+			it('setting and getting an item with encoded cookie name', async () => {
+				const testKey = encodeURIComponent('test@email.com');
+				const testValue = '123';
+				await cookieStore.setItem(testKey, testValue);
+				console.log(document.cookie);
+				expect(await cookieStore.getItem(testKey)).toEqual(testValue);
+			});
+
 			it('Clearing cookies should remove all items within the storage', async () => {
 				const cookieStore = new CookieStorage(cookieStoreData);
 				await cookieStore.setItem('testKey2', 'testValue');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

As of today, `signIn` is handled by the client side API, which uses js-cookie to operate the underlying cookie storage in a SSR use case (i.e. `Amplify.configure(config, {ssr: true})`).

According to [js-cookie document](https://github.com/js-cookie/js-cookie#encoding), it encodes cookie name.

In Amplify, we encode cookie name in the case of using `username` as a part of the cookie names, where the `username` can be an email address, for example, cookie name `test@email.com` will be encoded as `test%40email.com`.

When store the item into cookie store via js-cookie, the cookie name gets double encoded as `test%2540email.com`. 

In adapte-nextjs, we need to handle this ensure the sever side functionality can extra tokens from cookies. 


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
