### PR TITLE
feat(api-graphql): custom subscriptions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
 	"editor.detectIndentation": false,
 	"editor.insertSpaces": false,
-	"editor.tabSize": 4,
 	"prettier.requireConfig": true,
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"formattingToggle.affects": [

--- a/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.ts
@@ -1580,6 +1580,32 @@ const amplifyConfig = {
 				},
 			},
 		},
+		subscriptions: {
+			onPostLiked: {
+				name: 'onPostLiked',
+				isArray: false,
+				type: {
+					model: 'Post',
+				},
+				isRequired: false,
+			},
+			onPostUpdated: {
+				name: 'onPostUpdated',
+				isArray: false,
+				type: {
+					model: 'Post',
+				},
+				isRequired: false,
+				arguments: {
+					postId: {
+						name: 'postId',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+					},
+				},
+			},
+		},
 	},
 };
 export default amplifyConfig;

--- a/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
@@ -120,7 +120,7 @@ const schema = a.schema({
 			argumentContent: a.string().required(),
 		})
 		.returns(a.ref('EchoResult'))
-		.function('echoFunction')
+		.handler(a.handler.function('echoFunction'))
 		.authorization([a.allow.public()]),
 
 	// custom query returning a primitive type
@@ -130,7 +130,7 @@ const schema = a.schema({
 			inputString: a.string().required(),
 		})
 		.returns(a.string())
-		.function('echoFunction')
+		.handler(a.handler.function('echoFunction'))
 		.authorization([a.allow.public()]),
 	echoNestedCustomTypes: a
 		.query()
@@ -138,7 +138,7 @@ const schema = a.schema({
 			input: a.string().required(),
 		})
 		.returns(a.ref('ProductTrackingMeta'))
-		.function('echoFunction')
+		.handler(a.handler.function('echoFunction'))
 		.authorization([a.allow.public()]),
 	echoModelHasNestedTypes: a
 		.query()
@@ -146,7 +146,7 @@ const schema = a.schema({
 			input: a.string().required(),
 		})
 		.returns(a.ref('Product'))
-		.function('echoFunction')
+		.handler(a.handler.function('echoFunction'))
 		.authorization([a.allow.public()]),
 	// custom mutation returning a non-model type
 	PostLikeResult: a.customType({
@@ -158,7 +158,7 @@ const schema = a.schema({
 			postId: a.id().required(),
 		})
 		.returns(a.ref('PostLikeResult'))
-		.function('echoFunction')
+		.handler(a.handler.function('echoFunction'))
 		.authorization([a.allow.private()]),
 
 	// custom mutation returning a model type
@@ -182,9 +182,21 @@ const schema = a.schema({
 			postId: a.id().required(),
 		})
 		.returns(a.ref('Post'))
-		.function('echoFunction')
+		.handler(a.handler.function('echoFunction'))
 		.authorization([a.allow.private()]),
 
+	onPostLiked: a
+		.subscription()
+		.for(a.ref('likePostReturnPost'))
+		.returns(a.ref('Post'))
+		.handler(a.handler.custom({ entry: './jsResolver_base.js' })),
+
+	onPostUpdated: a
+		.subscription()
+		.for(a.ref('Post').mutations(['update']))
+		.arguments({ postId: a.string() })
+		.returns(a.ref('Post'))
+		.handler(a.handler.custom({ entry: './jsResolver_base.js' })),
 	//#endregion
 });
 

--- a/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
@@ -83,9 +83,9 @@ const schema = a.schema({
 			viewCount: a.integer(),
 			status: a.enum(['draft', 'pending', 'published']),
 		})
-		.secondaryIndexes([
-			a.index('title'),
-			a.index('description').sortKeys(['viewCount']),
+		.secondaryIndexes(index => [
+			index('title'),
+			index('description').sortKeys(['viewCount']),
 		]),
 	Product: a
 		.model({

--- a/packages/api-graphql/__tests__/internals/server/generateClientWithAmplifyInstance.test.ts
+++ b/packages/api-graphql/__tests__/internals/server/generateClientWithAmplifyInstance.test.ts
@@ -425,7 +425,7 @@ describe('server generateClient', () => {
 				return result;
 			});
 
-			const mockContextSpec = {};
+			const mockContextSpec = { token: { value: Symbol('test') } };
 
 			const result = await client.queries.echo(mockContextSpec, {
 				argumentContent: 'echo argumentContent value',

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -72,7 +72,7 @@
 	},
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
-		"@aws-amplify/data-schema": "^0.13.9",
+		"@aws-amplify/data-schema": "^0.13.19",
 		"@rollup/plugin-typescript": "11.1.5",
 		"rollup": "^4.9.6",
 		"typescript": "5.0.2"
@@ -87,7 +87,7 @@
 	"dependencies": {
 		"@aws-amplify/api-rest": "4.0.21",
 		"@aws-amplify/core": "6.0.21",
-		"@aws-amplify/data-schema-types": "^0.7.6",
+		"@aws-amplify/data-schema-types": "^0.7.10",
 		"@aws-sdk/types": "3.387.0",
 		"graphql": "15.8.0",
 		"rxjs": "^7.8.1",

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -72,7 +72,7 @@
 	},
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
-		"@aws-amplify/data-schema": "^0.13.19",
+		"@aws-amplify/data-schema": "^0.14.1",
 		"@rollup/plugin-typescript": "11.1.5",
 		"rollup": "^4.9.6",
 		"typescript": "5.0.2"

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -87,7 +87,7 @@
 	"dependencies": {
 		"@aws-amplify/api-rest": "4.0.21",
 		"@aws-amplify/core": "6.0.21",
-		"@aws-amplify/data-schema-types": "^0.7.10",
+		"@aws-amplify/data-schema-types": "^0.7.11",
 		"@aws-sdk/types": "3.387.0",
 		"graphql": "15.8.0",
 		"rxjs": "^7.8.1",

--- a/packages/api-graphql/src/internals/APIClient.ts
+++ b/packages/api-graphql/src/internals/APIClient.ts
@@ -19,7 +19,6 @@ import {
 	ListArgs,
 	QueryArgs,
 	V6Client,
-	V6ClientSSRRequest,
 	__authMode,
 	__authToken,
 	__headers,
@@ -138,9 +137,7 @@ export function initializeModel(
 							options?: LazyLoadOptions,
 						) => {
 							if (record[targetNames[0]]) {
-								return (
-									client as V6ClientSSRRequest<Record<string, any>>
-								).models[relatedModelName].get(
+								return (client as any).models[relatedModelName].get(
 									contextSpec,
 									{
 										[relatedModelPKFieldName]: record[targetNames[0]],
@@ -160,9 +157,7 @@ export function initializeModel(
 							options?: LazyLoadOptions,
 						) => {
 							if (record[targetNames[0]]) {
-								return (client as V6Client<Record<string, any>>).models[
-									relatedModelName
-								].get(
+								return (client as any).models[relatedModelName].get(
 									{
 										[relatedModelPKFieldName]: record[targetNames[0]],
 										...sortKeyValues,
@@ -213,15 +208,16 @@ export function initializeModel(
 								options?: LazyLoadOptions,
 							) => {
 								if (record[parentPk]) {
-									return (
-										client as V6ClientSSRRequest<Record<string, any>>
-									).models[relatedModelName].list(contextSpec, {
-										filter: { and: hasManyFilter },
-										limit: options?.limit,
-										nextToken: options?.nextToken,
-										authMode: options?.authMode || authMode,
-										authToken: options?.authToken || authToken,
-									});
+									return (client as any).models[relatedModelName].list(
+										contextSpec,
+										{
+											filter: { and: hasManyFilter },
+											limit: options?.limit,
+											nextToken: options?.nextToken,
+											authMode: options?.authMode || authMode,
+											authToken: options?.authToken || authToken,
+										},
+									);
 								}
 
 								return [];
@@ -231,9 +227,7 @@ export function initializeModel(
 								options?: LazyLoadOptions,
 							) => {
 								if (record[parentPk]) {
-									return (client as V6Client<Record<string, any>>).models[
-										relatedModelName
-									].list({
+									return (client as any).models[relatedModelName].list({
 										filter: { and: hasManyFilter },
 										limit: options?.limit,
 										nextToken: options?.nextToken,
@@ -265,15 +259,16 @@ export function initializeModel(
 							options?: LazyLoadOptions,
 						) => {
 							if (record[parentPk]) {
-								return (
-									client as V6ClientSSRRequest<Record<string, any>>
-								).models[relatedModelName].list(contextSpec, {
-									filter: { and: hasManyFilter },
-									limit: options?.limit,
-									nextToken: options?.nextToken,
-									authMode: options?.authMode || authMode,
-									authToken: options?.authToken || authToken,
-								});
+								return (client as any).models[relatedModelName].list(
+									contextSpec,
+									{
+										filter: { and: hasManyFilter },
+										limit: options?.limit,
+										nextToken: options?.nextToken,
+										authMode: options?.authMode || authMode,
+										authToken: options?.authToken || authToken,
+									},
+								);
 							}
 
 							return [];
@@ -283,9 +278,7 @@ export function initializeModel(
 							options?: LazyLoadOptions,
 						) => {
 							if (record[parentPk]) {
-								return (client as V6Client<Record<string, any>>).models[
-									relatedModelName
-								].list({
+								return (client as any).models[relatedModelName].list({
 									filter: { and: hasManyFilter },
 									limit: options?.limit,
 									nextToken: options?.nextToken,

--- a/packages/api-graphql/src/internals/generateClient.ts
+++ b/packages/api-graphql/src/internals/generateClient.ts
@@ -4,6 +4,7 @@ import { Hub } from '@aws-amplify/core';
 import {
 	CustomMutations,
 	CustomQueries,
+	CustomSubscriptions,
 	EnumTypes,
 	ModelTypes,
 } from '@aws-amplify/data-schema-types';
@@ -23,6 +24,7 @@ import { isApiGraphQLConfig } from './utils/runtimeTypeGuards/isApiGraphQLProvid
 import {
 	generateCustomMutationsProperty,
 	generateCustomQueriesProperty,
+	generateCustomSubscriptionsProperty,
 } from './generateCustomOperationsProperty';
 import { ClientGenerationParams } from './types';
 import { isConfigureEventWithResourceConfig } from './utils/runtimeTypeGuards/isConfigureEventWithResourceConfig';
@@ -51,6 +53,7 @@ export function generateClient<T extends Record<any, any> = never>(
 		enums: emptyProperty as EnumTypes<never>,
 		queries: emptyProperty as CustomQueries<never>,
 		mutations: emptyProperty as CustomMutations<never>,
+		subscriptions: emptyProperty as CustomSubscriptions<never>,
 	} as any;
 
 	const apiGraphqlConfig = params.amplify.getConfig().API?.GraphQL;
@@ -60,6 +63,10 @@ export function generateClient<T extends Record<any, any> = never>(
 		client.enums = generateEnumsProperty<T>(apiGraphqlConfig);
 		client.queries = generateCustomQueriesProperty<T>(client, apiGraphqlConfig);
 		client.mutations = generateCustomMutationsProperty<T>(
+			client,
+			apiGraphqlConfig,
+		);
+		client.subscriptions = generateCustomSubscriptionsProperty(
 			client,
 			apiGraphqlConfig,
 		);
@@ -98,6 +105,10 @@ const generateModelsPropertyOnAmplifyConfigure = (clientRef: any) => {
 				apiGraphQLConfig,
 			);
 			clientRef.mutations = generateCustomMutationsProperty(
+				clientRef,
+				apiGraphQLConfig,
+			);
+			clientRef.subscriptions = generateCustomSubscriptionsProperty(
 				clientRef,
 				apiGraphQLConfig,
 			);

--- a/packages/api-graphql/src/internals/generateCustomOperationsProperty.ts
+++ b/packages/api-graphql/src/internals/generateCustomOperationsProperty.ts
@@ -23,7 +23,9 @@ type CustomOpsProperty<
 	? CustomQueries<T>
 	: OpType extends 'mutations'
 		? CustomMutations<T>
-		: CustomSubscriptions<T>;
+		: OpType extends 'subscriptions'
+			? CustomSubscriptions<T>
+			: never;
 
 const operationTypeMap = {
 	queries: 'query',

--- a/packages/api-graphql/src/internals/generateCustomOperationsProperty.ts
+++ b/packages/api-graphql/src/internals/generateCustomOperationsProperty.ts
@@ -1,6 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { CustomMutations, CustomQueries } from '@aws-amplify/data-schema-types';
+import {
+	CustomMutations,
+	CustomQueries,
+	CustomSubscriptions,
+} from '@aws-amplify/data-schema-types';
 import {
 	GraphQLProviderConfig,
 	ModelIntrospectionSchema,
@@ -10,16 +14,21 @@ import { V6Client, __amplify } from '../types';
 
 import { customOpFactory } from './operations/custom';
 
-type OpTypes = 'queries' | 'mutations';
+type OpTypes = 'queries' | 'mutations' | 'subscriptions';
 
 type CustomOpsProperty<
 	T extends Record<any, any>,
 	OpType extends OpTypes,
-> = OpType extends 'queries' ? CustomQueries<T> : CustomMutations<T>;
+> = OpType extends 'queries'
+	? CustomQueries<T>
+	: OpType extends 'mutations'
+		? CustomMutations<T>
+		: CustomSubscriptions<T>;
 
 const operationTypeMap = {
 	queries: 'query',
 	mutations: 'mutation',
+	subscriptions: 'subscription',
 } as const;
 
 export function generateCustomOperationsProperty<
@@ -86,5 +95,16 @@ export function generateCustomQueriesProperty<T extends Record<any, any>>(
 		client,
 		config,
 		'queries',
+	);
+}
+
+export function generateCustomSubscriptionsProperty<T extends Record<any, any>>(
+	client: V6Client<Record<string, any>>,
+	config: GraphQLProviderConfig['GraphQL'],
+) {
+	return generateCustomOperationsProperty<T, 'subscriptions'>(
+		client,
+		config,
+		'subscriptions',
 	);
 }

--- a/packages/api-graphql/src/internals/operations/custom.ts
+++ b/packages/api-graphql/src/internals/operations/custom.ts
@@ -41,6 +41,15 @@ type OpArgs =
 	| [CustomOperationOptions];
 
 /**
+ * Type guard for checking whether a Custom Operation argument is a contextSpec object
+ */
+const argIsContextSpec = (
+	arg: OpArgs[number],
+): arg is AmplifyServer.ContextSpec => {
+	return typeof (arg as AmplifyServer.ContextSpec)?.token?.value === 'symbol';
+};
+
+/**
  * Builds an operation function, embedded with all client and context data, that
  * can be attached to a client as a custom query or mutation.
  *
@@ -115,8 +124,9 @@ export function customOpFactory(
 		let arg: QueryArgs | undefined;
 
 		if (useContext) {
-			contextSpec = args[0] as AmplifyServer.ContextSpec;
-			if (contextSpec?.token === undefined) {
+			if (argIsContextSpec(args[0])) {
+				contextSpec = args[0];
+			} else {
 				throw new Error(
 					`Invalid first argument passed to ${operation.name}. Expected contextSpec`,
 				);

--- a/packages/api-graphql/src/internals/operations/custom.ts
+++ b/packages/api-graphql/src/internals/operations/custom.ts
@@ -5,6 +5,7 @@ import {
 	CustomOperation,
 	ModelIntrospectionSchema,
 } from '@aws-amplify/core/internals/utils';
+import { map } from 'rxjs';
 
 import {
 	authModeParams,
@@ -18,13 +19,26 @@ import {
 import {
 	AuthModeParams,
 	ClientWithModels,
-	GraphQLOptionsV6,
 	GraphQLResult,
+	GraphqlSubscriptionResult,
 	ListArgs,
 	QueryArgs,
 	V6Client,
 	V6ClientSSRRequest,
 } from '../../types';
+
+type CustomOperationOptions = AuthModeParams & ListArgs;
+
+// these are the 4 possible sets of arguments custom operations methods can receive
+type OpArgs =
+	// SSR Request Client w Args defined
+	| [AmplifyServer.ContextSpec, QueryArgs, CustomOperationOptions]
+	// SSR Request Client without Args defined
+	| [AmplifyServer.ContextSpec, CustomOperationOptions]
+	// Client or SSR Cookies Client w Args defined
+	| [QueryArgs, CustomOperationOptions]
+	// Client or SSR Cookies Client without Args defined
+	| [CustomOperationOptions];
 
 /**
  * Builds an operation function, embedded with all client and context data, that
@@ -85,15 +99,49 @@ import {
 export function customOpFactory(
 	client: ClientWithModels,
 	modelIntrospection: ModelIntrospectionSchema,
-	operationType: 'query' | 'mutation',
+	operationType: 'query' | 'mutation' | 'subscription',
 	operation: CustomOperation,
 	useContext: boolean,
 ) {
-	const opWithContext = async (
-		contextSpec: AmplifyServer.ContextSpec & GraphQLOptionsV6<unknown, string>,
-		arg?: QueryArgs,
-		options?: AuthModeParams & ListArgs,
-	) => {
+	// .arguments() are defined for the custom operation in the schema builder
+	// and are present in the model introspection schema
+	const argsDefined = operation.arguments !== undefined;
+
+	const op = (...args: OpArgs) => {
+		// options is always the last argument
+		const options = args[args.length - 1] as CustomOperationOptions;
+
+		let contextSpec: AmplifyServer.ContextSpec | undefined;
+		let arg: QueryArgs | undefined;
+
+		if (useContext) {
+			contextSpec = args[0] as AmplifyServer.ContextSpec;
+			if (contextSpec?.token === undefined) {
+				throw new Error(
+					`Invalid first argument passed to ${operation.name}. Expected contextSpec`,
+				);
+			}
+		}
+
+		if (argsDefined) {
+			if (useContext) {
+				arg = args[1] as QueryArgs;
+			} else {
+				arg = args[0] as QueryArgs;
+			}
+		}
+
+		if (operationType === 'subscription') {
+			return _opSubscription(
+				// subscriptions are only enabled on the clientside
+				client as V6Client<Record<string, any>>,
+				modelIntrospection,
+				operation,
+				arg,
+				options,
+			);
+		}
+
 		return _op(
 			client,
 			modelIntrospection,
@@ -105,18 +153,7 @@ export function customOpFactory(
 		);
 	};
 
-	const op = async (arg?: QueryArgs, options?: AuthModeParams & ListArgs) => {
-		return _op(
-			client,
-			modelIntrospection,
-			operationType,
-			operation,
-			arg,
-			options,
-		);
-	};
-
-	return useContext ? opWithContext : op;
+	return op;
 }
 
 /**
@@ -160,6 +197,9 @@ function hasStringField<Field extends string>(
  * @returns "outer" arguments string
  */
 function outerArguments(operation: CustomOperation): string {
+	if (operation.arguments === undefined) {
+		return '';
+	}
 	const args = Object.entries(operation.arguments)
 		.map(([k, v]) => {
 			const baseType = v.type + (v.isRequired ? '!' : '');
@@ -194,6 +234,9 @@ function outerArguments(operation: CustomOperation): string {
  * @returns "outer" arguments string
  */
 function innerArguments(operation: CustomOperation): string {
+	if (operation.arguments === undefined) {
+		return '';
+	}
 	const args = Object.keys(operation.arguments)
 		.map(k => `${k}: $${k}`)
 		.join(', ');
@@ -259,6 +302,9 @@ function operationVariables(
 	args: QueryArgs = {},
 ): Record<string, unknown> {
 	const variables = {} as Record<string, unknown>;
+	if (operation.arguments === undefined) {
+		return variables;
+	}
 	for (const argDef of Object.values(operation.arguments)) {
 		if (typeof args[argDef.name] !== 'undefined') {
 			variables[argDef.name] = args[argDef.name];
@@ -365,4 +411,72 @@ async function _op(
 			throw error;
 		}
 	}
+}
+
+/**
+ * Executes an operation from the given model intro schema against a client, returning
+ * a fully instantiated model when relevant.
+ *
+ * @param client The client to operate `graphql()` calls through.
+ * @param modelIntrospection The model intro schema to construct requests from.
+ * @param operation The specific operation name, args, return type details.
+ * @param args The arguments to provide to the operation as variables.
+ * @param options Request options like headers, etc.
+ * @returns Result from the graphql request, model-instantiated when relevant.
+ */
+function _opSubscription(
+	client: V6Client<Record<string, any>>,
+	modelIntrospection: ModelIntrospectionSchema,
+	operation: CustomOperation,
+	args?: QueryArgs,
+	options?: AuthModeParams & ListArgs,
+) {
+	const operationType = 'subscription';
+	const { name: operationName } = operation;
+	const auth = authModeParams(client, options);
+	const headers = getCustomHeaders(client, options?.headers);
+	const outerArgsString = outerArguments(operation);
+	const innerArgsString = innerArguments(operation);
+	const selectionSet = operationSelectionSet(modelIntrospection, operation);
+
+	const returnTypeModelName = hasStringField(operation.type, 'model')
+		? operation.type.model
+		: undefined;
+
+	const query = `
+		${operationType.toLocaleLowerCase()}${outerArgsString} {
+			${operationName}${innerArgsString} ${selectionSet}
+		}
+	`;
+
+	const variables = operationVariables(operation, args);
+
+	const observable = client.graphql(
+		{
+			...auth,
+			query,
+			variables,
+		},
+		headers,
+	) as GraphqlSubscriptionResult<object>;
+
+	return observable.pipe(
+		map(value => {
+			const [key] = Object.keys(value.data);
+			const data = (value.data as any)[key];
+
+			const [initialized] = returnTypeModelName
+				? initializeModel(
+						client as V6Client<Record<string, any>>,
+						returnTypeModelName,
+						[data],
+						modelIntrospection,
+						auth.authMode,
+						auth.authToken,
+					)
+				: [data];
+
+			return initialized;
+		}),
+	);
 }

--- a/packages/api-graphql/src/internals/server/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/server/generateModelsProperty.ts
@@ -15,13 +15,16 @@ import { getFactory } from '../operations/get';
 import { getSecondaryIndexesFromSchemaModel } from '../clientUtils';
 
 export function generateModelsProperty<
-	_T extends Record<any, any> = never,
+	T extends Record<any, any> = never,
 	ClientType extends
 		| V6ClientSSRRequest<Record<string, any>>
 		| V6ClientSSRCookies<Record<string, any>> = V6ClientSSRCookies<
 		Record<string, any>
 	>,
->(client: ClientType, params: ServerClientGenerationParams): ClientType {
+>(
+	client: ClientType,
+	params: ServerClientGenerationParams,
+): ModelTypes<T> | ModelTypes<never> {
 	const models = {} as any;
 	const { config } = params;
 	const useContext = params.amplify === null;

--- a/packages/api-graphql/src/internals/utils/clientProperties/generateModelsProperty.ts
+++ b/packages/api-graphql/src/internals/utils/clientProperties/generateModelsProperty.ts
@@ -18,7 +18,7 @@ import { getSecondaryIndexesFromSchemaModel } from '../../clientUtils';
 export function generateModelsProperty<T extends Record<any, any> = never>(
 	client: V6Client<Record<string, any>>,
 	apiGraphQLConfig: GraphQLProviderConfig['GraphQL'],
-): ModelTypes<T> {
+): ModelTypes<T> | ModelTypes<never> {
 	const models = {} as any;
 
 	const modelIntrospection: ModelIntrospectionSchema | undefined =

--- a/packages/api-graphql/src/types/index.ts
+++ b/packages/api-graphql/src/types/index.ts
@@ -5,6 +5,7 @@ import {
 	CustomHeaders,
 	CustomMutations,
 	CustomQueries,
+	CustomSubscriptions,
 	EnumTypes,
 	ModelTypes,
 } from '@aws-amplify/data-schema-types';
@@ -394,6 +395,7 @@ export type V6Client<T extends Record<any, any> = never> = ExcludeNeverFields<{
 	enums: EnumTypes<T>;
 	queries: CustomQueries<T>;
 	mutations: CustomMutations<T>;
+	subscriptions: CustomSubscriptions<T>;
 }>;
 
 export type V6ClientSSRRequest<T extends Record<any, any> = never> =

--- a/packages/core/src/singleton/API/types.ts
+++ b/packages/core/src/singleton/API/types.ts
@@ -108,6 +108,7 @@ export interface ModelIntrospectionSchema {
 	enums: SchemaEnums;
 	queries?: CustomOperations;
 	mutations?: CustomOperations;
+	subscriptions?: CustomOperations;
 }
 
 /**
@@ -154,7 +155,7 @@ export interface CustomOperation {
 	type: FieldType;
 	isArray: boolean;
 	isRequired: boolean;
-	arguments: CustomOperationArguments;
+	arguments?: CustomOperationArguments;
 }
 
 export type CustomOperationArguments = Record<string, CustomOperationArgument>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-amplify/data-schema-types@*", "@aws-amplify/data-schema-types@^0.7.10":
-  version "0.7.10"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema-types/-/data-schema-types-0.7.10.tgz#daad8ceeac210dce023785c1eb414dc4c2a4d8a8"
-  integrity sha512-x2aPHw5a6zVZKugvkMp9SKcwzn+JGzxGe1ntgq9jTU67XgeyPpBlF/XY2drwQpSUDE+FES5PbY4cSHpc3iIEkw==
+"@aws-amplify/data-schema-types@*", "@aws-amplify/data-schema-types@^0.7.11":
+  version "0.7.11"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema-types/-/data-schema-types-0.7.11.tgz#d6c4b5be551fa0600f6bbf2b512f19e39a20e481"
+  integrity sha512-K16p1NF1entoNBDQUnH/wK3exmOg+AtF96uFaj3SxQDOBad+wBnzVHZNWaoemlX2ISnuH/fXbuFvB5D7w76zbQ==
   dependencies:
     rxjs "^7.8.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,15 +17,15 @@
 
 "@aws-amplify/data-schema-types@*", "@aws-amplify/data-schema-types@^0.7.10":
   version "0.7.10"
-  resolved "http://localhost:4873/@aws-amplify%2fdata-schema-types/-/data-schema-types-0.7.10.tgz#bad317ed818431e9a8dfdcc2c61d49f225d51ffc"
-  integrity sha512-M8HasHh29ZRmrWS7Xd3FLTLAPzC+3wsy+Nz4eqLnyZtQv19Sld8AKUZhObKLXTcXCqtm7ypBdMOGKkYy3B1Z5Q==
+  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema-types/-/data-schema-types-0.7.10.tgz#daad8ceeac210dce023785c1eb414dc4c2a4d8a8"
+  integrity sha512-x2aPHw5a6zVZKugvkMp9SKcwzn+JGzxGe1ntgq9jTU67XgeyPpBlF/XY2drwQpSUDE+FES5PbY4cSHpc3iIEkw==
   dependencies:
     rxjs "^7.8.1"
 
-"@aws-amplify/data-schema@^0.13.19":
-  version "0.13.19"
-  resolved "http://localhost:4873/@aws-amplify%2fdata-schema/-/data-schema-0.13.19.tgz#1bfc735e5b3ecdfeaf9387ea30f2aaf4833c3361"
-  integrity sha512-bwvNVaHu5+Fdp7+Ph8zWZT+mDq53xou8hZN+OViuj1ZZc3dUJGuzhtQRMunn6k+g8HDuXxCvE7yBjflHoTXrvg==
+"@aws-amplify/data-schema@^0.14.1":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema/-/data-schema-0.14.1.tgz#4208054e2c6c230a9abcc4607e3c38494dad3a38"
+  integrity sha512-V7Gx/HpNf7mOW90XBQMb94/whrysQ+NJCamb7aKSglXqWMVnc0zamFSkt2L+N0+avG+hEJaE+vH3157HfMYamA==
   dependencies:
     "@aws-amplify/data-schema-types" "*"
     "@types/aws-lambda" "^8.10.134"
@@ -4853,7 +4853,7 @@
 
 "@types/aws-lambda@^8.10.134":
   version "8.10.136"
-  resolved "http://localhost:4873/@types%2faws-lambda/-/aws-lambda-8.10.136.tgz#12a2af86b9123f4e4549992b27e1bf0dcf60d9f9"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.136.tgz#12a2af86b9123f4e4549992b27e1bf0dcf60d9f9"
   integrity sha512-cmmgqxdVGhxYK9lZMYYXYRJk6twBo53ivtXjIUEFZxfxe4TkZTZBK3RRWrY2HjJcUIix0mdifn15yjOAat5lTA==
 
 "@types/babel__core@^7.1.14":

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,19 +15,20 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-amplify/data-schema-types@*", "@aws-amplify/data-schema-types@^0.7.6":
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema-types/-/data-schema-types-0.7.6.tgz#7953e3c2eb22aba2bc9e4cc34a7b9023345a1b12"
-  integrity sha512-g5LmvLEJ5BDtfxRT6QK/+HhTfGGADbF7gbxtWPbhP9hRYwDai0A9ARJ6qETLPzUE/1vXtURlJV+MLutsDrIkPA==
+"@aws-amplify/data-schema-types@*", "@aws-amplify/data-schema-types@^0.7.10":
+  version "0.7.10"
+  resolved "http://localhost:4873/@aws-amplify%2fdata-schema-types/-/data-schema-types-0.7.10.tgz#bad317ed818431e9a8dfdcc2c61d49f225d51ffc"
+  integrity sha512-M8HasHh29ZRmrWS7Xd3FLTLAPzC+3wsy+Nz4eqLnyZtQv19Sld8AKUZhObKLXTcXCqtm7ypBdMOGKkYy3B1Z5Q==
   dependencies:
     rxjs "^7.8.1"
 
-"@aws-amplify/data-schema@^0.13.9":
-  version "0.13.9"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema/-/data-schema-0.13.9.tgz#ee9be4e97b9f16d8225792758c8bf451b1814ddb"
-  integrity sha512-M1Wc5D4Sr5YT+Vq6FSPL7mDYW1Atnj5eHxRTGXoDG7w7G4Zs5Lq0nE8MQSx6gIuq3Js3WSjNoxUhBvaerX+Lgw==
+"@aws-amplify/data-schema@^0.13.19":
+  version "0.13.19"
+  resolved "http://localhost:4873/@aws-amplify%2fdata-schema/-/data-schema-0.13.19.tgz#1bfc735e5b3ecdfeaf9387ea30f2aaf4833c3361"
+  integrity sha512-bwvNVaHu5+Fdp7+Ph8zWZT+mDq53xou8hZN+OViuj1ZZc3dUJGuzhtQRMunn6k+g8HDuXxCvE7yBjflHoTXrvg==
   dependencies:
     "@aws-amplify/data-schema-types" "*"
+    "@types/aws-lambda" "^8.10.134"
 
 "@aws-crypto/crc32@3.0.0":
   version "3.0.0"
@@ -4849,6 +4850,11 @@
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@types/archy/-/archy-0.0.32.tgz#8b572741dad9172dfbf289397af1bb41296d3e40"
   integrity sha512-5ZZ5+YGmUE01yejiXsKnTcvhakMZ2UllZlMsQni53Doc1JWhe21ia8VntRoRD6fAEWw08JBh/z9qQHJ+//MrIg==
+
+"@types/aws-lambda@^8.10.134":
+  version "8.10.136"
+  resolved "http://localhost:4873/@types%2faws-lambda/-/aws-lambda-8.10.136.tgz#12a2af86b9123f4e4549992b27e1bf0dcf60d9f9"
+  integrity sha512-cmmgqxdVGhxYK9lZMYYXYRJk6twBo53ivtXjIUEFZxfxe4TkZTZBK3RRWrY2HjJcUIix0mdifn15yjOAat5lTA==
 
 "@types/babel__core@^7.1.14":
   version "7.20.5"


### PR DESCRIPTION
~Draft until this is merged: https://github.com/aws-amplify/amplify-api-next/pull/131~

TODO: 
- [x] Update `data-schema` & `data-schema-types` dep versions after merging ^

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adds custom subscriptions support to data-client.

Given this schema
```ts
const schema = a.schema({
...,
onPostLiked: a
  .subscription()
  .for(a.ref('likePostReturnPost'))
  .returns(a.ref('Post'))
  .handler(a.handler.custom({ entry: './jsResolver_base.js' })),

onPostUpdated: a
  .subscription()
  .for(a.ref('Post').mutations(['update']))
  .arguments({ postId: a.string() })
  .returns(a.ref('Post'))
  .handler(a.handler.custom({ entry: './jsResolver_base.js' })),

}).authorization([a.allow.private()]),
```

data-client makes the following subscription functions available:

```ts
const sub = client.subscriptions.onPostLiked().subscribe({ next: ..., error: ... })
const sub2 = client.subscriptions.onPostUpdated({ postId: 'abc123' }).subscribe({ next: ..., error: ... })
```


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
