### PR TITLE
fix(api-graphql): server side iam auth mode is ineffective

### DIFF
--- a/packages/api-graphql/__tests__/GraphQLAPI.test.ts
+++ b/packages/api-graphql/__tests__/GraphQLAPI.test.ts
@@ -185,7 +185,7 @@ describe('API test', () => {
 					expect.objectContaining({
 						message: 'Unauthorized',
 						recoverySuggestion: expect.stringContaining(
-							`If you're calling an Amplify-generated API, make sure to set the "authMode" in generateClient`
+							`If you're calling an Amplify-generated API, make sure to set the "authMode" in generateClient`,
 						),
 					}),
 				]);
@@ -296,19 +296,26 @@ describe('API test', () => {
 			expect(errors).toBe(undefined);
 			expect(thread).toEqual(graphqlResponse.data.getThread);
 
-			expect(spy).toHaveBeenCalledWith({
-				abortController: expect.any(AbortController),
-				url: new URL('https://localhost/graphql'),
-				options: expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: 'mock-access-token',
-					}),
-					signingServiceInfo: expect.objectContaining({
-						region: 'local-host-h4x',
-						service: 'appsync',
-					}),
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					Auth: expect.any(Object),
+					configure: expect.any(Function),
+					getConfig: expect.any(Function),
 				}),
-			});
+				{
+					abortController: expect.any(AbortController),
+					url: new URL('https://localhost/graphql'),
+					options: expect.objectContaining({
+						headers: expect.objectContaining({
+							Authorization: 'mock-access-token',
+						}),
+						signingServiceInfo: expect.objectContaining({
+							region: 'local-host-h4x',
+							service: 'appsync',
+						}),
+					}),
+				},
+			);
 		});
 
 		test('happy-case-query-oidc with auth storage federated token', async () => {
@@ -358,19 +365,26 @@ describe('API test', () => {
 
 			expect(errors).toBe(undefined);
 			expect(thread).toEqual(graphqlResponse.data.getThread);
-			expect(spy).toHaveBeenCalledWith({
-				abortController: expect.any(AbortController),
-				url: new URL('https://localhost/graphql'),
-				options: expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: 'mock-access-token',
-					}),
-					signingServiceInfo: expect.objectContaining({
-						region: 'local-host-h4x',
-						service: 'appsync',
-					}),
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					Auth: expect.any(Object),
+					configure: expect.any(Function),
+					getConfig: expect.any(Function),
 				}),
-			});
+				{
+					abortController: expect.any(AbortController),
+					url: new URL('https://localhost/graphql'),
+					options: expect.objectContaining({
+						headers: expect.objectContaining({
+							Authorization: 'mock-access-token',
+						}),
+						signingServiceInfo: expect.objectContaining({
+							region: 'local-host-h4x',
+							service: 'appsync',
+						}),
+					}),
+				},
+			);
 		});
 
 		test('happy case query with AWS_LAMBDA', async () => {
@@ -421,19 +435,26 @@ describe('API test', () => {
 
 			expect(errors).toBe(undefined);
 			expect(thread).toEqual(graphqlResponse.data.getThread);
-			expect(spy).toHaveBeenCalledWith({
-				abortController: expect.any(AbortController),
-				url: new URL('https://localhost/graphql'),
-				options: expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: 'myAuthToken',
-					}),
-					signingServiceInfo: expect.objectContaining({
-						region: 'local-host-h4x',
-						service: 'appsync',
-					}),
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					Auth: expect.any(Object),
+					configure: expect.any(Function),
+					getConfig: expect.any(Function),
 				}),
-			});
+				{
+					abortController: expect.any(AbortController),
+					url: new URL('https://localhost/graphql'),
+					options: expect.objectContaining({
+						headers: expect.objectContaining({
+							Authorization: 'myAuthToken',
+						}),
+						signingServiceInfo: expect.objectContaining({
+							region: 'local-host-h4x',
+							service: 'appsync',
+						}),
+					}),
+				},
+			);
 		});
 
 		test('additional headers with AWS_LAMBDA', async () => {
@@ -480,7 +501,7 @@ describe('API test', () => {
 				},
 				{
 					Authorization: 'additional-header-auth-token',
-				}
+				},
 			);
 
 			const thread: GetThreadQuery['getThread'] = result.data?.getThread;
@@ -488,19 +509,26 @@ describe('API test', () => {
 
 			expect(errors).toBe(undefined);
 			expect(thread).toEqual(graphqlResponse.data.getThread);
-			expect(spy).toHaveBeenCalledWith({
-				abortController: expect.any(AbortController),
-				url: new URL('https://localhost/graphql'),
-				options: expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: 'additional-header-auth-token',
-					}),
-					signingServiceInfo: expect.objectContaining({
-						region: 'local-host-h4x',
-						service: 'appsync',
-					}),
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					Auth: expect.any(Object),
+					configure: expect.any(Function),
+					getConfig: expect.any(Function),
 				}),
-			});
+				{
+					abortController: expect.any(AbortController),
+					url: new URL('https://localhost/graphql'),
+					options: expect.objectContaining({
+						headers: expect.objectContaining({
+							Authorization: 'additional-header-auth-token',
+						}),
+						signingServiceInfo: expect.objectContaining({
+							region: 'local-host-h4x',
+							service: 'appsync',
+						}),
+					}),
+				},
+			);
 		});
 
 		test('multi-auth default case AWS_IAM, using API_KEY as auth mode', async () => {
@@ -551,14 +579,21 @@ describe('API test', () => {
 
 			expect(errors).toBe(undefined);
 			expect(thread).toEqual(graphqlResponse.data.getThread);
-			expect(spy).toHaveBeenCalledWith({
-				abortController: expect.any(AbortController),
-				url: new URL('https://localhost/graphql'),
-				options: expect.objectContaining({
-					headers: expect.objectContaining({ 'X-Api-Key': 'FAKE-KEY' }),
-					signingServiceInfo: undefined,
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					Auth: expect.any(Object),
+					configure: expect.any(Function),
+					getConfig: expect.any(Function),
 				}),
-			});
+				{
+					abortController: expect.any(AbortController),
+					url: new URL('https://localhost/graphql'),
+					options: expect.objectContaining({
+						headers: expect.objectContaining({ 'X-Api-Key': 'FAKE-KEY' }),
+						signingServiceInfo: undefined,
+					}),
+				},
+			);
 		});
 
 		test('multi-auth default case api-key, using AWS_IAM as auth mode', async () => {
@@ -610,17 +645,24 @@ describe('API test', () => {
 			expect(errors).toBe(undefined);
 			expect(thread).toEqual(graphqlResponse.data.getThread);
 
-			expect(spy).toHaveBeenCalledWith({
-				abortController: expect.any(AbortController),
-				url: new URL('https://localhost/graphql'),
-				options: expect.objectContaining({
-					headers: expect.not.objectContaining({ 'X-Api-Key': 'FAKE-KEY' }),
-					signingServiceInfo: expect.objectContaining({
-						region: 'local-host-h4x',
-						service: 'appsync',
-					}),
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					Auth: expect.any(Object),
+					configure: expect.any(Function),
+					getConfig: expect.any(Function),
 				}),
-			});
+				{
+					abortController: expect.any(AbortController),
+					url: new URL('https://localhost/graphql'),
+					options: expect.objectContaining({
+						headers: expect.not.objectContaining({ 'X-Api-Key': 'FAKE-KEY' }),
+						signingServiceInfo: expect.objectContaining({
+							region: 'local-host-h4x',
+							service: 'appsync',
+						}),
+					}),
+				},
+			);
 		});
 
 		test('multi-auth default case api-key, using AWS_LAMBDA as auth mode', async () => {
@@ -672,19 +714,27 @@ describe('API test', () => {
 
 			expect(errors).toBe(undefined);
 			expect(thread).toEqual(graphqlResponse.data.getThread);
-			expect(spy).toHaveBeenCalledWith({
-				abortController: expect.any(AbortController),
-				url: new URL('https://localhost/graphql'),
-				options: expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: 'myAuthToken',
-					}),
-					signingServiceInfo: expect.objectContaining({
-						region: 'local-host-h4x',
-						service: 'appsync',
-					}),
+
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					Auth: expect.any(Object),
+					configure: expect.any(Function),
+					getConfig: expect.any(Function),
 				}),
-			});
+				{
+					abortController: expect.any(AbortController),
+					url: new URL('https://localhost/graphql'),
+					options: expect.objectContaining({
+						headers: expect.objectContaining({
+							Authorization: 'myAuthToken',
+						}),
+						signingServiceInfo: expect.objectContaining({
+							region: 'local-host-h4x',
+							service: 'appsync',
+						}),
+					}),
+				},
+			);
 		});
 
 		test('multi-auth default case api-key, OIDC as auth mode, but no federatedSign', async () => {
@@ -754,7 +804,7 @@ describe('API test', () => {
 					query: typedQueries.getThread,
 					variables: graphqlVariables,
 					authMode: 'oidc',
-				})
+				}),
 			).rejects.toThrow('No current user');
 
 			// Cleanup:
@@ -806,7 +856,7 @@ describe('API test', () => {
 					query: typedQueries.getThread,
 					variables: graphqlVariables,
 					authMode: 'userPool',
-				})
+				}),
 			).rejects.toThrow();
 
 			// Cleanup:
@@ -831,7 +881,7 @@ describe('API test', () => {
 					query: typedQueries.getThread,
 					variables: graphqlVariables,
 					authMode: 'lambda',
-				})
+				}),
 			).rejects.toThrow(GraphQLAuthError.NO_AUTH_TOKEN);
 		});
 
@@ -853,7 +903,7 @@ describe('API test', () => {
 					query: typedQueries.getThread,
 					variables: graphqlVariables,
 					authMode: 'apiKey',
-				})
+				}),
 			).rejects.toThrow(GraphQLAuthError.NO_API_KEY);
 		});
 
@@ -879,7 +929,7 @@ describe('API test', () => {
 					query: typedQueries.getThread,
 					variables: graphqlVariables,
 					authMode: 'iam',
-				})
+				}),
 			).rejects.toThrow(GraphQLAuthError.NO_CREDENTIALS);
 
 			// Cleanup:
@@ -934,19 +984,26 @@ describe('API test', () => {
 
 			expect(errors).toBe(undefined);
 			expect(thread).toEqual(graphqlResponse.data.getThread);
-			expect(spy).toHaveBeenCalledWith({
-				abortController: expect.any(AbortController),
-				url: new URL('https://localhost/graphql'),
-				options: expect.objectContaining({
-					headers: expect.objectContaining({
-						Authorization: 'mock-access-token',
-					}),
-					signingServiceInfo: expect.objectContaining({
-						region: 'local-host-h4x',
-						service: 'appsync',
-					}),
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					Auth: expect.any(Object),
+					configure: expect.any(Function),
+					getConfig: expect.any(Function),
 				}),
-			});
+				{
+					abortController: expect.any(AbortController),
+					url: new URL('https://localhost/graphql'),
+					options: expect.objectContaining({
+						headers: expect.objectContaining({
+							Authorization: 'mock-access-token',
+						}),
+						signingServiceInfo: expect.objectContaining({
+							region: 'local-host-h4x',
+							service: 'appsync',
+						}),
+					}),
+				},
+			);
 		});
 
 		test('authMode on subscription', async () => {
@@ -979,7 +1036,7 @@ describe('API test', () => {
 				expect.objectContaining({
 					authenticationType: 'oidc',
 				}),
-				expect.anything()
+				expect.anything(),
 			);
 		});
 
@@ -1029,7 +1086,7 @@ describe('API test', () => {
 								],
 							});
 						});
-					})
+					}),
 				);
 
 			const query = `subscription SubscribeToEventComments($eventId: String!) {
@@ -1051,7 +1108,7 @@ describe('API test', () => {
 						expect.objectContaining({
 							message: 'Unauthorized',
 							recoverySuggestion: expect.stringContaining(
-								`If you're calling an Amplify-generated API, make sure to set the "authMode" in generateClient`
+								`If you're calling an Amplify-generated API, make sure to set the "authMode" in generateClient`,
 							),
 						}),
 					]);
@@ -1084,7 +1141,7 @@ describe('API test', () => {
 			const observable = (
 				client.graphql(
 					{ query, variables },
-					additionalHeaders
+					additionalHeaders,
 				) as unknown as Observable<object>
 			).subscribe({
 				next: () => {
@@ -1131,7 +1188,7 @@ describe('API test', () => {
 								}),
 						},
 					},
-				}
+				},
 			);
 
 			const threadToGet = {
@@ -1169,7 +1226,7 @@ describe('API test', () => {
 					query: typedQueries.getThread,
 					variables: graphqlVariables,
 				},
-				additionalHeaders
+				additionalHeaders,
 			);
 
 			const thread: GetThreadQuery['getThread'] = result.data?.getThread;
@@ -1177,18 +1234,25 @@ describe('API test', () => {
 
 			expect(errors).toBe(undefined);
 			expect(thread).toEqual(graphqlResponse.data.getThread);
-			expect(spy).toHaveBeenCalledWith({
-				abortController: expect.any(AbortController),
-				url: new URL('https://localhost/graphql'),
-				options: expect.objectContaining({
-					headers: expect.objectContaining({
-						someAdditionalHeader: 'foo',
-						someHeaderSetAtConfigThatWillBeOverridden: 'expectedValue',
-						someOtherHeaderSetAtConfig: 'expectedValue',
-					}),
-					signingServiceInfo: undefined,
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					Auth: expect.any(Object),
+					configure: expect.any(Function),
+					getConfig: expect.any(Function),
 				}),
-			});
+				{
+					abortController: expect.any(AbortController),
+					url: new URL('https://localhost/graphql'),
+					options: expect.objectContaining({
+						headers: expect.objectContaining({
+							someAdditionalHeader: 'foo',
+							someHeaderSetAtConfigThatWillBeOverridden: 'expectedValue',
+							someOtherHeaderSetAtConfig: 'expectedValue',
+						}),
+						signingServiceInfo: undefined,
+					}),
+				},
+			);
 		});
 
 		test('sends cookies with request', async () => {
@@ -1220,7 +1284,7 @@ describe('API test', () => {
 							withCredentials: true,
 						},
 					},
-				}
+				},
 			);
 
 			const threadToGet = {
@@ -1253,7 +1317,7 @@ describe('API test', () => {
 					query: typedQueries.getThread,
 					variables: graphqlVariables,
 					authMode: 'apiKey',
-				}
+				},
 			);
 
 			const thread: GetThreadQuery['getThread'] = result.data?.getThread;
@@ -1261,15 +1325,22 @@ describe('API test', () => {
 
 			expect(errors).toBe(undefined);
 			expect(thread).toEqual(graphqlResponse.data.getThread);
-			expect(spy).toHaveBeenCalledWith({
-				abortController: expect.any(AbortController),
-				url: new URL('https://localhost/graphql'),
-				options: expect.objectContaining({
-					headers: expect.objectContaining({ 'X-Api-Key': 'FAKE-KEY' }),
-					signingServiceInfo: undefined,
-					withCredentials: true,
+			expect(spy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					Auth: expect.any(Object),
+					configure: expect.any(Function),
+					getConfig: expect.any(Function),
 				}),
-			});
+				{
+					abortController: expect.any(AbortController),
+					url: new URL('https://localhost/graphql'),
+					options: expect.objectContaining({
+						headers: expect.objectContaining({ 'X-Api-Key': 'FAKE-KEY' }),
+						signingServiceInfo: undefined,
+						withCredentials: true,
+					}),
+				},
+			);
 		});
 	});
 });

--- a/packages/api-graphql/__tests__/internals/__snapshots__/generateClient.test.ts.snap
+++ b/packages/api-graphql/__tests__/internals/__snapshots__/generateClient.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`generateClient basic model operations - authMode: CuP override at the time of operation can create() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -47,6 +48,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
 exports[`generateClient basic model operations - authMode: CuP override at the time of operation can delete() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -90,6 +92,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
 exports[`generateClient basic model operations - authMode: CuP override at the time of operation can get() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -131,6 +134,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
 exports[`generateClient basic model operations - authMode: CuP override at the time of operation can lazy load with inherited authMode can lazy load @belongsTo 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -164,6 +168,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -205,6 +210,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
 exports[`generateClient basic model operations - authMode: CuP override at the time of operation can lazy load with inherited authMode can lazy load @hasMany 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -241,6 +247,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -291,6 +298,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
 exports[`generateClient basic model operations - authMode: CuP override at the time of operation can lazy load with inherited authMode can lazy load @hasOne 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -327,6 +335,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -364,6 +373,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
 exports[`generateClient basic model operations - authMode: CuP override at the time of operation can lazy load with overridden authMode can lazy load @belongsTo 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -397,6 +407,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -435,6 +446,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
 exports[`generateClient basic model operations - authMode: CuP override at the time of operation can lazy load with overridden authMode can lazy load @hasMany 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -471,6 +483,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -518,6 +531,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
 exports[`generateClient basic model operations - authMode: CuP override at the time of operation can lazy load with overridden authMode can lazy load @hasOne 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -554,6 +568,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -588,6 +603,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
 exports[`generateClient basic model operations - authMode: CuP override at the time of operation can list() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -637,6 +653,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
 exports[`generateClient basic model operations - authMode: CuP override at the time of operation can update() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -681,6 +698,7 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
 exports[`generateClient basic model operations - authMode: CuP override in the client can create() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -725,6 +743,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
 exports[`generateClient basic model operations - authMode: CuP override in the client can delete() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -768,6 +787,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
 exports[`generateClient basic model operations - authMode: CuP override in the client can get() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -809,6 +829,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
 exports[`generateClient basic model operations - authMode: CuP override in the client can lazy load with inherited authMode can lazy load @belongsTo 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -842,6 +863,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -883,6 +905,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
 exports[`generateClient basic model operations - authMode: CuP override in the client can lazy load with inherited authMode can lazy load @hasMany 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -919,6 +942,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -969,6 +993,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
 exports[`generateClient basic model operations - authMode: CuP override in the client can lazy load with inherited authMode can lazy load @hasOne 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1005,6 +1030,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1042,6 +1068,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
 exports[`generateClient basic model operations - authMode: CuP override in the client can lazy load with overridden authMode can lazy load @belongsTo 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1075,6 +1102,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1113,6 +1141,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
 exports[`generateClient basic model operations - authMode: CuP override in the client can lazy load with overridden authMode can lazy load @hasMany 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1149,6 +1178,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1196,6 +1226,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
 exports[`generateClient basic model operations - authMode: CuP override in the client can lazy load with overridden authMode can lazy load @hasOne 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1232,6 +1263,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1266,6 +1298,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
 exports[`generateClient basic model operations - authMode: CuP override in the client can list() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1315,6 +1348,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
 exports[`generateClient basic model operations - authMode: CuP override in the client can update() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1359,6 +1393,7 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
 exports[`generateClient basic model operations - authMode: lambda override at the time of operation can create() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1403,6 +1438,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
 exports[`generateClient basic model operations - authMode: lambda override at the time of operation can delete() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1446,6 +1482,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
 exports[`generateClient basic model operations - authMode: lambda override at the time of operation can get() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1487,6 +1524,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
 exports[`generateClient basic model operations - authMode: lambda override at the time of operation can lazy load with inherited authMode can lazy load @belongsTo 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1520,6 +1558,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1561,6 +1600,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
 exports[`generateClient basic model operations - authMode: lambda override at the time of operation can lazy load with inherited authMode can lazy load @hasMany 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1597,6 +1637,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1647,6 +1688,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
 exports[`generateClient basic model operations - authMode: lambda override at the time of operation can lazy load with inherited authMode can lazy load @hasOne 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1683,6 +1725,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1720,6 +1763,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
 exports[`generateClient basic model operations - authMode: lambda override at the time of operation can lazy load with overridden authMode can lazy load @belongsTo 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1753,6 +1797,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1794,6 +1839,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
 exports[`generateClient basic model operations - authMode: lambda override at the time of operation can lazy load with overridden authMode can lazy load @hasMany 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1830,6 +1876,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1880,6 +1927,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
 exports[`generateClient basic model operations - authMode: lambda override at the time of operation can lazy load with overridden authMode can lazy load @hasOne 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1916,6 +1964,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -1953,6 +2002,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
 exports[`generateClient basic model operations - authMode: lambda override at the time of operation can list() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2002,6 +2052,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
 exports[`generateClient basic model operations - authMode: lambda override at the time of operation can update() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2046,6 +2097,7 @@ exports[`generateClient basic model operations - authMode: lambda override at th
 exports[`generateClient basic model operations - authMode: lambda override in the client can create() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2090,6 +2142,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
 exports[`generateClient basic model operations - authMode: lambda override in the client can delete() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2133,6 +2186,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
 exports[`generateClient basic model operations - authMode: lambda override in the client can get() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2174,6 +2228,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
 exports[`generateClient basic model operations - authMode: lambda override in the client can lazy load with inherited authMode can lazy load @belongsTo 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2207,6 +2262,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2248,6 +2304,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
 exports[`generateClient basic model operations - authMode: lambda override in the client can lazy load with inherited authMode can lazy load @hasMany 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2284,6 +2341,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2334,6 +2392,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
 exports[`generateClient basic model operations - authMode: lambda override in the client can lazy load with inherited authMode can lazy load @hasOne 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2370,6 +2429,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2407,6 +2467,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
 exports[`generateClient basic model operations - authMode: lambda override in the client can lazy load with overridden authMode can lazy load @belongsTo 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2440,6 +2501,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2481,6 +2543,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
 exports[`generateClient basic model operations - authMode: lambda override in the client can lazy load with overridden authMode can lazy load @hasMany 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2517,6 +2580,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2567,6 +2631,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
 exports[`generateClient basic model operations - authMode: lambda override in the client can lazy load with overridden authMode can lazy load @hasOne 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2603,6 +2668,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2640,6 +2706,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
 exports[`generateClient basic model operations - authMode: lambda override in the client can list() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2689,6 +2756,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
 exports[`generateClient basic model operations - authMode: lambda override in the client can update() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2733,6 +2801,7 @@ exports[`generateClient basic model operations - authMode: lambda override in th
 exports[`generateClient basic model operations - custom client and request headers can create() - with custom client header functions 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2775,6 +2844,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations - custom client and request headers can create() - with custom client header functions that pass requestOptions 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2832,6 +2902,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations - custom client and request headers can create() - with custom client headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2874,6 +2945,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations - custom client and request headers can create() - with custom request header function 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2916,6 +2988,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations - custom client and request headers can create() - with custom request header function that accept requestOptions 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -2973,6 +3046,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations - custom client and request headers can create() - with custom request headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3015,6 +3089,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations - custom client and request headers can delete() - with custom client headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3056,6 +3131,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations - custom client and request headers can delete() - with custom request headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3097,6 +3173,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations - custom client and request headers can get() - with custom client headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3136,6 +3213,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations - custom client and request headers can get() - with custom request headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3175,6 +3253,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations - custom client and request headers can list() - with custom client headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3222,6 +3301,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations - custom client and request headers can list() - with custom request headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3269,6 +3349,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations - custom client and request headers can update() - with custom client headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3311,6 +3392,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations - custom client and request headers can update() - with custom request headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3353,6 +3435,7 @@ exports[`generateClient basic model operations - custom client and request heade
 exports[`generateClient basic model operations can create() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3394,6 +3477,7 @@ exports[`generateClient basic model operations can create() 1`] = `
 exports[`generateClient basic model operations can delete() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3434,6 +3518,7 @@ exports[`generateClient basic model operations can delete() 1`] = `
 exports[`generateClient basic model operations can get() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3472,6 +3557,7 @@ exports[`generateClient basic model operations can get() 1`] = `
 exports[`generateClient basic model operations can lazy load @belongsTo 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3502,6 +3588,7 @@ exports[`generateClient basic model operations can lazy load @belongsTo 1`] = `
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3540,6 +3627,7 @@ exports[`generateClient basic model operations can lazy load @belongsTo 1`] = `
 exports[`generateClient basic model operations can lazy load @hasMany 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3573,6 +3661,7 @@ exports[`generateClient basic model operations can lazy load @hasMany 1`] = `
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3620,6 +3709,7 @@ exports[`generateClient basic model operations can lazy load @hasMany 1`] = `
 exports[`generateClient basic model operations can lazy load @hasMany with limit 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3653,6 +3743,7 @@ exports[`generateClient basic model operations can lazy load @hasMany with limit
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3701,6 +3792,7 @@ exports[`generateClient basic model operations can lazy load @hasMany with limit
 exports[`generateClient basic model operations can lazy load @hasMany with nextToken 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3734,6 +3826,7 @@ exports[`generateClient basic model operations can lazy load @hasMany with nextT
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3782,6 +3875,7 @@ exports[`generateClient basic model operations can lazy load @hasMany with nextT
 exports[`generateClient basic model operations can lazy load @hasOne 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3815,6 +3909,7 @@ exports[`generateClient basic model operations can lazy load @hasOne 1`] = `
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3849,6 +3944,7 @@ exports[`generateClient basic model operations can lazy load @hasOne 1`] = `
 exports[`generateClient basic model operations can list() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3895,6 +3991,7 @@ exports[`generateClient basic model operations can list() 1`] = `
 exports[`generateClient basic model operations can list() with limit 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3942,6 +4039,7 @@ exports[`generateClient basic model operations can list() with limit 1`] = `
 exports[`generateClient basic model operations can list() with nextToken 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -3989,6 +4087,7 @@ exports[`generateClient basic model operations can list() with nextToken 1`] = `
 exports[`generateClient basic model operations can update() 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4030,6 +4129,7 @@ exports[`generateClient basic model operations can update() 1`] = `
 exports[`generateClient basic model operations with Amplify configuration options headers can create() - custom client headers should not overwrite library config headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4073,6 +4173,7 @@ exports[`generateClient basic model operations with Amplify configuration option
 exports[`generateClient basic model operations with Amplify configuration options headers can create() - custom request headers should not overwrite library config headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4116,6 +4217,7 @@ exports[`generateClient basic model operations with Amplify configuration option
 exports[`generateClient basic model operations with Amplify configuration options headers can create() - with library config headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4159,6 +4261,7 @@ exports[`generateClient basic model operations with Amplify configuration option
 exports[`generateClient basic model operations with Amplify configuration options headers can delete() - custom client headers should not overwrite library config headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4201,6 +4304,7 @@ exports[`generateClient basic model operations with Amplify configuration option
 exports[`generateClient basic model operations with Amplify configuration options headers can delete() - custom request headers should overwrite client headers but not library config headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4243,6 +4347,7 @@ exports[`generateClient basic model operations with Amplify configuration option
 exports[`generateClient basic model operations with Amplify configuration options headers can get() - custom client headers should not overwrite library config headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4283,6 +4388,7 @@ exports[`generateClient basic model operations with Amplify configuration option
 exports[`generateClient basic model operations with Amplify configuration options headers can get() - custom request headers overwrite client headers, but not library config headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4323,6 +4429,7 @@ exports[`generateClient basic model operations with Amplify configuration option
 exports[`generateClient basic model operations with Amplify configuration options headers can list() - custom client headers should not overwrite library config headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4371,6 +4478,7 @@ exports[`generateClient basic model operations with Amplify configuration option
 exports[`generateClient basic model operations with Amplify configuration options headers can list() - custom request headers should overwrite client headers but not library config headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4419,6 +4527,7 @@ exports[`generateClient basic model operations with Amplify configuration option
 exports[`generateClient basic model operations with Amplify configuration options headers can update() - custom client headers should not overwrite library config headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4462,6 +4571,7 @@ exports[`generateClient basic model operations with Amplify configuration option
 exports[`generateClient basic model operations with Amplify configuration options headers can update() - custom request headers should overwrite client headers but not library config headers 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4505,6 +4615,7 @@ exports[`generateClient basic model operations with Amplify configuration option
 exports[`generateClient graphql - client-level auth override client auth override query - lambda 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4542,6 +4653,7 @@ exports[`generateClient graphql - client-level auth override client auth overrid
 exports[`generateClient graphql - client-level auth override client auth override query 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4579,6 +4691,7 @@ exports[`generateClient graphql - client-level auth override client auth overrid
 exports[`generateClient graphql default auth default iam produces expected signingInfo 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4616,6 +4729,7 @@ exports[`generateClient graphql default auth default iam produces expected signi
 exports[`generateClient index queries PK and SK index query 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4666,6 +4780,7 @@ exports[`generateClient index queries PK and SK index query 1`] = `
 exports[`generateClient index queries PK-only index query 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4712,6 +4827,7 @@ exports[`generateClient index queries PK-only index query 1`] = `
 exports[`generateClient observeQuery can paginate through initial results 1`] = `
 [
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {
@@ -4748,6 +4864,7 @@ exports[`generateClient observeQuery can paginate through initial results 1`] = 
     },
   ],
   [
+    "AmplifyClassV6",
     {
       "abortController": AbortController {},
       "options": {

--- a/packages/api-graphql/__tests__/internals/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/internals/generateClient.test.ts
@@ -89,13 +89,18 @@ function makeAppSyncStreams() {
  */
 function normalizePostGraphqlCalls(spy: jest.SpyInstance<any, any>) {
 	return spy.mock.calls.map((call: any) => {
-		const [postOptions] = call;
+		// The 1st param in `call` is an instance of `AmplifyClassV6`
+		// The 2nd param in `call` is the actual `postOptions`
+		const [_, postOptions] = call;
 		const userAgent = postOptions?.options?.headers?.['x-amz-user-agent'];
 		if (userAgent) {
 			const staticUserAgent = userAgent.replace(/\/[\d.]+/g, '/latest');
 			postOptions.options.headers['x-amz-user-agent'] = staticUserAgent;
 		}
-		return call;
+		// Calling of `post` API with an instance of `AmplifyClassV6` has been
+		// unit tested in other test suites. To reduce the noise in the generated
+		// snapshot, we hide the details of the instance here.
+		return ['AmplifyClassV6', postOptions];
 	});
 }
 
@@ -2956,6 +2961,7 @@ describe('generateClient', () => {
 
 			// Request headers should overwrite client headers:
 			expect(spy).toHaveBeenCalledWith(
+				expect.any(AmplifyClassV6),
 				expect.objectContaining({
 					options: expect.objectContaining({
 						headers: expect.not.objectContaining({
@@ -3211,6 +3217,7 @@ describe('generateClient', () => {
 			expect(normalizePostGraphqlCalls(spy)).toMatchSnapshot();
 
 			expect(spy).toHaveBeenCalledWith(
+				expect.any(AmplifyClassV6),
 				expect.objectContaining({
 					options: expect.objectContaining({
 						body: expect.objectContaining({
@@ -3890,6 +3897,7 @@ describe('generateClient', () => {
 			expect(normalizePostGraphqlCalls(spy)).toMatchSnapshot();
 
 			expect(spy).toHaveBeenCalledWith(
+				expect.any(AmplifyClassV6),
 				expect.objectContaining({
 					options: expect.objectContaining({
 						body: expect.objectContaining({

--- a/packages/api-graphql/__tests__/internals/server/generateClientWithAmplifyInstance.test.ts
+++ b/packages/api-graphql/__tests__/internals/server/generateClientWithAmplifyInstance.test.ts
@@ -1,5 +1,5 @@
 import * as raw from '../../../src';
-import { Amplify, ResourcesConfig } from '@aws-amplify/core';
+import { Amplify, AmplifyClassV6, ResourcesConfig } from '@aws-amplify/core';
 import { generateClientWithAmplifyInstance } from '../../../src/internals/server';
 import configFixture from '../../fixtures/modeled/amplifyconfiguration';
 import { Schema } from '../../fixtures/modeled/schema';
@@ -97,6 +97,7 @@ describe('server generateClient', () => {
 			});
 
 			expect(spy).toHaveBeenCalledWith(
+				expect.any(AmplifyClassV6),
 				expect.objectContaining({
 					options: expect.objectContaining({
 						headers: expect.objectContaining({
@@ -104,7 +105,7 @@ describe('server generateClient', () => {
 						}),
 						body: {
 							query: expect.stringContaining(
-								'listTodos(filter: $filter, limit: $limit, nextToken: $nextToken)'
+								'listTodos(filter: $filter, limit: $limit, nextToken: $nextToken)',
 							),
 							variables: {
 								filter: {
@@ -115,10 +116,11 @@ describe('server generateClient', () => {
 							},
 						},
 					}),
-				})
+				}),
 			);
 
 			expect(spy).toHaveBeenCalledWith(
+				expect.any(AmplifyClassV6),
 				expect.objectContaining({
 					options: expect.objectContaining({
 						body: expect.objectContaining({
@@ -126,7 +128,7 @@ describe('server generateClient', () => {
 							query: expect.stringMatching(/^\s*nextToken\s*$/m),
 						}),
 					}),
-				})
+				}),
 			);
 
 			expect(data.length).toBe(1);
@@ -137,7 +139,7 @@ describe('server generateClient', () => {
 					owner: 'wirejobviously',
 					name: 'some name',
 					description: 'something something',
-				})
+				}),
 			);
 		});
 
@@ -176,6 +178,7 @@ describe('server generateClient', () => {
 			});
 
 			expect(spy).toHaveBeenCalledWith(
+				expect.any(AmplifyClassV6),
 				expect.objectContaining({
 					options: expect.objectContaining({
 						headers: expect.objectContaining({
@@ -183,7 +186,7 @@ describe('server generateClient', () => {
 						}),
 						body: {
 							query: expect.stringContaining(
-								'listTodos(filter: $filter, limit: $limit, nextToken: $nextToken)'
+								'listTodos(filter: $filter, limit: $limit, nextToken: $nextToken)',
 							),
 							variables: {
 								filter: {
@@ -195,10 +198,11 @@ describe('server generateClient', () => {
 							},
 						},
 					}),
-				})
+				}),
 			);
 
 			expect(spy).toHaveBeenCalledWith(
+				expect.any(AmplifyClassV6),
 				expect.objectContaining({
 					options: expect.objectContaining({
 						body: expect.objectContaining({
@@ -206,7 +210,7 @@ describe('server generateClient', () => {
 							query: expect.stringMatching(/^\s*nextToken\s*$/m),
 						}),
 					}),
-				})
+				}),
 			);
 		});
 
@@ -245,6 +249,7 @@ describe('server generateClient', () => {
 			});
 
 			expect(spy).toHaveBeenCalledWith(
+				expect.any(AmplifyClassV6),
 				expect.objectContaining({
 					options: expect.objectContaining({
 						headers: expect.objectContaining({
@@ -252,7 +257,7 @@ describe('server generateClient', () => {
 						}),
 						body: {
 							query: expect.stringContaining(
-								'listTodos(filter: $filter, limit: $limit, nextToken: $nextToken)'
+								'listTodos(filter: $filter, limit: $limit, nextToken: $nextToken)',
 							),
 							variables: {
 								filter: {
@@ -264,10 +269,11 @@ describe('server generateClient', () => {
 							},
 						},
 					}),
-				})
+				}),
 			);
 
 			expect(spy).toHaveBeenCalledWith(
+				expect.any(AmplifyClassV6),
 				expect.objectContaining({
 					options: expect.objectContaining({
 						body: expect.objectContaining({
@@ -275,7 +281,7 @@ describe('server generateClient', () => {
 							query: expect.stringMatching(/^\s*nextToken\s*$/m),
 						}),
 					}),
-				})
+				}),
 			);
 		});
 	});
@@ -321,7 +327,7 @@ describe('server generateClient', () => {
 				expect.objectContaining({
 					query: expect.stringContaining('listNotes'),
 				}),
-				{}
+				{},
 			);
 		});
 	});

--- a/packages/api-graphql/__tests__/utils/expects.ts
+++ b/packages/api-graphql/__tests__/utils/expects.ts
@@ -43,17 +43,23 @@ export function expectGet(
 	opName: string,
 	item: Record<string, any>
 ) {
-	expect(spy).toHaveBeenCalledWith({
-		abortController: expect.any(AbortController),
-		url: new URL('https://localhost/graphql'),
-		options: expect.objectContaining({
-			headers: expect.objectContaining({ 'X-Api-Key': 'FAKE-KEY' }),
-			body: expect.objectContaining({
-				query: expect.stringContaining(`${opName}(id: $id)`),
-				variables: expect.objectContaining(item),
+	expect(spy).toHaveBeenCalledWith(
+		expect.objectContaining({
+			Auth: expect.any(Object),
+			configure: expect.any(Function),
+			getConfig: expect.any(Function),
+		}), {
+			abortController: expect.any(AbortController),
+			url: new URL('https://localhost/graphql'),
+			options: expect.objectContaining({
+				headers: expect.objectContaining({ 'X-Api-Key': 'FAKE-KEY' }),
+				body: expect.objectContaining({
+					query: expect.stringContaining(`${opName}(id: $id)`),
+					variables: expect.objectContaining(item),
+				}),
 			}),
-		}),
-	});
+		}
+	);
 }
 
 /**

--- a/packages/api-rest/src/internals/index.ts
+++ b/packages/api-rest/src/internals/index.ts
@@ -1,9 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Amplify } from '@aws-amplify/core';
 
 import { post as internalPost } from '../apis/common/internalPost';
-import { InternalPostInput } from '../types';
 
 /**
  * Internal-only REST POST handler to send GraphQL request to given endpoint. By default, it will use IAM to authorize
@@ -21,9 +19,7 @@ import { InternalPostInput } from '../types';
  *
  * @internal
  */
-export const post = (input: InternalPostInput) => {
-	return internalPost(Amplify, input);
-};
+export const post = internalPost;
 
 export {
 	cancel,

--- a/packages/datastore/__tests__/mutation.test.ts
+++ b/packages/datastore/__tests__/mutation.test.ts
@@ -199,6 +199,11 @@ describe('MutationProcessor', () => {
 			await mutationProcessor.resume();
 			expect(mockRestPost).toHaveBeenCalledWith(
 				expect.objectContaining({
+					Auth: expect.any(Object),
+					configure: expect.any(Function),
+					getConfig: expect.any(Function),
+				}),
+				expect.objectContaining({
 					url: new URL(
 						'https://xxxxxxxxxxxxxxxxxxxxxx.appsync-api.us-west-2.amazonaws.com/graphql'
 					),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

1. Changed the api-rest exported internal `post` function for api-graphql to make it server side usable (can inject the instance of `AmplifyClassV6` from the server context)
2. Changed the api-graphql server `graphql` method `wrapper` implementation to ensure it's an `await` -able function so Amplify server context can ensure destroying context only after this function has completed
3. Updated test suites

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-js/issues/12984
https://github.com/aws-amplify/amplify-js/issues/12931
https://github.com/aws-amplify/amplify-js/issues/12867

#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
