### PR TITLE
fix(api-graphql): same results returned for queries on the same model with different selection sets

### DIFF
--- a/packages/api-graphql/src/internals/APIClient.ts
+++ b/packages/api-graphql/src/internals/APIClient.ts
@@ -310,7 +310,6 @@ export type ModelOperation = keyof typeof graphQLOperationsInfo;
 type OperationPrefix =
 	(typeof graphQLOperationsInfo)[ModelOperation]['operationPrefix'];
 
-const graphQLDocumentsCache = new Map<string, Map<ModelOperation, string>>();
 const SELECTION_SET_WILDCARD = '*';
 
 function defaultSelectionSetForModel(modelDefinition: SchemaModel): string[] {
@@ -550,18 +549,8 @@ export function generateGraphQLDocument(
 	const { operationPrefix, usePlural } = graphQLOperationsInfo[modelOperation];
 
 	const { selectionSet } = listArgs || {};
-
-	const fromCache = graphQLDocumentsCache.get(name)?.get(modelOperation);
-
-	if (fromCache !== undefined) {
-		return fromCache;
-	}
-
-	if (!graphQLDocumentsCache.has(name)) {
-		graphQLDocumentsCache.set(name, new Map());
-	}
-
 	const graphQLFieldName = `${operationPrefix}${usePlural ? pluralName : name}`;
+
 	let graphQLOperationType: 'mutation' | 'query' | 'subscription' | undefined;
 	let graphQLSelectionSet: string | undefined;
 	let graphQLArguments: Record<string, any> | undefined;
@@ -639,8 +628,6 @@ export function generateGraphQLDocument(
 			  )})`
 			: ''
 	} { ${graphQLSelectionSet} } }`;
-
-	graphQLDocumentsCache.get(name)?.set(modelOperation, graphQLDocument);
 
 	return graphQLDocument;
 }


### PR DESCRIPTION
- caused by the incomplete GraphQL documents caching

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Remove the incomplete cache implementation. This particular caching is not optimizing much.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
