### PR TITLE
fix(core): eslint migration caused wrong CustomScope type

### DIFF
--- a/packages/core/src/singleton/Auth/types.ts
+++ b/packages/core/src/singleton/Auth/types.ts
@@ -185,7 +185,9 @@ interface CustomProvider {
 	custom: string;
 }
 
-type CustomScope = string & Record<string, string>;
+// CustomScope is a non-nullish string, using `& NonNullable<unknown>` to ensure
+// `OAuthScope` is not resolved as a `string`
+type CustomScope = string & NonNullable<unknown>;
 export type OAuthScope =
 	| 'email'
 	| 'openid'


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

The `CustomScope` should be a string `type CustomScope = string & {}` was used to ensure `OAuthScope` won't resolve as a `string`.

The eslint migration required change of using `{}`, and the change was wrong.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
