### PR TITLE
chore: Refactor release workflow to allow workflow execution on generated PRs

### DIFF
--- a/.github/workflows/callable-npm-publish-release.yml
+++ b/.github/workflows/callable-npm-publish-release.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           yarn run docs
           git add ./docs/api/
-          git commit -m "chore(release): update API docs [ci skip]"
+          git commit -m "chore(release): update API docs [skip release]"
 
       - name: Push post release changes to the release branch
         working-directory: ./amplify-js

--- a/.github/workflows/push-latest-release.yml
+++ b/.github/workflows/push-latest-release.yml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   e2e:
-    # Skip the release workflow if the most recent commit in the triggering branch contains [skip build]
-    if: ${{ ! contains(github.event.commits[0].message, '[skip release]') }}
+    # Skip the release workflow if the head commit in the triggering branch contains [skip release]
+    if: ${{ !contains(github.event.head_commit.message, '[skip release]') }}
     secrets: inherit
     uses: ./.github/workflows/callable-release-verification.yml
   release:

--- a/.github/workflows/push-latest-release.yml
+++ b/.github/workflows/push-latest-release.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   e2e:
+    # Skip the release workflow if the most recent commit in the triggering branch contains [skip build]
+    if: ${{ ! contains(github.event.commits[0].message, '[skip release]') }}
     secrets: inherit
     uses: ./.github/workflows/callable-release-verification.yml
   release:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"unlink-all": "lerna exec --no-bail --parallel -- yarn unlink; exit 0",
 		"publish:preid": "./scripts/preid-env-vars-exist.sh && lerna publish --canary --force-publish --dist-tag=${PREID_PREFIX} --preid=${PREID_PREFIX}${PREID_HASH_SUFFIX} --yes",
 		"publish:main": "lerna publish --canary --force-publish --dist-tag=unstable --preid=unstable${PREID_HASH_SUFFIX} --yes",
-		"publish:release": "lerna publish --conventional-commits --message 'chore(release): Publish [ci skip]' --yes",
+		"publish:release": "lerna publish --conventional-commits --message 'chore(release): Publish [skip release]' --yes",
 		"publish:v5-stable": "lerna publish --conventional-commits --yes --dist-tag=stable-5 --message 'chore(release): Publish [ci skip]' --no-verify-access",
 		"publish:verdaccio": "lerna publish --canary --force-publish --no-push --dist-tag=unstable --preid=unstable --yes",
 		"ts-coverage": "lerna run ts-coverage",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR proposes a change to our usage of `[ci skip]` in releases by introducing a new `[skip release]` syntax which will skip the `push-latest-release.yml` workflow specifically (which is what we're achieving with our current usage of `[ci skip]`).

This is intended to address the following issue:
- A recent change (https://github.com/aws-amplify/amplify-js/pull/13044) refactored our release process to create a PR for merging `release` back into `main` instead of force-pushing.
- Because we're using `[ci skip]` in the "update API docs" & "Publish" commits which are generated during releases, the resulting PR does not trigger the `codeql` & `pr` workflows required to actually merge the PR as per the branch protection rules on `main`. As a result, admin intervention or additional commit is required to merge the PR.

Alternatives considered:
- Use `pull_request_target` instead of `pull_request` for the CodeQL & PR workflows, which bypasses the `[ci skip]` check
  - This was discarded because `pull_request_target` changes the security posture of the repo for PRs originating from forks
- Automatically merge the generated PR using `gh pr merge`
  - This was discarded because there may be merge conflicts due to changes on `main` (particularly in the case of hot-fixes) that would require manual intervention anyway

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Tested that this logic correctly skips the release workflow when `[skip release]` is present in the head commit of the triggering branch: https://github.com/aws-amplify/amplify-js/actions/runs/8180781321

Tested that PRs into `main` containing `[skip release]` still trigger the required PR workflows. Also verified that branches containing `[ci skip]` exhibit the same behavior we observed in the release (i.e. stuck PR workflows).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
