### PR TITLE
chore: Small cleanup to internal core utils

### DIFF
--- a/packages/core/src/libraryUtils.ts
+++ b/packages/core/src/libraryUtils.ts
@@ -1,10 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import WordArray from './utils/WordArray';
+
 /*
 This file maps top-level exports from `@aws-amplify/core/internals/utils`. These are intended to be internal
 utils for use throughout the library.
 */
+
 // Core utilities
 export {
 	generateRandomString,
@@ -57,7 +58,6 @@ export {
 export { Signer } from './Signer';
 export {
 	JWT,
-	StrictUnion,
 	CognitoIdentityPoolConfig,
 	JwtPayload,
 	AuthStandardAttributeKey,
@@ -119,10 +119,11 @@ export { Reachability } from './Reachability';
 export { USER_AGENT_HEADER } from './constants';
 export { fetchAuthSession } from './singleton/apis/internal/fetchAuthSession';
 export { AMPLIFY_SYMBOL } from './Hub';
+export { StrictUnion } from './types';
 export { base64Decoder, base64Encoder } from './utils/convert';
 export { getCrypto } from './utils/globalHelpers';
 export { cryptoSecureRandomInt } from './utils/cryptoSecureRandomInt';
-export { WordArray };
+export { WordArray } from './utils/WordArray';
 
 // Hub
 export { HubInternal } from './Hub';

--- a/packages/core/src/singleton/Auth/types.ts
+++ b/packages/core/src/singleton/Auth/types.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { StrictUnion } from '../../types';
 import { AtLeastOne } from '../types';
 
 // From https://github.com/awslabs/aws-jwt-verify/blob/main/src/safe-json-parse.ts
@@ -118,12 +119,6 @@ export type CognitoProviderConfig = StrictUnion<
 	| AuthUserPoolConfig
 	| AuthUserPoolAndIdentityPoolConfig
 >;
-
-type UnionKeys<T> = T extends T ? keyof T : never;
-type StrictUnionHelper<T, TAll> = T extends any
-	? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>>
-	: never;
-export type StrictUnion<T> = StrictUnionHelper<T, T>;
 
 export interface AuthIdentityPoolConfig {
 	Cognito: CognitoIdentityPoolConfig & {

--- a/packages/core/src/singleton/Auth/utils/index.ts
+++ b/packages/core/src/singleton/Auth/utils/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { base64Decoder } from '../../../utils/convert';
+import { StrictUnion } from '../../../types';
 import {
 	AuthConfig,
 	CognitoIdentityPoolConfig,
@@ -8,7 +9,6 @@ import {
 	CognitoUserPoolConfig,
 	JWT,
 	OAuthConfig,
-	StrictUnion,
 } from '../types';
 
 import { AuthConfigurationErrorCode, assert } from './errorHelpers';

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -4,3 +4,4 @@
 export * from './core';
 export * from './errors';
 export * from './storage';
+export * from './utils';

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -7,4 +7,8 @@ type StrictUnionHelper<T, TAll> = T extends any
 	? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>>
 	: never;
 
+/**
+ * Makes a union 'strict', such that members are disallowed from including the keys of other members. E.g.,
+ * `{x: 1, y: 1}` is a valid member of `{x: number} | {y: number}` but not of StrictUnion<{x: number} | {y: number}>.
+ */
 export type StrictUnion<T> = StrictUnionHelper<T, T>;

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+type UnionKeys<T> = T extends T ? keyof T : never;
+
+type StrictUnionHelper<T, TAll> = T extends any
+	? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>>
+	: never;
+
+export type StrictUnion<T> = StrictUnionHelper<T, T>;

--- a/packages/core/src/utils/WordArray.ts
+++ b/packages/core/src/utils/WordArray.ts
@@ -26,7 +26,7 @@ function hexStringify(wordArray: WordArray): string {
 	return hexChars.join('');
 }
 
-export default class WordArray {
+export class WordArray {
 	words: number[] = [];
 	sigBytes: number;
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR introduces some minor cleanup to improve consistency and structural semantics in `core`:
1. Export `WordArray` as module member so it can be re-exported directly by `libraryUtils.ts`
2. Extract `StrictUnion` to core root level types since it is not actually coupled to Auth (and will be used by Storage in future PRs)

#### Description of how you validated changes
```
$ yarn clean && yarn && yarn build && yarn test
```

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
