### PR TITLE
Revert "fix(api-graphql): default selection set regression"

### DIFF
--- a/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.ts
@@ -1,5 +1,5 @@
 /**
- * Generated from `./schema.ts` by amplify-backend generate config.
+ * Generated from `./schema.ts` by samsara.
  *
  * Cognito fields etc. omitted.
  */
@@ -1644,68 +1644,6 @@ const amplifyConfig = {
 									allow: 'groups',
 									groupsField: 'groupsField',
 									groupField: 'groups',
-									operations: ['create', 'update', 'delete', 'read'],
-								},
-							],
-						},
-					},
-				],
-				primaryKeyInfo: {
-					isCustomPrimaryKey: false,
-					primaryKeyFieldName: 'id',
-					sortKeyFieldNames: [],
-				},
-			},
-			ModelStaticGroup: {
-				name: 'ModelStaticGroup',
-				fields: {
-					id: {
-						name: 'id',
-						isArray: false,
-						type: 'ID',
-						isRequired: true,
-						attributes: [],
-					},
-					description: {
-						name: 'description',
-						isArray: false,
-						type: 'String',
-						isRequired: false,
-						attributes: [],
-					},
-					createdAt: {
-						name: 'createdAt',
-						isArray: false,
-						type: 'AWSDateTime',
-						isRequired: false,
-						attributes: [],
-						isReadOnly: true,
-					},
-					updatedAt: {
-						name: 'updatedAt',
-						isArray: false,
-						type: 'AWSDateTime',
-						isRequired: false,
-						attributes: [],
-						isReadOnly: true,
-					},
-				},
-				syncable: true,
-				pluralName: 'ModelStaticGroups',
-				attributes: [
-					{
-						type: 'model',
-						properties: {},
-					},
-					{
-						type: 'auth',
-						properties: {
-							rules: [
-								{
-									groupClaim: 'cognito:groups',
-									provider: 'userPools',
-									allow: 'groups',
-									groups: ['Admin'],
 									operations: ['create', 'update', 'delete', 'read'],
 								},
 							],

--- a/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
@@ -220,11 +220,6 @@ const schema = a.schema({
 			description: a.string(),
 		})
 		.authorization([a.allow.groupsDefinedIn('groupsField')]),
-	ModelStaticGroup: a
-		.model({
-			description: a.string(),
-		})
-		.authorization([a.allow.specificGroup('Admin')]),
 	// #endregion
 });
 

--- a/packages/api-graphql/__tests__/internals/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/internals/generateClient.test.ts
@@ -49,7 +49,6 @@ describe('generateClient', () => {
 			'CustomImplicitOwner',
 			'ModelGroupDefinedIn',
 			'ModelGroupsDefinedIn',
-			'ModelStaticGroup',
 		];
 
 		it('generates `models` property when Amplify.getConfig() returns valid GraphQL provider config', () => {

--- a/packages/api-graphql/__tests__/resolveOwnerFields.test.ts
+++ b/packages/api-graphql/__tests__/resolveOwnerFields.test.ts
@@ -14,9 +14,6 @@ describe('owner field resolution', () => {
 		ThingWithOwnerFieldSpecifiedInModel: ['owner'],
 		ThingWithAPIKeyAuth: [],
 		ThingWithoutExplicitAuth: [],
-		ModelGroupDefinedIn: ['groupField'],
-		ModelGroupsDefinedIn: ['groupsField'],
-		ModelStaticGroup: [],
 	};
 
 	for (const [modelName, expected] of Object.entries(expectedResolutions)) {
@@ -26,7 +23,7 @@ describe('owner field resolution', () => {
 			const model: SchemaModel = modelIntroSchema.models[modelName];
 
 			const resolvedField = resolveOwnerFields(model);
-			expect(resolvedField).toStrictEqual(expected);
+			expect(resolvedField).toEqual(expected);
 		});
 	}
 });

--- a/packages/api-graphql/src/utils/resolveOwnerFields.ts
+++ b/packages/api-graphql/src/utils/resolveOwnerFields.ts
@@ -42,10 +42,7 @@ export function resolveOwnerFields(model: Model): string[] {
 			for (const rule of attr.properties.rules) {
 				if (rule.allow === 'owner') {
 					ownerFields.add(rule.ownerField || 'owner');
-				} else if (rule.allow === 'groups' && rule.groupsField !== undefined) {
-					// only valid for dynamic group(s)
-					// static group auth will have an array of predefined groups in the attribute, groups: string[]
-					// but `groupsField` will be undefined
+				} else if (rule.allow === 'groups') {
 					ownerFields.add(rule.groupsField);
 				}
 			}


### PR DESCRIPTION
Reverts aws-amplify/amplify-js#13185

Reverting from main. We will deploy this as a hot fix instead.