### PR TITLE
feat: change `client.models` return to include data, errors, nextToken

### DIFF
--- a/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
@@ -17,13 +17,3 @@ const schema = a.schema({
 });
 
 export type Schema = ClientSchema<typeof schema>;
-
-type Todo = Schema['Todo'];
-type MaybeTodo = Exclude<
-	Awaited<ReturnType<Schema['Note']['todo']>>,
-	null | undefined
->;
-
-type TEST = Todo extends MaybeTodo ? 'yes' : 'no';
-
-type Note_dot_todo = Schema['Note']['todo'];

--- a/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
@@ -17,3 +17,13 @@ const schema = a.schema({
 });
 
 export type Schema = ClientSchema<typeof schema>;
+
+type Todo = Schema['Todo'];
+type MaybeTodo = Exclude<
+	Awaited<ReturnType<Schema['Note']['todo']>>,
+	null | undefined
+>;
+
+type TEST = Todo extends MaybeTodo ? 'yes' : 'no';
+
+type Note_dot_todo = Schema['Note']['todo'];

--- a/packages/api-graphql/__tests__/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/generateClient.test.ts
@@ -153,7 +153,7 @@ describe('generateClient', () => {
 			});
 
 			const client = generateClient<Schema>({ amplify: Amplify });
-			const result = await client.models.Todo.create({
+			const { data } = await client.models.Todo.create({
 				name: 'some name',
 				description: 'something something',
 			});
@@ -177,7 +177,7 @@ describe('generateClient', () => {
 				})
 			);
 
-			expect(result).toEqual(
+			expect(data).toEqual(
 				expect.objectContaining({
 					__typename: 'Todo',
 					id: 'some-id',
@@ -201,7 +201,7 @@ describe('generateClient', () => {
 			});
 
 			const client = generateClient<Schema>({ amplify: Amplify });
-			const result = await client.models.Todo.get({ id: 'asdf' });
+			const { data } = await client.models.Todo.get({ id: 'asdf' });
 
 			expect(spy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -219,7 +219,7 @@ describe('generateClient', () => {
 				})
 			);
 
-			expect(result).toEqual(
+			expect(data).toEqual(
 				expect.objectContaining({
 					__typename: 'Todo',
 					id: 'some-id',
@@ -247,7 +247,7 @@ describe('generateClient', () => {
 			});
 
 			const client = generateClient<Schema>({ amplify: Amplify });
-			const result = await client.models.Todo.list({
+			const { data } = await client.models.Todo.list({
 				filter: { name: { contains: 'name' } },
 			});
 
@@ -271,8 +271,8 @@ describe('generateClient', () => {
 				})
 			);
 
-			expect(result.length).toBe(1);
-			expect(result[0]).toEqual(
+			expect(data.length).toBe(1);
+			expect(data[0]).toEqual(
 				expect.objectContaining({
 					__typename: 'Todo',
 					id: 'some-id',
@@ -296,7 +296,7 @@ describe('generateClient', () => {
 			});
 
 			const client = generateClient<Schema>({ amplify: Amplify });
-			const result = await client.models.Todo.update({
+			const { data } = await client.models.Todo.update({
 				id: 'some-id',
 				name: 'some other name',
 			});
@@ -320,7 +320,7 @@ describe('generateClient', () => {
 				})
 			);
 
-			expect(result).toEqual(
+			expect(data).toEqual(
 				expect.objectContaining({
 					__typename: 'Todo',
 					id: 'some-id',
@@ -344,7 +344,7 @@ describe('generateClient', () => {
 			});
 
 			const client = generateClient<Schema>({ amplify: Amplify });
-			const result = await client.models.Todo.delete({
+			const { data } = await client.models.Todo.delete({
 				id: 'some-id',
 			});
 
@@ -366,7 +366,7 @@ describe('generateClient', () => {
 				})
 			);
 
-			expect(result).toEqual(
+			expect(data).toEqual(
 				expect.objectContaining({
 					__typename: 'Todo',
 					id: 'some-id',
@@ -391,7 +391,7 @@ describe('generateClient', () => {
 			});
 
 			const client = generateClient<Schema>({ amplify: Amplify });
-			const result = await client.models.Todo.get({ id: 'todo-id' });
+			const { data } = await client.models.Todo.get({ id: 'todo-id' });
 
 			const getChildNotesSpy = mockApiResponse({
 				data: {
@@ -408,7 +408,7 @@ describe('generateClient', () => {
 				},
 			});
 
-			const notes = await result.notes();
+			const { data: notes } = await data.notes();
 
 			expect(getChildNotesSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -453,7 +453,7 @@ describe('generateClient', () => {
 			});
 
 			const client = generateClient<Schema>({ amplify: Amplify });
-			const result = await client.models.Note.get({ id: 'note-id' });
+			const { data } = await client.models.Note.get({ id: 'note-id' });
 
 			const getChildNotesSpy = mockApiResponse({
 				data: {
@@ -467,7 +467,7 @@ describe('generateClient', () => {
 				},
 			});
 
-			const todo = await result.todo();
+			const { data: todo } = await data.todo();
 
 			expect(getChildNotesSpy).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -509,7 +509,7 @@ describe('generateClient', () => {
 			});
 
 			const client = generateClient<Schema>({ amplify: Amplify });
-			const result = await client.models.Todo.get({ id: 'todo-id' });
+			const { data } = await client.models.Todo.get({ id: 'todo-id' });
 
 			const getChildMetaSpy = mockApiResponse({
 				data: {
@@ -522,7 +522,7 @@ describe('generateClient', () => {
 				},
 			});
 
-			const todo = await result.meta();
+			const { data: todo } = await data.meta();
 
 			expect(getChildMetaSpy).toHaveBeenCalledWith(
 				expect.objectContaining({

--- a/packages/api-graphql/src/internals/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/generateModelsProperty.ts
@@ -50,7 +50,7 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 						);
 
 						try {
-							const { data, nextToken } = (await client.graphql({
+							const { data, nextToken, extensions } = (await client.graphql({
 								query,
 								variables,
 							})) as any;
@@ -67,6 +67,7 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 										return {
 											data: flattenedResult,
 											nextToken,
+											extensions,
 										};
 									} else {
 										const initialized = initializeModel(
@@ -79,6 +80,7 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 										return {
 											data: initialized,
 											nextToken,
+											extensions,
 										};
 									}
 								}
@@ -86,6 +88,7 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 								return {
 									data: data[key],
 									nextToken,
+									extensions,
 								};
 							}
 						} catch (error) {
@@ -113,7 +116,7 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 						);
 
 						try {
-							const { data } = (await client.graphql({
+							const { data, extensions } = (await client.graphql({
 								query,
 								variables,
 							})) as any;
@@ -130,9 +133,9 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 									modelIntrospection
 								);
 
-								return { data: initialized };
+								return { data: initialized, extensions };
 							} else {
-								return { data: null };
+								return { data: null, extensions };
 							}
 						} catch (error) {
 							if (error.errors) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Changes the return types on graphql client models to return `{data, errors, nextToken, extensions}`, so that these properties will be accessible to callers.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
