### PR TITLE
refactor(datastore): Refactor conflict resolution tests optimize for concise/readable

### DIFF
--- a/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
+++ b/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
@@ -66,7 +66,7 @@ describe('DataStore sync engine', () => {
 		describe('observed rapid single-field mutations with variable connection latencies', () => {
 			describe('single client updates', () => {
 				test('rapid mutations on poor connection when initial create is not pending', async () => {
-					harness.connectionSpeed = 'slow';
+					harness.userInputLatency = 'fasterThanOutbox';
 					harness.latency = 'high';
 					const postHarness = await harness.createPostHarness({
 						title: 'original title',
@@ -89,13 +89,13 @@ describe('DataStore sync engine', () => {
 						['post title 0', 3],
 					]);
 
-					postHarness.expectCurrentToMatch({
-						version: 3,
+					expect(await postHarness.currentContents).toMatchObject({
+						_version: 3,
 						title: 'post title 0',
 					});
 				});
 				test('rapid mutations on fast connection when initial create is not pending', async () => {
-					harness.connectionSpeed = 'fast';
+					harness.userInputLatency = 'slowerThanOutbox';
 					harness.latency = 'low';
 					const postHarness = await harness.createPostHarness({
 						title: 'original title',
@@ -120,13 +120,13 @@ describe('DataStore sync engine', () => {
 						['post title 0', 4],
 					]);
 
-					postHarness.expectCurrentToMatch({
-						version: 4,
+					expect(await postHarness.currentContents).toMatchObject({
+						_version: 4,
 						title: 'post title 0',
 					});
 				});
 				test('rapid mutations on poor connection when initial create is pending', async () => {
-					harness.connectionSpeed = 'slow';
+					harness.userInputLatency = 'fasterThanOutbox';
 					harness.latency = 'high';
 					const postHarness = await harness.createPostHarness({
 						title: 'original title',
@@ -149,13 +149,13 @@ describe('DataStore sync engine', () => {
 						['post title 2', 1],
 					]);
 
-					postHarness.expectCurrentToMatch({
-						version: 1,
+					expect(await postHarness.currentContents).toMatchObject({
+						_version: 1,
 						title: 'post title 2',
 					});
 				});
 				test('rapid mutations on fast connection when initial create is pending', async () => {
-					harness.connectionSpeed = 'fast';
+					harness.userInputLatency = 'slowerThanOutbox';
 					harness.latency = 'low';
 					const postHarness = await harness.createPostHarness({
 						title: 'original title',
@@ -178,13 +178,13 @@ describe('DataStore sync engine', () => {
 						['post title 2', 1],
 					]);
 
-					postHarness.expectCurrentToMatch({
-						version: 1,
+					expect(await postHarness.currentContents).toMatchObject({
+						_version: 1,
 						title: 'post title 2',
 					});
 				});
 				test('observe on poor connection with awaited outbox', async () => {
-					harness.connectionSpeed = 'slow';
+					harness.userInputLatency = 'fasterThanOutbox';
 					harness.latency = 'high';
 					const postHarness = await harness.createPostHarness({
 						title: 'original title',
@@ -217,8 +217,8 @@ describe('DataStore sync engine', () => {
 						['post title 2', 4],
 					]);
 
-					postHarness.expectCurrentToMatch({
-						version: 4,
+					expect(await postHarness.currentContents).toMatchObject({
+						_version: 4,
 						title: 'post title 2',
 					});
 				});
@@ -249,8 +249,8 @@ describe('DataStore sync engine', () => {
 						['post title 2', 4],
 					]);
 
-					postHarness.expectCurrentToMatch({
-						version: 4,
+					expect(await postHarness.currentContents).toMatchObject({
+						_version: 4,
 						title: 'post title 2',
 					});
 				});
@@ -266,7 +266,7 @@ describe('DataStore sync engine', () => {
 			describe('Multi-client updates', () => {
 				describe('Updates to the same field', () => {
 					test('rapid mutations on poor connection when initial create is not pending', async () => {
-						harness.connectionSpeed = 'slow';
+						harness.userInputLatency = 'fasterThanOutbox';
 						harness.latency = 'high';
 						const postHarness = await harness.createPostHarness({
 							title: 'original title',
@@ -293,13 +293,13 @@ describe('DataStore sync engine', () => {
 							['update from second client', 4],
 						]);
 
-						postHarness.expectCurrentToMatch({
-							version: 4,
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 4,
 							title: 'update from second client',
 						});
 					});
 					test('rapid mutations on fast connection when initial create is not pending', async () => {
-						harness.connectionSpeed = 'fast';
+						harness.userInputLatency = 'slowerThanOutbox';
 						harness.latency = 'low';
 						const postHarness = await harness.createPostHarness({
 							title: 'original title',
@@ -327,13 +327,13 @@ describe('DataStore sync engine', () => {
 							['post title 0', 5],
 						]);
 
-						postHarness.expectCurrentToMatch({
-							version: 5,
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 5,
 							title: 'post title 0',
 						});
 					});
 					test('observe on poor connection with awaited outbox', async () => {
-						harness.connectionSpeed = 'fast';
+						harness.userInputLatency = 'slowerThanOutbox';
 						harness.latency = 'high';
 						const postHarness = await harness.createPostHarness({
 							title: 'original title',
@@ -369,13 +369,13 @@ describe('DataStore sync engine', () => {
 							['post title 2', 5],
 						]);
 
-						postHarness.expectCurrentToMatch({
-							version: 5,
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 5,
 							title: 'post title 2',
 						});
 					});
 					test('observe on fast connection with awaited outbox', async () => {
-						harness.connectionSpeed = 'fast';
+						harness.userInputLatency = 'slowerThanOutbox';
 						harness.latency = 'low';
 
 						const postHarness = await harness.createPostHarness({
@@ -412,8 +412,8 @@ describe('DataStore sync engine', () => {
 							['post title 2', 5],
 						]);
 
-						postHarness.expectCurrentToMatch({
-							version: 5,
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 5,
 							title: 'post title 2',
 						});
 					});
@@ -432,7 +432,7 @@ describe('DataStore sync engine', () => {
 					 * ultimately resulting in different final states.
 					 */
 					test('poor connection, initial create is not pending, external request is first received update', async () => {
-						harness.connectionSpeed = 'fast';
+						harness.userInputLatency = 'slowerThanOutbox';
 						harness.latency = 'high';
 						const postHarness = await harness.createPostHarness({
 							title: 'original title',
@@ -464,14 +464,14 @@ describe('DataStore sync engine', () => {
 							['original title', 'update from second client', 4],
 						]);
 
-						postHarness.expectCurrentToMatch({
-							version: 4,
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 4,
 							title: 'original title',
 							blogId: 'update from second client',
 						});
 					});
 					test('poor connection, initial create is not pending, external request is second received update', async () => {
-						harness.connectionSpeed = 'slow';
+						harness.userInputLatency = 'fasterThanOutbox';
 						harness.latency = 'high';
 						const postHarness = await harness.createPostHarness({
 							title: 'original title',
@@ -509,14 +509,14 @@ describe('DataStore sync engine', () => {
 							['post title 0', 'update from second client', 5],
 						]);
 
-						postHarness.expectCurrentToMatch({
-							version: 5,
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 5,
 							title: 'post title 0',
 							blogId: 'update from second client',
 						});
 					});
 					test('rapid mutations on fast connection when initial create is not pending (second field is `null`)', async () => {
-						harness.connectionSpeed = 'fast';
+						harness.userInputLatency = 'slowerThanOutbox';
 						harness.latency = 'low';
 
 						const postHarness = await harness.createPostHarness({
@@ -549,8 +549,8 @@ describe('DataStore sync engine', () => {
 							['post title 0', 'update from second client', 5],
 						]);
 
-						postHarness.expectCurrentToMatch({
-							version: 5,
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 5,
 							title: 'post title 0',
 							blogId: 'update from second client',
 						});
@@ -562,7 +562,7 @@ describe('DataStore sync engine', () => {
 					 * in different behavior.
 					 */
 					test('rapid mutations on fast connection when initial create is not pending (second field has initial value)', async () => {
-						harness.connectionSpeed = 'fast';
+						harness.userInputLatency = 'slowerThanOutbox';
 						harness.latency = 'low';
 
 						const postHarness = await harness.createPostHarness({
@@ -596,14 +596,14 @@ describe('DataStore sync engine', () => {
 							['post title 0', 'original blogId', 5],
 						]);
 
-						postHarness.expectCurrentToMatch({
-							version: 5,
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 5,
 							title: 'post title 0',
 							blogId: 'original blogId',
 						});
 					});
 					test('observe on poor connection with awaited outbox', async () => {
-						harness.connectionSpeed = 'slow';
+						harness.userInputLatency = 'fasterThanOutbox';
 						harness.latency = 'high';
 						const postHarness = await harness.createPostHarness({
 							title: 'original title',
@@ -641,14 +641,14 @@ describe('DataStore sync engine', () => {
 							['post title 2', 'update from second client', 5],
 						]);
 
-						postHarness.expectCurrentToMatch({
-							version: 5,
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 5,
 							title: 'post title 2',
 							blogId: 'update from second client',
 						});
 					});
 					test('observe on fast connection with awaited outbox', async () => {
-						harness.connectionSpeed = 'slow';
+						harness.userInputLatency = 'fasterThanOutbox';
 						harness.latency = 'low';
 						const postHarness = await harness.createPostHarness({
 							title: 'original title',
@@ -686,8 +686,8 @@ describe('DataStore sync engine', () => {
 							['post title 2', 'update from second client', 5],
 						]);
 
-						postHarness.expectCurrentToMatch({
-							version: 5,
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 5,
 							title: 'post title 2',
 							blogId: 'update from second client',
 						});

--- a/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
+++ b/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
@@ -338,7 +338,7 @@ describe('DataStore sync engine', () => {
 							blogId: 'blog id',
 						});
 
-						harness.userInputLatency = 'slowerThanOutbox';
+						harness.userInputLatency = 'fasterThanOutbox';
 						harness.latency = 'high';
 						harness.settleOutboxAfterRevisions = true;
 

--- a/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
+++ b/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
@@ -71,7 +71,6 @@ describe('DataStore sync engine', () => {
 						blogId: 'blog id',
 					});
 
-					harness.userInputLatency = 'fasterThanOutbox';
 					harness.latency = 'high';
 
 					await postHarness.revise('post title 0');
@@ -100,7 +99,7 @@ describe('DataStore sync engine', () => {
 						blogId: 'blog id',
 					});
 
-					harness.userInputLatency = 'slowerThanOutbox';
+					harness.userInputDelayed();
 					harness.latency = 'low';
 
 					await postHarness.revise('post title 0');
@@ -132,7 +131,6 @@ describe('DataStore sync engine', () => {
 						false
 					);
 
-					harness.userInputLatency = 'fasterThanOutbox';
 					harness.latency = 'high';
 
 					await postHarness.revise('post title 0');
@@ -163,7 +161,7 @@ describe('DataStore sync engine', () => {
 						false
 					);
 
-					harness.userInputLatency = 'slowerThanOutbox';
+					harness.userInputDelayed();
 					harness.latency = 'low';
 
 					// Note: We do NOT wait for the outbox to be empty here, because
@@ -193,9 +191,8 @@ describe('DataStore sync engine', () => {
 						blogId: 'blog id',
 					});
 
-					harness.userInputLatency = 'fasterThanOutbox';
 					harness.latency = 'high';
-					harness.settleOutboxAfterRevisions = true;
+					harness.settleOutboxAfterRevisions();
 
 					/**
 					 * We wait for the empty outbox on each mutation, because
@@ -231,7 +228,7 @@ describe('DataStore sync engine', () => {
 					});
 
 					harness.latency = 'low';
-					harness.settleOutboxAfterRevisions = true;
+					harness.settleOutboxAfterRevisions();
 
 					await postHarness.revise('post title 0');
 					await postHarness.revise('post title 1');
@@ -271,7 +268,6 @@ describe('DataStore sync engine', () => {
 							blogId: 'blog id',
 						});
 
-						harness.userInputLatency = 'fasterThanOutbox';
 						harness.latency = 'high';
 
 						await postHarness.revise('post title 0');
@@ -304,7 +300,7 @@ describe('DataStore sync engine', () => {
 							blogId: 'blog id',
 						});
 
-						harness.userInputLatency = 'slowerThanOutbox';
+						harness.userInputDelayed();
 						harness.latency = 'low';
 
 						await postHarness.revise('post title 0');
@@ -338,9 +334,8 @@ describe('DataStore sync engine', () => {
 							blogId: 'blog id',
 						});
 
-						harness.userInputLatency = 'fasterThanOutbox';
 						harness.latency = 'high';
-						harness.settleOutboxAfterRevisions = true;
+						harness.settleOutboxAfterRevisions();
 
 						await postHarness.revise('post title 0');
 						await postHarness.revise('post title 1');
@@ -377,9 +372,8 @@ describe('DataStore sync engine', () => {
 							blogId: 'blog id',
 						});
 
-						harness.userInputLatency = 'fasterThanOutbox';
 						harness.latency = 'low';
-						harness.settleOutboxAfterRevisions = true;
+						harness.settleOutboxAfterRevisions();
 
 						await postHarness.revise('post title 0');
 						await postHarness.revise('post title 1');
@@ -429,7 +423,6 @@ describe('DataStore sync engine', () => {
 							title: 'original title',
 						});
 
-						harness.userInputLatency = 'fasterThanOutbox';
 						harness.latency = 'high';
 
 						await postHarness.revise('post title 0');
@@ -468,7 +461,6 @@ describe('DataStore sync engine', () => {
 							title: 'original title',
 						});
 
-						harness.userInputLatency = 'fasterThanOutbox';
 						harness.latency = 'high';
 
 						await postHarness.revise('post title 0');
@@ -513,7 +505,7 @@ describe('DataStore sync engine', () => {
 							title: 'original title',
 						});
 
-						harness.userInputLatency = 'slowerThanOutbox';
+						harness.userInputDelayed();
 						harness.latency = 'low';
 
 						await postHarness.revise('post title 0');
@@ -559,7 +551,7 @@ describe('DataStore sync engine', () => {
 							blogId: 'original blogId',
 						});
 
-						harness.userInputLatency = 'slowerThanOutbox';
+						harness.userInputDelayed();
 						harness.latency = 'low';
 
 						await postHarness.revise('post title 0');
@@ -598,9 +590,8 @@ describe('DataStore sync engine', () => {
 							title: 'original title',
 						});
 
-						harness.userInputLatency = 'fasterThanOutbox';
 						harness.latency = 'high';
-						harness.settleOutboxAfterRevisions = true;
+						harness.settleOutboxAfterRevisions();
 
 						await postHarness.revise('post title 0');
 						await postHarness.revise('post title 1');
@@ -640,9 +631,8 @@ describe('DataStore sync engine', () => {
 							title: 'original title',
 						});
 
-						harness.userInputLatency = 'fasterThanOutbox';
 						harness.latency = 'low';
-						harness.settleOutboxAfterRevisions = true;
+						harness.settleOutboxAfterRevisions();
 
 						await postHarness.revise('post title 0');
 						await postHarness.revise('post title 1');

--- a/packages/datastore/__tests__/connectivityHandling.test.ts
+++ b/packages/datastore/__tests__/connectivityHandling.test.ts
@@ -2,7 +2,6 @@ import { Observable } from 'rxjs';
 import {
 	pause,
 	getDataStore,
-	graphqlServiceSettled,
 	waitForEmptyOutbox,
 	waitForDataStoreReady,
 	waitForSyncQueriesReady,

--- a/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
+++ b/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
@@ -1,0 +1,266 @@
+import { Subscription } from 'rxjs';
+import { getDataStore } from './datastoreFactory';
+import { Post } from './schemas';
+import {
+	waitForExpectModelUpdateGraphqlCallCount,
+	pause,
+	waitForEmptyOutbox,
+} from './util';
+
+/**
+ * Simulate a second client updating the original post
+ * @param originalPostId id of the post to update
+ * @param updatedFields field(s) to update
+ * @param version version number to be sent with the request (what would have been
+ * returned from a query prior to update)
+ */
+type ExternalPostUpdateParams = {
+	originalPostId: string;
+	updatedFields: Partial<any>;
+	version: number | undefined;
+};
+
+/**
+ * @param postId `id` of the record that was updated
+ * @param version expected final `_version` of the record after all updates are complete
+ * @param title expected final `title` of the record after all updates are complete
+ * @param blogId expected final `blogId` of the record after all updates are complete
+ */
+type FinalAssertionParams = {
+	postId: string;
+	version: number;
+	title: string;
+	blogId?: string | null;
+};
+
+/**
+ * Since we're essentially testing race conditions, we want to test the outbox logic
+ * exactly the same each time the tests are run. Minor fluctuations in test runs can
+ * cause different outbox behavior, so we set jitter to `0`.
+ */
+const jitter: number = 0;
+const highLatency = 1000;
+const lowLatency = 15;
+
+class PostHarness {
+	harness: UpdateSequenceHarness;
+	original: Post;
+	constructor(post: Post, harness: UpdateSequenceHarness) {
+		this.original = post;
+		this.harness = harness;
+	}
+
+	async revise(title: string) {
+		await this.harness.revisePost(this.original.id, title);
+	}
+
+	expectCurrentToMatch(values: { version; title; blogId? }) {
+		this.harness.expectFinalRecordsToMatch({
+			postId: this.original.id,
+			...values,
+		});
+	}
+}
+
+export class UpdateSequenceHarness {
+	datastoreFake: ReturnType<typeof getDataStore>;
+	expectedNumberOfInternalUpdates = 0;
+	expectedNumberOfExternalUpdates = 0;
+	private latencyValue: 'low' | 'high' = 'low';
+	connectionSpeed: 'slow' | 'fast' = 'slow';
+	settleOutboxAfterRevisions: boolean = false;
+
+	/**
+	 * All observed updates. Also includes "updates" from initial record creation,
+	 * since we start the subscription in the `beforeEach` block.
+	 */
+	subscriptionLog: Post[] = [];
+
+	subscriptionLogSubscription: Subscription;
+
+	subscriptionLogs(attributes: string[] = ['title', '_version']) {
+		return this.subscriptionLog.map(post =>
+			attributes.map(attribute => post[attribute])
+		);
+	}
+
+	get latency(): 'low' | 'high' {
+		return this.latencyValue;
+	}
+
+	set latency(value: 'low' | 'high') {
+		if (value === 'low') {
+			this.datastoreFake.graphqlService.setLatencies({
+				request: lowLatency,
+				response: lowLatency,
+				subscriber: lowLatency,
+				jitter,
+			});
+		} else {
+			this.datastoreFake.graphqlService.setLatencies({
+				request: highLatency,
+				response: highLatency,
+				subscriber: highLatency,
+				jitter,
+			});
+		}
+		this.latencyValue = value;
+	}
+
+	constructor() {
+		this.datastoreFake = getDataStore({
+			online: true,
+			isNode: false,
+		});
+
+		this.subscriptionLogSubscription = this.datastoreFake.DataStore.observe(
+			this.datastoreFake.Post
+		).subscribe(({ opType, element }) => {
+			if (opType === 'UPDATE') {
+				// const response: SubscriptionLogTuple = [
+				// 	element.title,
+				// 	// No, TypeScript, there is a version:
+				// 	// @ts-ignore
+				// 	element._version,
+				// ];
+				// Track sequence of versions and titles
+				this.subscriptionLog.push(element);
+			}
+		});
+	}
+
+	async outboxSettled() {
+		await waitForEmptyOutbox();
+	}
+
+	async expectUpdateCallCount(expectedCallCount: number) {
+		/**
+		 * Because we have increased the latency, and don't wait for the outbox
+		 * to clear on each mutation, the outbox will merge some of the mutations.
+		 * In this example, we expect the number of requests received to be one less than
+		 * the actual number of updates. If we were running this test without
+		 * increased latency, we'd expect more requests to be received.
+		 */
+		await waitForExpectModelUpdateGraphqlCallCount({
+			graphqlService: this.datastoreFake.graphqlService,
+			expectedCallCount,
+			modelName: 'Post',
+		});
+	}
+
+	async createPostHarness(...args: ConstructorParameters<typeof Post>) {
+		const original = await this.datastoreFake.DataStore.save(
+			new this.datastoreFake.Post(...args)
+		);
+		return new PostHarness(original, this);
+	}
+
+	async destroy() {
+		this.subscriptionLogSubscription.unsubscribe();
+		await this.clearDatastore();
+	}
+
+	async startDatastore() {
+		await this.datastoreFake.DataStore.start();
+	}
+
+	private async clearDatastore() {
+		await this.datastoreFake.DataStore.clear();
+	}
+
+	async externalPostUpdate({
+		originalPostId,
+		updatedFields,
+		version,
+	}: ExternalPostUpdateParams) {
+		await this.datastoreFake.graphqlService.externalGraphql(
+			{
+				query: `
+                    mutation operation($input: UpdatePostInput!, $condition: ModelPostConditionInput) {
+                        updatePost(input: $input, condition: $condition) {
+                            id
+                            title
+                            blogId
+                            updatedAt
+                            createdAt
+                            _version
+                            _lastChangedAt
+                            _deleted
+                        }
+                    }
+                `,
+				variables: {
+					input: {
+						id: originalPostId,
+						...updatedFields,
+						_version: version,
+					},
+					condition: null,
+				},
+				authMode: undefined,
+				authToken: undefined,
+			},
+			// For now we always ignore latency for external mutations. This could be a param if needed.
+			true
+		);
+		this.expectedNumberOfExternalUpdates += 1;
+	}
+
+	/**
+	 * Query post, update, then increment counter.
+	 * @param postId - id of the post to update
+	 * @param updatedTitle - title to update the post with
+	 */
+	async revisePost(postId: string, updatedTitle: string) {
+		if (this.connectionSpeed === 'fast') {
+			await pause(200);
+		}
+		const retrieved = await this.datastoreFake.DataStore.query(
+			this.datastoreFake.Post,
+			postId
+		);
+		if (retrieved) {
+			const x = await this.datastoreFake.DataStore.save(
+				this.datastoreFake.Post.copyOf(retrieved, updated => {
+					updated.title = updatedTitle;
+				})
+			);
+		}
+		if (this.settleOutboxAfterRevisions) {
+			await this.outboxSettled();
+		}
+
+		this.expectedNumberOfInternalUpdates++;
+	}
+
+	async expectFinalRecordsToMatch({
+		postId,
+		version,
+		title,
+		blogId = undefined,
+	}: FinalAssertionParams) {
+		// Validate that the record was saved to the service:
+		const table = this.datastoreFake.graphqlService.tables.get('Post')!;
+		expect(table.size).toEqual(1);
+
+		// Validate that the title was updated successfully:
+		const savedItem = table.get(JSON.stringify([postId])) as any;
+		expect(savedItem.title).toEqual(title);
+
+		if (blogId) expect(savedItem.blogId).toEqual(blogId);
+
+		// Validate that the `_version` was incremented correctly:
+		expect(savedItem._version).toEqual(version);
+
+		// Validate that `query` returns the latest `title` and `_version`:
+		const queryResult = await this.datastoreFake.DataStore.query(
+			this.datastoreFake.Post,
+			postId
+		);
+		expect(queryResult?.title).toEqual(title);
+		// @ts-ignore
+		expect(queryResult?._version).toEqual(version);
+
+		if (blogId) expect(queryResult?.blogId).toEqual(blogId);
+	}
+}

--- a/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
+++ b/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
@@ -175,8 +175,6 @@ export class UpdateSequenceHarness {
 			isNode: false,
 		});
 
-		this.latency = 'low';
-
 		this.subscriptionLogSubscription = this.datastoreFake.DataStore.observe(
 			this.datastoreFake.Post
 		).subscribe(({ opType, element }) => {
@@ -201,7 +199,7 @@ export class UpdateSequenceHarness {
 	 *
 	 * @param expectedCallCount The number of graphql update Post calls expected.
 	 */
-	async expectUpdateCallCount(expectedCallCount: number) {
+	async expectGraphqlSettledWithUpdateCallCount(expectedCallCount: number) {
 		/**
 		 * Because we have increased the latency, and don't wait for the outbox
 		 * to clear on each mutation, the outbox will merge some of the mutations.
@@ -222,10 +220,16 @@ export class UpdateSequenceHarness {
 	 * @param postInputs The input arguments to create the new Post with
 	 * @returns
 	 */
-	async createPostHarness(...args: ConstructorParameters<typeof Post>) {
+	async createPostHarness(
+		args: ConstructorParameters<typeof Post>[0],
+		settleOutbox: boolean = true
+	) {
 		const original = await this.datastoreFake.DataStore.save(
-			new this.datastoreFake.Post(...args)
+			new this.datastoreFake.Post(args)
 		);
+		if (settleOutbox) {
+			await this.outboxSettled();
+		}
 		return new PostHarness(original, this);
 	}
 

--- a/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
+++ b/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
@@ -238,6 +238,7 @@ export class UpdateSequenceHarness {
 		const original = await this.datastoreFake.DataStore.save(
 			new this.datastoreFake.Post(args)
 		);
+        // We set this to `false` when we want to test updating a record that is still in the outbox.
 		if (settleOutbox) {
 			await this.outboxSettled();
 		}

--- a/packages/datastore/__tests__/helpers/datastoreFactory.ts
+++ b/packages/datastore/__tests__/helpers/datastoreFactory.ts
@@ -62,6 +62,10 @@ export function getDataStore({
 	online = false,
 	isNode = true,
 	storageAdapterFactory = () => undefined as any,
+}: {
+	online?: boolean;
+	isNode?: boolean;
+	storageAdapterFactory?: () => any;
 } = {}) {
 	jest.clearAllMocks();
 	jest.resetModules();

--- a/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
+++ b/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
@@ -91,6 +91,7 @@ export class FakeGraphQLService {
 			this.tables.set(model.name, new Map<string, any[]>());
 			this.tableDefinitions.set(model.name, model);
 			let CPKFound = false;
+
 			for (const attribute of model.attributes || []) {
 				if (isModelAttributePrimaryKey(attribute)) {
 					this.PKFields.set(model.name, attribute!.properties!.fields);
@@ -257,6 +258,22 @@ export class FakeGraphQLService {
 			],
 			message:
 				'The conditional request failed (Service: DynamoDb, Status Code: 400, Request ID: 123456789123456789012345678901234567890)',
+		};
+	}
+
+	private makeOCCConflictUnhandeled(existingObject, call) {
+		return {
+			data: existingObject,
+			errorType: 'ConflictUnhandled',
+			message: 'Conflict resolver rejects mutation.',
+			locations: [
+				{
+					line: 2,
+					column: 3,
+					sourceName: null,
+				},
+			],
+			path: [call],
 		};
 	}
 


### PR DESCRIPTION
#### Description of changes

Outcome: 
- ~1300 lines -> ~700 lines aimed at maintaining readability. All assertions are the same as they where before this refactor.
- All test assertions are maintained with the same expected result for each test

We want to add OCC tests in a subsequent change. Rather than duplicating these tests as they where, I have refactored them, extracting out shared logic that isn't core to the testing story into a test harness aimed to enable/clarify these tests specifically.

#### Description of how you validated changes
The test suite continues to run to success

#### Related changes
1. https://github.com/aws-amplify/amplify-js/pull/12728
2. :seedling:  **refactor(datastore): Refactor conflict resolution tests towards readability**
3. https://github.com/stocaaro/amplify-js/pull/85
4. https://github.com/stocaaro/amplify-js/pull/86
5. https://github.com/stocaaro/amplify-js/pull/87

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.