### PR TITLE
release(required): check error name as well as code for clock skew

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -395,7 +395,7 @@
 			"name": "[Auth] fetchMFAPreference (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ fetchMFAPreference }",
-			"limit": "8.35 kB"
+			"limit": "8.4 kB"
 		},
 		{
 			"name": "[Auth] verifyTOTPSetup (Cognito)",

--- a/packages/core/src/clients/middleware/retry/defaultRetryDecider.ts
+++ b/packages/core/src/clients/middleware/retry/defaultRetryDecider.ts
@@ -16,7 +16,7 @@ export const getRetryDecider =
 			(error as Error & { code: string }) ??
 			(await errorParser(response)) ??
 			undefined;
-		const errorCode = parsedError?.code;
+		const errorCode = parsedError?.code || parsedError?.name;
 		const statusCode = response?.statusCode;
 
 		return (


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
aws-sdk@3 updated the error code location to `name` instead of `code`, therefore we were not catching the clock skew error message and triggering a retry. This PR fixes retry on API (Rest) calls when a clock-skew error is encountered by checking the `name` property if `code` is undefined.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/13192


#### Description of how you validated changes
Tested in a sample app using Verdaccio.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
