### PR TITLE
fix: Lambda auth config value

### DIFF
--- a/packages/core/src/parseAWSExports.ts
+++ b/packages/core/src/parseAWSExports.ts
@@ -18,6 +18,7 @@ const authTypeMapping: Record<any, any> = {
 	AMAZON_COGNITO_USER_POOLS: 'userPool',
 	OPENID_CONNECT: 'oidc',
 	NONE: 'none',
+	LAMBDA: 'lambda',
 	AWS_LAMBDA: 'lambda',
 };
 

--- a/packages/core/src/parseAWSExports.ts
+++ b/packages/core/src/parseAWSExports.ts
@@ -18,7 +18,7 @@ const authTypeMapping: Record<any, any> = {
 	AMAZON_COGNITO_USER_POOLS: 'userPool',
 	OPENID_CONNECT: 'oidc',
 	NONE: 'none',
-	LAMBDA: 'lambda',
+	AWS_LAMBDA: 'lambda',
 };
 
 /**

--- a/packages/core/src/parseAWSExports.ts
+++ b/packages/core/src/parseAWSExports.ts
@@ -18,8 +18,13 @@ const authTypeMapping: Record<any, any> = {
 	AMAZON_COGNITO_USER_POOLS: 'userPool',
 	OPENID_CONNECT: 'oidc',
 	NONE: 'none',
-	LAMBDA: 'lambda',
 	AWS_LAMBDA: 'lambda',
+	// `LAMBDA` is an incorrect value that was added during the v6 rewrite.
+	// Keeping it as a valid value until v7 to prevent breaking customers who might
+	// be relying on it as a workaround.
+	// ref: https://github.com/aws-amplify/amplify-js/pull/12922
+	// TODO: @v7 remove next line
+	LAMBDA: 'lambda',
 };
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Both CLI & Gen2 emit Lambda auth config for GraphQL as `AWS_LAMBDA`, but we were looking for `LAMBDA` when parsing the config object. As a result the library was not respecting the default auth mode when it was configured as Lambda.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
