### PR TITLE
fix(core): adapter-core: make SetCookieOptions fields optional

### DIFF
--- a/packages/core/src/adapterCore/serverContext/types/cookieStorage.ts
+++ b/packages/core/src/adapterCore/serverContext/types/cookieStorage.ts
@@ -4,9 +4,11 @@
 import { CookieSerializeOptions } from 'cookie';
 
 export namespace CookieStorage {
-	export type SetCookieOptions = Pick<
-		CookieSerializeOptions,
-		'domain' | 'expires' | 'httpOnly' | 'maxAge' | 'sameSite' | 'secure'
+	export type SetCookieOptions = Partial<
+		Pick<
+			CookieSerializeOptions,
+			'domain' | 'expires' | 'httpOnly' | 'maxAge' | 'sameSite' | 'secure'
+		>
 	>;
 
 	export type Cookie = {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Made SetCookieOptions fields optional

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
