### PR TITLE
chore(aws-amplify): make adapter-core a non-internal subpath

### DIFF
--- a/packages/adapter-nextjs/__tests__/runWithAmplifyServerContext.test.ts
+++ b/packages/adapter-nextjs/__tests__/runWithAmplifyServerContext.test.ts
@@ -7,7 +7,7 @@ import {
 	createKeyValueStorageFromCookieStorageAdapter,
 	createUserPoolsTokenProvider,
 	runWithAmplifyServerContext as runWithAmplifyServerContextCore,
-} from 'aws-amplify/internals/adapter-core';
+} from 'aws-amplify/adapter-core';
 import { runWithAmplifyServerContext } from '../src';
 import { getAmplifyConfig } from '../src/utils';
 import { NextServer } from '../src/types';
@@ -32,7 +32,7 @@ jest.mock('../src/utils', () => ({
 	getAmplifyConfig: jest.fn(() => mockAmplifyConfig),
 	createCookieStorageAdapterFromNextServerContext: jest.fn(),
 }));
-jest.mock('aws-amplify/internals/adapter-core');
+jest.mock('aws-amplify/adapter-core');
 
 const mockGetAmplifyConfig = getAmplifyConfig as jest.Mock;
 const mockRunWithAmplifyServerContextCore =

--- a/packages/adapter-nextjs/internals/package.json
+++ b/packages/adapter-nextjs/internals/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "@aws-amplify/adapter-nextjs/internals",
+	"main": "../lib/internals/index.js",
+	"browser": "../lib-esm/internals/index.js",
+	"module": "../lib-esm/internals/index.js",
+	"typings": "../lib-esm/internals/index.d.ts"
+}

--- a/packages/adapter-nextjs/package.json
+++ b/packages/adapter-nextjs/package.json
@@ -37,13 +37,19 @@
 			"import": "./lib-esm/withAmplify.js",
 			"require": "./lib/withAmplify.js"
 		},
+		"./internals": {
+			"types": "./lib-esm/internals/index.d.ts",
+			"import": "./lib-esm/internals/index.js",
+			"require": "./lib/internals/index.js"
+		},
 		"./package.json": "./package.json"
 	},
 	"files": [
 		"lib",
 		"lib-esm",
 		"src",
-		"with-amplify"
+		"with-amplify",
+		"internals"
 	],
 	"homepage": "https://aws-amplify.github.io/",
 	"jest": {

--- a/packages/adapter-nextjs/src/internals/index.ts
+++ b/packages/adapter-nextjs/src/internals/index.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { getAmplifyConfig } from '../utils';
+export { NextServer } from '../types';

--- a/packages/adapter-nextjs/src/runWithAmplifyServerContext.ts
+++ b/packages/adapter-nextjs/src/runWithAmplifyServerContext.ts
@@ -12,7 +12,7 @@ import {
 	createKeyValueStorageFromCookieStorageAdapter,
 	createUserPoolsTokenProvider,
 	runWithAmplifyServerContext as runWithAmplifyServerContextCore,
-} from 'aws-amplify/internals/adapter-core';
+} from 'aws-amplify/adapter-core';
 
 /**
  * Runs the {@link operation} with the the context created from the {@link nextServerContext}.

--- a/packages/adapter-nextjs/src/withAmplify.ts
+++ b/packages/adapter-nextjs/src/withAmplify.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ResourcesConfig } from 'aws-amplify';
-import { LegacyConfig } from 'aws-amplify/internals/adapter-core';
+import { LegacyConfig } from 'aws-amplify/adapter-core';
 import { NextConfig } from 'next';
 
 // NOTE: this function is exported from the subpath `/with-amplify`.

--- a/packages/adapter-nextjs/with-amplify/package.json
+++ b/packages/adapter-nextjs/with-amplify/package.json
@@ -3,5 +3,5 @@
 	"main": "../lib/withAmplify.js",
 	"browser": "../lib-esm/withAmplify.js",
 	"module": "../lib-esm/withAmplify.js",
-	"typings": "../lib-esm/withAmplify.js"
+	"typings": "../lib-esm/withAmplify.d.ts"
 }

--- a/packages/aws-amplify/adapter-core/package.json
+++ b/packages/aws-amplify/adapter-core/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "aws-amplify/adapter-core",
+	"types": "../lib-esm/adapterCore/index.d.ts",
+	"main": "../lib/adapterCore/index.js",
+	"module": "../lib-esm/adapterCore/index.js",
+	"react-native": "../lib-esm/adapterCore/index.js",
+	"sideEffects": false
+}

--- a/packages/aws-amplify/internals/adapter-core/package.json
+++ b/packages/aws-amplify/internals/adapter-core/package.json
@@ -1,8 +1,0 @@
-{
-	"name": "aws-amplify/internals/adapter-core",
-	"types": "../../lib-esm/adapterCore/index.d.ts",
-	"main": "../../lib/adapterCore/index.js",
-	"module": "../../lib-esm/adapterCore/index.js",
-	"react-native": "../../lib-esm/adapterCore/index.js",
-	"sideEffects": false
-}

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -122,7 +122,7 @@
 			"import": "./lib-esm/push-notifications/pinpoint/index.js",
 			"require": "./lib/push-notifications/pinpoint/index.js"
 		},
-		"./internals/adapter-core": {
+		"./adapter-core": {
 			"types": "./lib-esm/adapterCore/index.d.ts",
 			"import": "./lib-esm/adapterCore/index.js",
 			"require": "./lib/adapterCore/index.js"
@@ -194,7 +194,7 @@
 			"push-notifications/pinpoint": [
 				"./lib-esm/push-notifications/pinpoint/index.d.ts"
 			],
-			"internals/adapter-core": [
+			"adapter-core": [
 				"./lib-esm/adapterCore/index.d.ts"
 			]
 		}
@@ -231,9 +231,9 @@
 		"lib-esm",
 		"src",
 		"analytics",
+		"adapter-core",
 		"api",
 		"auth",
-		"internals",
 		"storage",
 		"datastore",
 		"in-app-messaging",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Made the `adapter-core` a non-internals prefixed subpath


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
