### PR TITLE
fix(repo): rollup generated sourcemap has wrong src path

### DIFF
--- a/rollup/common.mjs
+++ b/rollup/common.mjs
@@ -19,6 +19,7 @@ export const cjsTSOptions = {
 	outDir: 'dist/cjs',
 	declaration: false, // declarations are handled by the ESM build
 	module: 'CommonJS',
+	sourceMap: false,
 	tsconfig: defaultTSConfigPath,
 	tsBuildInfoFile: 'dist/meta/cjs.tsbuildinfo',
 	noEmitOnError: !isWatch,
@@ -36,6 +37,7 @@ export const esmOutput = {
 
 export const esmTSOptions = {
 	outDir: 'dist/esm',
+	sourceMap: false,
 	tsconfig: defaultTSConfigPath,
 	tsBuildInfoFile: 'dist/meta/cjs.tsbuildinfo',
 	noEmitOnError: !isWatch,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Disabled sourceMap option in the tsconfig for the rollup typescript plugin, and let rollup to handle it. (this is the original setup, but got altered in this commit: https://github.com/aws-amplify/amplify-js/commit/8b3b20461289873f53f6c77bb231d2dea3a39743#diff-6db54c94dcda26ffae248a497178e6aa322cce7d7619738c5675bd382a5752cf)

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

Build locally and tested built artifacts with the smoke-testing app, warnings regarding sourcemap are gone.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
