### PR TITLE
feat: implicit group auth fields in selection sets

### DIFF
--- a/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.ts
@@ -1361,6 +1361,301 @@ const amplifyConfig = {
 					sortKeyFieldNames: ['factoryId', 'warehouseId'],
 				},
 			},
+			ImplicitOwner: {
+				name: 'ImplicitOwner',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					description: {
+						name: 'description',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					owner: {
+						name: 'owner',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: true,
+						attributes: [],
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: true,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'ImplicitOwners',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							fields: ['id'],
+						},
+					},
+					{
+						type: 'auth',
+						properties: {
+							rules: [
+								{
+									provider: 'userPools',
+									ownerField: 'owner',
+									allow: 'owner',
+									identityClaim: 'cognito:username',
+									operations: ['create', 'update', 'delete', 'read'],
+								},
+							],
+						},
+					},
+				],
+				primaryKeyInfo: {
+					isCustomPrimaryKey: false,
+					primaryKeyFieldName: 'id',
+					sortKeyFieldNames: [],
+				},
+			},
+			CustomImplicitOwner: {
+				name: 'CustomImplicitOwner',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					description: {
+						name: 'description',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					customOwner: {
+						name: 'customOwner',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: true,
+						attributes: [],
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: true,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'CustomImplicitOwners',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							fields: ['id'],
+						},
+					},
+					{
+						type: 'auth',
+						properties: {
+							rules: [
+								{
+									provider: 'userPools',
+									ownerField: 'customOwner',
+									allow: 'owner',
+									identityClaim: 'cognito:username',
+									operations: ['create', 'update', 'delete', 'read'],
+								},
+							],
+						},
+					},
+				],
+				primaryKeyInfo: {
+					isCustomPrimaryKey: false,
+					primaryKeyFieldName: 'id',
+					sortKeyFieldNames: [],
+				},
+			},
+			ModelGroupDefinedIn: {
+				name: 'ModelGroupDefinedIn',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					description: {
+						name: 'description',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					groupField: {
+						name: 'groupField',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: true,
+						attributes: [],
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: true,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'ModelGroupDefinedIns',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							fields: ['id'],
+						},
+					},
+					{
+						type: 'auth',
+						properties: {
+							rules: [
+								{
+									groupClaim: 'cognito:groups',
+									provider: 'userPools',
+									allow: 'groups',
+									groupsField: 'groupField',
+									groupField: 'groups',
+									operations: ['create', 'update', 'delete', 'read'],
+								},
+							],
+						},
+					},
+				],
+				primaryKeyInfo: {
+					isCustomPrimaryKey: false,
+					primaryKeyFieldName: 'id',
+					sortKeyFieldNames: [],
+				},
+			},
+			ModelGroupsDefinedIn: {
+				name: 'ModelGroupsDefinedIn',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					description: {
+						name: 'description',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					groupsField: {
+						name: 'groupsField',
+						isArray: true,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+						isArrayNullable: true,
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: true,
+						attributes: [],
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: true,
+						attributes: [],
+					},
+				},
+				syncable: true,
+				pluralName: 'ModelGroupsDefinedIns',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'key',
+						properties: {
+							fields: ['id'],
+						},
+					},
+					{
+						type: 'auth',
+						properties: {
+							rules: [
+								{
+									groupClaim: 'cognito:groups',
+									provider: 'userPools',
+									allow: 'groups',
+									groupsField: 'groupsField',
+									groupField: 'groups',
+									operations: ['create', 'update', 'delete', 'read'],
+								},
+							],
+						},
+					},
+				],
+				primaryKeyInfo: {
+					isCustomPrimaryKey: false,
+					primaryKeyFieldName: 'id',
+					sortKeyFieldNames: [],
+				},
+			},
 		},
 		enums: {
 			Status: {

--- a/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
@@ -184,8 +184,30 @@ const schema = a.schema({
 		.returns(a.ref('Post'))
 		.function('echoFunction')
 		.authorization([a.allow.private()]),
-
 	//#endregion
+
+	// #region implicit ownership models
+	ImplicitOwner: a
+		.model({
+			description: a.string(),
+		})
+		.authorization([a.allow.owner()]),
+	CustomImplicitOwner: a
+		.model({
+			description: a.string(),
+		})
+		.authorization([a.allow.owner().inField('customOwner')]),
+	ModelGroupDefinedIn: a
+		.model({
+			description: a.string(),
+		})
+		.authorization([a.allow.groupDefinedIn('groupField')]),
+	ModelGroupsDefinedIn: a
+		.model({
+			description: a.string(),
+		})
+		.authorization([a.allow.groupsDefinedIn('groupsField')]),
+	// #endregion
 });
 
 export type Schema = ClientSchema<typeof schema>;

--- a/packages/api-graphql/__tests__/internals/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/internals/generateClient.test.ts
@@ -4,7 +4,6 @@ import { generateClient } from '../../src/internals';
 import configFixture from '../fixtures/modeled/amplifyconfiguration';
 import { Schema } from '../fixtures/modeled/schema';
 import { Observable, from } from 'rxjs';
-import * as internals from '../../src/internals';
 import {
 	normalizePostGraphqlCalls,
 	expectSub,

--- a/packages/api-graphql/__tests__/internals/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/internals/generateClient.test.ts
@@ -3,14 +3,15 @@ import { Amplify, AmplifyClassV6 } from '@aws-amplify/core';
 import { generateClient } from '../../src/internals';
 import configFixture from '../fixtures/modeled/amplifyconfiguration';
 import { Schema } from '../fixtures/modeled/schema';
+import { Observable, from } from 'rxjs';
+import * as internals from '../../src/internals';
 import {
+	normalizePostGraphqlCalls,
 	expectSub,
 	expectSubWithHeaders,
 	expectSubWithHeadersFn,
 	expectSubWithlibraryConfigHeaders,
-} from '../utils/expects';
-import { Observable, from } from 'rxjs';
-import * as internals from '../../src/internals';
+} from '../utils/index';
 
 const serverManagedFields = {
 	id: 'some-id',
@@ -63,47 +64,6 @@ function makeAppSyncStreams() {
 	return { streams, spy };
 }
 
-/**
- * For each call against the spy, assuming the spy is a `post()` spy,
- * replaces fields that are likely to change between calls (or library version revs)
- * with static values. When possible, on the unpredicable portions of these values
- * are replaced.
- *
- * ## THIS IS DESTRUCTIVE
- *
- * The original `spy.mocks.calls` will be updated *and* returned.
- *
- * For example,
- *
- * ```plain
- * headers.x-amz-user-agent: "aws-amplify/6.0.5 api/1 framework/0"
- * ```
- *
- * Is replaced with:
- *
- * ```plain
- * headers.x-amz-user-agent: "aws-amplify/latest api/latest framework/latest"
- * ```
- *
- * @param spy The Jest spy
- */
-function normalizePostGraphqlCalls(spy: jest.SpyInstance<any, any>) {
-	return spy.mock.calls.map((call: any) => {
-		// The 1st param in `call` is an instance of `AmplifyClassV6`
-		// The 2nd param in `call` is the actual `postOptions`
-		const [_, postOptions] = call;
-		const userAgent = postOptions?.options?.headers?.['x-amz-user-agent'];
-		if (userAgent) {
-			const staticUserAgent = userAgent.replace(/\/[\d.]+/g, '/latest');
-			postOptions.options.headers['x-amz-user-agent'] = staticUserAgent;
-		}
-		// Calling of `post` API with an instance of `AmplifyClassV6` has been
-		// unit tested in other test suites. To reduce the noise in the generated
-		// snapshot, we hide the details of the instance here.
-		return ['AmplifyClassV6', postOptions];
-	});
-}
-
 const USER_AGENT_DETAILS = {
 	action: '1',
 	category: 'api',
@@ -128,6 +88,10 @@ describe('generateClient', () => {
 			'Post',
 			'Comment',
 			'Product',
+			'ImplicitOwner',
+			'CustomImplicitOwner',
+			'ModelGroupDefinedIn',
+			'ModelGroupsDefinedIn',
 		];
 
 		it('generates `models` property when Amplify.getConfig() returns valid GraphQL provider config', () => {

--- a/packages/api-graphql/__tests__/internals/implicit-auth-fields.test.ts
+++ b/packages/api-graphql/__tests__/internals/implicit-auth-fields.test.ts
@@ -1,0 +1,106 @@
+import * as raw from '../../src';
+import { Amplify, AmplifyClassV6 } from '@aws-amplify/core';
+import { generateClient } from '../../src/internals';
+import configFixture from '../fixtures/modeled/amplifyconfiguration';
+import { Schema } from '../fixtures/modeled/schema';
+import { Observable, from } from 'rxjs';
+import * as internals from '../../src/internals';
+import {
+	normalizePostGraphqlCalls,
+	expectSub,
+	expectSubWithHeaders,
+	expectSubWithHeadersFn,
+	expectSubWithlibraryConfigHeaders,
+	expectSelectionSetContains,
+	expectSelectionSetNotContains,
+	expectVariables,
+} from '../utils/index';
+
+const serverManagedFields = {
+	id: 'some-id',
+	owner: 'wirejobviously',
+	createdAt: new Date().toISOString(),
+	updatedAt: new Date().toISOString(),
+};
+
+/**
+ *
+ * @param value Value to be returned. Will be `awaited`, and can
+ * therefore be a simple JSON value or a `Promise`.
+ * @returns
+ */
+function mockApiResponse(value: any) {
+	return jest
+		.spyOn((raw.GraphQLAPI as any)._api, 'post')
+		.mockImplementation(async () => {
+			const result = await value;
+			return {
+				body: {
+					json: () => result,
+				},
+			};
+		});
+}
+
+describe('implicit auth field handling', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	for (const [modelName, authField] of [
+		['ImplicitOwner', 'owner'],
+		['CustomImplicitOwner', 'customOwner'],
+		['ModelGroupDefinedIn', 'groupField'],
+		['ModelGroupsDefinedIn', 'groupsField'],
+	] as const) {
+		test(`get ${modelName} includes auth field ${authField} in selection set`, async () => {
+			// This config hackery can be removed once the schema builder is updated to omit
+			// implicit auth fields from the graphql schema and the amplifyconfiguration.ts fixture
+			// is updated accordingly. Until then, we're creating a copy of the generated fixture
+			// minus the auth field that will eventually be omitted from the model.
+			const config = JSON.parse(JSON.stringify(configFixture));
+			delete (config.modelIntrospection.models[modelName].fields as any)[
+				authField
+			];
+
+			Amplify.configure(config as any);
+
+			const spy = mockApiResponse({
+				data: null,
+			});
+
+			const client = generateClient<Schema>({ amplify: Amplify });
+			const { data } = await client.models[modelName].get({ id: 'some-id' });
+
+			expectSelectionSetContains(spy, [authField]);
+		});
+
+		test(`can list ${modelName} with filter on auth field ${authField}`, async () => {
+			// This config hackery can be removed once the schema builder is updated to omit
+			// implicit auth fields from the graphql schema and the amplifyconfiguration.ts fixture
+			// is updated accordingly. Until then, we're creating a copy of the generated fixture
+			// minus the auth field that will eventually be omitted from the model.
+			const config = JSON.parse(JSON.stringify(configFixture));
+			delete (config.modelIntrospection.models[modelName].fields as any)[
+				authField
+			];
+
+			const spy = mockApiResponse({
+				data: {
+					[`list${config.modelIntrospection.models[modelName].pluralName}`]: {
+						items: [],
+					},
+				},
+			});
+
+			const client = generateClient<Schema>({ amplify: Amplify });
+			const { data } = await client.models[modelName].list({
+				filter: { [authField]: { contains: 'something' } },
+			});
+
+			expectVariables(spy, {
+				filter: { [authField]: { contains: 'something' } },
+			});
+		});
+	}
+});

--- a/packages/api-graphql/__tests__/internals/implicit-auth-fields.test.ts
+++ b/packages/api-graphql/__tests__/internals/implicit-auth-fields.test.ts
@@ -1,19 +1,11 @@
-import * as raw from '../../src';
-import { Amplify, AmplifyClassV6 } from '@aws-amplify/core';
+import { Amplify } from '@aws-amplify/core';
 import { generateClient } from '../../src/internals';
 import configFixture from '../fixtures/modeled/amplifyconfiguration';
 import { Schema } from '../fixtures/modeled/schema';
-import { Observable, from } from 'rxjs';
-import * as internals from '../../src/internals';
 import {
-	normalizePostGraphqlCalls,
-	expectSub,
-	expectSubWithHeaders,
-	expectSubWithHeadersFn,
-	expectSubWithlibraryConfigHeaders,
 	expectSelectionSetContains,
-	expectSelectionSetNotContains,
 	expectVariables,
+	mockApiResponse,
 } from '../utils/index';
 
 const serverManagedFields = {
@@ -22,25 +14,6 @@ const serverManagedFields = {
 	createdAt: new Date().toISOString(),
 	updatedAt: new Date().toISOString(),
 };
-
-/**
- *
- * @param value Value to be returned. Will be `awaited`, and can
- * therefore be a simple JSON value or a `Promise`.
- * @returns
- */
-function mockApiResponse(value: any) {
-	return jest
-		.spyOn((raw.GraphQLAPI as any)._api, 'post')
-		.mockImplementation(async () => {
-			const result = await value;
-			return {
-				body: {
-					json: () => result,
-				},
-			};
-		});
-}
 
 describe('implicit auth field handling', () => {
 	beforeEach(() => {

--- a/packages/api-graphql/__tests__/internals/server/generateClientWithAmplifyInstance.test.ts
+++ b/packages/api-graphql/__tests__/internals/server/generateClientWithAmplifyInstance.test.ts
@@ -1,9 +1,9 @@
-import * as raw from '../../../src';
 import { Amplify, AmplifyClassV6, ResourcesConfig } from '@aws-amplify/core';
 import { generateClientWithAmplifyInstance } from '../../../src/internals/server';
 import configFixture from '../../fixtures/modeled/amplifyconfiguration';
 import { Schema } from '../../fixtures/modeled/schema';
 import { V6ClientSSRRequest, V6ClientSSRCookies } from '../../../src/types';
+import { mockApiResponse, normalizePostGraphqlCalls } from '../../utils';
 
 const serverManagedFields = {
 	id: 'some-id',
@@ -24,66 +24,6 @@ const config: ResourcesConfig = {
 		},
 	},
 };
-
-/**
- *
- * @param value Value to be returned. Will be `awaited`, and can
- * therefore be a simple JSON value or a `Promise`.
- * @returns
- */
-function mockApiResponse(value: any) {
-	return jest
-		.spyOn((raw.GraphQLAPI as any)._api, 'post')
-		.mockImplementation(async () => {
-			const result = await value;
-			return {
-				body: {
-					json: () => result,
-				},
-			};
-		});
-}
-
-/**
- * For each call against the spy, assuming the spy is a `post()` spy,
- * replaces fields that are likely to change between calls (or library version revs)
- * with static values. When possible, on the unpredicable portions of these values
- * are replaced.
- *
- * ## THIS IS DESTRUCTIVE
- *
- * The original `spy.mocks.calls` will be updated *and* returned.
- *
- * For example,
- *
- * ```plain
- * headers.x-amz-user-agent: "aws-amplify/6.0.5 api/1 framework/0"
- * ```
- *
- * Is replaced with:
- *
- * ```plain
- * headers.x-amz-user-agent: "aws-amplify/latest api/latest framework/latest"
- * ```
- *
- * @param spy The Jest spy
- */
-function normalizePostGraphqlCalls(spy: jest.SpyInstance<any, any>) {
-	return spy.mock.calls.map((call: any) => {
-		// The 1st param in `call` is an instance of `AmplifyClassV6`
-		// The 2nd param in `call` is the actual `postOptions`
-		const [_, postOptions] = call;
-		const userAgent = postOptions?.options?.headers?.['x-amz-user-agent'];
-		if (userAgent) {
-			const staticUserAgent = userAgent.replace(/\/[\d.]+/g, '/latest');
-			postOptions.options.headers['x-amz-user-agent'] = staticUserAgent;
-		}
-		// Calling of `post` API with an instance of `AmplifyClassV6` has been
-		// unit tested in other test suites. To reduce the noise in the generated
-		// snapshot, we hide the details of the instance here.
-		return ['AmplifyClassV6', postOptions];
-	});
-}
 
 describe('server generateClient', () => {
 	beforeEach(() => {

--- a/packages/api-graphql/__tests__/utils/expects.ts
+++ b/packages/api-graphql/__tests__/utils/expects.ts
@@ -1,4 +1,6 @@
+import { parse, print, DocumentNode } from 'graphql';
 import { CustomHeaders } from '@aws-amplify/data-schema-types';
+import { Amplify } from 'aws-amplify';
 
 /**
  * Performs an `expect()` on a jest spy with some basic nested argument checks
@@ -217,4 +219,134 @@ export function expectSubWithlibraryConfigHeaders(
 			category: 'api',
 		},
 	);
+}
+
+/**
+ *
+ * @param spy a GraphQL.api._post spy
+ * @returns
+ */
+export function extractCallDetails(spy: jest.SpyInstance) {
+	return spy.mock.calls.map((call: any) => {
+		const [
+			amplify,
+			{
+				abortController,
+				options: {
+					body: { query, variables },
+				},
+				headers,
+			},
+		] = call;
+		return { abortController, query, variables, headers };
+	});
+}
+
+/**
+ * Given the plural name of a model, find the singular name.
+ *
+ * Assumes `Amplify.configure()` has already called with a config
+ * holding a valid `modelIntrospection` schema.
+ *
+ * @param pluralName plural name of model (e.g. "Todos")
+ * @returns singular name of model (e.g. "Todo")
+ */
+export function findSingularName(pluralName: string): string {
+	const config = Amplify.getConfig();
+	const model = Object.values(
+		config.API?.GraphQL?.modelIntrospection?.models || {},
+	).find(m => m.pluralName === pluralName);
+	if (!model) throw new Error(`No model found for plural name ${pluralName}`);
+	return model.name;
+}
+
+/**
+ * Parses a graphql query into the core components we need to valid
+ * in testing.
+ *
+ * @param query graphql query or DocumentNode
+ * @returns
+ */
+export function parseQuery(query: string | DocumentNode) {
+	const q: any =
+		typeof query === 'string'
+			? parse(query).definitions[0]
+			: parse(print(query)).definitions[0];
+
+	const operation: string = q.operation;
+	const selections = q.selectionSet.selections[0];
+	const selection: string = selections.name.value;
+	const type = selection.match(
+		/^(create|update|delete|sync|get|list|onCreate|onUpdate|onDelete)(\w+)$/,
+	)?.[1] as string;
+
+	let table: string;
+	// `selection` here could be `syncTodos` or `syncCompositePKChildren`
+	if (type === 'sync' || type === 'list') {
+		// e.g. `Models`
+		const pluralName = selection.match(
+			/^(create|sync|get|list)([A-Za-z]+)$/,
+		)?.[2] as string;
+		table = findSingularName(pluralName);
+	} else {
+		table = selection.match(
+			/^(create|update|delete|sync|get|list|onCreate|onUpdate|onDelete)(\w+)$/,
+		)?.[2] as string;
+	}
+
+	const selectionSet: string[] =
+		operation === 'query' && type === 'list'
+			? selections?.selectionSet?.selections[0]?.selectionSet?.selections?.map(
+					(i: any) => i.name.value,
+				)
+			: selections?.selectionSet?.selections?.map((i: any) => i.name.value);
+
+	return { operation, selection, type, table, selectionSet };
+}
+
+/**
+ *
+ * @param spy a GraphQLAPI._api.post spy
+ * @param fields
+ * @param requestIndex
+ */
+export function expectSelectionSetContains(
+	spy: jest.SpyInstance,
+	fields: string[],
+	requestIndex = 0,
+) {
+	const { query } = extractCallDetails(spy)[requestIndex];
+	const { selectionSet } = parseQuery(query);
+	expect(fields.every(f => selectionSet.includes(f))).toBe(true);
+}
+
+/**
+ *
+ * @param spy a GraphQL._api.post spy
+ * @param fields
+ * @param requestIndex
+ */
+export function expectSelectionSetNotContains(
+	spy: jest.SpyInstance,
+	fields: string[],
+	requestIndex = 0,
+) {
+	const { query } = extractCallDetails(spy)[requestIndex];
+	const { selectionSet } = parseQuery(query);
+	expect(fields.every(f => !selectionSet.includes(f))).toBe(true);
+}
+
+/**
+ *
+ * @param spy A GraphQL._api.post spy
+ * @param expectedVariables
+ * @param requestIndex
+ */
+export function expectVariables(
+	spy: jest.SpyInstance,
+	expectedVariables: Record<string, any>,
+	requestIndex = 0,
+) {
+	const { variables } = extractCallDetails(spy)[requestIndex];
+	expect(variables).toEqual(expectedVariables);
 }

--- a/packages/api-graphql/__tests__/utils/index.ts
+++ b/packages/api-graphql/__tests__/utils/index.ts
@@ -1,0 +1,42 @@
+export * from './expects';
+
+/**
+ * For each call against the spy, assuming the spy is a `post()` spy,
+ * replaces fields that are likely to change between calls (or library version revs)
+ * with static values. When possible, on the unpredicable portions of these values
+ * are replaced.
+ *
+ * ## THIS IS DESTRUCTIVE
+ *
+ * The original `spy.mocks.calls` will be updated *and* returned.
+ *
+ * For example,
+ *
+ * ```plain
+ * headers.x-amz-user-agent: "aws-amplify/6.0.5 api/1 framework/0"
+ * ```
+ *
+ * Is replaced with:
+ *
+ * ```plain
+ * headers.x-amz-user-agent: "aws-amplify/latest api/latest framework/latest"
+ * ```
+ *
+ * @param spy The Jest spy
+ */
+export function normalizePostGraphqlCalls(spy: jest.SpyInstance<any, any>) {
+	return spy.mock.calls.map((call: any) => {
+		// The 1st param in `call` is an instance of `AmplifyClassV6`
+		// The 2nd param in `call` is the actual `postOptions`
+		const [_, postOptions] = call;
+		const userAgent = postOptions?.options?.headers?.['x-amz-user-agent'];
+		if (userAgent) {
+			const staticUserAgent = userAgent.replace(/\/[\d.]+/g, '/latest');
+			postOptions.options.headers['x-amz-user-agent'] = staticUserAgent;
+		}
+		// Calling of `post` API with an instance of `AmplifyClassV6` has been
+		// unit tested in other test suites. To reduce the noise in the generated
+		// snapshot, we hide the details of the instance here.
+		return ['AmplifyClassV6', postOptions];
+	});
+}

--- a/packages/api-graphql/src/utils/resolveOwnerFields.ts
+++ b/packages/api-graphql/src/utils/resolveOwnerFields.ts
@@ -19,10 +19,15 @@ interface AuthAttribute {
 /**
  * Only the portions of an Auth rule we care about.
  */
-interface AuthRule {
-	allow: string;
-	ownerField?: string;
-}
+type AuthRule =
+	| {
+			allow: 'owner';
+			ownerField?: string;
+	  }
+	| {
+			allow: 'groups';
+			groupsField: string;
+	  };
 
 /**
  * Given an introspection schema model, returns all owner fields.
@@ -37,6 +42,8 @@ export function resolveOwnerFields(model: Model): string[] {
 			for (const rule of attr.properties.rules) {
 				if (rule.allow === 'owner') {
 					ownerFields.add(rule.ownerField || 'owner');
+				} else if (rule.allow === 'groups') {
+					ownerFields.add(rule.groupsField);
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adds implied group fields from auth rules to selection sets. (Implicit owner fields were already being included.)

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

Added models and tests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
