### PR TITLE
fix: i18n default language resolution

### DIFF
--- a/packages/core/__tests__/I18n.test.ts
+++ b/packages/core/__tests__/I18n.test.ts
@@ -10,6 +10,12 @@ describe('I18n test', () => {
 	});
 
 	describe('get test', () => {
+		let languageGetterSpy;
+
+		beforeEach(() => {
+			languageGetterSpy = jest.spyOn(window.navigator, 'language', 'get')
+		});
+
 		test('no language', () => {
 			const i18n = new I18n();
 
@@ -58,6 +64,20 @@ describe('I18n test', () => {
 			expect(i18n.get('key')).toBe('key');
 
 			spyon.mockClear();
+		});
+
+		test('sets default language', () => {
+			languageGetterSpy.mockReturnValue('fr')
+
+			const i18n = new I18n();
+
+			i18n.putVocabularies({
+				'fr': {
+					'Sign In': 'Se connecter',
+				}
+			});
+
+			expect(i18n.get('Sign In')).toBe('Se connecter');
 		});
 	});
 

--- a/packages/core/src/I18n/I18n.ts
+++ b/packages/core/src/I18n/I18n.ts
@@ -65,6 +65,8 @@ export class I18n {
 	 * @param {String} defVal - Default value
 	 */
 	get(key: string, defVal: string | undefined = undefined) {
+		this.setDefaultLanguage();
+
 		if (!this._lang) {
 			return typeof defVal !== 'undefined' ? defVal : key;
 		}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes a regression that was introduced with some v6 refactoring that prevented the default browser language from being set in the i18n utility.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/12767

#### Description of how you validated changes
Tested in sample application.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
