### PR TITLE
fix(api-graphql): wrong arguments for GET operation of a CPK model

### DIFF
--- a/packages/api-graphql/__tests__/fixtures/schema-models/with-custom-primary-key/models.ts
+++ b/packages/api-graphql/__tests__/fixtures/schema-models/with-custom-primary-key/models.ts
@@ -1,0 +1,199 @@
+import { SchemaModel } from '@aws-amplify/core/internals/utils';
+
+export const userSchemaModel: SchemaModel = {
+	name: 'User',
+	fields: {
+		userId: {
+			name: 'userId',
+			isArray: false,
+			type: 'ID',
+			isRequired: true,
+			attributes: [],
+		},
+		name: {
+			name: 'name',
+			isArray: false,
+			type: 'String',
+			isRequired: true,
+			attributes: [],
+		},
+		createdTodos: {
+			name: 'createdTodos',
+			isArray: true,
+			type: {
+				model: 'Todo',
+			},
+			isRequired: false,
+			attributes: [],
+			isArrayNullable: true,
+			association: {
+				connectionType: 'HAS_MANY' as any,
+				associatedWith: ['userCreatedTodosUserId'],
+			},
+		},
+		assignedTodos: {
+			name: 'assignedTodos',
+			isArray: true,
+			type: {
+				model: 'Todo',
+			},
+			isRequired: false,
+			attributes: [],
+			isArrayNullable: true,
+			association: {
+				connectionType: 'HAS_MANY' as any,
+				associatedWith: ['userAssignedTodosUserId'],
+			},
+		},
+		owner: {
+			name: 'owner',
+			isArray: false,
+			type: 'String',
+			isRequired: false,
+			attributes: [],
+		},
+		createdAt: {
+			name: 'createdAt',
+			isArray: false,
+			type: 'AWSDateTime',
+			isRequired: true,
+			attributes: [],
+		},
+		updatedAt: {
+			name: 'updatedAt',
+			isArray: false,
+			type: 'AWSDateTime',
+			isRequired: true,
+			attributes: [],
+		},
+	},
+	syncable: true,
+	pluralName: 'Users',
+	attributes: [
+		{
+			type: 'model',
+			properties: {},
+		},
+		{
+			type: 'key',
+			properties: {
+				fields: ['userId'],
+			},
+		},
+		{
+			type: 'auth',
+			properties: {
+				rules: [
+					{
+						provider: 'userPools',
+						ownerField: 'owner',
+						allow: 'owner',
+						identityClaim: 'cognito:username',
+						operations: ['create', 'update', 'delete', 'read'],
+					},
+					{
+						allow: 'public',
+						operations: ['read'],
+					},
+				],
+			},
+		},
+	],
+	primaryKeyInfo: {
+		isCustomPrimaryKey: true,
+		primaryKeyFieldName: 'userId',
+		sortKeyFieldNames: [],
+	},
+};
+
+export const productSchemaModel: SchemaModel = {
+	name: 'Product',
+	fields: {
+		sku: {
+			name: 'sku',
+			isArray: false,
+			type: 'String',
+			isRequired: true,
+			attributes: [],
+		},
+		factoryId: {
+			name: 'factoryId',
+			isArray: false,
+			type: 'String',
+			isRequired: true,
+			attributes: [],
+		},
+		warehouseId: {
+			name: 'warehouseId',
+			isArray: false,
+			type: 'String',
+			isRequired: true,
+			attributes: [],
+		},
+		description: {
+			name: 'description',
+			isArray: false,
+			type: 'String',
+			isRequired: false,
+			attributes: [],
+		},
+		owner: {
+			name: 'owner',
+			isArray: false,
+			type: 'String',
+			isRequired: false,
+			attributes: [],
+		},
+		createdAt: {
+			name: 'createdAt',
+			isArray: false,
+			type: 'AWSDateTime',
+			isRequired: true,
+			attributes: [],
+		},
+		updatedAt: {
+			name: 'updatedAt',
+			isArray: false,
+			type: 'AWSDateTime',
+			isRequired: true,
+			attributes: [],
+		},
+	},
+	syncable: true,
+	pluralName: 'Products',
+	attributes: [
+		{
+			type: 'model',
+			properties: {},
+		},
+		{
+			type: 'key',
+			properties: {
+				fields: ['sku', 'factoryId', 'warehouseId'],
+			},
+		},
+		{
+			type: 'auth',
+			properties: {
+				rules: [
+					{
+						provider: 'userPools',
+						ownerField: 'owner',
+						allow: 'owner',
+						identityClaim: 'cognito:username',
+						operations: ['create', 'update', 'delete', 'read'],
+					},
+					{
+						allow: 'public',
+						operations: ['read'],
+					},
+				],
+			},
+		},
+	],
+	primaryKeyInfo: {
+		isCustomPrimaryKey: true,
+		primaryKeyFieldName: 'sku',
+		sortKeyFieldNames: ['factoryId', 'warehouseId'],
+	},
+};

--- a/packages/api-graphql/src/internals/APIClient.ts
+++ b/packages/api-graphql/src/internals/APIClient.ts
@@ -589,7 +589,7 @@ export function generateGraphQLDocument(
 				(graphQLArguments = isCustomPrimaryKey
 					? [primaryKeyFieldName, ...sortKeyFieldNames].reduce(
 							(acc: Record<string, any>, fieldName) => {
-								acc[fieldName] = fields[fieldName].type;
+								acc[fieldName] = `${fields[fieldName].type}!`;
 
 								return acc;
 							},


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Append `!` to the generated arguments in the GraphQL document for a GET operation of a model that has custom primary key defined.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* Unit testing
* Manual integration test in a sample app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
