### PR TITLE
fix(core): not appending notification configs properly

### DIFF
--- a/packages/core/__tests__/parseAWSExports.test.ts
+++ b/packages/core/__tests__/parseAWSExports.test.ts
@@ -262,4 +262,43 @@ describe('parseAWSExports', () => {
 			'Invalid config parameter.'
 		);
 	});
+	it('should append Notification configs when both Push and InApp configs are available', () => {
+		const testConfig = {
+			aws_project_region: 'us-west-2',
+			aws_user_pools_id: userPoolId,
+			Notifications: {
+				Push: {
+					AWSPinpoint: {
+						appId: "appId",
+						region: "region"
+					}
+				},
+				InAppMessaging: {
+					AWSPinpoint: {
+						appId: "appId",
+						region: "region"
+					}
+				}
+			}
+		};
+
+		expect(parseAWSExports(testConfig)).toMatchObject(
+			{
+				Notifications: {
+					PushNotification: {
+						Pinpoint: {
+							appId: "appId",
+							region: "region"
+						}
+					},
+					InAppMessaging: {
+						Pinpoint: {
+							appId: "appId",
+							region: "region"
+						}
+					}
+				}	
+			}
+		);
+	});
 });

--- a/packages/core/src/parseAWSExports.ts
+++ b/packages/core/src/parseAWSExports.ts
@@ -107,6 +107,7 @@ export const parseAWSExports = (
 		if (Push?.AWSPinpoint) {
 			const { appId, region } = Push.AWSPinpoint;
 			amplifyConfig.Notifications = {
+				...amplifyConfig.Notifications,
 				PushNotification: {
 					Pinpoint: {
 						appId,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
When parsing the aws exports file, Push Notification config will now be appended to the existing config rather than replacing it. 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/12913


#### Description of how you validated changes
- Linked the library and a sample app locally
- Added InApp and Push to the sample app
- Observe no error


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
