### PR TITLE
fix(api-rest): infinite retry when clock skew go back and forth

### DIFF
--- a/packages/api-rest/__tests__/RestAPI-test.ts
+++ b/packages/api-rest/__tests__/RestAPI-test.ts
@@ -28,9 +28,6 @@ const config = {
 	},
 };
 
-const expectSimilarNumbers = (value1: number, value2: number, margin = 0) =>
-	expect(Math.abs(value1 - value2) <= margin);
-
 afterEach(() => {
 	jest.restoreAllMocks();
 	mockAxios.mockClear();
@@ -478,7 +475,7 @@ describe('Rest API test', () => {
 			expect(spyon4).toBeCalled();
 		});
 
-		test('clock skew', async () => {
+		describe('clock skew', () => {
 			const api = new API({});
 			api.configure({
 				endpoints: [
@@ -489,104 +486,116 @@ describe('Rest API test', () => {
 				],
 			});
 
-			const normalError = new Error('Response Error');
+			const signSpy = jest.spyOn(RestClient.prototype as any, '_sign');
+			signSpy.mockImplementation(() => ({
+				headers: {
+					'x-amz-date': DateUtils.getHeaderStringFromDate(
+						DateUtils.getDateWithClockOffset()
+					),
+					Authorization: 'signed',
+				},
+			}));
 
+			const now = new Date();
+			// Server is always "correct"
+			let serverDate = new Date(now.getTime() + 60 * 60 * 1000);
 			// Local machine is behind by 1 hour
 			// It's important to change the _server_ time in this test,
 			// because the local time "looks correct" to the user & DateUtils
 			// compares the server response to local time.
-			const now = new Date();
-			// Server is always "correct"
-			const serverDate = new Date(now.setHours(now.getHours() + 1));
-			const requestDate = now;
+			const clientDate = now;
 
-			const clockSkewError: any = new Error('BadRequestException');
-			const init = {
-				headers: {
-					'x-amz-date': DateUtils.getHeaderStringFromDate(requestDate),
-				},
+			const clockSkewErrorMockImplementation = async (req: any) => {
+				const requestDate = DateUtils.getDateFromHeaderString(
+					req.headers['x-amz-date']
+				);
+
+				const FIVE_MINUTES_IN_MS = 1000 * 60 * 5;
+				if (
+					Math.abs(serverDate.getTime() - requestDate.getTime()) >
+					FIVE_MINUTES_IN_MS
+				) {
+					const clockSkewError: any = new Error('BadRequestException');
+
+					clockSkewError.response = {
+						headers: {
+							'x-amzn-errortype': 'BadRequestException',
+							date: serverDate.toString(),
+						},
+					};
+					throw clockSkewError;
+				} else {
+					return {
+						data: [{ name: 'Bob' }],
+					};
+				}
 			};
 
-			clockSkewError.response = {
-				headers: {
-					'x-amzn-errortype': 'BadRequestException',
-					date: serverDate.toString(),
-				},
-			};
+			beforeEach(() => {
+				jest.clearAllMocks();
+				jest
+					.spyOn(RestClient.prototype as any, 'endpoint')
+					.mockImplementation(() => 'endpoint');
 
-			// Clock should not be skewed yet
-			expect(DateUtils.getClockOffset()).toBe(0);
-			// Ensure the errors are the correct type for gating
-			expect(DateUtils.isClockSkewError(normalError)).toBe(false);
-			expect(DateUtils.isClockSkewError(clockSkewError)).toBe(true);
-			expect(DateUtils.isClockSkewed(serverDate)).toBe(true);
-
-			jest
-				.spyOn(RestClient.prototype as any, 'endpoint')
-				.mockImplementation(() => 'endpoint');
-
-			jest.spyOn(Credentials, 'get').mockResolvedValue('creds');
-			const signSpy = jest.spyOn(RestClient.prototype as any, '_sign');
-			signSpy.mockReturnValue({
-				...init,
-				headers: { ...init.headers, Authorization: 'signed' },
-			});
-			mockAxios.mockImplementationOnce(() => {
-				return new Promise((_, rej) => {
-					rej(normalError);
-				});
+				jest.spyOn(Credentials, 'get').mockResolvedValue('creds');
+				DateUtils.setClockOffset(0);
 			});
 
-			await expect(api.post('url', 'path', init)).rejects.toThrow(normalError);
+			test('should not apply offset for normal errors', async () => {
+				const normalError = new Error('Response Error');
+				// Clock should not be skewed yet
+				expect(DateUtils.getClockOffset()).toBe(0);
 
-			// Clock should not be skewed from normal errors
-			expect(DateUtils.getClockOffset()).toBe(0);
-
-			// mock clock skew error response and successful response after retry
-			mockAxios
-				.mockImplementationOnce(() => {
+				const signSpy = jest.spyOn(RestClient.prototype as any, '_sign');
+				signSpy.mockReturnValue({
+					// ...init,
+					headers: {
+						'x-amz-date': DateUtils.getHeaderStringFromDate(clientDate),
+						Authorization: 'signed',
+					},
+				});
+				mockAxios.mockImplementationOnce(() => {
 					return new Promise((_, rej) => {
-						rej(clockSkewError);
+						rej(normalError);
 					});
-				})
-				.mockResolvedValue({
-					data: [{ name: 'Bob' }],
 				});
 
-			await expect(api.post('url', 'path', init)).resolves.toEqual([
-				{ name: 'Bob' },
-			]);
+				await expect(api.post('url', 'path', {})).rejects.toThrow(normalError);
+				expect(mockAxios).toBeCalledTimes(1);
+			});
 
-			// With a clock skew error, the clock will get offset with the difference
-			expect(DateUtils.getClockOffset()).toBe(
-				serverDate.getTime() - requestDate.getTime()
-			);
+			test('should apply clock skew offset if client clock is skewed', async () => {
+				mockAxios.mockImplementation(clockSkewErrorMockImplementation);
 
-			// When client clock back and forth. Fixes: https://github.com/aws-amplify/amplify-js/issues/12450#issuecomment-1787945008
-			// Mock a consequent clock skew error when client and server clock are in sync but offset is still applied
-			mockAxios.mockClear();
-			const clockSkewError2: any = new Error('BadRequestException');
-			clockSkewError2.response = {
-				headers: {
-					'x-amzn-errortype': 'BadRequestException',
-					date: requestDate.toString(),
-				},
-			};
-			mockAxios
-				.mockImplementationOnce(() => {
-					return new Promise((_, rej) => {
-						rej(clockSkewError2);
-					});
-				})
-				.mockResolvedValueOnce({
-					data: [{ name: 'Bob' }],
-				});
+				await expect(api.post('url', 'path', {})).resolves.toEqual([
+					{ name: 'Bob' },
+				]);
 
-			await expect(api.post('url', 'path', {})).resolves.toEqual([
-				{ name: 'Bob' },
-			]);
-			// Validate incorrectly applied offset is reset.
-			expect(DateUtils.getClockOffset()).toBe(0);
+				// With a clock skew error, the clock will get offset with the difference
+				expect(DateUtils.getClockOffset()).toBe(
+					serverDate.getTime() - clientDate.getTime()
+				);
+				expect(mockAxios).toBeCalledTimes(2);
+			});
+
+			test('should update clock skew offset when client clock is back and forth', async () => {
+				mockAxios.mockImplementation(clockSkewErrorMockImplementation);
+				await expect(api.post('url', 'path', {})).resolves.toEqual([
+					{ name: 'Bob' },
+				]);
+
+				// clock skew of 1 hour should be applied
+				expect(DateUtils.getClockOffset()).toBe(
+					serverDate.getTime() - clientDate.getTime()
+				);
+
+				// Mock a consequent clock skew error when client and server clock are in sync but offset is still applied,
+				// We cannot change client clock, so changing server clock is equivalent to change client clock.
+				serverDate = now;
+				await expect(api.post('url', 'path', {})).resolves.toEqual([
+					{ name: 'Bob' },
+				]);
+			});
 		});
 
 		test('cancel request', async () => {

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -56,7 +56,7 @@
       "name": "API (rest client)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, RestAPI }",
-      "limit": "31 kB"
+      "limit": "31.3 kB"
     }
   ],
   "jest": {

--- a/packages/api-rest/src/RestClient.ts
+++ b/packages/api-rest/src/RestClient.ts
@@ -198,9 +198,9 @@ export class RestClient {
 
 				// Compare local clock to the server clock
 				if (DateUtils.isClockSkewed(responseDate)) {
-					DateUtils.setClockOffset(
-						responseDate.getTime() - requestDate.getTime()
-					);
+					const rawClientDate =
+						requestDate.getTime() - DateUtils.getClockOffset();
+					DateUtils.setClockOffset(responseDate.getTime() - rawClientDate);
 
 					return this.ajax(urlOrApiInfo, method, init);
 				}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change makes sure when updating the clock skew offset, always compare to raw client clock instead the one adjusted by clock skew offset.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
For more details on why this happens: https://github.com/aws-amplify/amplify-js/issues/12450#issuecomment-1787945008


#### Description of how you validated changes
Unit test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
