### PR TITLE
fix(auth): replace window history with current browser session's state

### DIFF
--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -3680,7 +3680,7 @@ describe('auth unit test', () => {
 			);
 		});
 
-		test('User Pools and Identity Pools', async () => {
+		test.only('User Pools and Identity Pools', async () => {
 			const options: AuthOptions = {
 				region: 'region',
 				userPoolId: 'userPoolId',

--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -110,7 +110,7 @@ jest.mock('amazon-cognito-identity-js/lib/CognitoUserPool', () => {
 });
 
 jest.mock('amazon-cognito-identity-js/lib/CognitoUser', () => {
-	const CognitoUser = function () {
+	const CognitoUser = function() {
 		// mock private member
 		this.signInUserSession = null;
 	};
@@ -255,7 +255,7 @@ jest.mock('amazon-cognito-identity-js/lib/CognitoUser', () => {
 	CognitoUser.prototype.listDevices = (limit, paginationToken, callback) => {
 		callback.onSuccess('success');
 	};
-	CognitoUser.prototype.getSignInUserSession = function () {
+	CognitoUser.prototype.getSignInUserSession = function() {
 		return this.signInUserSession;
 	};
 
@@ -1879,7 +1879,7 @@ describe('auth unit test', () => {
 			const concurrency = 10;
 			const spyon = jest
 				.spyOn(CognitoUser.prototype, 'getSession')
-				.mockImplementationOnce(function (callback: any) {
+				.mockImplementationOnce(function(callback: any) {
 					this.signInUserSession = session;
 					callback(null, session);
 				});

--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -110,7 +110,7 @@ jest.mock('amazon-cognito-identity-js/lib/CognitoUserPool', () => {
 });
 
 jest.mock('amazon-cognito-identity-js/lib/CognitoUser', () => {
-	const CognitoUser = function() {
+	const CognitoUser = function () {
 		// mock private member
 		this.signInUserSession = null;
 	};
@@ -255,7 +255,7 @@ jest.mock('amazon-cognito-identity-js/lib/CognitoUser', () => {
 	CognitoUser.prototype.listDevices = (limit, paginationToken, callback) => {
 		callback.onSuccess('success');
 	};
-	CognitoUser.prototype.getSignInUserSession = function() {
+	CognitoUser.prototype.getSignInUserSession = function () {
 		return this.signInUserSession;
 	};
 
@@ -277,7 +277,7 @@ const createMockLocalStorage = () =>
 		removeItem(key: string) {
 			delete this._items[key];
 		},
-	} as unknown as Storage);
+	}) as unknown as Storage;
 
 import { AuthOptions, SignUpParams, AwsCognitoOAuthOpts } from '../src/types';
 import { AuthClass as Auth } from '../src/Auth';
@@ -1407,38 +1407,38 @@ describe('auth unit test', () => {
 			spyon.mockClear();
 		});
 
-        test('currentUserPoolUser fails but hub event still dispatches', async () => {
-            const auth = new Auth(authOptions);
-            const spyon = jest
-                .spyOn(CognitoUser.prototype, 'sendMFACode')
-                .mockImplementationOnce((code, callback) => {
-                    callback.onSuccess(session);
-                });
+		test('currentUserPoolUser fails but hub event still dispatches', async () => {
+			const auth = new Auth(authOptions);
+			const spyon = jest
+				.spyOn(CognitoUser.prototype, 'sendMFACode')
+				.mockImplementationOnce((code, callback) => {
+					callback.onSuccess(session);
+				});
 
-            const spyon2 = jest
-                .spyOn(auth, 'currentUserPoolUser')
-                .mockImplementationOnce(() => {
-                    return Promise.reject('Could not get current user.');
-                });
-            const hubSpy = jest.spyOn(Hub, 'dispatch');
-            const user = new CognitoUser({
-                Username: 'username',
-                Pool: userPool,
-            });
-            const result = await auth.confirmSignIn(user, 'code', null);
-            expect(result).toEqual(user);
-            expect(hubSpy).toHaveBeenCalledWith(
-                'auth',
-                {
-                    data: user,
-                    event: 'signIn',
-                    message: 'A user username has been signed in',
-                },
-                'Auth',
-                Symbol.for('amplify_default')
-            );
-            spyon.mockClear();
-        });
+			const spyon2 = jest
+				.spyOn(auth, 'currentUserPoolUser')
+				.mockImplementationOnce(() => {
+					return Promise.reject('Could not get current user.');
+				});
+			const hubSpy = jest.spyOn(Hub, 'dispatch');
+			const user = new CognitoUser({
+				Username: 'username',
+				Pool: userPool,
+			});
+			const result = await auth.confirmSignIn(user, 'code', null);
+			expect(result).toEqual(user);
+			expect(hubSpy).toHaveBeenCalledWith(
+				'auth',
+				{
+					data: user,
+					event: 'signIn',
+					message: 'A user username has been signed in',
+				},
+				'Auth',
+				Symbol.for('amplify_default')
+			);
+			spyon.mockClear();
+		});
 
 		test('onFailure', async () => {
 			const spyon = jest
@@ -1879,7 +1879,7 @@ describe('auth unit test', () => {
 			const concurrency = 10;
 			const spyon = jest
 				.spyOn(CognitoUser.prototype, 'getSession')
-				.mockImplementationOnce(function(callback: any) {
+				.mockImplementationOnce(function (callback: any) {
 					this.signInUserSession = session;
 					callback(null, session);
 				});
@@ -3058,12 +3058,13 @@ describe('auth unit test', () => {
 			spyon.mockClear();
 		});
 
-		test('error hub event', async (done) => {
+		test('error hub event', async done => {
 			expect.assertions(3);
-			const spyon = jest.spyOn(CognitoUser.prototype, 'updateAttributes')
+			const spyon = jest
+				.spyOn(CognitoUser.prototype, 'updateAttributes')
 				.mockImplementationOnce((attrs, callback: any) => {
 					callback(new Error('Error'), null, null);
-			});
+				});
 
 			const auth = new Auth(authOptions);
 
@@ -3097,19 +3098,20 @@ describe('auth unit test', () => {
 			spyon.mockClear();
 		});
 
-		test('happy case code delivery details hub event', async (done) => {
+		test('happy case code delivery details hub event', async done => {
 			expect.assertions(2);
-			
+
 			const codeDeliverDetailsResult: any = {
-				'CodeDeliveryDetailsList': [ 
-				   { 
-					  'AttributeName': 'email',
-					  'DeliveryMedium': 'EMAIL',
-					  'Destination': 'e***@e***'
-				   }
-				]
+				CodeDeliveryDetailsList: [
+					{
+						AttributeName: 'email',
+						DeliveryMedium: 'EMAIL',
+						Destination: 'e***@e***',
+					},
+				],
 			};
-			const spyon = jest.spyOn(CognitoUser.prototype, 'updateAttributes')
+			const spyon = jest
+				.spyOn(CognitoUser.prototype, 'updateAttributes')
 				.mockImplementationOnce((attrs, callback: any) => {
 					callback(null, 'SUCCESS', codeDeliverDetailsResult);
 				});
@@ -3126,20 +3128,20 @@ describe('auth unit test', () => {
 				sub: 'sub',
 			};
 			const payloadData = {
-				'email': {
+				email: {
 					isUpdated: false,
 					codeDeliveryDetails: {
 						AttributeName: 'email',
 						DeliveryMedium: 'EMAIL',
-						Destination: 'e***@e***'
-					}
+						Destination: 'e***@e***',
+					},
 				},
-				'phone_number': {
-					isUpdated: true
+				phone_number: {
+					isUpdated: true,
 				},
-				'sub': {
-					isUpdated: true
-				}
+				sub: {
+					isUpdated: true,
+				},
 			};
 			const listenToHub = Hub.listen('auth', ({ payload }) => {
 				const { event } = payload;
@@ -3588,8 +3590,8 @@ describe('auth unit test', () => {
 
 			expect(handleAuthResponseSpy).toHaveBeenCalledWith(url);
 			expect(replaceStateSpy).toHaveBeenCalledWith(
-				{},
-				null,
+				window.history.state,
+				'',
 				(options.oauth as AwsCognitoOAuthOpts).redirectSignIn
 			);
 
@@ -3601,7 +3603,7 @@ describe('auth unit test', () => {
 			    "Hub.dispatch('auth', { data: ..., event: 'parsingCallbackUrl' })",
 			  ],
 			  Array [
-			    "window.history.replaceState({}, null, 'http://localhost:3000/')",
+			    "window.history.replaceState(null, "", 'http://localhost:3000/')",
 			  ],
 			  Array [
 			    "Hub.dispatch('auth', { data: ..., event: 'signIn' })",
@@ -3653,8 +3655,8 @@ describe('auth unit test', () => {
 
 			expect(handleAuthResponseSpy).toHaveBeenCalledWith(url);
 			expect(replaceStateSpy).toHaveBeenCalledWith(
-				{},
-				null,
+				window.history.state,
+				'',
 				(options.oauth as AwsCognitoOAuthOpts).redirectSignIn
 			);
 		});
@@ -3717,8 +3719,8 @@ describe('auth unit test', () => {
 
 			expect(handleAuthResponseSpy).toHaveBeenCalledWith(url);
 			expect(replaceStateSpy).toHaveBeenCalledWith(
-				{},
-				null,
+				window.history.state,
+				'',
 				(options.oauth as AwsCognitoOAuthOpts).redirectSignIn
 			);
 		});

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -2552,8 +2552,8 @@ export class AuthClass {
 
 					if (window && typeof window.history !== 'undefined') {
 						window.history.replaceState(
-							{},
-							null,
+							window.history.state,
+							'',
 							(this._config.oauth as AwsCognitoOAuthOpts).redirectSignIn
 						);
 					}

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -2588,8 +2588,8 @@ export class AuthClass {
 					// Otherwise, reloading the page will throw errors as the `code` has already been spent.
 					if (window && typeof window.history !== 'undefined') {
 						window.history.replaceState(
-							{},
-							null,
+							window.history.state,
+							'',
 							(this._config.oauth as AwsCognitoOAuthOpts).redirectSignIn
 						);
 					}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

changes the overridden `window.history.state` by the current session's browser `state`

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

- Smoked test changes in a sample app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
