### PR TITLE
chore: v6 re-enable DataStore tests - batch 1

### DIFF
--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -79,13 +79,13 @@ tests:
     sample_name: private-auth-iam
     spec: private-auth-iam
     browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth-public-auth-default
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: public-auth-default
-  #   spec: public-auth-default
-  #   browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-public-auth-default
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: public-auth-default
+    spec: public-auth-default
+    browser: *minimal_browser_list
   - test_name: integ_datastore_auth-public-auth-iam
     desc: 'DataStore Auth'
     framework: react

--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -93,7 +93,7 @@ tests:
     sample_name: public-auth-iam
     spec: public-auth-iam
     browser: *minimal_browser_list
-  - test_name: integ_datastore_auth-AuthUser
+  - test_name: integ_datastore_auth-owner-custom-claim-default
     desc: 'DataStore Auth'
     framework: react
     category: datastore

--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -51,34 +51,34 @@ tests:
   #   sample_name: owner-and-group-same-model-operations
   #   spec: owner-and-group-same-model-operations
   #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth-dynamic-user-pool-groups-default
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: dynamic-user-pool-groups-default
-  #   spec: dynamic-user-pool-groups-default
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth-dynamic-user-pool-groups-owner-based-default
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: dynamic-user-pool-groups-owner-based-default
-  #   spec: dynamic-user-pool-groups-owner-based-default
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth-private-auth-default
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: private-auth-default
-  #   spec: private-auth-default
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth-private-auth-iam
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: private-auth-iam
-  #   spec: private-auth-iam
-  #   browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-dynamic-user-pool-groups-default
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: dynamic-user-pool-groups-default
+    spec: dynamic-user-pool-groups-default
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-dynamic-user-pool-groups-owner-based-default
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: dynamic-user-pool-groups-owner-based-default
+    spec: dynamic-user-pool-groups-owner-based-default
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-private-auth-default
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: private-auth-default
+    spec: private-auth-default
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-private-auth-iam
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: private-auth-iam
+    spec: private-auth-iam
+    browser: *minimal_browser_list
   # - test_name: integ_datastore_auth-public-auth-default
   #   desc: 'DataStore Auth'
   #   framework: react
@@ -86,27 +86,27 @@ tests:
   #   sample_name: public-auth-default
   #   spec: public-auth-default
   #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth-public-auth-iam
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: public-auth-iam
-  #   spec: public-auth-iam
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth-owner-custom-claim-default
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: owner-custom-claim-default
-  #   spec: owner-custom-claim-default
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth-owner-custom-field-default
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: owner-custom-field-default
-  #   spec: owner-custom-field-default
-  #   browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-public-auth-iam
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: public-auth-iam
+    spec: public-auth-iam
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-AuthUser
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: owner-custom-claim-default
+    spec: owner-custom-claim-default
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-owner-custom-field-default
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: owner-custom-field-default
+    spec: owner-custom-field-default
+    browser: *minimal_browser_list
   - test_name: integ_datastore_auth_v2-owner-based-default
     desc: 'DataStore Auth CLI v2'
     framework: react
@@ -689,14 +689,14 @@ tests:
   #   browser: *minimal_browser_list
 
   # PUBSUB
-  # - test_name: integ_react_iot_reconnect
-  #   desc: 'PubSub - Reconnection for IoT'
-  #   framework: react
-  #   category: pubsub
-  #   sample_name: [reconnection-iot]
-  #   spec: reconnection
-  #   # Firefox doesn't support network state management in cypress
-  #   browser: [chrome]
+  - test_name: integ_react_iot_reconnect
+    desc: 'PubSub - Reconnection for IoT'
+    framework: react
+    category: pubsub
+    sample_name: [reconnection-iot]
+    spec: reconnection
+    # Firefox doesn't support network state management in cypress
+    browser: [chrome]
   - test_name: integ_react_api_reconnect
     desc: 'PubSub - Reconnection for API'
     framework: react

--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -202,13 +202,13 @@ tests:
   #   sample_name: v2/owner-custom-claim-default-v2
   #   spec: owner-custom-claim-default
   #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth_v2-owner-custom-field-default
-  #   desc: 'DataStore Auth CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: v2/owner-custom-field-default-v2
-  #   spec: owner-custom-field-default
-  #   browser: *minimal_browser_list
+  - test_name: integ_datastore_auth_v2-owner-custom-field-default
+    desc: 'DataStore Auth CLI v2'
+    framework: react
+    category: datastore
+    sample_name: v2/owner-custom-field-default-v2
+    spec: owner-custom-field-default
+    browser: *minimal_browser_list
   # - test_name: integ_react_datastore
   #   desc: 'React DataStore'
   #   framework: react

--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -689,14 +689,14 @@ tests:
   #   browser: *minimal_browser_list
 
   # PUBSUB
-  - test_name: integ_react_iot_reconnect
-    desc: 'PubSub - Reconnection for IoT'
-    framework: react
-    category: pubsub
-    sample_name: [reconnection-iot]
-    spec: reconnection
-    # Firefox doesn't support network state management in cypress
-    browser: [chrome]
+  # - test_name: integ_react_iot_reconnect
+  #   desc: 'PubSub - Reconnection for IoT'
+  #   framework: react
+  #   category: pubsub
+  #   sample_name: [reconnection-iot]
+  #   spec: reconnection
+  #   # Firefox doesn't support network state management in cypress
+  #   browser: [chrome]
   - test_name: integ_react_api_reconnect
     desc: 'PubSub - Reconnection for API'
     framework: react


### PR DESCRIPTION
#### Description of changes

Depends on https://github.com/aws-amplify/amplify-js-samples-staging/pull/637

V6 migration of the following datastore tests
- owner-custom-field-default
- owner-custom-claim-default
- public-auth-iam
- public-auth-default
- private-auth-iam
- private-auth-default
- dynamic-user-pool-groups-owner-based-default
- dynamic-user-pool-groups-default

#### Description of how you validated changes
Tested locally, app by app, then on a run for all against my repo fork: https://github.com/stocaaro/amplify-js/actions/runs/6512430947

Individual test success links:
- [owner-custom-field-default](https://github.com/stocaaro/amplify-js/actions/runs/6512430947/job/17690232305)
- [owner-custom-claim-default](https://github.com/stocaaro/amplify-js/actions/runs/6512430947/job/17690230890)
- [public-auth-iam](https://github.com/stocaaro/amplify-js/actions/runs/6512430947/job/17690232571)
- [public-auth-default](https://github.com/stocaaro/amplify-js/actions/runs/6512947872/job/17691760765)
- [private-auth-iam](https://github.com/stocaaro/amplify-js/actions/runs/6512430947/job/17690231462)
- [private-auth-default](https://github.com/stocaaro/amplify-js/actions/runs/6512430947/job/17690232162)
- [dynamic-user-pool-groups-owner-based-default](https://github.com/stocaaro/amplify-js/actions/runs/6512430947/job/17690230584)
- [dynamic-user-pool-groups-default](https://github.com/stocaaro/amplify-js/actions/runs/6512430947/job/17690231315)


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
