### PR TITLE
test(core): unit validating clockskew offset is updated when client clock back and forth

### DIFF
--- a/packages/core/__tests__/clients/middleware/signing/utils/getUpdatedSystemClockOffset.test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/utils/getUpdatedSystemClockOffset.test.ts
@@ -15,7 +15,7 @@ describe('getUpdatedSystemClockOffset', () => {
 		Date.now = jest.fn(() => signingDate.valueOf());
 	});
 
-	test('returns the current offset if not skewed', () => {
+	it('should return the current offset if not skewed', () => {
 		mockIsClockSkewed.mockReturnValue(false);
 		const offset = 1500;
 		expect(getUpdatedSystemClockOffset(signingDate.getTime(), offset)).toBe(
@@ -23,7 +23,7 @@ describe('getUpdatedSystemClockOffset', () => {
 		);
 	});
 
-	test('returns the updated offset if system clock is behind', () => {
+	it('should return the updated offset if system clock is behind', () => {
 		mockIsClockSkewed.mockReturnValue(true);
 		const clockTime = new Date(signingDate);
 		clockTime.setMinutes(signingDate.getMinutes() + 15);
@@ -32,12 +32,25 @@ describe('getUpdatedSystemClockOffset', () => {
 		);
 	});
 
-	test('returns the updated offset if system clock is ahead', () => {
+	it('should return the updated offset if system clock is ahead', () => {
 		mockIsClockSkewed.mockReturnValue(true);
 		const clockTime = new Date(signingDate);
 		clockTime.setMinutes(signingDate.getMinutes() - 15);
 		expect(getUpdatedSystemClockOffset(clockTime.getTime(), 0)).toBe(
 			-15 * 60 * 1000
 		);
+	});
+
+	// Addresses: https://github.com/aws-amplify/amplify-js/issues/12450#issuecomment-1787945008
+	it('should return the updated offset if system clock is back and forth', () => {
+		// initialize client clock skew to be 15 mins behind
+		mockIsClockSkewed.mockReturnValue(true);
+		const clockTime = new Date(signingDate);
+		clockTime.setMinutes(signingDate.getMinutes() - 15);
+		let offset = getUpdatedSystemClockOffset(clockTime.getTime(), 0);
+		// client clock skew is now 15 mins ahead, making is sync with server clock
+		clockTime.setMinutes(signingDate.getMinutes() + 15);
+		offset = getUpdatedSystemClockOffset(clockTime.getTime(), offset);
+		expect(offset).toBe(0);
 	});
 });


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add extra unit test to make validate the error mentioned in https://github.com/aws-amplify/amplify-js/issues/12450#issuecomment-1787945008 is handled in v6

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Tandem with https://github.com/aws-amplify/amplify-js/pull/12488



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
