### PR TITLE
fix(adapter-nextjs): remove the constraint of calling createServerRunner only once

### DIFF
--- a/packages/adapter-nextjs/__tests__/createServerRunner.test.ts
+++ b/packages/adapter-nextjs/__tests__/createServerRunner.test.ts
@@ -73,11 +73,6 @@ describe('createServerRunner', () => {
 		});
 	});
 
-	it('throws when get called more than once', () => {
-		createServerRunner({ config: mockAmplifyConfig });
-		expect(() => createServerRunner({ config: mockAmplifyConfig })).toThrow();
-	});
-
 	describe('runWithAmplifyServerContext', () => {
 		describe('when amplifyConfig.Auth is not defined', () => {
 			it('should call runWithAmplifyServerContextCore without Auth library options', () => {

--- a/packages/adapter-nextjs/src/createServerRunner.ts
+++ b/packages/adapter-nextjs/src/createServerRunner.ts
@@ -2,11 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ResourcesConfig } from 'aws-amplify';
-import { AmplifyServerContextError } from '@aws-amplify/core/internals/adapter-core';
 import { createRunWithAmplifyServerContext, getAmplifyConfig } from './utils';
 import { NextServer } from './types';
-
-let amplifyConfig: ResourcesConfig | undefined;
 
 /**
  * Creates the `runWithAmplifyServerContext` function to run Amplify server side APIs in an isolated request context.
@@ -30,13 +27,7 @@ let amplifyConfig: ResourcesConfig | undefined;
 export const createServerRunner: NextServer.CreateServerRunner = ({
 	config,
 }) => {
-	if (amplifyConfig) {
-		throw new AmplifyServerContextError({
-			message: '`createServerRunner` needs to be called only once.',
-		});
-	}
-
-	amplifyConfig = getAmplifyConfig(config);
+	const amplifyConfig = getAmplifyConfig(config);
 
 	return {
 		runWithAmplifyServerContext: createRunWithAmplifyServerContext({


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Removed the blocking exception as no harm to call this function more than once

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
