### PR TITLE
feat(auth): add a default deviceName when remembering device

### DIFF
--- a/packages/auth/__tests__/providers/cognito/fetchDevices.test.ts
+++ b/packages/auth/__tests__/providers/cognito/fetchDevices.test.ts
@@ -26,7 +26,10 @@ describe('fetchDevices', () => {
 	const dateEpoch = 1.696296885807e9;
 	const date = new Date(dateEpoch * 1000);
 	const clientResponseDevice = {
-		DeviceAttributes: [{ Name: 'attributeName', Value: 'attributeValue' }],
+		DeviceAttributes: [
+			{ Name: 'attributeName', Value: 'attributeValue' },
+			{ Name: 'device_name', Value: 'deviceNameValue' },
+		],
 		DeviceCreateDate: dateEpoch,
 		DeviceKey: 'DeviceKey',
 		DeviceLastAuthenticatedDate: dateEpoch,
@@ -34,9 +37,10 @@ describe('fetchDevices', () => {
 	};
 	const apiOutputDevice = {
 		id: 'DeviceKey',
-		name: undefined,
+		name: 'deviceNameValue',
 		attributes: {
 			attributeName: 'attributeValue',
+			device_name: 'deviceNameValue',
 		},
 		createDate: date,
 		lastModifiedDate: date,

--- a/packages/auth/src/providers/cognito/apis/fetchDevices.ts
+++ b/packages/auth/src/providers/cognito/apis/fetchDevices.ts
@@ -59,9 +59,11 @@ const parseDevicesResponse = async (
 			DeviceLastModifiedDate,
 			DeviceLastAuthenticatedDate,
 		}) => {
+			let deviceName: string | undefined;
 			const attributes = DeviceAttributes.reduce(
 				(attrs: any, { Name, Value }) => {
 					if (Name && Value) {
+						if (Name === 'device_name') deviceName = Value;
 						attrs[Name] = Value;
 					}
 
@@ -72,6 +74,7 @@ const parseDevicesResponse = async (
 
 			return {
 				id,
+				name: deviceName,
 				attributes,
 				createDate: DeviceCreateDate
 					? new Date(DeviceCreateDate * 1000)

--- a/packages/auth/src/providers/cognito/utils/signInHelpers.ts
+++ b/packages/auth/src/providers/cognito/utils/signInHelpers.ts
@@ -7,6 +7,7 @@ import {
 	AuthAction,
 	assertTokenProviderConfig,
 	base64Encoder,
+	getDeviceName,
 } from '@aws-amplify/core/internals/utils';
 
 import { ClientMetadata, ConfirmSignInOptions } from '../types';
@@ -1072,6 +1073,7 @@ export async function getNewDeviceMetatada(
 			{ region: getRegion(userPoolId) },
 			{
 				AccessToken: accessToken,
+				DeviceName: await getDeviceName(),
 				DeviceKey: newDeviceMetadata?.DeviceKey,
 				DeviceSecretVerifierConfig: deviceSecretVerifierConfig,
 			},

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -383,7 +383,7 @@
 			"name": "[Auth] confirmSignIn (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmSignIn }",
-			"limit": "28.10 kB"
+			"limit": "28.26 kB"
 		},
 		{
 			"name": "[Auth] updateMFAPreference (Cognito)",
@@ -449,7 +449,7 @@
 			"name": "[Auth] Basic Auth Flow (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ signIn, signOut, fetchAuthSession, confirmSignIn }",
-			"limit": "29.90 kB"
+			"limit": "30.06 kB"
 		},
 		{
 			"name": "[Auth] OAuth Auth Flow (Cognito)",

--- a/packages/core/src/libraryUtils.ts
+++ b/packages/core/src/libraryUtils.ts
@@ -29,6 +29,7 @@ export { amplifyUuid } from './utils/amplifyUuid';
 export { AmplifyUrl, AmplifyUrlSearchParams } from './utils/amplifyUrl';
 export { parseAmplifyConfig } from './utils/parseAmplifyConfig';
 export { getClientInfo } from './utils';
+export { getDeviceName } from './utils/deviceName';
 
 // Auth utilities
 export {

--- a/packages/core/src/utils/deviceName/getDeviceName.native.ts
+++ b/packages/core/src/utils/deviceName/getDeviceName.native.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getDeviceName as getDeviceNameNative } from '@aws-amplify/react-native';
+
+/**
+ * Retrieves the device name using name in ios and model in android,
+ *
+ * @returns {Promise<string>} A promise that resolves with a string representing the device name.
+ *
+ * Example Output:
+ * ios: 'iPhone' / 'user's iPhone'
+ * android: 'sdk_gphone64_arm64'
+ */
+export const getDeviceName = async (): Promise<string> => getDeviceNameNative();

--- a/packages/core/src/utils/deviceName/getDeviceName.ts
+++ b/packages/core/src/utils/deviceName/getDeviceName.ts
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { NavigatorUA } from './types';
+/**
+ * Retrieves the device name using the User-Agent Client Hints API if available,
+ * falling back to the traditional userAgent string if not.
+ *
+ * @returns {Promise<string>} A promise that resolves with a string representing the device name.
+ *
+ * Example Output:
+ * navigator.userAgentData:
+ *   'macOS 14.2.1 arm macOS Not A(Brand/99.0.0.0;Google Chrome/121.0.6167.160;Chromium/121.0.6167.160'
+ * navigator.userAgent:
+ *   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/115.0'
+ */
+export const getDeviceName = async (): Promise<string> => {
+	const { userAgentData } = navigator as NavigatorUA;
+
+	if (!userAgentData) return navigator.userAgent;
+
+	const {
+		platform = '',
+		platformVersion = '',
+		model = '',
+		architecture = '',
+		fullVersionList = [],
+	} = await userAgentData.getHighEntropyValues([
+		'platform',
+		'platformVersion',
+		'architecture',
+		'model',
+		'fullVersionList',
+	]);
+
+	const versionList = fullVersionList
+		.map((v: { brand: string; version: string }) => `${v.brand}/${v.version}`)
+		.join(';');
+
+	const deviceName = [
+		platform,
+		platformVersion,
+		architecture,
+		model,
+		platform,
+		versionList,
+	]
+		.filter(value => value)
+		.join(' ');
+
+	return deviceName;
+};

--- a/packages/core/src/utils/deviceName/index.ts
+++ b/packages/core/src/utils/deviceName/index.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { getDeviceName } from './getDeviceName';

--- a/packages/core/src/utils/deviceName/types.ts
+++ b/packages/core/src/utils/deviceName/types.ts
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// WICG Spec: https://wicg.github.io/ua-client-hints
+
+// https://wicg.github.io/ua-client-hints/#navigatorua
+export interface NavigatorUA {
+	readonly userAgentData?: NavigatorUAData;
+}
+
+// https://wicg.github.io/ua-client-hints/#dictdef-navigatoruabrandversion
+interface NavigatorUABrandVersion {
+	readonly brand: string;
+	readonly version: string;
+}
+
+// https://wicg.github.io/ua-client-hints/#dictdef-uadatavalues
+interface UADataValues {
+	readonly brands?: NavigatorUABrandVersion[];
+	readonly mobile?: boolean;
+	readonly platform?: string;
+	readonly architecture?: string;
+	readonly bitness?: string;
+	readonly formFactor?: string[];
+	readonly model?: string;
+	readonly platformVersion?: string;
+	/** @deprecated in favour of fullVersionList */
+	readonly uaFullVersion?: string;
+	readonly fullVersionList?: NavigatorUABrandVersion[];
+	readonly wow64?: boolean;
+}
+
+// https://wicg.github.io/ua-client-hints/#dictdef-ualowentropyjson
+interface UALowEntropyJSON {
+	readonly brands: NavigatorUABrandVersion[];
+	readonly mobile: boolean;
+	readonly platform: string;
+}
+
+// https://wicg.github.io/ua-client-hints/#navigatoruadata
+interface NavigatorUAData extends UALowEntropyJSON {
+	getHighEntropyValues(hints: string[]): Promise<UADataValues>;
+	toJSON(): UALowEntropyJSON;
+}


### PR DESCRIPTION
### Description of changes
- Add a default deviceName for web and RN when making a [ConfirmDevice](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ConfirmDevice.html) service call
- The `navigator.userAgent` API [causes a warning in Chrome DevTools](https://blog.chromium.org/2021/05/update-on-user-agent-string-reduction.html) (Issues tab) starting with version 92
  - Use `navigator.userAgentData` (when available) instead of `navigator.userAgent`

Note:
The `navigator.userAgentData` API involves introducing randomness by adding a string `Not_A_Brand | Not_A Brand | Not A(Brand |  ...` to prevent user fingerprinting. The deviceName passed to the `ConfirmDevice` service API is called every time the user signs-in until the `rememberDevice` API is called, after which it just updates the status. It isn't a concern if the deviceName changes later on.

 
### Device name output / platform
Verified the following devices names on cognito console
<img width="1583" alt="Screenshot 2024-02-17 at 6 56 15 AM" src="https://github.com/aws-amplify/amplify-js/assets/22762119/c3a897f4-c964-48e5-95f4-b6b7a7075686">

### Issue #, if available
#12854


### Description of how you validated changes
Tested the following flows
```
MFA: always; DeviceTracking: Opt-in
1. signIn -> confirmSignIn -> signOut
new entry added in "Device tracking log" (cognito console) table each time this is done with "Remembered" as NO

2. signIn -> confirmSignIn -> rememberDevice -> signOut
new entry added in "Device tracking log" table time with "Remembered" as YES. (calling rememberDevice
again has no affect)

3. signIn -> fetchdevices() ->  signOut
device is remembered, able to bypass MFA. 
deviceName is present in new `name` key
```

Verified `fetchDevices` returns
```
[
    {
        "id": "us-west-2...",
        "name": "macOS 14.3.1 arm macOS Not A(Brand/99.0.0.0;Google Chrome/121.0.6167.184;Chromium/121.0.6167.184",
        "attributes": {
            "device_status": "valid",
            "device_name": "macOS 14.3.1 arm macOS Not A(Brand/99.0.0.0;Google Chrome/121.0.6167.184;Chromium/121.0.6167.184",
            "last_ip_used": "240...."
        },
        "createDate": "2024-02-17T01:17:42.046Z",
        "lastModifiedDate": "2024-02-17T01:33:11.770Z",
        "lastAuthenticatedDate": "2024-02-17T01:17:42.000Z"
    }
]
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
