### PR TITLE
release(required): fix fetchAuthSession may hang on OAuth cancel

### DIFF
--- a/.github/workflows/callable-npm-publish-release.yml
+++ b/.github/workflows/callable-npm-publish-release.yml
@@ -51,5 +51,6 @@ jobs:
         working-directory: ./amplify-js
         run: |
           git push origin release
-          if [ $(git tag -l "required-release") ]; then git push -f origin required-release; fi
-          git push --force-with-lease origin release:main
+          # Disable for this release (6.0.11)
+          # if [ $(git tag -l "required-release") ]; then git push -f origin required-release; fi
+          # git push --force-with-lease origin release:main

--- a/packages/auth/src/providers/cognito/utils/oauth/attemptCompleteOAuthFlow.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/attemptCompleteOAuthFlow.ts
@@ -37,11 +37,11 @@ export const attemptCompleteOAuthFlow = async (
 	// when there is valid oauth config and there is an inflight oauth flow, try
 	// to block async calls that require fetching tokens before the oauth flow completes
 	// e.g. getCurrentUser, fetchAuthSession etc.
+	const asyncGetSessionBlocker = new Promise<void>((resolve, _) => {
+		addInflightPromise(resolve);
+	});
 	cognitoUserPoolsTokenProvider.setWaitForInflightOAuth(
-		() =>
-			new Promise(async (res, _rej) => {
-				addInflightPromise(res);
-			})
+		() => asyncGetSessionBlocker
 	);
 
 	try {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Bug: `cognitoUserPoolsTokenProvider.setWaitForInflightOAuth` sets a function that creates and returns a new promise every time.

Correction: The function sets by `cognitoUserPoolsTokenProvider.setWaitForInflightOAuth` should return the same promise.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-js/issues/12814

#### Description of how you validated changes

* Unit tests (updated the unit tests to verify the correction)
* Next.js sample app - redirect to provider hosted UI, closing the tab, reopening the web app, `fetchAuthSession` should resolve.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
