### PR TITLE
chore(auth): improve error message on failure of getCurrentUser while dispatching signedIn event

### DIFF
--- a/packages/auth/__tests__/providers/cognito/utils/dispatchSignedInHubEvent.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/dispatchSignedInHubEvent.test.ts
@@ -3,10 +3,12 @@
 
 import { Hub } from '@aws-amplify/core';
 import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
-import { dispatchSignedInHubEvent } from '../../../../src/providers/cognito/utils/dispatchSignedInHubEvent';
+import {
+	dispatchSignedInHubEvent,
+	ERROR_MESSAGE,
+} from '../../../../src/providers/cognito/utils/dispatchSignedInHubEvent';
 import { getCurrentUser } from '../../../../src/providers/cognito/apis/getCurrentUser';
 import { assertAuthTokens } from '../../../../src/providers/cognito/utils/types';
-import { UNEXPECTED_SIGN_IN_INTERRUPTION_EXCEPTION } from '../../../../src/errors/constants';
 
 jest.mock('../../../../src/providers/cognito/apis/getCurrentUser', () => ({
 	getCurrentUser: jest.fn(),
@@ -50,9 +52,7 @@ describe('dispatchSignedInHubEvent()', () => {
 			assertAuthTokens(null);
 		});
 
-		expect(() => dispatchSignedInHubEvent()).rejects.toThrow(
-			'Could not get user session right after signing in successfully.',
-		);
+		expect(() => dispatchSignedInHubEvent()).rejects.toThrow(ERROR_MESSAGE);
 	});
 
 	it('rethrows error if the error is not handled by itself', () => {

--- a/packages/auth/__tests__/providers/cognito/utils/dispatchSignedInHubEvent.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/dispatchSignedInHubEvent.test.ts
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Hub } from '@aws-amplify/core';
+import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
+import { dispatchSignedInHubEvent } from '../../../../src/providers/cognito/utils/dispatchSignedInHubEvent';
+import { getCurrentUser } from '../../../../src/providers/cognito/apis/getCurrentUser';
+import { assertAuthTokens } from '../../../../src/providers/cognito/utils/types';
+import { UNEXPECTED_SIGN_IN_INTERRUPTION_EXCEPTION } from '../../../../src/errors/constants';
+
+jest.mock('../../../../src/providers/cognito/apis/getCurrentUser', () => ({
+	getCurrentUser: jest.fn(),
+}));
+jest.mock('@aws-amplify/core', () => ({
+	Hub: {
+		dispatch: jest.fn(),
+	},
+}));
+jest.mock('@aws-amplify/core/internals/utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/utils'),
+	AMPLIFY_SYMBOL: Symbol('AMPLIFY_SYMBOL'),
+}));
+
+const mockGetCurrentUser = getCurrentUser as jest.Mock;
+const mockDispatch = Hub.dispatch as jest.Mock;
+
+describe('dispatchSignedInHubEvent()', () => {
+	it('dispatches Hub event `signedIn` with `getCurrentUser()` returned data', async () => {
+		const mockGetCurrentUserPayload = {
+			username: 'hello',
+			userId: 'userId',
+		};
+		mockGetCurrentUser.mockResolvedValueOnce(mockGetCurrentUserPayload);
+
+		await dispatchSignedInHubEvent();
+
+		expect(mockDispatch).toHaveBeenCalledWith(
+			'auth',
+			{
+				event: 'signedIn',
+				data: mockGetCurrentUserPayload,
+			},
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+
+	it('throws error when `getCurrentUser()` throws `USER_UNAUTHENTICATED_EXCEPTION`', () => {
+		mockGetCurrentUser.mockImplementationOnce(() => {
+			assertAuthTokens(null);
+		});
+
+		expect(() => dispatchSignedInHubEvent()).rejects.toThrow(
+			'Could not get user session right after signing in successfully.',
+		);
+	});
+
+	it('rethrows error if the error is not handled by itself', () => {
+		const mockError = new Error('some other error');
+
+		mockGetCurrentUser.mockImplementationOnce(() => {
+			throw mockError;
+		});
+
+		expect(() => dispatchSignedInHubEvent()).rejects.toThrow(mockError);
+	});
+});

--- a/packages/auth/src/errors/constants.ts
+++ b/packages/auth/src/errors/constants.ts
@@ -26,3 +26,4 @@ export const invalidOriginException = new AuthError({
 });
 export const OAUTH_SIGNOUT_EXCEPTION = 'OAuthSignOutException';
 export const TOKEN_REFRESH_EXCEPTION = 'TokenRefreshException';
+export const UNEXPECTED_SIGN_IN_INTERRUPTION_EXCEPTION = 'UnexpectedSignInInterruptionException';

--- a/packages/auth/src/providers/cognito/apis/confirmSignIn.ts
+++ b/packages/auth/src/providers/cognito/apis/confirmSignIn.ts
@@ -35,6 +35,7 @@ import {
 } from '../utils/clients/CognitoIdentityProvider/types';
 import { tokenOrchestrator } from '../tokenProvider';
 import { getCurrentUser } from './getCurrentUser';
+import { dispatchSignedInHubEvent } from '../utils/dispatchSignedInHubEvent';
 
 /**
  * Continues or completes the sign in process when required by the initial call to `signIn`.
@@ -122,15 +123,9 @@ export async function confirmSignIn(
 				),
 				signInDetails,
 			});
-			Hub.dispatch(
-				'auth',
-				{
-					event: 'signedIn',
-					data: await getCurrentUser(),
-				},
-				'Auth',
-				AMPLIFY_SYMBOL,
-			);
+
+			await dispatchSignedInHubEvent();
+
 			return {
 				isSignedIn: true,
 				nextStep: { signInStep: 'DONE' },

--- a/packages/auth/src/providers/cognito/apis/signInWithCustomAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithCustomAuth.ts
@@ -34,6 +34,7 @@ import {
 } from '../utils/clients/CognitoIdentityProvider/types';
 import { tokenOrchestrator } from '../tokenProvider';
 import { getCurrentUser } from './getCurrentUser';
+import { dispatchSignedInHubEvent } from '../utils/dispatchSignedInHubEvent';
 
 /**
  * Signs a user in using a custom authentication flow without password
@@ -98,12 +99,9 @@ export async function signInWithCustomAuth(
 				),
 				signInDetails,
 			});
-			Hub.dispatch(
-				'auth',
-				{ event: 'signedIn', data: await getCurrentUser() },
-				'Auth',
-				AMPLIFY_SYMBOL,
-			);
+
+			await dispatchSignedInHubEvent();
+
 			return {
 				isSignedIn: true,
 				nextStep: { signInStep: 'DONE' },

--- a/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
@@ -36,6 +36,7 @@ import {
 } from '../utils/clients/CognitoIdentityProvider/types';
 import { tokenOrchestrator } from '../tokenProvider';
 import { getCurrentUser } from './getCurrentUser';
+import { dispatchSignedInHubEvent } from '../utils/dispatchSignedInHubEvent';
 
 /**
  * Signs a user in using a custom authentication flow with SRP
@@ -102,15 +103,9 @@ export async function signInWithCustomSRPAuth(
 				signInDetails,
 			});
 			cleanActiveSignInState();
-			Hub.dispatch(
-				'auth',
-				{
-					event: 'signedIn',
-					data: await getCurrentUser(),
-				},
-				'Auth',
-				AMPLIFY_SYMBOL,
-			);
+
+			await dispatchSignedInHubEvent();
+
 			return {
 				isSignedIn: true,
 				nextStep: { signInStep: 'DONE' },

--- a/packages/auth/src/providers/cognito/apis/signInWithSRP.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithSRP.ts
@@ -36,6 +36,7 @@ import {
 import { cacheCognitoTokens } from '../tokenProvider/cacheTokens';
 import { tokenOrchestrator } from '../tokenProvider';
 import { getCurrentUser } from './getCurrentUser';
+import { dispatchSignedInHubEvent } from '../utils/dispatchSignedInHubEvent';
 
 /**
  * Signs a user in
@@ -102,15 +103,9 @@ export async function signInWithSRP(
 				),
 				signInDetails,
 			});
-			Hub.dispatch(
-				'auth',
-				{
-					event: 'signedIn',
-					data: await getCurrentUser(),
-				},
-				'Auth',
-				AMPLIFY_SYMBOL,
-			);
+
+			await dispatchSignedInHubEvent();
+
 			return {
 				isSignedIn: true,
 				nextStep: { signInStep: 'DONE' },

--- a/packages/auth/src/providers/cognito/apis/signInWithUserPassword.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithUserPassword.ts
@@ -34,6 +34,7 @@ import {
 import { cacheCognitoTokens } from '../tokenProvider/cacheTokens';
 import { tokenOrchestrator } from '../tokenProvider';
 import { getCurrentUser } from './getCurrentUser';
+import { dispatchSignedInHubEvent } from '../utils/dispatchSignedInHubEvent';
 
 /**
  * Signs a user in using USER_PASSWORD_AUTH AuthFlowType
@@ -97,15 +98,9 @@ export async function signInWithUserPassword(
 				signInDetails,
 			});
 			cleanActiveSignInState();
-			Hub.dispatch(
-				'auth',
-				{
-					event: 'signedIn',
-					data: await getCurrentUser(),
-				},
-				'Auth',
-				AMPLIFY_SYMBOL,
-			);
+
+			await dispatchSignedInHubEvent();
+
 			return {
 				isSignedIn: true,
 				nextStep: { signInStep: 'DONE' },

--- a/packages/auth/src/providers/cognito/utils/dispatchSignedInHubEvent.ts
+++ b/packages/auth/src/providers/cognito/utils/dispatchSignedInHubEvent.ts
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Hub } from '@aws-amplify/core';
+import { getCurrentUser } from '../apis/getCurrentUser';
+import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
+import {
+	UNEXPECTED_SIGN_IN_INTERRUPTION_EXCEPTION,
+	USER_UNAUTHENTICATED_EXCEPTION,
+} from '../../../errors/constants';
+import { AuthError } from '../../../errors/AuthError';
+
+export const dispatchSignedInHubEvent = async () => {
+	try {
+		Hub.dispatch(
+			'auth',
+			{
+				event: 'signedIn',
+				data: await getCurrentUser(),
+			},
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	} catch (error) {
+		if ((error as AuthError).name === USER_UNAUTHENTICATED_EXCEPTION) {
+			throw new AuthError({
+				name: UNEXPECTED_SIGN_IN_INTERRUPTION_EXCEPTION,
+				message:
+					'Could not get user session right after signing in successfully.',
+				recoverySuggestion:
+					'This most likely is due to the auth tokens cannot be persisted. If you are using cookie store, please check if cookies can be correctly set from your server.',
+			});
+		}
+
+		throw error;
+	}
+};

--- a/packages/auth/src/providers/cognito/utils/dispatchSignedInHubEvent.ts
+++ b/packages/auth/src/providers/cognito/utils/dispatchSignedInHubEvent.ts
@@ -26,9 +26,9 @@ export const dispatchSignedInHubEvent = async () => {
 			throw new AuthError({
 				name: UNEXPECTED_SIGN_IN_INTERRUPTION_EXCEPTION,
 				message:
-					'Could not get user session right after signing in successfully.',
+					'Unable to get user session following successful sign-in.',
 				recoverySuggestion:
-					'This most likely is due to the auth tokens cannot be persisted. If you are using cookie store, please check if cookies can be correctly set from your server.',
+					'This most likely is due to auth tokens not being persisted. If you are using cookie store, please ensure cookies can be correctly set from your server.',
 			});
 		}
 

--- a/packages/auth/src/providers/cognito/utils/dispatchSignedInHubEvent.ts
+++ b/packages/auth/src/providers/cognito/utils/dispatchSignedInHubEvent.ts
@@ -10,6 +10,9 @@ import {
 } from '../../../errors/constants';
 import { AuthError } from '../../../errors/AuthError';
 
+export const ERROR_MESSAGE =
+	'Unable to get user session following successful sign-in.';
+
 export const dispatchSignedInHubEvent = async () => {
 	try {
 		Hub.dispatch(
@@ -25,8 +28,7 @@ export const dispatchSignedInHubEvent = async () => {
 		if ((error as AuthError).name === USER_UNAUTHENTICATED_EXCEPTION) {
 			throw new AuthError({
 				name: UNEXPECTED_SIGN_IN_INTERRUPTION_EXCEPTION,
-				message:
-					'Unable to get user session following successful sign-in.',
+				message: ERROR_MESSAGE,
 				recoverySuggestion:
 					'This most likely is due to auth tokens not being persisted. If you are using cookie store, please ensure cookies can be correctly set from your server.',
 			});

--- a/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
@@ -15,6 +15,7 @@ import { cacheCognitoTokens } from '../../tokenProvider/cacheTokens';
 import { getCurrentUser } from '../../apis/getCurrentUser';
 import { createOAuthError } from './createOAuthError';
 import { cognitoUserPoolsTokenProvider } from '../../tokenProvider';
+import { dispatchSignedInHubEvent } from '../dispatchSignedInHubEvent';
 
 export const completeOAuthFlow = async ({
 	currentUrl,
@@ -250,12 +251,7 @@ const completeFlow = async ({
 		);
 	}
 	Hub.dispatch('auth', { event: 'signInWithRedirect' }, 'Auth', AMPLIFY_SYMBOL);
-	Hub.dispatch(
-		'auth',
-		{ event: 'signedIn', data: await getCurrentUser() },
-		'Auth',
-		AMPLIFY_SYMBOL,
-	);
+	await dispatchSignedInHubEvent();
 	clearHistory(redirectUri);
 };
 

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -382,7 +382,7 @@
 			"name": "[Auth] confirmSignIn (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmSignIn }",
-			"limit": "25.96 kB"
+			"limit": "26.40 kB"
 		},
 		{
 			"name": "[Auth] updateMFAPreference (Cognito)",
@@ -448,7 +448,7 @@
 			"name": "[Auth] Basic Auth Flow (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ signIn, signOut, fetchAuthSession, confirmSignIn }",
-			"limit": "28.00 kB"
+			"limit": "28.50 kB"
 		},
 		{
 			"name": "[Auth] OAuth Auth Flow (Cognito)",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This is an action item came out while triaging issue: https://github.com/aws-amplify/amplify-js/issues/12873

Now it handles error that may be thrown from the `getCurrentUser()` call used by dispatching the `signedIn` Auth Hub event, and convert the error to be more contextual.

Error message wording is open for suggestion.

Before:

<img width="677" alt="image" src="https://github.com/aws-amplify/amplify-js/assets/10602282/a1575ee4-8290-4efc-b05d-51e5e7b0ec42">


After:

<img width="884" alt="image" src="https://github.com/aws-amplify/amplify-js/assets/10602282/5806fdb7-def4-4153-8072-8f60482474b3">


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* Unit tests
* Sample app testing locally observing the error handling behavior

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
