### PR TITLE
ci: add next.js data client e2e

### DIFF
--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -441,6 +441,13 @@ tests:
     sample_name: [optimistic-ui]
     spec: optimistic-ui
     browser: *minimal_browser_list
+  - test_name: integ_next_api_data_client_gen2
+    desc: Next.js Data Client Gen 2
+    framework: next
+    category: api
+    sample_name: [data-client-gen2]
+    spec: data-client-gen2
+    browser: [chrome] # Issues using Auth category / setting secure cookies in FF using Cypress with a Next.js app. Manual testing in FF works as expected
 
   # AUTH
   - test_name: integ_react_javascript_authentication


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds the e2e from [this samples PR](https://github.com/aws-amplify/amplify-js-samples-staging/pull/759) to the ci/cd pipeline


#### Description of how you validated changes
* Manually tested sample app in Chrome and FF
* Ran cypress against dev and prod build in Chrome
* Ran into issues with Cypress on FF. Seems to be related to [this issue](https://github.com/cypress-io/cypress/issues/18690). I noticed that our other Next.js e2es only run on Chrome as well, so I'm assuming it's a known limitation. The sample works as expected when I manually exercise it in FF.

For reference, here are the warnings I see in the console when Cypress calls `Auth.signIn` in FF:
![image](https://github.com/aws-amplify/amplify-js/assets/29709626/2429d94a-8d98-4316-8ed3-69ae33319a72)

This does not occur when manually running the sample in FF. It logs in and sets the cookies successfully. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
