### PR TITLE
chore: Add validation to ensure key & path not specified at the same time

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -473,7 +473,7 @@
 			"name": "[Storage] getProperties (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getProperties }",
-			"limit": "13.50 kB"
+			"limit": "13.53 kB"
 		},
 		{
 			"name": "[Storage] getUrl (S3)",

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -461,13 +461,13 @@
 			"name": "[Storage] copy (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ copy }",
-			"limit": "13.61 kB"
+			"limit": "13.69 kB"
 		},
 		{
 			"name": "[Storage] downloadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ downloadData }",
-			"limit": "14.23 kB"
+			"limit": "14.32 kB"
 		},
 		{
 			"name": "[Storage] getProperties (S3)",

--- a/packages/storage/__tests__/providers/s3/apis/utils/validateStorageOperationInput.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/validateStorageOperationInput.test.ts
@@ -51,7 +51,7 @@ describe('validateStorageOperationInput', () => {
 		);
 	});
 
-	it('should throw an error when input is invalid', () => {
+	it('should throw an error when key and path are not specified', () => {
 		const input = { invalid: 'test' } as any;
 		expect(() => validateStorageOperationInput(input)).toThrow(
 			validationErrorMap[

--- a/packages/storage/__tests__/providers/s3/apis/utils/validateStorageOperationInput.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/validateStorageOperationInput.test.ts
@@ -59,4 +59,13 @@ describe('validateStorageOperationInput', () => {
 			].message,
 		);
 	});
+
+	it('should throw an error when both key & path are specified', () => {
+		const input = { path: 'testPath/object', key: 'key' } as any;
+		expect(() => validateStorageOperationInput(input)).toThrow(
+			validationErrorMap[
+				StorageValidationErrorCode.InvalidStorageOperationInput
+			].message,
+		);
+	});
 });

--- a/packages/storage/src/errors/types/validation.ts
+++ b/packages/storage/src/errors/types/validation.ts
@@ -60,7 +60,8 @@ export const validationErrorMap: AmplifyErrorMap<StorageValidationErrorCode> = {
 			'Upload source type can only be a `Blob`, `File`, `ArrayBuffer`, or `string`.',
 	},
 	[StorageValidationErrorCode.InvalidStorageOperationInput]: {
-		message: 'Missing path or key parameter in Input.',
+		message:
+			'Missing path or key parameter in Input. Key and path can not be specified at the same time.',
 	},
 	[StorageValidationErrorCode.InvalidStoragePathInput]: {
 		message: 'Input `path` does not allow a leading slash (/).',

--- a/packages/storage/src/errors/types/validation.ts
+++ b/packages/storage/src/errors/types/validation.ts
@@ -61,7 +61,7 @@ export const validationErrorMap: AmplifyErrorMap<StorageValidationErrorCode> = {
 	},
 	[StorageValidationErrorCode.InvalidStorageOperationInput]: {
 		message:
-			'Missing path or key parameter in Input. Key and path can not be specified at the same time.',
+			'Path or key parameter must be specified in the input. Both can not be specified at the same time.',
 	},
 	[StorageValidationErrorCode.InvalidStoragePathInput]: {
 		message: 'Input `path` does not allow a leading slash (/).',

--- a/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
+++ b/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
@@ -12,9 +12,11 @@ export const validateStorageOperationInput = (
 	input: Input,
 	identityId?: string,
 ) => {
-	// Validate key or path present
 	assertValidationError(
-		!!(input as Input).key || !!(input as Input).path,
+		// Key present without a path
+		(!!(input as Input).key && !(input as Input).path) ||
+			// Path present without a key
+			(!(input as Input).key && !!(input as Input).path),
 		StorageValidationErrorCode.InvalidStorageOperationInput,
 	);
 

--- a/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
+++ b/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
@@ -20,7 +20,7 @@ export const validateStorageOperationInput = (
 
 	// Validate key & path not present at the same time
 	assertValidationError(
-		!!(input as Input).key || !!(input as Input).path,
+		(input as Input).key === undefined || (input as Input).path === undefined,
 		StorageValidationErrorCode.InvalidStorageOperationInput,
 	);
 

--- a/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
+++ b/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
@@ -20,12 +20,6 @@ export const validateStorageOperationInput = (
 		StorageValidationErrorCode.InvalidStorageOperationInput,
 	);
 
-	// Validate key & path not present at the same time
-	assertValidationError(
-		!(input as Input).key || !(input as Input).path,
-		StorageValidationErrorCode.InvalidStorageOperationInput,
-	);
-
 	if (isInputWithPath(input)) {
 		const { path } = input;
 		const objectKey = typeof path === 'string' ? path : path({ identityId });

--- a/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
+++ b/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
@@ -20,7 +20,7 @@ export const validateStorageOperationInput = (
 
 	// Validate key & path not present at the same time
 	assertValidationError(
-		(input as Input).key === undefined || (input as Input).path === undefined,
+		!!(input as Input).key || !!(input as Input).path,
 		StorageValidationErrorCode.InvalidStorageOperationInput,
 	);
 

--- a/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
+++ b/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
@@ -20,7 +20,7 @@ export const validateStorageOperationInput = (
 
 	// Validate key & path not present at the same time
 	assertValidationError(
-		(input as Input).key === undefined || (input as Input).path === undefined,
+		!(input as Input).key || !(input as Input).path,
 		StorageValidationErrorCode.InvalidStorageOperationInput,
 	);
 

--- a/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
+++ b/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
@@ -12,8 +12,15 @@ export const validateStorageOperationInput = (
 	input: Input,
 	identityId?: string,
 ) => {
+	// Validate key or path present
 	assertValidationError(
 		!!(input as Input).key || !!(input as Input).path,
+		StorageValidationErrorCode.InvalidStorageOperationInput,
+	);
+
+	// Validate key & path not present at the same time
+	assertValidationError(
+		(input as Input).key === undefined || (input as Input).path === undefined,
 		StorageValidationErrorCode.InvalidStorageOperationInput,
 	);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds runtime validation to ensure that key & path aren't specified at the same time to protect JavaScript customers from undefined behavior.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Local testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
