### PR TITLE
chore: Update jest config type to use ts-jest provided type

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,6 @@
-/** @type {import('jest').Config} */
+/** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-	coveragePathIgnorePatterns: [
-		'/node_modules/',
-		'dist',
-		'__tests__',
-	],
+	coveragePathIgnorePatterns: ['/node_modules/', 'dist', '__tests__'],
 	setupFiles: ['../../jest.setup.js'],
 	testEnvironment: 'jsdom',
 	testRegex: '/__tests__/.*\\.(test|spec)\\.[jt]sx?$',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR just adjusts the type for jest config to use one provided by ts-jest for more informative typing.

#### Description of how you validated changes
* `yarn test`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
