### PR TITLE
fix: Resolving in-flight OAuth promises when sign-in flow cancelled

### DIFF
--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -165,6 +165,7 @@ async function handleCodeFlow({
 
 	if (!code) {
 		await store.clearOAuthData();
+		invokeAndClearPromise();
 		return;
 	}
 
@@ -263,6 +264,7 @@ async function handleImplicitFlow({
 		});
 	if (!access_token) {
 		await store.clearOAuthData();
+		invokeAndClearPromise();
 		return;
 	}
 

--- a/packages/core/src/singleton/Auth/index.ts
+++ b/packages/core/src/singleton/Auth/index.ts
@@ -24,11 +24,7 @@ export class AuthClass {
 	private authConfig?: AuthConfig;
 	private authOptions?: LibraryAuthOptions;
 
-	constructor() {
-		this.fetchAuthSession = this.fetchAuthSession.bind(this);
-		this.clearCredentials = this.clearCredentials.bind(this);
-		this.getTokens = this.getTokens.bind(this);
-	}
+	constructor() {}
 
 	/**
 	 * Configure Auth category

--- a/packages/core/src/singleton/Auth/index.ts
+++ b/packages/core/src/singleton/Auth/index.ts
@@ -24,7 +24,11 @@ export class AuthClass {
 	private authConfig?: AuthConfig;
 	private authOptions?: LibraryAuthOptions;
 
-	constructor() {}
+	constructor() {
+		this.fetchAuthSession = this.fetchAuthSession.bind(this);
+		this.clearCredentials = this.clearCredentials.bind(this);
+		this.getTokens = this.getTokens.bind(this);
+	}
 
 	/**
 	 * Configure Auth category


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change fixes a bug where promises weren't being resolved when in-flight OAuth flows are cancelled, leading to `getCurrentUser` to hang indefinitely.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->


#### Description of how you validated changes
Tested in reproduction sample apps (Angular & Next.js).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
