### PR TITLE
fix(analytics): cache event buffer without session info

### DIFF
--- a/packages/analytics/__tests__/providers/kinesis-firehose/utils/getEventBuffer.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis-firehose/utils/getEventBuffer.test.ts
@@ -5,7 +5,8 @@ import { getEventBuffer } from '../../../../src/providers/kinesis-firehose/utils
 import { EventBuffer } from '../../../../src/utils';
 import {
 	mockBufferConfig,
-	mockCredentialConfig, mockKinesisConfig,
+	mockCredentialConfig,
+	mockKinesisConfig,
 } from '../../../testUtils/mockConstants.test';
 
 jest.mock('../../../../src/utils');
@@ -42,18 +43,24 @@ describe('KinesisFirehose Provider Util: getEventBuffer', () => {
 		expect(testBuffer1).toBe(testBuffer2);
 	});
 
-	it('release other buffers & creates a new one if credential has changed', () => {
+	it('release other buffers & creates a new one if identity has changed', async () => {
 		const testBuffer1 = getEventBuffer({
 			...mockKinesisConfig,
 			...mockCredentialConfig,
 		});
+		jest.spyOn(testBuffer1, 'flushAll').mockReturnValue(Promise.resolve());
+		jest.spyOn(testBuffer1, 'release');
+
 		const testBuffer2 = getEventBuffer({
 			...mockKinesisConfig,
 			...mockCredentialConfig,
 			identityId: 'identityId2',
 		});
 
-		expect(testBuffer1.release).toHaveBeenCalledTimes(1);
+		await new Promise(process.nextTick);
+
+		expect(testBuffer1.flushAll).toBeCalledTimes(1);
+		expect(testBuffer1.release).toBeCalledTimes(1);
 		expect(testBuffer1).not.toBe(testBuffer2);
 	});
 });

--- a/packages/analytics/__tests__/providers/kinesis/utils/getEventBuffer.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis/utils/getEventBuffer.test.ts
@@ -43,18 +43,23 @@ describe('Kinesis Provider Util: getEventBuffer', () => {
 		expect(testBuffer1).toBe(testBuffer2);
 	});
 
-	it('release other buffers & creates a new one if credential has changed', () => {
+	it('release other buffers & creates a new one if identity has changed', async () => {
 		const testBuffer1 = getEventBuffer({
 			...mockKinesisConfig,
 			...mockCredentialConfig,
 		});
+		jest.spyOn(testBuffer1, 'flushAll').mockReturnValue(Promise.resolve());
+		jest.spyOn(testBuffer1, 'release');
+
 		const testBuffer2 = getEventBuffer({
 			...mockKinesisConfig,
 			...mockCredentialConfig,
 			identityId: 'identityId2',
 		});
 
-		expect(testBuffer1.release).toHaveBeenCalledTimes(1);
+		await new Promise(process.nextTick);
+		expect(testBuffer1.flushAll).toBeCalledTimes(1);
+		expect(testBuffer1.release).toBeCalledTimes(1);
 		expect(testBuffer1).not.toBe(testBuffer2);
 	});
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- cache event buffer without session info
  - the async calls on `fetchAuthSession` would cause several event buffers being created
- flush events in the old buffers before releasing them

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
