### PR TITLE
chore: Disable interactions tests and enable iot reconnect test

### DIFF
--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -516,7 +516,7 @@ tests:
     timeout_minutes: 45
     retry_count: 10
 
-  # DISABLED Angular/Vue tests: 
+  # DISABLED Angular/Vue tests:
   # TODO: delete tests or add custom ui logic to support them.
 
   # - test_name: integ_angular_auth_angular_authenticator
@@ -548,7 +548,7 @@ tests:
   #   spec: new-ui-authenticator
   #   browser: *minimal_browser_list
 
-  # DISABLED CDN test: 
+  # DISABLED CDN test:
   # TODO: delete this test after making sure CDN won't be supported
 
   # - test_name: integ_javascript_auth
@@ -641,48 +641,48 @@ tests:
   #   amplifyjs_dir: true
 
   # INTERACTIONS
-  - test_name: integ_react_interactions_react_interactions
-    desc: 'React Interactions'
-    framework: react
-    category: interactions
-    sample_name: [chatbot-component]
-    spec: chatbot-component
-    browser: *minimal_browser_list
-  - test_name: integ_react_interactions_chatbot_v1
-    desc: 'Chatbot V1'
-    framework: react
-    category: interactions
-    sample_name: [lex-test-component]
-    spec: chatbot-v1
-    browser: *minimal_browser_list
-  - test_name: integ_react_interactions_chatbot_v2
-    desc: 'Chatbot V2'
-    framework: react
-    category: interactions
-    sample_name: [lex-test-component]
-    spec: chatbot-v2
-    browser: *minimal_browser_list
-  - test_name: integ_angular_interactions
-    desc: 'Angular Interactions'
-    framework: angular
-    category: interactions
-    sample_name: [chatbot-component]
-    spec: chatbot-component
-    browser: *minimal_browser_list
-  - test_name: integ_vue_interactions_vue_2_interactions
-    desc: 'Vue 2 Interactions'
-    framework: vue
-    category: interactions
-    sample_name: [chatbot-component]
-    spec: chatbot-component
-    browser: [chrome]
-  - test_name: integ_vue_interactionsvue_3_interactions
-    desc: 'Vue 3 Interactions'
-    framework: vue
-    category: interactions
-    sample_name: [chatbot-component-vue3]
-    spec: chatbot-component
-    browser: [chrome]
+  # - test_name: integ_react_interactions_react_interactions
+  #   desc: 'React Interactions'
+  #   framework: react
+  #   category: interactions
+  #   sample_name: [chatbot-component]
+  #   spec: chatbot-component
+  #   browser: *minimal_browser_list
+  # - test_name: integ_react_interactions_chatbot_v1
+  #   desc: 'Chatbot V1'
+  #   framework: react
+  #   category: interactions
+  #   sample_name: [lex-test-component]
+  #   spec: chatbot-v1
+  #   browser: *minimal_browser_list
+  # - test_name: integ_react_interactions_chatbot_v2
+  #   desc: 'Chatbot V2'
+  #   framework: react
+  #   category: interactions
+  #   sample_name: [lex-test-component]
+  #   spec: chatbot-v2
+  #   browser: *minimal_browser_list
+  # - test_name: integ_angular_interactions
+  #   desc: 'Angular Interactions'
+  #   framework: angular
+  #   category: interactions
+  #   sample_name: [chatbot-component]
+  #   spec: chatbot-component
+  #   browser: *minimal_browser_list
+  # - test_name: integ_vue_interactions_vue_2_interactions
+  #   desc: 'Vue 2 Interactions'
+  #   framework: vue
+  #   category: interactions
+  #   sample_name: [chatbot-component]
+  #   spec: chatbot-component
+  #   browser: [chrome]
+  # - test_name: integ_vue_interactionsvue_3_interactions
+  #   desc: 'Vue 3 Interactions'
+  #   framework: vue
+  #   category: interactions
+  #   sample_name: [chatbot-component-vue3]
+  #   spec: chatbot-component
+  #   browser: [chrome]
 
   # PREDICTIONS
   # - test_name: integ_react_predictions
@@ -694,14 +694,14 @@ tests:
   #   browser: *minimal_browser_list
 
   # PUBSUB
-  # - test_name: integ_react_iot_reconnect
-  #   desc: 'PubSub - Reconnection for IoT'
-  #   framework: react
-  #   category: pubsub
-  #   sample_name: [reconnection-iot]
-  #   spec: reconnection
-  #   # Firefox doesn't support network state management in cypress
-  #   browser: [chrome]
+  - test_name: integ_react_iot_reconnect
+    desc: 'PubSub - Reconnection for IoT'
+    framework: react
+    category: pubsub
+    sample_name: [reconnection-iot]
+    spec: reconnection
+    # Firefox doesn't support network state management in cypress
+    browser: [chrome]
   - test_name: integ_react_api_reconnect
     desc: 'PubSub - Reconnection for API'
     framework: react


### PR DESCRIPTION
#### Description of changes
Reviewing the most recent [integ test run](https://github.com/aws-amplify/amplify-js/actions/runs/6569155198):
- Rremoving interactions tests, which haven't been worked on yet
- Adding the IoT reconnect test, which I have confirmed is working

I expect this to remove some noise and so we can focus effort on the remaining failures to either remove them as not relevant or fix them if they are good quality checks.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
