### PR TITLE
fix(auth): rename type CognitoAuthUser to AuthUser

### DIFF
--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -29,6 +29,7 @@ export {
 	forgetDevice,
 	fetchDevices,
 	autoSignIn,
+	AuthUser,
 } from './providers/cognito';
 
 export {

--- a/packages/auth/src/providers/cognito/apis/internal/getCurrentUser.ts
+++ b/packages/auth/src/providers/cognito/apis/internal/getCurrentUser.ts
@@ -6,7 +6,7 @@ import { assertTokenProviderConfig } from '@aws-amplify/core/internals/utils';
 import { assertAuthTokens } from '../../utils/types';
 import {
 	CognitoAuthSignInDetails,
-	CognitoAuthUser,
+	AuthUser,
 	GetCurrentUserOutput,
 } from '../../types';
 
@@ -21,7 +21,7 @@ export const getCurrentUser = async (
 	assertAuthTokens(tokens);
 	const { 'cognito:username': username, sub } = tokens.idToken?.payload ?? {};
 
-	const authUser: CognitoAuthUser = {
+	const authUser: AuthUser = {
 		username: username as string,
 		userId: sub as string,
 	};

--- a/packages/auth/src/providers/cognito/index.ts
+++ b/packages/auth/src/providers/cognito/index.ts
@@ -64,7 +64,7 @@ export {
 	SendUserAttributeVerificationCodeOutput,
 	FetchDevicesOutput,
 } from './types/outputs';
-export { CognitoAuthUser } from './types/models';
+export { AuthUser } from './types/models';
 export {
 	cognitoCredentialsProvider,
 	CognitoAWSCredentialsAndIdentityIdProvider,

--- a/packages/auth/src/providers/cognito/types/index.ts
+++ b/packages/auth/src/providers/cognito/types/index.ts
@@ -9,7 +9,7 @@ export {
 	VerifiableUserAttributeKey,
 	MFAPreference,
 	AWSAuthDevice,
-	CognitoAuthUser,
+	AuthUser,
 	CognitoAuthSignInDetails,
 } from './models';
 

--- a/packages/auth/src/providers/cognito/types/models.ts
+++ b/packages/auth/src/providers/cognito/types/models.ts
@@ -5,7 +5,7 @@ import {
 	AuthStandardAttributeKey,
 	AuthVerifiableAttributeKey,
 } from '@aws-amplify/core/internals/utils';
-import { AuthUserAttribute, AuthDevice, AuthUser } from '../../../types';
+import { AuthUserAttribute, AuthDevice, AWSAuthUser } from '../../../types';
 import { AuthProvider } from '../../../types/inputs';
 import { SignUpOutput } from './outputs';
 
@@ -92,6 +92,6 @@ export type CognitoAuthSignInDetails = {
 /**
  * Holds the user information along with the sign in details.
  */
-export interface CognitoAuthUser extends AuthUser {
+export interface AuthUser extends AWSAuthUser {
 	signInDetails?: CognitoAuthSignInDetails;
 }

--- a/packages/auth/src/providers/cognito/types/outputs.ts
+++ b/packages/auth/src/providers/cognito/types/outputs.ts
@@ -5,7 +5,6 @@ import { AuthVerifiableAttributeKey } from '@aws-amplify/core/internals/utils';
 import {
 	AuthMFAType,
 	AuthUserAttributes,
-	AuthUser,
 	AuthCodeDeliveryDetails,
 	AuthTOTPSetupDetails,
 	AuthSignInOutput,
@@ -14,7 +13,7 @@ import {
 	AuthUpdateUserAttributesOutput,
 	AuthUpdateUserAttributeOutput,
 } from '../../../types';
-import { AWSAuthDevice, CognitoAuthUser, UserAttributeKey } from '../types';
+import { AWSAuthDevice, AuthUser, UserAttributeKey } from '../types';
 
 export type FetchMFAPreferenceOutput = {
 	enabled?: AuthMFAType[];
@@ -29,7 +28,7 @@ export type FetchUserAttributesOutput = AuthUserAttributes<UserAttributeKey>;
 /**
  * Output type for Cognito getCurrentUser API.
  */
-export type GetCurrentUserOutput = CognitoAuthUser;
+export type GetCurrentUserOutput = AuthUser;
 
 /**
  * Output type for Cognito confirmSignIn API.

--- a/packages/auth/src/providers/cognito/utils/signInHelpers.ts
+++ b/packages/auth/src/providers/cognito/utils/signInHelpers.ts
@@ -26,7 +26,7 @@ import {
 import { AuthError } from '../../../errors/AuthError';
 import { InitiateAuthException } from '../types/errors';
 import {
-	AuthUser,
+	AWSAuthUser,
 	AuthUserAttributes,
 	AuthMFAType,
 	AuthTOTPSetupDetails,
@@ -1001,7 +1001,7 @@ export function isMFATypeEnabled(
 }
 
 export async function assertUserNotAuthenticated() {
-	let authUser: AuthUser | undefined;
+	let authUser: AWSAuthUser | undefined;
 	try {
 		authUser = await getCurrentUser();
 	} catch (error) {}

--- a/packages/auth/src/types/index.ts
+++ b/packages/auth/src/types/index.ts
@@ -15,7 +15,7 @@ export {
 	AuthNextUpdateAttributeStep,
 	AuthMFAType,
 	AuthAllowedMFATypes,
-	AuthUser,
+	AWSAuthUser,
 	AuthTOTPSetupDetails,
 	AuthResetPasswordStep,
 	AuthUpdateAttributeStep,

--- a/packages/auth/src/types/models.ts
+++ b/packages/auth/src/types/models.ts
@@ -259,9 +259,9 @@ export type AuthNextUpdateAttributeStep<
 };
 
 /**
- * The AuthUser object contains username and userId from the idToken.
+ * The AWSAuthUser object contains username and userId from the idToken.
  */
-export type AuthUser = {
+export type AWSAuthUser = {
 	username: string;
 	userId: string;
 };


### PR DESCRIPTION
#### Description of changes
- rename internal auth category type `AuthUser` to `AWSAuthUser`
- rename public auth provider type `CognitoAuthUser` to `AuthUser`
- expose `AuthUser` from the following path

```
import { AuthUser } from "aws-amplify/auth/cognito";
import { AuthUser } from "aws-amplify/auth";
```

#### Description of how you validated changes
validated the `AuthUser` is exposed in the above paths


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
