### PR TITLE
fix: export generateClient return types; don't throw error in genClient

### DIFF
--- a/packages/adapter-nextjs/src/api/index.ts
+++ b/packages/adapter-nextjs/src/api/index.ts
@@ -5,3 +5,8 @@ export {
 	generateServerClientUsingReqRes,
 	generateServerClientUsingCookies,
 } from './generateServerClient';
+
+export {
+	V6ClientSSRCookies as ClientUsingSSRCookies,
+	V6ClientSSRRequest as ClientUsingSSRReq,
+} from '@aws-amplify/api-graphql';

--- a/packages/api-graphql/__tests__/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/generateClient.test.ts
@@ -65,15 +65,15 @@ const USER_AGENT_DETAILS = {
 };
 
 describe('generateClient', () => {
-	test('raises clear error when API GraphQL isnt configured', () => {
-		const getConfig = jest.fn().mockReturnValue({});
-		const amplify = {
-			getConfig,
-		} as unknown as AmplifyClassV6;
-		expect(() => generateClient({ amplify })).toThrow(
-			'The API configuration is missing. This is likely due to Amplify.configure() not being called prior to generateClient()'
-		);
-	});
+	// test('raises clear error when API GraphQL isnt configured', () => {
+	// 	const getConfig = jest.fn().mockReturnValue({});
+	// 	const amplify = {
+	// 		getConfig,
+	// 	} as unknown as AmplifyClassV6;
+	// 	expect(() => generateClient({ amplify })).toThrow(
+	// 		'The API configuration is missing. This is likely due to Amplify.configure() not being called prior to generateClient()'
+	// 	);
+	// });
 
 	test('can produce a client bound to an arbitrary amplify object for getConfig()', async () => {
 		// TS lies: We don't care what `amplify` is or does. We want want to make sure

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -67,7 +67,7 @@
 	},
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
-		"@aws-amplify/data-schema": "^0.12.5",
+		"@aws-amplify/data-schema": "^0.12.6",
 		"@rollup/plugin-typescript": "11.1.5",
 		"rollup": "3.29.4",
 		"typescript": "5.0.2"
@@ -81,7 +81,7 @@
 	"dependencies": {
 		"@aws-amplify/api-rest": "4.0.2",
 		"@aws-amplify/core": "6.0.2",
-		"@aws-amplify/data-schema-types": "^0.6.3",
+		"@aws-amplify/data-schema-types": "^0.6.4",
 		"@aws-sdk/types": "3.387.0",
 		"graphql": "15.8.0",
 		"rxjs": "^7.8.1",

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -67,7 +67,7 @@
 	},
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
-		"@aws-amplify/data-schema": "^0.12.2",
+		"@aws-amplify/data-schema": "^0.12.5",
 		"@rollup/plugin-typescript": "11.1.5",
 		"rollup": "3.29.4",
 		"typescript": "5.0.2"
@@ -81,7 +81,7 @@
 	"dependencies": {
 		"@aws-amplify/api-rest": "4.0.2",
 		"@aws-amplify/core": "6.0.2",
-		"@aws-amplify/data-schema-types": "^0.6.2",
+		"@aws-amplify/data-schema-types": "^0.6.3",
 		"@aws-sdk/types": "3.387.0",
 		"graphql": "15.8.0",
 		"rxjs": "^7.8.1",

--- a/packages/api-graphql/src/internals/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/generateModelsProperty.ts
@@ -19,11 +19,12 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 	const config = params.amplify.getConfig();
 
 	if (!config.API?.GraphQL) {
-		// breaks compatibility with certain bundler, e.g. Vite where component files are evaluated before the entry point
-		// causing false positive errors. Revisit how to better handle this post-launch
+		// breaks compatibility with certain bundler, e.g. Vite where component files are evaluated before
+		// the entry point causing false positive errors. Revisit how to better handle this post-launch
 
 		// throw new Error(
-		// 	'The API configuration is missing. This is likely due to Amplify.configure() not being called prior to generateClient().'
+		// 	'The API configuration is missing. This is likely due to Amplify.configure() not being called
+		// prior to generateClient().'
 		// );
 		return {} as ModelTypes<never>;
 	}

--- a/packages/api-graphql/src/internals/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/generateModelsProperty.ts
@@ -19,9 +19,13 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
 	const config = params.amplify.getConfig();
 
 	if (!config.API?.GraphQL) {
-		throw new Error(
-			'The API configuration is missing. This is likely due to Amplify.configure() not being called prior to generateClient().'
-		);
+		// breaks compatibility with certain bundler, e.g. Vite where component files are evaluated before the entry point
+		// causing false positive errors. Revisit how to better handle this post-launch
+
+		// throw new Error(
+		// 	'The API configuration is missing. This is likely due to Amplify.configure() not being called prior to generateClient().'
+		// );
+		return {} as ModelTypes<never>;
 	}
 
 	const modelIntrospection: ModelIntrospectionSchema | undefined =

--- a/packages/api-graphql/src/internals/server/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/server/generateModelsProperty.ts
@@ -26,10 +26,6 @@ export function generateModelsProperty<
 	}
 
 	if (!config.API?.GraphQL) {
-		// throw new Error(
-		// 	'The API configuration is missing. This is likely due to Amplify.configure()
-		// not being called prior to generateClient().'
-		// );
 		return {} as ModelTypes<never>;
 	}
 

--- a/packages/api-graphql/src/internals/server/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/server/generateModelsProperty.ts
@@ -10,7 +10,7 @@ import { listFactory } from '../operations/list';
 import { getFactory } from '../operations/get';
 
 export function generateModelsProperty<
-	T extends Record<any, any> = never,
+	_T extends Record<any, any> = never,
 	ClientType extends
 		| V6ClientSSRRequest<Record<string, any>>
 		| V6ClientSSRCookies<Record<string, any>> = V6ClientSSRCookies<
@@ -26,9 +26,10 @@ export function generateModelsProperty<
 	}
 
 	if (!config.API?.GraphQL) {
-		throw new Error(
-			'The API configuration is missing. This is likely due to Amplify.configure() not being called prior to generateClient().'
-		);
+		// throw new Error(
+		// 	'The API configuration is missing. This is likely due to Amplify.configure() not being called prior to generateClient().'
+		// );
+		return {} as ModelTypes<never>;
 	}
 
 	const modelIntrospection: ModelIntrospectionSchema | undefined =

--- a/packages/api-graphql/src/internals/server/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/server/generateModelsProperty.ts
@@ -27,7 +27,8 @@ export function generateModelsProperty<
 
 	if (!config.API?.GraphQL) {
 		// throw new Error(
-		// 	'The API configuration is missing. This is likely due to Amplify.configure() not being called prior to generateClient().'
+		// 	'The API configuration is missing. This is likely due to Amplify.configure()
+		// not being called prior to generateClient().'
 		// );
 		return {} as ModelTypes<never>;
 	}

--- a/packages/api-graphql/src/utils/resolveConfig.ts
+++ b/packages/api-graphql/src/utils/resolveConfig.ts
@@ -1,13 +1,24 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AmplifyClassV6, ConsoleLogger } from '@aws-amplify/core';
 import { APIValidationErrorCode, assertValidationError } from './errors';
+
+const logger = new ConsoleLogger('GraphQLAPI resovleConfig');
 
 /**
  * @internal
  */
 export const resolveConfig = (amplify: AmplifyClassV6) => {
+	const config = amplify.getConfig();
+
+	if (!config.API?.GraphQL) {
+		logger.warn(
+			'The API configuration is missing. This is likely due to Amplify.configure() not being called prior to generateClient().'
+		);
+		return {};
+	}
+
 	const {
 		apiKey,
 		customEndpoint,
@@ -15,7 +26,7 @@ export const resolveConfig = (amplify: AmplifyClassV6) => {
 		defaultAuthMode,
 		endpoint,
 		region,
-	} = amplify.getConfig().API?.GraphQL ?? {};
+	} = config.API.GraphQL;
 
 	// TODO: re-enable when working in all test environments:
 	// assertValidationError(!!endpoint, APIValidationErrorCode.NoEndpoint);

--- a/packages/api-graphql/src/utils/resolveConfig.ts
+++ b/packages/api-graphql/src/utils/resolveConfig.ts
@@ -16,7 +16,6 @@ export const resolveConfig = (amplify: AmplifyClassV6) => {
 		logger.warn(
 			'The API configuration is missing. This is likely due to Amplify.configure() not being called prior to generateClient().'
 		);
-		return {};
 	}
 
 	const {
@@ -26,7 +25,7 @@ export const resolveConfig = (amplify: AmplifyClassV6) => {
 		defaultAuthMode,
 		endpoint,
 		region,
-	} = config.API.GraphQL;
+	} = config.API?.GraphQL ?? {};
 
 	// TODO: re-enable when working in all test environments:
 	// assertValidationError(!!endpoint, APIValidationErrorCode.NoEndpoint);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -12,6 +12,8 @@ export type {
 	CONNECTION_STATE_CHANGE,
 } from '@aws-amplify/api-graphql';
 
+export type { V6Client as Client } from '@aws-amplify/api-graphql';
+
 export {
 	get,
 	put,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,17 +10,24 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-amplify/data-schema-types@*", "@aws-amplify/data-schema-types@^0.6.2":
+"@aws-amplify/data-schema-types@*":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema-types/-/data-schema-types-0.6.2.tgz#5ca7ae0383341fe693ba491dbb72437e2cede902"
   integrity sha512-7MbIInUHQcL0pSp/1O+gRhUFJ+0igEbTbVvprIXQLjVAqv0d3dfWZRpOE/VmxdYoUoljM4BeMvsyx1FVN68UQQ==
   dependencies:
     rxjs "^7.8.1"
 
-"@aws-amplify/data-schema@^0.12.2":
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema/-/data-schema-0.12.3.tgz#196965af12502731d201034f693e1b8c93738de4"
-  integrity sha512-TWYqXJYWEu4HTWcITQmHjy3yYuqHdmxyBIOi4wP5sR7Nfpg24wIhaK/ViCez5GB9dRIWxi0gH+m0uMhSQxKKKA==
+"@aws-amplify/data-schema-types@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema-types/-/data-schema-types-0.6.3.tgz#7741d943e70b4b1b53dda7b63b2c5a77d725624b"
+  integrity sha512-Zxal0UGNK4BEE6YeDg48FQ0obtKq1KCxr09pyFZR/ml0SLF5zJA5c2d+EWATpifWIFCB0QfpoDmXZFaYuEjmcA==
+  dependencies:
+    rxjs "^7.8.1"
+
+"@aws-amplify/data-schema@^0.12.5":
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema/-/data-schema-0.12.5.tgz#0241883e1058512f07b7367c354e56e122d03b88"
+  integrity sha512-cpUHG4kCmpfToTe2iARXdDOePIPoTlPWqbhYsEewtDKGiCyhBmDu3nwWaEgj3uoHn8Xfk3Qyq4WaaykHYGM1WQ==
   dependencies:
     "@aws-amplify/data-schema-types" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,17 +17,17 @@
   dependencies:
     rxjs "^7.8.1"
 
-"@aws-amplify/data-schema-types@^0.6.3":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema-types/-/data-schema-types-0.6.3.tgz#7741d943e70b4b1b53dda7b63b2c5a77d725624b"
-  integrity sha512-Zxal0UGNK4BEE6YeDg48FQ0obtKq1KCxr09pyFZR/ml0SLF5zJA5c2d+EWATpifWIFCB0QfpoDmXZFaYuEjmcA==
+"@aws-amplify/data-schema-types@^0.6.4":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema-types/-/data-schema-types-0.6.4.tgz#a618cf4a9f989f2b9dafcab921012d7cded42a54"
+  integrity sha512-NyHYinr5OZXGlRzvYZoqFvFYf2J2zBhxAqjrTVdC/+3EKHRu0wnjeLhe0214qKydGdkHj4ehQDy5sPfdCh/cHg==
   dependencies:
     rxjs "^7.8.1"
 
-"@aws-amplify/data-schema@^0.12.5":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema/-/data-schema-0.12.5.tgz#0241883e1058512f07b7367c354e56e122d03b88"
-  integrity sha512-cpUHG4kCmpfToTe2iARXdDOePIPoTlPWqbhYsEewtDKGiCyhBmDu3nwWaEgj3uoHn8Xfk3Qyq4WaaykHYGM1WQ==
+"@aws-amplify/data-schema@^0.12.6":
+  version "0.12.6"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema/-/data-schema-0.12.6.tgz#7cdaa8f68bd3dd6da86e59433e9f0646176ca50e"
+  integrity sha512-ZNpEHxIbNHbNvsKmKO8+X0+wdyoI+sGqzEN44zd8k9zvFqs60cnkLt2ayhcb0h7ew+ytf7+ESkos+ccM8+HkaA==
   dependencies:
     "@aws-amplify/data-schema-types" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,14 +10,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-amplify/data-schema-types@*":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema-types/-/data-schema-types-0.6.2.tgz#5ca7ae0383341fe693ba491dbb72437e2cede902"
-  integrity sha512-7MbIInUHQcL0pSp/1O+gRhUFJ+0igEbTbVvprIXQLjVAqv0d3dfWZRpOE/VmxdYoUoljM4BeMvsyx1FVN68UQQ==
-  dependencies:
-    rxjs "^7.8.1"
-
-"@aws-amplify/data-schema-types@^0.6.4":
+"@aws-amplify/data-schema-types@*", "@aws-amplify/data-schema-types@^0.6.4":
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema-types/-/data-schema-types-0.6.4.tgz#a618cf4a9f989f2b9dafcab921012d7cded42a54"
   integrity sha512-NyHYinr5OZXGlRzvYZoqFvFYf2J2zBhxAqjrTVdC/+3EKHRu0wnjeLhe0214qKydGdkHj4ehQDy5sPfdCh/cHg==


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
* export generateClient return types
* don't throw error if genClient is called before Amplify.configure. Silent return instead
* Bump data-schema dep versions


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
