### PR TITLE
feat(predictions): specify identifyEntity metadata type

### DIFF
--- a/packages/predictions/src/types/Predictions.ts
+++ b/packages/predictions/src/types/Predictions.ts
@@ -295,7 +295,12 @@ export type IdentifyEntity = {
 	ageRange?: EntityAgeRange;
 	landmarks?: (EntityLandmark | undefined)[];
 	attributes?: FaceAttributes;
-	metadata?: object;
+	metadata?: {
+		id?: string;
+		name?: string;
+		urls?: string[];
+		externalImageId?: string;
+	};
 };
 
 export interface IdentifyEntitiesOutput {

--- a/packages/predictions/src/types/Predictions.ts
+++ b/packages/predictions/src/types/Predictions.ts
@@ -284,10 +284,25 @@ export type EntityAgeRange = {
 	low?: Number;
 	high?: Number;
 };
+
 export type EntityLandmark = {
 	type?: string;
 	x?: number;
 	y?: number;
+};
+
+export type EntityMetadata = {
+	id?: string;
+	name?: string;
+	pose?: {
+		roll?: number;
+		yaw?: number;
+		pitch?: number;
+	};
+	urls?: string[];
+	externalImageId?: string;
+	similarity?: number;
+	confidence?: number;
 };
 
 export type IdentifyEntity = {
@@ -295,12 +310,7 @@ export type IdentifyEntity = {
 	ageRange?: EntityAgeRange;
 	landmarks?: (EntityLandmark | undefined)[];
 	attributes?: FaceAttributes;
-	metadata?: {
-		id?: string;
-		name?: string;
-		urls?: string[];
-		externalImageId?: string;
-	};
+	metadata?: EntityMetadata;
 };
 
 export interface IdentifyEntitiesOutput {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
I noticed a gap in our typings: a return type had a generic object type that was difficult to work with. I added definition to what object we are expecting from IdentifyEntity.metadata



#### Description of how you validated changes
Tested in sample app with celebrity and collection. Unit tests pass.



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
