### PR TITLE
feat(auth): passwordless sign in and sign up for OTP

### DIFF
--- a/packages/auth/src/providers/cognito/apis/confirmSignInWithOTP.ts
+++ b/packages/auth/src/providers/cognito/apis/confirmSignInWithOTP.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Amplify, Hub } from '@aws-amplify/core';
 import { respondToAuthChallenge } from '../utils/clients/CognitoIdentityProvider';
 import {

--- a/packages/auth/src/providers/cognito/apis/confirmSignInWithOTP.ts
+++ b/packages/auth/src/providers/cognito/apis/confirmSignInWithOTP.ts
@@ -59,8 +59,8 @@ export const confirmSignInWithOTP = async (
 		},
 		Session: signInSession,
 		ClientMetadata: {
-			signInMethod: 'OTP',
-			action: 'CONFIRM',
+			"Amplify.Passwordless.signInMethod": "OTP",
+			"Amplify.Passwordless.action": "CONFIRM",
 		},
 		ClientId: userPoolClientId,
 	};

--- a/packages/auth/src/providers/cognito/apis/passwordless/index.ts
+++ b/packages/auth/src/providers/cognito/apis/passwordless/index.ts
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export {handlePasswordlessSignIn} from "./passwordlessSignIn";
-
-export {getDeliveryMedium} from "./utils";
+export {createUserForPasswordlessSignUp} from "./passwordlessCreateUser";
+export {getDeliveryMedium, parseApiServiceError} from "./utils";
+export {PasswordlessSignInPayload, PreInitiateAuthPayload, PasswordlessSignUpPayload} from './types';

--- a/packages/auth/src/providers/cognito/apis/passwordless/index.ts
+++ b/packages/auth/src/providers/cognito/apis/passwordless/index.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export {handlePasswordlessSignIn} from "./passwordlessSignIn";
+
+export {getDeliveryMedium} from "./utils";

--- a/packages/auth/src/providers/cognito/apis/passwordless/passwordlessCreateUser.ts
+++ b/packages/auth/src/providers/cognito/apis/passwordless/passwordlessCreateUser.ts
@@ -1,0 +1,81 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	HttpRequest,
+	unauthenticatedHandler,
+	Headers,
+	getRetryDecider,
+	jitteredBackoff,
+} from '@aws-amplify/core/internals/aws-client-utils';
+import { normalizeHeaders } from "../../utils/apiHelpers";
+import { getDeliveryMedium, parseApiServiceError } from "./utils";
+import { getRegion } from "../../utils/clients/CognitoIdentityProvider/utils";
+import { AuthUserAttributes } from "../../../../types";
+import { PreInitiateAuthPayload, PasswordlessSignUpPayload } from './types';
+
+/**
+ * Internal method to create a user when signing up passwordless.
+ */
+export async function createUserForPasswordlessSignUp(
+	payload: PasswordlessSignUpPayload,
+	userPoolId: string,
+	userAttributes?: AuthUserAttributes
+	){
+
+		const { email, phone_number, username, destination} = payload
+				
+		// pre-auth api request
+		const body: PreInitiateAuthPayload = {
+			phone_number: phone_number,
+			email: email,
+			username: username,
+			deliveryMedium: getDeliveryMedium(destination),
+			region: getRegion(userPoolId),
+			userPoolId: userPoolId,
+			userAttributes,
+		};
+
+		const resolvedBody = body
+			? body instanceof FormData
+				? body
+				: JSON.stringify(body ?? '')
+			: undefined;
+
+		const headers: Headers = {};
+
+		const resolvedHeaders: Headers = {
+			...normalizeHeaders(headers),
+			...(resolvedBody
+				? {
+						'content-type':
+							body instanceof FormData
+								? 'multipart/form-data'
+								: 'application/json; charset=UTF-8',
+				  }
+				: {}),
+		};
+
+		const method = 'PUT';
+		
+		// TODO: url should come from the config
+		const url = new URL(
+			'https://8bzzjguuck.execute-api.us-west-2.amazonaws.com/prod'
+		);
+		const request: HttpRequest = {
+			url,
+			headers: resolvedHeaders,
+			method,
+			body: resolvedBody,
+		};
+		const baseOptions = {
+			retryDecider: getRetryDecider(parseApiServiceError),
+			computeDelay: jitteredBackoff,
+			withCrossDomainCredentials: false,
+		};
+
+		// creating a new user on Cognito via API endpoint
+		return await unauthenticatedHandler(request, {
+			...baseOptions,
+		});
+}

--- a/packages/auth/src/providers/cognito/apis/passwordless/passwordlessSignIn.ts
+++ b/packages/auth/src/providers/cognito/apis/passwordless/passwordlessSignIn.ts
@@ -12,6 +12,10 @@ import {  AuthConfig } from '@aws-amplify/core';
 import {
 	AuthAction
 } from '@aws-amplify/core/internals/utils';
+<<<<<<< Updated upstream
+=======
+import { getDeliveryMedium } from "./utils";
+>>>>>>> Stashed changes
 
 
 export async function handlePasswordlessSignIn(

--- a/packages/auth/src/providers/cognito/apis/passwordless/passwordlessSignIn.ts
+++ b/packages/auth/src/providers/cognito/apis/passwordless/passwordlessSignIn.ts
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getAuthUserAgentValue } from "../../../../utils";
+import { SignInWithOTPInput } from "../../types/inputs";
+import { AuthPasswordlessDeliveryDestination } from "../../types/models";
+import { initiateAuth, respondToAuthChallenge } from "../../utils/clients/CognitoIdentityProvider";
+import { InitiateAuthCommandInput, RespondToAuthChallengeCommandInput } from "../../utils/clients/CognitoIdentityProvider/types";
+import { getRegion } from "../../utils/clients/CognitoIdentityProvider/utils";
+import { setActiveSignInUsername } from "../../utils/signInHelpers";
+import {  AuthConfig } from '@aws-amplify/core';
+import {
+	AuthAction
+} from '@aws-amplify/core/internals/utils';
+
+
+export async function handlePasswordlessSignIn(
+	input: SignInWithOTPInput,
+	authConfig: AuthConfig['Cognito']
+) {
+	const { userPoolId, userPoolClientId } = authConfig;
+	const { username, options, destination } = input;
+	const { clientMetadata } = options ?? {};
+	const authParameters: Record<string, string> = {
+		USERNAME: username,
+	};
+
+	const jsonReqInitiateAuth: InitiateAuthCommandInput = {
+		AuthFlow: 'CUSTOM_AUTH',
+		AuthParameters: authParameters,
+		ClientId: userPoolClientId,
+	};
+
+	console.log('jsonReqInitiateAuth: ', jsonReqInitiateAuth);
+	const { Session, ChallengeParameters } = await initiateAuth(
+		{
+			region: getRegion(userPoolId),
+			userAgentValue: getAuthUserAgentValue(AuthAction.SignIn),
+		},
+		jsonReqInitiateAuth
+	);
+	const activeUsername = ChallengeParameters?.USERNAME ?? username;
+
+	setActiveSignInUsername(activeUsername);
+
+	// The answer is not used by the service. It is just a placeholder to make the request happy.
+	const dummyAnswer = 'dummyAnswer';
+	const jsonReqRespondToAuthChallenge: RespondToAuthChallengeCommandInput = {
+		ChallengeName: 'CUSTOM_CHALLENGE',
+		ChallengeResponses: {
+			USERNAME: activeUsername,
+			ANSWER: dummyAnswer,
+		},
+		Session,
+		ClientMetadata: {
+			...clientMetadata,
+			'Amplify.Passwordless.signInMethod': 'OTP',
+			'Amplify.Passwordless.action': 'REQUEST',
+			'Amplify.Passwordless.deliveryMedium': getDeliveryMedium(destination),
+		},
+		ClientId: userPoolClientId,
+	};
+	console.log('jsonReqRespondToAuthChallenge: ', jsonReqRespondToAuthChallenge);
+
+	return await respondToAuthChallenge(
+		{
+			region: getRegion(userPoolId),
+			userAgentValue: getAuthUserAgentValue(AuthAction.ConfirmSignIn),
+		},
+		jsonReqRespondToAuthChallenge
+	);
+}
+

--- a/packages/auth/src/providers/cognito/apis/passwordless/types.ts
+++ b/packages/auth/src/providers/cognito/apis/passwordless/types.ts
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AuthPasswordlessDeliveryDestination, ClientMetadata } from "../../types/models";
+
+/**
+ * Payload sent to the backend when creating a user.
+ */
+export type PasswordlessSignUpPayload = {
+	destination: AuthPasswordlessDeliveryDestination;
+	email?: string;
+	phone_number?: string;
+	username: string;
+}
+
+/**
+ * Payload sent to the backend when signing a user in.
+ */
+export type PasswordlessSignInPayload = ({
+	signInMethod: 'MAGIC_LINK';
+	destination: Extract<AuthPasswordlessDeliveryDestination, "EMAIL">;
+} | {
+	signInMethod: 'OTP';
+	destination: AuthPasswordlessDeliveryDestination;
+}) & {
+	username: string;
+	clientMetadata?: ClientMetadata;
+}
+
+export type PreInitiateAuthPayload = {
+	/**
+	 * Optional fields to indicate where the code/link should be delivered.
+	 */
+	email?: string;
+	phone_number?: string;
+	username: string;
+
+	/**
+	 * Any optional user attributes that were provided during sign up.
+	 */
+	userAttributes?: { [name: string]: string | undefined };
+
+	/**
+	 * The delivery medium for passwordless sign in. For magic link this will
+	 * always be "EMAIL". For OTP, it will be the value provided by the customer.
+	 */
+	deliveryMedium: string;
+
+	/**
+	 * The user pool ID
+	 */
+	userPoolId: string;
+
+	/**
+	 * The user pool region
+	 */
+	region: string;
+};

--- a/packages/auth/src/providers/cognito/apis/passwordless/utils.ts
+++ b/packages/auth/src/providers/cognito/apis/passwordless/utils.ts
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { HttpResponse, parseJsonError } from "@aws-amplify/core/internals/aws-client-utils";
 import { AuthPasswordlessDeliveryDestination } from "../../types/models";
+import { MetadataBearer } from "@aws-amplify/core/dist/esm/clients/types/aws";
 
 export function getDeliveryMedium(destination: AuthPasswordlessDeliveryDestination) {
 	const deliveryMediumMap: Record<AuthPasswordlessDeliveryDestination, string> =
@@ -11,3 +13,16 @@ export function getDeliveryMedium(destination: AuthPasswordlessDeliveryDestinati
 		};
 	return deliveryMediumMap[destination];
 }
+
+export const parseApiServiceError = async (
+	response?: HttpResponse
+): Promise<(Error & MetadataBearer) | undefined> => {
+	const parsedError = await parseJsonError(response);
+	if (!parsedError) {
+		// Response is not an error.
+		return;
+	}
+	return Object.assign(parsedError, {
+		$metadata: parsedError.$metadata,
+	});
+};

--- a/packages/auth/src/providers/cognito/apis/passwordless/utils.ts
+++ b/packages/auth/src/providers/cognito/apis/passwordless/utils.ts
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AuthPasswordlessDeliveryDestination } from "../../types/models";
+
+export function getDeliveryMedium(destination: AuthPasswordlessDeliveryDestination) {
+	const deliveryMediumMap: Record<AuthPasswordlessDeliveryDestination, string> =
+		{
+			EMAIL: 'EMAIL',
+			PHONE: 'SMS',
+		};
+	return deliveryMediumMap[destination];
+}

--- a/packages/auth/src/providers/cognito/apis/signInWithOTP.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithOTP.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Amplify, AuthConfig } from '@aws-amplify/core';
 import { AuthAdditionalInfo, AuthDeliveryMedium } from '../../../types';
 import {
@@ -28,15 +31,32 @@ import {
 	getActiveSignInUsername,
 	setActiveSignInUsername,
 } from '../utils/signInHelpers';
+import { AuthPasswordlessSignInAndSignUpOptions } from '../types/options';
+import {
+	HttpRequest,
+	unauthenticatedHandler,
+	Headers,
+	getRetryDecider,
+	jitteredBackoff,
+	HttpResponse,
+	parseJsonError,
+} from '@aws-amplify/core/internals/aws-client-utils';
+import { normalizeHeaders } from '../utils/apiHelpers';
+import { MetadataBearer } from '@aws-amplify/core/dist/esm/clients/types/aws';
+import { AuthError } from '../../../Errors';
+import { handlePasswordlessSignIn } from './passwordless';
 
 export const signInWithOTP = async <
-	T extends AuthPasswordlessFlow = AuthPasswordlessFlow,
+	T extends AuthPasswordlessFlow = AuthPasswordlessFlow
 >(
 	input: SignInWithOTPInput<T>
 ): Promise<SignInWithOTPOutput> => {
 	const authConfig = Amplify.getConfig().Auth?.Cognito;
+	console.log('authConfig in signinwithotp: ', authConfig);
+
 	assertTokenProviderConfig(authConfig);
-	const { username, flow } = input;
+	const { userPoolId } = authConfig;
+	const { username, flow, destination, options } = input;
 
 	assertValidationError(
 		!!username,
@@ -49,98 +69,146 @@ export const signInWithOTP = async <
 	};
 
 	switch (flow) {
-		case 'SIGN_IN':
-			const { ChallengeParameters, Session } = await handlePasswordlessSignIn(
-				input,
-				authConfig as AuthConfig['Cognito']
-			);
-			// sets up local state used during the sign-in process
-			setActiveSignInState({
-				signInSession: Session,
-				username: getActiveSignInUsername(username),
-				signInDetails,
-			});
-
-			return {
-				isSignedIn: false,
-				nextStep: {
-					signInStep: 'CONFIRM_SIGN_IN_WITH_OTP',
-					additionalInfo: ChallengeParameters as AuthAdditionalInfo,
-					codeDeliveryDetails: {
-						deliveryMedium:
-							ChallengeParameters?.deliveryMedium as AuthDeliveryMedium,
-						destination: ChallengeParameters?.destination,
-					},
-				},
+		case 'SIGN_UP_AND_SIGN_IN':
+			const signUpOptions = options as AuthPasswordlessSignInAndSignUpOptions;
+			const userAttributes = signUpOptions?.userAttributes;
+			// creating a new user on Cognito
+			// pre-auth api request
+			const body: PreInitiateAuthPayload = {
+				email: username,
+				username: username,
+				deliveryMedium: getDeliveryMedium(destination),
+				region: getRegion(userPoolId),
+				userPoolId: userPoolId,
+				userAttributes,
 			};
 
-		case 'SIGN_UP_AND_SIGN_IN':
-			throw new Error('Not implemented');
+			const resolvedBody = body
+				? body instanceof FormData
+					? body
+					: JSON.stringify(body ?? '')
+				: undefined;
+
+			const headers: Headers = {};
+
+			const resolvedHeaders: Headers = {
+				...normalizeHeaders(headers),
+				...(resolvedBody
+					? {
+							'content-type':
+								body instanceof FormData
+									? 'multipart/form-data'
+									: 'application/json; charset=UTF-8',
+					  }
+					: {}),
+			};
+
+			const method = 'PUT';
+			// TODO: url should come from the config
+			const url = new URL(
+				'https://8bzzjguuck.execute-api.us-west-2.amazonaws.com/prod'
+			);
+			const request: HttpRequest = {
+				url,
+				headers: resolvedHeaders,
+				method,
+				body: resolvedBody,
+			};
+			const baseOptions = {
+				retryDecider: getRetryDecider(parseApiServiceError),
+				computeDelay: jitteredBackoff,
+				withCrossDomainCredentials: false,
+				// abortSignal,
+			};
+
+			// Default options are marked with *
+			// const response = await fetch(url, {
+			// 	method: 'PUT', // *GET, POST, PUT, DELETE, etc.
+			// 	// mode: 'no-cors', // no-cors, *cors, same-origin
+			// 	headers: resolvedHeaders,
+			// 	body: resolvedBody, // body data type must match "Content-Type" header
+			// });
+
+			const response = await unauthenticatedHandler(request, {
+				...baseOptions,
+			});
+			console.log('response: ', response);
+			// api gateway response
+			const preIntitiateAuthResponse = {
+				username: 'Joe@example.com',
+				userAttributes: {
+					email: 'Joe@example.com',
+					phone_number: '+15551237890',
+				},
+				deliveryMedium: 'SMS',
+				userPoolId: 'abcde12345678',
+				region: 'us-west-2',
+			};
 	}
 
-	throw new Error('Not implemented');
+	const { ChallengeParameters, Session } = await handlePasswordlessSignIn(
+		input,
+		authConfig as AuthConfig['Cognito']
+	);
+
+	// sets up local state used during the sign-in process
+	setActiveSignInState({
+		signInSession: Session,
+		username: getActiveSignInUsername(username),
+		signInDetails,
+	});
+
+	return {
+		isSignedIn: false,
+		nextStep: {
+			signInStep: 'CONFIRM_SIGN_IN_WITH_OTP',
+			additionalInfo: ChallengeParameters as AuthAdditionalInfo,
+			codeDeliveryDetails: {
+				deliveryMedium:
+					ChallengeParameters?.deliveryMedium as AuthDeliveryMedium,
+				destination: ChallengeParameters?.destination,
+			},
+		},
+	};
 };
 
-async function handlePasswordlessSignIn(
-	input: SignInWithOTPInput,
-	authConfig: AuthConfig['Cognito']
-) {
-	const { userPoolId, userPoolClientId } = authConfig;
-	const { username, options, destination } = input;
-	const { clientMetadata } = options ?? {};
-	const authParameters: Record<string, string> = {
-		USERNAME: username,
-	};
+type PreInitiateAuthPayload = {
+	//TODO: Added this as pre auth lambda expects it to be there
+	email: string;
 
-	const jsonReqInitiateAuth: InitiateAuthCommandInput = {
-		AuthFlow: 'CUSTOM_AUTH',
-		AuthParameters: authParameters,
-		ClientId: userPoolClientId,
-	};
+	username: string;
 
-	const { Session, ChallengeParameters } = await initiateAuth(
-		{
-			region: getRegion(userPoolId),
-			userAgentValue: getAuthUserAgentValue(AuthAction.SignIn),
-		},
-		jsonReqInitiateAuth
-	);
-	const activeUsername = ChallengeParameters?.USERNAME ?? username;
+	/**
+	 * Any optional user attributes that were provided during sign up.
+	 */
+	userAttributes?: { [name: string]: string | undefined };
 
-	setActiveSignInUsername(activeUsername);
+	/**
+	 * The delivery medium for passwordless sign in. For magic link this will
+	 * always be "EMAIL". For OTP, it will be the value provided by the customer.
+	 */
+	deliveryMedium: string;
 
-	// The answer is not used by the service. It is just a placeholder to make the request happy.
-	const dummyAnswer = 'dummyAnswer';
-	const jsonReqRespondToAuthChallenge: RespondToAuthChallengeCommandInput = {
-		ChallengeName: 'CUSTOM_CHALLENGE',
-		ChallengeResponses: {
-			USERNAME: activeUsername,
-			ANSWER: dummyAnswer,
-		},
-		Session,
-		ClientMetadata: {
-			...clientMetadata,
-			signInMethod: 'OTP',
-			deliveryMedium: getDeliveryMedium(destination),
-			action: 'REQUEST',
-		},
-		ClientId: userPoolClientId,
-	};
+	/**
+	 * The user pool ID
+	 */
+	userPoolId: string;
 
-	return await respondToAuthChallenge(
-		{
-			region: getRegion(userPoolId),
-			userAgentValue: getAuthUserAgentValue(AuthAction.ConfirmSignIn),
-		},
-		jsonReqRespondToAuthChallenge
-	);
-}
+	/**
+	 * The user pool region
+	 */
+	region: string;
+};
 
-function getDeliveryMedium(destination: AuthPasswordlessDeliveryDestination) {
-	const deliveryMediumMap: Record<AuthPasswordlessDeliveryDestination, string> =
-		{
-			EMAIL: 'EMAIL',
-			PHONE: 'SMS',
-		};
-	return deliveryMediumMap[destination];
-}
+const parseApiServiceError = async (
+	response?: HttpResponse
+): Promise<(Error & MetadataBearer) | undefined> => {
+	const parsedError = await parseJsonError(response);
+	if (!parsedError) {
+		// Response is not an error.
+		return;
+	}
+	return Object.assign(parsedError, {
+		$metadata: parsedError.$metadata,
+	});
+};

--- a/packages/auth/src/providers/cognito/apis/signInWithOTP.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithOTP.ts
@@ -3,6 +3,7 @@
 
 import { Amplify, AuthConfig } from '@aws-amplify/core';
 import { AuthAdditionalInfo, AuthDeliveryMedium } from '../../../types';
+<<<<<<< Updated upstream
 import {
 	initiateAuth,
 	respondToAuthChallenge,
@@ -21,16 +22,27 @@ import { getRegion } from '../utils/clients/CognitoIdentityProvider/utils';
 import { getAuthUserAgentValue } from '../../../utils';
 import {
 	AuthPasswordlessDeliveryDestination,
+=======
+import { assertTokenProviderConfig } from '@aws-amplify/core/internals/utils';
+import { assertValidationError } from '../../../errors/utils/assertValidationError';
+import { AuthValidationErrorCode } from '../../../errors/types/validation';
+import { getRegion } from '../utils/clients/CognitoIdentityProvider/utils';
+import {
+>>>>>>> Stashed changes
 	AuthPasswordlessFlow,
 	CognitoAuthSignInDetails,
 } from '../types/models';
 import { SignInWithOTPInput } from '../types/inputs';
 import { SignInWithOTPOutput } from '../types/outputs';
 import { setActiveSignInState } from '../utils/signInStore';
+<<<<<<< Updated upstream
 import {
 	getActiveSignInUsername,
 	setActiveSignInUsername,
 } from '../utils/signInHelpers';
+=======
+import { getActiveSignInUsername } from '../utils/signInHelpers';
+>>>>>>> Stashed changes
 import { AuthPasswordlessSignInAndSignUpOptions } from '../types/options';
 import {
 	HttpRequest,
@@ -43,8 +55,12 @@ import {
 } from '@aws-amplify/core/internals/aws-client-utils';
 import { normalizeHeaders } from '../utils/apiHelpers';
 import { MetadataBearer } from '@aws-amplify/core/dist/esm/clients/types/aws';
+<<<<<<< Updated upstream
 import { AuthError } from '../../../Errors';
 import { handlePasswordlessSignIn } from './passwordless';
+=======
+import { getDeliveryMedium, handlePasswordlessSignIn } from './passwordless';
+>>>>>>> Stashed changes
 
 export const signInWithOTP = async <
 	T extends AuthPasswordlessFlow = AuthPasswordlessFlow

--- a/packages/auth/src/providers/cognito/apis/signUp.ts
+++ b/packages/auth/src/providers/cognito/apis/signUp.ts
@@ -43,6 +43,7 @@ export async function signUp(input: SignUpInput): Promise<SignUpOutput> {
 	const signUpVerificationMethod =
 		authConfig?.signUpVerificationMethod ?? 'code';
 	const { clientMetadata, validationData, autoSignIn } = input.options ?? {};
+	console.log("authConfig: ", authConfig)
 	assertTokenProviderConfig(authConfig);
 	assertValidationError(
 		!!username,

--- a/packages/auth/src/providers/cognito/apis/signUp.ts
+++ b/packages/auth/src/providers/cognito/apis/signUp.ts
@@ -43,7 +43,6 @@ export async function signUp(input: SignUpInput): Promise<SignUpOutput> {
 	const signUpVerificationMethod =
 		authConfig?.signUpVerificationMethod ?? 'code';
 	const { clientMetadata, validationData, autoSignIn } = input.options ?? {};
-	console.log("authConfig: ", authConfig)
 	assertTokenProviderConfig(authConfig);
 	assertValidationError(
 		!!username,

--- a/packages/auth/src/providers/cognito/utils/apiHelpers.ts
+++ b/packages/auth/src/providers/cognito/utils/apiHelpers.ts
@@ -33,3 +33,12 @@ export function toAuthUserAttribute<T extends string = string>(
 	});
 	return userAttributes;
 }
+
+
+export const normalizeHeaders = (headers?: Record<string, string>) => {
+	const normalizedHeaders: Record<string, string> = {};
+	for (const key in headers) {
+		normalizedHeaders[key.toLowerCase()] = headers[key];
+	}
+	return normalizedHeaders;
+};

--- a/packages/auth/src/types/models.ts
+++ b/packages/auth/src/types/models.ts
@@ -20,7 +20,7 @@ export type AuthDeliveryMedium = 'EMAIL' | 'SMS' | 'PHONE' | 'UNKNOWN';
  * Data describing the dispatch of a confirmation code.
  */
 export type AuthCodeDeliveryDetails<
-	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey,
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
 > = {
 	destination?: string;
 	deliveryMedium?: AuthDeliveryMedium;
@@ -31,7 +31,7 @@ export type AuthCodeDeliveryDetails<
  */
 export type AuthResetPasswordStep = 'CONFIRM_RESET_PASSWORD_WITH_CODE' | 'DONE';
 export type AuthNextResetPasswordStep<
-	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey,
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
 > = {
 	resetPasswordStep: AuthResetPasswordStep;
 	additionalInfo?: AuthAdditionalInfo;
@@ -106,7 +106,7 @@ export type ConfirmSignInWithCustomChallenge = {
 };
 
 export type ConfirmSignInWithNewPasswordRequired<
-	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey,
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
 > = {
 	/**
 	 * Auth step requires user to change their password with any required attributes.
@@ -173,7 +173,7 @@ export type DoneSignInStep = {
 };
 
 export type AuthNextSignInStep<
-	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey,
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
 > =
 	| ConfirmSignInWithCustomChallenge
 	| ContinueSignInWithMFASelection
@@ -189,7 +189,7 @@ export type AuthNextSignInStep<
  * Key/value pairs describing a user attributes.
  */
 export type AuthUserAttributes<
-	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey,
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
 > = {
 	[Attribute in UserAttributeKey]?: string;
 };
@@ -198,7 +198,7 @@ export type AuthUserAttributes<
  * The interface of a user attribute.
  */
 export type AuthUserAttribute<
-	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey,
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
 > = {
 	attributeKey: UserAttributeKey;
 	value: string;
@@ -226,7 +226,7 @@ export type AuthUpdateAttributeStep =
  * Data encapsulating the next step in the Sign Up process
  */
 export type AuthNextSignUpStep<
-	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey,
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
 > =
 	| ConfirmSignUpSignUpStep<UserAttributeKey>
 	| AutoSignInSignUpStep<UserAttributeKey>
@@ -238,21 +238,21 @@ export type DoneSignUpStep = {
 };
 
 export type ConfirmSignUpSignUpStep<
-	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey,
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
 > = {
 	signUpStep: 'CONFIRM_SIGN_UP';
 	codeDeliveryDetails: AuthCodeDeliveryDetails<UserAttributeKey>;
 };
 
 export type AutoSignInSignUpStep<
-	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey,
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
 > = {
 	signUpStep: 'COMPLETE_AUTO_SIGN_IN';
 	codeDeliveryDetails?: AuthCodeDeliveryDetails<UserAttributeKey>;
 };
 
 export type AuthNextUpdateAttributeStep<
-	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey,
+	UserAttributeKey extends AuthUserAttributeKey = AuthUserAttributeKey
 > = {
 	updateAttributeStep: AuthUpdateAttributeStep;
 	codeDeliveryDetails?: AuthCodeDeliveryDetails<UserAttributeKey>;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

DRAFT PR pending some backend work for signUp stack to generate and place the endpoint url in config.

Contains new and rearranged code for Sign in and Sign up via OTP.
Common methods that can be used for MagicLink is extracted to a common place. 

TODO: Test signIn and signUp via SMS

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
