### PR TITLE
fix(api-graphql): cannot generate selection set for nested custom types

### DIFF
--- a/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.ts
@@ -1261,6 +1261,106 @@ const amplifyConfig = {
 					sortKeyFieldNames: [],
 				},
 			},
+			Product: {
+				name: 'Product',
+				fields: {
+					sku: {
+						name: 'sku',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					factoryId: {
+						name: 'factoryId',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					warehouseId: {
+						name: 'warehouseId',
+						isArray: false,
+						type: 'String',
+						isRequired: true,
+						attributes: [],
+					},
+					description: {
+						name: 'description',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					trackingMeta: {
+						name: 'trackingMeta',
+						isArray: false,
+						type: {
+							nonModel: 'ProductTrackingMeta',
+						},
+						isRequired: false,
+						attributes: [],
+					},
+					owner: {
+						name: 'owner',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: true,
+						attributes: [],
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: true,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'Products',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							fields: ['sku', 'factoryId', 'warehouseId'],
+						},
+					},
+					{
+						type: 'auth',
+						properties: {
+							rules: [
+								{
+									provider: 'userPools',
+									ownerField: 'owner',
+									allow: 'owner',
+									identityClaim: 'cognito:username',
+									operations: ['create', 'update', 'delete', 'read'],
+								},
+								{
+									allow: 'public',
+									operations: ['read'],
+								},
+							],
+						},
+					},
+				],
+				primaryKeyInfo: {
+					isCustomPrimaryKey: true,
+					primaryKeyFieldName: 'sku',
+					sortKeyFieldNames: ['factoryId', 'warehouseId'],
+				},
+			},
 		},
 		enums: {
 			Status: {
@@ -1309,6 +1409,69 @@ const amplifyConfig = {
 						isArray: false,
 						type: 'Int',
 						isRequired: true,
+						attributes: [],
+					},
+				},
+			},
+			ProductMeta: {
+				name: 'ProductMeta',
+				fields: {
+					releaseDate: {
+						name: 'releaseDate',
+						isArray: false,
+						type: 'AWSDate',
+						isRequired: false,
+						attributes: [],
+					},
+					status: {
+						name: 'status',
+						isArray: false,
+						type: {
+							enum: 'ProductMetaStatus',
+						},
+						isRequired: false,
+						attributes: [],
+					},
+					deepMeta: {
+						name: 'deepMeta',
+						isArray: false,
+						type: {
+							nonModel: 'ProductMetaDeepMeta',
+						},
+						isRequired: false,
+						attributes: [],
+					},
+				},
+			},
+			ProductTrackingMeta: {
+				name: 'ProductTrackingMeta',
+				fields: {
+					productMeta: {
+						name: 'productMeta',
+						isArray: false,
+						type: {
+							nonModel: 'ProductMeta',
+						},
+						isRequired: false,
+						attributes: [],
+					},
+					note: {
+						name: 'note',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+				},
+			},
+			ProductMetaDeepMeta: {
+				name: 'ProductMetaDeepMeta',
+				fields: {
+					content: {
+						name: 'content',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
 						attributes: [],
 					},
 				},

--- a/packages/api-graphql/__tests__/internals/APIClient.test.ts
+++ b/packages/api-graphql/__tests__/internals/APIClient.test.ts
@@ -43,7 +43,7 @@ describe('APIClient', () => {
 			const normalized = normalizeMutationInput(
 				note,
 				noteModelDef,
-				modelIntroSchema,
+				modelIntroSchema
 			);
 
 			expect(normalized).toEqual(expectedInput);
@@ -427,6 +427,15 @@ describe('flattenItems', () => {
 			expect(selSet).toEqual(expected);
 		});
 
+		it('generates default selection set for nested custom types', () => {
+			const generated = generateSelectionSet(modelIntroSchema, 'Product');
+
+			const expected =
+				'sku factoryId warehouseId description trackingMeta { productMeta { releaseDate status deepMeta { content } } note } owner createdAt updatedAt';
+
+			expect(generated).toEqual(expected);
+		});
+
 		test('it should generate custom selection set - top-level fields', () => {
 			const selSet = generateSelectionSet(modelIntroSchema, 'Todo', [
 				'id',
@@ -476,6 +485,20 @@ describe('flattenItems', () => {
 
 			expect(selSet).toEqual(expected);
 		});
+
+		it('generates custom selection set for nested custom types', () => {
+			const generated = generateSelectionSet(modelIntroSchema, 'Product', [
+				'sku',
+				'trackingMeta.note',
+				'trackingMeta.productMeta.status',
+				'trackingMeta.productMeta.deepMeta.content',
+			]);
+
+			const expected =
+				'sku trackingMeta { note productMeta { status deepMeta { content } } }';
+
+			expect(generated).toEqual(expected);
+		});
 	});
 });
 
@@ -489,7 +512,7 @@ describe('generateGraphQLDocument()', () => {
 			models: {
 				User: userSchemaModel,
 				Product: productSchemaModel,
-			}
+			},
 		};
 
 		test.each([
@@ -501,11 +524,11 @@ describe('generateGraphQLDocument()', () => {
 				const document = generateGraphQLDocument(
 					mockModelDefinitions,
 					modelName,
-					modelOperation,
+					modelOperation
 				);
 
 				expect(document.includes(expectedArgs)).toBe(true);
-			},
+			}
 		);
 	});
 });

--- a/packages/api-graphql/__tests__/internals/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/internals/generateClient.test.ts
@@ -127,6 +127,7 @@ describe('generateClient', () => {
 			'SecondaryIndexModel',
 			'Post',
 			'Comment',
+			'Product',
 		];
 
 		it('generates `models` property when Amplify.getConfig() returns valid GraphQL provider config', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Updated the function for generating the default selection set for non-model types to be capable to generate selection set for nested custom types
* Updated the internal `dotNotationToObject` function so it can resolve `fields` from `modelIntrospection.nonModels` to handle `trackingMeta.productMeta.status` where:
  1. `trackingMeta` is a field of a model
  2. `trackingMeta` field is a custom type
  3. `productMeta` is a filed of `trackingMeta`'s custom type
  4. `productMeta` field is a custom type

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* Unit tests
* Manual E2E testing in a sample app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
