### PR TITLE
fix(api-graphql): default selection set regression

### DIFF
--- a/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.ts
@@ -1,5 +1,5 @@
 /**
- * Generated from `./schema.ts` by samsara.
+ * Generated from `./schema.ts` by amplify-backend generate config.
  *
  * Cognito fields etc. omitted.
  */
@@ -1644,6 +1644,68 @@ const amplifyConfig = {
 									allow: 'groups',
 									groupsField: 'groupsField',
 									groupField: 'groups',
+									operations: ['create', 'update', 'delete', 'read'],
+								},
+							],
+						},
+					},
+				],
+				primaryKeyInfo: {
+					isCustomPrimaryKey: false,
+					primaryKeyFieldName: 'id',
+					sortKeyFieldNames: [],
+				},
+			},
+			ModelStaticGroup: {
+				name: 'ModelStaticGroup',
+				fields: {
+					id: {
+						name: 'id',
+						isArray: false,
+						type: 'ID',
+						isRequired: true,
+						attributes: [],
+					},
+					description: {
+						name: 'description',
+						isArray: false,
+						type: 'String',
+						isRequired: false,
+						attributes: [],
+					},
+					createdAt: {
+						name: 'createdAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: false,
+						attributes: [],
+						isReadOnly: true,
+					},
+					updatedAt: {
+						name: 'updatedAt',
+						isArray: false,
+						type: 'AWSDateTime',
+						isRequired: false,
+						attributes: [],
+						isReadOnly: true,
+					},
+				},
+				syncable: true,
+				pluralName: 'ModelStaticGroups',
+				attributes: [
+					{
+						type: 'model',
+						properties: {},
+					},
+					{
+						type: 'auth',
+						properties: {
+							rules: [
+								{
+									groupClaim: 'cognito:groups',
+									provider: 'userPools',
+									allow: 'groups',
+									groups: ['Admin'],
 									operations: ['create', 'update', 'delete', 'read'],
 								},
 							],

--- a/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
@@ -220,6 +220,11 @@ const schema = a.schema({
 			description: a.string(),
 		})
 		.authorization([a.allow.groupsDefinedIn('groupsField')]),
+	ModelStaticGroup: a
+		.model({
+			description: a.string(),
+		})
+		.authorization([a.allow.specificGroup('Admin')]),
 	// #endregion
 });
 

--- a/packages/api-graphql/__tests__/internals/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/internals/generateClient.test.ts
@@ -49,6 +49,7 @@ describe('generateClient', () => {
 			'CustomImplicitOwner',
 			'ModelGroupDefinedIn',
 			'ModelGroupsDefinedIn',
+			'ModelStaticGroup',
 		];
 
 		it('generates `models` property when Amplify.getConfig() returns valid GraphQL provider config', () => {

--- a/packages/api-graphql/__tests__/resolveOwnerFields.test.ts
+++ b/packages/api-graphql/__tests__/resolveOwnerFields.test.ts
@@ -14,6 +14,9 @@ describe('owner field resolution', () => {
 		ThingWithOwnerFieldSpecifiedInModel: ['owner'],
 		ThingWithAPIKeyAuth: [],
 		ThingWithoutExplicitAuth: [],
+		ModelGroupDefinedIn: ['groupField'],
+		ModelGroupsDefinedIn: ['groupsField'],
+		ModelStaticGroup: [],
 	};
 
 	for (const [modelName, expected] of Object.entries(expectedResolutions)) {
@@ -23,7 +26,7 @@ describe('owner field resolution', () => {
 			const model: SchemaModel = modelIntroSchema.models[modelName];
 
 			const resolvedField = resolveOwnerFields(model);
-			expect(resolvedField).toEqual(expected);
+			expect(resolvedField).toStrictEqual(expected);
 		});
 	}
 });

--- a/packages/api-graphql/src/utils/resolveOwnerFields.ts
+++ b/packages/api-graphql/src/utils/resolveOwnerFields.ts
@@ -42,7 +42,10 @@ export function resolveOwnerFields(model: Model): string[] {
 			for (const rule of attr.properties.rules) {
 				if (rule.allow === 'owner') {
 					ownerFields.add(rule.ownerField || 'owner');
-				} else if (rule.allow === 'groups') {
+				} else if (rule.allow === 'groups' && rule.groupsField !== undefined) {
+					// only valid for dynamic group(s)
+					// static group auth will have an array of predefined groups in the attribute, groups: string[]
+					// but `groupsField` will be undefined
 					ownerFields.add(rule.groupsField);
 				}
 			}


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

When generating the default selection set for a model, we were attempting to inject the `groupsField` of a static group auth rule e.g. `a.allow.specificGroup('Admin')`. Only dynamic group model introspection auth attributes contain a `groupsField` value, so we were inadvertently adding an explicit `undefined` to the default selection set, which was causing unexpected behavior.

This PR adds an additional check to make sure we're only adding the `groupsField` value when it's defined.



#### Description of how you validated changes
* Red/green TDD
* Manual e2e testing


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
