### PR TITLE
feat: Add GraphQL user agent info.

### DIFF
--- a/packages/api-graphql/__tests__/utils/expects.ts
+++ b/packages/api-graphql/__tests__/utils/expects.ts
@@ -105,6 +105,9 @@ export function expectSub(
 			),
 			variables: expect.objectContaining(item),
 		}),
-		undefined
+		{
+			action: '1', 
+			category: 'api'
+		}
 	);
 }

--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { AmplifyClassV6 } from '@aws-amplify/core';
+import { Category, ApiAction } from '@aws-amplify/core/internals/utils';
 import { GraphQLOptions, GraphQLResult } from './types';
 import { InternalGraphQLAPIClass } from './internals';
 import { Observable } from 'rxjs';
@@ -35,7 +36,10 @@ export class GraphQLAPIClass extends InternalGraphQLAPIClass {
 		options: GraphQLOptions,
 		additionalHeaders?: { [key: string]: string }
 	): Observable<GraphQLResult<T>> | Promise<GraphQLResult<T>> {
-		return super.graphql(amplify, options, additionalHeaders);
+		return super.graphql(amplify, options, additionalHeaders, {
+			category: Category.API,
+			action: ApiAction.GraphQl
+		});
 	}
 
 	/**

--- a/packages/api/__tests__/API.test.ts
+++ b/packages/api/__tests__/API.test.ts
@@ -11,7 +11,11 @@ describe('API generateClient', () => {
 		expect(spy).toBeCalledWith(
 			{ Auth: {}, libraryOptions: {}, resourcesConfig: {} },
 			{ query: 'query' },
-			undefined
+			undefined,
+			{
+				action: '1', 
+				category: 'api'
+			}
 		);
 	});
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Small change to add user agent action info to GraphQL. DataStore is already setting the correct UA values.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Verified in sample app that correct headers are being sent for AppSync requests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
