### PR TITLE
chore: Remove I18n & Cache from global configuration

### DIFF
--- a/packages/core/src/Cache/StorageCacheCommon.ts
+++ b/packages/core/src/Cache/StorageCacheCommon.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '../singleton';
 import { ConsoleLogger as Logger } from '../Logger';
 import { KeyValueStorageInterface } from '../types';
 import { currentSizeKey, defaultConfig } from './constants';

--- a/packages/core/src/Cache/StorageCacheCommon.ts
+++ b/packages/core/src/Cache/StorageCacheCommon.ts
@@ -31,11 +31,8 @@ export abstract class StorageCacheCommon {
 		config?: CacheConfig;
 		keyValueStorage: KeyValueStorageInterface;
 	}) {
-		const globalCacheConfig = Amplify.getConfig().Cache ?? {};
-
 		this.config = {
 			...defaultConfig,
-			...globalCacheConfig,
 			...config,
 		};
 		this.keyValueStorage = keyValueStorage;

--- a/packages/core/src/I18n/I18n.ts
+++ b/packages/core/src/I18n/I18n.ts
@@ -37,12 +37,7 @@ export class I18n {
 	 * Sets the default language from the configuration when required.
 	 */
 	setDefaultLanguage() {
-		if (!this._lang) {
-			const i18nConfig = Amplify.getConfig().I18n;
-			this._lang = i18nConfig?.language;
-		}
-
-		// Default to window language if not set in config
+		// Default to window language if not set in instance
 		if (
 			!this._lang &&
 			typeof window !== 'undefined' &&

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,6 @@ export {
 	AuthUserPoolConfig,
 	AuthUserPoolAndIdentityPoolConfig,
 	APIConfig,
-	CacheConfig,
 	StorageAccessLevel,
 	StorageConfig,
 	GetCredentialsOptions,
@@ -62,6 +61,7 @@ export { KeyValueStorageInterface } from './types';
 
 // Cache exports
 export { Cache } from './Cache';
+export { CacheConfig } from './Cache/types';
 
 // Internationalization utilities
 export { I18n } from './I18n';

--- a/packages/core/src/singleton/types.ts
+++ b/packages/core/src/singleton/types.ts
@@ -12,14 +12,12 @@ import {
 	GetCredentialsOptions,
 	CognitoIdentityPoolConfig,
 } from './Auth/types';
-import { CacheConfig } from './Cache/types';
 import { GeoConfig } from './Geo/types';
 import {
 	LibraryStorageOptions,
 	StorageAccessLevel,
 	StorageConfig,
 } from './Storage/types';
-import { I18nConfig } from '../I18n/types';
 import { NotificationsConfig } from './Notifications/types';
 
 export type LegacyConfig = {
@@ -33,9 +31,6 @@ export type ResourcesConfig = {
 	API?: APIConfig;
 	Analytics?: AnalyticsConfig;
 	Auth?: AuthConfig;
-	Cache?: CacheConfig;
-	// DataStore?: {};
-	I18n?: I18nConfig;
 	// Interactions?: {};
 	Notifications?: NotificationsConfig;
 	// Predictions?: {};
@@ -56,7 +51,6 @@ export {
 	AuthUserPoolConfig,
 	AuthIdentityPoolConfig,
 	AuthUserPoolAndIdentityPoolConfig,
-	CacheConfig,
 	GetCredentialsOptions,
 	StorageAccessLevel,
 	StorageConfig,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Removes I18n & Cache from global library configuration in favor of configuring the instances directly.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
