### PR TITLE
fix(notifications): Duplicate types from optional packages

### DIFF
--- a/packages/notifications/src/pushNotifications/types/index.ts
+++ b/packages/notifications/src/pushNotifications/types/index.ts
@@ -3,6 +3,7 @@
 
 export * from './errors';
 export * from './inputs';
+export * from './module';
 export * from './options';
 export * from './outputs';
 export * from './pushNotifications';

--- a/packages/notifications/src/pushNotifications/types/inputs.ts
+++ b/packages/notifications/src/pushNotifications/types/inputs.ts
@@ -3,10 +3,10 @@
 
 import { UserProfile } from '@aws-amplify/core';
 import { PushNotificationServiceOptions } from './options';
+import { PushNotificationPermissions } from './module';
 import {
 	OnPushNotificationMessageHandler,
 	OnTokenReceivedHandler,
-	PushNotificationPermissions,
 } from './pushNotifications';
 
 export type PushNotificationIdentifyUserInput<

--- a/packages/notifications/src/pushNotifications/types/module.ts
+++ b/packages/notifications/src/pushNotifications/types/module.ts
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Types here are duplicated from `rtn-push-notifications` as it is not possible to share a source of truth
+ * with a package that may conditionally not exist for developers not using push notifications. Modifications
+ * made to these types should be reflected in the native module package and vice-versa!
+ */
+interface ApnsPlatformOptions {
+	subtitle?: string;
+}
+
+interface FcmPlatformOptions {
+	channelId: string;
+	messageId: string;
+	senderId: string;
+	sendTime: Date;
+}
+
+export interface PushNotificationMessage {
+	title?: string;
+	body?: string;
+	imageUrl?: string;
+	deeplinkUrl?: string;
+	goToUrl?: string;
+	fcmOptions?: FcmPlatformOptions;
+	apnsOptions?: ApnsPlatformOptions;
+	data?: Record<string, unknown>;
+}
+
+export type PushNotificationPermissionStatus =
+	| 'denied'
+	| 'granted'
+	| 'shouldRequest'
+	| 'shouldExplainThenRequest';
+
+export interface PushNotificationPermissions
+	extends Partial<Record<string, boolean>> {
+	alert?: boolean;
+	badge?: boolean;
+	sound?: boolean;
+}

--- a/packages/notifications/src/pushNotifications/types/pushNotifications.ts
+++ b/packages/notifications/src/pushNotifications/types/pushNotifications.ts
@@ -1,12 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { PushNotificationMessage } from '@aws-amplify/react-native';
-export type {
-	PushNotificationMessage,
-	PushNotificationPermissionStatus,
-	PushNotificationPermissions,
-} from '@aws-amplify/react-native';
+import { PushNotificationMessage } from './module';
 
 export type OnTokenReceivedHandler = (token: string) => void;
 

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,11 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export type {
-	PushNotificationMessage,
-	PushNotificationPermissions,
-	PushNotificationPermissionStatus,
-} from '@aws-amplify/rtn-push-notification';
 export { computeModPow, computeS, getOperatingSystem } from './apis';
 export {
 	loadAmplifyPushNotification,

--- a/packages/rtn-push-notification/src/types/module.ts
+++ b/packages/rtn-push-notification/src/types/module.ts
@@ -1,6 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * Types here are duplicated to the push notificaiton category within Amplify as it is not possible to share a
+ * source of truth with a package that may conditionally not exist for developers not using push notifications.
+ * Modifications made to these types should be reflected in the Amplify library and vice-versa!
+ */
+
 export interface PushNotificationPermissions
 	extends Partial<Record<string, boolean>> {
 	alert?: boolean;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR duplicates the Push Notification types from the native module as it is unfortunately not feasible to rely on an optional package as a source of truth since typescript will attempt to fully analyze all types whether used or not when `skipLibCheck` is disabled.

#### Description of how you validated changes
* Published to Verdaccio and verified that app previously failing `tsc` is now passing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
