### PR TITLE
Use getRedirectUrl in all cases where redirectUri is passed

### DIFF
--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -127,7 +127,7 @@ export async function oauthSignIn({
 			currentUrl: url,
 			clientId,
 			domain,
-			redirectUri: redirectSignIn[0],
+			redirectUri,
 			responseType,
 			userAgentValue: getAuthUserAgentValue(AuthAction.SignInWithRedirect),
 			preferPrivateSession,
@@ -464,12 +464,13 @@ export async function parseRedirectURL() {
 		const currentUrl = window.location.href;
 		const { loginWith, userPoolClientId } = authConfig;
 		const { domain, redirectSignIn, responseType } = loginWith.oauth;
+		const redirectUri = getRedirectUrl(redirectSignIn);
 
 		await handleAuthResponse({
 			currentUrl,
 			clientId: userPoolClientId,
 			domain,
-			redirectUri: redirectSignIn[0],
+			redirectUri,
 			responseType,
 			userAgentValue: getAuthUserAgentValue(AuthAction.SignInWithRedirect),
 		});


### PR DESCRIPTION
#### Description of changes
This PR uses getRedirectUrl to resolve the correct url when multiple are provided in oauth config. The function was implemented in #12415 but two usages were missed. These missed usages cause errors when handling responses from oauth redirects. The PR adds these usages, completing the functionality.

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
