### PR TITLE
feat(ci): allow 0BSD license

### DIFF
--- a/.github/dependency-review/dependecy-review-config.yml
+++ b/.github/dependency-review/dependecy-review-config.yml
@@ -1,5 +1,6 @@
 allow-licenses:
   - 'Apache-2.0'
+  - '0BSD'
   - 'BSL-1.0'
   - 'BSD-1-Clause'
   - 'BSD-2-Clause-FreeBSD'


### PR DESCRIPTION
### Description of changes
GH actions workflow `aws-amplify-dependency-check.yml` checks for license of newly added packages on the PR. 

Package [tslib](https://www.npmjs.com/package/tslib) licensed under `0BSD` [is flagged](https://github.com/aws-amplify/amplify-js/actions/runs/7342179815/attempts/1#summary-19991088882) since this isn't present in the list of allowed licenses. Update to allow the same

reference: [Open Source Licenses for Distribution wiki](https://w.amazon.com/bin/view/Open_Source/Distributions/Process/License_Instructions_for_Distribution/)

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.