### PR TITLE
fix(datastore): parse error status code without axios-specific error message

### DIFF
--- a/packages/datastore/__tests__/sync.test.ts
+++ b/packages/datastore/__tests__/sync.test.ts
@@ -1,5 +1,9 @@
 // These tests should be replaced once SyncEngine.partialDataFeatureFlagEnabled is removed.
-import { Category, DataStoreAction } from '@aws-amplify/core/internals/utils';
+import {
+	AmplifyError,
+	Category,
+	DataStoreAction,
+} from '@aws-amplify/core/internals/utils';
 import { defaultAuthStrategy } from '../src/authModeStrategies';
 
 let mockGraphQl;
@@ -210,7 +214,11 @@ describe('Sync', () => {
 				data: null,
 				errors: [
 					{
-						message: 'Request failed with status code 403',
+						originalError: {
+							$metadata: {
+								httpStatusCode: 403,
+							},
+						},
 					},
 				],
 			};
@@ -389,7 +397,11 @@ describe('Sync', () => {
 					data,
 					errors: [
 						{
-							message: 'Error: Request failed with status code 500',
+							originalError: {
+								$metadata: {
+									httpStatusCode: 500,
+								},
+							},
 						},
 					],
 				},

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -65,6 +65,7 @@
 		"dexie": "3.2.2",
 		"dexie-export-import": "1.0.3",
 		"fake-indexeddb": "3.0.0",
+		"graphql": "15.8.0",
 		"typescript": "5.0.2"
 	},
 	"size-limit": [

--- a/packages/datastore/src/sync/processors/errorMaps.ts
+++ b/packages/datastore/src/sync/processors/errorMaps.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ErrorType } from '../../types';
+import { resolveServiceErrorStatusCode } from '../utils';
 
 export type ErrorMap = Partial<{
 	[key in ErrorType]: (error: Error) => boolean;
@@ -9,8 +10,7 @@ export type ErrorMap = Partial<{
 const connectionTimeout = error =>
 	/^Connection failed: Connection Timeout/.test(error.message);
 
-const serverError = error =>
-	/^Error: Request failed with status code 5\d\d/.test(error.message);
+const serverError = error => resolveServiceErrorStatusCode(error) >= 500;
 
 export const mutationErrorMap: ErrorMap = {
 	BadModel: () => false,
@@ -25,7 +25,7 @@ export const mutationErrorMap: ErrorMap = {
 	Transient: error => connectionTimeout(error) || serverError(error),
 	Unauthorized: error =>
 		error.message === 'Unauthorized' ||
-		/^Request failed with status code 401/.test(error.message),
+		resolveServiceErrorStatusCode(error) === 401,
 };
 
 export const subscriptionErrorMap: ErrorMap = {

--- a/packages/datastore/src/sync/processors/sync.ts
+++ b/packages/datastore/src/sync/processors/sync.ts
@@ -342,7 +342,7 @@ class SyncProcessor {
 						throw new NonRetryableError(error);
 					}
 
-					if (result.data?.[opName].items?.length) {
+					if (result.data?.[opName]?.items?.length) {
 						return result;
 					}
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The retry bahavior in datastore requires Axios-specific error messages for error messages: `Request failed with status code xxx`, hence determine which failure to retry. 

With this change, the status code are retrieved from the `response.$metadata.httpStatusCode` of the custom HTTP handlers.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
This change unblockes te v2/private-auth-iam-v2 integration test.


#### Description of how you validated changes
Manual test, Unit test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
