### PR TITLE
feat(api-graphql): limit, nextToken on list and lazy loaded lists

### DIFF
--- a/packages/api-graphql/src/internals/APIClient.ts
+++ b/packages/api-graphql/src/internals/APIClient.ts
@@ -10,6 +10,8 @@ type ListArgs = { selectionSet?: string[]; filter?: {} };
 type LazyLoadOptions = {
 	authMode?: GraphQLAuthMode;
 	authToken?: string | undefined;
+	limit?: number | undefined;
+	nextToken?: string | undefined | null;
 };
 
 const connectionType = {
@@ -160,6 +162,8 @@ export function initializeModel(
 								if (record[parentPk]) {
 									return client.models[relatedModelName].list(contextSpec, {
 										filter: { and: hasManyFilter },
+										limit: options?.limit,
+										nextToken: options?.nextToken,
 										authMode: options?.authMode || authMode,
 										authToken: options?.authToken || authToken,
 									});
@@ -173,6 +177,8 @@ export function initializeModel(
 								if (record[parentPk]) {
 									return client.models[relatedModelName].list({
 										filter: { and: hasManyFilter },
+										limit: options?.limit,
+										nextToken: options?.nextToken,
 										authMode: options?.authMode || authMode,
 										authToken: options?.authToken || authToken,
 									});
@@ -200,6 +206,8 @@ export function initializeModel(
 							if (record[parentPk]) {
 								return client.models[relatedModelName].list(contextSpec, {
 									filter: { and: hasManyFilter },
+									limit: options?.limit,
+									nextToken: options?.nextToken,
 									authMode: options?.authMode || authMode,
 									authToken: options?.authToken || authToken,
 								});
@@ -213,6 +221,8 @@ export function initializeModel(
 							if (record[parentPk]) {
 								return client.models[relatedModelName].list({
 									filter: { and: hasManyFilter },
+									limit: options?.limit,
+									nextToken: options?.nextToken,
 									authMode: options?.authMode || authMode,
 									authToken: options?.authToken || authToken,
 								});
@@ -599,6 +609,9 @@ export function buildGraphQLVariables(
 			}
 			if (arg?.nextToken) {
 				variables.nextToken = arg.nextToken;
+			}
+			if (arg?.limit) {
+				variables.limit = arg.limit;
 			}
 			break;
 		case 'ONCREATE':


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

E.g.

```typescript
({ data: listed, nextToken } = await client.models.Note.list({
  nextToken,
  limit: 5,
}));
```

Or this:

```typescript
({ data: listed, nextToken } = await todo.notes({
  nextToken,
  limit: 5,
}));
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

1. Added tests.
2. Manually in app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
