### PR TITLE
chore: Enable pre-id publication for gen2-storage

### DIFF
--- a/.github/workflows/push-integ-test.yml
+++ b/.github/workflows/push-integ-test.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - next/main
-      - gen2-storage
 
 jobs:
   e2e:

--- a/.github/workflows/push-preid-release.yml
+++ b/.github/workflows/push-preid-release.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       # Change this to your branch name where "example-preid" corresponds to the preid you want your changes released on
-      - feat/example-preid-branch/main
+      - gen2-storage
 
 jobs:
   e2e:
@@ -35,4 +35,4 @@ jobs:
     # The preid should be detected from the branch name recommending feat/{PREID}/whatever as branch naming pattern
     #   if your branch doesn't follow this pattern, you can override it here for your branch.
     with:
-      preid: ${{ needs.parse-preid.outputs.preid }}
+      preid: gen2-storage


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Enable pre-id publication and continuous E2E tests for the Gen2 storage branch. Changes will be published to `gen2-storage` when E2E tests pass.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
