### PR TITLE
fix(core): disable type to accept empty config for analytics

### DIFF
--- a/packages/core/src/providers/kinesis-firehose/types/kinesis-firehose.ts
+++ b/packages/core/src/providers/kinesis-firehose/types/kinesis-firehose.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export type KinesisFirehoseProviderConfig = {
-	KinesisFirehose?: {
+	KinesisFirehose: {
 		region: string;
 		bufferSize?: number;
 		flushSize?: number;

--- a/packages/core/src/providers/kinesis/types/kinesis.ts
+++ b/packages/core/src/providers/kinesis/types/kinesis.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export type KinesisProviderConfig = {
-	Kinesis?: {
+	Kinesis: {
 		region: string;
 		bufferSize?: number;
 		flushSize?: number;

--- a/packages/core/src/providers/personalize/types/personalize.ts
+++ b/packages/core/src/providers/personalize/types/personalize.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export type PersonalizeProviderConfig = {
-	Personalize?: {
+	Personalize: {
 		trackingId: string;
 		region: string;
 		flushSize?: number;

--- a/packages/core/src/providers/pinpoint/types/pinpoint.ts
+++ b/packages/core/src/providers/pinpoint/types/pinpoint.ts
@@ -13,7 +13,7 @@ export type SupportedCategory =
 type SupportedChannelType = 'APNS' | 'APNS_SANDBOX' | 'GCM' | 'IN_APP';
 
 export type PinpointProviderConfig = {
-	Pinpoint?: {
+	Pinpoint: {
 		appId: string;
 		region: string;
 	};

--- a/packages/core/src/singleton/Analytics/types.ts
+++ b/packages/core/src/singleton/Analytics/types.ts
@@ -6,7 +6,12 @@ import { KinesisProviderConfig } from '../../providers/kinesis/types';
 import { KinesisFirehoseProviderConfig } from '../../providers/kinesis-firehose/types';
 import { PersonalizeProviderConfig } from '../../providers/personalize/types';
 
-export type AnalyticsConfig = PinpointProviderConfig &
-	KinesisProviderConfig &
-	KinesisFirehoseProviderConfig &
-	PersonalizeProviderConfig;
+type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> &
+	U[keyof U];
+
+export type AnalyticsConfig = AtLeastOne<
+	PinpointProviderConfig &
+		KinesisProviderConfig &
+		KinesisFirehoseProviderConfig &
+		PersonalizeProviderConfig
+>;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- disable `AnalyticsConfig` type to accept empty config `{}`

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

- tested at local

<img width="582" alt="image" src="https://github.com/aws-amplify/amplify-js/assets/459711/4de8c582-a95c-44ea-86cd-7de373bd1bf3">


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
