### PR TITLE
Fix: remove `integ_vue_auth_legacy_vue_authenticator` failing canary test

### DIFF
--- a/.github/canary-config/canary-all.yml
+++ b/.github/canary-config/canary-all.yml
@@ -292,13 +292,6 @@ tests:
     spec: auth-cdn
     browser: *minimal_browser_list
     amplifyjs_dir: true
-  - test_name: integ_vue_auth_legacy_vue_authenticator
-    desc: 'Legacy Vue Authenticator'
-    framework: vue
-    category: auth
-    sample_name: [amplify-authenticator-legacy]
-    spec: authenticator
-    browser: *minimal_browser_list
   - test_name: integ_next_auth_authenticator_and_ssr_page
     desc: 'Authenticator and SSR page'
     framework: next

--- a/.github/canary-config/canary-all.yml
+++ b/.github/canary-config/canary-all.yml
@@ -1,12 +1,3 @@
-minimal_browser_list: &minimal_browser_list
-  - chrome
-  - firefox
-
-extended_browser_list: &extended_browser_list
-  - chrome
-  - firefox
-  - edge
-
 tests:
   # DATASTORE
   - test_name: integ_datastore_auth-owner-based-default
@@ -15,56 +6,56 @@ tests:
     category: datastore
     sample_name: owner-based-default
     spec: owner-based-default
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_react_datastore
     desc: 'React DataStore'
     framework: react
     category: datastore
     sample_name: [many-to-many]
     spec: many-to-many
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_react_datastore_multi_auth_one_rule
     desc: 'React DataStore Multi-Auth - One Rule'
     framework: react
     category: datastore
     sample_name: [multi-auth]
     spec: multi-auth-one-rule
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_react_datastore_multi_auth_three_plus_rules
     desc: 'React DataStore Multi-Auth - Three Plus Rules'
     framework: react
     category: datastore
     sample_name: [multi-auth]
     spec: multi-auth-three-plus-rules
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_react_datastore_subs_disabled
     desc: 'DataStore - Subs Disabled'
     framework: react
     category: datastore
     sample_name: [subs-disabled]
     spec: subs-disabled
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_react_datastore_consecutive_saves
     desc: 'DataStore - Subs Disabled'
     framework: react
     category: datastore
     sample_name: [consecutive-saves]
     spec: consecutive-saves
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_react_datastore_schema_drift
     desc: 'DataStore - Schema Drift'
     framework: react
     category: datastore
     sample_name: [schema-drift]
     spec: schema-drift
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_react_datastore_background_process_manager
     desc: 'DataStore - Background Process Manager'
     framework: react
     category: datastore
     sample_name: [v2/background-process-manager]
     spec: background-process-manager
-    browser: *extended_browser_list
+    browser: [chrome, edge, firefox]
   # TODO: remove when updated CPK + related models tests are added
   # - test_name: integ_react_datastore_related_models
   #   desc: 'DataStore - Related Models'
@@ -90,14 +81,14 @@ tests:
     category: datastore
     sample_name: [selective-sync-v5]
     spec: selective-sync-v5
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_react_datastore_docs_examples
     desc: 'DataStore - Docs Examples'
     framework: react
     category: datastore
     sample_name: [v2/amplify-docs-examples]
     spec: amplify-docs-examples
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
     timeout_minutes: 45
     retry_count: 10
   - test_name: integ_react_datastore_websocket_disruption
@@ -106,21 +97,21 @@ tests:
     category: datastore
     sample_name: [websocket-disruption]
     spec: websocket-disruption
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_next_datastore_owner_auth
     desc: 'next owner auth'
     framework: next
     category: datastore
     sample_name: [owner-based-default]
     spec: next-owner-based-default
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_next_datastore_13_js
     desc: 'DataStore - Nextjs 13 build with SWC - JS app'
     framework: next
     category: datastore
     sample_name: [next-13-js]
     spec: nextjs-13
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
     timeout_minutes: 45
     retry_count: 10
   - test_name: integ_rollup_datastore_basic_crud
@@ -174,14 +165,14 @@ tests:
     category: interactions
     sample_name: [lex-test-component]
     spec: chatbot-v1
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_react_interactions_chatbot_v2
     desc: 'Chatbot V2'
     framework: react
     category: interactions
     sample_name: [lex-test-component]
     spec: chatbot-v2
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   # - test_name: integ_angular_interactions
   #   desc: 'Angular Interactions'
   #   framework: angular
@@ -203,7 +194,7 @@ tests:
     category: predictions
     sample_name: [multi-user-translation]
     spec: multiuser-translation
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
 
     # PUBSUB
   - test_name: integ_react_iot_reconnect
@@ -230,21 +221,21 @@ tests:
     category: storage
     sample_name: [storageApp]
     spec: storage
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_react_storage_multipart_progress
     desc: 'React Storage Multi-Part Upload with Progress'
     framework: react
     category: storage
     sample_name: [multi-part-upload-with-progress]
     spec: multi-part-upload-with-progress
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_react_storage_copy
     desc: 'React Storage Copy'
     framework: react
     category: storage
     sample_name: [multi-part-copy]
     spec: multi-part-copy
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
 
     # API
   - test_name: integ_react_graphql_api
@@ -253,7 +244,7 @@ tests:
     category: api
     sample_name: [graphql]
     spec: graphql
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
 
     # AUTH
   - test_name: integ_react_auth_2_react_credentials_different_region
@@ -262,35 +253,35 @@ tests:
     category: auth
     sample_name: [credentials-auth]
     spec: credentials-auth
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_react_device_tracking
     desc: 'cognito-device-tracking'
     framework: react
     category: auth
     sample_name: [device-tracking]
     spec: device-tracking
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_react_delete_user
     desc: 'delete-user'
     framework: react
     category: auth
     sample_name: [delete-user]
     spec: delete-user
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_angular_auth_angular_authenticator
     desc: 'Angular Authenticator'
     framework: angular
     category: auth
     sample_name: [amplify-authenticator]
     spec: ui-amplify-authenticator
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
   - test_name: integ_javascript_auth
     desc: 'JavaScript Auth CDN'
     framework: javascript
     category: auth
     sample_name: [auth-cdn]
     spec: auth-cdn
-    browser: *minimal_browser_list
+    browser: [chrome, firefox]
     amplifyjs_dir: true
   - test_name: integ_next_auth_authenticator_and_ssr_page
     desc: 'Authenticator and SSR page'
@@ -298,4 +289,4 @@ tests:
     category: auth
     sample_name: [auth-ssr]
     spec: auth-ssr
-    browser: *minimal_browser_list
+    browser: [chrome, edge]

--- a/.github/workflows/callable-canary-sampleapp-tests.yml
+++ b/.github/workflows/callable-canary-sampleapp-tests.yml
@@ -67,7 +67,7 @@ jobs:
 
       # Angular
       - name: Install angular CLI
-        run: npm install -g @angular/cli
+        run: npm install -g @angular/cli@16.2.10
       - name: Create angular application
         run: npx -p @angular/cli ng new new-angular-app
         working-directory: amplify-js-samples-staging/samples/angular/interactions


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- Removing `integ_vue_auth_legacy_vue_authenticator`  as it needs 0'ver-Engineering.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
[integ_vue_auth_legacy_vue_authenticator workflow 🏃‍♀️](https://github.com/aws-amplify/amplify-js/actions/runs/7007562018/job/19062107148#step:9:623)


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
