### PR TITLE
fix(api-graphql): Subscription authtype overriding

### DIFF
--- a/packages/api-graphql/src/internals/InternalGraphQLAPI.ts
+++ b/packages/api-graphql/src/internals/InternalGraphQLAPI.ts
@@ -375,7 +375,7 @@ export class InternalGraphQLAPIClass {
 				variables,
 				appSyncGraphqlEndpoint: config?.endpoint,
 				region: config?.region,
-				authenticationType: config?.defaultAuthMode,
+				authenticationType: authMode ?? config?.defaultAuthMode,
 				apiKey: config?.apiKey,
 				additionalHeaders,
 			},


### PR DESCRIPTION
#### Description of changes
Re-introduce authMode passthrough to subscription

#### Description of how you validated changes
Linking to a test and verifying first that the problem existed without this fix and then is fixed by applying this change.

Manual testing for API subscriptions authmodes have been disabled. I will re-enable and update them in a followup PR.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
