### PR TITLE
fix: Remove special e2e treatment for validated tests

### DIFF
--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -135,8 +135,6 @@ tests:
     sample_name: v2/owner-and-group-different-models-default-v2
     spec: owner-and-group-different-models-default
     browser: *minimal_browser_list
-    timeout_minutes: 45
-    retry_count: 10
   - test_name: integ_datastore_auth_v2-owner-and-group-same-model-default
     desc: 'DataStore Auth CLI v2'
     framework: react
@@ -158,8 +156,6 @@ tests:
     sample_name: v2/dynamic-user-pool-groups-default-v2
     spec: dynamic-user-pool-groups-default
     browser: *minimal_browser_list
-    timeout_minutes: 45
-    retry_count: 10
   - test_name: integ_datastore_auth_v2-dynamic-user-pool-groups-owner-based-default
     desc: 'DataStore Auth CLI v2'
     framework: react
@@ -349,8 +345,6 @@ tests:
     sample_name: [v2/related-models]
     spec: cpk-related-models
     browser: *extended_browser_list
-    timeout_minutes: 45
-    retry_count: 10
   - test_name: integ_react_datastore_selective_sync
     desc: 'DataStore - Selective Sync'
     framework: react
@@ -512,8 +506,6 @@ tests:
     sample_name: [auth-rsc]
     spec: auth-rsc
     browser: [chrome]
-    timeout_minutes: 45
-    retry_count: 10
   - test_name: integ_next_sign_in_with_oauth
     desc: 'Sign-in with the OAuth flow'
     framework: next
@@ -521,8 +513,6 @@ tests:
     sample_name: [sign-in-with-oauth]
     spec: sign-in-with-oauth
     browser: [chrome]
-    timeout_minutes: 45
-    retry_count: 10
 
   # DISABLED Angular/Vue tests:
   # TODO: delete tests or add custom ui logic to support them.


### PR DESCRIPTION
#### Description of changes
These tests have been isolated due to past flakiness. I have run them many times and observe sufficient stability that I recommend we remove their special treatment.

Process: [Link](https://github.com/stocaaro/amplify-js/actions/runs/7746613180)
- Setup e2e execution on my for that runs this subset of the suite 6x in parallel
- Reduce these tests to 1 retry (current config default is for 3 retries)
- Rerun this suite with this configuration 5 times

Observation: Across this test pattern, one test failed twice in a row such that only 1 out of the 5 tests runs was a failure.

The [test that failed](https://github.com/stocaaro/amplify-js/actions/runs/7746613180/job/21126252595) 2 consecutive runs to cause the failure (`integ_datastore_auth_v2-owner-and-group-different-models-default`) runs on 2 browsers, so this is such 1 failure out of 60 executions.

#### Description of how you validated changes
I ran it a bunch - with lots of parallelism.  See links above.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
