### PR TITLE
fix(adapter-nextjs): ensure to use meaningful exception on config resolution

### DIFF
--- a/packages/adapter-nextjs/__tests__/utils/getAmplifyConfig.test.ts
+++ b/packages/adapter-nextjs/__tests__/utils/getAmplifyConfig.test.ts
@@ -79,6 +79,7 @@ describe('getAmplifyConfig', () => {
 	});
 
 	it('should throw error when amplifyConfig is not found from env vars', () => {
+		mockGetConfig.mockReturnValueOnce(undefined);
 		expect(() => getAmplifyConfig()).toThrow();
 	});
 });

--- a/packages/adapter-nextjs/src/utils/getAmplifyConfig.ts
+++ b/packages/adapter-nextjs/src/utils/getAmplifyConfig.ts
@@ -14,7 +14,7 @@ export const getAmplifyConfig = (): ResourcesConfig => {
 	// via process.env.<key> at some occasion. Using the following as a fallback
 	// See: https://github.com/vercel/next.js/issues/39299
 	if (!configStr) {
-		const { serverRuntimeConfig } = getConfig();
+		const { serverRuntimeConfig } = getConfig() ?? {};
 		configStr = serverRuntimeConfig?.amplifyConfig;
 	}
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Added fallback for when `getConfig()` of Next. JS returns an `undefined` value to ensure the `getAmplifyConfig` util function always throws the `AmplifyServerContextError` instead of the JS runtime error, "reading undefined"

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
