### PR TITLE
fix: Add clear error when API GraphQl isn't configured

### DIFF
--- a/packages/api-graphql/__tests__/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/generateClient.test.ts
@@ -61,6 +61,16 @@ const USER_AGENT_DETAILS = {
 };
 
 describe('generateClient', () => {
+	test('raises clear error when API GraphQL isnt configured', () => {
+		const getConfig = jest.fn().mockReturnValue({});
+		const amplify = {
+			getConfig,
+		} as unknown as AmplifyClassV6;
+		expect(() => generateClient({ amplify })).toThrow(
+			'The API configuration is missing. This is likely due to Amplify.configure() not being called prior to generateClient()'
+		);
+	});
+
 	test('can produce a client bound to an arbitrary amplify object for getConfig()', async () => {
 		// TS lies: We don't care what `amplify` is or does. We want want to make sure
 		// it shows up in the client in the right spot.

--- a/packages/api-graphql/src/internals/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/generateModelsProperty.ts
@@ -17,6 +17,12 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 	const models = {} as any;
 	const config = params.amplify.getConfig();
 
+	if (!config.API?.GraphQL) {
+		throw new Error(
+			'The API configuration is missing. This is likely due to Amplify.configure() not being called prior to generateClient().'
+		);
+	}
+
 	const modelIntrospection = config.API?.GraphQL?.modelIntrospection;
 	if (!modelIntrospection) {
 		return {} as any;

--- a/packages/api/__tests__/API.test.ts
+++ b/packages/api/__tests__/API.test.ts
@@ -2,6 +2,7 @@ import { ResourcesConfig } from 'aws-amplify';
 import { InternalGraphQLAPIClass } from '@aws-amplify/api-graphql/internals';
 import { generateClient } from '@aws-amplify/api';
 import { generateClient as generateClientSSR } from '@aws-amplify/api/server';
+import { AmplifyClassV6 } from '@aws-amplify/core';
 // import { runWithAmplifyServerContext } from 'aws-amplify/internals/adapter-core';
 
 const serverManagedFields = {
@@ -17,6 +18,11 @@ describe('API generateClient', () => {
 	});
 
 	test('client-side client.graphql', async () => {
+		jest.spyOn(AmplifyClassV6.prototype, 'getConfig').mockImplementation(() => {
+			return {
+				API: { GraphQL: { endpoint: 'test', defaultAuthMode: 'none' } },
+			};
+		});
 		const spy = jest
 			.spyOn(InternalGraphQLAPIClass.prototype, 'graphql')
 			.mockResolvedValue('grapqhqlResponse' as any);

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -302,7 +302,7 @@
 			"name": "[API] generateClient (AppSync)",
 			"path": "./lib-esm/api/index.js",
 			"import": "{ generateClient }",
-			"limit": "32.49 kB"
+			"limit": "35.89 kB"
 		},
 		{
 			"name": "[API] REST API handlers",


### PR DESCRIPTION
#### Description of changes

Gracefully handle the error my throwing an informative handling message:
"The API configuration is missing. This is likely due to Amplify.configure() not being called prior to generateClient()."

#### Description of how you validated changes
Validated by adding unit testing and testing in a sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
