### PR TITLE
chore(auth|aws-amplify): fix instance naming (use camel-case)

### DIFF
--- a/packages/auth/__tests__/providers/cognito/autoSignIn.test.ts
+++ b/packages/auth/__tests__/providers/cognito/autoSignIn.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-	CognitoUserPoolsTokenProvider,
+	cognitoUserPoolsTokenProvider,
 	signUp,
 } from '../../../src/providers/cognito';
 import { autoSignIn } from '../../../src/providers/cognito/apis/autoSignIn';
@@ -20,7 +20,7 @@ const authConfig = {
 		userPoolId: 'us-west-2_zzzzz',
 	},
 };
-CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+cognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
 Amplify.configure({
 	Auth: authConfig,
 });

--- a/packages/auth/__tests__/providers/cognito/confirmSignInHappyCases.test.ts
+++ b/packages/auth/__tests__/providers/cognito/confirmSignInHappyCases.test.ts
@@ -11,7 +11,7 @@ import {
 import * as signInHelpers from '../../../src/providers/cognito/utils/signInHelpers';
 import { RespondToAuthChallengeCommandOutput } from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider/types';
 import {
-	CognitoUserPoolsTokenProvider,
+	cognitoUserPoolsTokenProvider,
 	tokenOrchestrator,
 } from '../../../src/providers/cognito/tokenProvider';
 import * as clients from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider';
@@ -34,7 +34,7 @@ describe('confirmSignIn API happy path cases', () => {
 	const password = authAPITestParams.user1.password;
 
 	beforeEach(async () => {
-		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+		cognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
 
 		handleChallengeNameSpy = jest
 			.spyOn(signInHelpers, 'handleChallengeName')

--- a/packages/auth/__tests__/providers/cognito/fetchAuthSession.test.ts
+++ b/packages/auth/__tests__/providers/cognito/fetchAuthSession.test.ts
@@ -2,7 +2,7 @@ import { Amplify } from '@aws-amplify/core';
 import { fetchAuthSession } from '@aws-amplify/core';
 import {
 	CognitoAWSCredentialsAndIdentityIdProvider,
-	CognitoUserPoolsTokenProvider,
+	cognitoUserPoolsTokenProvider,
 	cognitoCredentialsProvider,
 } from '../../../src/providers/cognito';
 import { decodeJWT } from '@aws-amplify/core/internals/utils';
@@ -43,7 +43,7 @@ describe('fetchAuthSession behavior for IdentityPools only', () => {
 			{
 				Auth: {
 					credentialsProvider: cognitoCredentialsProvider,
-					tokenProvider: CognitoUserPoolsTokenProvider,
+					tokenProvider: cognitoUserPoolsTokenProvider,
 				},
 			}
 		);
@@ -78,7 +78,7 @@ describe.only('fetchAuthSession behavior for UserPools only', () => {
 	let tokenProviderSpy;
 	beforeEach(() => {
 		tokenProviderSpy = jest
-			.spyOn(CognitoUserPoolsTokenProvider, 'getTokens')
+			.spyOn(cognitoUserPoolsTokenProvider, 'getTokens')
 			.mockImplementation(async () => {
 				return {
 					accessToken: decodeJWT(
@@ -104,7 +104,7 @@ describe.only('fetchAuthSession behavior for UserPools only', () => {
 			{
 				Auth: {
 					credentialsProvider: cognitoCredentialsProvider,
-					tokenProvider: CognitoUserPoolsTokenProvider,
+					tokenProvider: cognitoUserPoolsTokenProvider,
 				},
 			}
 		);

--- a/packages/auth/__tests__/providers/cognito/signInErrorCases.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInErrorCases.test.ts
@@ -7,7 +7,7 @@ import { authAPITestParams } from './testUtils/authApiTestParams';
 import {
 	signIn,
 	getCurrentUser,
-	CognitoUserPoolsTokenProvider,
+	cognitoUserPoolsTokenProvider,
 } from '../../../src/providers/cognito';
 import { InitiateAuthException } from '../../../src/providers/cognito/types/errors';
 import { Amplify } from 'aws-amplify';
@@ -27,7 +27,7 @@ const authConfig = {
 Amplify.configure({
 	Auth: authConfig,
 });
-CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+cognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
 
 describe('signIn API error path cases:', () => {
 	test('signIn API should throw a validation AuthError when a user is already signed-in', async () => {

--- a/packages/auth/__tests__/providers/cognito/signInStateManagement.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInStateManagement.test.ts
@@ -7,7 +7,7 @@ import * as signInHelpers from '../../../src/providers/cognito/utils/signInHelpe
 import { signInStore } from '../../../src/providers/cognito/utils/signInStore';
 import { Amplify } from '@aws-amplify/core';
 import { RespondToAuthChallengeCommandOutput } from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider/types';
-import { CognitoUserPoolsTokenProvider } from '../../../src/providers/cognito/tokenProvider';
+import { cognitoUserPoolsTokenProvider } from '../../../src/providers/cognito/tokenProvider';
 jest.mock('../../../src/providers/cognito/apis/getCurrentUser');
 
 //  getCurrentUser is mocked so Hub is able to dispatch a mocked AuthUser
@@ -26,7 +26,7 @@ describe('local sign-in state management tests', () => {
 	};
 
 	beforeEach(() => {
-		CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+		cognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
 	});
 
 	test('local state management should return state after signIn returns a ChallengeName', async () => {

--- a/packages/auth/__tests__/providers/cognito/signInWithCustomAuth.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithCustomAuth.test.ts
@@ -8,7 +8,7 @@ import { signInWithCustomAuth } from '../../../src/providers/cognito/apis/signIn
 import * as initiateAuthHelpers from '../../../src/providers/cognito/utils/signInHelpers';
 import { InitiateAuthCommandOutput } from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider/types';
 import {
-	CognitoUserPoolsTokenProvider,
+	cognitoUserPoolsTokenProvider,
 	tokenOrchestrator,
 } from '../../../src/providers/cognito/tokenProvider';
 import * as clients from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider';
@@ -23,7 +23,7 @@ const authConfig = {
 Amplify.configure({
 	Auth: authConfig,
 });
-CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+cognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
 describe('signIn API happy path cases', () => {
 	let handleCustomAuthFlowWithoutSRPSpy;
 

--- a/packages/auth/__tests__/providers/cognito/signInWithCustomSRPAuth.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithCustomSRPAuth.test.ts
@@ -8,7 +8,7 @@ import { signInWithCustomSRPAuth } from '../../../src/providers/cognito/apis/sig
 import { RespondToAuthChallengeCommandOutput } from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider/types';
 import { Amplify } from 'aws-amplify';
 import {
-	CognitoUserPoolsTokenProvider,
+	cognitoUserPoolsTokenProvider,
 	tokenOrchestrator,
 } from '../../../src/providers/cognito/tokenProvider';
 import * as clients from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider';
@@ -19,7 +19,7 @@ const authConfig = {
 		userPoolId: 'us-west-2_zzzzz',
 	},
 };
-CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+cognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
 Amplify.configure({
 	Auth: authConfig,
 });

--- a/packages/auth/__tests__/providers/cognito/signInWithSRP.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithSRP.test.ts
@@ -8,7 +8,7 @@ import * as initiateAuthHelpers from '../../../src/providers/cognito/utils/signI
 import { RespondToAuthChallengeCommandOutput } from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider/types';
 import { Amplify } from 'aws-amplify';
 import {
-	CognitoUserPoolsTokenProvider,
+	cognitoUserPoolsTokenProvider,
 	tokenOrchestrator,
 } from '../../../src/providers/cognito/tokenProvider';
 import { AuthError } from '../../../src';
@@ -22,7 +22,7 @@ const authConfig = {
 	},
 };
 
-CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+cognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
 Amplify.configure({
 	Auth: authConfig,
 });

--- a/packages/auth/__tests__/providers/cognito/signInWithUserPassword.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithUserPassword.test.ts
@@ -8,7 +8,7 @@ import { signInWithUserPassword } from '../../../src/providers/cognito/apis/sign
 import { RespondToAuthChallengeCommandOutput } from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider/types';
 import { Amplify } from 'aws-amplify';
 import {
-	CognitoUserPoolsTokenProvider,
+	cognitoUserPoolsTokenProvider,
 	tokenOrchestrator,
 } from '../../../src/providers/cognito/tokenProvider';
 import * as clients from '../../../src/providers/cognito/utils/clients/CognitoIdentityProvider';
@@ -20,7 +20,7 @@ const authConfig = {
 	},
 };
 
-CognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+cognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
 Amplify.configure({
 	Auth: authConfig,
 });

--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -15,7 +15,7 @@ import {
 	AmplifyUrl,
 } from '@aws-amplify/core/internals/utils';
 import { cacheCognitoTokens } from '../tokenProvider/cacheTokens';
-import { CognitoUserPoolsTokenProvider } from '../tokenProvider';
+import { cognitoUserPoolsTokenProvider } from '../tokenProvider';
 import { cognitoHostedUIIdentityProviderMap } from '../types/models';
 import { DefaultOAuthStore } from '../utils/signInWithRedirectStore';
 import { AuthError } from '../../../errors/AuthError';
@@ -472,7 +472,7 @@ const invokeAndClearPromise = () => {
 };
 
 isBrowser() &&
-	CognitoUserPoolsTokenProvider.setWaitForInflightOAuth(
+	cognitoUserPoolsTokenProvider.setWaitForInflightOAuth(
 		() =>
 			new Promise(async (res, _rej) => {
 				if (!(await store.loadOAuthInFlight())) {

--- a/packages/auth/src/providers/cognito/index.ts
+++ b/packages/auth/src/providers/cognito/index.ts
@@ -75,7 +75,7 @@ export {
 	DefaultIdentityIdStore,
 } from './credentialsProvider';
 export {
-	CognitoUserPoolsTokenProvider,
+	cognitoUserPoolsTokenProvider,
 	CognitoUserPoolTokenProviderType,
 	TokenOrchestrator,
 	DefaultTokenStore,

--- a/packages/auth/src/providers/cognito/tokenProvider/index.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/index.ts
@@ -42,11 +42,11 @@ class CognitoUserPoolsTokenProviderClass
 	}
 }
 
-export const CognitoUserPoolsTokenProvider =
+export const cognitoUserPoolsTokenProvider =
 	new CognitoUserPoolsTokenProviderClass();
 
 export const tokenOrchestrator =
-	CognitoUserPoolsTokenProvider.tokenOrchestrator;
+	cognitoUserPoolsTokenProvider.tokenOrchestrator;
 
 export {
 	CognitoUserPoolTokenProviderType,

--- a/packages/aws-amplify/__tests__/exports.test.ts
+++ b/packages/aws-amplify/__tests__/exports.test.ts
@@ -210,7 +210,7 @@ describe('aws-amplify Exports', () => {
 					'fetchDevices',
 					'autoSignIn',
 					'cognitoCredentialsProvider',
-					'CognitoUserPoolsTokenProvider',
+					'cognitoUserPoolsTokenProvider',
 					'CognitoAWSCredentialsAndIdentityIdProvider',
 					'DefaultIdentityIdStore',
 					'TokenOrchestrator',

--- a/packages/aws-amplify/__tests__/initSingleton.test.ts
+++ b/packages/aws-amplify/__tests__/initSingleton.test.ts
@@ -9,7 +9,7 @@ import {
 	defaultStorage,
 } from '@aws-amplify/core';
 import {
-	CognitoUserPoolsTokenProvider,
+	cognitoUserPoolsTokenProvider,
 	cognitoCredentialsProvider,
 } from '../src/auth/cognito';
 
@@ -17,7 +17,7 @@ import { Amplify } from '../src';
 
 jest.mock('@aws-amplify/core');
 jest.mock('../src/auth/cognito', () => ({
-	CognitoUserPoolsTokenProvider: {
+	cognitoUserPoolsTokenProvider: {
 		setAuthConfig: jest.fn(),
 		setKeyValueStorage: jest.fn(),
 	},
@@ -25,9 +25,9 @@ jest.mock('../src/auth/cognito', () => ({
 }));
 
 const mockCognitoUserPoolsTokenProviderSetAuthConfig =
-	CognitoUserPoolsTokenProvider.setAuthConfig as jest.Mock;
+	cognitoUserPoolsTokenProvider.setAuthConfig as jest.Mock;
 const mockCognitoUserPoolsTokenProviderSetKeyValueStorage =
-	CognitoUserPoolsTokenProvider.setKeyValueStorage as jest.Mock;
+	cognitoUserPoolsTokenProvider.setKeyValueStorage as jest.Mock;
 const mockAmplifySingletonConfigure = AmplifySingleton.configure as jest.Mock;
 const mockAmplifySingletonGetConfig = AmplifySingleton.getConfig as jest.Mock;
 const MockCookieStorage = CookieStorage as jest.Mock;
@@ -137,7 +137,7 @@ describe('initSingleton (DefaultAmplify)', () => {
 						mockResourceConfig,
 						{
 							Auth: {
-								tokenProvider: CognitoUserPoolsTokenProvider,
+								tokenProvider: cognitoUserPoolsTokenProvider,
 								credentialsProvider: cognitoCredentialsProvider,
 							},
 						}
@@ -200,7 +200,7 @@ describe('initSingleton (DefaultAmplify)', () => {
 						mockResourceConfig,
 						{
 							Auth: {
-								tokenProvider: CognitoUserPoolsTokenProvider,
+								tokenProvider: cognitoUserPoolsTokenProvider,
 								credentialsProvider: cognitoCredentialsProvider,
 							},
 							...libraryOptionsWithStorage,

--- a/packages/aws-amplify/src/initSingleton.ts
+++ b/packages/aws-amplify/src/initSingleton.ts
@@ -12,7 +12,7 @@ import {
 	parseAWSExports,
 } from '@aws-amplify/core/internals/utils';
 import {
-	CognitoUserPoolsTokenProvider,
+	cognitoUserPoolsTokenProvider,
 	cognitoCredentialsProvider,
 } from './auth/cognito';
 
@@ -36,17 +36,17 @@ export const DefaultAmplify = {
 			!libraryOptions?.Auth &&
 			!Amplify.libraryOptions.Auth
 		) {
-			CognitoUserPoolsTokenProvider.setAuthConfig(resolvedResourceConfig.Auth);
+			cognitoUserPoolsTokenProvider.setAuthConfig(resolvedResourceConfig.Auth);
 
 			const libraryOptionsWithDefaultAuthProviders: LibraryOptions = {
 				...libraryOptions,
 				Auth: {
-					tokenProvider: CognitoUserPoolsTokenProvider,
+					tokenProvider: cognitoUserPoolsTokenProvider,
 					credentialsProvider: cognitoCredentialsProvider,
 				},
 			};
 
-			CognitoUserPoolsTokenProvider.setKeyValueStorage(
+			cognitoUserPoolsTokenProvider.setKeyValueStorage(
 				libraryOptions?.ssr
 					? // TODO: allow configure with a public interface
 					  new CookieStorage({


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Use camel-case naming for the `cognitoUserPoolsTokenProvider` instance.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
