### PR TITLE
chore: Re-enable all integ tests

### DIFF
--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -9,48 +9,48 @@ extended_browser_list: &extended_browser_list
 
 tests:
   # DATASTORE
-  # - test_name: integ_datastore_auth-owner-based-default
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: owner-based-default
-  #   spec: owner-based-default
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth-static-user-pool-groups-default
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: static-user-pool-groups-default
-  #   spec: static-user-pool-groups-default
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth-static-user-pool-groups-operations
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: static-user-pool-groups-operations
-  #   spec: static-user-pool-groups-operations
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth-owner-and-group-different-models-default
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: owner-and-group-different-models-default
-  #   spec: owner-and-group-different-models-default
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth-owner-and-group-same-model-default
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: owner-and-group-same-model-default
-  #   spec: owner-and-group-same-model-default
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth-owner-and-group-same-model-operations
-  #   desc: 'DataStore Auth'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: owner-and-group-same-model-operations
-  #   spec: owner-and-group-same-model-operations
-  #   browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-owner-based-default
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: owner-based-default
+    spec: owner-based-default
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-static-user-pool-groups-default
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: static-user-pool-groups-default
+    spec: static-user-pool-groups-default
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-static-user-pool-groups-operations
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: static-user-pool-groups-operations
+    spec: static-user-pool-groups-operations
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-owner-and-group-different-models-default
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: owner-and-group-different-models-default
+    spec: owner-and-group-different-models-default
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-owner-and-group-same-model-default
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: owner-and-group-same-model-default
+    spec: owner-and-group-same-model-default
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth-owner-and-group-same-model-operations
+    desc: 'DataStore Auth'
+    framework: react
+    category: datastore
+    sample_name: owner-and-group-same-model-operations
+    spec: owner-and-group-same-model-operations
+    browser: *minimal_browser_list
   - test_name: integ_datastore_auth-dynamic-user-pool-groups-default
     desc: 'DataStore Auth'
     framework: react
@@ -114,80 +114,80 @@ tests:
     sample_name: v2/owner-based-default-v2
     spec: owner-based-default
     browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth_v2-static-user-pool-groups-default
-  #   desc: 'DataStore Auth CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: v2/static-user-pool-groups-default-v2
-  #   spec: static-user-pool-groups-default
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth_v2-static-user-pool-groups-operations
-  #   desc: 'DataStore Auth CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: v2/static-user-pool-groups-operations-v2
-  #   spec: static-user-pool-groups-operations
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth_v2-owner-and-group-different-models-default
-  #   desc: 'DataStore Auth CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: v2/owner-and-group-different-models-default-v2
-  #   spec: owner-and-group-different-models-default
-  #   browser: *minimal_browser_list
-  #   timeout_minutes: 45
-  #   retry_count: 10
-  # - test_name: integ_datastore_auth_v2-owner-and-group-same-model-default
-  #   desc: 'DataStore Auth CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: v2/owner-and-group-same-model-default-v2
-  #   spec: owner-and-group-same-model-default
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth_v2-owner-and-group-same-model-operations
-  #   desc: 'DataStore Auth CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: v2/owner-and-group-same-model-operations-v2
-  #   spec: owner-and-group-same-model-operations
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth_v2-dynamic-user-pool-groups-default
-  #   desc: 'DataStore Auth CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: v2/dynamic-user-pool-groups-default-v2
-  #   spec: dynamic-user-pool-groups-default
-  #   browser: *minimal_browser_list
-  #   timeout_minutes: 45
-  #   retry_count: 10
-  # - test_name: integ_datastore_auth_v2-dynamic-user-pool-groups-owner-based-default
-  #   desc: 'DataStore Auth CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: v2/dynamic-user-pool-groups-owner-based-default-v2
-  #   spec: dynamic-user-pool-groups-owner-based-default
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth_v2-private-auth-default
-  #   desc: 'DataStore Auth CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: v2/private-auth-default-v2
-  #   spec: private-auth-default
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth_v2-private-auth-iam
-  #   desc: 'DataStore Auth CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: v2/private-auth-iam-v2
-  #   spec: private-auth-iam
-  #   browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth_v2-public-auth-default
-  #   desc: 'DataStore Auth CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: v2/public-auth-default-v2
-  #   spec: public-auth-default
-  #   browser: *minimal_browser_list
+  - test_name: integ_datastore_auth_v2-static-user-pool-groups-default
+    desc: 'DataStore Auth CLI v2'
+    framework: react
+    category: datastore
+    sample_name: v2/static-user-pool-groups-default-v2
+    spec: static-user-pool-groups-default
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth_v2-static-user-pool-groups-operations
+    desc: 'DataStore Auth CLI v2'
+    framework: react
+    category: datastore
+    sample_name: v2/static-user-pool-groups-operations-v2
+    spec: static-user-pool-groups-operations
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth_v2-owner-and-group-different-models-default
+    desc: 'DataStore Auth CLI v2'
+    framework: react
+    category: datastore
+    sample_name: v2/owner-and-group-different-models-default-v2
+    spec: owner-and-group-different-models-default
+    browser: *minimal_browser_list
+    timeout_minutes: 45
+    retry_count: 10
+  - test_name: integ_datastore_auth_v2-owner-and-group-same-model-default
+    desc: 'DataStore Auth CLI v2'
+    framework: react
+    category: datastore
+    sample_name: v2/owner-and-group-same-model-default-v2
+    spec: owner-and-group-same-model-default
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth_v2-owner-and-group-same-model-operations
+    desc: 'DataStore Auth CLI v2'
+    framework: react
+    category: datastore
+    sample_name: v2/owner-and-group-same-model-operations-v2
+    spec: owner-and-group-same-model-operations
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth_v2-dynamic-user-pool-groups-default
+    desc: 'DataStore Auth CLI v2'
+    framework: react
+    category: datastore
+    sample_name: v2/dynamic-user-pool-groups-default-v2
+    spec: dynamic-user-pool-groups-default
+    browser: *minimal_browser_list
+    timeout_minutes: 45
+    retry_count: 10
+  - test_name: integ_datastore_auth_v2-dynamic-user-pool-groups-owner-based-default
+    desc: 'DataStore Auth CLI v2'
+    framework: react
+    category: datastore
+    sample_name: v2/dynamic-user-pool-groups-owner-based-default-v2
+    spec: dynamic-user-pool-groups-owner-based-default
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth_v2-private-auth-default
+    desc: 'DataStore Auth CLI v2'
+    framework: react
+    category: datastore
+    sample_name: v2/private-auth-default-v2
+    spec: private-auth-default
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth_v2-private-auth-iam
+    desc: 'DataStore Auth CLI v2'
+    framework: react
+    category: datastore
+    sample_name: v2/private-auth-iam-v2
+    spec: private-auth-iam
+    browser: *minimal_browser_list
+  - test_name: integ_datastore_auth_v2-public-auth-default
+    desc: 'DataStore Auth CLI v2'
+    framework: react
+    category: datastore
+    sample_name: v2/public-auth-default-v2
+    spec: public-auth-default
+    browser: *minimal_browser_list
   - test_name: integ_datastore_auth_v2-public-auth-iam
     desc: 'DataStore Auth CLI v2'
     framework: react
@@ -195,13 +195,13 @@ tests:
     sample_name: v2/public-auth-iam-v2
     spec: public-auth-iam
     browser: *minimal_browser_list
-  # - test_name: integ_datastore_auth_v2-owner-custom-claim-default
-  #   desc: 'DataStore Auth CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: v2/owner-custom-claim-default-v2
-  #   spec: owner-custom-claim-default
-  #   browser: *minimal_browser_list
+  - test_name: integ_datastore_auth_v2-owner-custom-claim-default
+    desc: 'DataStore Auth CLI v2'
+    framework: react
+    category: datastore
+    sample_name: v2/owner-custom-claim-default-v2
+    spec: owner-custom-claim-default
+    browser: *minimal_browser_list
   - test_name: integ_datastore_auth_v2-owner-custom-field-default
     desc: 'DataStore Auth CLI v2'
     framework: react
@@ -209,90 +209,90 @@ tests:
     sample_name: v2/owner-custom-field-default-v2
     spec: owner-custom-field-default
     browser: *minimal_browser_list
-  # - test_name: integ_react_datastore
-  #   desc: 'React DataStore'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [many-to-many]
-  #   spec: many-to-many
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_v2
-  #   desc: 'React DataStore CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [v2/many-to-many-v2]
-  #   spec: many-to-many
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_multi_auth_one_rule
-  #   desc: 'React DataStore Multi-Auth - One Rule'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [multi-auth]
-  #   spec: multi-auth-one-rule
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_multi_auth_one_rule_v2
-  #   desc: 'React DataStore Multi-Auth - One Rule CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [v2/multi-auth-v2]
-  #   spec: multi-auth-one-rule
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_multi_auth_two_rules
-  #   desc: 'React DataStore Multi-Auth - Two Rules'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [multi-auth]
-  #   spec: multi-auth-two-rules
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_multi_auth_two_rules_v2
-  #   desc: 'React DataStore Multi-Auth - Two Rules CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [v2/multi-auth-v2]
-  #   spec: multi-auth-two-rules
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_multi_auth_three_plus_rules
-  #   desc: 'React DataStore Multi-Auth - Three Plus Rules'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [multi-auth]
-  #   spec: multi-auth-three-plus-rules
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_multi_auth_three_plus_rules_v2
-  #   desc: 'React DataStore Multi-Auth - Three Plus Rules CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [v2/multi-auth-v2]
-  #   spec: multi-auth-three-plus-rules
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_subs_disabled
-  #   desc: 'DataStore - Subs Disabled'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [subs-disabled]
-  #   spec: subs-disabled
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_subs_disabled_v2
-  #   desc: 'DataStore - Subs Disabled CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [v2/subs-disabled-v2]
-  #   spec: subs-disabled
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_consecutive_saves
-  #   desc: 'DataStore - Subs Disabled'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [consecutive-saves]
-  #   spec: consecutive-saves
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_consecutive_saves_v2
-  #   desc: 'DataStore - Subs Disabled CLI v2'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [v2/consecutive-saves-v2]
-  #   spec: consecutive-saves
-  #   browser: *minimal_browser_list
+  - test_name: integ_react_datastore
+    desc: 'React DataStore'
+    framework: react
+    category: datastore
+    sample_name: [many-to-many]
+    spec: many-to-many
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_v2
+    desc: 'React DataStore CLI v2'
+    framework: react
+    category: datastore
+    sample_name: [v2/many-to-many-v2]
+    spec: many-to-many
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_multi_auth_one_rule
+    desc: 'React DataStore Multi-Auth - One Rule'
+    framework: react
+    category: datastore
+    sample_name: [multi-auth]
+    spec: multi-auth-one-rule
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_multi_auth_one_rule_v2
+    desc: 'React DataStore Multi-Auth - One Rule CLI v2'
+    framework: react
+    category: datastore
+    sample_name: [v2/multi-auth-v2]
+    spec: multi-auth-one-rule
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_multi_auth_two_rules
+    desc: 'React DataStore Multi-Auth - Two Rules'
+    framework: react
+    category: datastore
+    sample_name: [multi-auth]
+    spec: multi-auth-two-rules
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_multi_auth_two_rules_v2
+    desc: 'React DataStore Multi-Auth - Two Rules CLI v2'
+    framework: react
+    category: datastore
+    sample_name: [v2/multi-auth-v2]
+    spec: multi-auth-two-rules
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_multi_auth_three_plus_rules
+    desc: 'React DataStore Multi-Auth - Three Plus Rules'
+    framework: react
+    category: datastore
+    sample_name: [multi-auth]
+    spec: multi-auth-three-plus-rules
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_multi_auth_three_plus_rules_v2
+    desc: 'React DataStore Multi-Auth - Three Plus Rules CLI v2'
+    framework: react
+    category: datastore
+    sample_name: [v2/multi-auth-v2]
+    spec: multi-auth-three-plus-rules
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_subs_disabled
+    desc: 'DataStore - Subs Disabled'
+    framework: react
+    category: datastore
+    sample_name: [subs-disabled]
+    spec: subs-disabled
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_subs_disabled_v2
+    desc: 'DataStore - Subs Disabled CLI v2'
+    framework: react
+    category: datastore
+    sample_name: [v2/subs-disabled-v2]
+    spec: subs-disabled
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_consecutive_saves
+    desc: 'DataStore - Subs Disabled'
+    framework: react
+    category: datastore
+    sample_name: [consecutive-saves]
+    spec: consecutive-saves
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_consecutive_saves_v2
+    desc: 'DataStore - Subs Disabled CLI v2'
+    framework: react
+    category: datastore
+    sample_name: [v2/consecutive-saves-v2]
+    spec: consecutive-saves
+    browser: *minimal_browser_list
   # - test_name: integ_react_datastore_observe_query
   #   desc: 'DataStore - Observe Query'
   #   framework: react
@@ -307,20 +307,20 @@ tests:
   #   sample_name: [v2/observe-query-v2]
   #   spec: observe-query
   #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_schema_drift
-  #   desc: 'DataStore - Schema Drift'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [schema-drift]
-  #   spec: schema-drift
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_background_process_manager
-  #   desc: 'DataStore - Background Process Manager'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [v2/background-process-manager]
-  #   spec: background-process-manager
-  #   browser: *extended_browser_list
+  - test_name: integ_react_datastore_schema_drift
+    desc: 'DataStore - Schema Drift'
+    framework: react
+    category: datastore
+    sample_name: [schema-drift]
+    spec: schema-drift
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_background_process_manager
+    desc: 'DataStore - Background Process Manager'
+    framework: react
+    category: datastore
+    sample_name: [v2/background-process-manager]
+    spec: background-process-manager
+    browser: *extended_browser_list
   # - test_name: integ_react_datastore_background_process_manager_webkit
   #   desc: 'DataStore - Background Process Manager'
   #   framework: react
@@ -328,105 +328,105 @@ tests:
   #   sample_name: [v2/background-process-manager]
   #   spec: background-process-manager
   #   browser: [webkit]
-  # - test_name: integ_react_datastore_cpk_related_models
-  #   desc: 'DataStore - Custom Primary Key + Related Models'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [v2/related-models]
-  #   spec: cpk-related-models
-  #   browser: *extended_browser_list
-  #   timeout_minutes: 45
-  #   retry_count: 10
-  # - test_name: integ_react_datastore_selective_sync
-  #   desc: 'DataStore - Selective Sync'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [selective-sync-v5]
-  #   spec: selective-sync-v5
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_nested_predicate
-  #   desc: 'DataStore - Nested Predicate'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [nested-predicate]
-  #   spec: nested-predicate
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_datastore_docs_examples
-  #   desc: 'DataStore - Docs Examples'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [v2/amplify-docs-examples]
-  #   spec: amplify-docs-examples
-  #   browser: *minimal_browser_list
-  #   timeout_minutes: 45
-  #   retry_count: 10
-  # - test_name: integ_react_datastore_websocket_disruption
-  #   desc: 'DataStore - WebSocket Disruption'
-  #   framework: react
-  #   category: datastore
-  #   sample_name: [websocket-disruption]
-  #   spec: websocket-disruption
-  #   browser: *minimal_browser_list
-  # - test_name: integ_vanilla_js_datastore_basic_crud
-  #   desc: 'Vanilla JS + Webpack 4 + DataStore - Basic CRUD'
-  #   framework: javascript
-  #   category: datastore
-  #   sample_name: [basic-crud]
-  #   browser: *minimal_browser_list
-  #   spec: vanilla-js-basic-crud
-  #   amplifyjs_dir: true
-  #   timeout_minutes: 45
-  #   retry_count: 10
-  # - test_name: integ_next_datastore_owner_auth
-  #   desc: 'next owner auth'
-  #   framework: next
-  #   category: datastore
-  #   sample_name: [owner-based-default]
-  #   spec: next-owner-based-default
-  #   browser: *minimal_browser_list
-  # - test_name: integ_next_datastore_13_basic
-  #   desc: 'DataStore - Nextjs 13 build with SWC - basic JS app'
-  #   framework: next
-  #   category: datastore
-  #   sample_name: [next-13-basic]
-  #   spec: nextjs-13-basic
-  #   browser: *minimal_browser_list
-  # - test_name: integ_next_datastore_13_js
-  #   desc: 'DataStore - Nextjs 13 build with SWC - JS app'
-  #   framework: next
-  #   category: datastore
-  #   sample_name: [next-13-js]
-  #   spec: nextjs-13
-  #   browser: *minimal_browser_list
-  # - test_name: integ_vite_datastore_basic_crud
-  #   desc: 'Vite + DataStore - Basic CRUD'
-  #   framework: vite
-  #   category: datastore
-  #   sample_name: [v2/basic-crud]
-  #   spec: vite-basic-crud
-  #   # TODO: run on firefox
-  #   browser: [chrome]
-  #   timeout_minutes: 45
-  #   retry_count: 10
-  # - test_name: integ_rollup_datastore_basic_crud
-  #   desc: 'Rollup + DataStore - Basic CRUD'
-  #   framework: rollup
-  #   category: datastore
-  #   sample_name: [rollup-basic-crud]
-  #   spec: rollup-basic-crud
-  #   # TODO: run on firefox
-  #   browser: [chrome]
-  #   timeout_minutes: 45
-  #   retry_count: 10
+  - test_name: integ_react_datastore_cpk_related_models
+    desc: 'DataStore - Custom Primary Key + Related Models'
+    framework: react
+    category: datastore
+    sample_name: [v2/related-models]
+    spec: cpk-related-models
+    browser: *extended_browser_list
+    timeout_minutes: 45
+    retry_count: 10
+  - test_name: integ_react_datastore_selective_sync
+    desc: 'DataStore - Selective Sync'
+    framework: react
+    category: datastore
+    sample_name: [selective-sync-v5]
+    spec: selective-sync-v5
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_nested_predicate
+    desc: 'DataStore - Nested Predicate'
+    framework: react
+    category: datastore
+    sample_name: [nested-predicate]
+    spec: nested-predicate
+    browser: *minimal_browser_list
+  - test_name: integ_react_datastore_docs_examples
+    desc: 'DataStore - Docs Examples'
+    framework: react
+    category: datastore
+    sample_name: [v2/amplify-docs-examples]
+    spec: amplify-docs-examples
+    browser: *minimal_browser_list
+    timeout_minutes: 45
+    retry_count: 10
+  - test_name: integ_react_datastore_websocket_disruption
+    desc: 'DataStore - WebSocket Disruption'
+    framework: react
+    category: datastore
+    sample_name: [websocket-disruption]
+    spec: websocket-disruption
+    browser: *minimal_browser_list
+  - test_name: integ_vanilla_js_datastore_basic_crud
+    desc: 'Vanilla JS + Webpack 4 + DataStore - Basic CRUD'
+    framework: javascript
+    category: datastore
+    sample_name: [basic-crud]
+    browser: *minimal_browser_list
+    spec: vanilla-js-basic-crud
+    amplifyjs_dir: true
+    timeout_minutes: 45
+    retry_count: 10
+  - test_name: integ_next_datastore_owner_auth
+    desc: 'next owner auth'
+    framework: next
+    category: datastore
+    sample_name: [owner-based-default]
+    spec: next-owner-based-default
+    browser: *minimal_browser_list
+  - test_name: integ_next_datastore_13_basic
+    desc: 'DataStore - Nextjs 13 build with SWC - basic JS app'
+    framework: next
+    category: datastore
+    sample_name: [next-13-basic]
+    spec: nextjs-13-basic
+    browser: *minimal_browser_list
+  - test_name: integ_next_datastore_13_js
+    desc: 'DataStore - Nextjs 13 build with SWC - JS app'
+    framework: next
+    category: datastore
+    sample_name: [next-13-js]
+    spec: nextjs-13
+    browser: *minimal_browser_list
+  - test_name: integ_vite_datastore_basic_crud
+    desc: 'Vite + DataStore - Basic CRUD'
+    framework: vite
+    category: datastore
+    sample_name: [v2/basic-crud]
+    spec: vite-basic-crud
+    # TODO: run on firefox
+    browser: [chrome]
+    timeout_minutes: 45
+    retry_count: 10
+  - test_name: integ_rollup_datastore_basic_crud
+    desc: 'Rollup + DataStore - Basic CRUD'
+    framework: rollup
+    category: datastore
+    sample_name: [rollup-basic-crud]
+    spec: rollup-basic-crud
+    # TODO: run on firefox
+    browser: [chrome]
+    timeout_minutes: 45
+    retry_count: 10
 
   # API
-  # - test_name: integ_react_graphql_api
-  #   desc: React GraphQL API
-  #   framework: react
-  #   category: api
-  #   sample_name: [graphql]
-  #   spec: graphql
-  #   browser: *minimal_browser_list
+  - test_name: integ_react_graphql_api
+    desc: React GraphQL API
+    framework: react
+    category: api
+    sample_name: [graphql]
+    spec: graphql
+    browser: *minimal_browser_list
 
   # AUTH
   - test_name: integ_react_javascript_authentication
@@ -437,13 +437,13 @@ tests:
     spec: functional-auth
     browser: *minimal_browser_list
   # TODO(v6) Migrate?
-  # - test_name: integ_react_auth_1_guest_to_authenticated_user
-  #   desc: 'Guest to Authenticated User'
-  #   framework: react
-  #   category: auth
-  #   sample_name: [guest-to-auth-user]
-  #   spec: guest-to-auth-user
-  #   browser: *minimal_browser_list
+  - test_name: integ_react_auth_1_guest_to_authenticated_user
+    desc: 'Guest to Authenticated User'
+    framework: react
+    category: auth
+    sample_name: [guest-to-auth-user]
+    spec: guest-to-auth-user
+    browser: *minimal_browser_list
   - test_name: integ_react_typescript_authentication
     desc: 'React Typescript Authentication'
     framework: react
@@ -458,13 +458,13 @@ tests:
     sample_name: [credentials-auth]
     spec: credentials-auth
     browser: *minimal_browser_list
-  # - test_name: integ_react_auth_2_sign_in_after_sign_up
-  #   desc: 'Sign In after Sign Up'
-  #   framework: react
-  #   category: auth
-  #   sample_name: [auto-signin-after-signup]
-  #   spec: auto-signin-after-signup
-  #   browser: *minimal_browser_list
+  - test_name: integ_react_auth_2_sign_in_after_sign_up
+    desc: 'Sign In after Sign Up'
+    framework: react
+    category: auth
+    sample_name: [auto-signin-after-signup]
+    spec: auto-signin-after-signup
+    browser: *minimal_browser_list
   - test_name: integ_react_amazon_cognito_identity_js_cookie_storage
     desc: 'amazon-cognito-identity-js-cookie-storage'
     framework: react
@@ -479,81 +479,81 @@ tests:
     sample_name: [amazon-cognito-identity-js]
     spec: amazon-cognito-identity-js
     browser: *minimal_browser_list
-  # - test_name: integ_react_device_tracking
-  #   desc: 'cognito-device-tracking'
-  #   framework: react
-  #   category: auth
-  #   sample_name: [device-tracking]
-  #   spec: device-tracking
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_delete_user
-  #   desc: 'delete-user'
-  #   framework: react
-  #   category: auth
-  #   sample_name: [delete-user]
-  #   spec: delete-user
-  #   browser: *minimal_browser_list
-  # - test_name: integ_angular_auth_angular_authenticator
-  #   desc: 'Angular Authenticator'
-  #   framework: angular
-  #   category: auth
-  #   sample_name: [amplify-authenticator]
-  #   spec: ui-amplify-authenticator
-  #   browser: *minimal_browser_list
-  # - test_name: integ_angular_auth_angular_custom_authenticator
-  #   desc: 'Angular Custom Authenticator'
-  #   framework: angular
-  #   category: auth
-  #   sample_name: [amplify-authenticator]
-  #   spec: custom-authenticator
-  #   browser: *minimal_browser_list
-  # - test_name: integ_javascript_auth
-  #   desc: 'JavaScript Auth CDN'
-  #   framework: javascript
-  #   category: auth
-  #   sample_name: [auth-cdn]
-  #   spec: auth-cdn
-  #   browser: *minimal_browser_list
-  #   amplifyjs_dir: true
-  # - test_name: integ_vue_auth_legacy_vue_authenticator
-  #   desc: 'Legacy Vue Authenticator'
-  #   framework: vue
-  #   category: auth
-  #   sample_name: [amplify-authenticator-legacy]
-  #   spec: authenticator
-  #   browser: *minimal_browser_list
-  # - test_name: integ_vue_auth_vue_3_authenticator
-  #   desc: 'Vue 3 Authenticator'
-  #   framework: vue
-  #   category: auth
-  #   sample_name: [authenticator-vue3]
-  #   spec: new-ui-authenticator
-  #   browser: *minimal_browser_list
+  - test_name: integ_react_device_tracking
+    desc: 'cognito-device-tracking'
+    framework: react
+    category: auth
+    sample_name: [device-tracking]
+    spec: device-tracking
+    browser: *minimal_browser_list
+  - test_name: integ_react_delete_user
+    desc: 'delete-user'
+    framework: react
+    category: auth
+    sample_name: [delete-user]
+    spec: delete-user
+    browser: *minimal_browser_list
+  - test_name: integ_angular_auth_angular_authenticator
+    desc: 'Angular Authenticator'
+    framework: angular
+    category: auth
+    sample_name: [amplify-authenticator]
+    spec: ui-amplify-authenticator
+    browser: *minimal_browser_list
+  - test_name: integ_angular_auth_angular_custom_authenticator
+    desc: 'Angular Custom Authenticator'
+    framework: angular
+    category: auth
+    sample_name: [amplify-authenticator]
+    spec: custom-authenticator
+    browser: *minimal_browser_list
+  - test_name: integ_javascript_auth
+    desc: 'JavaScript Auth CDN'
+    framework: javascript
+    category: auth
+    sample_name: [auth-cdn]
+    spec: auth-cdn
+    browser: *minimal_browser_list
+    amplifyjs_dir: true
+  - test_name: integ_vue_auth_legacy_vue_authenticator
+    desc: 'Legacy Vue Authenticator'
+    framework: vue
+    category: auth
+    sample_name: [amplify-authenticator-legacy]
+    spec: authenticator
+    browser: *minimal_browser_list
+  - test_name: integ_vue_auth_vue_3_authenticator
+    desc: 'Vue 3 Authenticator'
+    framework: vue
+    category: auth
+    sample_name: [authenticator-vue3]
+    spec: new-ui-authenticator
+    browser: *minimal_browser_list
   # TODO(v6) Migrate once SSR updates available
-  # - test_name: integ_next_auth_authenticator_and_ssr_page
-  #   desc: 'Authenticator and SSR page'
-  #   framework: next
-  #   category: auth
-  #   sample_name: [auth-ssr]
-  #   spec: auth-ssr
-  #   browser: *minimal_browser_list
+  - test_name: integ_next_auth_authenticator_and_ssr_page
+    desc: 'Authenticator and SSR page'
+    framework: next
+    category: auth
+    sample_name: [auth-ssr]
+    spec: auth-ssr
+    browser: *minimal_browser_list
   # TODO(v6) Migrate once SSR updates available
-  # - test_name: integ_next_auth_authenticator_and_rsc_page
-  #   desc: 'Authenticator and RSC page'
-  #   framework: next
-  #   category: auth
-  #   sample_name: [auth-rsc]
-  #   spec: auth-rsc
-  #   browser: [chrome]
-  #   timeout_minutes: 45
-  #   retry_count: 10
-  # - test_name: integ_next_auth_nextjs_auth_custom_implementation_with_ssr
-  #   desc: 'NextJS Auth Custom Implementation with SSR'
-  #   framework: next
-  #   category: auth
-  #   sample_name: [custom-auth-ssr]
-  #   spec: authenticator
-  #   browser: *minimal_browser_list
+  - test_name: integ_next_auth_authenticator_and_rsc_page
+    desc: 'Authenticator and RSC page'
+    framework: next
+    category: auth
+    sample_name: [auth-rsc]
+    spec: auth-rsc
+    browser: [chrome]
+    timeout_minutes: 45
+    retry_count: 10
+  - test_name: integ_next_auth_nextjs_auth_custom_implementation_with_ssr
+    desc: 'NextJS Auth Custom Implementation with SSR'
+    framework: next
+    category: auth
+    sample_name: [custom-auth-ssr]
+    spec: authenticator
+    browser: *minimal_browser_list
 
   # ANALYTICS
   - test_name: integ_react_analytics_pinpoint
@@ -602,22 +602,22 @@ tests:
     browser: *minimal_browser_list
 
   # GEO
-  # - test_name: integ_react_geo_display_map
-  #   desc: 'Display Map'
-  #   framework: react
-  #   category: geo
-  #   sample_name: [display-map]
-  #   spec: display-map
-  #   # Temp fix:
-  #   browser: [chrome]
-  # - test_name: integ_react_geo_search_outside_map
-  #   desc: 'Search Outside Map'
-  #   framework: react
-  #   category: geo
-  #   sample_name: [search-outside-map]
-  #   spec: search-outside-map
-  #   # Temp fix:
-  #   browser: [chrome]
+  - test_name: integ_react_geo_display_map
+    desc: 'Display Map'
+    framework: react
+    category: geo
+    sample_name: [display-map]
+    spec: display-map
+    # Temp fix:
+    browser: [chrome]
+  - test_name: integ_react_geo_search_outside_map
+    desc: 'Search Outside Map'
+    framework: react
+    category: geo
+    sample_name: [search-outside-map]
+    spec: search-outside-map
+    # Temp fix:
+    browser: [chrome]
   # - test_name: integ_javascript_geo_display_map
   #   desc: 'Display Map'
   #   framework: javascript
@@ -636,48 +636,48 @@ tests:
   #   amplifyjs_dir: true
 
   # INTERACTIONS
-  # - test_name: integ_react_interactions_react_interactions
-  #   desc: 'React Interactions'
-  #   framework: react
-  #   category: interactions
-  #   sample_name: [chatbot-component]
-  #   spec: chatbot-component
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_interactions_chatbot_v1
-  #   desc: 'Chatbot V1'
-  #   framework: react
-  #   category: interactions
-  #   sample_name: [lex-test-component]
-  #   spec: chatbot-v1
-  #   browser: *minimal_browser_list
-  # - test_name: integ_react_interactions_chatbot_v2
-  #   desc: 'Chatbot V2'
-  #   framework: react
-  #   category: interactions
-  #   sample_name: [lex-test-component]
-  #   spec: chatbot-v2
-  #   browser: *minimal_browser_list
-  # - test_name: integ_angular_interactions
-  #   desc: 'Angular Interactions'
-  #   framework: angular
-  #   category: interactions
-  #   sample_name: [chatbot-component]
-  #   spec: chatbot-component
-  #   browser: *minimal_browser_list
-  # - test_name: integ_vue_interactions_vue_2_interactions
-  #   desc: 'Vue 2 Interactions'
-  #   framework: vue
-  #   category: interactions
-  #   sample_name: [chatbot-component]
-  #   spec: chatbot-component
-  #   browser: [chrome]
-  # - test_name: integ_vue_interactionsvue_3_interactions
-  #   desc: 'Vue 3 Interactions'
-  #   framework: vue
-  #   category: interactions
-  #   sample_name: [chatbot-component-vue3]
-  #   spec: chatbot-component
-  #   browser: [chrome]
+  - test_name: integ_react_interactions_react_interactions
+    desc: 'React Interactions'
+    framework: react
+    category: interactions
+    sample_name: [chatbot-component]
+    spec: chatbot-component
+    browser: *minimal_browser_list
+  - test_name: integ_react_interactions_chatbot_v1
+    desc: 'Chatbot V1'
+    framework: react
+    category: interactions
+    sample_name: [lex-test-component]
+    spec: chatbot-v1
+    browser: *minimal_browser_list
+  - test_name: integ_react_interactions_chatbot_v2
+    desc: 'Chatbot V2'
+    framework: react
+    category: interactions
+    sample_name: [lex-test-component]
+    spec: chatbot-v2
+    browser: *minimal_browser_list
+  - test_name: integ_angular_interactions
+    desc: 'Angular Interactions'
+    framework: angular
+    category: interactions
+    sample_name: [chatbot-component]
+    spec: chatbot-component
+    browser: *minimal_browser_list
+  - test_name: integ_vue_interactions_vue_2_interactions
+    desc: 'Vue 2 Interactions'
+    framework: vue
+    category: interactions
+    sample_name: [chatbot-component]
+    spec: chatbot-component
+    browser: [chrome]
+  - test_name: integ_vue_interactionsvue_3_interactions
+    desc: 'Vue 3 Interactions'
+    framework: vue
+    category: interactions
+    sample_name: [chatbot-component-vue3]
+    spec: chatbot-component
+    browser: [chrome]
 
   # PREDICTIONS
   # - test_name: integ_react_predictions

--- a/.github/workflows/callable-e2e-tests.yml
+++ b/.github/workflows/callable-e2e-tests.yml
@@ -43,32 +43,32 @@ jobs:
       timeout_minutes: ${{ matrix.integ-config.timeout_minutes || 35 }}
       retry_count: ${{ matrix.integ-config.retry_count || 3 }}
 
-  # e2e-test-runner-headless:
-  #   name: E2E test runnner_headless
-  #   needs: e2e-prep
-  #   secrets: inherit
-  #   strategy:
-  #     matrix:
-  #       integ-config: ${{ fromJson(needs.e2e-prep.outputs.integ-config-headless) }}
-  #     fail-fast: false
-  #   uses: ./.github/workflows/callable-e2e-test-headless.yml
-  #   with:
-  #     test_name: ${{ matrix.integ-config.test_name }}
-  #     category: ${{ matrix.integ-config.category }}
-  #     spec: ${{ matrix.integ-config.spec || '' }}
-  #     timeout_minutes: ${{ matrix.integ-config.timeout_minutes || 35 }}
-  #     retry_count: ${{ matrix.integ-config.retry_count || 3 }}
+  e2e-test-runner-headless:
+    name: E2E test runnner_headless
+    needs: e2e-prep
+    secrets: inherit
+    strategy:
+      matrix:
+        integ-config: ${{ fromJson(needs.e2e-prep.outputs.integ-config-headless) }}
+      fail-fast: false
+    uses: ./.github/workflows/callable-e2e-test-headless.yml
+    with:
+      test_name: ${{ matrix.integ-config.test_name }}
+      category: ${{ matrix.integ-config.category }}
+      spec: ${{ matrix.integ-config.spec || '' }}
+      timeout_minutes: ${{ matrix.integ-config.timeout_minutes || 35 }}
+      retry_count: ${{ matrix.integ-config.retry_count || 3 }}
 
-  # detox-e2e-test-runner:
-  #   name: E2E test runner
-  #   needs: e2e-prep
-  #   strategy:
-  #     matrix:
-  #       integ-config: ${{ fromJson(needs.e2e-prep.outputs.detox-integ-config) }}
-  #     fail-fast: false
-  #   secrets: inherit
-  #   uses: ./.github/workflows/callable-e2e-test-detox.yml
-  #   with:
-  #     test_name: ${{ matrix.integ-config.test_name }}
-  #     working_directory: ${{ matrix.integ-config.working_directory }}
-  #     timeout_minutes: ${{ matrix.integ-config.timeout_minutes || 45 }}
+  detox-e2e-test-runner:
+    name: E2E test runner
+    needs: e2e-prep
+    strategy:
+      matrix:
+        integ-config: ${{ fromJson(needs.e2e-prep.outputs.detox-integ-config) }}
+      fail-fast: false
+    secrets: inherit
+    uses: ./.github/workflows/callable-e2e-test-detox.yml
+    with:
+      test_name: ${{ matrix.integ-config.test_name }}
+      working_directory: ${{ matrix.integ-config.working_directory }}
+      timeout_minutes: ${{ matrix.integ-config.timeout_minutes || 45 }}


### PR DESCRIPTION
#### Description of changes
In the spirit of red > green > refactor, while we're working to get all the integ tests working for V6, lets turn them all on so we have a reasonably complete list of what is left not working. We will then fix (or disable if not useful) to get ourselves down to the tests we will be running for CI/CD at GA.

#### Description of how you validated changes
This change is [running on my work](https://github.com/aws-amplify/amplify-js/actions/runs/6535908366).


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
