### PR TITLE
fix(auth): dispatch signInWithRedirect error

### DIFF
--- a/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
@@ -54,214 +54,205 @@ describe('signInWithRedirect API', () => {
 	it('should try to clear oauth data before starting an oauth flow.', async () => {
 		// TODO: ADD Test: previous test was invalid
 	});
-});
 
-describe('signInWithRedirect API error cases', () => {
-	const oauthErrorMessage = 'an oauth error has occurred';
-	const oauthError = new AuthError({
-		name: 'OAuthSignInException',
-		message: oauthErrorMessage,
-	});
-	const mockOpenAuthSession = openAuthSession as jest.Mock;
-
-	it('should throw and dispatch when an error is returned in the URL in RN', async () => {
-		mockOpenAuthSession.mockResolvedValueOnce({
-			type: 'error',
-			error: oauthErrorMessage,
+	describe('signInWithRedirect API error cases', () => {
+		const oauthErrorMessage = 'an oauth error has occurred';
+		const oauthError = new AuthError({
+			name: 'OAuthSignInException',
+			message: oauthErrorMessage,
 		});
-
-		try {
-			await signInWithRedirect();
+		const invalidStateOauthError = new AuthError({
+			name: 'OAuthSignInException',
+			message: "An error occurred while validating the state",
+		});
+		const mockOpenAuthSession = openAuthSession as jest.Mock;
+		const mockHubDispatch = Hub.dispatch as jest.Mock;
+	
+		afterEach(() => {
+			mockOpenAuthSession.mockReset();
+		});
+	
+		it('should throw and dispatch when an error is returned in the URL in RN', async () => {
+			mockOpenAuthSession.mockResolvedValueOnce({
+				type: 'error',
+				error: oauthErrorMessage,
+			});
+	
+			await expect(signInWithRedirect()).rejects.toThrow(oauthError);
 			expect(Hub.dispatch).toHaveBeenCalledWith(
 				'auth',
 				{
 					event: 'signInWithRedirect_failure',
-					data: {
-						error: oauthError,
-					},
+					data: { error: oauthError },
 				},
 				'Auth',
 				AMPLIFY_SYMBOL
 			);
-		} catch (error: any) {
-			expect(error).toBeInstanceOf(AuthError);
-			expect(error.name).toBe(oauthError.name);
-		}
-	});
-
-	it('should throw when state is not valid after calling signInWithRedirect', async () => {
-		mockOpenAuthSession.mockResolvedValueOnce({
-			type: 'success',
-			url: 'http:localhost:3000/oauth2/redirect?state=invalid_state&code=mock_code&scope=openid%20email%20profile&session_state=mock_session_state',
 		});
-		try {
-			await signInWithRedirect();
-			expect(Hub.dispatch).toHaveBeenCalledWith(
+	
+		it('should throw when state is not valid after calling signInWithRedirect', async () => {
+			mockOpenAuthSession.mockResolvedValueOnce({
+				type: 'success',
+				url: 'http:localhost:3000/oauth2/redirect?state=invalid_state&code=mock_code&scope=openid%20email%20profile&session_state=mock_session_state',
+			});
+	
+			await expect(signInWithRedirect()).rejects.toThrow(invalidStateOauthError);
+			expect(mockHubDispatch).toHaveBeenCalledWith(
 				'auth',
 				{
 					event: 'signInWithRedirect_failure',
-					data: {
-						error: oauthError,
-					},
+					data: { error: invalidStateOauthError },
 				},
 				'Auth',
 				AMPLIFY_SYMBOL
 			);
-		} catch (error: any) {
-			expect(error).toBeInstanceOf(AuthError);
-			expect(error.message).toBe(
-				'An error occurred while validating the state'
-			);
-		}
-	});
-
-	it('should dispatch the signInWithRedirect_failure event when an error is returned in the URL', async () => {
-		Object.defineProperty(window, 'location', {
-			value: {
-				href: 'http:localhost:3000/oauth2/redirect?error=OAuthSignInException&error_description=an+oauth+error+has+occurred',
-			},
-			writable: true,
+	
 		});
-		expect(parseRedirectURL).not.toThrow();
-		await parseRedirectURL();
-		expect(Hub.dispatch).toHaveBeenCalledWith(
-			'auth',
-			{
-				event: 'signInWithRedirect_failure',
-				data: {
-					error: oauthError,
+	
+		it('should dispatch the signInWithRedirect_failure event when an error is returned in the URL', async () => {
+			Object.defineProperty(window, 'location', {
+				value: {
+					href: 'http:localhost:3000/oauth2/redirect?error=OAuthSignInException&error_description=an+oauth+error+has+occurred',
 				},
-			},
-			'Auth',
-			AMPLIFY_SYMBOL
-		);
-	});
-
-	it('should dispatch the signInWithRedirect_failure event when state is not valid', async () => {
-		Object.defineProperty(window, 'location', {
-			value: {
-				href: `http:localhost:3000/oauth2/redirect?state='invalid_state'&code=mock_code&scope=openid%20email%20profile&session_state=mock_session_state`,
-			},
-			writable: true,
-		});
-		expect(parseRedirectURL).not.toThrow();
-		await parseRedirectURL();
-		expect(Hub.dispatch).toHaveBeenCalledWith(
-			'auth',
-			{
-				event: 'signInWithRedirect_failure',
-				data: {
-					error: oauthError,
-				},
-			},
-			'Auth',
-			AMPLIFY_SYMBOL
-		);
-	});
-});
-
-describe('getRedirectUrl on web', () => {
-	const originalWindowLocation = window.location;
-
-	const currentWindownLocationParamsList: {
-		origin: string;
-		pathname: string;
-	}[] = [
-		{ origin: 'https://example.com', pathname: '/' },
-		{ origin: 'https://example.com', pathname: '/app' },
-		{ origin: 'https://example.com', pathname: '/app/page' },
-		{ origin: 'http://localhost:3000', pathname: '/' },
-		{ origin: 'http://localhost:3000', pathname: '/app' },
-	];
-	afterEach(() => {
-		Object.defineProperty(globalThis, 'window', {
-			value: originalWindowLocation,
-		});
-	});
-	it.each(currentWindownLocationParamsList)(
-		'should pick the url that matches the current window',
-		async windowParams => {
-			const { origin, pathname } = windowParams;
-			Object.defineProperty(globalThis, 'window', {
-				value: { location: { origin, pathname } },
 				writable: true,
 			});
-			const redirectsFromConfig = [
-				'http://localhost:3000/',
-				'https://example.com/',
-				'https://example.com/app',
-				'https://example.com/app/page',
-				'http://localhost:3000/app',
-			];
-			const redirect = getRedirectUrl(redirectsFromConfig);
-			expect(redirect).toBe(
-				redirectsFromConfig.find(redir => redir === redirect)
-			);
-		}
-	);
-	it('should pick the first url that is comming from a different pathname but same domain', async () => {
-		Object.defineProperty(globalThis, 'window', {
-			value: {
-				location: {
-					origin: 'https://example.com',
-					pathname: '/app',
-					hostname: 'example.com',
+			await expect(parseRedirectURL).not.toThrow();
+			expect(mockHubDispatch).toHaveBeenCalledWith(
+				'auth',
+				{
+					event: 'signInWithRedirect_failure',
+					data: { error: oauthError },
 				},
-			},
-			writable: true,
+				'Auth',
+				AMPLIFY_SYMBOL
+			);
 		});
-		const redirect = getRedirectUrl(['https://example.com/another-app']);
-		expect(redirect).toBe('https://example.com/another-app');
+	
+		it('should dispatch the signInWithRedirect_failure event when state is not valid', async () => {
+			Object.defineProperty(window, 'location', {
+				value: {
+					href: `http:localhost:3000/oauth2/redirect?state='invalid_state'&code=mock_code&scope=openid%20email%20profile&session_state=mock_session_state`,
+				},
+				writable: true,
+			});
+			await expect(parseRedirectURL).not.toThrow();
+			expect(mockHubDispatch).toHaveBeenCalledWith(
+				'auth',
+				{
+					event: 'signInWithRedirect_failure',
+					data: { error: oauthError },
+				},
+				'Auth',
+				AMPLIFY_SYMBOL
+			);
+		});
 	});
-
-	it('should throw if the url is not comming from the same origin', async () => {
-		Object.defineProperty(globalThis, 'window', {
-			value: {
-				location: { origin: 'https://differentorigin.com', pathname: '/app' },
-			},
-			writable: true,
+	
+	describe('getRedirectUrl on web', () => {
+		const originalWindowLocation = window.location;
+	
+		const currentWindownLocationParamsList: {
+			origin: string;
+			pathname: string;
+		}[] = [
+			{ origin: 'https://example.com', pathname: '/' },
+			{ origin: 'https://example.com', pathname: '/app' },
+			{ origin: 'https://example.com', pathname: '/app/page' },
+			{ origin: 'http://localhost:3000', pathname: '/' },
+			{ origin: 'http://localhost:3000', pathname: '/app' },
+		];
+		afterEach(() => {
+			Object.defineProperty(globalThis, 'window', {
+				value: originalWindowLocation,
+			});
 		});
-
-		try {
-			return getRedirectUrl(['http://localhost:3000/', 'https://example.com/']);
-		} catch (error: any) {
-			expect(error).toBeInstanceOf(AuthError);
-			expect(error.name).toBe(INVALID_ORIGIN_EXCEPTION);
-		}
+		it.each(currentWindownLocationParamsList)(
+			'should pick the url that matches the current window',
+			async windowParams => {
+				const { origin, pathname } = windowParams;
+				Object.defineProperty(globalThis, 'window', {
+					value: { location: { origin, pathname } },
+					writable: true,
+				});
+				const redirectsFromConfig = [
+					'http://localhost:3000/',
+					'https://example.com/',
+					'https://example.com/app',
+					'https://example.com/app/page',
+					'http://localhost:3000/app',
+				];
+				const redirect = getRedirectUrl(redirectsFromConfig);
+				expect(redirect).toBe(
+					redirectsFromConfig.find(redir => redir === redirect)
+				);
+			}
+		);
+		it('should pick the first url that is comming from a different pathname but same domain', async () => {
+			Object.defineProperty(globalThis, 'window', {
+				value: {
+					location: {
+						origin: 'https://example.com',
+						pathname: '/app',
+						hostname: 'example.com',
+					},
+				},
+				writable: true,
+			});
+			const redirect = getRedirectUrl(['https://example.com/another-app']);
+			expect(redirect).toBe('https://example.com/another-app');
+		});
+	
+		it('should throw if the url is not comming from the same origin', async () => {
+			Object.defineProperty(globalThis, 'window', {
+				value: {
+					location: { origin: 'https://differentorigin.com', pathname: '/app' },
+				},
+				writable: true,
+			});
+	
+			try {
+				return getRedirectUrl(['http://localhost:3000/', 'https://example.com/']);
+			} catch (error: any) {
+				expect(error).toBeInstanceOf(AuthError);
+				expect(error.name).toBe(INVALID_ORIGIN_EXCEPTION);
+			}
+		});
+	
+		it('should throw if the url is not found or invalid', async () => {
+			Object.defineProperty(globalThis, 'window', {
+				value: {
+					location: { origin: 'http://localhost:3000', pathname: '/' },
+				},
+				writable: true,
+			});
+	
+			try {
+				return getRedirectUrl(['novalid']);
+			} catch (error: any) {
+				expect(error).toBeInstanceOf(AuthError);
+				expect(error.name).toBe(INVALID_REDIRECT_EXCEPTION);
+			}
+		});
 	});
-
-	it('should throw if the url is not found or invalid', async () => {
-		Object.defineProperty(globalThis, 'window', {
-			value: {
-				location: { origin: 'http://localhost:3000', pathname: '/' },
-			},
-			writable: true,
+	
+	describe('getRedirectUrl on React Native', () => {
+		it('should pick the first non http or https redirect', async () => {
+			const redirect = getRedirectUrlRN([
+				'app:custom',
+				'https://example.com/',
+				'http://localhost:3000/',
+			]);
+			expect(redirect).toBe('app:custom');
 		});
-
-		try {
-			return getRedirectUrl(['novalid']);
-		} catch (error: any) {
-			expect(error).toBeInstanceOf(AuthError);
-			expect(error.name).toBe(INVALID_REDIRECT_EXCEPTION);
-		}
+		it('should throw if the redirect is invalid or not found', async () => {
+			try {
+				return getRedirectUrlRN(['invalid']);
+			} catch (error: any) {
+				expect(error).toBeInstanceOf(AuthError);
+				expect(error.name).toBe(INVALID_REDIRECT_EXCEPTION);
+			}
+		});
 	});
 });
 
-describe('getRedirectUrl on React Native', () => {
-	it('should pick the first non http or https redirect', async () => {
-		const redirect = getRedirectUrlRN([
-			'app:custom',
-			'https://example.com/',
-			'http://localhost:3000/',
-		]);
-		expect(redirect).toBe('app:custom');
-	});
-	it('should throw if the redirect is invalid or not found', async () => {
-		try {
-			return getRedirectUrlRN(['invalid']);
-		} catch (error: any) {
-			expect(error).toBeInstanceOf(AuthError);
-			expect(error.name).toBe(INVALID_REDIRECT_EXCEPTION);
-		}
-	});
-});
+

--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -116,6 +116,8 @@ export async function oauthSignIn({
 	const { type, error, url } =
 		(await openAuthSession(oAuthUrl, redirectSignIn, preferPrivateSession)) ??
 		{};
+	// This code will run in RN applications only as calling signInWithRedirect will
+	// resolve the promise.
 	if (type === 'success' && url) {
 		// ensure the code exchange completion resolves the signInWithRedirect
 		// returned promise in react-native
@@ -129,6 +131,8 @@ export async function oauthSignIn({
 			preferPrivateSession,
 		});
 	}
+	// This code will run in RN applications only as calling signInWithRedirect will
+	// resolve the promise.
 	if (type === 'error') {
 		await handleFailure(String(error));
 	}
@@ -157,7 +161,7 @@ async function handleCodeFlow({
 		validatedState = await validateState(getStateFromURL(url));
 	} catch (err) {
 		invokeAndClearPromise();
-		
+		// validateState method will always throw an AuthError when the state is not valid. The if statement is making TS happy.
 		if (err instanceof AuthError) {
 			await handleFailure(err.message);
 		}
@@ -289,6 +293,7 @@ async function handleImplicitFlow({
 		validatedState = await validateState(state);
 	} catch (error) {
 		invokeAndClearPromise();
+		// validateState method will always throw an AuthError when the state is not valid. The if statement is making TS happy.
 		if (error instanceof AuthError) {
 			await handleFailure(error.message);
 		}

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -445,7 +445,7 @@
 			"name": "[Auth] OAuth Auth Flow (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ signInWithRedirect, signOut, fetchAuthSession }",
-			"limit": "19.61 kB"
+			"limit": "19.68 kB"
 		},
 		{
 			"name": "[Storage] copy (S3)",

--- a/packages/core/src/Hub/types/AuthTypes.ts
+++ b/packages/core/src/Hub/types/AuthTypes.ts
@@ -5,12 +5,19 @@ type AuthUser = {
 	username: string;
 	userId: string;
 };
-
+type AuthError = {
+	name: string;
+	message: string;
+	recoverySuggestion?: string;
+};
 export type AuthHubEventData =
 	/** Dispatched when a user signs in with an oauth provider such as Google.*/
 	| { event: 'signInWithRedirect' }
 	/** Dispatched when there is an error in the oauth flow process.*/
-	| { event: 'signInWithRedirect_failure' }
+	| {
+			event: 'signInWithRedirect_failure';
+			data: { error?: AuthError | unknown };
+	  }
 	/** Dispatched when auth tokens are successfully refreshed.*/
 	| { event: 'tokenRefresh' }
 	/** Dispatched when there is an error in the refresh of tokens.*/

--- a/packages/core/src/Hub/types/AuthTypes.ts
+++ b/packages/core/src/Hub/types/AuthTypes.ts
@@ -16,7 +16,7 @@ export type AuthHubEventData =
 	/** Dispatched when there is an error in the oauth flow process.*/
 	| {
 			event: 'signInWithRedirect_failure';
-			data: { error?: AuthError | unknown };
+			data: { error?: AuthError };
 	  }
 	/** Dispatched when auth tokens are successfully refreshed.*/
 	| { event: 'tokenRefresh' }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
In case of an oauth exception: 
- Web: Avoids Uncaught exception and dispatches a hub event
- RN: throws an error and dispatches a hub event

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

created a sample app in web and validated that the  library dispatches a `signInWithRedirect_failure` under the following circumstances: 
- `responseType` is `code` and there is an error returned from hostedUI 
- `responseType` is `code` and the oauth state is not valid
- `responseType` is `token` and there is an error returned from hostedUI 
- `responseType` is `token` and the oauth state is not valid

PR was validated in RN with the same testing criteria as above.
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
