### PR TITLE
chore(api): hide generateClient from api/server subpath

### DIFF
--- a/packages/adapter-nextjs/package.json
+++ b/packages/adapter-nextjs/package.json
@@ -49,7 +49,8 @@
 		"lib-esm",
 		"src",
 		"with-amplify",
-		"internals"
+		"internals",
+		"api"
 	],
 	"homepage": "https://aws-amplify.github.io/",
 	"jest": {

--- a/packages/adapter-nextjs/src/api/generateServerClient.ts
+++ b/packages/adapter-nextjs/src/api/generateServerClient.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { generateClient as internalGenerateClient } from '@aws-amplify/api/server';
+import { generateServerClient } from '@aws-amplify/api/internals';
 import {
 	getAmplifyServerContext,
 	AmplifyServerContextError,
@@ -56,7 +56,7 @@ export function generateServerClientUsingCookies<
 				fn(getAmplifyServerContext(contextSpec).amplify),
 		});
 
-	return internalGenerateClient<T, V6Client<T>>({
+	return generateServerClient<T, V6Client<T>>({
 		amplify: getAmplify,
 		config: resourcesConfig,
 	});
@@ -84,7 +84,7 @@ export function generateServerClientUsingReqRes<
 	const amplifyConfig = getAmplifyConfig(config);
 	// passing `null` instance because each (future model) method must retrieve a valid instance
 	// from server context
-	const client = internalGenerateClient<T, V6ClientSSR<T>>({
+	const client = generateServerClient<T, V6ClientSSR<T>>({
 		amplify: null,
 		config: amplifyConfig,
 	});

--- a/packages/api/src/internals/generateServerClient.ts
+++ b/packages/api/src/internals/generateServerClient.ts
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	ServerClientGenerationParams,
+	V6Client,
+	V6ClientSSR,
+	__amplify,
+} from '@aws-amplify/api-graphql';
+import {
+	graphql,
+	cancel,
+	isCancelError,
+} from '@aws-amplify/api-graphql/internals';
+
+/**
+ * @private
+ *
+ * Creates a client that can be used to make GraphQL requests, using a provided `AmplifyClassV6`
+ * compatible context object for config and auth fetching.
+ *
+ * @param params
+ * @returns
+ */
+export function generateServerClient<
+	T extends Record<any, any> = never,
+	ClientType extends V6ClientSSR<T> | V6Client<T> = V6ClientSSR<T>
+>(params: ServerClientGenerationParams): ClientType {
+	const client = {
+		[__amplify]: params.amplify,
+		graphql,
+		cancel,
+		isCancelError,
+		models: {},
+	} as any;
+
+	return client as ClientType;
+}

--- a/packages/api/src/internals/index.ts
+++ b/packages/api/src/internals/index.ts
@@ -1,3 +1,4 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 export { InternalAPI, InternalAPIClass } from './InternalAPI';
+export { generateServerClient } from './generateServerClient';

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -1,53 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export { GraphQLQuery, GraphQLSubscription } from './types';
-import {
-	graphql,
-	cancel,
-	isCancelError,
-} from '@aws-amplify/api-graphql/internals';
-import {
-	AmplifyServer,
-	getAmplifyServerContext,
-} from '@aws-amplify/core/internals/adapter-core';
-
-import {
-	__amplify,
-	V6Client,
-	V6ClientSSR,
-	ServerClientGenerationParams,
-} from '@aws-amplify/api-graphql';
-
-export type {
-	GraphQLResult,
-	GraphQLReturnType,
-} from '@aws-amplify/api-graphql';
-
-/**
- * @private
- *
- * Creates a client that can be used to make GraphQL requests, using a provided `AmplifyClassV6`
- * compatible context object for config and auth fetching.
- *
- * @param params
- * @returns
- */
-export function generateClient<
-	T extends Record<any, any> = never,
-	ClientType extends V6ClientSSR<T> | V6Client<T> = V6ClientSSR<T>
->(params: ServerClientGenerationParams): ClientType {
-	const client = {
-		[__amplify]: params.amplify,
-		graphql,
-		cancel,
-		isCancelError,
-		models: {},
-	} as any;
-
-	return client as ClientType;
-}
-
 export {
 	get,
 	put,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Fixed missing `api` in `adapter-nextjs` packages.json `files`
* Hide `generateClient` from `aws-amplify/api/server`


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
