### PR TITLE
fix(auth): oAuthStore is used before a valid OAuth config is confirmed

### DIFF
--- a/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
@@ -21,9 +21,7 @@ import {
 	completeOAuthFlow,
 } from '../../../src/providers/cognito/utils/oauth';
 import { attemptCompleteOAuthFlow } from '../../../src/providers/cognito/utils/oauth/attemptCompleteOAuthFlow';
-import { addInflightPromise } from '../../../src/providers/cognito/utils/oauth/inflightPromise';
 import { createOAuthError } from '../../../src/providers/cognito/utils/oauth/createOAuthError';
-import { cognitoUserPoolsTokenProvider } from '../../../src/providers/cognito/tokenProvider/tokenProvider';
 
 import { signInWithRedirect } from '../../../src/providers/cognito/apis/signInWithRedirect';
 
@@ -72,18 +70,8 @@ jest.mock('../../../src/providers/cognito/utils/oauth/oAuthStore', () => ({
 		clearOAuthInflightData: jest.fn(),
 	} as OAuthStore,
 }));
-jest.mock('../../../src/providers/cognito/utils/oauth/inflightPromise', () => ({
-	addInflightPromise: jest.fn(resolver => {
-		resolver();
-	}),
-}));
 jest.mock('../../../src/providers/cognito/utils/oauth/createOAuthError');
 jest.mock('../../../src/utils');
-jest.mock('../../../src/providers/cognito/tokenProvider/tokenProvider', () => ({
-	cognitoUserPoolsTokenProvider: {
-		setWaitForInflightOAuth: jest.fn(),
-	},
-}));
 
 const mockAssertOAuthConfig = assertOAuthConfig as jest.Mock;
 const mockAssertTokenProviderConfig = assertTokenProviderConfig as jest.Mock;
@@ -93,7 +81,6 @@ const mockOpenAuthSession = openAuthSession as jest.Mock;
 const mockGenerateCodeVerifier = generateCodeVerifier as jest.Mock;
 const mockGenerateState = generateState as jest.Mock;
 const mockIsBrowser = isBrowser as jest.Mock;
-const mockAddInflightPromise = addInflightPromise as jest.Mock;
 
 const mockCompleteOAuthFlow = completeOAuthFlow as jest.Mock;
 const mockGetAuthUserAgentValue = getAuthUserAgentValue as jest.Mock;
@@ -199,31 +186,6 @@ describe('signInWithRedirect', () => {
 				expect(Amplify[ADD_OAUTH_LISTENER]).toHaveBeenCalledWith(
 					attemptCompleteOAuthFlow
 				);
-				expect(
-					cognitoUserPoolsTokenProvider.setWaitForInflightOAuth
-				).toHaveBeenCalledTimes(1);
-
-				const callback = (
-					cognitoUserPoolsTokenProvider.setWaitForInflightOAuth as jest.Mock
-				).mock.calls[0][0];
-
-				await callback();
-
-				expect(oAuthStore.loadOAuthInFlight).toHaveBeenCalledTimes(1);
-			});
-
-			it('adds a promise to block auth process when there is an inflight oauth process', async () => {
-				(oAuthStore.loadOAuthInFlight as jest.Mock).mockResolvedValueOnce(true);
-				expect(
-					cognitoUserPoolsTokenProvider.setWaitForInflightOAuth
-				).toHaveBeenCalledTimes(1);
-
-				const callback = (
-					cognitoUserPoolsTokenProvider.setWaitForInflightOAuth as jest.Mock
-				).mock.calls[0][0];
-
-				await callback();
-				expect(mockAddInflightPromise).toHaveBeenCalledTimes(1);
 			});
 		});
 	});

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/attemptCompleteOAuthFlow.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/attemptCompleteOAuthFlow.test.ts
@@ -10,6 +10,8 @@ import { attemptCompleteOAuthFlow } from '../../../../../src/providers/cognito/u
 import { completeOAuthFlow } from '../../../../../src/providers/cognito/utils/oauth/completeOAuthFlow';
 import { getRedirectUrl } from '../../../../../src/providers/cognito/utils/oauth/getRedirectUrl';
 import { oAuthStore } from '../../../../../src/providers/cognito/utils/oauth/oAuthStore';
+import { addInflightPromise } from '../../../../../src/providers/cognito/utils/oauth/inflightPromise';
+import { cognitoUserPoolsTokenProvider } from '../../../../../src/providers/cognito/tokenProvider/tokenProvider';
 import { mockAuthConfigWithOAuth } from '../../../../mockData';
 
 import type { OAuthStore } from '../../../../../src/providers/cognito/utils/types';
@@ -35,11 +37,28 @@ jest.mock(
 		} as OAuthStore,
 	})
 );
+jest.mock(
+	'../../../../../src/providers/cognito/tokenProvider/tokenProvider',
+	() => ({
+		cognitoUserPoolsTokenProvider: {
+			setWaitForInflightOAuth: jest.fn(),
+		},
+	})
+);
+jest.mock(
+	'../../../../../src/providers/cognito/utils/oauth/inflightPromise',
+	() => ({
+		addInflightPromise: jest.fn(resolver => {
+			resolver();
+		}),
+	})
+);
 
 const mockAssertOAuthConfig = assertOAuthConfig as jest.Mock;
 const mockAssertTokenProviderConfig = assertTokenProviderConfig as jest.Mock;
 const mockCompleteOAuthFlow = completeOAuthFlow as jest.Mock;
 const mockGetRedirectUrl = getRedirectUrl as jest.Mock;
+const mockAddInflightPromise = addInflightPromise as jest.Mock;
 
 describe('attemptCompleteOAuthFlow', () => {
 	let windowSpy = jest.spyOn(window, 'window', 'get');
@@ -90,7 +109,7 @@ describe('attemptCompleteOAuthFlow', () => {
 		expect(mockCompleteOAuthFlow).not.toHaveBeenCalled();
 	});
 
-	it('invokes `completeOAuthFlow` to complete an inflight oauth process', async () => {
+	it('sets inflight oauth promise and invokes `completeOAuthFlow` to complete an inflight oauth process', async () => {
 		(oAuthStore.loadOAuthInFlight as jest.Mock).mockResolvedValueOnce(true);
 
 		await attemptCompleteOAuthFlow(mockAuthConfigWithOAuth.Auth.Cognito);
@@ -101,6 +120,17 @@ describe('attemptCompleteOAuthFlow', () => {
 				redirectUri: 'http://localhost:3000/',
 			})
 		);
+
+		expect(
+			cognitoUserPoolsTokenProvider.setWaitForInflightOAuth
+		).toHaveBeenCalledTimes(1);
+
+		const callback = (
+			cognitoUserPoolsTokenProvider.setWaitForInflightOAuth as jest.Mock
+		).mock.calls[0][0];
+
+		// the blocking promise should resolve
+		expect(callback()).resolves.toBeUndefined();
 	});
 
 	test.each([

--- a/packages/auth/src/providers/cognito/utils/oauth/enableOAuthListener.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/enableOAuthListener.ts
@@ -17,17 +17,6 @@ isBrowser() &&
 	(() => {
 		// add the listener to the singleton for triggering
 		Amplify[ADD_OAUTH_LISTENER](attemptCompleteOAuthFlow);
-
-		cognitoUserPoolsTokenProvider.setWaitForInflightOAuth(
-			() =>
-				new Promise(async (res, _rej) => {
-					if (!(await oAuthStore.loadOAuthInFlight())) {
-						res();
-					} else {
-						addInflightPromise(res);
-					}
-				})
-		);
 	})();
 
 // required to present for module loaders


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Moved the origin call of `cognitoUserPoolsTokenProvider.setWaitForInflightOAuth()` in the `enableOAuthListener` side effect into the `attemptCompleteOAuthFlow` function.

The latter ensures the `oAuthStore` gets configured before using. 


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
