### PR TITLE
fix(api): issue 12756 by exporting CONNECTION_STATE_CHANGE as a value

### DIFF
--- a/packages/api/__tests__/API.test.ts
+++ b/packages/api/__tests__/API.test.ts
@@ -1,6 +1,6 @@
 import { ResourcesConfig } from 'aws-amplify';
 import { InternalGraphQLAPIClass } from '@aws-amplify/api-graphql/internals';
-import { generateClient } from '@aws-amplify/api';
+import { generateClient, CONNECTION_STATE_CHANGE } from '@aws-amplify/api';
 import { AmplifyClassV6 } from '@aws-amplify/core';
 // import { runWithAmplifyServerContext } from 'aws-amplify/internals/adapter-core';
 
@@ -38,6 +38,9 @@ describe('API generateClient', () => {
 		);
 	});
 
+	test('CONNECTION_STATE_CHANGE importable as a value, not a type', async () => {
+		expect(CONNECTION_STATE_CHANGE).toBe('ConnectionStateChange');
+	})
 	// test('server-side client.graphql', async () => {
 	// 	const config: ResourcesConfig = {
 	// 		API: {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,8 +9,9 @@ export { GraphQLAuthError, ConnectionState } from '@aws-amplify/api-graphql';
 export type {
 	GraphQLResult,
 	GraphQLReturnType,
-	CONNECTION_STATE_CHANGE,
 } from '@aws-amplify/api-graphql';
+
+export { CONNECTION_STATE_CHANGE } from '@aws-amplify/api-graphql';
 
 import type { V6Client } from '@aws-amplify/api-graphql';
 

--- a/packages/aws-amplify/__tests__/exports.test.ts
+++ b/packages/aws-amplify/__tests__/exports.test.ts
@@ -51,6 +51,7 @@ describe('aws-amplify Exports', () => {
 		it('should only export expected symbols from the top level', () => {
 			expect(Object.keys(apiTopLevelExports).sort()).toEqual(
 				[
+					'CONNECTION_STATE_CHANGE',
 					'ConnectionState',
 					'GraphQLAuthError',
 					'del',


### PR DESCRIPTION
rather than as a type

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

It looks like a simple oversight, that CONNECTION_STATE_CHANGE was included in an `export type` statement rather than in a plain `export` statement.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

[12756](https://github.com/aws-amplify/amplify-js/issues/12756)


#### Description of how you validated changes

Writing a failing unit test, writing the fix, seeing the unit test pass.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
