### PR TITLE
fix: Update initSingleton logic to handle multiple configure calls in…

### DIFF
--- a/packages/aws-amplify/src/initSingleton.ts
+++ b/packages/aws-amplify/src/initSingleton.ts
@@ -29,39 +29,57 @@ export const DefaultAmplify = {
 			resolvedResourceConfig = resourceConfig as ResourcesConfig;
 		}
 
-		// When Auth config is provided but no custom Auth provider defined
-		// use the default Auth Providers
-		if (
-			resolvedResourceConfig.Auth &&
-			!libraryOptions?.Auth &&
-			!Amplify.libraryOptions.Auth
-		) {
-			cognitoUserPoolsTokenProvider.setAuthConfig(resolvedResourceConfig.Auth);
+		// If no Auth config is provided, no special handling will be required, configure as is.
+		// Otherwise, we can assume an Auth config is provided from here on.
+		if (!resolvedResourceConfig.Auth) {
+			return Amplify.configure(resolvedResourceConfig, libraryOptions);
+		}
 
-			const libraryOptionsWithDefaultAuthProviders: LibraryOptions = {
+		// If Auth options are provided, always just configure as is.
+		// Otherwise, we can assume no Auth libraryOptions were provided from here on.
+		if (libraryOptions?.Auth) {
+			return Amplify.configure(resolvedResourceConfig, libraryOptions);
+		}
+
+		// If no Auth libraryOptions were previously configured, then always add default providers.
+		if (!Amplify.libraryOptions.Auth) {
+			cognitoUserPoolsTokenProvider.setAuthConfig(resolvedResourceConfig.Auth);
+			cognitoUserPoolsTokenProvider.setKeyValueStorage(
+				// TODO: allow configure with a public interface
+				libraryOptions?.ssr
+					? new CookieStorage({ sameSite: 'lax' })
+					: defaultStorage
+			);
+			return Amplify.configure(resolvedResourceConfig, {
 				...libraryOptions,
 				Auth: {
 					tokenProvider: cognitoUserPoolsTokenProvider,
 					credentialsProvider: cognitoCredentialsProvider,
 				},
-			};
-
-			cognitoUserPoolsTokenProvider.setKeyValueStorage(
-				libraryOptions?.ssr
-					? // TODO: allow configure with a public interface
-					  new CookieStorage({
-							sameSite: 'lax',
-					  })
-					: defaultStorage
-			);
-
-			Amplify.configure(
-				resolvedResourceConfig,
-				libraryOptionsWithDefaultAuthProviders
-			);
-		} else {
-			Amplify.configure(resolvedResourceConfig, libraryOptions);
+			});
 		}
+
+		// At this point, Auth libraryOptions would have been previously configured and no overriding
+		// Auth options were given, so we should preserve the currently configured Auth libraryOptions.
+		if (libraryOptions) {
+			// If ssr is provided through libraryOptions, we should respect the intentional reconfiguration.
+			if (libraryOptions.ssr !== undefined) {
+				cognitoUserPoolsTokenProvider.setKeyValueStorage(
+					// TODO: allow configure with a public interface
+					libraryOptions.ssr
+						? new CookieStorage({ sameSite: 'lax' })
+						: defaultStorage
+				);
+			}
+			return Amplify.configure(resolvedResourceConfig, {
+				Auth: Amplify.libraryOptions.Auth,
+				...libraryOptions,
+			});
+		}
+
+		// Finally, if there were no libraryOptions given at all, we should simply not touch the currently
+		// configured libraryOptions.
+		Amplify.configure(resolvedResourceConfig);
 	},
 	getConfig(): ResourcesConfig {
 		return Amplify.getConfig();


### PR DESCRIPTION
… various libraryOptions permutations

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR refactors the Singleton initialization to cover various scenarios in which `Amplify.configure` may be called - especially when called multiple times with different `libraryOptions` combinations.

| Call 1                       | Result 1                         | Call N                       | Result N                         |
|------------------------------|----------------------------------|------------------------------|----------------------------------|
| No `libraryOptions`          | Configure with default Providers | No `libraryOptions`          | Preserve default Providers       |
| No `libraryOptions`          | Configure with default Providers | No **Auth** `libraryOptions` | Preserve default Providers       |
| No `libraryOptions`          | Configure with default Providers | **Auth** `libraryOptions`    | Configure as is (override)       |
| No **Auth** `libraryOptions` | Configure with default Providers | No `libraryOptions`          | Preserve default Providers       |
| No **Auth** `libraryOptions` | Configure with default Providers | No **Auth** `libraryOptions` | Preserve default Providers       |
| No **Auth** `libraryOptions` | Configure with default Providers | **Auth** `libraryOptions`    | Configure as is (override)       |
| **Auth** `libraryOptions`    | Configure as is                  | No `libraryOptions`          | Preserve custom Providers        |
| **Auth** `libraryOptions`    | Configure as is                  | No **Auth** `libraryOptions` | Preserve custom Providers        |
| **Auth** `libraryOptions`    | Configure as is                  | **Auth** `libraryOptions`    | Configure as is (override)       |

Some actual examples which led to this change include:

Given the below, `ssr` should remain true and default providers should remain configured after the second configure call. 
```ts
Amplify.configure(config, { ssr: true });

Amplify.configure({
    ...Amplify.getConfig(),
    Analytics: {
        Kinesis: {
            region: 'us-west-2'
        },
    },
});
```

Given the below, `ssr` should become false and default providers should remain configured after the second configure call. Previously, this call would overwrite libraryOptions with the provided options - overwriting the default providers even though the `Auth` key was not present
```ts
Amplify.configure(config, { ssr: true });

// Configure Analytics providers which are not managed by the CLI
Amplify.configure({
    ...Amplify.getConfig(),
    Analytics: {
        Kinesis: {
            region: 'us-west-2'
        }
    }
}, {ssr: false})
```

#### Description of how you validated changes
* `yarn test`
* Tested with sample apps (@HuiSF ❤️)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
