### PR TITLE
fix(datastore): Make ds tests run on M1 by using uuid for randomness

### DIFF
--- a/packages/datastore/__tests__/commonAdapterTests.ts
+++ b/packages/datastore/__tests__/commonAdapterTests.ts
@@ -1,4 +1,4 @@
-import { ulid } from 'ulid';
+import { v4 as uuid } from 'uuid';
 
 import {
 	DataStore as DataStoreType,
@@ -1060,10 +1060,10 @@ export function addCommonQueryTests({
 				if (fkFields.has(field)) continue;
 				switch (def.type) {
 					case 'ID':
-						initializer[field] = ulid();
+						initializer[field] = uuid();
 						break;
 					case 'String':
-						initializer[field] = `some random content ${ulid()}`;
+						initializer[field] = `some random content ${uuid()}`;
 						break;
 					case 'Int':
 						initializer[field] =


### PR DESCRIPTION
#### Description of changes
fix(datastore): Make ds tests run on M1 by using uuid for randomness


#### Description of how you validated changes
By running the unit tests on both intel and M1 macbooks. This PR will prompt an ubuntu run to ensure we're covered.


#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
