### PR TITLE
fix(auth): refreshToken unawaited async operation caused race condition

### DIFF
--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
@@ -1,0 +1,76 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Hub } from '@aws-amplify/core';
+import { assertTokenProviderConfig } from '@aws-amplify/core/internals/utils';
+import { tokenOrchestrator } from '../../../../src/providers/cognito/tokenProvider';
+import { CognitoAuthTokens } from '../../../../src/providers/cognito/tokenProvider/types';
+
+jest.mock('@aws-amplify/core/internals/utils');
+jest.mock('@aws-amplify/core', () => ({
+	...jest.requireActual('@aws-amplify/core'),
+	Hub: {
+		dispatch: jest.fn(),
+	},
+}));
+
+const mockAssertTokenProviderConfig = assertTokenProviderConfig as jest.Mock;
+
+describe('tokenOrchestrator', () => {
+	const mockTokenRefresher = jest.fn();
+	const mockTokenStore = {
+		storeTokens: jest.fn(),
+		getLastAuthUser: jest.fn(),
+		loadTokens: jest.fn(),
+		clearTokens: jest.fn(),
+		setKeyValueStorage: jest.fn(),
+		getDeviceMetadata: jest.fn(),
+		clearDeviceMetadata: jest.fn(),
+	};
+
+	beforeAll(() => {
+		tokenOrchestrator.setTokenRefresher(mockTokenRefresher);
+		tokenOrchestrator.setAuthTokenStore(mockTokenStore);
+	});
+
+	describe('refreshTokens method', () => {
+		it('calls the set tokenRefresher, tokenStore and Hub while refreshing tokens', async () => {
+			const testUsername = 'username';
+			const testInputTokens = {
+				accessToken: {
+					payload: {},
+				},
+				clockDrift: 400000,
+				username: testUsername,
+			};
+
+			const mockTokens: CognitoAuthTokens = {
+				accessToken: {
+					payload: {},
+				},
+				clockDrift: 300,
+				username: testUsername,
+			};
+			mockTokenRefresher.mockResolvedValueOnce(mockTokens);
+			mockTokenStore.storeTokens.mockResolvedValue(void 0);
+			const newTokens = await tokenOrchestrator['refreshTokens']({
+				tokens: testInputTokens,
+				username: testUsername,
+			});
+
+			// ensure the underlying async operations to be completed
+			// async #1
+			expect(mockTokenRefresher).toHaveBeenCalledWith(
+				expect.objectContaining({
+					tokens: testInputTokens,
+					username: testUsername,
+				})
+			);
+			// async #2
+			expect(mockTokenStore.storeTokens).toHaveBeenCalledWith(mockTokens);
+
+			// ensure the result is correct
+			expect(newTokens).toEqual(mockTokens);
+		});
+	});
+});

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -124,7 +124,7 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 				username,
 			});
 
-			this.setTokens({ tokens: newTokens });
+			await this.setTokens({ tokens: newTokens });
 			Hub.dispatch('auth', { event: 'tokenRefresh' }, 'Auth', AMPLIFY_SYMBOL);
 
 			return newTokens;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* await for the `storeTokens` operation to complete the `refreshTokens` operation to avoid unexpected race condition between returning result of `fetchAuthSession` (when token expired) and store the tokens into token store.
  This caused unexpected warning for attempting set `SetCookie` header after operation has completed
* added relevant unit test


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
