### PR TITLE
Use URL class for creating oauth2 redirect url

### DIFF
--- a/packages/auth/__tests__/oauth-test.ts
+++ b/packages/auth/__tests__/oauth-test.ts
@@ -188,4 +188,58 @@ describe('OAuth', () => {
 			});
 		});
 	});
+	describe('oauthSignIn', () => {
+		test('redirect to the correct url', () => {
+			const responseType = 'something';
+			const domain = 'test.com';
+			const redirectSignIn = 'https://redirect.com';
+			const clientId = 'clientId';
+			const provider = 'provider';
+			const scopes = ['openid'];
+			const state = 'state';
+
+			const config = {
+				domain: '',
+				clientID: '',
+				scope: '',
+				redirectUri: '',
+				audience: '',
+				responseType: 'code',
+				returnTo: '',
+				redirectSignIn,
+				urlOpener: jest.fn(),
+			};
+
+			const oAuth = new OAuth({
+				scopes,
+				config,
+				cognitoClientId: '',
+			});
+
+			oAuth['_generateState'] = () => state;
+
+			oAuth.oauthSignIn(
+				responseType,
+				domain,
+				redirectSignIn,
+				clientId,
+				provider
+			);
+
+			const searchParams = new URLSearchParams({
+				redirect_uri: redirectSignIn,
+				response_type: responseType,
+				client_id: clientId,
+				identity_provider: provider,
+				scope: scopes.join(' '),
+				state,
+			});
+
+			expect(config.urlOpener).toHaveBeenCalledTimes(1);
+			expect(config.urlOpener).toHaveBeenCalledWith(
+				`https://${domain}/oauth2/authorize?${searchParams.toString()}`,
+				redirectSignIn
+			);
+		});
+	});
 });

--- a/packages/auth/src/OAuth/OAuth.ts
+++ b/packages/auth/src/OAuth/OAuth.ts
@@ -113,9 +113,8 @@ export default class OAuth {
 			url.searchParams.set('code_challenge_method', code_challenge_method);
 		}
 
-		const URL = url.toString();
-		logger.debug(`Redirecting to ${URL}`);
-		this._urlOpener(URL, redirectSignIn);
+		logger.debug(`Redirecting to ${url.toString()}`);
+		this._urlOpener(url.toString(), redirectSignIn);
 	}
 
 	private async _handleCodeFlow(currentUrl: string) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Updates OAuth2 to create the redirect URL using the `URL` class instead of manually.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

Wrote a unit test.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
