### PR TITLE
feat(data): add support for initialValues to observeQuery

### DIFF
--- a/packages/api-graphql/src/internals/operations/observeQuery.ts
+++ b/packages/api-graphql/src/internals/operations/observeQuery.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Observable, map } from 'rxjs';
+import { Observable } from 'rxjs';
 import { findIndexByFields, resolvePKFields } from '../../utils';
 
 export function observeQueryFactory(models, model) {
@@ -9,6 +9,13 @@ export function observeQueryFactory(models, model) {
 
 	const observeQuery = (arg?: any) =>
 		new Observable(subscriber => {
+			// if we have initial values, send them immediately
+			if (arg?.initialValues) {
+				subscriber.next({
+					items: arg.initialValues,
+					isSynced: false,
+				});
+			}
 			// what we'll be sending to our subscribers
 			const items: object[] = [];
 

--- a/packages/api-graphql/src/internals/operations/observeQuery.ts
+++ b/packages/api-graphql/src/internals/operations/observeQuery.ts
@@ -9,7 +9,7 @@ export function observeQueryFactory(models, model) {
 
 	const observeQuery = (arg?: any) =>
 		new Observable(subscriber => {
-			// if we have initial values, send them immediately
+			// If we have initial values, send them immediately
 			if (arg?.initialValues) {
 				subscriber.next({
 					items: arg.initialValues,
@@ -107,10 +107,17 @@ export function observeQueryFactory(models, model) {
 						messageQueue.length === 0 &&
 						(nextToken === null || nextToken === undefined);
 
-					subscriber.next({
-						items,
-						isSynced,
-					});
+					/**
+					 * If we don't have initial values, return paged results.
+					 * If we do have initial values, we wait until all remote 
+					 * data is received before sending the remote data.
+					 */
+					if (!arg?.initialValues || (arg?.initialValues && isSynced)) {
+						subscriber.next({
+							items,
+							isSynced,
+						});
+					}
 
 					if (Array.isArray(errors)) {
 						for (const error of errors) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
`observeQuery` will now accept an initial data set that will return immediately (i.e. before making requests for remote data). Additionally, `observeQuery` will withhold paged results, and will return the full snapshot once the "sync" is complete.

[Corresponding PR to update types](https://github.com/aws-amplify/amplify-api-next/pull/39)

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
