### PR TITLE
chore: unable angular and vue auth integ tests

### DIFF
--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -436,7 +436,6 @@ tests:
     sample_name: [javascript-auth]
     spec: functional-auth
     browser: *minimal_browser_list
-  # TODO(v6) Migrate?
   - test_name: integ_react_auth_1_guest_to_authenticated_user
     desc: 'Guest to Authenticated User'
     framework: react
@@ -493,20 +492,20 @@ tests:
     sample_name: [delete-user]
     spec: delete-user
     browser: *minimal_browser_list
-  - test_name: integ_angular_auth_angular_authenticator
-    desc: 'Angular Authenticator'
-    framework: angular
-    category: auth
-    sample_name: [amplify-authenticator]
-    spec: ui-amplify-authenticator
-    browser: *minimal_browser_list
-  - test_name: integ_angular_auth_angular_custom_authenticator
-    desc: 'Angular Custom Authenticator'
-    framework: angular
-    category: auth
-    sample_name: [amplify-authenticator]
-    spec: custom-authenticator
-    browser: *minimal_browser_list
+  # - test_name: integ_angular_auth_angular_authenticator
+  #   desc: 'Angular Authenticator'
+  #   framework: angular
+  #   category: auth
+  #   sample_name: [amplify-authenticator]
+  #   spec: ui-amplify-authenticator
+  #   browser: *minimal_browser_list
+  # - test_name: integ_angular_auth_angular_custom_authenticator
+  #   desc: 'Angular Custom Authenticator'
+  #   framework: angular
+  #   category: auth
+  #   sample_name: [amplify-authenticator]
+  #   spec: custom-authenticator
+  #   browser: *minimal_browser_list
   - test_name: integ_javascript_auth
     desc: 'JavaScript Auth CDN'
     framework: javascript
@@ -515,20 +514,20 @@ tests:
     spec: auth-cdn
     browser: *minimal_browser_list
     amplifyjs_dir: true
-  - test_name: integ_vue_auth_legacy_vue_authenticator
-    desc: 'Legacy Vue Authenticator'
-    framework: vue
-    category: auth
-    sample_name: [amplify-authenticator-legacy]
-    spec: authenticator
-    browser: *minimal_browser_list
-  - test_name: integ_vue_auth_vue_3_authenticator
-    desc: 'Vue 3 Authenticator'
-    framework: vue
-    category: auth
-    sample_name: [authenticator-vue3]
-    spec: new-ui-authenticator
-    browser: *minimal_browser_list
+  # - test_name: integ_vue_auth_legacy_vue_authenticator
+  #   desc: 'Legacy Vue Authenticator'
+  #   framework: vue
+  #   category: auth
+  #   sample_name: [amplify-authenticator-legacy]
+  #   spec: authenticator
+  #   browser: *minimal_browser_list
+  # - test_name: integ_vue_auth_vue_3_authenticator
+  #   desc: 'Vue 3 Authenticator'
+  #   framework: vue
+  #   category: auth
+  #   sample_name: [authenticator-vue3]
+  #   spec: new-ui-authenticator
+  #   browser: *minimal_browser_list
   # TODO(v6) Migrate once SSR updates available
   - test_name: integ_next_auth_authenticator_and_ssr_page
     desc: 'Authenticator and SSR page'


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Unable the following tests:
- `integ_angular_auth_angular_authenticator`
- `integ_angular_auth_angular_custom_authenticator`
- `integ_vue_auth_legacy_vue_authenticator`
- `integ_vue_auth_vue_3_authenticator`

These tests are currently testing some UI Authenticator functionality and some basic auth flow, which is already tested by the `functional-auth` spec, which currently works for react only. However to enable this spec for angular/vue we need to create custom components for each platform. As previously discussed, this is something that the UI team might be testing on their end. However we can still test this flow at a later point so we can detect any amplify build issues before hand.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
