### PR TITLE
fix(auth): set auth config to `oAuthStore`

### DIFF
--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -33,7 +33,6 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 	tokenRefresher?: TokenRefresher;
 	inflightPromise: Promise<void> | undefined;
 	waitForInflightOAuth: () => Promise<void> = async () => {
-
 		if (!(await oAuthStore.loadOAuthInFlight())) {
 			return;
 		}
@@ -54,7 +53,7 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 	};
 
 	setAuthConfig(authConfig: AuthConfig) {
-		oAuthStore.setAuthConfig(authConfig.Cognito as CognitoUserPoolConfig)
+		oAuthStore.setAuthConfig(authConfig.Cognito as CognitoUserPoolConfig);
 		this.authConfig = authConfig;
 	}
 

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -3,6 +3,7 @@
 import {
 	AuthConfig,
 	AuthTokens,
+	CognitoUserPoolConfig,
 	FetchAuthSessionOptions,
 	Hub,
 } from '@aws-amplify/core';
@@ -32,6 +33,7 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 	tokenRefresher?: TokenRefresher;
 	inflightPromise: Promise<void> | undefined;
 	waitForInflightOAuth: () => Promise<void> = async () => {
+
 		if (!(await oAuthStore.loadOAuthInFlight())) {
 			return;
 		}
@@ -52,6 +54,7 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 	};
 
 	setAuthConfig(authConfig: AuthConfig) {
+		oAuthStore.setAuthConfig(authConfig.Cognito as CognitoUserPoolConfig)
 		this.authConfig = authConfig;
 	}
 

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -383,7 +383,7 @@
 			"name": "[Auth] confirmSignIn (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmSignIn }",
-			"limit": "26.45 kB"
+			"limit": "26.48 kB"
 		},
 		{
 			"name": "[Auth] updateMFAPreference (Cognito)",


### PR DESCRIPTION
* fix(auth): add inflight promise in token orchestrator<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

The issue was caused due to the `oAuthStore` not having the AuthConfig available. This change will set the config to the oAuthStore

#### Verification
- e2e [tests](https://github.com/aws-amplify/amplify-js/actions/runs/8420957701) are passing


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
