### PR TITLE
fix(api-graphql): fix missing model enum in default selection sets

### DIFF
--- a/packages/api-graphql/__tests__/APIClient.test.ts
+++ b/packages/api-graphql/__tests__/APIClient.test.ts
@@ -301,7 +301,7 @@ describe('flattenItems', () => {
 			const selSet = generateSelectionSet(modelIntroSchema.models, 'Todo');
 
 			const expected =
-				'id name description createdAt updatedAt todoMetaId owner';
+				'id name description status createdAt updatedAt todoMetaId owner';
 
 			expect(selSet).toEqual(expected);
 		});

--- a/packages/api-graphql/__tests__/APIClient.test.ts
+++ b/packages/api-graphql/__tests__/APIClient.test.ts
@@ -301,7 +301,7 @@ describe('flattenItems', () => {
 			const selSet = generateSelectionSet(modelIntroSchema.models, 'Todo');
 
 			const expected =
-				'id name description status createdAt updatedAt todoMetaId owner';
+				'id name description status tags createdAt updatedAt todoMetaId owner';
 
 			expect(selSet).toEqual(expected);
 		});

--- a/packages/api-graphql/__tests__/__snapshots__/generateClient.test.ts.snap
+++ b/packages/api-graphql/__tests__/__snapshots__/generateClient.test.ts.snap
@@ -13,6 +13,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -56,6 +57,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -98,6 +100,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -171,6 +174,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -211,6 +215,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -296,6 +301,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -401,6 +407,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -438,6 +445,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -520,6 +528,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -590,6 +599,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
       name
       description
       status
+      tags
       createdAt
       updatedAt
       todoMetaId
@@ -637,6 +647,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -680,6 +691,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -723,6 +735,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -765,6 +778,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -838,6 +852,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -878,6 +893,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -963,6 +979,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1068,6 +1085,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1105,6 +1123,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1187,6 +1206,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1257,6 +1277,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
       name
       description
       status
+      tags
       createdAt
       updatedAt
       todoMetaId
@@ -1304,6 +1325,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1347,6 +1369,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1390,6 +1413,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1432,6 +1456,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1505,6 +1530,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1545,6 +1571,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1630,6 +1657,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1735,6 +1763,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1775,6 +1804,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1860,6 +1890,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -1933,6 +1964,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
       name
       description
       status
+      tags
       createdAt
       updatedAt
       todoMetaId
@@ -1980,6 +2012,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2023,6 +2056,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2066,6 +2100,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2108,6 +2143,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2181,6 +2217,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2221,6 +2258,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2306,6 +2344,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2411,6 +2450,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2451,6 +2491,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2536,6 +2577,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2609,6 +2651,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
       name
       description
       status
+      tags
       createdAt
       updatedAt
       todoMetaId
@@ -2656,6 +2699,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2699,6 +2743,7 @@ exports[`generateClient basic model operations - custom client and request heade
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2740,6 +2785,7 @@ exports[`generateClient basic model operations - custom client and request heade
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2781,6 +2827,7 @@ exports[`generateClient basic model operations - custom client and request heade
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2822,6 +2869,7 @@ exports[`generateClient basic model operations - custom client and request heade
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2863,6 +2911,7 @@ exports[`generateClient basic model operations - custom client and request heade
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2903,6 +2952,7 @@ exports[`generateClient basic model operations - custom client and request heade
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2943,6 +2993,7 @@ exports[`generateClient basic model operations - custom client and request heade
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -2981,6 +3032,7 @@ exports[`generateClient basic model operations - custom client and request heade
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3020,6 +3072,7 @@ exports[`generateClient basic model operations - custom client and request heade
       name
       description
       status
+      tags
       createdAt
       updatedAt
       todoMetaId
@@ -3066,6 +3119,7 @@ exports[`generateClient basic model operations - custom client and request heade
       name
       description
       status
+      tags
       createdAt
       updatedAt
       todoMetaId
@@ -3111,6 +3165,7 @@ exports[`generateClient basic model operations - custom client and request heade
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3152,6 +3207,7 @@ exports[`generateClient basic model operations - custom client and request heade
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3193,6 +3249,7 @@ exports[`generateClient basic model operations can create() 1`] = `
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3233,6 +3290,7 @@ exports[`generateClient basic model operations can delete() 1`] = `
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3272,6 +3330,7 @@ exports[`generateClient basic model operations can get() 1`] = `
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3339,6 +3398,7 @@ exports[`generateClient basic model operations can lazy load @belongsTo 1`] = `
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3376,6 +3436,7 @@ exports[`generateClient basic model operations can lazy load @hasMany 1`] = `
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3455,6 +3516,7 @@ exports[`generateClient basic model operations can lazy load @hasMany with limit
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3535,6 +3597,7 @@ exports[`generateClient basic model operations can lazy load @hasMany with nextT
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3615,6 +3678,7 @@ exports[`generateClient basic model operations can lazy load @hasOne 1`] = `
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3682,6 +3746,7 @@ exports[`generateClient basic model operations can list() 1`] = `
       name
       description
       status
+      tags
       createdAt
       updatedAt
       todoMetaId
@@ -3727,6 +3792,7 @@ exports[`generateClient basic model operations can list() with limit 1`] = `
       name
       description
       status
+      tags
       createdAt
       updatedAt
       todoMetaId
@@ -3773,6 +3839,7 @@ exports[`generateClient basic model operations can list() with nextToken 1`] = `
       name
       description
       status
+      tags
       createdAt
       updatedAt
       todoMetaId
@@ -3818,6 +3885,7 @@ exports[`generateClient basic model operations can update() 1`] = `
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3858,6 +3926,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3900,6 +3969,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3942,6 +4012,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -3984,6 +4055,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -4025,6 +4097,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -4066,6 +4139,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -4105,6 +4179,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -4145,6 +4220,7 @@ exports[`generateClient basic model operations with Amplify configuration option
       name
       description
       status
+      tags
       createdAt
       updatedAt
       todoMetaId
@@ -4192,6 +4268,7 @@ exports[`generateClient basic model operations with Amplify configuration option
       name
       description
       status
+      tags
       createdAt
       updatedAt
       todoMetaId
@@ -4238,6 +4315,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -4280,6 +4358,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     name
     description
     status
+    tags
     createdAt
     updatedAt
     todoMetaId
@@ -4434,6 +4513,7 @@ exports[`generateClient observeQuery can paginate through initial results 1`] = 
       name
       description
       status
+      tags
       createdAt
       updatedAt
       todoMetaId
@@ -4469,6 +4549,7 @@ exports[`generateClient observeQuery can paginate through initial results 1`] = 
       name
       description
       status
+      tags
       createdAt
       updatedAt
       todoMetaId

--- a/packages/api-graphql/__tests__/__snapshots__/generateClient.test.ts.snap
+++ b/packages/api-graphql/__tests__/__snapshots__/generateClient.test.ts.snap
@@ -12,6 +12,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -54,6 +55,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -95,6 +97,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -167,6 +170,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -206,6 +210,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -290,6 +295,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -394,6 +400,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -430,6 +437,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -511,6 +519,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -580,6 +589,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
       id
       name
       description
+      status
       createdAt
       updatedAt
       todoMetaId
@@ -626,6 +636,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -668,6 +679,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -710,6 +722,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -751,6 +764,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -823,6 +837,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -862,6 +877,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -946,6 +962,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1050,6 +1067,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1086,6 +1104,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1167,6 +1186,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1236,6 +1256,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
       id
       name
       description
+      status
       createdAt
       updatedAt
       todoMetaId
@@ -1282,6 +1303,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1324,6 +1346,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1366,6 +1389,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1407,6 +1431,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1479,6 +1504,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1518,6 +1544,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1602,6 +1629,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1706,6 +1734,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1745,6 +1774,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1829,6 +1859,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1901,6 +1932,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
       id
       name
       description
+      status
       createdAt
       updatedAt
       todoMetaId
@@ -1947,6 +1979,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -1989,6 +2022,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2031,6 +2065,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2072,6 +2107,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2144,6 +2180,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2183,6 +2220,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2267,6 +2305,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2371,6 +2410,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2410,6 +2450,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2494,6 +2535,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2566,6 +2608,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
       id
       name
       description
+      status
       createdAt
       updatedAt
       todoMetaId
@@ -2612,6 +2655,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2654,6 +2698,7 @@ exports[`generateClient basic model operations - custom client and request heade
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2694,6 +2739,7 @@ exports[`generateClient basic model operations - custom client and request heade
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2734,6 +2780,7 @@ exports[`generateClient basic model operations - custom client and request heade
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2774,6 +2821,7 @@ exports[`generateClient basic model operations - custom client and request heade
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2814,6 +2862,7 @@ exports[`generateClient basic model operations - custom client and request heade
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2853,6 +2902,7 @@ exports[`generateClient basic model operations - custom client and request heade
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2892,6 +2942,7 @@ exports[`generateClient basic model operations - custom client and request heade
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2929,6 +2980,7 @@ exports[`generateClient basic model operations - custom client and request heade
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -2967,6 +3019,7 @@ exports[`generateClient basic model operations - custom client and request heade
       id
       name
       description
+      status
       createdAt
       updatedAt
       todoMetaId
@@ -3012,6 +3065,7 @@ exports[`generateClient basic model operations - custom client and request heade
       id
       name
       description
+      status
       createdAt
       updatedAt
       todoMetaId
@@ -3056,6 +3110,7 @@ exports[`generateClient basic model operations - custom client and request heade
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3096,6 +3151,7 @@ exports[`generateClient basic model operations - custom client and request heade
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3136,6 +3192,7 @@ exports[`generateClient basic model operations can create() 1`] = `
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3175,6 +3232,7 @@ exports[`generateClient basic model operations can delete() 1`] = `
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3213,6 +3271,7 @@ exports[`generateClient basic model operations can get() 1`] = `
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3279,6 +3338,7 @@ exports[`generateClient basic model operations can lazy load @belongsTo 1`] = `
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3315,6 +3375,7 @@ exports[`generateClient basic model operations can lazy load @hasMany 1`] = `
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3393,6 +3454,7 @@ exports[`generateClient basic model operations can lazy load @hasMany with limit
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3472,6 +3534,7 @@ exports[`generateClient basic model operations can lazy load @hasMany with nextT
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3551,6 +3614,7 @@ exports[`generateClient basic model operations can lazy load @hasOne 1`] = `
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3617,6 +3681,7 @@ exports[`generateClient basic model operations can list() 1`] = `
       id
       name
       description
+      status
       createdAt
       updatedAt
       todoMetaId
@@ -3661,6 +3726,7 @@ exports[`generateClient basic model operations can list() with limit 1`] = `
       id
       name
       description
+      status
       createdAt
       updatedAt
       todoMetaId
@@ -3706,6 +3772,7 @@ exports[`generateClient basic model operations can list() with nextToken 1`] = `
       id
       name
       description
+      status
       createdAt
       updatedAt
       todoMetaId
@@ -3750,6 +3817,7 @@ exports[`generateClient basic model operations can update() 1`] = `
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3789,6 +3857,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3830,6 +3899,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3871,6 +3941,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3912,6 +3983,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3952,6 +4024,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -3992,6 +4065,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -4030,6 +4104,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -4069,6 +4144,7 @@ exports[`generateClient basic model operations with Amplify configuration option
       id
       name
       description
+      status
       createdAt
       updatedAt
       todoMetaId
@@ -4115,6 +4191,7 @@ exports[`generateClient basic model operations with Amplify configuration option
       id
       name
       description
+      status
       createdAt
       updatedAt
       todoMetaId
@@ -4160,6 +4237,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -4201,6 +4279,7 @@ exports[`generateClient basic model operations with Amplify configuration option
     id
     name
     description
+    status
     createdAt
     updatedAt
     todoMetaId
@@ -4354,6 +4433,7 @@ exports[`generateClient observeQuery can paginate through initial results 1`] = 
       id
       name
       description
+      status
       createdAt
       updatedAt
       todoMetaId
@@ -4388,6 +4468,7 @@ exports[`generateClient observeQuery can paginate through initial results 1`] = 
       id
       name
       description
+      status
       createdAt
       updatedAt
       todoMetaId

--- a/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.js
+++ b/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.js
@@ -63,15 +63,15 @@ const amplifyConfig = {
 							targetNames: ['todoMetaId'],
 						},
 					},
-					"status": {
-						"name": "status",
-						"isArray": false,
-						"type": {
-						  "enum": "Status"
+					status: {
+						name: 'status',
+						isArray: false,
+						type: {
+							enum: 'Status',
 						},
-						"isRequired": false,
-						"attributes": []
-					  },
+						isRequired: false,
+						attributes: [],
+					},
 					createdAt: {
 						name: 'createdAt',
 						isArray: false,
@@ -615,17 +615,12 @@ const amplifyConfig = {
 				},
 			},
 		},
-		"enums": {
-			"Status": {
-			  "name": "Status",
-			  "values": [
-				"NOT_STARTED",
-				"STARTED",
-				"DONE",
-				"CANCELED"
-			  ]
-			}
-		  },
+		enums: {
+			Status: {
+				name: 'Status',
+				values: ['NOT_STARTED', 'STARTED', 'DONE', 'CANCELED'],
+			},
+		},
 		nonModels: {},
 	},
 };

--- a/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.js
+++ b/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.js
@@ -63,6 +63,15 @@ const amplifyConfig = {
 							targetNames: ['todoMetaId'],
 						},
 					},
+					"status": {
+						"name": "status",
+						"isArray": false,
+						"type": {
+						  "enum": "Status"
+						},
+						"isRequired": false,
+						"attributes": []
+					  },
 					createdAt: {
 						name: 'createdAt',
 						isArray: false,
@@ -606,7 +615,17 @@ const amplifyConfig = {
 				},
 			},
 		},
-		enums: {},
+		"enums": {
+			"Status": {
+			  "name": "Status",
+			  "values": [
+				"NOT_STARTED",
+				"STARTED",
+				"DONE",
+				"CANCELED"
+			  ]
+			}
+		  },
 		nonModels: {},
 	},
 };

--- a/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.js
+++ b/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.js
@@ -72,6 +72,14 @@ const amplifyConfig = {
 						isRequired: false,
 						attributes: [],
 					},
+					tags: {
+						name: 'tags',
+						isArray: true,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+						isArrayNullable: true,
+					},
 					createdAt: {
 						name: 'createdAt',
 						isArray: false,

--- a/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
@@ -7,6 +7,7 @@ const schema = a.schema({
 			description: a.string(),
 			notes: a.hasMany('Note'),
 			meta: a.hasOne('TodoMetadata'),
+			status: a.enum(["NOT_STARTED", "STARTED", "DONE", "CANCELED"]),
 		})
 		.authorization([a.allow.public('apiKey'), a.allow.owner()]),
 	Note: a

--- a/packages/api-graphql/src/internals/APIClient.ts
+++ b/packages/api-graphql/src/internals/APIClient.ts
@@ -319,9 +319,12 @@ function defaultSelectionSetForModel(modelDefinition: SchemaModel): string[] {
 	const { fields } = modelDefinition;
 	const explicitFields = Object.values<any>(fields)
 		// Default selection set omits model fields
-		.map(({ type, name }) =>
-			(typeof type === 'string'
-			|| (typeof type === 'object' && typeof type?.enum === 'string')) && name)
+		.map(
+			({ type, name }) =>
+				(typeof type === 'string' ||
+					(typeof type === 'object' && typeof type?.enum === 'string')) &&
+				name
+		)
 		.filter(Boolean);
 
 	// fields used for owner auth rules that may or may not also

--- a/packages/api-graphql/src/internals/APIClient.ts
+++ b/packages/api-graphql/src/internals/APIClient.ts
@@ -318,7 +318,10 @@ function defaultSelectionSetForModel(modelDefinition: SchemaModel): string[] {
 	// inferred from owner auth rules.
 	const { fields } = modelDefinition;
 	const explicitFields = Object.values<any>(fields)
-		.map(({ type, name }) => typeof type === 'string' && name) // Default selection set omits model fields
+		// Default selection set omits model fields
+		.map(({ type, name }) =>
+			(typeof type === 'string'
+			|| (typeof type === 'object' && typeof type?.enum === 'string')) && name)
 		.filter(Boolean);
 
 	// fields used for owner auth rules that may or may not also


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Enum fields were missing from default selection sets due to field filtering which was intended to only filter out related model fields.

Also adds the missing `tags` field to the model intro schema test fixture.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

1. Red/Green testing.
2. Manually confirmed in a sample app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
