### PR TITLE
fix(aws-amplify): destroyAmplifyServerContext may not be called

### DIFF
--- a/packages/aws-amplify/__tests__/adapterCore/runWithAmplifyServerContext.test.ts
+++ b/packages/aws-amplify/__tests__/adapterCore/runWithAmplifyServerContext.test.ts
@@ -29,6 +29,10 @@ describe('runWithAmplifyServerContext', () => {
 		mockCreateAmplifyServerContext.mockReturnValueOnce(mockContextSpec);
 	});
 
+	afterEach(() => {
+		mockDestroyAmplifyServerContext.mockReset();
+	});
+
 	it('should run the operation with the context', () => {
 		const mockOperation = jest.fn();
 		runWithAmplifyServerContext(
@@ -45,7 +49,7 @@ describe('runWithAmplifyServerContext', () => {
 		expect(mockOperation).toHaveBeenCalledWith(mockContextSpec);
 	});
 
-	it('should destroy the context after the operation', async () => {
+	it('should destroy the context after the operation completed', async () => {
 		const mockOperation = jest.fn();
 		await runWithAmplifyServerContext(
 			mockAmplifyConfig,
@@ -57,6 +61,29 @@ describe('runWithAmplifyServerContext', () => {
 			},
 			mockOperation
 		);
+
+		expect(mockDestroyAmplifyServerContext).toHaveBeenCalledWith(
+			mockContextSpec
+		);
+	});
+
+	it('should destroy the context when the operation throws', async () => {
+		const testError = new Error('some error');
+		const mockOperation = jest.fn();
+		mockOperation.mockRejectedValueOnce(testError);
+
+		await expect(
+			runWithAmplifyServerContext(
+				mockAmplifyConfig,
+				{
+					Auth: {
+						tokenProvider: mockTokenProvider,
+						credentialsProvider: mockCredentialAndIdentityProvider,
+					},
+				},
+				mockOperation
+			)
+		).rejects.toThrow(testError);
 
 		expect(mockDestroyAmplifyServerContext).toHaveBeenCalledWith(
 			mockContextSpec

--- a/packages/aws-amplify/src/adapterCore/runWithAmplifyServerContext.ts
+++ b/packages/aws-amplify/src/adapterCore/runWithAmplifyServerContext.ts
@@ -26,9 +26,12 @@ export const runWithAmplifyServerContext: AmplifyServer.RunOperationWithContext 
 		);
 
 		// run the operation with injecting the context
-		const result = await operation(contextSpec);
+		try {
+			const result = await operation(contextSpec);
 
-		destroyAmplifyServerContext(contextSpec);
-
-		return result;
+			return result;
+		} finally {
+			// ensures destroy the context regardless whether the operation succeeded or failed
+			destroyAmplifyServerContext(contextSpec);
+		}
 	};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fix `destroyAmplifyServerContext` may no be called when the `operation` executed by `runWithAmplifyServerContext` throws.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
