### PR TITLE
fix(core): Amplify.configure dispatches Hub event with unparsed config object

### DIFF
--- a/packages/core/__tests__/singleton/Singleton.test.ts
+++ b/packages/core/__tests__/singleton/Singleton.test.ts
@@ -1,10 +1,21 @@
 import { Amplify } from '../../src/singleton';
+import { Hub, AMPLIFY_SYMBOL } from '../../src/Hub';
 import { AuthClass as Auth } from '../../src/singleton/Auth';
 import { decodeJWT } from '../../src/singleton/Auth/utils';
 import { CredentialsAndIdentityId } from '../../src/singleton/Auth/types';
 import { TextEncoder, TextDecoder } from 'util';
 import { fetchAuthSession, ResourcesConfig } from '../../src';
 Object.assign(global, { TextDecoder, TextEncoder });
+
+jest.mock('../../src/Hub', () => ({
+	...jest.requireActual('../../src/Hub'),
+	Hub: {
+		dispatch: jest.fn(),
+	},
+}));
+
+const mockHubDispatch = Hub.dispatch as jest.Mock;
+
 type ArgumentTypes<F extends Function> = F extends (...args: infer A) => any
 	? A
 	: never;
@@ -85,64 +96,82 @@ const modelIntrospection: ModelIntrospection = {
 };
 
 describe('Amplify.configure() and Amplify.getConfig()', () => {
-	it('should take the legacy CLI shaped config object for configuring and return it from getConfig()', () => {
-		const mockLegacyConfig = {
-			aws_project_region: 'us-west-2',
-			aws_cognito_identity_pool_id: 'aws_cognito_identity_pool_id',
-			aws_cognito_region: 'aws_cognito_region',
-			aws_user_pools_id: 'aws_user_pools_id',
-			aws_user_pools_web_client_id: 'aws_user_pools_web_client_id',
-			oauth: {},
-			aws_cognito_username_attributes: [],
-			aws_cognito_social_providers: [],
-			aws_cognito_signup_attributes: [],
-			aws_cognito_mfa_configuration: 'OFF',
-			aws_cognito_mfa_types: ['SMS'],
-			aws_cognito_password_protection_settings: {
-				passwordPolicyMinLength: 8,
-				passwordPolicyCharacters: [],
+	const mockLegacyConfig = {
+		aws_project_region: 'us-west-2',
+		aws_cognito_identity_pool_id: 'aws_cognito_identity_pool_id',
+		aws_cognito_region: 'aws_cognito_region',
+		aws_user_pools_id: 'aws_user_pools_id',
+		aws_user_pools_web_client_id: 'aws_user_pools_web_client_id',
+		oauth: {},
+		aws_cognito_username_attributes: [],
+		aws_cognito_social_providers: [],
+		aws_cognito_signup_attributes: [],
+		aws_cognito_mfa_configuration: 'OFF',
+		aws_cognito_mfa_types: ['SMS'],
+		aws_cognito_password_protection_settings: {
+			passwordPolicyMinLength: 8,
+			passwordPolicyCharacters: [],
+		},
+		aws_cognito_verification_mechanisms: ['PHONE_NUMBER'],
+		aws_appsync_graphqlEndpoint: 'https://some.domain.com/graphql',
+		aws_appsync_region: 'us-west-1',
+		aws_appsync_authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+		aws_appsync_apiKey: 'some-key',
+		modelIntrospection,
+	};
+	const expectedResourceConfig: ResourcesConfig = {
+		Auth: {
+			Cognito: {
+				allowGuestAccess: true,
+				identityPoolId: 'aws_cognito_identity_pool_id',
+				userPoolClientId: 'aws_user_pools_web_client_id',
+				userPoolId: 'aws_user_pools_id',
+				loginWith: { email: false, phone: false, username: true },
+				mfa: { smsEnabled: true, status: 'off', totpEnabled: false },
+				passwordFormat: {
+					minLength: 8,
+					requireLowercase: false,
+					requireNumbers: false,
+					requireSpecialCharacters: false,
+					requireUppercase: false,
+				},
+				userAttributes: { phone_number: { required: true } },
 			},
-			aws_cognito_verification_mechanisms: ['PHONE_NUMBER'],
-			aws_appsync_graphqlEndpoint: 'https://some.domain.com/graphql',
-			aws_appsync_region: 'us-west-1',
-			aws_appsync_authenticationType: 'AMAZON_COGNITO_USER_POOLS',
-			aws_appsync_apiKey: 'some-key',
-			modelIntrospection,
-		};
+		},
+		API: {
+			GraphQL: {
+				apiKey: 'some-key',
+				defaultAuthMode: 'userPool',
+				endpoint: 'https://some.domain.com/graphql',
+				region: 'us-west-1',
+				modelIntrospection,
+			},
+		},
+	};
 
+	afterEach(() => {
+		mockHubDispatch.mockClear();
+	});
+
+	it('should take the legacy CLI shaped config object for configuring and return it from getConfig()', () => {
 		Amplify.configure(mockLegacyConfig);
 		const result = Amplify.getConfig();
-		const expected: ResourcesConfig = {
-			Auth: {
-				Cognito: {
-					allowGuestAccess: true,
-					identityPoolId: 'aws_cognito_identity_pool_id',
-					userPoolClientId: 'aws_user_pools_web_client_id',
-					userPoolId: 'aws_user_pools_id',
-					loginWith: { email: false, phone: false, username: true },
-					mfa: { smsEnabled: true, status: 'off', totpEnabled: false },
-					passwordFormat: {
-						minLength: 8,
-						requireLowercase: false,
-						requireNumbers: false,
-						requireSpecialCharacters: false,
-						requireUppercase: false,
-					},
-					userAttributes: { phone_number: { required: true } },
-				},
-			},
-			API: {
-				GraphQL: {
-					apiKey: 'some-key',
-					defaultAuthMode: 'userPool',
-					endpoint: 'https://some.domain.com/graphql',
-					region: 'us-west-1',
-					modelIntrospection,
-				},
-			},
-		};
 
-		expect(result).toEqual(expected);
+		expect(result).toEqual(expectedResourceConfig);
+	});
+
+	it('dispatches hub event with parsed ResourceConfig from the legacy config', () => {
+		Amplify.configure(mockLegacyConfig);
+
+		expect(mockHubDispatch).toHaveBeenCalledWith(
+			'core',
+			{
+				event: 'configure',
+				data: expectedResourceConfig,
+			},
+			'Configure',
+			AMPLIFY_SYMBOL
+		);
 	});
 
 	it('should take the v6 shaped config object for configuring and return it from getConfig()', () => {

--- a/packages/core/src/singleton/Amplify.ts
+++ b/packages/core/src/singleton/Amplify.ts
@@ -72,7 +72,7 @@ export class AmplifyClass {
 			'core',
 			{
 				event: 'configure',
-				data: resourcesConfig,
+				data: this.resourcesConfig,
 			},
 			'Configure',
 			AMPLIFY_SYMBOL


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* unit testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
