### PR TITLE
fix: Make Reachability node safe

### DIFF
--- a/packages/core/src/Reachability/Reachability.ts
+++ b/packages/core/src/Reachability/Reachability.ts
@@ -9,7 +9,7 @@ export class Reachability {
 	private static _observers: Array<CompletionObserver<NetworkStatus>> = [];
 
 	networkMonitor(_?: unknown): Observable<NetworkStatus> {
-		const globalObj = isWebWorker() ? self : window;
+		const globalObj = isWebWorker() ? self : typeof window !== 'undefined' && window;
 
 		if (!globalObj) {
 			return from([{ online: true }]);

--- a/packages/core/src/Reachability/Reachability.ts
+++ b/packages/core/src/Reachability/Reachability.ts
@@ -18,16 +18,8 @@ export class Reachability {
 		return new Observable(observer => {
 			observer.next({ online: globalObj.navigator.onLine });
 
-			const notifyOnline = () => { 
-				console.log('+ Notify online');
-
-				observer.next({ online: true });
-			}
-			const notifyOffline = () => { 
-				console.log('+ Notify offline');
-
-				observer.next({ online: false });
-			}
+			const notifyOnline = () => observer.next({ online: true });
+			const notifyOffline = () => observer.next({ online: false });
 
 			globalObj.addEventListener('online', notifyOnline);
 			globalObj.addEventListener('offline', notifyOffline);

--- a/packages/core/src/Reachability/Reachability.ts
+++ b/packages/core/src/Reachability/Reachability.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { CompletionObserver, Observable } from 'rxjs';
+import { CompletionObserver, Observable, from } from 'rxjs';
 import { isWebWorker } from '../libraryUtils';
 import { NetworkStatus } from './types';
 
@@ -10,6 +10,10 @@ export class Reachability {
 
 	networkMonitor(_?: unknown): Observable<NetworkStatus> {
 		const globalObj = isWebWorker() ? self : window;
+
+		if (!globalObj) {
+			return from([{ online: true }]);
+		}
 
 		return new Observable(observer => {
 			observer.next({ online: globalObj.navigator.onLine });

--- a/packages/core/src/Reachability/Reachability.ts
+++ b/packages/core/src/Reachability/Reachability.ts
@@ -18,8 +18,16 @@ export class Reachability {
 		return new Observable(observer => {
 			observer.next({ online: globalObj.navigator.onLine });
 
-			const notifyOnline = () => observer.next({ online: true });
-			const notifyOffline = () => observer.next({ online: false });
+			const notifyOnline = () => { 
+				console.log('+ Notify online');
+
+				observer.next({ online: true });
+			}
+			const notifyOffline = () => { 
+				console.log('+ Notify offline');
+
+				observer.next({ online: false });
+			}
 
 			globalObj.addEventListener('online', notifyOnline);
 			globalObj.addEventListener('offline', notifyOffline);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Makes the `Reachability` utility node safe to allow it to be built on Next.js applications, even when not using SSR.

Previously this behavior was enforced by this check which was removed to avoid a dependency on `process`: https://github.com/aws-amplify/amplify-js/blob/main/packages/core/src/Util/Reachability.ts#L16

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Tested `Reachability` in a Web application to make sure the observable was still firing by disconnecting/reconnecting my network. Associated DS integ test now passing.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
