### PR TITLE
fix(datastore): Update outbox comparison logic to fix update versioning problems

### DIFF
--- a/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
+++ b/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
@@ -88,13 +88,13 @@ describe('DataStore sync engine', () => {
 						['post title 0', 1],
 						['post title 1', 1],
 						['post title 2', 1],
-						['post title 0', 3],
-						['post title 0', 3],
+						['post title 2', 3],
+						['post title 2', 3],
 					]);
 
 					expect(await postHarness.currentContents).toMatchObject({
 						_version: 3,
-						title: 'post title 0',
+						title: 'post title 2',
 					});
 				});
 				test('delayed input, low latency where we wait for the create to clear the outbox', async () => {
@@ -118,12 +118,12 @@ describe('DataStore sync engine', () => {
 						['post title 0', 1],
 						['post title 1', 1],
 						['post title 2', 1],
-						['post title 0', 4],
+						['post title 2', 4],
 					]);
 
 					expect(await postHarness.currentContents).toMatchObject({
 						_version: 4,
-						title: 'post title 0',
+						title: 'post title 2',
 					});
 				});
 				test("no input delay, high latency where we don't wait for the create to clear the outbox", async () => {
@@ -717,11 +717,7 @@ describe('DataStore sync engine', () => {
 					await postHarness.revise('post title 2');
 
 					await harness.fullSettle();
-					await harness.expectGraphqlSettledWithEventCount({
-						update: 3,
-						updateSubscriptionMessage: 2,
-						updateError: 1,
-					});
+					await harness.expectGraphqlSettledWithEventCount(2);
 
 					expect(harness.subscriptionLogs()).toEqual([
 						['original title', 1],
@@ -751,11 +747,7 @@ describe('DataStore sync engine', () => {
 					await postHarness.revise('post title 2');
 
 					await harness.fullSettle();
-					await harness.expectGraphqlSettledWithEventCount({
-						update: 4,
-						updateSubscriptionMessage: 3,
-						updateError: 1,
-					});
+					await harness.expectGraphqlSettledWithEventCount(3);
 
 					expect(harness.subscriptionLogs()).toEqual([
 						['original title', 1],

--- a/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
+++ b/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
@@ -317,6 +317,9 @@ describe('DataStore sync engine', () => {
 						await harness.externalPostUpdate({
 							originalPostId: postHarness.original.id,
 							updatedFields: { title: 'update from second client' },
+							// The fake service version will be 2, having received the 'post title 0' update
+							// Because of this, the title will not be updated, but the
+							// version number will increment to 3
 							version: 1,
 						});
 						await postHarness.revise('post title 2');
@@ -329,6 +332,16 @@ describe('DataStore sync engine', () => {
 							['post title 0', 1],
 							['post title 1', 1],
 							['post title 2', 1],
+							// The title remains 'post title 0' having failed
+							// the external update and each revision after the
+							// 'post title 0' change due to not having or matching
+							// the latest version number and not matching
+							// the response fields to the update.
+							//
+							// In other cases, waiting to process through the subscriptions
+							// clears this up, but in this instance the subscription
+							// messages arrive before the outbox mutations are processed
+							// which causes them to be dropped.
 							['post title 0', 5],
 						]);
 

--- a/packages/datastore/src/sync/outbox.ts
+++ b/packages/datastore/src/sync/outbox.ts
@@ -15,7 +15,7 @@ import {
 	QueryOne,
 	SchemaModel,
 } from '../types';
-import { USER, SYNC, valuesEqual } from '../util';
+import { USER, SYNC, objectMatches } from '../util';
 import { getIdentifierValue, TransformerMutationType } from './utils';
 
 // TODO: Persist deleted ids
@@ -193,10 +193,12 @@ class MutationEventOutbox {
 		// Don't sync the version when the data in the response does not match the data
 		// in the request, i.e., when there's a handled conflict
 		//
-		// NOTE: `incomingData` contains all the fields in the record, and `outgoingData`
-		// only contains updated fields, resulting in an error when doing a comparison
-		// of two equal mutations. Fix this, or mitigate otherwise.
-		if (!valuesEqual(incomingData, outgoingData, true)) {
+		// NOTE: `incomingData` contains all the fields in the record received from AppSync
+		// and `outgoingData` only contains updated fields sent to AppSync
+		// If all send data isn't matched in the returned data then the update was rejected
+		// by AppSync and we should not update the version on other outbox entries for this
+		// object
+		if (!objectMatches(outgoingData, incomingData, true)) {
 			return;
 		}
 

--- a/packages/datastore/src/sync/outbox.ts
+++ b/packages/datastore/src/sync/outbox.ts
@@ -15,7 +15,7 @@ import {
 	QueryOne,
 	SchemaModel,
 } from '../types';
-import { USER, SYNC, objectMatches } from '../util';
+import { USER, SYNC, directedValueEquality } from '../util';
 import { getIdentifierValue, TransformerMutationType } from './utils';
 
 // TODO: Persist deleted ids
@@ -198,7 +198,7 @@ class MutationEventOutbox {
 		// If all send data isn't matched in the returned data then the update was rejected
 		// by AppSync and we should not update the version on other outbox entries for this
 		// object
-		if (!objectMatches(outgoingData, incomingData, true)) {
+		if (!directedValueEquality(outgoingData, incomingData, true)) {
 			return;
 		}
 

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -473,6 +473,32 @@ export function sortCompareFunction<T extends PersistentModel>(
 	};
 }
 
+/* deep directed comparison ensuring that all fields on object A exist and are equal to values on object B
+ * Note: This same guarauntee is not applied for values on object B that aren't on object A
+ *
+ * @param valA - The object that may be an equal subset of valB.
+ * @param valB - The object that may be an equal superset of valA.
+ * @returns True if valA is a equal subset of valB and False otherwise.
+ */
+export function objectMatches(
+	valA: object,
+	valB: object,
+	nullish: boolean = false
+) {
+	const aKeys = Object.keys(valA);
+
+	for (const key of aKeys) {
+		const aVal = valA[key];
+		const bVal = valB[key];
+
+		if (!valuesEqual(aVal, bVal, nullish)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 // deep compare any 2 values
 // primitives or object types (including arrays, Sets, and Maps)
 // returns true if equal by value

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -473,25 +473,28 @@ export function sortCompareFunction<T extends PersistentModel>(
 	};
 }
 
-/* deep directed comparison ensuring that all fields on object A exist and are equal to values on object B
- * Note: This same guarauntee is not applied for values on object B that aren't on object A
+/* deep directed comparison ensuring that all fields on "from" object exist and
+ * are equal to values on an "against" object
  *
- * @param valA - The object that may be an equal subset of valB.
- * @param valB - The object that may be an equal superset of valA.
- * @returns True if valA is a equal subset of valB and False otherwise.
+ * Note: This same guarauntee is not applied for values on "against" that aren't on "from"
+ *
+ * @param fromObject - The object that may be an equal subset of the againstObject.
+ * @param againstObject - The object that may be an equal superset of the fromObject.
+ *
+ * @returns True if fromObject is a equal subset of againstObject and False otherwise.
  */
-export function objectMatches(
-	valA: object,
-	valB: object,
+export function directedValueEquality(
+	fromObject: object,
+	againstObject: object,
 	nullish: boolean = false
 ) {
-	const aKeys = Object.keys(valA);
+	const aKeys = Object.keys(fromObject);
 
 	for (const key of aKeys) {
-		const aVal = valA[key];
-		const bVal = valB[key];
+		const fromValue = fromObject[key];
+		const againstValue = againstObject[key];
 
-		if (!valuesEqual(aVal, bVal, nullish)) {
+		if (!valuesEqual(fromValue, againstValue, nullish)) {
 			return false;
 		}
 	}


### PR DESCRIPTION
#### Description of changes
Outcome:
- To allow multiple partial updates, outbox checks compare all updated fields for deep equality with the returned object, but ignore extra returned fields when gating outbox `_version` maintenance.
- As a result, our rapid update use-cases will not drop updates


#### Issue #, if available
- https://github.com/aws-amplify/amplify-js/issues/12729
- https://github.com/aws-amplify/amplify-js/issues/9979

#### Description of how you validated changes
Validated by updating tests and testing against sample apps manaully for both Automerge and OCC usecases

#### Related changes
1. https://github.com/aws-amplify/amplify-js/pull/12728
2. https://github.com/aws-amplify/amplify-js/pull/12732
3. https://github.com/aws-amplify/amplify-js/pull/12740
4. https://github.com/aws-amplify/amplify-js/pull/12795
6. :seedling:  **fix(datastore): Update outbox comparison logic to fix update versioning problems**

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
