### PR TITLE
feat(api-graphql): add library options to generateServerClientUsingCookies

### DIFF
--- a/packages/adapter-nextjs/src/api/createServerRunnerForAPI.ts
+++ b/packages/adapter-nextjs/src/api/createServerRunnerForAPI.ts
@@ -7,6 +7,7 @@ import { NextServer } from '../types';
 
 export const createServerRunnerForAPI = ({
 	config,
+	libraryOptions,
 }: NextServer.CreateServerRunnerInput): NextServer.CreateServerRunnerOutput & {
 	resourcesConfig: ResourcesConfig;
 } => {
@@ -15,6 +16,7 @@ export const createServerRunnerForAPI = ({
 	return {
 		runWithAmplifyServerContext: createRunWithAmplifyServerContext({
 			config: amplifyConfig,
+			libraryOptions,
 		}),
 		resourcesConfig: amplifyConfig,
 	};

--- a/packages/adapter-nextjs/src/api/generateServerClient.ts
+++ b/packages/adapter-nextjs/src/api/generateServerClient.ts
@@ -20,6 +20,7 @@ import { GraphQLAuthMode } from '@aws-amplify/core/internals/utils';
 type CookiesClientParams = {
 	cookies: NextServer.ServerComponentContext['cookies'];
 	config: NextServer.CreateServerRunnerInput['config'];
+	libraryOptions?: NextServer.CreateServerRunnerInput['libraryOptions'];
 	authMode?: GraphQLAuthMode;
 	authToken?: string;
 };
@@ -44,6 +45,7 @@ export function generateServerClientUsingCookies<
 >({
 	config,
 	cookies,
+	libraryOptions,
 	authMode,
 	authToken,
 }: CookiesClientParams): V6ClientSSRCookies<T> {
@@ -58,7 +60,7 @@ export function generateServerClientUsingCookies<
 	}
 
 	const { runWithAmplifyServerContext, resourcesConfig } =
-		createServerRunnerForAPI({ config });
+		createServerRunnerForAPI({ config, libraryOptions });
 
 	// This function reference gets passed down to InternalGraphQLAPI.ts.graphql
 	// where this._graphql is passed in as the `fn` argument

--- a/packages/adapter-nextjs/src/createServerRunner.ts
+++ b/packages/adapter-nextjs/src/createServerRunner.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ResourcesConfig } from 'aws-amplify';
+import { LibraryOptions, ResourcesConfig } from 'aws-amplify';
 
 import { createRunWithAmplifyServerContext, getAmplifyConfig } from './utils';
 import { NextServer } from './types';
@@ -16,6 +16,7 @@ import { NextServer } from './types';
  * @param input The input used to create the `runWithAmplifyServerContext` function.
  * @param input.config The {@link ResourcesConfig} imported from the `amplifyconfiguration.json` file or manually
  * created.
+ * @param input.libraryOptions The {@link LibraryOptions} additional options for the library.
  * @returns An object that contains the `runWithAmplifyServerContext` function.
  *
  * @example
@@ -27,12 +28,14 @@ import { NextServer } from './types';
  */
 export const createServerRunner: NextServer.CreateServerRunner = ({
 	config,
+	libraryOptions,
 }) => {
 	const amplifyConfig = getAmplifyConfig(config);
 
 	return {
 		runWithAmplifyServerContext: createRunWithAmplifyServerContext({
 			config: amplifyConfig,
+			libraryOptions,
 		}),
 	};
 };

--- a/packages/adapter-nextjs/src/types/NextServer.ts
+++ b/packages/adapter-nextjs/src/types/NextServer.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from 'next/server.js';
 import { cookies } from 'next/headers.js';
 import { LegacyConfig } from 'aws-amplify/adapter-core';
 import { AmplifyServer } from '@aws-amplify/core/internals/adapter-core';
-import { ResourcesConfig } from '@aws-amplify/core';
+import { LibraryOptions, ResourcesConfig } from '@aws-amplify/core';
 
 export declare namespace NextServer {
 	/**
@@ -75,6 +75,7 @@ export declare namespace NextServer {
 
 	export interface CreateServerRunnerInput {
 		config: ResourcesConfig | LegacyConfig;
+		libraryOptions: LibraryOptions;
 	}
 
 	export interface CreateServerRunnerOutput {

--- a/packages/adapter-nextjs/src/utils/createRunWithAmplifyServerContext.ts
+++ b/packages/adapter-nextjs/src/utils/createRunWithAmplifyServerContext.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ResourcesConfig, sharedInMemoryStorage } from '@aws-amplify/core';
+import { LibraryOptions, ResourcesConfig, sharedInMemoryStorage } from '@aws-amplify/core';
 import {
 	createAWSCredentialsAndIdentityIdProvider,
 	createKeyValueStorageFromCookieStorageAdapter,
@@ -15,8 +15,10 @@ import { createCookieStorageAdapterFromNextServerContext } from './createCookieS
 
 export const createRunWithAmplifyServerContext = ({
 	config: resourcesConfig,
+	libraryOptions,
 }: {
 	config: ResourcesConfig;
+	libraryOptions?: LibraryOptions
 }) => {
 	const runWithAmplifyServerContext: NextServer.RunOperationWithContext =
 		async ({ nextServerContext, operation }) => {
@@ -55,7 +57,7 @@ export const createRunWithAmplifyServerContext = ({
 
 			// Otherwise it may be the case that auth is not used, e.g. API key.
 			// Omitting the `Auth` in the second parameter.
-			return runWithAmplifyServerContextCore(resourcesConfig, {}, operation);
+			return runWithAmplifyServerContextCore(resourcesConfig, libraryOptions, operation);
 		};
 
 	return runWithAmplifyServerContext;


### PR DESCRIPTION
#### Description of changes
In Amplify.configure (client side), we are able to override `libraryOptions` in order to use the idToken. However, this option is not available on server side.

```
Amplify.configure(awsConfig, {
    ssr: true,
    API: {
        GraphQL: {
            headers: async () => ({
                Authorization: (await fetchAuthSession()).tokens?.idToken?.toString(),
            }),
        },
    },
});
```

This PR allows `libraryOptions` to be passed into `generateServerClientUsingCookies`

#### Issue #, if available
#12971 

#### Description of how you validated changes
Local Dev Server w/ fork

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ X ] PR description included
- [ X ] `yarn test` passes
- [ X ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ X ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
