### PR TITLE
feat(api-graphql):  observeQuery

### DIFF
--- a/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.js
+++ b/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.js
@@ -544,6 +544,67 @@ const amplifyConfig = {
 					sortKeyFieldNames: [],
 				},
 			},
+			ThingWithCustomPk: {
+				name: 'ThingWithCustomPk',
+				fields: {
+					cpk_cluster_key: {
+						name: 'cpk_cluster_key',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					cpk_sort_key: {
+						name: 'cpk_sort_key',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					otherField: {
+						name: 'otherField',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: false,
+						attributes: [],
+						isReadOnly: true,
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: false,
+						attributes: [],
+						isReadOnly: true,
+					},
+				},
+				syncable: true,
+				pluralName: 'ThingWithCustomPks',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							fields: ['cpk_cluster_key', 'cpk_sort_key'],
+						},
+					},
+				],
+				primaryKeyInfo: {
+					isCustomPrimaryKey: true,
+					primaryKeyFieldName: 'cpk_cluster_key',
+					sortKeyFieldNames: ['cpk_sort_key'],
+				},
+			},
 		},
 		enums: {},
 		nonModels: {},

--- a/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
@@ -43,6 +43,13 @@ const schema = a.schema({
 		id: a.id(),
 		description: a.string(),
 	}),
+	ThingWithCustomPk: a
+		.model({
+			cpk_cluster_key: a.string().required(),
+			cpk_sort_key: a.string().required(),
+			otherField: a.string(),
+		})
+		.identifier(['cpk_cluster_key', 'cpk_sort_key']),
 });
 
 export type Schema = ClientSchema<typeof schema>;

--- a/packages/api-graphql/__tests__/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/generateClient.test.ts
@@ -303,6 +303,16 @@ describe('generateClient', () => {
 				})
 			);
 
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					options: expect.objectContaining({
+						body: expect.objectContaining({
+							query: expect.stringContaining('nextToken'),
+						}),
+					}),
+				})
+			);
+
 			expect(data.length).toBe(1);
 			expect(data[0]).toEqual(
 				expect.objectContaining({
@@ -699,7 +709,7 @@ describe('generateClient', () => {
 		});
 	});
 
-	describe.only('observeQuery', () => {
+	describe('observeQuery', () => {
 		beforeEach(() => {
 			jest.clearAllMocks();
 			Amplify.configure(configFixture as any);
@@ -725,7 +735,6 @@ describe('generateClient', () => {
 			});
 
 			const { streams, spy } = makeAppSyncStreams();
-			console.log({ streams });
 
 			client.models.Todo.observeQuery().subscribe({
 				next({ items, isSynced }) {

--- a/packages/api-graphql/__tests__/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/generateClient.test.ts
@@ -290,7 +290,9 @@ describe('generateClient', () => {
 							'X-Api-Key': 'FAKE-KEY',
 						}),
 						body: {
-							query: expect.stringContaining('listTodos(filter: $filter)'),
+							query: expect.stringContaining(
+								'listTodos(filter: $filter, limit: $limit, nextToken: $nextToken)'
+							),
 							variables: {
 								filter: {
 									name: {
@@ -576,7 +578,9 @@ describe('generateClient', () => {
 							'X-Api-Key': 'FAKE-KEY',
 						}),
 						body: {
-							query: expect.stringContaining('listNotes(filter: $filter)'),
+							query: expect.stringContaining(
+								'listNotes(filter: $filter, limit: $limit, nextToken: $nextToken)'
+							),
 							variables: {
 								filter: {
 									and: [{ todoNotesId: { eq: 'todo-id' } }],
@@ -756,7 +760,7 @@ describe('generateClient', () => {
 			const client = generateClient<Schema>({ amplify: Amplify });
 			const { streams } = makeAppSyncStreams();
 
-			mockApiResponse({
+			let spy = mockApiResponse({
 				data: {
 					listTodos: {
 						items: [
@@ -787,7 +791,7 @@ describe('generateClient', () => {
 								description: 'something something first',
 							}),
 						]);
-						mockApiResponse({
+						spy = mockApiResponse({
 							data: {
 								listTodos: {
 									items: [
@@ -818,6 +822,20 @@ describe('generateClient', () => {
 								description: 'something something second',
 							}),
 						]);
+
+						// ensure we actually got a request that included our next token
+						expect(spy).toHaveBeenCalledWith(
+							expect.objectContaining({
+								options: expect.objectContaining({
+									body: expect.objectContaining({
+										variables: expect.objectContaining({
+											nextToken: 'sometoken',
+										}),
+									}),
+								}),
+							})
+						);
+
 						done();
 					}
 				},

--- a/packages/api-graphql/__tests__/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/generateClient.test.ts
@@ -708,9 +708,9 @@ describe('generateClient', () => {
 					done();
 				},
 			});
-		}, 500);
+		});
 
-		test.only('can paginate through initial results', done => {
+		test('can paginate through initial results', done => {
 			const client = generateClient<Schema>({ amplify: Amplify });
 
 			mockApiResponse({
@@ -779,7 +779,7 @@ describe('generateClient', () => {
 					}
 				},
 			});
-		}, 500);
+		});
 
 		// test('can see creates', async done => {});
 

--- a/packages/api-graphql/__tests__/v6-test.ts
+++ b/packages/api-graphql/__tests__/v6-test.ts
@@ -264,7 +264,7 @@ describe('client', () => {
 				data: {
 					listThreads: {
 						items: threadsToList,
-						nextToken: null,
+						nextToken: 'something',
 					},
 				},
 			};
@@ -295,6 +295,7 @@ describe('client', () => {
 			expectList(spy, 'listThreads', graphqlVariables);
 			expect(errors).toBe(undefined);
 			expect(items).toEqual(graphqlResponse.data.listThreads.items);
+			expect(nextToken).toEqual('something');
 		});
 
 		test('subscribe', done => {

--- a/packages/api-graphql/src/internals/APIClient.ts
+++ b/packages/api-graphql/src/internals/APIClient.ts
@@ -415,7 +415,7 @@ export function generateGraphQLDocument(
 				});
 			graphQLOperationType ?? (graphQLOperationType = 'query');
 			graphQLSelectionSet ??
-				(graphQLSelectionSet = `items { ${selectionSetFields} }`);
+				(graphQLSelectionSet = `items { ${selectionSetFields} } nextToken`);
 		case 'ONCREATE':
 		case 'ONUPDATE':
 		case 'ONDELETE':

--- a/packages/api-graphql/src/internals/APIClient.ts
+++ b/packages/api-graphql/src/internals/APIClient.ts
@@ -157,6 +157,7 @@ export const graphQLOperationsInfo = {
 	ONCREATE: { operationPrefix: 'onCreate' as const, usePlural: false },
 	ONUPDATE: { operationPrefix: 'onUpdate' as const, usePlural: false },
 	ONDELETE: { operationPrefix: 'onDelete' as const, usePlural: false },
+	OBSERVE_QUERY: { operationPrefix: 'observeQuery' as const, usePlural: false },
 };
 export type ModelOperation = keyof typeof graphQLOperationsInfo;
 
@@ -424,6 +425,12 @@ export function generateGraphQLDocument(
 				});
 			graphQLOperationType ?? (graphQLOperationType = 'subscription');
 			graphQLSelectionSet ?? (graphQLSelectionSet = selectionSetFields);
+			break;
+		case 'OBSERVE_QUERY':
+		default:
+			throw new Error(
+				'Internal error: Attempted to generate graphql document for observeQuery. Please report this error.'
+			);
 	}
 
 	const graphQLDocument = `${graphQLOperationType}${
@@ -508,6 +515,11 @@ export function buildGraphQLVariables(
 			if (arg?.filter) {
 				variables = { filter: arg.filter };
 			}
+			break;
+		case 'OBSERVE_QUERY':
+			throw new Error(
+				'Internal error: Attempted to build variables for observeQuery. Please report this error.'
+			);
 			break;
 		default:
 			const exhaustiveCheck: never = operation;

--- a/packages/api-graphql/src/internals/APIClient.ts
+++ b/packages/api-graphql/src/internals/APIClient.ts
@@ -412,10 +412,12 @@ export function generateGraphQLDocument(
 			graphQLArguments ??
 				(graphQLArguments = {
 					filter: `Model${name}FilterInput`,
+					limit: 'Int',
+					nextToken: 'String',
 				});
 			graphQLOperationType ?? (graphQLOperationType = 'query');
 			graphQLSelectionSet ??
-				(graphQLSelectionSet = `items { ${selectionSetFields} } nextToken`);
+				(graphQLSelectionSet = `items { ${selectionSetFields} } nextToken __typename`);
 		case 'ONCREATE':
 		case 'ONUPDATE':
 		case 'ONDELETE':
@@ -467,7 +469,7 @@ export function buildGraphQLVariables(
 		},
 	} = modelDefinition;
 
-	let variables = {};
+	let variables: Record<string, any> = {};
 
 	// TODO: process input
 	switch (operation) {
@@ -509,6 +511,14 @@ export function buildGraphQLVariables(
 			}
 			break;
 		case 'LIST':
+			if (arg?.filter) {
+				variables.filter = arg.filter;
+			}
+			if (arg?.nextToken) {
+				console.log;
+				variables.nextToken = arg.nextToken;
+			}
+			break;
 		case 'ONCREATE':
 		case 'ONUPDATE':
 		case 'ONDELETE':

--- a/packages/api-graphql/src/internals/APIClient.ts
+++ b/packages/api-graphql/src/internals/APIClient.ts
@@ -515,7 +515,6 @@ export function buildGraphQLVariables(
 				variables.filter = arg.filter;
 			}
 			if (arg?.nextToken) {
-				console.log;
 				variables.nextToken = arg.nextToken;
 			}
 			break;

--- a/packages/api-graphql/src/internals/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/generateModelsProperty.ts
@@ -233,6 +233,10 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 											);
 									}
 								}
+								subscriber.next({
+									items,
+									isSynced: true,
+								});
 							}
 
 							const pkFields = getPkFields(model);
@@ -272,19 +276,13 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 								}
 
 								// play through the queue
-								ingestMessages(messageQueue);
-								subscriber.next({
-									items,
-									isSynced: true,
-								});
+								if (messageQueue.length > 0) {
+									ingestMessages(messageQueue);
+								}
 
 								// switch the queue to write directly to the items collection
 								messageQueue.push = (...messages: typeof messageQueue) => {
 									ingestMessages(messages);
-									subscriber.next({
-										items,
-										isSynced: true,
-									});
 									return items.length;
 								};
 							})();

--- a/packages/api-graphql/src/internals/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/generateModelsProperty.ts
@@ -194,7 +194,7 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 									}
 								}
 
-								// if not found, return -1 as is traditional.
+								// use -1 to signal "not found" as is the norm for indexOf-like searches
 								return -1;
 							}
 

--- a/packages/api-graphql/src/internals/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/generateModelsProperty.ts
@@ -52,7 +52,7 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 						);
 
 						try {
-							const { data, nextToken, extensions } = (await client.graphql({
+							const { data, extensions } = (await client.graphql({
 								query,
 								variables,
 							})) as any;
@@ -68,7 +68,7 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 									if (args?.selectionSet) {
 										return {
 											data: flattenedResult,
-											nextToken,
+											nextToken: data[key].nextToken,
 											extensions,
 										};
 									} else {
@@ -81,7 +81,7 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 
 										return {
 											data: initialized,
-											nextToken,
+											nextToken: data[key].nextToken,
 											extensions,
 										};
 									}
@@ -89,7 +89,7 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 
 								return {
 									data: data[key],
-									nextToken,
+									nextToken: data[key].nextToken,
 									extensions,
 								};
 							}
@@ -154,19 +154,13 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 									const {
 										data: page,
 										errors,
-										_nextToken,
+										nextToken: _nextToken,
 									} = await models[name].list(arg, options);
 									nextToken = _nextToken;
 
 									for (const item of page) {
 										items.push(item);
 									}
-
-									console.log({
-										page,
-										errors,
-										_nextToken,
-									});
 
 									subscriber.next({
 										items,

--- a/packages/api-graphql/src/internals/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/generateModelsProperty.ts
@@ -294,8 +294,8 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 								onUpdateSub.unsubscribe();
 								onDeleteSub.unsubscribe();
 
-								// 2. no need to explicitly stop paging at this point, because the
-								// `subscriber` object has a `closed` property we can use to stop paging.
+								// 2. there is no need to explicitly stop paging. instead, we
+								// just check `subscriber.closed` above before fetching each page.
 							};
 						});
 				} else {

--- a/packages/api-graphql/src/internals/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/generateModelsProperty.ts
@@ -252,7 +252,7 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 										data: page,
 										errors,
 										nextToken: _nextToken,
-									} = await models[name].list(arg, options);
+									} = await models[name].list({ ...arg, nextToken }, options);
 									nextToken = _nextToken;
 
 									items.push(...page);

--- a/packages/api-graphql/src/utils/findIndexByFields.ts
+++ b/packages/api-graphql/src/utils/findIndexByFields.ts
@@ -1,0 +1,27 @@
+/**
+ * Iterates through a collection to find a matching item and returns the index.
+ *
+ * @param needle The item to search for
+ * @param haystack The collection to search
+ * @param keyFields The fields used to indicate a match
+ * @returns Index of `needle` in `haystack`, otherwise -1 if not found.
+ */
+export function findIndexByFields<T>(
+	needle: T,
+	haystack: T[],
+	keyFields: Array<keyof T>
+): number {
+	const searchObject = Object.fromEntries(
+		keyFields.map(fieldName => [fieldName, needle[fieldName]])
+	);
+
+	for (let i = 0; i < haystack.length; i++) {
+		if (
+			Object.keys(searchObject).every(k => searchObject[k] === haystack[i][k])
+		) {
+			return i;
+		}
+	}
+
+	return -1;
+}

--- a/packages/api-graphql/src/utils/findIndexByFields.ts
+++ b/packages/api-graphql/src/utils/findIndexByFields.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Iterates through a collection to find a matching item and returns the index.
  *

--- a/packages/api-graphql/src/utils/index.ts
+++ b/packages/api-graphql/src/utils/index.ts
@@ -3,3 +3,5 @@
 
 export { resolveConfig } from './resolveConfig';
 export { resolveLibraryOptions } from './resolveLibraryOptions';
+export { resolvePKFields } from './resolvePKFields';
+export { findIndexByFields } from './findIndexByFields';

--- a/packages/api-graphql/src/utils/resolvePKFields.ts
+++ b/packages/api-graphql/src/utils/resolvePKFields.ts
@@ -1,0 +1,20 @@
+import { ResourcesConfig } from '@aws-amplify/core';
+
+type GraphQLConfig = Exclude<ResourcesConfig['API'], undefined>['GraphQL'];
+type ModelIntrospectionSchema = Exclude<
+	Exclude<GraphQLConfig, undefined>['modelIntrospection'],
+	undefined
+>;
+type SchemaModel = ModelIntrospectionSchema['models'][string];
+
+/**
+ * Given a SchemaModel from a ModelIntrospectionSchema, returns the primary key
+ * as an array of field names.
+ *
+ * @param model The model object
+ * @returns Array of field names
+ */
+export function resolvePKFields(model: SchemaModel) {
+	const { primaryKeyFieldName, sortKeyFieldNames } = model.primaryKeyInfo;
+	return [primaryKeyFieldName, ...sortKeyFieldNames];
+}

--- a/packages/api-graphql/src/utils/resolvePKFields.ts
+++ b/packages/api-graphql/src/utils/resolvePKFields.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { ResourcesConfig } from '@aws-amplify/core';
 
 type GraphQLConfig = Exclude<ResourcesConfig['API'], undefined>['GraphQL'];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

1. Ability to `observeQuery()` on a model.
2. Fixes pagination (`nextToken` handling) in `list()` on a model.

For example, the following will call `setNotes` with the full list of notes we have access to in realtime as notes exposed in the query are added, updated, or removed via the API from any client.

```typescript
const sub = client.models.Note.observeQuery().subscribe({
    next({ items }) {
      setNotes(items);
    },
  });
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

1. new unit tests
3. sample app testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
