### PR TITLE
chore(actions): remove usage of set-output

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,7 +51,7 @@ jobs:
       success: ${{ steps.setoutput.outputs.success }}
     steps:
       - id: setoutput
-        run: echo "::set-output name=success::true"
+        run: echo "success=true" >> $GITHUB_OUTPUT
   ci:
     runs-on: ubuntu-latest
     if: always() # always run, so we never skip the check


### PR DESCRIPTION
### Description of changes
Fix GH actions warning ["set-output" to be depreciated](https://github.com/aws-amplify/amplify-js/actions/runs/6884156327)

### Testing
The `ci - Unit and Bundle tests have passed` jobs works as expected. Tested branch protection with this change as well
- [failure case on fork](https://github.com/ashwinkumar6/amplify-js/pull/16): merge blocked
- [success case on fork](https://github.com/ashwinkumar6/amplify-js/pull/15): mergeable
(Will remove draft once the above 2 actions reach completion)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
