### PR TITLE
chore: update generateClient tests to full snapshots

### DIFF
--- a/packages/api-graphql/__tests__/__snapshots__/generateClient.test.ts.snap
+++ b/packages/api-graphql/__tests__/__snapshots__/generateClient.test.ts.snap
@@ -1,0 +1,4417 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateClient basic model operations - authMode: CuP override at the time of operation can create() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: CreateTodoInput!) {
+  createTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "description": "something something",
+              "name": "some name",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override at the time of operation can delete() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: DeleteTodoInput!) {
+  deleteTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override at the time of operation can get() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "asdf",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override at the time of operation can lazy load with inherited authMode can lazy load @belongsTo 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getNote(id: $id) {
+    id
+    body
+    createdAt
+    updatedAt
+    todoNotesId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "note-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override at the time of operation can lazy load with inherited authMode can lazy load @hasMany 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      body
+      createdAt
+      updatedAt
+      todoNotesId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "and": [
+                {
+                  "todoNotesId": {
+                    "eq": "todo-id",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override at the time of operation can lazy load with inherited authMode can lazy load @hasOne 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodoMetadata(id: $id) {
+    id
+    data
+    createdAt
+    updatedAt
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "meta-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override at the time of operation can lazy load with overridden authMode can lazy load @belongsTo 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getNote(id: $id) {
+    id
+    body
+    createdAt
+    updatedAt
+    todoNotesId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "note-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override at the time of operation can lazy load with overridden authMode can lazy load @hasMany 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      body
+      createdAt
+      updatedAt
+      todoNotesId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "and": [
+                {
+                  "todoNotesId": {
+                    "eq": "todo-id",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override at the time of operation can lazy load with overridden authMode can lazy load @hasOne 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodoMetadata(id: $id) {
+    id
+    data
+    createdAt
+    updatedAt
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "meta-id",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override at the time of operation can list() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override at the time of operation can update() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: UpdateTodoInput!) {
+  updateTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+              "name": "some other name",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override in the client can create() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: CreateTodoInput!) {
+  createTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "description": "something something",
+              "name": "some name",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override in the client can delete() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: DeleteTodoInput!) {
+  deleteTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override in the client can get() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "asdf",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override in the client can lazy load with inherited authMode can lazy load @belongsTo 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getNote(id: $id) {
+    id
+    body
+    createdAt
+    updatedAt
+    todoNotesId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "note-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override in the client can lazy load with inherited authMode can lazy load @hasMany 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      body
+      createdAt
+      updatedAt
+      todoNotesId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "and": [
+                {
+                  "todoNotesId": {
+                    "eq": "todo-id",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override in the client can lazy load with inherited authMode can lazy load @hasOne 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodoMetadata(id: $id) {
+    id
+    data
+    createdAt
+    updatedAt
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "meta-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override in the client can lazy load with overridden authMode can lazy load @belongsTo 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getNote(id: $id) {
+    id
+    body
+    createdAt
+    updatedAt
+    todoNotesId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "note-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override in the client can lazy load with overridden authMode can lazy load @hasMany 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      body
+      createdAt
+      updatedAt
+      todoNotesId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "and": [
+                {
+                  "todoNotesId": {
+                    "eq": "todo-id",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override in the client can lazy load with overridden authMode can lazy load @hasOne 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodoMetadata(id: $id) {
+    id
+    data
+    createdAt
+    updatedAt
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "meta-id",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override in the client can list() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: CuP override in the client can update() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: UpdateTodoInput!) {
+  updateTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+              "name": "some other name",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override at the time of operation can create() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: CreateTodoInput!) {
+  createTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "description": "something something",
+              "name": "some name",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override at the time of operation can delete() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: DeleteTodoInput!) {
+  deleteTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override at the time of operation can get() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "asdf",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override at the time of operation can lazy load with inherited authMode can lazy load @belongsTo 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getNote(id: $id) {
+    id
+    body
+    createdAt
+    updatedAt
+    todoNotesId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "note-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override at the time of operation can lazy load with inherited authMode can lazy load @hasMany 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      body
+      createdAt
+      updatedAt
+      todoNotesId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "and": [
+                {
+                  "todoNotesId": {
+                    "eq": "todo-id",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override at the time of operation can lazy load with inherited authMode can lazy load @hasOne 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodoMetadata(id: $id) {
+    id
+    data
+    createdAt
+    updatedAt
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "meta-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override at the time of operation can lazy load with overridden authMode can lazy load @belongsTo 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getNote(id: $id) {
+    id
+    body
+    createdAt
+    updatedAt
+    todoNotesId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "note-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override at the time of operation can lazy load with overridden authMode can lazy load @hasMany 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      body
+      createdAt
+      updatedAt
+      todoNotesId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "and": [
+                {
+                  "todoNotesId": {
+                    "eq": "todo-id",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override at the time of operation can lazy load with overridden authMode can lazy load @hasOne 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodoMetadata(id: $id) {
+    id
+    data
+    createdAt
+    updatedAt
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "meta-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override at the time of operation can list() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override at the time of operation can update() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: UpdateTodoInput!) {
+  updateTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+              "name": "some other name",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override in the client can create() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: CreateTodoInput!) {
+  createTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "description": "something something",
+              "name": "some name",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override in the client can delete() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: DeleteTodoInput!) {
+  deleteTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override in the client can get() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "asdf",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override in the client can lazy load with inherited authMode can lazy load @belongsTo 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getNote(id: $id) {
+    id
+    body
+    createdAt
+    updatedAt
+    todoNotesId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "note-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override in the client can lazy load with inherited authMode can lazy load @hasMany 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      body
+      createdAt
+      updatedAt
+      todoNotesId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "and": [
+                {
+                  "todoNotesId": {
+                    "eq": "todo-id",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override in the client can lazy load with inherited authMode can lazy load @hasOne 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodoMetadata(id: $id) {
+    id
+    data
+    createdAt
+    updatedAt
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "meta-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override in the client can lazy load with overridden authMode can lazy load @belongsTo 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getNote(id: $id) {
+    id
+    body
+    createdAt
+    updatedAt
+    todoNotesId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "note-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override in the client can lazy load with overridden authMode can lazy load @hasMany 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      body
+      createdAt
+      updatedAt
+      todoNotesId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "and": [
+                {
+                  "todoNotesId": {
+                    "eq": "todo-id",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override in the client can lazy load with overridden authMode can lazy load @hasOne 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "Authorization": "test",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodoMetadata(id: $id) {
+    id
+    data
+    createdAt
+    updatedAt
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "meta-id",
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override in the client can list() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - authMode: lambda override in the client can update() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: UpdateTodoInput!) {
+  updateTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+              "name": "some other name",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "some-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - custom client and request headers can create() - with custom client header functions 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: CreateTodoInput!) {
+  createTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "description": "something something",
+              "name": "some name",
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "client-header-function": "should return this header",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - custom client and request headers can create() - with custom client headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: CreateTodoInput!) {
+  createTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "description": "something something",
+              "name": "some name",
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "client-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - custom client and request headers can create() - with custom request header function 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: CreateTodoInput!) {
+  createTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "description": "something something",
+              "name": "some name",
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "request-header-function": "should return this header",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - custom client and request headers can create() - with custom request headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: CreateTodoInput!) {
+  createTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "description": "something something",
+              "name": "some name",
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "request-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - custom client and request headers can delete() - with custom client headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: DeleteTodoInput!) {
+  deleteTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "client-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - custom client and request headers can delete() - with custom request headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: DeleteTodoInput!) {
+  deleteTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "request-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - custom client and request headers can get() - with custom client headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "asdf",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "client-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - custom client and request headers can get() - with custom request headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "asdf",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "request-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - custom client and request headers can list() - with custom client headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "client-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - custom client and request headers can list() - with custom request headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "request-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - custom client and request headers can update() - with custom client headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: UpdateTodoInput!) {
+  updateTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+              "name": "some other name",
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "client-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations - custom client and request headers can update() - with custom request headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: UpdateTodoInput!) {
+  updateTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+              "name": "some other name",
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "request-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can create() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: CreateTodoInput!) {
+  createTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "description": "something something",
+              "name": "some name",
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can delete() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: DeleteTodoInput!) {
+  deleteTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can get() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "asdf",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can lazy load @belongsTo 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getNote(id: $id) {
+    id
+    body
+    createdAt
+    updatedAt
+    todoNotesId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "note-id",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can lazy load @hasMany 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      body
+      createdAt
+      updatedAt
+      todoNotesId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "and": [
+                {
+                  "todoNotesId": {
+                    "eq": "todo-id",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can lazy load @hasMany with limit 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      body
+      createdAt
+      updatedAt
+      todoNotesId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "and": [
+                {
+                  "todoNotesId": {
+                    "eq": "todo-id",
+                  },
+                },
+              ],
+            },
+            "limit": 5,
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can lazy load @hasMany with nextToken 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      body
+      createdAt
+      updatedAt
+      todoNotesId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "and": [
+                {
+                  "todoNotesId": {
+                    "eq": "todo-id",
+                  },
+                },
+              ],
+            },
+            "nextToken": "some-token",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can lazy load @hasOne 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "todo-id",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodoMetadata(id: $id) {
+    id
+    data
+    createdAt
+    updatedAt
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "meta-id",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can list() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can list() with limit 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+            "limit": 5,
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can list() with nextToken 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+            "nextToken": "some-token",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can update() 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: UpdateTodoInput!) {
+  updateTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+              "name": "some other name",
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations with Amplify configuration options headers can create() - custom client headers should not overwrite library config headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: CreateTodoInput!) {
+  createTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "description": "something something",
+              "name": "some name",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "client-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations with Amplify configuration options headers can create() - custom request headers should not overwrite library config headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: CreateTodoInput!) {
+  createTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "description": "something something",
+              "name": "some name",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "request-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations with Amplify configuration options headers can create() - with library config headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: CreateTodoInput!) {
+  createTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "description": "something something",
+              "name": "some name",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "client-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations with Amplify configuration options headers can delete() - custom client headers should not overwrite library config headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: DeleteTodoInput!) {
+  deleteTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "client-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations with Amplify configuration options headers can delete() - custom request headers should overwrite client headers but not library config headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: DeleteTodoInput!) {
+  deleteTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "request-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations with Amplify configuration options headers can get() - custom client headers should not overwrite library config headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "asdf",
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "client-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations with Amplify configuration options headers can get() - custom request headers overwrite client headers, but not library config headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($id: ID!) {
+  getTodo(id: $id) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "id": "asdf",
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "request-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations with Amplify configuration options headers can list() - custom client headers should not overwrite library config headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "client-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations with Amplify configuration options headers can list() - custom request headers should overwrite client headers but not library config headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "request-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations with Amplify configuration options headers can update() - custom client headers should not overwrite library config headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: UpdateTodoInput!) {
+  updateTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+              "name": "some other name",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "client-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations with Amplify configuration options headers can update() - custom request headers should overwrite client headers but not library config headers 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "mutation ($input: UpdateTodoInput!) {
+  updateTodo(input: $input) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    todoMetaId
+    owner
+  }
+}
+",
+          "variables": {
+            "input": {
+              "id": "some-id",
+              "name": "some other name",
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "request-header": "should exist",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient graphql - client-level auth override client auth override query - lambda 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "{
+  listTodos {
+    __typename
+    id
+    owner
+    createdAt
+    updatedAt
+    name
+    description
+  }
+}
+",
+          "variables": {},
+        },
+        "headers": {
+          "Authorization": "trustno1",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient graphql - client-level auth override client auth override query 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "{
+  listTodos {
+    __typename
+    id
+    owner
+    createdAt
+    updatedAt
+    name
+    description
+  }
+}
+",
+          "variables": {},
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient graphql default auth default iam produces expected signingInfo 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "{
+  listTodos {
+    __typename
+    id
+    owner
+    createdAt
+    updatedAt
+    name
+    description
+  }
+}
+",
+          "variables": {},
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": {
+          "region": "us-west-1",
+          "service": "appsync",
+        },
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient observeQuery can paginate through initial results 1`] = `
+[
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {},
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+  [
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      name
+      description
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "nextToken": "sometoken",
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

There are no functional changes.

This PR only updates the `generateClient` tests to use full snapshots to validate post requests instead of cherrypicking invariants to test on. The jest spy calls are "normalized" to eliminate portions that would otherwise change from version to version of the library.

This is being done to perform more precise and comprehensive validation of all aspects of requests made to `post()`.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
