### PR TITLE
chore: Prepare for major version release

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"link-all": "yarn unlink-all && lerna exec --no-bail --parallel yarn link",
 		"unlink-all": "lerna exec --no-bail --parallel -- yarn unlink; exit 0",
 		"publish:preid": "./scripts/preid-env-vars-exist.sh && lerna publish --canary --force-publish --dist-tag=${PREID_PREFIX} --preid=${PREID_PREFIX}${PREID_HASH_SUFFIX} --yes",
-		"publish:main": "lerna publish --canary --force-publish --dist-tag=unstable --preid=unstable${PREID_HASH_SUFFIX} --yes",
+		"publish:main": "lerna publish from-package --force-publish --dist-tag=unstable --preid=unstable${PREID_HASH_SUFFIX} --yes",
 		"publish:release": "lerna publish from-package --message 'chore(release): Publish [ci skip]' --yes",
 		"publish:verdaccio": "lerna publish --canary --force-publish --no-push --dist-tag=unstable --preid=unstable --yes",
 		"ts-coverage": "lerna run ts-coverage",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"link-all": "yarn unlink-all && lerna exec --no-bail --parallel yarn link",
 		"unlink-all": "lerna exec --no-bail --parallel -- yarn unlink; exit 0",
 		"publish:preid": "./scripts/preid-env-vars-exist.sh && lerna publish --canary --force-publish --dist-tag=${PREID_PREFIX} --preid=${PREID_PREFIX}${PREID_HASH_SUFFIX} --yes",
-		"publish:main": "lerna publish major --canary --force-publish --dist-tag=unstable --preid=unstable${PREID_HASH_SUFFIX} --yes",
+		"publish:main": "lerna publish --canary --force-publish --dist-tag=unstable --preid=unstable${PREID_HASH_SUFFIX} --yes",
 		"publish:release": "lerna publish from-package --message 'chore(release): Publish [ci skip]' --yes",
 		"publish:verdaccio": "lerna publish --canary --force-publish --no-push --dist-tag=unstable --preid=unstable --yes",
 		"ts-coverage": "lerna run ts-coverage",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"link-all": "yarn unlink-all && lerna exec --no-bail --parallel yarn link",
 		"unlink-all": "lerna exec --no-bail --parallel -- yarn unlink; exit 0",
 		"publish:preid": "./scripts/preid-env-vars-exist.sh && lerna publish --canary --force-publish --dist-tag=${PREID_PREFIX} --preid=${PREID_PREFIX}${PREID_HASH_SUFFIX} --yes",
-		"publish:main": "lerna publish from-package --force-publish --dist-tag=unstable --preid=unstable${PREID_HASH_SUFFIX} --yes",
+		"publish:main": "lerna publish major --canary --force-publish --dist-tag=unstable --preid=unstable${PREID_HASH_SUFFIX} --yes",
 		"publish:release": "lerna publish from-package --message 'chore(release): Publish [ci skip]' --yes",
 		"publish:verdaccio": "lerna publish --canary --force-publish --no-push --dist-tag=unstable --preid=unstable --yes",
 		"ts-coverage": "lerna run ts-coverage",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"unlink-all": "lerna exec --no-bail --parallel -- yarn unlink; exit 0",
 		"publish:preid": "./scripts/preid-env-vars-exist.sh && lerna publish --canary --force-publish --dist-tag=${PREID_PREFIX} --preid=${PREID_PREFIX}${PREID_HASH_SUFFIX} --yes",
 		"publish:main": "lerna publish --canary --force-publish --dist-tag=unstable --preid=unstable${PREID_HASH_SUFFIX} --yes",
-		"publish:release": "lerna publish --conventional-commits --message 'chore(release): Publish [ci skip]' --yes",
+		"publish:release": "lerna publish from-package --message 'chore(release): Publish [ci skip]' --yes",
 		"publish:verdaccio": "lerna publish --canary --force-publish --no-push --dist-tag=unstable --preid=unstable --yes",
 		"ts-coverage": "lerna run ts-coverage",
 		"prepare": "./scripts/set-preid-versions.sh"

--- a/packages/adapter-nextjs/package.json
+++ b/packages/adapter-nextjs/package.json
@@ -113,5 +113,5 @@
 		"ts-coverage": "typescript-coverage-report -p ./tsconfig.build.json -t 90.31"
 	},
 	"typings": "./lib-esm/index.d.ts",
-	"version": "0.0.1"
+	"version": "1.0.0"
 }

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aws-amplify/pubsub",
-	"private": false,
+	"private": true,
 	"version": "6.0.0",
 	"description": "Pubsub category of aws-amplify",
 	"main": "./lib/index.js",

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aws-amplify/pubsub",
-	"private": true,
+	"private": false,
 	"version": "6.0.0",
 	"description": "Pubsub category of aws-amplify",
 	"main": "./lib/index.js",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change prepares the repo for the v6 major version release. It uses the `from-package` Lerna feature for the `publish:release` script to ensure that the manually set versions are used for the initial release. After v6 goes out, we will revert this back to using conventional commits. Also bumped the version of `adapter-nextjs` to v1.0.0 for the release.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Tested `publish:release` in Verdaccio.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
