### PR TITLE
fix: Client type explicit default type arg

### DIFF
--- a/packages/adapter-nextjs/src/api/index.ts
+++ b/packages/adapter-nextjs/src/api/index.ts
@@ -6,7 +6,18 @@ export {
 	generateServerClientUsingCookies,
 } from './generateServerClient';
 
-export {
-	V6ClientSSRCookies as ClientUsingSSRCookies,
-	V6ClientSSRRequest as ClientUsingSSRReq,
+import {
+	V6ClientSSRCookies,
+	V6ClientSSRRequest,
 } from '@aws-amplify/api-graphql';
+
+// explicitly defaulting to `never` here resolves
+// TS2589: Type instantiation is excessively deep and possibly infinite.
+// When this type is used without a generic type arg, i.e. `let client: Client`
+type ClientUsingSSRCookies<T extends Record<any, any> = never> =
+	V6ClientSSRCookies<T>;
+
+type ClientUsingSSRReq<T extends Record<any, any> = never> =
+	V6ClientSSRRequest<T>;
+
+export { ClientUsingSSRCookies, ClientUsingSSRReq };

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -12,7 +12,13 @@ export type {
 	CONNECTION_STATE_CHANGE,
 } from '@aws-amplify/api-graphql';
 
-export type { V6Client as Client } from '@aws-amplify/api-graphql';
+import type { V6Client } from '@aws-amplify/api-graphql';
+
+// explicitly defaulting to `never` here resolves
+// TS2589: Type instantiation is excessively deep and possibly infinite.
+// When this type is used without a generic type arg, i.e. `let client: Client`
+type Client<T extends Record<any, any> = never> = V6Client<T>;
+export { Client };
 
 export {
 	get,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Resolves "TS2589: Type instantiation is excessively deep and possibly infinite." error when `Client` type is used without a type arg, e.g.
```ts
let client: Client;
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
