### PR TITLE
Update Path assertion

### DIFF
--- a/packages/storage/__tests__/providers/s3/apis/copy.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/copy.test.ts
@@ -199,15 +199,15 @@ describe('copy API', () => {
 
 			test.each([
 				{
-					sourcePath: '/sourcePathAsString',
+					sourcePath: 'sourcePathAsString',
 					expectedSourcePath: 'sourcePathAsString',
-					destinationPath: '/destinationPathAsString',
+					destinationPath: 'destinationPathAsString',
 					expectedDestinationPath: 'destinationPathAsString',
 				},
 				{
-					sourcePath: () => '/sourcePathAsFunction',
+					sourcePath: () => 'sourcePathAsFunction',
 					expectedSourcePath: 'sourcePathAsFunction',
-					destinationPath: () => '/destinationPathAsFunction',
+					destinationPath: () => 'destinationPathAsFunction',
 					expectedDestinationPath: 'destinationPathAsFunction',
 				},
 			])(

--- a/packages/storage/__tests__/providers/s3/apis/downloadData.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/downloadData.test.ts
@@ -218,11 +218,11 @@ describe('downloadData with path', () => {
 
 	test.each([
 		{
-			path: '/path',
+			path: 'path',
 			expectedKey: 'path',
 		},
 		{
-			path: () => '/path',
+			path: () => 'path',
 			expectedKey: 'path',
 		},
 	])(

--- a/packages/storage/__tests__/providers/s3/apis/utils/validateStorageOperationInput.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/validateStorageOperationInput.test.ts
@@ -42,7 +42,7 @@ describe('validateStorageOperationInput', () => {
 		});
 	});
 
-	it('should throw an error when input path does not start with a /', () => {
+	it('should throw an error when input path starts with a /', () => {
 		const input = { path: '/leading-slash-path' };
 		expect(() => validateStorageOperationInput(input)).toThrow(
 			validationErrorMap[

--- a/packages/storage/__tests__/providers/s3/apis/utils/validateStorageOperationInput.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/validateStorageOperationInput.test.ts
@@ -13,7 +13,7 @@ import {
 
 describe('validateStorageOperationInput', () => {
 	it('should return inputType as STORAGE_INPUT_PATH and objectKey as testPath when input is path as string', () => {
-		const input = { path: '/testPath' };
+		const input = { path: 'testPath' };
 		const result = validateStorageOperationInput(input);
 		expect(result).toEqual({
 			inputType: STORAGE_INPUT_PATH,
@@ -24,7 +24,7 @@ describe('validateStorageOperationInput', () => {
 	it('should return inputType as STORAGE_INPUT_PATH and objectKey as result of path function when input is path as function', () => {
 		const input = {
 			path: ({ identityId }: { identityId?: string }) =>
-				`/testPath/${identityId}`,
+				`testPath/${identityId}`,
 		};
 		const result = validateStorageOperationInput(input, '123');
 		expect(result).toEqual({
@@ -43,7 +43,7 @@ describe('validateStorageOperationInput', () => {
 	});
 
 	it('should throw an error when input path does not start with a /', () => {
-		const input = { path: 'test' } as any;
+		const input = { path: '/leading-slash-path' };
 		expect(() => validateStorageOperationInput(input)).toThrow(
 			validationErrorMap[
 				StorageValidationErrorCode.InvalidStoragePathInput

--- a/packages/storage/src/errors/types/validation.ts
+++ b/packages/storage/src/errors/types/validation.ts
@@ -63,6 +63,6 @@ export const validationErrorMap: AmplifyErrorMap<StorageValidationErrorCode> = {
 		message: 'Missing path or key parameter in Input.',
 	},
 	[StorageValidationErrorCode.InvalidStoragePathInput]: {
-		message: 'Input `path` is missing a leading slash (/).',
+		message: 'Input `path` does not allow a leading slash (/).',
 	},
 };

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -20,8 +20,16 @@ interface CommonOptions {
 
 /** @deprecated This may be removed in the next major version. */
 type ReadOptions =
-	| { accessLevel?: 'guest' | 'private' }
-	| { accessLevel: 'protected'; targetIdentityId?: string };
+	| {
+			/** @deprecated This may be removed in the next major version. */
+			accessLevel?: 'guest' | 'private';
+	  }
+	| {
+			/** @deprecated This may be removed in the next major version. */
+			accessLevel: 'protected';
+			/** @deprecated This may be removed in the next major version. */
+			targetIdentityId?: string;
+	  };
 
 /** @deprecated This may be removed in the next major version. */
 interface WriteOptions {

--- a/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
+++ b/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
@@ -21,13 +21,13 @@ export const validateStorageOperationInput = (
 		const { path } = input;
 		const objectKey = typeof path === 'string' ? path : path({ identityId });
 		assertValidationError(
-			objectKey.startsWith('/'),
+			!objectKey.startsWith('/'),
 			StorageValidationErrorCode.InvalidStoragePathInput,
 		);
 
 		return {
 			inputType: STORAGE_INPUT_PATH,
-			objectKey: objectKey.slice(1),
+			objectKey,
 		};
 	} else {
 		return { inputType: STORAGE_INPUT_KEY, objectKey: input.key };


### PR DESCRIPTION
#### Description of changes
- Fixes Path assertion to validate `path` to not start with leading slash
- Updates test

#### Description of how you validated changes
- Unit tests and manual testing 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
