### PR TITLE
Revert "chore(repo): disable force push release to main for 6.0.11"

### DIFF
--- a/.github/workflows/callable-npm-publish-release.yml
+++ b/.github/workflows/callable-npm-publish-release.yml
@@ -51,6 +51,5 @@ jobs:
         working-directory: ./amplify-js
         run: |
           git push origin release
-          # Disable for this release (6.0.11)
-          # if [ $(git tag -l "required-release") ]; then git push -f origin required-release; fi
-          # git push --force-with-lease origin release:main
+          if [ $(git tag -l "required-release") ]; then git push -f origin required-release; fi
+          git push --force-with-lease origin release:main


### PR DESCRIPTION
This reverts commit c8c3a9f50482795af986efd9bd54fc7f88e22de6.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
