### PR TITLE
fix(auth): returns refreshToken from login 

### DIFF
--- a/packages/auth/__tests__/providers/cognito/refreshToken.test.ts
+++ b/packages/auth/__tests__/providers/cognito/refreshToken.test.ts
@@ -8,6 +8,8 @@ import * as clients from '../../../src/providers/cognito/utils/clients/CognitoId
 jest.mock('@aws-amplify/core/lib/clients/handlers/fetch');
 
 describe('refresh token tests', () => {
+	const mockedUsername = 'mockedUsername';
+	const mockedRefreshToken = 'mockedRefreshToken';
 	test('Default Cognito Token Refresh Handler', async () => {
 		const succeedResponse = {
 			status: 200,
@@ -38,10 +40,11 @@ describe('refresh token tests', () => {
 			idToken: decodeJWT(
 				'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzB9.YzDpgJsrB3z-ZU1XxMcXSQsMbgCzwH_e-_76rnfehh0'
 			),
-			metadata: {
-				refreshToken: 'refreshtoken',
-			},
+
+			refreshToken: mockedRefreshToken,
+
 			clockDrift: 0,
+			username: mockedRefreshToken,
 		};
 		const expectedRequest = {
 			url: new URL('https://cognito-idp.us-east-1.amazonaws.com/'),
@@ -56,7 +59,7 @@ describe('refresh token tests', () => {
 				ClientId: 'aaaaaaaaaaaa',
 				AuthFlow: 'REFRESH_TOKEN_AUTH',
 				AuthParameters: {
-					REFRESH_TOKEN: 'refreshtoken',
+					REFRESH_TOKEN: mockedRefreshToken,
 				},
 			}),
 		};
@@ -70,7 +73,8 @@ describe('refresh token tests', () => {
 					payload: {},
 				},
 				clockDrift: 0,
-				refreshToken: 'refreshtoken',
+				refreshToken: mockedRefreshToken,
+				username: mockedUsername,
 			},
 			authConfig: {
 				Cognito: {
@@ -78,11 +82,15 @@ describe('refresh token tests', () => {
 					userPoolClientId: 'aaaaaaaaaaaa',
 				},
 			},
+			username: mockedUsername,
 		});
 
 		expect(response.accessToken.toString()).toEqual(
 			expectedOutput.accessToken.toString()
 		);
+
+		expect(response.refreshToken).toEqual(expectedOutput.refreshToken);
+
 		expect(fetchTransferHandler).toBeCalledWith(
 			expectedRequest,
 			expect.anything()
@@ -92,7 +100,6 @@ describe('refresh token tests', () => {
 
 describe('Cognito ASF', () => {
 	let initiateAuthSpy;
-	let tokenProviderSpy;
 	afterAll(() => {
 		jest.restoreAllMocks();
 	});

--- a/packages/auth/__tests__/providers/cognito/refreshToken.test.ts
+++ b/packages/auth/__tests__/providers/cognito/refreshToken.test.ts
@@ -44,7 +44,7 @@ describe('refresh token tests', () => {
 			refreshToken: mockedRefreshToken,
 
 			clockDrift: 0,
-			username: mockedRefreshToken,
+			username: mockedUsername,
 		};
 		const expectedRequest = {
 			url: new URL('https://cognito-idp.us-east-1.amazonaws.com/'),

--- a/packages/auth/src/providers/cognito/utils/refreshAuthTokens.ts
+++ b/packages/auth/src/providers/cognito/utils/refreshAuthTokens.ts
@@ -63,13 +63,12 @@ export const refreshAuthTokens: TokenRefresher = async ({
 		});
 	}
 	const clockDrift = iat * 1000 - new Date().getTime();
-	const refreshToken = AuthenticationResult?.RefreshToken ?? refreshTokenString;
 
 	return {
 		accessToken,
 		idToken,
 		clockDrift,
-		refreshToken,
+		refreshToken: refreshTokenString,
 		username: `${accessToken.payload.username}`,
 	};
 };

--- a/packages/auth/src/providers/cognito/utils/refreshAuthTokens.ts
+++ b/packages/auth/src/providers/cognito/utils/refreshAuthTokens.ts
@@ -63,7 +63,7 @@ export const refreshAuthTokens: TokenRefresher = async ({
 		});
 	}
 	const clockDrift = iat * 1000 - new Date().getTime();
-	const refreshToken = AuthenticationResult?.RefreshToken;
+	const refreshToken = AuthenticationResult?.RefreshToken ?? refreshTokenString;
 
 	return {
 		accessToken,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The `refreshToken` originated from login was cleared after `refreshAuthTokens` was triggered, and any subsequent call would end up in an `AuthError`.

This PR returns the original `refreshToken`, that was issued during sign-in, when calling `refreshAuthTokens`.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

- added a unit test to check the same refreshToken is return
- test in a sample app that multiple calls to `fetchAuthSession({forceRefresh:true})` would not result in an AuthError

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
