### PR TITLE
fix: Check for OAuth URLs before splitting

### DIFF
--- a/packages/core/__tests__/parseAWSExports.test.ts
+++ b/packages/core/__tests__/parseAWSExports.test.ts
@@ -236,4 +236,42 @@ describe('Parser', () => {
 			},
 		});
 	});
+
+	it('should handle missing `redirectSignIn` or `redirectSignOut` configuration', () => {
+		expect(
+			parseAWSExports({
+				aws_user_pools_id: userPoolId,
+				oauth: {
+					domain: oAuthDomain,
+					scope: oAuthScopes,
+					responseType: oAuthResponseType,
+				},
+			})
+		).toStrictEqual({
+			Auth: {
+				Cognito: {
+					allowGuestAccess: true,
+					identityPoolId: undefined,
+					loginWith: {
+						email: false,
+						oauth: {
+							domain: oAuthDomain,
+							redirectSignIn: [],
+							redirectSignOut: [],
+							responseType: oAuthResponseType,
+							scopes: oAuthScopes,
+						},
+						phone: false,
+						username: true,
+					},
+					mfa: undefined,
+					passwordFormat: undefined,
+					signUpVerificationMethod: undefined,
+					userAttributes: [],
+					userPoolClientId: undefined,
+					userPoolId: userPoolId,
+				},
+			},
+		});
+	});
 });

--- a/packages/core/src/parseAWSExports.ts
+++ b/packages/core/src/parseAWSExports.ts
@@ -276,7 +276,7 @@ export const parseAWSExports = (
 };
 
 const getRedirectUrl = (redirectStr: string): string[] =>
-	redirectStr.split(',');
+	redirectStr?.split(',') ?? [];
 
 const getOAuthConfig = ({
 	domain,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Checks for OAuth URLs before splitting, defaulting to empty arrays if they're not present in the CLI generated config.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
