### PR TITLE
chore(storage): extract isInputWithPath into separate file

### DIFF
--- a/packages/storage/__tests__/providers/s3/apis/utils/isInputWithPath.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/isInputWithPath.test.ts
@@ -3,7 +3,7 @@
 
 import { isInputWithPath } from '../../../../../src/providers/s3/utils';
 
-describe('resolvePrefix', () => {
+describe('isInputWithPath', () => {
 	it('should return true if input contains path', async () => {
 		expect(isInputWithPath({ path: '' })).toBe(true);
 	});

--- a/packages/storage/__tests__/providers/s3/apis/utils/isInputWithPath.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/isInputWithPath.test.ts
@@ -7,7 +7,7 @@ describe('isInputWithPath', () => {
 	it('should return true if input contains path', async () => {
 		expect(isInputWithPath({ path: '' })).toBe(true);
 	});
-	it('should return false if input contains key', async () => {
+	it('should return false if input does not contain key', async () => {
 		expect(isInputWithPath({ key: '' })).toBe(false);
 	});
 });

--- a/packages/storage/__tests__/providers/s3/apis/utils/isInputWithPath.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/isInputWithPath.test.ts
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isInputWithPath } from '../../../../../src/providers/s3/utils';
+
+describe('resolvePrefix', () => {
+	it('should return true if input contains path', async () => {
+		expect(isInputWithPath({ path: '' })).toBe(true);
+	});
+	it('should return false if input contains key', async () => {
+		expect(isInputWithPath({ key: '' })).toBe(false);
+	});
+});

--- a/packages/storage/__tests__/providers/s3/apis/utils/isInputWithPath.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/isInputWithPath.test.ts
@@ -7,7 +7,7 @@ describe('isInputWithPath', () => {
 	it('should return true if input contains path', async () => {
 		expect(isInputWithPath({ path: '' })).toBe(true);
 	});
-	it('should return false if input does not contain key', async () => {
+	it('should return false if input does not contain path', async () => {
 		expect(isInputWithPath({ key: '' })).toBe(false);
 	});
 });

--- a/packages/storage/src/providers/s3/utils/index.ts
+++ b/packages/storage/src/providers/s3/utils/index.ts
@@ -5,3 +5,4 @@ export { calculateContentMd5 } from './md5';
 export { resolveS3ConfigAndInput } from './resolveS3ConfigAndInput';
 export { createDownloadTask, createUploadTask } from './transferTask';
 export { validateStorageOperationInput } from './validateStorageOperationInput';
+export { isInputWithPath } from './isInputWithPath';

--- a/packages/storage/src/providers/s3/utils/isInputWithPath.ts
+++ b/packages/storage/src/providers/s3/utils/isInputWithPath.ts
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	StorageOperationInputPath,
+	StorageOperationInputType,
+} from '../../../types/inputs';
+
+export const isInputWithPath = (
+	input: StorageOperationInputType,
+): input is StorageOperationInputPath => {
+	return input.path !== undefined;
+};

--- a/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
+++ b/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
@@ -1,22 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { StrictUnion } from '@aws-amplify/core/internals/utils';
-
-import {
-	StorageOperationInputKey,
-	StorageOperationInputPath,
-} from '../../../types/inputs';
+import { StorageOperationInputType as Input } from '../../../types/inputs';
 import { assertValidationError } from '../../../errors/utils/assertValidationError';
 import { StorageValidationErrorCode } from '../../../errors/types/validation';
 
+import { isInputWithPath } from './isInputWithPath';
 import { STORAGE_INPUT_KEY, STORAGE_INPUT_PATH } from './constants';
-
-type Input = StrictUnion<StorageOperationInputKey | StorageOperationInputPath>;
-
-const isInputWithPath = (input: Input): input is StorageOperationInputPath => {
-	return input.path !== undefined;
-};
 
 export const validateStorageOperationInput = (
 	input: Input,

--- a/packages/storage/src/types/inputs.ts
+++ b/packages/storage/src/types/inputs.ts
@@ -1,11 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { StrictUnion } from '@aws-amplify/core/internals/utils';
+
 import {
 	StorageListAllOptions,
 	StorageListPaginateOptions,
 	StorageOptions,
 } from './options';
+
+// TODO: rename to StorageOperationInput once the other type with
+// the same named is removed
+export type StorageOperationInputType = StrictUnion<
+	StorageOperationInputKey | StorageOperationInputPath
+>;
 
 /** @deprecated Use {@link StorageOperationInputPath} instead. */
 export interface StorageOperationInputKey {


### PR DESCRIPTION
#### Description of changes
Extract `isInputWithPath` from `validateStorageOperationInput` to a separate file of it's own to reuse across other APIs


#### Description of how you validated changes
added unit test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
