### PR TITLE
fix: Default branch resolution when running E2E tests

### DIFF
--- a/.github/actions/setup-samples-staging/action.yml
+++ b/.github/actions/setup-samples-staging/action.yml
@@ -34,9 +34,7 @@ runs:
       env:
         BRANCH: ${{ github.ref_name }}
       run: |
-        queryOutput=$(git ls-remote --exit-code --heads origin refs/heads/$BRANCH)
-        branchQueryCode=$?
-        if [ "$branchQueryCode" -eq 0 ]; then
+        if git ls-remote --exit-code --heads origin refs/heads/$BRANCH; then
             # Corresponding branch on sample repo exists, check it out
             git fetch origin $BRANCH
             git checkout $BRANCH

--- a/.github/actions/setup-samples-staging/action.yml
+++ b/.github/actions/setup-samples-staging/action.yml
@@ -34,7 +34,7 @@ runs:
       env:
         BRANCH: ${{ github.ref_name }}
       run: |
-        (git ls-remote --exit-code --heads origin refs/heads/$BRANCH)
+        queryOutput=$(git ls-remote --exit-code --heads origin refs/heads/$BRANCH)
         branchQueryCode=$?
         if [ "$branchQueryCode" -eq 0 ]; then
             # Corresponding branch on sample repo exists, check it out

--- a/.github/actions/setup-samples-staging/action.yml
+++ b/.github/actions/setup-samples-staging/action.yml
@@ -34,13 +34,15 @@ runs:
       env:
         BRANCH: ${{ github.ref_name }}
       run: |
-        if git ls-remote origin $BRANCH | grep -q refs/heads/next/$BRANCH$; then
-            # Branch exists, checkout and echo success message
+        git ls-remote --exit-code --heads origin refs/heads/$BRANCH
+        branchQueryCode=$?
+        if [ "$branchQueryCode" -eq 0 ]; then
+            # Corresponding branch on sample repo exists, check it out
             git fetch origin $BRANCH
             git checkout $BRANCH
             echo "Checked out branch: $BRANCH"
         else
-            # Branch doesn't exist, echo error message
+            # Corresponding branch doesn't exist, default to main
             echo "Branch '$BRANCH' does not exist"
         fi
 

--- a/.github/actions/setup-samples-staging/action.yml
+++ b/.github/actions/setup-samples-staging/action.yml
@@ -34,7 +34,7 @@ runs:
       env:
         BRANCH: ${{ github.ref_name }}
       run: |
-        git ls-remote --exit-code --heads origin refs/heads/$BRANCH
+        (git ls-remote --exit-code --heads origin refs/heads/$BRANCH)
         branchQueryCode=$?
         if [ "$branchQueryCode" -eq 0 ]; then
             # Corresponding branch on sample repo exists, check it out

--- a/.github/workflows/push-preid-release.yml
+++ b/.github/workflows/push-preid-release.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       # Change this to your branch name where "example-preid" corresponds to the preid you want your changes released on
-      - test-branch-selection
+      - feat/example-preid-branch/main
 
 jobs:
   e2e:
@@ -26,13 +26,13 @@ jobs:
     outputs:
       preid: ${{ steps.output_preid.outputs.preid }}
 
-  # preid-release:
-  #   needs:
-  #     - e2e
-  #     - parse-preid
-  #   secrets: inherit
-  #   uses: ./.github/workflows/callable-npm-publish-preid.yml
-  #   # The preid should be detected from the branch name recommending feat/{PREID}/whatever as branch naming pattern
-  #   #   if your branch doesn't follow this pattern, you can override it here for your branch.
-  #   with:
-  #     preid: ${{ needs.parse-preid.outputs.preid }}
+  preid-release:
+    needs:
+      - e2e
+      - parse-preid
+    secrets: inherit
+    uses: ./.github/workflows/callable-npm-publish-preid.yml
+    # The preid should be detected from the branch name recommending feat/{PREID}/whatever as branch naming pattern
+    #   if your branch doesn't follow this pattern, you can override it here for your branch.
+    with:
+      preid: ${{ needs.parse-preid.outputs.preid }}

--- a/.github/workflows/push-preid-release.yml
+++ b/.github/workflows/push-preid-release.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       # Change this to your branch name where "example-preid" corresponds to the preid you want your changes released on
-      - feat/example-preid-branch/main
+      - test-branch-selection
 
 jobs:
   e2e:
@@ -26,13 +26,13 @@ jobs:
     outputs:
       preid: ${{ steps.output_preid.outputs.preid }}
 
-  preid-release:
-    needs:
-      - e2e
-      - parse-preid
-    secrets: inherit
-    uses: ./.github/workflows/callable-npm-publish-preid.yml
-    # The preid should be detected from the branch name recommending feat/{PREID}/whatever as branch naming pattern
-    #   if your branch doesn't follow this pattern, you can override it here for your branch.
-    with:
-      preid: ${{ needs.parse-preid.outputs.preid }}
+  # preid-release:
+  #   needs:
+  #     - e2e
+  #     - parse-preid
+  #   secrets: inherit
+  #   uses: ./.github/workflows/callable-npm-publish-preid.yml
+  #   # The preid should be detected from the branch name recommending feat/{PREID}/whatever as branch naming pattern
+  #   #   if your branch doesn't follow this pattern, you can override it here for your branch.
+  #   with:
+  #     preid: ${{ needs.parse-preid.outputs.preid }}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR fixes an issue where default branch selection sometimes fails in situations where a `foo/branch` branch also exists in the sample staging repo. This is frequently encountered, for example, when running releases from the `release` branch which conflicts with `next/release`.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Tested various scenarios in CI:
- No matching `$BRANCH` (default to `main`): https://github.com/aws-amplify/amplify-js/actions/runs/7673370302/job/20915856173
- Matching `$BRANCH` (use that branch): https://github.com/aws-amplify/amplify-js/actions/runs/7673370302/job/20915935775
- No matching `$BRANCH` but `next/$BRANCH` exists (default to `main`): https://github.com/aws-amplify/amplify-js/actions/runs/7673370302/job/20916014564 <- The common friction point during releases
- Both `$BRANCH` & `next/$BRANCH` exist (use `$BRANCH`): https://github.com/aws-amplify/amplify-js/actions/runs/7673370302/job/20915979157


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
