### PR TITLE
fix(inapp): make the correct isBrowser check 

### DIFF
--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.ts
@@ -10,6 +10,7 @@ import { Hub, HubCapsule } from '@aws-amplify/core';
 import { dispatchEvent } from './dispatchEvent';
 import { incrementMessageCounts, sessionStateChangeHandler } from '../utils';
 import { isInitialized, initialize } from '../../../utils';
+import { Amplify } from '@aws-amplify/core';
 
 /**
  * Initialize and set up in-app messaging category. This API needs to be called to enable other InAppMessaging APIs.
@@ -26,13 +27,13 @@ export function initializeInAppMessaging(): void {
 	if (isInitialized()) {
 		return;
 	}
+	console.log('Confin in initializeInAppMessaging: ', Amplify.getConfig());
 	// set up the session tracker and start it
 	const sessionTracker = new SessionTracker(sessionStateChangeHandler);
 	sessionTracker.start();
 
 	// wire up default Pinpoint message event handling
 	addEventListener('messageDisplayed', (message: InAppMessage) => {
-		console.log('Recording message displayed event');
 		recordAnalyticsEvent(PinpointMessageEvent.MESSAGE_DISPLAYED, message);
 		incrementMessageCounts(message.id);
 	});

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.ts
@@ -10,7 +10,6 @@ import { Hub, HubCapsule } from '@aws-amplify/core';
 import { dispatchEvent } from './dispatchEvent';
 import { incrementMessageCounts, sessionStateChangeHandler } from '../utils';
 import { isInitialized, initialize } from '../../../utils';
-import { Amplify } from '@aws-amplify/core';
 
 /**
  * Initialize and set up in-app messaging category. This API needs to be called to enable other InAppMessaging APIs.
@@ -27,7 +26,6 @@ export function initializeInAppMessaging(): void {
 	if (isInitialized()) {
 		return;
 	}
-	console.log('Confin in initializeInAppMessaging: ', Amplify.getConfig());
 	// set up the session tracker and start it
 	const sessionTracker = new SessionTracker(sessionStateChangeHandler);
 	sessionTracker.start();

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/messageProcessingHelpers.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/messageProcessingHelpers.ts
@@ -71,7 +71,6 @@ export async function processInAppMessages(
 
 export function sessionStateChangeHandler(state: SessionState): void {
 	if (state === 'started') {
-		console.log('Resetting the count');
 		// reset all session counts
 		sessionMessageCountMap = {};
 	}

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/resolveConfig.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/resolveConfig.ts
@@ -11,6 +11,8 @@ import {
  * @internal
  */
 export const resolveConfig = () => {
+	const config = Amplify.getConfig();
+	console.log('Config: ', config);
 	const { appId, region } =
 		Amplify.getConfig().Notifications?.InAppMessaging.Pinpoint ?? {};
 	assertValidationError(!!appId, InAppMessagingValidationErrorCode.NoAppId);

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/resolveConfig.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/resolveConfig.ts
@@ -11,8 +11,6 @@ import {
  * @internal
  */
 export const resolveConfig = () => {
-	const config = Amplify.getConfig();
-	console.log('Config: ', config);
 	const { appId, region } =
 		Amplify.getConfig().Notifications?.InAppMessaging.Pinpoint ?? {};
 	assertValidationError(!!appId, InAppMessagingValidationErrorCode.NoAppId);

--- a/packages/notifications/src/inAppMessaging/sessionTracker/SessionTracker.ts
+++ b/packages/notifications/src/inAppMessaging/sessionTracker/SessionTracker.ts
@@ -15,7 +15,7 @@ import {
 let hidden: string;
 let visibilityChange: string;
 
-if (isBrowser && document) {
+if (isBrowser() && document) {
 	if (typeof document.hidden !== 'undefined') {
 		hidden = 'hidden';
 		visibilityChange = 'visibilitychange';
@@ -38,7 +38,7 @@ export default class SessionTracker implements SessionTrackerInterface {
 	}
 
 	start = (): SessionState => {
-		if (isBrowser) {
+		if (isBrowser()) {
 			document?.addEventListener(
 				visibilityChange,
 				this.visibilityChangeHandler
@@ -48,7 +48,7 @@ export default class SessionTracker implements SessionTrackerInterface {
 	};
 
 	end = (): SessionState => {
-		if (isBrowser) {
+		if (isBrowser()) {
 			document?.removeEventListener(
 				visibilityChange,
 				this.visibilityChangeHandler
@@ -58,7 +58,7 @@ export default class SessionTracker implements SessionTrackerInterface {
 	};
 
 	private getSessionState = (): SessionState => {
-		if (isBrowser && document && !document[hidden]) {
+		if (isBrowser() && document && !document[hidden]) {
 			return 'started';
 		}
 		// If, for any reason, document is undefined the session will never start
@@ -66,7 +66,7 @@ export default class SessionTracker implements SessionTrackerInterface {
 	};
 
 	private visibilityChangeHandler = () => {
-		if (!isBrowser || !document) {
+		if (!isBrowser() || !document) {
 			return;
 		}
 		if (document[hidden]) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Corrects the use of isBrowser that checks if the env is a browser or not. This fixes a bug that blocks from running on Next js apps where the default is server side component until a client component is rendered where the InApp APIs are intended to work. 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
- amplify-ui repo's next app works as expected
- custom next app can use InApp APIs


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
