### PR TITLE
fix(datastore): Change outbox comparison to allow partial matching

### DIFF
--- a/packages/datastore/__tests__/connectivityHandling.test.ts
+++ b/packages/datastore/__tests__/connectivityHandling.test.ts
@@ -978,8 +978,7 @@ describe('DataStore sync engine', () => {
 				const retrieved = await DataStore.query(Post, postId);
 
 				await DataStore.save(
-					// @ts-ignore
-					Post.copyOf(retrieved, updated => {
+					Post.copyOf(retrieved!, updated => {
 						updated.title = updatedTitle;
 					})
 				);
@@ -1022,8 +1021,7 @@ describe('DataStore sync engine', () => {
 				// Validate that `query` returns the latest `title` and `_version`:
 				const queryResult = await DataStore.query(Post, postId);
 				expect(queryResult?.title).toEqual(title);
-				// @ts-ignore
-				expect(queryResult?._version).toEqual(version);
+				expect(queryResult!['_version'].toEqual(version));
 
 				if (blogId) expect(queryResult?.blogId).toEqual(blogId);
 			};
@@ -1040,9 +1038,7 @@ describe('DataStore sync engine', () => {
 						if (opType === 'UPDATE') {
 							const response: SubscriptionLogTuple = [
 								element.title,
-								// No, TypeScript, there is a version:
-								// @ts-ignore
-								element._version,
+								element['_version'],
 							];
 							// Track sequence of versions and titles
 							subscriptionLog.push(response);
@@ -1115,13 +1111,13 @@ describe('DataStore sync engine', () => {
 						['post title 0', 1],
 						['post title 1', 1],
 						['post title 2', 1],
-						['post title 0', 3],
+						['post title 2', 3],
 					]);
 
 					expectFinalRecordsToMatch({
 						postId: original.id,
 						version: 3,
-						title: 'post title 0',
+						title: 'post title 2',
 					});
 				});
 				test('rapid mutations on fast connection when initial create is not pending', async () => {
@@ -1176,13 +1172,13 @@ describe('DataStore sync engine', () => {
 						['post title 0', 1],
 						['post title 1', 1],
 						['post title 2', 1],
-						['post title 0', 4],
+						['post title 2', 4],
 					]);
 
 					expectFinalRecordsToMatch({
 						postId: original.id,
 						version: 4,
-						title: 'post title 0',
+						title: 'post title 2',
 					});
 				});
 				test('rapid mutations on poor connection when initial create is pending', async () => {
@@ -1463,9 +1459,7 @@ describe('DataStore sync engine', () => {
 							if (opType === 'UPDATE') {
 								const response: SubscriptionLogTuple = [
 									element.title,
-									// No, TypeScript, there is a version:
-									// @ts-ignore
-									element._version,
+									element['_version'],
 								];
 								// Track sequence of versions and titles
 								subscriptionLog.push(response);
@@ -1703,10 +1697,8 @@ describe('DataStore sync engine', () => {
 						await DataStore.observe(Post).subscribe(({ opType, element }) => {
 							const response: SubscriptionLogMultiField = [
 								element.title,
-								// @ts-ignore
-								element.blogId,
-								// @ts-ignore
-								element._version,
+								element.blogId!,
+								element['_version'],
 							];
 							subscriptionLog.push(response);
 						});
@@ -2187,9 +2179,8 @@ describe('DataStore sync engine', () => {
 			};
 
 			await resyncWith([
-				syncExpression(
-					LegacyJSONPost,
-					p => p?.title.eq("whatever, it doesn't matter.")
+				syncExpression(LegacyJSONPost, p =>
+					p?.title.eq("whatever, it doesn't matter.")
 				),
 			]);
 

--- a/packages/datastore/__tests__/connectivityHandling.test.ts
+++ b/packages/datastore/__tests__/connectivityHandling.test.ts
@@ -1021,7 +1021,8 @@ describe('DataStore sync engine', () => {
 				// Validate that `query` returns the latest `title` and `_version`:
 				const queryResult = await DataStore.query(Post, postId);
 				expect(queryResult?.title).toEqual(title);
-				expect(queryResult!['_version'].toEqual(version));
+				// @ts-ignore
+				expect(queryResult?._version).toEqual(version);
 
 				if (blogId) expect(queryResult?.blogId).toEqual(blogId);
 			};
@@ -1038,7 +1039,9 @@ describe('DataStore sync engine', () => {
 						if (opType === 'UPDATE') {
 							const response: SubscriptionLogTuple = [
 								element.title,
-								element['_version'],
+								// No, TypeScript, there is a version:
+								// @ts-ignore
+								element._version,
 							];
 							// Track sequence of versions and titles
 							subscriptionLog.push(response);
@@ -1459,7 +1462,9 @@ describe('DataStore sync engine', () => {
 							if (opType === 'UPDATE') {
 								const response: SubscriptionLogTuple = [
 									element.title,
-									element['_version'],
+									// No, TypeScript, there is a version:
+									// @ts-ignore
+									element._version,
 								];
 								// Track sequence of versions and titles
 								subscriptionLog.push(response);
@@ -1697,8 +1702,10 @@ describe('DataStore sync engine', () => {
 						await DataStore.observe(Post).subscribe(({ opType, element }) => {
 							const response: SubscriptionLogMultiField = [
 								element.title,
-								element.blogId!,
-								element['_version'],
+								// @ts-ignore
+								element.blogId,
+								// @ts-ignore
+								element._version,
 							];
 							subscriptionLog.push(response);
 						});

--- a/packages/datastore/__tests__/utils.test.ts
+++ b/packages/datastore/__tests__/utils.test.ts
@@ -14,7 +14,7 @@ import {
 	countFilterCombinations,
 	repeatedFieldInGroup,
 } from '../src/sync/utils';
-import { DeferredCallbackResolver } from '../src/util';
+import { DeferredCallbackResolver, objectMatches } from '../src/util';
 
 describe('DataStore - utils', () => {
 	describe('generateSelectionSet', () => {
@@ -880,6 +880,33 @@ _deleted`;
 			};
 
 			expect(countFilterCombinations(group2)).toEqual(3);
+		});
+	});
+	describe('objectMatches', () => {
+		test('shallow comparison match', () => {
+			const valA = { a: 1, b: 2 };
+			const valB = { a: 1, b: 2, c: 3 };
+			expect(objectMatches(valA, valB)).toEqual(true);
+		});
+		test('shallow comparison mismatch', () => {
+			const valA = { a: 1, b: 2, c: 3 };
+			const valB = { a: 1, b: 2 };
+			expect(objectMatches(valA, valB)).toEqual(false);
+		});
+		test('nested comparison match', () => {
+			const valA = { outer: { a: 1, b: 2, c: 3 } };
+			const valB = { outer: { a: 1, b: 2, c: 3 }, otherValue: { a: 'a' } };
+			expect(objectMatches(valA, valB)).toEqual(true);
+		});
+		test('nested comparison mismatch', () => {
+			const valA = { outer: { a: 1, b: 2, c: 3 } };
+			const valB = { outer: { a: 1, b: 2 }, otherValue: { a: 'a' } };
+			expect(objectMatches(valA, valB)).toEqual(false);
+		});
+		test('nested comparison mismatch without full equality', () => {
+			const valA = { outer: { a: 1, b: 2 } };
+			const valB = { outer: { a: 1, b: 2, c: 3 }, otherValue: { a: 'a' } };
+			expect(objectMatches(valA, valB)).toEqual(false);
 		});
 	});
 });

--- a/packages/datastore/src/sync/outbox.ts
+++ b/packages/datastore/src/sync/outbox.ts
@@ -15,7 +15,7 @@ import {
 	QueryOne,
 	SchemaModel,
 } from '../types';
-import { USER, SYNC, valuesEqual } from '../util';
+import { USER, SYNC, objectMatches } from '../util';
 import { getIdentifierValue, TransformerMutationType } from './utils';
 
 // TODO: Persist deleted ids
@@ -193,10 +193,12 @@ class MutationEventOutbox {
 		// Don't sync the version when the data in the response does not match the data
 		// in the request, i.e., when there's a handled conflict
 		//
-		// NOTE: `incomingData` contains all the fields in the record, and `outgoingData`
-		// only contains updated fields, resulting in an error when doing a comparison
-		// of two equal mutations. Fix this, or mitigate otherwise.
-		if (!valuesEqual(incomingData, outgoingData, true)) {
+		// NOTE: `incomingData` contains all the fields in the record received from AppSync
+		// and `outgoingData` only contains updated fields sent to AppSync
+		// If all send data isn't matched in the returned data then the update was rejected
+		// by AppSync and we should not update the version on other outbox entries for this
+		// object
+		if (!objectMatches(outgoingData, incomingData, true)) {
 			return;
 		}
 

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -473,6 +473,32 @@ export function sortCompareFunction<T extends PersistentModel>(
 	};
 }
 
+/* deep directed comparison ensuring that all fields on object A exist and are equal to values on object B
+ * Note: This same guarauntee is not applied for values on object B that aren't on object A
+ *
+ * @param valA - The object that may be an equal subset of valB.
+ * @param valB - The object that may be an equal superset of valA.
+ * @returns True if valA is a equal subset of valB and False otherwise.
+ */
+export function objectMatches(
+	valA: object,
+	valB: object,
+	nullish: boolean = false
+) {
+	const aKeys = Object.keys(valA);
+
+	for (const key of aKeys) {
+		const aVal = valA[key];
+		const bVal = valB[key];
+
+		if (!valuesEqual(aVal, bVal, nullish)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 // deep compare any 2 values
 // primitives or object types (including arrays, Sets, and Maps)
 // returns true if equal by value


### PR DESCRIPTION
#### Description of changes
**Brief:** When multiple object updates for a single DataStore object are queued in the outbox to be synced to AppSync, comparison logic is overly strict and as a result only the first update is successfully applied. As a result Datastore appears to accept each update before reverting to the first update made while the outbox was queuing.

We have a number of tests the exercise variations on the problem and may be helpful to review. [Example](https://github.com/aws-amplify/amplify-js/blob/main/packages/datastore/__tests__/connectivityHandling.test.ts#L1129-L1180)


**Context:** When model changes are queued up in the outbox, `_version` field updates are passed on to other updates to the same object that are queued up in the outbox **IF** the object being processed is exactly and deeply equal to the return value from the AppSync update.

**Problem:** Updates send partial models to AppSync, for which AppSync returns complete models. These complete models may contain the same fields that are sent for update, but by also including all other fields, these fail the equality match and as a result we don't update the other objects queued up in the outbox. Since these objects don't receive the updated `_version`, they are rejected by AppSync conflict resolution and the object in Datastore reverts to the last saved content.

**Proposed fix:** Instead of comparing all fields, compare only the fields being updated when checking equality before updating object versions in the outbox.

**Example:**
Object sent to AppSync as an update (when updating only the title
`{title: 'post title 0', id: '1a94e616-506c-47f0-8dbc-db81f264e7e8'}`

Object returned from AppSync after successfully updating
`{id: '1a94e616-506c-47f0-8dbc-db81f264e7e8', title: 'post title 0', order: 348, altText: 'Alt Text - 617', blogPostsId: '52ba510d-5233-4866-a531-1563291d72b1', …}`

While these are obviously not an exact full equality match, all fields from the input object are exactly the same as the output object.

#### Description of how you validated changes
- Updated unit tests
- Added tests around the new `objectMatches` comparison function
- Tested in a sample application

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
