### PR TITLE
fix: determine timeoutid type based on return type of setTimeout

### DIFF
--- a/packages/core/src/clients/middleware/retry/middleware.ts
+++ b/packages/core/src/clients/middleware/retry/middleware.ts
@@ -109,7 +109,7 @@ const cancellableSleep = (timeoutMs: number, abortSignal?: AbortSignal) => {
 	if (abortSignal?.aborted) {
 		return Promise.resolve();
 	}
-	let timeoutId: number;
+	let timeoutId: ReturnType<typeof setTimeout>;
 	let sleepPromiseResolveFn: Function;
 	const sleepPromise = new Promise<void>(resolve => {
 		sleepPromiseResolveFn = resolve;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Updates timeoutId type to account for differences in Node vs browser environment.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Builds successfully locally without type errors.



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
