### PR TITLE
TypeError: callback is not a function fix

### DIFF
--- a/packages/amazon-cognito-identity-js/src/CognitoUserPool.js
+++ b/packages/amazon-cognito-identity-js/src/CognitoUserPool.js
@@ -113,6 +113,9 @@ export default class CognitoUserPool {
 			ValidationData: validationData,
 			ClientMetadata: clientMetadata,
 		};
+		if (typeof callback !== 'function') {
+    return new Error('Callback function is missing or not a valid function.');
+    }
 		if (this.getUserContextData(username)) {
 			jsonReq.UserContextData = this.getUserContextData(username);
 		}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
### Changes Made
In this pull request, we have made improvements to the signUp function in the `CognitoUserPool.js` file. The primary change is related to error handling when the callback function is missing or invalid.

### Details

Added a validation check to ensure that the callback parameter is a valid JavaScript function.
If the callback is missing or not a function, the function will now return an error with a clear message: "Callback function is missing or not a valid function."
### Why is this change necessary?
This change is essential to enhance the robustness and usability of the signUp function. Prior to this update, if the callback was missing or not a function, it would result in a less informative "TypeError." With this change, we provide a specific error message that helps developers understand the issue and take appropriate action.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
