### PR TITLE
chore: Regenerate xml2js in yarn.lock file

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15596,7 +15596,7 @@ xml-name-validator@^4.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
 
-xml2js@0.5.0:
+xml2js@0.4.23, xml2js@0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
   integrity sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -15598,7 +15598,7 @@ xml-name-validator@^4.0.0:
 
 xml2js@0.4.23, xml2js@0.5.0:
   version "0.5.0"
-  resolved "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
   integrity sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==
   dependencies:
     sax ">=0.6.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Regenerates xml2js in our yarn.lock file to resolve publish failures, e.g. https://github.com/aws-amplify/amplify-js/actions/runs/8176950274/job/22359566096

Generated by running `yarn install` on a clean repository.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Local testing, yarn audit

```
b0f1d8581327:amplify-js jablanch$ yarn why xml2js
yarn why v1.22.19
[1/4] 🤔  Why do we have the module "xml2js"...?
[2/4] 🚚  Initialising dependency graph...
warning Resolution field "path-scurry@1.10.0" is incompatible with requested version "path-scurry@^1.10.1"
warning Resolution field "minipass@6.0.2" is incompatible with requested version "minipass@^4.2.4"
warning Resolution field "xml2js@0.5.0" is incompatible with requested version "xml2js@0.4.23"
warning Resolution field "minipass@6.0.2" is incompatible with requested version "minipass@^4.2.4"
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "xml2js@0.5.0"
info Reasons this module exists
   - "_project_#@aws-amplify#datastore-storage-adapter#expo-file-system#@expo#config-plugins" depends on it
   - Hoisted from "_project_#@aws-amplify#datastore-storage-adapter#expo-file-system#@expo#config-plugins#xml2js"
info Disk size without dependencies: "364KB"
info Disk size with unique dependencies: "888KB"
info Disk size with transitive dependencies: "888KB"
info Number of shared dependencies: 2
✨  Done in 0.46s.
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
