### PR TITLE
feat(api): expose generateClient from /server subpath

### DIFF
--- a/packages/api-graphql/__tests__/internals/server/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/internals/server/generateClient.test.ts
@@ -1,0 +1,328 @@
+import * as raw from '../../../src';
+import { Amplify, ResourcesConfig } from '@aws-amplify/core';
+import { generateClientWithAmplifyInstance } from '../../../src/internals/server';
+import configFixture from '../../fixtures/modeled/amplifyconfiguration';
+import { Schema } from '../../fixtures/modeled/schema';
+import { V6ClientSSRRequest, V6ClientSSRCookies } from '../../../src/types';
+
+const serverManagedFields = {
+	id: 'some-id',
+	owner: 'wirejobviously',
+	createdAt: new Date().toISOString(),
+	updatedAt: new Date().toISOString(),
+};
+
+const config: ResourcesConfig = {
+	API: {
+		GraphQL: {
+			apiKey: 'apikey',
+			customEndpoint: undefined,
+			customEndpointRegion: undefined,
+			defaultAuthMode: 'apiKey',
+			endpoint: 'https://0.0.0.0/graphql',
+			region: 'us-east-1',
+		},
+	},
+};
+
+/**
+ *
+ * @param value Value to be returned. Will be `awaited`, and can
+ * therefore be a simple JSON value or a `Promise`.
+ * @returns
+ */
+function mockApiResponse(value: any) {
+	return jest
+		.spyOn((raw.GraphQLAPI as any)._api, 'post')
+		.mockImplementation(async () => {
+			const result = await value;
+			return {
+				body: {
+					json: () => result,
+				},
+			};
+		});
+}
+
+describe('server generateClient', () => {
+	describe('with cookies', () => {
+		test('subscriptions are disabled', () => {
+			const getAmplify = async (fn: any) => await fn(Amplify);
+
+			const client = generateClientWithAmplifyInstance<
+				Schema,
+				V6ClientSSRCookies<Schema>
+			>({
+				amplify: getAmplify,
+				config: config,
+			});
+
+			expect(() => {
+				// @ts-expect-error
+				client.models.Note.onCreate().subscribe();
+			}).toThrow();
+		});
+
+		test('can list', async () => {
+			Amplify.configure(configFixture as any);
+			const config = Amplify.getConfig();
+
+			const spy = mockApiResponse({
+				data: {
+					listTodos: {
+						items: [
+							{
+								__typename: 'Todo',
+								...serverManagedFields,
+								name: 'some name',
+								description: 'something something',
+							},
+						],
+					},
+				},
+			});
+
+			const getAmplify = async (fn: any) => await fn(Amplify);
+
+			const client = generateClientWithAmplifyInstance<
+				Schema,
+				V6ClientSSRCookies<Schema>
+			>({
+				amplify: getAmplify,
+				config: config,
+			});
+
+			const { data } = await client.models.Todo.list({
+				filter: { name: { contains: 'name' } },
+			});
+
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					options: expect.objectContaining({
+						headers: expect.objectContaining({
+							'X-Api-Key': 'FAKE-KEY',
+						}),
+						body: {
+							query: expect.stringContaining(
+								'listTodos(filter: $filter, limit: $limit, nextToken: $nextToken)'
+							),
+							variables: {
+								filter: {
+									name: {
+										contains: 'name',
+									},
+								},
+							},
+						},
+					}),
+				})
+			);
+
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					options: expect.objectContaining({
+						body: expect.objectContaining({
+							// match nextToken in selection set
+							query: expect.stringMatching(/^\s*nextToken\s*$/m),
+						}),
+					}),
+				})
+			);
+
+			expect(data.length).toBe(1);
+			expect(data[0]).toEqual(
+				expect.objectContaining({
+					__typename: 'Todo',
+					id: 'some-id',
+					owner: 'wirejobviously',
+					name: 'some name',
+					description: 'something something',
+				})
+			);
+		});
+
+		test('can list with nextToken', async () => {
+			Amplify.configure(configFixture as any);
+			const config = Amplify.getConfig();
+
+			const spy = mockApiResponse({
+				data: {
+					listTodos: {
+						items: [
+							{
+								__typename: 'Todo',
+								...serverManagedFields,
+								name: 'some name',
+								description: 'something something',
+							},
+						],
+					},
+				},
+			});
+
+			const getAmplify = async (fn: any) => await fn(Amplify);
+
+			const client = generateClientWithAmplifyInstance<
+				Schema,
+				V6ClientSSRCookies<Schema>
+			>({
+				amplify: getAmplify,
+				config: config,
+			});
+
+			const { data } = await client.models.Todo.list({
+				filter: { name: { contains: 'name' } },
+				nextToken: 'some-token',
+			});
+
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					options: expect.objectContaining({
+						headers: expect.objectContaining({
+							'X-Api-Key': 'FAKE-KEY',
+						}),
+						body: {
+							query: expect.stringContaining(
+								'listTodos(filter: $filter, limit: $limit, nextToken: $nextToken)'
+							),
+							variables: {
+								filter: {
+									name: {
+										contains: 'name',
+									},
+								},
+								nextToken: 'some-token',
+							},
+						},
+					}),
+				})
+			);
+
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					options: expect.objectContaining({
+						body: expect.objectContaining({
+							// match nextToken in selection set
+							query: expect.stringMatching(/^\s*nextToken\s*$/m),
+						}),
+					}),
+				})
+			);
+		});
+
+		test('can list with limit', async () => {
+			Amplify.configure(configFixture as any);
+			const config = Amplify.getConfig();
+
+			const spy = mockApiResponse({
+				data: {
+					listTodos: {
+						items: [
+							{
+								__typename: 'Todo',
+								...serverManagedFields,
+								name: 'some name',
+								description: 'something something',
+							},
+						],
+					},
+				},
+			});
+
+			const getAmplify = async (fn: any) => await fn(Amplify);
+
+			const client = generateClientWithAmplifyInstance<
+				Schema,
+				V6ClientSSRCookies<Schema>
+			>({
+				amplify: getAmplify,
+				config: config,
+			});
+
+			const { data } = await client.models.Todo.list({
+				filter: { name: { contains: 'name' } },
+				limit: 5,
+			});
+
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					options: expect.objectContaining({
+						headers: expect.objectContaining({
+							'X-Api-Key': 'FAKE-KEY',
+						}),
+						body: {
+							query: expect.stringContaining(
+								'listTodos(filter: $filter, limit: $limit, nextToken: $nextToken)'
+							),
+							variables: {
+								filter: {
+									name: {
+										contains: 'name',
+									},
+								},
+								limit: 5,
+							},
+						},
+					}),
+				})
+			);
+
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					options: expect.objectContaining({
+						body: expect.objectContaining({
+							// match nextToken in selection set
+							query: expect.stringMatching(/^\s*nextToken\s*$/m),
+						}),
+					}),
+				})
+			);
+		});
+	});
+	describe('with request', () => {
+		test('subscriptions are disabled', () => {
+			const client = generateClientWithAmplifyInstance<
+				Schema,
+				V6ClientSSRRequest<Schema>
+			>({
+				amplify: null,
+				config: config,
+			});
+
+			expect(() => {
+				// @ts-expect-error
+				client.models.Note.onCreate().subscribe();
+			}).toThrow();
+		});
+
+		test('contextSpec param gets passed through to client.graphql', async () => {
+			Amplify.configure(configFixture as any);
+			const config = Amplify.getConfig();
+
+			const client = generateClientWithAmplifyInstance<
+				Schema,
+				V6ClientSSRRequest<Schema>
+			>({
+				amplify: null,
+				config: config,
+			});
+
+			const mockContextSpec = {};
+
+			const spy = jest.spyOn(client, 'graphql').mockImplementation(async () => {
+				const result: any = {};
+				return result;
+			});
+
+			await client.models.Note.list(mockContextSpec);
+
+			expect(spy).toHaveBeenCalledWith(
+				mockContextSpec,
+				expect.objectContaining({
+					query: expect.stringContaining('listNotes'),
+				}),
+				{}
+			);
+		});
+	});
+});

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -47,6 +47,11 @@
 			"require": "./dist/cjs/internals/server/index.js",
 			"react-native": "./src/internals/server/index.ts"
 		},
+		"./server": {
+			"types": "./dist/esm/server/index.d.ts",
+			"import": "./dist/esm/server/index.mjs",
+			"require": "./dist/cjs/server/index.js"
+		},
 		"./package.json": "./package.json"
 	},
 	"typesVersions": {
@@ -76,7 +81,8 @@
 		"dist/cjs",
 		"dist/esm",
 		"src",
-		"internals"
+		"internals",
+		"server"
 	],
 	"dependencies": {
 		"@aws-amplify/api-rest": "4.0.6",

--- a/packages/api-graphql/server/package.json
+++ b/packages/api-graphql/server/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "@aws-amplify/api-graphql/server",
+	"types": "../dist/esm/server/index.d.ts",
+	"main": "../dist/cjs/server/index.js",
+	"module": "../dist/esm/server/index.mjs",
+	"sideEffects": false
+}

--- a/packages/api-graphql/src/internals/server/generateClientWithAmplifyInstance.ts
+++ b/packages/api-graphql/src/internals/server/generateClientWithAmplifyInstance.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { graphql, cancel, isCancelError } from '../';
+import { graphql, cancel, isCancelError } from '..';
 import { generateModelsProperty } from './generateModelsProperty';
 import {
 	__amplify,
@@ -16,13 +16,15 @@ import {
 /**
  * @private
  *
+ * Used internally by `adapter-nextjs` package.
+ *
  * Creates a client that can be used to make GraphQL requests, using a provided `AmplifyClassV6`
  * compatible context object for config and auth fetching.
  *
  * @param params
  * @returns
  */
-export function generateClient<
+export function generateClientWithAmplifyInstance<
 	T extends Record<any, any> = never,
 	ClientType extends
 		| V6ClientSSRRequest<T>

--- a/packages/api-graphql/src/server/generateClient.ts
+++ b/packages/api-graphql/src/server/generateClient.ts
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+import { generateClientWithAmplifyInstance } from '../internals/server';
+import {
+	GenerateServerClientParams,
+	GraphQLMethod,
+	GraphQLMethodSSR,
+	GraphQLOptionsV6,
+	V6ClientSSRRequest,
+	__amplify,
+} from '../types';
+import { CustomHeaders } from '@aws-amplify/data-schema-types';
+
+/**
+ * Generates an GraphQL API client that works with Amplify server context.
+ *
+ * @example
+ * import config from './amplifyconfiguration.json';
+ * import { listPosts } from './graphql/queries';
+ *
+ * const client = generateServerClient({ config });
+ *
+ * const result = await runWithAmplifyServerContext({
+ *   nextServerContext: { request, response },
+ *   operation: (contextSpec) => client.graphql(contextSpec, {
+ *     query: listPosts,
+ *   }),
+ * });
+ */
+export function generateClient<T extends Record<any, any> = never>({
+	config,
+	authMode,
+	authToken,
+}: GenerateServerClientParams): V6ClientSSRRequest<T> {
+	// passing `null` instance because each (future model) method must retrieve a valid instance
+	// from server context
+	const client = generateClientWithAmplifyInstance<T, V6ClientSSRRequest<T>>({
+		amplify: null,
+		config,
+		authMode,
+		authToken,
+	});
+
+	// TODO: improve this and the next type
+	const prevGraphql = client.graphql as unknown as GraphQLMethod;
+
+	const wrappedGraphql = (
+		contextSpec: AmplifyServer.ContextSpec,
+		options: GraphQLOptionsV6,
+		additionalHeaders?: CustomHeaders
+	) => {
+		const amplifyInstance = getAmplifyServerContext(contextSpec).amplify;
+		return prevGraphql.call(
+			{ [__amplify]: amplifyInstance },
+			options,
+			additionalHeaders as any
+		);
+	};
+
+	client.graphql = wrappedGraphql as unknown as GraphQLMethodSSR;
+	return client;
+}

--- a/packages/api-graphql/src/server/index.ts
+++ b/packages/api-graphql/src/server/index.ts
@@ -1,4 +1,4 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export { generateClientWithAmplifyInstance } from './generateClientWithAmplifyInstance';
+export { generateClient } from './generateClient';

--- a/packages/api-graphql/src/types/index.ts
+++ b/packages/api-graphql/src/types/index.ts
@@ -451,3 +451,9 @@ export type AuthModeParams = {
 	authMode?: GraphQLAuthMode;
 	authToken?: string;
 };
+
+export type GenerateServerClientParams = {
+	config: ResourcesConfig;
+	authMode?: GraphQLAuthMode;
+	authToken?: string;
+};

--- a/packages/api/src/internals/index.ts
+++ b/packages/api/src/internals/index.ts
@@ -1,4 +1,4 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 export { InternalAPI, InternalAPIClass } from './InternalAPI';
-export { generateClient as generateServerClient } from '@aws-amplify/api-graphql/internals/server';
+export { generateClientWithAmplifyInstance } from '@aws-amplify/api-graphql/internals/server';

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -10,3 +10,4 @@ export {
 	patch,
 	isCancelError,
 } from '@aws-amplify/api-rest/server';
+export { generateClient } from '@aws-amplify/api-graphql/server';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Exposed the `generateClient` from the subpath `aws-amplify/api/server` to support use cases with the generic SSR framework adapter `runWithAmplifyServerContext` exported from the subpath `aws-amplify/adapter-core`

This PR includes all relevant changes.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Supporting: https://github.com/aws-amplify/docs/pull/6591

#### Description of how you validated changes

1. unit tests
2. local tests with:
    * with a Next.js sample app to test the functionalities provided by `adapter-nextjs` originally
    * with a Nuxt sample app to test the newly expose `generateClient`


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
