### PR TITLE
fix: refactor to avoid importing from current index

### DIFF
--- a/packages/analytics/src/providers/pinpoint/types/inputs.ts
+++ b/packages/analytics/src/providers/pinpoint/types/inputs.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PinpointAnalyticsEvent } from '@aws-amplify/core/internals/providers/pinpoint';
-import { IdentifyUserOptions } from '.';
+import { IdentifyUserOptions } from './options';
 import {
 	AnalyticsConfigureAutoTrackInput,
 	AnalyticsIdentifyUserInput,

--- a/packages/analytics/src/types/inputs.ts
+++ b/packages/analytics/src/types/inputs.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { UserProfile } from '@aws-amplify/core';
-import { AnalyticsServiceOptions } from '.';
+import { AnalyticsServiceOptions } from './options';
 import {
 	SessionTrackingOptions,
 	PageViewTrackingOptions,

--- a/packages/auth/src/providers/cognito/tokenProvider/CognitoUserPoolsTokenProvider.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/CognitoUserPoolsTokenProvider.ts
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AuthConfig,
+	AuthTokens,
+	FetchAuthSessionOptions,
+	KeyValueStorageInterface,
+	defaultStorage,
+} from '@aws-amplify/core';
+import { refreshAuthTokens } from '../utils/refreshAuthTokens';
+import { DefaultTokenStore } from './TokenStore';
+import { TokenOrchestrator } from './TokenOrchestrator';
+import { CognitoUserPoolTokenProviderType } from './types';
+
+export class CognitoUserPoolsTokenProvider
+	implements CognitoUserPoolTokenProviderType
+{
+	authTokenStore: DefaultTokenStore;
+	tokenOrchestrator: TokenOrchestrator;
+	constructor() {
+		this.authTokenStore = new DefaultTokenStore();
+		this.authTokenStore.setKeyValueStorage(defaultStorage);
+		this.tokenOrchestrator = new TokenOrchestrator();
+		this.tokenOrchestrator.setAuthTokenStore(this.authTokenStore);
+		this.tokenOrchestrator.setTokenRefresher(refreshAuthTokens);
+	}
+	getTokens(
+		{ forceRefresh }: FetchAuthSessionOptions = { forceRefresh: false }
+	): Promise<AuthTokens | null> {
+		return this.tokenOrchestrator.getTokens({ forceRefresh });
+	}
+
+	setKeyValueStorage(keyValueStorage: KeyValueStorageInterface): void {
+		this.authTokenStore.setKeyValueStorage(keyValueStorage);
+	}
+	setWaitForInflightOAuth(waitForInflightOAuth: () => Promise<void>): void {
+		this.tokenOrchestrator.setWaitForInflightOAuth(waitForInflightOAuth);
+	}
+	setAuthConfig(authConfig: AuthConfig) {
+		this.authTokenStore.setAuthConfig(authConfig);
+		this.tokenOrchestrator.setAuthConfig(authConfig);
+	}
+}

--- a/packages/auth/src/providers/cognito/tokenProvider/cacheTokens.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/cacheTokens.ts
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { AmplifyError, decodeJWT } from '@aws-amplify/core/internals/utils';
-import { tokenOrchestrator } from '.';
-import { AuthenticationResultType } from '../utils/clients/CognitoIdentityProvider/types';
-import { CognitoAuthTokens, DeviceMetadata } from './types';
 import { CognitoAuthSignInDetails } from '../types';
+import { AuthenticationResultType } from '../utils/clients/CognitoIdentityProvider/types';
+import { tokenOrchestrator } from './tokenProvider';
+import { CognitoAuthTokens, DeviceMetadata } from './types';
 
 export async function cacheCognitoTokens(
 	AuthenticationResult: AuthenticationResultType & {

--- a/packages/auth/src/providers/cognito/tokenProvider/index.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/index.ts
@@ -1,56 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import {
-	AuthConfig,
-	AuthTokens,
-	FetchAuthSessionOptions,
-	KeyValueStorageInterface,
-	defaultStorage,
-} from '@aws-amplify/core';
-import { refreshAuthTokens } from '../utils/refreshAuthTokens';
-import { DefaultTokenStore } from './TokenStore';
-import { TokenOrchestrator } from './TokenOrchestrator';
-import { CognitoUserPoolTokenProviderType } from './types';
 
-class CognitoUserPoolsTokenProviderClass
-	implements CognitoUserPoolTokenProviderType
-{
-	authTokenStore: DefaultTokenStore;
-	tokenOrchestrator: TokenOrchestrator;
-	constructor() {
-		this.authTokenStore = new DefaultTokenStore();
-		this.authTokenStore.setKeyValueStorage(defaultStorage);
-		this.tokenOrchestrator = new TokenOrchestrator();
-		this.tokenOrchestrator.setAuthTokenStore(this.authTokenStore);
-		this.tokenOrchestrator.setTokenRefresher(refreshAuthTokens);
-	}
-	getTokens(
-		{ forceRefresh }: FetchAuthSessionOptions = { forceRefresh: false }
-	): Promise<AuthTokens | null> {
-		return this.tokenOrchestrator.getTokens({ forceRefresh });
-	}
-
-	setKeyValueStorage(keyValueStorage: KeyValueStorageInterface): void {
-		this.authTokenStore.setKeyValueStorage(keyValueStorage);
-	}
-	setWaitForInflightOAuth(waitForInflightOAuth: () => Promise<void>): void {
-		this.tokenOrchestrator.setWaitForInflightOAuth(waitForInflightOAuth);
-	}
-	setAuthConfig(authConfig: AuthConfig) {
-		this.authTokenStore.setAuthConfig(authConfig);
-		this.tokenOrchestrator.setAuthConfig(authConfig);
-	}
-}
-
-export const cognitoUserPoolsTokenProvider =
-	new CognitoUserPoolsTokenProviderClass();
-
-export const tokenOrchestrator =
-	cognitoUserPoolsTokenProvider.tokenOrchestrator;
-
+export { refreshAuthTokens } from '../utils/refreshAuthTokens';
+export { DefaultTokenStore } from './TokenStore';
+export { TokenOrchestrator } from './TokenOrchestrator';
+export { CognitoUserPoolTokenProviderType } from './types';
 export {
-	CognitoUserPoolTokenProviderType,
-	DefaultTokenStore,
-	TokenOrchestrator,
-	refreshAuthTokens,
-};
+	cognitoUserPoolsTokenProvider,
+	tokenOrchestrator,
+} from './tokenProvider';

--- a/packages/auth/src/providers/cognito/tokenProvider/tokenProvider.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/tokenProvider.ts
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CognitoUserPoolsTokenProvider } from './CognitoUserPoolsTokenProvider';
+
+export const cognitoUserPoolsTokenProvider =
+	new CognitoUserPoolsTokenProvider();
+
+export const tokenOrchestrator =
+	cognitoUserPoolsTokenProvider.tokenOrchestrator;

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/types/inputs.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/types/inputs.ts
@@ -1,11 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { IdentifyUserOptions } from './options';
 import {
-	IdentifyUserOptions,
 	InAppMessageConflictHandler,
 	OnMessageInteractionEventHandler,
-} from '.';
+} from './types';
 import {
 	InAppMessage,
 	InAppMessageInteractionEvent,

--- a/packages/notifications/src/inAppMessaging/types/inputs.ts
+++ b/packages/notifications/src/inAppMessaging/types/inputs.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { UserProfile } from '@aws-amplify/core';
-import { InAppMessagingServiceOptions } from '.';
+import { InAppMessagingServiceOptions } from './options';
 
 /**
  * Input type for `identifyUser`.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR updates import paths which reference index files within the current directory via the relative `'.'` path to avoid doing so. Babel module resolvers configured with `root: ['.']` are unable to resolve this path correctly.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/12622

#### Description of how you validated changes
Tested locally with an React Native app with the above configuration to verify that changes resolved issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
