### PR TITLE
fix(auth): remove username en/decode logic 

### DIFF
--- a/packages/auth/__tests__/providers/cognito/tokenProvider.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider.test.ts
@@ -84,19 +84,18 @@ describe('Loading tokens', () => {
 		const memoryStorage = new MemoryStorage();
 		const userPoolClientId = 'userPoolClientId';
 		const userSub1 = 'user1@email.com';
-		const userSub1Encoded = 'user1%40email.com';
 		const userSub2 = 'user2@email.com';
 
 		memoryStorage.setItem(
-			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub1Encoded}.deviceKey`,
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub1}.deviceKey`,
 			'user1-device-key'
 		);
 		memoryStorage.setItem(
-			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub1Encoded}.deviceGroupKey`,
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub1}.deviceGroupKey`,
 			'user1-device-group-key'
 		);
 		memoryStorage.setItem(
-			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub1Encoded}.randomPasswordKey`,
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub1}.randomPasswordKey`,
 			'user1-random-password'
 		);
 		memoryStorage.setItem(
@@ -144,7 +143,7 @@ describe('saving tokens', () => {
 				userPoolClientId,
 			},
 		});
-
+		const lastAuthUser = 'amplify@user';
 		await tokenStore.storeTokens({
 			accessToken: decodeJWT(
 				'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.AAA'
@@ -159,22 +158,20 @@ describe('saving tokens', () => {
 				deviceGroupKey: 'device-group-key2',
 				randomPassword: 'random-password2',
 			},
-			username: 'amplify@user',
+			username: lastAuthUser,
 		});
-
-		const usernameDecoded = 'amplify%40user';
 
 		expect(
 			await memoryStorage.getItem(
 				`CognitoIdentityServiceProvider.${userPoolClientId}.LastAuthUser`
 			)
-		).toBe(usernameDecoded); // from decoded JWT
+		).toBe(lastAuthUser);
 
 		// Refreshed tokens
 
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.accessToken`
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${lastAuthUser}.accessToken`
 			)
 		).toBe(
 			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.AAA'
@@ -182,7 +179,7 @@ describe('saving tokens', () => {
 
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.idToken`
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${lastAuthUser}.idToken`
 			)
 		).toBe(
 			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.III'
@@ -190,28 +187,28 @@ describe('saving tokens', () => {
 
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.refreshToken`
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${lastAuthUser}.refreshToken`
 			)
 		).toBe('refresh-token');
 
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.clockDrift`
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${lastAuthUser}.clockDrift`
 			)
 		).toBe('150');
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.deviceKey`
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${lastAuthUser}.deviceKey`
 			)
 		).toBe('device-key2');
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.deviceGroupKey`
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${lastAuthUser}.deviceGroupKey`
 			)
 		).toBe('device-group-key2');
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.randomPasswordKey`
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${lastAuthUser}.randomPasswordKey`
 			)
 		).toBe('random-password2');
 	});
@@ -276,22 +273,20 @@ describe('saving tokens', () => {
 				deviceGroupKey: 'device-group-key2',
 				randomPassword: 'random-password2',
 			},
-			username: 'amplify@user',
+			username: oldUserName,
 		});
-
-		const usernameEncoded = 'amplify%40user';
 
 		expect(
 			await memoryStorage.getItem(
 				`CognitoIdentityServiceProvider.${userPoolClientId}.LastAuthUser`
 			)
-		).toBe(usernameEncoded); // from decoded JWT
+		).toBe(oldUserName);
 
 		// Refreshed tokens
 
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.accessToken`
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.accessToken`
 			)
 		).toBe(
 			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.AAA'
@@ -299,7 +294,7 @@ describe('saving tokens', () => {
 
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.idToken`
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.idToken`
 			)
 		).toBe(
 			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.III'
@@ -307,84 +302,30 @@ describe('saving tokens', () => {
 
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.refreshToken`
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.refreshToken`
 			)
 		).toBe('refresh-token');
 
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.clockDrift`
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.clockDrift`
 			)
 		).toBe('150');
 
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.deviceKey`
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.deviceKey`
 			)
 		).toBe('device-key2');
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.deviceGroupKey`
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.deviceGroupKey`
 			)
 		).toBe('device-group-key2');
 		expect(
 			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.randomPasswordKey`
-			)
-		).toBe('random-password2');
-
-		// old tokens cleared
-		expect(
-			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.accessToken`
-			)
-		).toBeUndefined();
-		expect(
-			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.idToken`
-			)
-		).toBeUndefined();
-		expect(
-			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.refreshToken`
-			)
-		).toBeUndefined();
-		expect(
-			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.clockDrift`
-			)
-		).toBeUndefined();
-
-		expect(
-			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.idToken`
-			)
-		).toBeUndefined();
-		expect(
-			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.refreshToken`
-			)
-		).toBeUndefined();
-		expect(
-			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.clockDrift`
-			)
-		).toBeUndefined();
-
-		expect(
-			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.deviceKey`
-			)
-		).not.toBeUndefined();
-		expect(
-			await memoryStorage.getItem(
-				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.deviceGroupKey`
-			)
-		).not.toBeUndefined();
-		expect(
-			await memoryStorage.getItem(
 				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.randomPasswordKey`
 			)
-		).not.toBeUndefined();
+		).toBe('random-password2');
 	});
 });

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
@@ -71,7 +71,7 @@ export class DefaultTokenStore implements AuthTokenStore {
 				refreshToken,
 				deviceMetadata: (await this.getDeviceMetadata()) ?? undefined,
 				clockDrift,
-				username: decodeURIComponent(await this.getLastAuthUser()),
+				username: await this.getLastAuthUser(),
 			};
 		} catch (err) {
 			return null;
@@ -81,8 +81,7 @@ export class DefaultTokenStore implements AuthTokenStore {
 		assert(tokens !== undefined, TokenProviderErrorCode.InvalidAuthTokens);
 		await this.clearTokens();
 
-		const lastAuthUser =
-			(tokens.username && encodeURIComponent(tokens.username)) ?? 'username';
+		const lastAuthUser = tokens.username;
 		await this.getKeyValueStorage().setItem(
 			this.getLastAuthUserKey(),
 			lastAuthUser
@@ -146,7 +145,7 @@ export class DefaultTokenStore implements AuthTokenStore {
 	}
 
 	async getDeviceMetadata(username?: string): Promise<DeviceMetadata | null> {
-		const authKeys = await this.getDeviceAuthKeys(username);
+		const authKeys = await this.getAuthKeys(username);
 		const deviceKey = await this.getKeyValueStorage().getItem(
 			authKeys.deviceKey
 		);
@@ -166,7 +165,7 @@ export class DefaultTokenStore implements AuthTokenStore {
 			: null;
 	}
 	async clearDeviceMetadata(username?: string): Promise<void> {
-		const authKeys = await this.getDeviceAuthKeys(username);
+		const authKeys = await this.getAuthKeys(username);
 		await Promise.all([
 			this.getKeyValueStorage().removeItem(authKeys.deviceKey),
 			this.getKeyValueStorage().removeItem(authKeys.deviceGroupKey),
@@ -183,24 +182,6 @@ export class DefaultTokenStore implements AuthTokenStore {
 			this.name,
 			`${this.authConfig.Cognito.userPoolClientId}.${lastAuthUser}`
 		);
-	}
-	private async getDeviceAuthKeys(
-		username?: string
-	): Promise<AuthKeys<keyof typeof AuthTokenStorageKeys>> {
-		let authKeys: AuthKeys<keyof typeof AuthTokenStorageKeys>;
-		if (username) {
-			const authEncodedKeys = await this.getAuthKeys(
-				encodeURIComponent(username)
-			);
-			const authNonEncodedKeys = await this.getAuthKeys(username);
-			const isEncodedKeysPresent = !!(await this.getKeyValueStorage().getItem(
-				authEncodedKeys.randomPasswordKey
-			));
-			authKeys = isEncodedKeysPresent ? authEncodedKeys : authNonEncodedKeys;
-		} else {
-			authKeys = await this.getAuthKeys();
-		}
-		return authKeys;
 	}
 
 	private getLastAuthUserKey() {

--- a/packages/auth/src/providers/cognito/utils/refreshAuthTokens.ts
+++ b/packages/auth/src/providers/cognito/utils/refreshAuthTokens.ts
@@ -69,6 +69,6 @@ export const refreshAuthTokens: TokenRefresher = async ({
 		idToken,
 		clockDrift,
 		refreshToken: refreshTokenString,
-		username: `${accessToken.payload.username}`,
+		username,
 	};
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Currently the library create auth keys to store tokens and uses the `username` as identifier. E.g 
`CognitoIdentityServiceProvider.${userPoolClientId}.${username}.idToken`

This username is encoded when setting tokens and decoded when getting tokens. This works fine in `LocalStorage`. The issue happens in Cookies as `js-cookie`(the package used by the library) will encode the keys and if username is an `email` it will double encode the `@` symbol.

This removes the encoding logic and attaches the plain username in the keys.

**NOTE:**

This change when published to `console-preview` will log out any users that were authenticated with the encoded key format.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
