### PR TITLE
feat(storage): expose the defaultPrefixResolver from storage/s3/utils subpath

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -97,6 +97,11 @@
 			"import": "./lib-esm/storage/s3/server.js",
 			"require": "./lib/storage/s3/server.js"
 		},
+		"./storage/s3/utils": {
+			"types": "./lib-esm/storage/s3/utils.d.ts",
+			"import": "./lib-esm/storage/s3/utils.js",
+			"require": "./lib/storage/s3/utils.js"
+		},
 		"./in-app-messaging": {
 			"types": "./lib-esm/in-app-messaging/index.d.ts",
 			"import": "./lib-esm/in-app-messaging/index.js",

--- a/packages/aws-amplify/src/storage/s3/utils.ts
+++ b/packages/aws-amplify/src/storage/s3/utils.ts
@@ -1,0 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+This file maps exports from `aws-amplify/storage/s3/utils`. It provides access to S3 utility APIs.
+*/
+export * from '@aws-amplify/storage/s3/utils';

--- a/packages/aws-amplify/storage/s3/utils/package.json
+++ b/packages/aws-amplify/storage/s3/utils/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "aws-amplify/storage/s3/utils",
+	"main": "../../../lib/storage/s3/utils.js",
+	"browser": "../../../lib-esm/storage/s3/utils.js",
+	"module": "../../../lib-esm/storage/s3/utils.js",
+	"typings": "../../../lib-esm/storage/s3/utils.d.ts"
+}

--- a/packages/storage/__tests__/providers/s3/apis/utilityApis/accessLevelAndIdentityAwarePrefixResolver.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utilityApis/accessLevelAndIdentityAwarePrefixResolver.test.ts
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+import { accessLevelAndIdentityAwarePrefixResolver } from '../../../../../src/providers/s3/apis/utilityApis/accessLevelAndIdentityAwarePrefixResolver';
+
+jest.mock('@aws-amplify/core', () => ({
+	Amplify: {
+		getConfig: jest.fn(),
+		Auth: {
+			fetchAuthSession: jest.fn(),
+		},
+	},
+}));
+
+const mockFetchAuthSession = Amplify.Auth.fetchAuthSession as jest.Mock;
+
+describe('accessLevelAndIdentityAwarePrefixResolver', () => {
+	const mockIdentityId = 'mockIdentityId';
+
+	beforeAll(() => {
+		mockFetchAuthSession.mockResolvedValue({
+			identityId: mockIdentityId,
+		});
+	});
+
+	it('returns private prefix when accessLevel is private', async () => {
+		const prefix = await accessLevelAndIdentityAwarePrefixResolver({
+			accessLevel: 'private',
+		});
+		expect(prefix).toEqual(`private/${mockIdentityId}/`);
+	});
+
+	it('returns protected prefix when accessLevel is protected', async () => {
+		const mockTargetIdentityId = 'targetIdentityId';
+		const prefix = await accessLevelAndIdentityAwarePrefixResolver({
+			accessLevel: 'protected',
+			targetIdentityId: mockTargetIdentityId,
+		});
+		expect(prefix).toEqual(`protected/${mockTargetIdentityId}/`);
+	});
+
+	it('returns public prefix when accessLevel is guest', async () => {
+		const prefix = await accessLevelAndIdentityAwarePrefixResolver({
+			accessLevel: 'guest',
+		});
+		expect(prefix).toEqual('public/');
+	});
+});

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -97,6 +97,11 @@
 			"import": "./lib-esm/providers/s3/server.js",
 			"require": "./lib/providers/s3/server.js"
 		},
+		"./s3/utils": {
+			"types": "./lib-esm/providers/s3/utilityApis.d.ts",
+			"import": "./lib-esm/providers/s3/utilityApis.js",
+			"require": "./lib/providers/s3/utilityApis.js"
+		},
 		"./package.json": "./package.json"
 	},
 	"peerDependencies": {

--- a/packages/storage/s3/utils/package.json
+++ b/packages/storage/s3/utils/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "@aws-amplify/storage/s3/utils",
+	"main": "../../lib/providers/s3/utilityApis.js",
+	"browser": "../../lib-esm/providers/s3/utilityApis.js",
+	"module": "../../lib-esm/providers/s3/utilityApis.js",
+	"typings": "../../lib-esm/providers/s3/utilityApis.d.ts"
+}

--- a/packages/storage/src/providers/s3/apis/utilityApis/accessLevelAndIdentityAwarePrefixResolver.ts
+++ b/packages/storage/src/providers/s3/apis/utilityApis/accessLevelAndIdentityAwarePrefixResolver.ts
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+import { resolvePrefix as defaultPrefixResolver } from '../../../../utils/resolvePrefix';
+import { ResolvePrefixInput } from '../../../../types/inputs';
+
+/**
+ * Resolves the object prefix based on the {@link accessLevel} and {@link targetIdentityId}.
+ *
+ * This is the default prefix resolver used by the storage category and S3 provider.
+ * You can use this util function to determine the "full path" of an object in your
+ * interest.
+ *
+ * @param input The input that's required to resolve prefix.
+ * @param input.accessLevel The access level associated with the prefix.
+ * @param input.targetIdentityId  The target identity associated with the prefix,
+ * if `undefined`, its value will be the identity id of current signed in user.
+ * @returns resolved prefix.
+ *
+ * @example
+ * import { defaultPrefixResolver } from 'aws-amplify/storage/s3/utils';
+ * import { StorageAccessLevel } from '@aws-amplify/core';
+ *
+ * async function getFullPathForKey({
+ *   key,
+ *   accessLevel = 'guest',
+ *   targetIdentityId,
+ * }: {
+ *   key: string,
+ *   accessLevel?: StorageAccessLevel,
+ *   targetIdentityId?: string,
+ * }) {
+ *   const prefix = await defaultPrefixResolver({
+ *     accessLevel,
+ *     targetIdentityId,
+ *   });
+ *
+ *   return `${prefix}${key}`;
+ * }
+ *
+ * const fullPath = await getFullPathForKey({ key: ''my-file.txt, accessLevel: 'private' });
+ */
+export const accessLevelAndIdentityAwarePrefixResolver = async (
+	input: ResolvePrefixInput
+) => {
+	const { accessLevel, targetIdentityId } = input;
+	const { identityId } = await Amplify.Auth.fetchAuthSession();
+	return defaultPrefixResolver({
+		accessLevel,
+		targetIdentityId: targetIdentityId ?? identityId,
+	});
+};

--- a/packages/storage/src/providers/s3/utilityApis.ts
+++ b/packages/storage/src/providers/s3/utilityApis.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { accessLevelAndIdentityAwarePrefixResolver as defaultPrefixResolver } from './apis/utilityApis/accessLevelAndIdentityAwarePrefixResolver';

--- a/packages/storage/src/types/inputs.ts
+++ b/packages/storage/src/types/inputs.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { StorageAccessLevel } from '@aws-amplify/core';
 import {
 	StorageOptions,
 	StorageListAllOptions,
@@ -54,3 +55,8 @@ export type StorageUploadDataPayload =
 	| ArrayBufferView
 	| ArrayBuffer
 	| string;
+
+export type ResolvePrefixInput = {
+	accessLevel: StorageAccessLevel;
+	targetIdentityId?: string;
+};

--- a/packages/storage/src/utils/resolvePrefix.ts
+++ b/packages/storage/src/utils/resolvePrefix.ts
@@ -1,19 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { StorageAccessLevel } from '@aws-amplify/core';
 import { assertValidationError } from '../errors/utils/assertValidationError';
 import { StorageValidationErrorCode } from '../errors/types/validation';
-
-type ResolvePrefixOptions = {
-	accessLevel: StorageAccessLevel;
-	targetIdentityId?: string;
-};
+import { ResolvePrefixInput } from '../types/inputs';
 
 export const resolvePrefix = ({
 	accessLevel,
 	targetIdentityId,
-}: ResolvePrefixOptions) => {
+}: ResolvePrefixInput) => {
 	if (accessLevel === 'private') {
 		assertValidationError(
 			!!targetIdentityId,


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Expose a util function from the `aws-amplify/storage/s3/utils` subpath. Developers can use this util function to determine the full path of an object in the S3 bucket.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* unit tests
* manual testing with a next.js app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
