### PR TITLE
feat(auth): fix inflight promise on RN

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,8 +35,25 @@ module.exports = {
 		'setupTests.ts',
 		'jest.setup.*',
 		'jest.config.*',
-		// temporarily disable lint on __tests__
-		'__tests__',
+		// 'packages/adapter-nextjs/__tests__',
+		'packages/analytics/__tests__',
+		'packages/api/__tests__',
+		'packages/api-graphql/__tests__',
+		'packages/api-rest/__tests__',
+		'packages/auth/__tests__',
+		// 'packages/aws-amplify/__tests__',
+		// 'packages/core/__tests__',
+		'packages/datastore/__tests__',
+		'packages/datastore-storage-adapter/__tests__',
+		'packages/geo/__tests__',
+		'packages/interactions/__tests__',
+		'packages/notifications/__tests__',
+		'packages/predictions/__tests__',
+		'packages/pubsub/__tests__',
+		'packages/react-native/__tests__',
+		'packages/rtn-push-notification/__tests__',
+		'packages/rtn-web-browser/__tests__',
+		'packages/storage/__tests__',
 		// will enable lint by packages
 		// 'adapter-nextjs',
 		// 'packages/analytics',
@@ -63,6 +80,10 @@ module.exports = {
 			'error',
 			{
 				allow: [
+					// exceptions for core package
+					'phone_number',
+					'search_indices',
+					// exceptions for api packages
 					'graphql_headers',
 					// exceptions for the legacy config
 					/^(aws_|amazon_)/,
@@ -105,6 +126,7 @@ module.exports = {
 		'no-useless-constructor': 'off',
 		'no-trailing-spaces': 'error',
 		'no-return-await': 'error',
+		'n/no-callback-literal': 'off',
 		'object-shorthand': 'error',
 		'prefer-destructuring': 'off',
 		'promise/catch-or-return': [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,12 +10,12 @@
 			"type": "node",
 			"request": "launch",
 			// The debugger will only run tests for the package specified here:
-			"cwd": "${workspaceFolder}/packages/datastore",
+			"cwd": "${workspaceFolder}/packages/api-graphql",
 			"runtimeArgs": [
 				"--inspect-brk",
 				"${workspaceRoot}/node_modules/.bin/jest",
 				// Optionally specify a single test file to run/debug:
-				"connectivityHandling.test.ts",
+				"generateClientWithAmplifyInstance.test.ts",
 				"--runInBand",
 				"--testTimeout",
 				"600000", // 10 min timeout so jest doesn't error while we're stepping through code

--- a/packages/adapter-nextjs/__tests__/api/generateServerClient.test.ts
+++ b/packages/adapter-nextjs/__tests__/api/generateServerClient.test.ts
@@ -1,11 +1,12 @@
 import { ResourcesConfig } from '@aws-amplify/core';
+
 import {
 	generateServerClientUsingCookies,
 	generateServerClientUsingReqRes,
 } from '../../src/api';
 import {
-	getAmplifyConfig,
 	createRunWithAmplifyServerContext,
+	getAmplifyConfig,
 } from '../../src/utils';
 import { NextApiRequestMock, NextApiResponseMock } from '../mocks/headers';
 import { createServerRunnerForAPI } from '../../src/api/createServerRunnerForAPI';
@@ -59,7 +60,7 @@ describe('generateServerClientUsingCookies', () => {
 	});
 
 	it('should call createRunWithAmplifyServerContext to create runWithAmplifyServerContext function', async () => {
-		const cookies = (await headers).cookies;
+		const { cookies } = await headers;
 
 		generateServerClientUsingCookies({ config: mockAmplifyConfig, cookies });
 		expect(mockCreateRunWithAmplifyServerContext).toHaveBeenCalledWith({
@@ -94,7 +95,7 @@ describe('generateServerClient', () => {
 		}));
 
 		jest.mock('@aws-amplify/core/internals/adapter-core', () => ({
-			getAmplifyServerContext: () => {},
+			getAmplifyServerContext: jest.fn(),
 		}));
 
 		const client = generateServerClientUsingReqRes({

--- a/packages/adapter-nextjs/__tests__/createServerRunner.test.ts
+++ b/packages/adapter-nextjs/__tests__/createServerRunner.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ResourcesConfig, sharedInMemoryStorage } from '@aws-amplify/core';
+
 import { NextServer } from '../src/types';
 
 const mockAmplifyConfig: ResourcesConfig = {
@@ -50,7 +51,7 @@ describe('createServerRunner', () => {
 			parseAWSExports: mockParseAWSExports,
 		}));
 
-		createServerRunner = require('../src').createServerRunner;
+		({ createServerRunner } = require('../src'));
 	});
 
 	afterEach(() => {
@@ -76,7 +77,7 @@ describe('createServerRunner', () => {
 	describe('runWithAmplifyServerContext', () => {
 		describe('when amplifyConfig.Auth is not defined', () => {
 			it('should call runWithAmplifyServerContextCore without Auth library options', () => {
-				const mockAmplifyConfig: ResourcesConfig = {
+				const mockAmplifyConfigWithoutAuth: ResourcesConfig = {
 					Analytics: {
 						Pinpoint: {
 							appId: 'app-id',
@@ -85,12 +86,12 @@ describe('createServerRunner', () => {
 					},
 				};
 				const { runWithAmplifyServerContext } = createServerRunner({
-					config: mockAmplifyConfig,
+					config: mockAmplifyConfigWithoutAuth,
 				});
 				const operation = jest.fn();
 				runWithAmplifyServerContext({ operation, nextServerContext: null });
 				expect(mockRunWithAmplifyServerContextCore).toHaveBeenCalledWith(
-					mockAmplifyConfig,
+					mockAmplifyConfigWithoutAuth,
 					{},
 					operation,
 				);

--- a/packages/adapter-nextjs/__tests__/mocks/headers.ts
+++ b/packages/adapter-nextjs/__tests__/mocks/headers.ts
@@ -1,10 +1,11 @@
+import { Socket } from 'net';
+import { IncomingMessage } from 'http';
+
 import { NextApiRequest, NextApiResponse } from 'next/index.js';
 import {
 	NextApiRequestCookies,
 	NextApiRequestQuery,
 } from 'next/dist/server/api-utils/index.js';
-import { Socket } from 'net';
-import { IncomingMessage } from 'http';
 
 export type NextApiRequestOptions = Partial<NextApiRequestMock>;
 export class NextApiRequestMock

--- a/packages/adapter-nextjs/__tests__/utils/createCookieStorageAdapterFromNextServerContext.test.ts
+++ b/packages/adapter-nextjs/__tests__/utils/createCookieStorageAdapterFromNextServerContext.test.ts
@@ -1,17 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { IncomingMessage, ServerResponse } from 'http';
+import { Socket } from 'net';
+
 import { enableFetchMocks } from 'jest-fetch-mock';
+import { NextRequest, NextResponse } from 'next/server.js';
+import { cookies } from 'next/headers.js';
+
+import {
+	DATE_IN_THE_PAST,
+	createCookieStorageAdapterFromNextServerContext,
+} from '../../src/utils/createCookieStorageAdapterFromNextServerContext';
 
 // Make global Request available during test
 enableFetchMocks();
-
-import { NextRequest, NextResponse } from 'next/server.js';
-import { cookies } from 'next/headers.js';
-import { createCookieStorageAdapterFromNextServerContext } from '../../src/utils/createCookieStorageAdapterFromNextServerContext';
-import { DATE_IN_THE_PAST } from '../../src/utils/createCookieStorageAdapterFromNextServerContext';
-import { IncomingMessage, ServerResponse } from 'http';
-import { Socket } from 'net';
 
 jest.mock('next/headers', () => ({
 	cookies: jest.fn(),

--- a/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/amplifyconfiguration.ts
@@ -1,5 +1,5 @@
 /**
- * Generated from `./schema.ts` by amplify-backend generate config.
+ * Generated from `./schema.ts` by samsara.
  *
  * Cognito fields etc. omitted.
  */
@@ -1644,68 +1644,6 @@ const amplifyConfig = {
 									allow: 'groups',
 									groupsField: 'groupsField',
 									groupField: 'groups',
-									operations: ['create', 'update', 'delete', 'read'],
-								},
-							],
-						},
-					},
-				],
-				primaryKeyInfo: {
-					isCustomPrimaryKey: false,
-					primaryKeyFieldName: 'id',
-					sortKeyFieldNames: [],
-				},
-			},
-			ModelStaticGroup: {
-				name: 'ModelStaticGroup',
-				fields: {
-					id: {
-						name: 'id',
-						isArray: false,
-						type: 'ID',
-						isRequired: true,
-						attributes: [],
-					},
-					description: {
-						name: 'description',
-						isArray: false,
-						type: 'String',
-						isRequired: false,
-						attributes: [],
-					},
-					createdAt: {
-						name: 'createdAt',
-						isArray: false,
-						type: 'AWSDateTime',
-						isRequired: false,
-						attributes: [],
-						isReadOnly: true,
-					},
-					updatedAt: {
-						name: 'updatedAt',
-						isArray: false,
-						type: 'AWSDateTime',
-						isRequired: false,
-						attributes: [],
-						isReadOnly: true,
-					},
-				},
-				syncable: true,
-				pluralName: 'ModelStaticGroups',
-				attributes: [
-					{
-						type: 'model',
-						properties: {},
-					},
-					{
-						type: 'auth',
-						properties: {
-							rules: [
-								{
-									groupClaim: 'cognito:groups',
-									provider: 'userPools',
-									allow: 'groups',
-									groups: ['Admin'],
 									operations: ['create', 'update', 'delete', 'read'],
 								},
 							],

--- a/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
+++ b/packages/api-graphql/__tests__/fixtures/modeled/schema.ts
@@ -220,11 +220,6 @@ const schema = a.schema({
 			description: a.string(),
 		})
 		.authorization([a.allow.groupsDefinedIn('groupsField')]),
-	ModelStaticGroup: a
-		.model({
-			description: a.string(),
-		})
-		.authorization([a.allow.specificGroup('Admin')]),
 	// #endregion
 });
 

--- a/packages/api-graphql/__tests__/internals/__snapshots__/generateClient.test.ts.snap
+++ b/packages/api-graphql/__tests__/internals/__snapshots__/generateClient.test.ts.snap
@@ -252,14 +252,8 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listNotes(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       body
@@ -494,14 +488,8 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listNotes(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       body
@@ -620,14 +608,8 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -965,14 +947,8 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listNotes(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       body
@@ -1207,14 +1183,8 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listNotes(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       body
@@ -1333,14 +1303,8 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -1678,14 +1642,8 @@ exports[`generateClient basic model operations - authMode: lambda override at th
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listNotes(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       body
@@ -1923,14 +1881,8 @@ exports[`generateClient basic model operations - authMode: lambda override at th
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listNotes(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       body
@@ -2055,14 +2007,8 @@ exports[`generateClient basic model operations - authMode: lambda override at th
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -2400,14 +2346,8 @@ exports[`generateClient basic model operations - authMode: lambda override in th
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listNotes(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       body
@@ -2645,14 +2585,8 @@ exports[`generateClient basic model operations - authMode: lambda override in th
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listNotes(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       body
@@ -2777,14 +2711,8 @@ exports[`generateClient basic model operations - authMode: lambda override in th
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -3330,14 +3258,8 @@ exports[`generateClient basic model operations - custom client and request heade
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -3384,14 +3306,8 @@ exports[`generateClient basic model operations - custom client and request heade
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -3750,14 +3666,8 @@ exports[`generateClient basic model operations can lazy load @hasMany 1`] = `
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listNotes(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       body
@@ -3838,14 +3748,8 @@ exports[`generateClient basic model operations can lazy load @hasMany with limit
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listNotes(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       body
@@ -3927,14 +3831,8 @@ exports[`generateClient basic model operations can lazy load @hasMany with nextT
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listNotes(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
+  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       body
@@ -4051,14 +3949,8 @@ exports[`generateClient basic model operations can list() 1`] = `
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -4104,14 +3996,8 @@ exports[`generateClient basic model operations can list() with limit 1`] = `
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -4158,14 +4044,8 @@ exports[`generateClient basic model operations can list() with nextToken 1`] = `
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -4648,14 +4528,8 @@ exports[`generateClient basic model operations with Amplify configuration option
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -4703,14 +4577,8 @@ exports[`generateClient basic model operations with Amplify configuration option
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -5094,14 +4962,8 @@ exports[`generateClient custom operations can return model (Post) that with lazy
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelCommentFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listComments(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelCommentFilterInput, $limit: Int, $nextToken: String) {
+  listComments(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       content
@@ -5635,14 +5497,8 @@ exports[`generateClient observeQuery can paginate through initial results 1`] = 
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -5678,14 +5534,8 @@ exports[`generateClient observeQuery can paginate through initial results 1`] = 
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name

--- a/packages/api-graphql/__tests__/internals/__snapshots__/generateClient.test.ts.snap
+++ b/packages/api-graphql/__tests__/internals/__snapshots__/generateClient.test.ts.snap
@@ -252,8 +252,14 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
-  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listNotes(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       body
@@ -488,8 +494,14 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
-  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listNotes(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       body
@@ -608,8 +620,14 @@ exports[`generateClient basic model operations - authMode: CuP override at the t
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
-  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       name
@@ -947,8 +965,14 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
-  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listNotes(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       body
@@ -1183,8 +1207,14 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
-  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listNotes(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       body
@@ -1303,8 +1333,14 @@ exports[`generateClient basic model operations - authMode: CuP override in the c
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
-  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       name
@@ -1642,8 +1678,14 @@ exports[`generateClient basic model operations - authMode: lambda override at th
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
-  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listNotes(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       body
@@ -1881,8 +1923,14 @@ exports[`generateClient basic model operations - authMode: lambda override at th
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
-  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listNotes(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       body
@@ -2007,8 +2055,14 @@ exports[`generateClient basic model operations - authMode: lambda override at th
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
-  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       name
@@ -2346,8 +2400,14 @@ exports[`generateClient basic model operations - authMode: lambda override in th
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
-  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listNotes(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       body
@@ -2585,8 +2645,14 @@ exports[`generateClient basic model operations - authMode: lambda override in th
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
-  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listNotes(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       body
@@ -2711,8 +2777,14 @@ exports[`generateClient basic model operations - authMode: lambda override in th
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
-  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       name
@@ -3258,8 +3330,14 @@ exports[`generateClient basic model operations - custom client and request heade
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
-  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       name
@@ -3306,8 +3384,14 @@ exports[`generateClient basic model operations - custom client and request heade
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
-  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       name
@@ -3666,8 +3750,14 @@ exports[`generateClient basic model operations can lazy load @hasMany 1`] = `
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
-  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listNotes(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       body
@@ -3748,8 +3838,14 @@ exports[`generateClient basic model operations can lazy load @hasMany with limit
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
-  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listNotes(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       body
@@ -3831,8 +3927,14 @@ exports[`generateClient basic model operations can lazy load @hasMany with nextT
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelNoteFilterInput, $limit: Int, $nextToken: String) {
-  listNotes(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelNoteFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listNotes(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       body
@@ -3949,8 +4051,14 @@ exports[`generateClient basic model operations can list() 1`] = `
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
-  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       name
@@ -3996,8 +4104,14 @@ exports[`generateClient basic model operations can list() with limit 1`] = `
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
-  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       name
@@ -4044,8 +4158,14 @@ exports[`generateClient basic model operations can list() with nextToken 1`] = `
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
-  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       name
@@ -4069,6 +4189,100 @@ exports[`generateClient basic model operations can list() with nextToken 1`] = `
               },
             },
             "nextToken": "some-token",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can list() with sortDirection (ASC) 1`] = `
+[
+  [
+    "AmplifyClassV6",
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelThingWithCustomPkFilterInput, $sortDirection: ModelSortDirection, $cpk_cluster_key: String, $cpk_sort_key: String, $limit: Int, $nextToken: String) {
+  listThingWithCustomPks(
+    filter: $filter
+    sortDirection: $sortDirection
+    cpk_cluster_key: $cpk_cluster_key
+    cpk_sort_key: $cpk_sort_key
+    limit: $limit
+    nextToken: $nextToken
+  ) {
+    items {
+      cpk_cluster_key
+      cpk_sort_key
+      otherField
+      createdAt
+      updatedAt
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "cpk_cluster_key": "1",
+            "sortDirection": "ASC",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient basic model operations can list() with sortDirection (DESC) 1`] = `
+[
+  [
+    "AmplifyClassV6",
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelThingWithCustomPkFilterInput, $sortDirection: ModelSortDirection, $cpk_cluster_key: String, $cpk_sort_key: String, $limit: Int, $nextToken: String) {
+  listThingWithCustomPks(
+    filter: $filter
+    sortDirection: $sortDirection
+    cpk_cluster_key: $cpk_cluster_key
+    cpk_sort_key: $cpk_sort_key
+    limit: $limit
+    nextToken: $nextToken
+  ) {
+    items {
+      cpk_cluster_key
+      cpk_sort_key
+      otherField
+      createdAt
+      updatedAt
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "cpk_cluster_key": "1",
+            "sortDirection": "DESC",
           },
         },
         "headers": {
@@ -4434,8 +4648,14 @@ exports[`generateClient basic model operations with Amplify configuration option
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
-  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       name
@@ -4483,8 +4703,14 @@ exports[`generateClient basic model operations with Amplify configuration option
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
-  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       name
@@ -4868,8 +5094,14 @@ exports[`generateClient custom operations can return model (Post) that with lazy
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelCommentFilterInput, $limit: Int, $nextToken: String) {
-  listComments(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelCommentFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listComments(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       content
@@ -5197,11 +5429,12 @@ exports[`generateClient index queries PK and SK index query 1`] = `
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($description: String!, $viewCount: ModelIntKeyConditionInput, $filter: ModelSecondaryIndexModelFilterInput, $limit: Int, $nextToken: String) {
+          "query": "query ($description: String!, $viewCount: ModelIntKeyConditionInput, $filter: ModelSecondaryIndexModelFilterInput, $sortDirection: ModelSortDirection, $limit: Int, $nextToken: String) {
   listByDescriptionAndViewCount(
     description: $description
     viewCount: $viewCount
     filter: $filter
+    sortDirection: $sortDirection
     limit: $limit
     nextToken: $nextToken
   ) {
@@ -5240,6 +5473,112 @@ exports[`generateClient index queries PK and SK index query 1`] = `
 ]
 `;
 
+exports[`generateClient index queries PK and SK index query, with sort direction (ascending) 1`] = `
+[
+  [
+    "AmplifyClassV6",
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($description: String!, $viewCount: ModelIntKeyConditionInput, $filter: ModelSecondaryIndexModelFilterInput, $sortDirection: ModelSortDirection, $limit: Int, $nextToken: String) {
+  listByDescriptionAndViewCount(
+    description: $description
+    viewCount: $viewCount
+    filter: $filter
+    sortDirection: $sortDirection
+    limit: $limit
+    nextToken: $nextToken
+  ) {
+    items {
+      id
+      title
+      description
+      viewCount
+      status
+      createdAt
+      updatedAt
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "description": "match",
+            "sortDirection": "ASC",
+            "viewCount": {
+              "lt": 4,
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`generateClient index queries PK and SK index query, with sort direction (descending) 1`] = `
+[
+  [
+    "AmplifyClassV6",
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($description: String!, $viewCount: ModelIntKeyConditionInput, $filter: ModelSecondaryIndexModelFilterInput, $sortDirection: ModelSortDirection, $limit: Int, $nextToken: String) {
+  listByDescriptionAndViewCount(
+    description: $description
+    viewCount: $viewCount
+    filter: $filter
+    sortDirection: $sortDirection
+    limit: $limit
+    nextToken: $nextToken
+  ) {
+    items {
+      id
+      title
+      description
+      viewCount
+      status
+      createdAt
+      updatedAt
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "description": "match",
+            "sortDirection": "DESC",
+            "viewCount": {
+              "lt": 4,
+            },
+          },
+        },
+        "headers": {
+          "Authorization": "amplify-config-auth-token",
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
 exports[`generateClient index queries PK-only index query 1`] = `
 [
   [
@@ -5248,10 +5587,11 @@ exports[`generateClient index queries PK-only index query 1`] = `
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($title: String!, $filter: ModelSecondaryIndexModelFilterInput, $limit: Int, $nextToken: String) {
+          "query": "query ($title: String!, $filter: ModelSecondaryIndexModelFilterInput, $sortDirection: ModelSortDirection, $limit: Int, $nextToken: String) {
   listByTitle(
     title: $title
     filter: $filter
+    sortDirection: $sortDirection
     limit: $limit
     nextToken: $nextToken
   ) {
@@ -5295,8 +5635,14 @@ exports[`generateClient observeQuery can paginate through initial results 1`] = 
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
-  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       name
@@ -5332,8 +5678,14 @@ exports[`generateClient observeQuery can paginate through initial results 1`] = 
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
-  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       id
       name

--- a/packages/api-graphql/__tests__/internals/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/internals/generateClient.test.ts
@@ -383,6 +383,58 @@ describe('generateClient', () => {
 			expect(normalizePostGraphqlCalls(spy)).toMatchSnapshot();
 		});
 
+		test('can list() with sortDirection (ASC)', async () => {
+			const spy = mockApiResponse({
+				data: {
+					listThingWithCustomPks: {
+						items: [
+							{
+								__typename: 'ThingWithCustomPk',
+								...serverManagedFields,
+								cpk_cluster_key: '1',
+								cpk_sort_key: 'a',
+							},
+						],
+					},
+				},
+			});
+
+			const client = generateClient<Schema>({ amplify: Amplify });
+
+			const { data } = await client.models.ThingWithCustomPk.list({
+				cpk_cluster_key: '1',
+				sortDirection: 'ASC',
+			});
+
+			expect(normalizePostGraphqlCalls(spy)).toMatchSnapshot();
+		});
+
+		test('can list() with sortDirection (DESC)', async () => {
+			const spy = mockApiResponse({
+				data: {
+					listThingWithCustomPks: {
+						items: [
+							{
+								__typename: 'ThingWithCustomPk',
+								...serverManagedFields,
+								cpk_cluster_key: '1',
+								cpk_sort_key: 'c',
+							},
+						],
+					},
+				},
+			});
+
+			const client = generateClient<Schema>({ amplify: Amplify });
+
+			const { data } = await client.models.ThingWithCustomPk.list({
+				cpk_cluster_key: '1',
+				sortDirection: 'DESC',
+			});
+
+			expect(normalizePostGraphqlCalls(spy)).toMatchSnapshot();
+		});
+
 		test('can update()', async () => {
 			const spy = mockApiResponse({
 				data: {
@@ -5098,6 +5150,104 @@ describe('generateClient', () => {
 					viewCount: 5,
 				}),
 			);
+		});
+
+		test('PK and SK index query, with sort direction (ascending)', async () => {
+			const spy = mockApiResponse({
+				data: {
+					listByDescriptionAndViewCount: {
+						items: [
+							{
+								__typename: 'SecondaryIndexModel',
+								...serverManagedFields,
+								title: 'first',
+								description: 'match',
+								viewCount: 1,
+							},
+							{
+								__typename: 'SecondaryIndexModel',
+								...serverManagedFields,
+								title: 'second',
+								description: 'match',
+								viewCount: 2,
+							},
+							{
+								__typename: 'SecondaryIndexModel',
+								...serverManagedFields,
+								title: 'third',
+								description: 'match',
+								viewCount: 3,
+							},
+						],
+					},
+				},
+			});
+
+			const client = generateClient<Schema>({ amplify: Amplify });
+
+			const { data } =
+				await client.models.SecondaryIndexModel.listByDescriptionAndViewCount(
+					{
+						description: 'match',
+						viewCount: { lt: 4 },
+					},
+					{
+						sortDirection: 'ASC',
+					},
+				);
+
+			expect(normalizePostGraphqlCalls(spy)).toMatchSnapshot();
+
+			expect(data.length).toBe(3);
+		});
+
+		test('PK and SK index query, with sort direction (descending)', async () => {
+			const spy = mockApiResponse({
+				data: {
+					listByDescriptionAndViewCount: {
+						items: [
+							{
+								__typename: 'SecondaryIndexModel',
+								...serverManagedFields,
+								title: 'third',
+								description: 'match',
+								viewCount: 3,
+							},
+							{
+								__typename: 'SecondaryIndexModel',
+								...serverManagedFields,
+								title: 'second',
+								description: 'match',
+								viewCount: 2,
+							},
+							{
+								__typename: 'SecondaryIndexModel',
+								...serverManagedFields,
+								title: 'first',
+								description: 'match',
+								viewCount: 1,
+							},
+						],
+					},
+				},
+			});
+
+			const client = generateClient<Schema>({ amplify: Amplify });
+
+			const { data } =
+				await client.models.SecondaryIndexModel.listByDescriptionAndViewCount(
+					{
+						description: 'match',
+						viewCount: { lt: 4 },
+					},
+					{
+						sortDirection: 'DESC',
+					},
+				);
+
+			expect(normalizePostGraphqlCalls(spy)).toMatchSnapshot();
+
+			expect(data.length).toBe(3);
 		});
 	});
 

--- a/packages/api-graphql/__tests__/internals/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/internals/generateClient.test.ts
@@ -49,7 +49,6 @@ describe('generateClient', () => {
 			'CustomImplicitOwner',
 			'ModelGroupDefinedIn',
 			'ModelGroupsDefinedIn',
-			'ModelStaticGroup',
 		];
 
 		it('generates `models` property when Amplify.getConfig() returns valid GraphQL provider config', () => {

--- a/packages/api-graphql/__tests__/internals/server/__snapshots__/generateClientWithAmplifyInstance.test.ts.snap
+++ b/packages/api-graphql/__tests__/internals/server/__snapshots__/generateClientWithAmplifyInstance.test.ts.snap
@@ -31,7 +31,268 @@ exports[`server generateClient with cookies can custom query 1`] = `
 ]
 `;
 
-exports[`server generateClient with request can custom query 1`] = `
+exports[`server generateClient with cookies can list 1`] = `
+[
+  [
+    "AmplifyClassV6",
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
+    items {
+      id
+      name
+      description
+      status
+      tags
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`server generateClient with cookies can list with limit 1`] = `
+[
+  [
+    "AmplifyClassV6",
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
+    items {
+      id
+      name
+      description
+      status
+      tags
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+            "limit": 5,
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`server generateClient with cookies can list with nextToken 1`] = `
+[
+  [
+    "AmplifyClassV6",
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
+    items {
+      id
+      name
+      description
+      status
+      tags
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "filter": {
+              "name": {
+                "contains": "name",
+              },
+            },
+            "nextToken": "some-token",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`server generateClient with cookies can list with sort direction (ascending) 1`] = `
+[
+  [
+    "AmplifyClassV6",
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
+    items {
+      id
+      name
+      description
+      status
+      tags
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "id": "some-id",
+            "sortDirection": "ASC",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`server generateClient with cookies can list with sort direction (descending) 1`] = `
+[
+  [
+    "AmplifyClassV6",
+    {
+      "abortController": AbortController {},
+      "options": {
+        "body": {
+          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
+  listTodos(
+    filter: $filter
+    sortDirection: $sortDirection
+    id: $id
+    limit: $limit
+    nextToken: $nextToken
+  ) {
+    items {
+      id
+      name
+      description
+      status
+      tags
+      createdAt
+      updatedAt
+      todoMetaId
+      owner
+    }
+    nextToken
+    __typename
+  }
+}
+",
+          "variables": {
+            "id": "some-id",
+            "sortDirection": "DESC",
+          },
+        },
+        "headers": {
+          "X-Api-Key": "FAKE-KEY",
+          "x-amz-user-agent": "aws-amplify/latest api/latest framework/latest",
+        },
+        "signingServiceInfo": undefined,
+        "withCredentials": undefined,
+      },
+      "url": "https://localhost/graphql",
+    },
+  ],
+]
+`;
+
+exports[`server generateClient with cookies with request can custom query 1`] = `
 [
   [
     "AmplifyClassV6",

--- a/packages/api-graphql/__tests__/internals/server/__snapshots__/generateClientWithAmplifyInstance.test.ts.snap
+++ b/packages/api-graphql/__tests__/internals/server/__snapshots__/generateClientWithAmplifyInstance.test.ts.snap
@@ -39,14 +39,8 @@ exports[`server generateClient with cookies can list 1`] = `
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -92,14 +86,8 @@ exports[`server generateClient with cookies can list with limit 1`] = `
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -146,14 +134,8 @@ exports[`server generateClient with cookies can list with nextToken 1`] = `
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -200,14 +182,8 @@ exports[`server generateClient with cookies can list with sort direction (ascend
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name
@@ -250,14 +226,8 @@ exports[`server generateClient with cookies can list with sort direction (descen
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelTodoFilterInput, $sortDirection: ModelSortDirection, $id: ID, $limit: Int, $nextToken: String) {
-  listTodos(
-    filter: $filter
-    sortDirection: $sortDirection
-    id: $id
-    limit: $limit
-    nextToken: $nextToken
-  ) {
+          "query": "query ($filter: ModelTodoFilterInput, $limit: Int, $nextToken: String) {
+  listTodos(filter: $filter, limit: $limit, nextToken: $nextToken) {
     items {
       id
       name

--- a/packages/api-graphql/__tests__/resolveOwnerFields.test.ts
+++ b/packages/api-graphql/__tests__/resolveOwnerFields.test.ts
@@ -14,9 +14,6 @@ describe('owner field resolution', () => {
 		ThingWithOwnerFieldSpecifiedInModel: ['owner'],
 		ThingWithAPIKeyAuth: [],
 		ThingWithoutExplicitAuth: [],
-		ModelGroupDefinedIn: ['groupField'],
-		ModelGroupsDefinedIn: ['groupsField'],
-		ModelStaticGroup: [],
 	};
 
 	for (const [modelName, expected] of Object.entries(expectedResolutions)) {
@@ -26,7 +23,7 @@ describe('owner field resolution', () => {
 			const model: SchemaModel = modelIntroSchema.models[modelName];
 
 			const resolvedField = resolveOwnerFields(model);
-			expect(resolvedField).toStrictEqual(expected);
+			expect(resolvedField).toEqual(expected);
 		});
 	}
 });

--- a/packages/api-graphql/src/internals/APIClient.ts
+++ b/packages/api-graphql/src/internals/APIClient.ts
@@ -732,6 +732,15 @@ export function generateGraphQLDocument(
 			graphQLArguments ??
 				(graphQLArguments = {
 					filter: `Model${name}FilterInput`,
+					sortDirection: 'ModelSortDirection',
+					...[primaryKeyFieldName, ...sortKeyFieldNames].reduce(
+						(acc: Record<string, any>, fieldName) => {
+							acc[fieldName] = `${fields[fieldName].type}`;
+
+							return acc;
+						},
+						[],
+					),
 					limit: 'Int',
 					nextToken: 'String',
 				});
@@ -745,6 +754,7 @@ export function generateGraphQLDocument(
 				(graphQLArguments = {
 					...indexQueryArgs!,
 					filter: `Model${name}FilterInput`,
+					sortDirection: 'ModelSortDirection',
 					limit: 'Int',
 					nextToken: 'String',
 				});
@@ -858,6 +868,10 @@ export function buildGraphQLVariables(
 			if (arg?.filter) {
 				variables.filter = arg.filter;
 			}
+			if (arg?.sortDirection) {
+				variables.sortDirection = arg.sortDirection;
+				variables[primaryKeyFieldName] = arg[primaryKeyFieldName];
+			}
 			if (arg?.nextToken) {
 				variables.nextToken = arg.nextToken;
 			}
@@ -877,6 +891,11 @@ export function buildGraphQLVariables(
 			if (arg?.filter) {
 				variables.filter = arg.filter;
 			}
+
+			if (arg?.sortDirection) {
+				variables.sortDirection = arg.sortDirection;
+			}
+
 			if (arg?.nextToken) {
 				variables.nextToken = arg.nextToken;
 			}

--- a/packages/api-graphql/src/internals/APIClient.ts
+++ b/packages/api-graphql/src/internals/APIClient.ts
@@ -732,15 +732,16 @@ export function generateGraphQLDocument(
 			graphQLArguments ??
 				(graphQLArguments = {
 					filter: `Model${name}FilterInput`,
-					sortDirection: 'ModelSortDirection',
-					...[primaryKeyFieldName, ...sortKeyFieldNames].reduce(
-						(acc: Record<string, any>, fieldName) => {
-							acc[fieldName] = `${fields[fieldName].type}`;
+					...(sortKeyFieldNames.length > 0
+						? [primaryKeyFieldName, ...sortKeyFieldNames].reduce(
+								(acc: Record<string, any>, fieldName) => {
+									acc[fieldName] = `${fields[fieldName].type}`;
 
-							return acc;
-						},
-						[],
-					),
+									return acc;
+								},
+								{ sortDirection: 'ModelSortDirection' },
+							)
+						: []),
 					limit: 'Int',
 					nextToken: 'String',
 				});

--- a/packages/api-graphql/src/internals/InternalGraphQLAPI.ts
+++ b/packages/api-graphql/src/internals/InternalGraphQLAPI.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import {
 	DocumentNode,
-	GraphQLError,
 	OperationDefinitionNode,
 	OperationTypeNode,
 	parse,
@@ -25,14 +24,20 @@ import {
 import { CustomHeaders, RequestOptions } from '@aws-amplify/data-schema-types';
 
 import { AWSAppSyncRealTimeProvider } from '../Providers/AWSAppSyncRealTimeProvider';
-import {
-	GraphQLAuthError,
-	GraphQLOperation,
-	GraphQLOptions,
-	GraphQLResult,
-} from '../types';
+import { GraphQLOperation, GraphQLOptions, GraphQLResult } from '../types';
 import { resolveConfig, resolveLibraryOptions } from '../utils';
-import { repackageUnauthError } from '../utils/errors/repackageAuthError';
+import { repackageUnauthorizedError } from '../utils/errors/repackageAuthError';
+import {
+	NO_API_KEY,
+	NO_AUTH_TOKEN_HEADER,
+	NO_ENDPOINT,
+	NO_SIGNED_IN_USER,
+	NO_VALID_AUTH_TOKEN,
+	NO_VALID_CREDENTIALS,
+} from '../utils/errors/constants';
+import { GraphQLApiError, createGraphQLResultWithError } from '../utils/errors';
+
+import { isGraphQLResponseWithErrors } from './utils/runtimeTypeGuards/isGraphQLResponseWithErrors';
 
 const USER_AGENT_HEADER = 'x-amz-user-agent';
 
@@ -76,7 +81,7 @@ export class InternalGraphQLAPIClass {
 		switch (authMode) {
 			case 'apiKey':
 				if (!apiKey) {
-					throw new Error(GraphQLAuthError.NO_API_KEY);
+					throw new GraphQLApiError(NO_API_KEY);
 				}
 				headers = {
 					'X-Api-Key': apiKey,
@@ -85,33 +90,44 @@ export class InternalGraphQLAPIClass {
 			case 'iam': {
 				const session = await amplify.Auth.fetchAuthSession();
 				if (session.credentials === undefined) {
-					throw new Error(GraphQLAuthError.NO_CREDENTIALS);
+					throw new GraphQLApiError(NO_VALID_CREDENTIALS);
 				}
 				break;
 			}
 			case 'oidc':
-			case 'userPool':
+			case 'userPool': {
+				let token: string | undefined;
+
 				try {
-					const token = (
+					token = (
 						await amplify.Auth.fetchAuthSession()
 					).tokens?.accessToken.toString();
-
-					if (!token) {
-						throw new Error(GraphQLAuthError.NO_FEDERATED_JWT);
-					}
-					headers = {
-						Authorization: token,
-					};
 				} catch (e) {
-					throw new Error(GraphQLAuthError.NO_CURRENT_USER);
+					// fetchAuthSession failed
+					throw new GraphQLApiError({
+						...NO_SIGNED_IN_USER,
+						underlyingError: e,
+					});
 				}
+
+				// `fetchAuthSession()` succeeded but didn't return `tokens`.
+				// This may happen when unauthenticated access is enabled and there is
+				// no user signed in.
+				if (!token) {
+					throw new GraphQLApiError(NO_VALID_AUTH_TOKEN);
+				}
+
+				headers = {
+					Authorization: token,
+				};
 				break;
+			}
 			case 'lambda':
 				if (
 					typeof additionalHeaders === 'object' &&
 					!additionalHeaders.Authorization
 				) {
-					throw new Error(GraphQLAuthError.NO_AUTH_TOKEN);
+					throw new GraphQLApiError(NO_AUTH_TOKEN_HEADER);
 				}
 
 				headers = {
@@ -350,18 +366,15 @@ export class InternalGraphQLAPIClass {
 		const endpoint = customEndpoint || appSyncGraphqlEndpoint;
 
 		if (!endpoint) {
-			const error = new GraphQLError('No graphql endpoint provided.');
-			// TODO(Eslint): refactor this to throw an Error instead of a plain object
-			// eslint-disable-next-line no-throw-literal
-			throw {
-				data: {},
-				errors: [error],
-			};
+			throw createGraphQLResultWithError<T>(new GraphQLApiError(NO_ENDPOINT));
 		}
 
 		let response: any;
 
 		try {
+			// See the inline doc of the REST `post()` API for possible errors to be thrown.
+			// As these errors are catastrophic they should be caught and handled by GraphQL
+			// API consumers.
 			const { body: responseBody } = await this._api.post(amplify, {
 				url: new AmplifyUrl(endpoint),
 				options: {
@@ -373,39 +386,20 @@ export class InternalGraphQLAPIClass {
 				abortController,
 			});
 
-			const result = await responseBody.json();
-
-			response = result;
-		} catch (err) {
-			// If the exception is because user intentionally
-			// cancelled the request, do not modify the exception
-			// so that clients can identify the exception correctly.
-			if (this.isCancelError(err)) {
-				throw err;
+			response = await responseBody.json();
+		} catch (error) {
+			if (this.isCancelError(error)) {
+				throw error;
 			}
 
-			response = {
-				data: {},
-				errors: [
-					new GraphQLError(
-						(err as any).message,
-						null,
-						null,
-						null,
-						null,
-						err as any,
-					),
-				],
-			};
+			response = createGraphQLResultWithError<T>(error as any);
 		}
 
-		const { errors } = response;
-
-		if (errors && errors.length) {
-			throw repackageUnauthError(response);
+		if (isGraphQLResponseWithErrors(response)) {
+			throw repackageUnauthorizedError(response);
 		}
 
-		return response;
+		return response as unknown as GraphQLResult<T>;
 	}
 
 	/**
@@ -463,7 +457,7 @@ export class InternalGraphQLAPIClass {
 			.pipe(
 				catchError(e => {
 					if (e.errors) {
-						throw repackageUnauthError(e);
+						throw repackageUnauthorizedError(e);
 					}
 					throw e;
 				}),

--- a/packages/api-graphql/src/internals/utils/runtimeTypeGuards/isGraphQLResponseWithErrors.ts
+++ b/packages/api-graphql/src/internals/utils/runtimeTypeGuards/isGraphQLResponseWithErrors.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { GraphQLResult } from '../../../types';
+
+export function isGraphQLResponseWithErrors(
+	response: unknown,
+): response is GraphQLResult {
+	if (!response) {
+		return false;
+	}
+	const r = response as GraphQLResult;
+
+	return Array.isArray(r.errors) && r.errors.length > 0;
+}

--- a/packages/api-graphql/src/types/index.ts
+++ b/packages/api-graphql/src/types/index.ts
@@ -7,6 +7,7 @@ import {
 	CustomQueries,
 	CustomSubscriptions,
 	EnumTypes,
+	ModelSortDirection,
 	ModelTypes,
 } from '@aws-amplify/data-schema-types';
 import { DocumentNode, GraphQLError, Source } from 'graphql';
@@ -464,6 +465,7 @@ export type QueryArgs = Record<string, unknown>;
 export interface ListArgs extends Record<string, unknown> {
 	selectionSet?: string[];
 	filter?: Record<string, unknown>;
+	sortDirection?: ModelSortDirection;
 	headers?: CustomHeaders;
 }
 

--- a/packages/api-graphql/src/utils/errors/constants.ts
+++ b/packages/api-graphql/src/utils/errors/constants.ts
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AmplifyErrorParams } from '@aws-amplify/core/internals/utils';
+
+import { GraphQLAuthError } from '../../types';
+
+export const NO_API_KEY: AmplifyErrorParams = {
+	name: 'NoApiKey',
+	// ideal: No API key configured.
+	message: GraphQLAuthError.NO_API_KEY,
+	recoverySuggestion:
+		'The API request was made with `authMode: "apiKey"` but no API Key was passed into `Amplify.configure()`. Review if your API key is passed into the `Amplify.configure()` function.',
+};
+
+export const NO_VALID_CREDENTIALS: AmplifyErrorParams = {
+	name: 'NoCredentials',
+	// ideal: No auth credentials available.
+	message: GraphQLAuthError.NO_CREDENTIALS,
+	recoverySuggestion: `The API request was made with \`authMode: "iam"\` but no authentication credentials are available.
+
+If you intended to make a request using an authenticated role, review if your user is signed in before making the request.
+
+If you intend to make a request using an unauthenticated role or also known as "guest access", verify if "Auth.Cognito.allowGuestAccess" is set to "true" in the \`Amplify.configure()\` function.`,
+};
+
+export const NO_VALID_AUTH_TOKEN: AmplifyErrorParams = {
+	name: 'NoValidAuthTokens',
+	// ideal: No valid JWT auth token provided to make the API request..
+	message: GraphQLAuthError.NO_FEDERATED_JWT,
+	recoverySuggestion:
+		'If you intended to make an authenticated API request, review if the current user is signed in.',
+};
+
+export const NO_SIGNED_IN_USER: AmplifyErrorParams = {
+	name: 'NoSignedUser',
+	// ideal: Couldn't retrieve authentication credentials to make the API request.
+	message: GraphQLAuthError.NO_CURRENT_USER,
+	recoverySuggestion:
+		'Review the underlying exception field for more details. If you intended to make an authenticated API request, review if the current user is signed in.',
+};
+
+export const NO_AUTH_TOKEN_HEADER: AmplifyErrorParams = {
+	name: 'NoAuthorizationHeader',
+	// ideal: Authorization header not specified.
+	message: GraphQLAuthError.NO_AUTH_TOKEN,
+	recoverySuggestion:
+		'The API request was made with `authMode: "lambda"` but no `authToken` is set. Review if a valid authToken is passed into the request options or in the `Amplify.configure()` function.',
+};
+
+export const NO_ENDPOINT: AmplifyErrorParams = {
+	name: 'NoEndpoint',
+	message: 'No GraphQL endpoint configured in `Amplify.configure()`.',
+	recoverySuggestion:
+		'Review if the GraphQL API endpoint is set in the `Amplify.configure()` function.',
+};

--- a/packages/api-graphql/src/utils/errors/createGraphQLResultWithError.ts
+++ b/packages/api-graphql/src/utils/errors/createGraphQLResultWithError.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { GraphQLError } from 'graphql';
+
+import { GraphQLResult } from '../../types';
+
+export const createGraphQLResultWithError = <T>(
+	error: Error,
+): GraphQLResult<T> => {
+	return {
+		data: {} as T,
+		errors: [new GraphQLError(error.message, null, null, null, null, error)],
+	};
+};

--- a/packages/api-graphql/src/utils/errors/index.ts
+++ b/packages/api-graphql/src/utils/errors/index.ts
@@ -4,3 +4,4 @@
 export { GraphQLApiError } from './GraphQLApiError';
 export { assertValidationError } from './assertValidationError';
 export { APIValidationErrorCode, validationErrorMap } from './validation';
+export { createGraphQLResultWithError } from './createGraphQLResultWithError';

--- a/packages/api-graphql/src/utils/errors/repackageAuthError.ts
+++ b/packages/api-graphql/src/utils/errors/repackageAuthError.ts
@@ -1,23 +1,21 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyErrorParams } from '@aws-amplify/core/internals/utils';
-
-interface ErrorObject {
-	errors: AmplifyErrorParams[];
-}
+import { GraphQLResult } from '../../types';
 
 /**
  * Checks to see if the given response or subscription message contains an
- * unauth error. If it does, it changes the error message to include instructions
+ * Unauthorized error. If it does, it changes the error message to include instructions
  * for the app developer.
  */
-export function repackageUnauthError<T extends ErrorObject>(content: T): T {
+export function repackageUnauthorizedError<T extends GraphQLResult<any>>(
+	content: T,
+): T {
 	if (content.errors && Array.isArray(content.errors)) {
 		content.errors.forEach(e => {
-			if (isUnauthError(e)) {
+			if (isUnauthorizedError(e)) {
 				e.message = 'Unauthorized';
-				e.recoverySuggestion =
+				(e as any).recoverySuggestion =
 					`If you're calling an Amplify-generated API, make sure ` +
 					`to set the "authMode" in generateClient({ authMode: '...' }) to the backend authorization ` +
 					`rule's auth provider ('apiKey', 'userPool', 'iam', 'oidc', 'lambda')`;
@@ -28,7 +26,7 @@ export function repackageUnauthError<T extends ErrorObject>(content: T): T {
 	return content;
 }
 
-function isUnauthError(error: any): boolean {
+function isUnauthorizedError(error: any): boolean {
 	// Error pattern corresponding to appsync calls
 	if (error?.originalError?.name?.startsWith('UnauthorizedException')) {
 		return true;

--- a/packages/api-graphql/src/utils/resolveOwnerFields.ts
+++ b/packages/api-graphql/src/utils/resolveOwnerFields.ts
@@ -42,10 +42,7 @@ export function resolveOwnerFields(model: Model): string[] {
 			for (const rule of attr.properties.rules) {
 				if (rule.allow === 'owner') {
 					ownerFields.add(rule.ownerField || 'owner');
-				} else if (rule.allow === 'groups' && rule.groupsField !== undefined) {
-					// only valid for dynamic group(s)
-					// static group auth will have an array of predefined groups in the attribute, groups: string[]
-					// but `groupsField` will be undefined
+				} else if (rule.allow === 'groups') {
 					ownerFields.add(rule.groupsField);
 				}
 			}

--- a/packages/api-graphql/tsconfig.json
+++ b/packages/api-graphql/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"strictNullChecks": true,
-		"baseUrl": ".",
 		"paths": {
 			"@aws-amplify/data-schema-types": [
 				"../../node_modules/@aws-amplify/data-schema-types"

--- a/packages/api-rest/src/apis/common/internalPost.ts
+++ b/packages/api-rest/src/apis/common/internalPost.ts
@@ -5,6 +5,7 @@ import { AmplifyClassV6 } from '@aws-amplify/core';
 
 import { InternalPostInput, RestApiResponse } from '../../types';
 import { createCancellableOperation } from '../../utils';
+import { CanceledError } from '../../errors';
 
 import { transferHandler } from './handler';
 
@@ -23,6 +24,33 @@ const cancelTokenMap = new WeakMap<Promise<any>, AbortController>();
 
 /**
  * @internal
+ *
+ * REST POST handler to send GraphQL request to given endpoint. By default, it will use IAM to authorize
+ * the request. In some auth modes, the IAM auth has to be disabled. Here's how to set up the request auth correctly:
+ * * If auth mode is 'iam', you MUST NOT set 'authorization' header and 'x-api-key' header, since it would disable IAM
+ *   auth. You MUST also set 'input.options.signingServiceInfo' option.
+ *   * The including 'input.options.signingServiceInfo.service' and 'input.options.signingServiceInfo.region' are
+ *     optional. If omitted, the signing service and region will be inferred from url.
+ * * If auth mode is 'none', you MUST NOT set 'options.signingServiceInfo' option.
+ * * If auth mode is 'apiKey', you MUST set 'x-api-key' custom header.
+ * * If auth mode is 'oidc' or 'lambda' or 'userPool', you MUST set 'authorization' header.
+ *
+ * To make the internal post cancellable, you must also call `updateRequestToBeCancellable()` with the promise from
+ * internal post call and the abort controller supplied to the internal post call.
+ *
+ * @param amplify the AmplifyClassV6 instance - it may be the singleton used on Web, or an instance created within
+ * a context created by `runWithAmplifyServerContext`
+ * @param postInput an object of {@link InternalPostInput}
+ * @param postInput.url The URL that the POST request sends to
+ * @param postInput.options Options of the POST request
+ * @param postInput.abortController The abort controller used to cancel the POST request
+ * @returns a {@link RestApiResponse}
+ *
+ * @throws an {@link Error} with `Network error` as the `message` when the external resource is unreachable due to one
+ * of the following reasons:
+ *   1. no network connection
+ *   2. CORS error
+ * @throws a {@link CanceledError} when the ongoing POST request get cancelled
  */
 export const post = (
 	amplify: AmplifyClassV6,

--- a/packages/api-rest/src/internals/index.ts
+++ b/packages/api-rest/src/internals/index.ts
@@ -1,26 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { post as internalPost } from '../apis/common/internalPost';
-
-/**
- * Internal-only REST POST handler to send GraphQL request to given endpoint. By default, it will use IAM to authorize
- * the request. In some auth modes, the IAM auth has to be disabled. Here's how to set up the request auth correctly:
- * * If auth mode is 'iam', you MUST NOT set 'authorization' header and 'x-api-key' header, since it would disable IAM
- *   auth. You MUST also set 'input.options.signingServiceInfo' option.
- *   * The including 'input.options.signingServiceInfo.service' and 'input.options.signingServiceInfo.region' are
- *     optional. If omitted, the signing service and region will be inferred from url.
- * * If auth mode is 'none', you MUST NOT set 'options.signingServiceInfo' option.
- * * If auth mode is 'apiKey', you MUST set 'x-api-key' custom header.
- * * If auth mode is 'oidc' or 'lambda' or 'userPool', you MUST set 'authorization' header.
- *
- * To make the internal post cancellable, you must also call `updateRequestToBeCancellable()` with the promise from
- * internal post call and the abort controller supplied to the internal post call.
- *
- * @internal
- */
-export const post = internalPost;
-
+export { post } from '../apis/common/internalPost';
 export {
 	cancel,
 	updateRequestToBeCancellable,

--- a/packages/api-rest/src/utils/createCancellableOperation.ts
+++ b/packages/api-rest/src/utils/createCancellableOperation.ts
@@ -67,6 +67,8 @@ export function createCancellableOperation(
 				const canceledError = new CanceledError({
 					...(message && { message }),
 					underlyingError: error,
+					recoverySuggestion:
+						'The API request was explicitly canceled. If this is not intended, validate if you called the `cancel()` function on the API request erroneously.',
 				});
 				logger.debug(error);
 				throw canceledError;

--- a/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
@@ -191,6 +191,9 @@ describe('signInWithRedirect', () => {
 	});
 
 	describe('specifications on react-native', () => {
+		beforeAll(() => {
+			mockIsBrowser.mockReturnValue(false);
+		});
 		it('invokes `completeOAuthFlow` when `openAuthSession`completes', async () => {
 			const mockOpenAuthSessionResult = {
 				type: 'success',
@@ -258,6 +261,19 @@ describe('signInWithRedirect', () => {
 				}),
 			);
 			expect(mockHandleFailure).toHaveBeenCalledWith(expectedError);
+		});
+		it('should not set the Oauth flag on non-browser environments', async () => {
+			const mockOpenAuthSessionResult = {
+				type: 'success',
+				url: 'http://redrect-in-react-native.com',
+			};
+			mockOpenAuthSession.mockResolvedValueOnce(mockOpenAuthSessionResult);
+
+			await signInWithRedirect({
+				provider: 'Google',
+			});
+
+			expect(oAuthStore.storeOAuthInFlight).toHaveBeenCalledTimes(0);
 		});
 	});
 

--- a/packages/auth/__tests__/providers/cognito/signUp.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signUp.test.ts
@@ -23,6 +23,8 @@ jest.mock(
 	'../../../src/providers/cognito/utils/clients/CognitoIdentityProvider',
 );
 
+const userId = '1234567890';
+
 describe('signUp', () => {
 	const { user1 } = authAPITestParams;
 	// assert mocks
@@ -32,81 +34,184 @@ describe('signUp', () => {
 		setUpGetConfig(Amplify);
 	});
 
-	beforeEach(() => {
-		mockSignUp.mockResolvedValue(authAPITestParams.signUpHttpCallResult);
-	});
-
-	afterEach(() => {
-		mockSignUp.mockReset();
-	});
-
-	it('should call signUp and return a result', async () => {
-		const result = await signUp({
-			username: user1.username,
-			password: user1.password,
-			options: {
-				userAttributes: { email: user1.email },
-			},
+	describe('Happy Path Cases:', () => {
+		beforeEach(() => {
+			mockSignUp.mockResolvedValue(authAPITestParams.signUpHttpCallResult);
 		});
-		expect(result).toEqual({
-			isSignUpComplete: false,
-			nextStep: {
-				signUpStep: 'CONFIRM_SIGN_UP',
-				codeDeliveryDetails: {
-					destination: user1.email,
-					deliveryMedium: 'EMAIL',
-					attributeName: 'email',
+
+		afterEach(() => {
+			mockSignUp.mockReset();
+		});
+
+		it('should call SignUp service client with correct params', async () => {
+			await signUp({
+				username: user1.username,
+				password: user1.password,
+				options: {
+					userAttributes: { email: user1.email },
 				},
-			},
-			userId: '1234567890',
+			});
+			expect(mockSignUp).toHaveBeenCalledWith(
+				{
+					region: 'us-west-2',
+					userAgentValue: expect.any(String),
+				},
+				{
+					ClientMetadata: undefined,
+					Password: user1.password,
+					UserAttributes: [{ Name: 'email', Value: user1.email }],
+					Username: user1.username,
+					ValidationData: undefined,
+					ClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
+				},
+			);
+			expect(mockSignUp).toHaveBeenCalledTimes(1);
 		});
-		expect(mockSignUp).toHaveBeenCalledWith(
-			{
-				region: 'us-west-2',
-				userAgentValue: expect.any(String),
-			},
-			{
-				ClientMetadata: undefined,
-				Password: user1.password,
-				UserAttributes: [{ Name: 'email', Value: user1.email }],
-				Username: user1.username,
-				ValidationData: undefined,
-				ClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
-			},
-		);
-		expect(mockSignUp).toHaveBeenCalledTimes(1);
-	});
 
-	it('should throw an error when username is empty', async () => {
-		expect.assertions(2);
-		try {
-			await signUp({ username: '', password: user1.password });
-		} catch (error: any) {
-			expect(error).toBeInstanceOf(AuthError);
-			expect(error.name).toBe(AuthValidationErrorCode.EmptySignUpUsername);
-		}
-	});
-
-	it('should throw an error when password is empty', async () => {
-		expect.assertions(2);
-		try {
-			await signUp({ username: user1.username, password: '' });
-		} catch (error: any) {
-			expect(error).toBeInstanceOf(AuthError);
-			expect(error.name).toBe(AuthValidationErrorCode.EmptySignUpPassword);
-		}
-	});
-
-	it('should throw an error when service returns an error response', async () => {
-		expect.assertions(2);
-		mockSignUp.mockImplementation(() => {
-			throw getMockError(SignUpException.InvalidParameterException);
+		it('should return `CONFIRM_SIGN_UP` step when user isn`t confirmed yet', async () => {
+			const result = await signUp({
+				username: user1.username,
+				password: user1.password,
+				options: {
+					userAttributes: { email: user1.email },
+				},
+			});
+			expect(result).toEqual({
+				isSignUpComplete: false,
+				nextStep: {
+					signUpStep: 'CONFIRM_SIGN_UP',
+					codeDeliveryDetails: {
+						destination: user1.email,
+						deliveryMedium: 'EMAIL',
+						attributeName: 'email',
+					},
+				},
+				userId,
+			});
 		});
-		try {
-			await signUp({ username: user1.username, password: user1.password });
-		} catch (error: any) {
-			expect(error).toBeInstanceOf(AuthError);
-			expect(error.name).toBe(SignUpException.InvalidParameterException);
-		}
+
+		it('should return `DONE` step when user is confirmed', async () => {
+			mockSignUp.mockResolvedValue({
+				UserConfirmed: true,
+				UserSub: userId,
+			});
+			const result = await signUp({
+				username: user1.username,
+				password: user1.password,
+				options: {
+					userAttributes: { email: user1.email },
+				},
+			});
+			expect(result).toEqual({
+				isSignUpComplete: true,
+				nextStep: {
+					signUpStep: 'DONE',
+				},
+				userId,
+			});
+		});
+
+		it('should return `COMPLETE_AUTO_SIGN_IN` step with `isSignUpComplete` false when autoSignIn is enabled and user isn`t confirmed yet', async () => {
+			// set up signUpVerificationMethod as link in auth config
+			(Amplify.getConfig as any).mockReturnValue({
+				Auth: {
+					Cognito: {
+						userPoolClientId: '111111-aaaaa-42d8-891d-ee81a1549398',
+						userPoolId: 'us-west-2_zzzzz',
+						identityPoolId: 'us-west-2:xxxxxx',
+						signUpVerificationMethod: 'link',
+					},
+				},
+			});
+
+			const result = await signUp({
+				username: user1.username,
+				password: user1.password,
+				options: {
+					userAttributes: { email: user1.email },
+					autoSignIn: true,
+				},
+			});
+
+			expect(result).toEqual({
+				isSignUpComplete: false,
+				nextStep: {
+					signUpStep: 'COMPLETE_AUTO_SIGN_IN',
+					codeDeliveryDetails: {
+						destination: user1.email,
+						deliveryMedium: 'EMAIL',
+						attributeName: 'email',
+					},
+				},
+				userId,
+			});
+		});
+
+		it('should return `COMPLETE_AUTO_SIGN_IN` step with `isSignUpComplete` true when autoSignIn is enabled and user is confirmed', async () => {
+			mockSignUp.mockResolvedValue({
+				UserConfirmed: true,
+				UserSub: userId,
+			});
+
+			const result = await signUp({
+				username: user1.username,
+				password: user1.password,
+				options: {
+					userAttributes: { email: user1.email },
+					autoSignIn: true,
+				},
+			});
+
+			expect(result).toEqual({
+				isSignUpComplete: true,
+				nextStep: {
+					signUpStep: 'COMPLETE_AUTO_SIGN_IN',
+				},
+				userId,
+			});
+		});
+	});
+
+	describe('Error Path Cases:', () => {
+		beforeEach(() => {
+			mockSignUp.mockResolvedValue(authAPITestParams.signUpHttpCallResult);
+		});
+
+		afterEach(() => {
+			mockSignUp.mockReset();
+		});
+
+		it('should throw an error when username is empty', async () => {
+			expect.assertions(2);
+			try {
+				await signUp({ username: '', password: user1.password });
+			} catch (error: any) {
+				expect(error).toBeInstanceOf(AuthError);
+				expect(error.name).toBe(AuthValidationErrorCode.EmptySignUpUsername);
+			}
+		});
+
+		it('should throw an error when password is empty', async () => {
+			expect.assertions(2);
+			try {
+				await signUp({ username: user1.username, password: '' });
+			} catch (error: any) {
+				expect(error).toBeInstanceOf(AuthError);
+				expect(error.name).toBe(AuthValidationErrorCode.EmptySignUpPassword);
+			}
+		});
+
+		it('should throw an error when service returns an error response', async () => {
+			expect.assertions(2);
+			mockSignUp.mockImplementation(() => {
+				throw getMockError(SignUpException.InvalidParameterException);
+			});
+			try {
+				await signUp({ username: user1.username, password: user1.password });
+			} catch (error: any) {
+				expect(error).toBeInstanceOf(AuthError);
+				expect(error.name).toBe(SignUpException.InvalidParameterException);
+			}
+		});
 	});
 });

--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -6,6 +6,7 @@ import {
 	AuthAction,
 	assertOAuthConfig,
 	assertTokenProviderConfig,
+	isBrowser,
 	urlSafeEncode,
 } from '@aws-amplify/core/internals/utils';
 
@@ -87,7 +88,7 @@ const oauthSignIn = async ({
 	const { value, method, toCodeChallenge } = generateCodeVerifier(128);
 	const redirectUri = getRedirectUrl(oauthConfig.redirectSignIn);
 
-	oAuthStore.storeOAuthInFlight(true);
+	if (isBrowser()) oAuthStore.storeOAuthInFlight(true);
 	oAuthStore.storeOAuthState(state);
 	oAuthStore.storePKCE(value);
 

--- a/packages/auth/src/providers/cognito/apis/signUp.ts
+++ b/packages/auth/src/providers/cognito/apis/signUp.ts
@@ -96,6 +96,7 @@ export async function signUp(input: SignUpInput): Promise<SignUpOutput> {
 			nextStep: {
 				signUpStep: 'COMPLETE_AUTO_SIGN_IN',
 			},
+			userId: UserSub,
 		};
 	} else if (isSignUpComplete(clientOutput) && !isAutoSignInStarted()) {
 		return {
@@ -103,6 +104,7 @@ export async function signUp(input: SignUpInput): Promise<SignUpOutput> {
 			nextStep: {
 				signUpStep: 'DONE',
 			},
+			userId: UserSub,
 		};
 	} else if (
 		!isSignUpComplete(clientOutput) &&

--- a/packages/aws-amplify/__tests__/adapterCore/authProvidersFactories/cognito/createAWSCredentialsAndIdentityIdProvider.test.ts
+++ b/packages/aws-amplify/__tests__/adapterCore/authProvidersFactories/cognito/createAWSCredentialsAndIdentityIdProvider.test.ts
@@ -5,11 +5,8 @@ import {
 	CognitoAWSCredentialsAndIdentityIdProvider,
 	DefaultIdentityIdStore,
 } from '@aws-amplify/auth/cognito';
-import {
-	CredentialsAndIdentityIdProvider,
-	AuthConfig,
-	KeyValueStorageInterface,
-} from '@aws-amplify/core';
+import { AuthConfig, KeyValueStorageInterface } from '@aws-amplify/core';
+
 import { createAWSCredentialsAndIdentityIdProvider } from '../../../../src/adapter-core';
 
 jest.mock('@aws-amplify/auth/cognito');

--- a/packages/aws-amplify/__tests__/adapterCore/authProvidersFactories/cognito/createUserPoolsTokenProvider.test.ts
+++ b/packages/aws-amplify/__tests__/adapterCore/authProvidersFactories/cognito/createUserPoolsTokenProvider.test.ts
@@ -6,8 +6,8 @@ import {
 	TokenOrchestrator,
 	refreshAuthTokens,
 } from '@aws-amplify/auth/cognito';
-
 import { AuthConfig, KeyValueStorageInterface } from '@aws-amplify/core';
+
 import { createUserPoolsTokenProvider } from '../../../../src/adapter-core';
 
 jest.mock('@aws-amplify/auth/cognito');

--- a/packages/aws-amplify/__tests__/adapterCore/runWithAmplifyServerContext.test.ts
+++ b/packages/aws-amplify/__tests__/adapterCore/runWithAmplifyServerContext.test.ts
@@ -1,11 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { runWithAmplifyServerContext } from '../../src/adapter-core';
 import {
 	createAmplifyServerContext,
 	destroyAmplifyServerContext,
 } from '@aws-amplify/core/internals/adapter-core';
+
+import { runWithAmplifyServerContext } from '../../src/adapter-core';
 
 // mock serverContext
 jest.mock('@aws-amplify/core/internals/adapter-core');

--- a/packages/aws-amplify/__tests__/initSingleton.test.ts
+++ b/packages/aws-amplify/__tests__/initSingleton.test.ts
@@ -7,11 +7,11 @@ import {
 	ResourcesConfig,
 	defaultStorage,
 } from '@aws-amplify/core';
-import {
-	cognitoUserPoolsTokenProvider,
-	cognitoCredentialsProvider,
-} from '../src/auth/cognito';
 
+import {
+	cognitoCredentialsProvider,
+	cognitoUserPoolsTokenProvider,
+} from '../src/auth/cognito';
 import { Amplify } from '../src';
 
 jest.mock('@aws-amplify/core');

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -335,7 +335,7 @@
 			"name": "[API] generateClient (AppSync)",
 			"path": "./dist/esm/api/index.mjs",
 			"import": "{ generateClient }",
-			"limit": "38.00 kB"
+			"limit": "38.5 kB"
 		},
 		{
 			"name": "[API] REST API handlers",

--- a/packages/core/__tests__/BackgroundProcessManager.test.ts
+++ b/packages/core/__tests__/BackgroundProcessManager.test.ts
@@ -1,4 +1,5 @@
 import { Observable } from 'rxjs';
+
 import { BackgroundProcessManager } from '../src/BackgroundProcessManager';
 import { BackgroundProcessManagerState } from '../src/BackgroundProcessManager/types';
 
@@ -95,9 +96,9 @@ describe('BackgroundProcessManager', () => {
 		const manager = new BackgroundProcessManager();
 
 		const resultPromise = manager.add(async () => {
-			return new Promise((resolve, raise) => {
+			return new Promise((resolve, reject) => {
 				setTimeout(() => {
-					raise(new Error('a fuss'));
+					reject(new Error('a fuss'));
 				}, 50);
 			});
 		});
@@ -145,7 +146,7 @@ describe('BackgroundProcessManager', () => {
 		const manager = new BackgroundProcessManager();
 
 		// add a job that will not have completed by the time we open() again
-		manager.add(async () => new Promise(unsleep => setTimeout(unsleep, 10)));
+		manager.add(async () => new Promise(resolve => setTimeout(resolve, 10)));
 
 		// close, but don't want, because we want to prove that open() will wait
 		// internally for close to resolve before re-opening.
@@ -175,8 +176,13 @@ describe('BackgroundProcessManager', () => {
 		expect(manager.isClosing).toBe(false);
 		expect(manager.isClosed).toBe(false);
 
-		let unblock;
-		manager.add(async () => new Promise(_unblock => (unblock = _unblock)));
+		let unblock: () => void = () => undefined;
+		manager.add(
+			async () =>
+				new Promise<void>(resolve => {
+					unblock = resolve;
+				}),
+		);
 
 		expect(manager.state).toEqual(BackgroundProcessManagerState.Open);
 		expect(manager.isOpen).toBe(true);
@@ -194,7 +200,7 @@ describe('BackgroundProcessManager', () => {
 		// promise layers handling by awaiting another promise before the
 		// manager can register completion.
 
-		unblock();
+		unblock?.();
 		await new Promise(process.nextTick);
 
 		expect(manager.state).toEqual(BackgroundProcessManagerState.Closed);
@@ -251,8 +257,8 @@ describe('BackgroundProcessManager', () => {
 		let completed = false;
 		const manager = new BackgroundProcessManager();
 
-		const resultPromise = manager.add(async onTerminate => {
-			return new Promise<void>((resolve, reject) => {
+		const _ = manager.add(async (onTerminate: Promise<void>) => {
+			return new Promise<void>((resolve, _reject) => {
 				const timer = setTimeout(() => {
 					// this is the happy path that we plan not to reach in
 					// this test.
@@ -287,10 +293,11 @@ describe('BackgroundProcessManager', () => {
 
 	test('can send termination signals to jobs that support termination, with reject', async () => {
 		let completed = false;
-		let thrown = undefined;
+		let thrown;
 		const manager = new BackgroundProcessManager();
+		const expectedError = new Error('badness happened');
 
-		const resultPromise = manager.add(async onTerminate => {
+		const resultPromise = manager.add(async (onTerminate: Promise<void>) => {
 			return new Promise<void>((resolve, reject) => {
 				const timer = setTimeout(() => {
 					// this is the happy path that we plan not to reach in
@@ -304,7 +311,7 @@ describe('BackgroundProcessManager', () => {
 				// or reject.
 				onTerminate.then(() => {
 					clearTimeout(timer);
-					reject('badness happened');
+					reject(expectedError);
 				});
 			});
 		});
@@ -328,7 +335,7 @@ describe('BackgroundProcessManager', () => {
 
 		// then making sure the job really really didn't fire.
 		expect(completed).toBe(false);
-		expect(thrown).toEqual('badness happened');
+		expect(thrown).toEqual(expectedError);
 	});
 
 	test('attempts to terminate all, but patiently waits for persistent jobs', async () => {
@@ -340,7 +347,7 @@ describe('BackgroundProcessManager', () => {
 		for (let i = 0; i < 10; i++) {
 			const _i = i;
 			results.push(false);
-			manager.add(async onTerminate => {
+			manager.add(async (onTerminate: Promise<void>) => {
 				return new Promise<void>((resolve, reject) => {
 					const timer = setTimeout(() => {
 						results[_i] = true;
@@ -356,7 +363,7 @@ describe('BackgroundProcessManager', () => {
 
 							// remember, if a job *does* terminate, it still
 							// needs resolve/reject to unblock `close()`.
-							_i > 5 ? resolve() : reject();
+							_i > 5 ? resolve() : reject(new Error());
 						}
 					});
 				});
@@ -370,7 +377,9 @@ describe('BackgroundProcessManager', () => {
 		expect(results.length).toEqual(10); // sanity check
 		expect(results.filter(v => v === true).length).toBe(5);
 		expect(terminationAttemptCount).toEqual(10);
-		expect(resolutions.filter(r => r.status === 'rejected').length).toEqual(3);
+		expect(
+			resolutions.filter((r: any) => r.status === 'rejected').length,
+		).toEqual(3);
 	});
 
 	test('can be used to terminate other types of bg jobs, like zen subscriptions', async () => {
@@ -383,7 +392,9 @@ describe('BackgroundProcessManager', () => {
 		// that the observable constructor can manage it like a hook.
 		new Observable(observer => {
 			const { resolve, onTerminate } = manager.add();
-			const interval = setInterval(() => observer.next({}), 10);
+			const interval = setInterval(() => {
+				observer.next({});
+			}, 10);
 
 			const unsubscribe = () => {
 				resolve(); // always remember to resolve/reject!
@@ -392,6 +403,7 @@ describe('BackgroundProcessManager', () => {
 			};
 
 			onTerminate.then(unsubscribe);
+
 			return unsubscribe;
 		}).subscribe(() => count++);
 
@@ -414,8 +426,10 @@ describe('BackgroundProcessManager', () => {
 		const manager = new BackgroundProcessManager();
 		let count = 0;
 
-		const subscription = new Observable(observer => {
-			const interval = setInterval(() => observer.next({}), 10);
+		new Observable(observer => {
+			const interval = setInterval(() => {
+				observer.next({});
+			}, 10);
 
 			// LOOK: here's the magic. (tada!)
 			return manager.addCleaner(async () => {
@@ -443,7 +457,9 @@ describe('BackgroundProcessManager', () => {
 		let count = 0;
 
 		const subscription = new Observable(observer => {
-			const interval = setInterval(() => observer.next({}), 10);
+			const interval = setInterval(() => {
+				observer.next({});
+			}, 10);
 
 			// LOOK: here's the magic. (tada!)
 			return manager.addCleaner(async () => {
@@ -494,7 +510,7 @@ describe('BackgroundProcessManager', () => {
 
 		// accumulate a bunch of close promises, only the first of which should
 		// send the close signal, but all of which should await resolution.
-		const closes = [0, 1, 2, 3, 4, 5].map(i => manager.close());
+		const closes = [0, 1, 2, 3, 4, 5].map(() => manager.close());
 
 		// ensure everything has settled
 		const resolved = await Promise.allSettled(closes);
@@ -556,7 +572,7 @@ describe('BackgroundProcessManager', () => {
 		const manager = new BackgroundProcessManager();
 
 		manager.add(
-			async () => new Promise(unsleep => setTimeout(unsleep, 1)),
+			async () => new Promise(resolve => setTimeout(resolve, 1)),
 			'async function',
 		);
 
@@ -571,9 +587,9 @@ describe('BackgroundProcessManager', () => {
 		const manager = new BackgroundProcessManager();
 
 		manager.add(
-			async onTerminate =>
-				new Promise(finishJob => {
-					onTerminate.then(finishJob);
+			async (onTerminate: Promise<void>) =>
+				new Promise(resolve => {
+					onTerminate.then(resolve);
 				}),
 			'cancelable async function',
 		);
@@ -613,9 +629,7 @@ describe('BackgroundProcessManager', () => {
 	test('cleaners can be named', async () => {
 		const manager = new BackgroundProcessManager();
 
-		manager.addCleaner(async () => {
-			// no op
-		}, 'cleaner name');
+		manager.addCleaner(() => Promise.resolve(), 'cleaner name');
 
 		expect(manager.pending.length).toBe(1);
 		expect(manager.pending[0]).toEqual('cleaner name');
@@ -627,27 +641,27 @@ describe('BackgroundProcessManager', () => {
 		const manager = new BackgroundProcessManager();
 		await manager.close();
 
-		await expect(manager.add(async () => {}, 'some job')).rejects.toThrow(
-			'some job',
-		);
+		await expect(
+			manager.add(() => Promise.resolve(), 'some job'),
+		).rejects.toThrow('some job');
 	});
 
 	test('manager closed error shows names of pending items in error', async () => {
 		const manager = new BackgroundProcessManager();
 
-		let unblock;
+		let unblock: any;
 		manager.add(
-			() => new Promise(_unblock => (unblock = _unblock)),
+			() => new Promise<void>(resolve => (unblock = resolve)),
 			'blocking job',
 		);
 
 		const close = manager.close();
 
-		await expect(manager.add(async () => {}, 'some job')).rejects.toThrow(
-			'blocking job',
-		);
+		await expect(
+			manager.add(() => Promise.resolve(), 'some job'),
+		).rejects.toThrow('blocking job');
 
-		unblock();
+		unblock?.();
 		await close;
 	});
 });

--- a/packages/core/__tests__/Cache/StorageCache.test.ts
+++ b/packages/core/__tests__/Cache/StorageCache.test.ts
@@ -46,8 +46,8 @@ describe('StorageCache', () => {
 		}
 	}
 	// create test helpers
-	const getStorageCache = (config?: CacheConfig) =>
-		new StorageCacheTest(config);
+	const getStorageCache = (storageCacheConfig?: CacheConfig) =>
+		new StorageCacheTest(storageCacheConfig);
 
 	beforeAll(() => {
 		mockGetCurrentSizeKey.mockReturnValue(currentSizeKey);

--- a/packages/core/__tests__/Cache/utils/CacheList.test.ts
+++ b/packages/core/__tests__/Cache/utils/CacheList.test.ts
@@ -125,8 +125,8 @@ describe('CacheList', () => {
 			test('get all keys in the list', () => {
 				const list: CacheList = new CacheList();
 				const keys: string[] = ['0', '1', '2'];
-				for (let i = 0; i < keys.length; i++) {
-					list.insertItem(keys[i]);
+				for (const key of keys) {
+					list.insertItem(key);
 				}
 
 				const listKeys: string[] = list.getKeys();

--- a/packages/core/__tests__/Cache/utils/cacheUtils.test.ts
+++ b/packages/core/__tests__/Cache/utils/cacheUtils.test.ts
@@ -3,7 +3,7 @@ import { getByteLength } from '../../../src/Cache/utils/cacheHelpers';
 describe('cacheHelpers', () => {
 	describe('getByteLength()', () => {
 		test('happy case', () => {
-			const str: string = 'abc';
+			const str = 'abc';
 			expect(getByteLength(str)).toBe(3);
 
 			const str2: string = String.fromCharCode(0x80);

--- a/packages/core/__tests__/ConsoleLogger.test.ts
+++ b/packages/core/__tests__/ConsoleLogger.test.ts
@@ -1,22 +1,22 @@
 import { ConsoleLogger } from '../src';
-import { LoggingProvider, LogType } from '../src/Logger/types';
+import { LogType, LoggingProvider } from '../src/Logger/types';
 
 type LogEvent = 'verbose' | 'debug' | 'info' | 'warn' | 'error';
 
 describe('ConsoleLogger', () => {
 	beforeAll(() => {
-		jest.spyOn(console, 'log').mockImplementation(() => {});
-		jest.spyOn(console, 'error').mockImplementation(() => {});
-		jest.spyOn(console, 'warn').mockImplementation(() => {});
-		jest.spyOn(console, 'info').mockImplementation(() => {});
-		jest.spyOn(console, 'debug').mockImplementation(() => {});
+		jest.spyOn(console, 'log');
+		jest.spyOn(console, 'error');
+		jest.spyOn(console, 'warn');
+		jest.spyOn(console, 'info');
+		jest.spyOn(console, 'debug');
 	});
 	afterEach(() => {
 		jest.clearAllMocks();
 	});
 
 	describe('pluggables', () => {
-		/*it('should store pluggables correctly when addPluggable is called', () => {
+		/* it('should store pluggables correctly when addPluggable is called', () => {
 			const provider = new AWSCloudWatchProvider();
 			const logger = new Logger('name');
 			logger.addPluggable(provider);
@@ -26,7 +26,7 @@ describe('ConsoleLogger', () => {
 			expect(pluggables[0].getProviderName()).toEqual(
 				AWS_CLOUDWATCH_PROVIDER_NAME
 			);
-		});*/
+		}); */
 
 		it('should do nothing when no plugin is provided to addPluggable', () => {
 			const logger = new ConsoleLogger('name');
@@ -38,16 +38,16 @@ describe('ConsoleLogger', () => {
 
 		it('should do nothing when a non-logging category plugin is provided to addPluggable', () => {
 			const provider = {
-				getCategoryName: function () {
+				getCategoryName: () => {
 					return 'non-logging';
 				},
-				getProviderName: function () {
+				getProviderName: () => {
 					return 'lol';
 				},
-				configure: function () {
+				configure: () => {
 					return {};
 				},
-				pushLogs: () => {},
+				pushLogs: jest.fn(),
 			} as LoggingProvider;
 
 			const logger = new ConsoleLogger('name');

--- a/packages/core/__tests__/DateUtils.test.ts
+++ b/packages/core/__tests__/DateUtils.test.ts
@@ -1,16 +1,15 @@
 import { DateUtils } from '../src/Signer/DateUtils';
 
-// Mock Date (https://github.com/facebook/jest/issues/2234#issuecomment-308121037)
-const OriginalDate = Date;
-// @ts-ignore Type 'typeof Date' is not assignable to type 'DateConstructor'.
-Date = class extends Date {
-	// @ts-ignore Constructors for derived classes must contain a 'super' call.ts(2377)
-	constructor() {
-		return new OriginalDate('2020-01-01');
-	}
-};
-
 describe('DateUtils', () => {
+	beforeAll(() => {
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date('2020-01-01'));
+	});
+
+	afterAll(() => {
+		jest.useRealTimers();
+	});
+
 	describe('getDateWithClockOffset()', () => {
 		it('should return a new Date()', () => {
 			expect(DateUtils.getDateWithClockOffset()).toEqual(new Date());
@@ -63,7 +62,7 @@ describe('DateUtils', () => {
 
 		it('should be true when over 5 minutes', () => {
 			const serverDate = new Date();
-			serverDate.setMinutes(5);
+			serverDate.setMinutes(5, 0, 1000);
 
 			expect(DateUtils.isClockSkewed(serverDate)).toBe(true);
 		});

--- a/packages/core/__tests__/Hub.test.ts
+++ b/packages/core/__tests__/Hub.test.ts
@@ -1,4 +1,4 @@
-import { Hub, AMPLIFY_SYMBOL } from '../src/Hub';
+import { Hub } from '../src/Hub';
 import { ConsoleLogger } from '../src';
 
 describe('Hub', () => {
@@ -9,7 +9,7 @@ describe('Hub', () => {
 	});
 
 	test('happy case', () => {
-		const listener = jest.fn(() => {});
+		const listener = jest.fn();
 
 		Hub.listen('auth', listener);
 
@@ -28,7 +28,7 @@ describe('Hub', () => {
 	});
 
 	test('Protected channel', () => {
-		const listener = jest.fn(() => {});
+		const listener = jest.fn();
 
 		Hub.listen('auth', listener);
 
@@ -50,7 +50,7 @@ describe('Hub', () => {
 	});
 
 	test('Protected channel - ui', () => {
-		const listener = jest.fn(() => {});
+		const listener = jest.fn();
 
 		Hub.listen('ui', listener);
 
@@ -67,7 +67,7 @@ describe('Hub', () => {
 		);
 	});
 	test('Remove listener', () => {
-		const listener = jest.fn(() => {});
+		const listener = jest.fn();
 
 		const unsubscribe = Hub.listen('auth', listener);
 

--- a/packages/core/__tests__/JS-browser-runtime.test.ts
+++ b/packages/core/__tests__/JS-browser-runtime.test.ts
@@ -9,12 +9,11 @@ describe('isBrowser build test', () => {
 	// testing the Node.js process.
 	const originalVersions = process.versions;
 	beforeEach(() => {
-		//@ts-ignore
+		// @ts-expect-error test overrides
 		delete global.process.versions;
 	});
 
 	afterEach(() => {
-		//@ts-ignore
 		global.process.versions = originalVersions;
 	});
 

--- a/packages/core/__tests__/Mutex.test.ts
+++ b/packages/core/__tests__/Mutex.test.ts
@@ -24,12 +24,12 @@
 
 import { Mutex } from '../src/Mutex';
 
-describe('Mutex', function () {
+describe('Mutex', () => {
 	let mutex: Mutex;
 
 	beforeEach(() => (mutex = new Mutex()));
 
-	test('ownership is exclusive', function () {
+	test('ownership is exclusive', () => {
 		let flag = false;
 
 		mutex.acquire().then(release =>
@@ -46,39 +46,51 @@ describe('Mutex', function () {
 		});
 	});
 
-	test('runExclusive passes result (immediate)', function () {
+	test('runExclusive passes result (immediate)', () => {
 		return mutex
 			.runExclusive<number>(() => 10)
-			.then(value => expect(value).toBe(10));
+			.then(value => {
+				expect(value).toBe(10);
+			});
 	});
 
-	test('runExclusive passes result (promise)', function () {
+	test('runExclusive passes result (promise)', () => {
 		return mutex
 			.runExclusive<number>(() => Promise.resolve(10))
-			.then(value => expect(value).toBe(10));
+			.then(value => {
+				expect(value).toBe(10);
+			});
 	});
 
-	test('runExclusive passes rejection', function () {
+	test('runExclusive passes rejection', () => {
+		const expectedError = new Error('foo');
+
 		return mutex
-			.runExclusive<number>(() => Promise.reject('foo'))
+			.runExclusive<number>(() => Promise.reject(expectedError))
 			.then(
-				() => Promise.reject('should have been rejected'),
-				value => expect(value).toBe('foo'),
+				() => Promise.reject(new Error('should have been rejected')),
+				value => {
+					expect(value).toBe(expectedError);
+				},
 			);
 	});
 
-	test('runExclusive passes exception', function () {
+	test('runExclusive passes exception', () => {
+		const expectedError = new Error('foo');
+
 		return mutex
 			.runExclusive<number>(() => {
-				throw 'foo';
+				throw expectedError;
 			})
 			.then(
-				() => Promise.reject('should have been rejected'),
-				value => expect(value).toBe('foo'),
+				() => Promise.reject(new Error('should have been rejected')),
+				value => {
+					expect(value).toBe(expectedError);
+				},
 			);
 	});
 
-	test('runExclusive is exclusive', function () {
+	test('runExclusive is exclusive', () => {
 		let flag = false;
 
 		mutex.runExclusive(
@@ -91,10 +103,12 @@ describe('Mutex', function () {
 				),
 		);
 
-		return mutex.runExclusive(() => expect(flag).toBe(true));
+		return mutex.runExclusive(() => {
+			expect(flag).toBe(true);
+		});
 	});
 
-	test('exceptions during runExclusive do not leave mutex locked', function () {
+	test('exceptions during runExclusive do not leave mutex locked', () => {
 		let flag = false;
 
 		mutex
@@ -107,16 +121,18 @@ describe('Mutex', function () {
 				() => undefined,
 			);
 
-		return mutex.runExclusive(() => expect(flag).toBe(true));
+		return mutex.runExclusive(() => {
+			expect(flag).toBe(true);
+		});
 	});
 
-	test('new mutex is unlocked', function () {
+	test('new mutex is unlocked', () => {
 		expect(!mutex.isLocked()).toBe(true);
 	});
 
-	test('isLocked reflects the mutex state', async function () {
-		const lock1 = mutex.acquire(),
-			lock2 = mutex.acquire();
+	test('isLocked reflects the mutex state', async () => {
+		const lock1 = mutex.acquire();
+		const lock2 = mutex.acquire();
 
 		expect(mutex.isLocked()).toBe(true);
 

--- a/packages/core/__tests__/Platform/customUserAgent.test.ts
+++ b/packages/core/__tests__/Platform/customUserAgent.test.ts
@@ -1,8 +1,9 @@
 import {
-	Category,
+	AdditionalDetails,
 	AuthAction,
-	StorageAction,
+	Category,
 	SetCustomUserAgentInput,
+	StorageAction,
 } from '../../src/Platform/types';
 
 const MOCK_AUTH_UA_STATE: SetCustomUserAgentInput = {
@@ -18,15 +19,18 @@ const MOCK_STORAGE_UA_STATE: SetCustomUserAgentInput = {
 };
 
 describe('Custom user agent utilities', () => {
-	let getCustomUserAgent;
-	let setCustomUserAgent;
+	let getCustomUserAgent: (
+		category: string,
+		api: string,
+	) => AdditionalDetails | undefined;
+	let setCustomUserAgent: (input: SetCustomUserAgentInput) => () => void;
 
 	beforeEach(() => {
 		jest.resetModules();
-		getCustomUserAgent =
-			require('../../src/Platform/customUserAgent').getCustomUserAgent;
-		setCustomUserAgent =
-			require('../../src/Platform/customUserAgent').setCustomUserAgent;
+		({
+			getCustomUserAgent,
+			setCustomUserAgent,
+		} = require('../../src/Platform/customUserAgent'));
 	});
 
 	it('sets custom user agent state for multiple categories and APIs', () => {

--- a/packages/core/__tests__/Platform/userAgent.test.ts
+++ b/packages/core/__tests__/Platform/userAgent.test.ts
@@ -1,18 +1,13 @@
 import {
-	getAmplifyUserAgentObject,
-	getAmplifyUserAgent,
 	Platform,
+	getAmplifyUserAgent,
+	getAmplifyUserAgentObject,
 } from '../../src/Platform';
 import { version } from '../../src/Platform/version';
+import { AuthAction, Category, Framework } from '../../src/Platform/types';
 import {
-	ApiAction,
-	AuthAction,
-	Category,
-	Framework,
-} from '../../src/Platform/types';
-import {
-	detectFramework,
 	clearCache,
+	detectFramework,
 } from '../../src/Platform/detectFramework';
 import * as detection from '../../src/Platform/detection';
 import { getCustomUserAgent } from '../../src/Platform/customUserAgent';

--- a/packages/core/__tests__/Retry.test.ts
+++ b/packages/core/__tests__/Retry.test.ts
@@ -1,7 +1,7 @@
 import {
-	retry,
-	jitteredExponentialRetry,
 	NonRetryableError,
+	jitteredExponentialRetry,
+	retry,
 } from '../src/utils/retry';
 import { BackgroundProcessManager } from '../src/BackgroundProcessManager';
 
@@ -60,9 +60,10 @@ describe('retry', () => {
 			}
 		}
 
-		function delayFunction(attempt, args) {
-			receivedAttempt = attempt;
+		function delayFunction(attemptForDelayed: number, args: any[] | undefined) {
+			receivedAttempt = attemptForDelayed;
 			receivedArgs = args;
+
 			return 1;
 		}
 
@@ -83,6 +84,7 @@ describe('retry', () => {
 				return false;
 			}
 			count++;
+
 			return 1;
 		}
 

--- a/packages/core/__tests__/ServiceWorker.test.ts
+++ b/packages/core/__tests__/ServiceWorker.test.ts
@@ -17,11 +17,11 @@ describe('ServiceWorker test', () => {
 				serviceWorker.enablePush('publicKey');
 			};
 
-			return expect(enablePush).toThrow(AmplifyError);
+			expect(enablePush).toThrow(AmplifyError);
 		});
 		test('fails when registering', async () => {
 			(global as any).navigator.serviceWorker = {
-				register: () => Promise.reject('an error'),
+				register: () => Promise.reject(new Error('an error')),
 			};
 
 			const serviceWorker = new ServiceWorker();
@@ -38,7 +38,11 @@ describe('ServiceWorker test', () => {
 		const statuses = ['installing', 'waiting', 'active'];
 		statuses.forEach(status => {
 			test(`can register (${status})`, () => {
-				const bla = { [status]: { addEventListener: () => {} } };
+				const bla = {
+					[status]: {
+						addEventListener: jest.fn(),
+					},
+				};
 				(global as any).navigator.serviceWorker = {
 					register: () => Promise.resolve(bla),
 				};
@@ -62,7 +66,7 @@ describe('ServiceWorker test', () => {
 				const serviceWorker = new ServiceWorker();
 				await serviceWorker.register();
 
-				return expect(bla[status].addEventListener).toHaveBeenCalledTimes(2);
+				expect(bla[status].addEventListener).toHaveBeenCalledTimes(2);
 			});
 		});
 	});
@@ -80,7 +84,7 @@ describe('ServiceWorker test', () => {
 
 			serviceWorker.send('A message');
 
-			return expect(bla.installing.postMessage).toHaveBeenCalledTimes(0);
+			expect(bla.installing.postMessage).toHaveBeenCalledTimes(0);
 		});
 		test('can send string message after registration', async () => {
 			const bla = {
@@ -96,9 +100,7 @@ describe('ServiceWorker test', () => {
 
 			serviceWorker.send('A message');
 
-			return expect(bla.installing.postMessage).toHaveBeenCalledWith(
-				'A message',
-			);
+			expect(bla.installing.postMessage).toHaveBeenCalledWith('A message');
 		});
 		test('can send object message after registration', async () => {
 			const bla = {
@@ -114,7 +116,7 @@ describe('ServiceWorker test', () => {
 
 			serviceWorker.send({ property: 'value' });
 
-			return expect(bla.installing.postMessage).toHaveBeenCalledWith(
+			expect(bla.installing.postMessage).toHaveBeenCalledWith(
 				JSON.stringify({ property: 'value' }),
 			);
 		});

--- a/packages/core/__tests__/Signer.test.ts
+++ b/packages/core/__tests__/Signer.test.ts
@@ -5,6 +5,7 @@ import { SignRequestOptions } from '../src/clients/middleware/signing/signer/sig
 import { Signer } from '../src/Signer';
 import { DateUtils } from '../src/Signer/DateUtils';
 import * as getSignatureModule from '../src/clients/middleware/signing/signer/signatureV4/utils/getSignature';
+
 import {
 	credentials,
 	credentialsWithToken,
@@ -39,6 +40,7 @@ describe('Signer.sign', () => {
 					...signingOptions,
 					...options,
 				};
+
 				return [name, updatedRequest, updatedOptions, expectedAuthorization];
 			},
 		),
@@ -46,22 +48,26 @@ describe('Signer.sign', () => {
 		'signs request with %s',
 		(
 			_,
-			{ url, ...request },
-			{ credentials, signingRegion, signingService },
+			{ url: testUrl, ...request },
+			{
+				credentials: testCredentials,
+				signingRegion: testSigningRegion,
+				signingService: testSigningService,
+			},
 			expected,
 		) => {
-			const { accessKeyId, secretAccessKey, sessionToken } = credentials;
+			const { accessKeyId, secretAccessKey, sessionToken } = testCredentials;
 			const accessInfo = {
 				access_key: accessKeyId,
 				secret_key: secretAccessKey,
 				session_token: sessionToken,
 			};
 			const serviceInfo = {
-				region: signingRegion,
-				service: signingService,
+				region: testSigningRegion,
+				service: testSigningService,
 			};
 			const signedRequest = Signer.sign(
-				{ ...request, url: url.toString() },
+				{ ...request, url: testUrl.toString() },
 				accessInfo as any,
 				serviceInfo as any,
 			);
@@ -146,6 +152,7 @@ describe('Signer.signUrl', () => {
 					...signingOptions,
 					...options,
 				};
+
 				return [name, updatedRequest, updatedOptions, expectedUrl];
 			},
 		),
@@ -153,22 +160,26 @@ describe('Signer.signUrl', () => {
 		'signs url with %s',
 		(
 			_,
-			{ url, ...request },
-			{ credentials, signingRegion, signingService },
+			{ url: testUrl, ...request },
+			{
+				credentials: testCredentials,
+				signingRegion: testSigningRegion,
+				signingService: testSigningService,
+			},
 			expected,
 		) => {
-			const { accessKeyId, secretAccessKey, sessionToken } = credentials;
+			const { accessKeyId, secretAccessKey, sessionToken } = testCredentials;
 			const accessInfo = {
 				access_key: accessKeyId,
 				secret_key: secretAccessKey,
 				session_token: sessionToken,
 			};
 			const serviceInfo = {
-				region: signingRegion,
-				service: signingService,
+				region: testSigningRegion,
+				service: testSigningService,
 			};
 			const signedUrl = Signer.signUrl(
-				{ ...request, url: url.toString() },
+				{ ...request, url: testUrl.toString() },
 				accessInfo,
 				serviceInfo as any,
 			);

--- a/packages/core/__tests__/StringUtils.test.ts
+++ b/packages/core/__tests__/StringUtils.test.ts
@@ -1,5 +1,7 @@
-import { urlSafeEncode, urlSafeDecode } from '../src/utils';
 import { TextDecoder, TextEncoder } from 'util';
+
+import { urlSafeDecode, urlSafeEncode } from '../src/utils';
+
 (global as any).TextEncoder = TextEncoder;
 (global as any).TextDecoder = TextDecoder;
 

--- a/packages/core/__tests__/adapterCore/serverContext.test.ts
+++ b/packages/core/__tests__/adapterCore/serverContext.test.ts
@@ -3,8 +3,8 @@
 
 import {
 	createAmplifyServerContext,
-	getAmplifyServerContext,
 	destroyAmplifyServerContext,
+	getAmplifyServerContext,
 } from '../../src/adapterCore';
 
 const mockConfigure = jest.fn();

--- a/packages/core/__tests__/awsClients/cognitoIdentity/getCredentialsForIdentity.test.ts
+++ b/packages/core/__tests__/awsClients/cognitoIdentity/getCredentialsForIdentity.test.ts
@@ -1,8 +1,8 @@
 import { fetchTransferHandler } from '../../../src/clients/handlers/fetch';
 import {
-	getCredentialsForIdentity,
 	GetCredentialsForIdentityInput,
 	GetCredentialsForIdentityOutput,
+	getCredentialsForIdentity,
 } from '../../../src/awsClients/cognitoIdentity';
 import {
 	cognitoIdentityHandlerOptions,

--- a/packages/core/__tests__/awsClients/cognitoIdentity/getId.test.ts
+++ b/packages/core/__tests__/awsClients/cognitoIdentity/getId.test.ts
@@ -1,8 +1,8 @@
 import { fetchTransferHandler } from '../../../src/clients/handlers/fetch';
 import {
-	getId,
 	GetIdInput,
 	GetIdOutput,
+	getId,
 } from '../../../src/awsClients/cognitoIdentity';
 import {
 	cognitoIdentityHandlerOptions,

--- a/packages/core/__tests__/awsClients/pinpoint/getInAppMessages.test.ts
+++ b/packages/core/__tests__/awsClients/pinpoint/getInAppMessages.test.ts
@@ -3,9 +3,9 @@
 
 import { fetchTransferHandler } from '../../../src/clients/handlers/fetch';
 import {
-	getInAppMessages,
 	GetInAppMessagesInput,
 	GetInAppMessagesOutput,
+	getInAppMessages,
 } from '../../../src/awsClients/pinpoint';
 import {
 	mockApplicationId,

--- a/packages/core/__tests__/awsClients/pinpoint/putEvents.test.ts
+++ b/packages/core/__tests__/awsClients/pinpoint/putEvents.test.ts
@@ -3,9 +3,9 @@
 
 import { fetchTransferHandler } from '../../../src/clients/handlers/fetch';
 import {
-	putEvents,
 	PutEventsInput,
 	PutEventsOutput,
+	putEvents,
 } from '../../../src/awsClients/pinpoint';
 import {
 	mockApplicationId,

--- a/packages/core/__tests__/awsClients/pinpoint/updateEndpoint.test.ts
+++ b/packages/core/__tests__/awsClients/pinpoint/updateEndpoint.test.ts
@@ -3,9 +3,9 @@
 
 import { fetchTransferHandler } from '../../../src/clients/handlers/fetch';
 import {
-	updateEndpoint,
 	UpdateEndpointInput,
 	UpdateEndpointOutput,
+	updateEndpoint,
 } from '../../../src/awsClients/pinpoint';
 import {
 	mockApplicationId,

--- a/packages/core/__tests__/awsClients/testUtils/data.ts
+++ b/packages/core/__tests__/awsClients/testUtils/data.ts
@@ -20,6 +20,7 @@ export const mockJsonResponse = ({
 		blob: async () => fail('blob() should not be called'),
 		text: async () => fail('text() should not be called'),
 	} as HttpResponse['body'];
+
 	return {
 		statusCode: status,
 		headers,

--- a/packages/core/__tests__/clients/composeApiHandler.test.ts
+++ b/packages/core/__tests__/clients/composeApiHandler.test.ts
@@ -20,19 +20,15 @@ describe(composeServiceApi.name, () => {
 
 	test('should call transfer handler with resolved config including default config values', async () => {
 		const mockTransferHandler = jest.fn().mockResolvedValue(defaultResponse);
-		const config = {
-			...defaultConfig,
-			foo: 'bar',
-		};
 		const api = composeServiceApi(
 			mockTransferHandler,
-			input => defaultRequest,
-			async output => ({
+			() => defaultRequest,
+			async () => ({
 				Result: 'from API',
 			}),
 			defaultConfig,
 		);
-		const output = await api({ bar: 'baz', foo: 'foo' }, 'Input');
+		await api({ bar: 'baz', foo: 'foo' }, 'Input');
 		expect(mockTransferHandler).toHaveBeenCalledTimes(1);
 		expect(mockTransferHandler).toHaveBeenCalledWith(
 			defaultRequest,
@@ -51,8 +47,8 @@ describe(composeServiceApi.name, () => {
 		};
 		const api = composeServiceApi(
 			mockTransferHandler,
-			input => defaultRequest,
-			async output => ({
+			() => defaultRequest,
+			async () => ({
 				Result: 'from API',
 			}),
 			defaultConfig,
@@ -67,7 +63,7 @@ describe(composeServiceApi.name, () => {
 
 	test('should call serializer and deserializer', async () => {
 		const mockTransferHandler = jest.fn().mockResolvedValue(defaultResponse);
-		const defaultConfig = {
+		const defaultConfigWithEndpointResolver = {
 			foo: 'bar',
 			endpointResolver: jest.fn().mockReturnValue('https://a.b'),
 		};
@@ -79,13 +75,13 @@ describe(composeServiceApi.name, () => {
 			mockTransferHandler,
 			mockSerializer,
 			mockDeserializer,
-			defaultConfig,
+			defaultConfigWithEndpointResolver,
 		);
-		const output = await api({ bar: 'baz', foo: 'foo' }, 'Input');
+		await api({ bar: 'baz', foo: 'foo' }, 'Input');
 		expect(mockSerializer).toHaveBeenCalledTimes(1);
 		expect(mockSerializer).toHaveBeenCalledWith(
 			'Input',
-			defaultConfig.endpointResolver.mock.results[0].value,
+			defaultConfigWithEndpointResolver.endpointResolver.mock.results[0].value,
 		);
 		expect(mockDeserializer).toHaveBeenCalledTimes(1);
 		expect(mockDeserializer).toHaveBeenCalledWith(defaultResponse);

--- a/packages/core/__tests__/clients/fetch.test.ts
+++ b/packages/core/__tests__/clients/fetch.test.ts
@@ -23,7 +23,7 @@ describe(fetchTransferHandler.name, () => {
 	const mockFetch = jest.fn();
 
 	beforeAll(() => {
-		global['fetch'] = mockFetch;
+		(global as any).fetch = mockFetch;
 	});
 
 	beforeEach(() => {
@@ -32,7 +32,7 @@ describe(fetchTransferHandler.name, () => {
 	});
 
 	it('should support abort signal', async () => {
-		const signal = new AbortController().signal;
+		const { signal } = new AbortController();
 		await fetchTransferHandler(mockRequest, { abortSignal: signal });
 		expect(mockFetch).toHaveBeenCalledTimes(1);
 		expect(mockFetch.mock.calls[0][1]).toEqual(
@@ -68,8 +68,8 @@ describe(fetchTransferHandler.name, () => {
 	});
 
 	it('should support headers', async () => {
-		mockFetchResponse.headers.forEach.mockImplementation((cb: any) => {
-			cb('foo', 'bar');
+		mockFetchResponse.headers.forEach.mockImplementation((callback: any) => {
+			callback('foo', 'bar');
 		});
 		const { headers } = await fetchTransferHandler(mockRequest, {});
 		expect(headers).toEqual({ bar: 'foo' });

--- a/packages/core/__tests__/clients/middleware/signing/middleware.test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/middleware.test.ts
@@ -3,8 +3,8 @@
 
 import { composeTransferHandler } from '../../../../src/clients/internal/composeTransferHandler';
 import {
-	signingMiddlewareFactory,
 	SigningOptions,
+	signingMiddlewareFactory,
 } from '../../../../src/clients/middleware/signing';
 import { getSkewCorrectedDate } from '../../../../src/clients/middleware/signing/utils/getSkewCorrectedDate';
 import { getUpdatedSystemClockOffset } from '../../../../src/clients/middleware/signing/utils/getUpdatedSystemClockOffset';
@@ -13,6 +13,7 @@ import {
 	HttpResponse,
 	MiddlewareHandler,
 } from '../../../../src/clients/types';
+
 import {
 	credentials,
 	signingDate,

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/presignUrl.test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/presignUrl.test.ts
@@ -3,14 +3,15 @@
 
 import { presignUrl } from '../../../../../../src/clients/middleware/signing/signer/signatureV4/presignUrl';
 import { HttpRequest } from '../../../../../../src/clients/types';
+import { PresignUrlOptions } from '../../../../../../src/clients/middleware/signing/signer/signatureV4/types';
+import { getSignature } from '../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getSignature';
+
 import { signingTestTable } from './testUtils/signingTestTable';
 import {
 	formattedDates,
 	getDefaultRequest,
 	signingOptions,
 } from './testUtils/data';
-import { PresignUrlOptions } from '../../../../../../src/clients/middleware/signing/signer/signatureV4/types';
-import { getSignature } from '../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getSignature';
 
 jest.mock(
 	'../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getSignature',
@@ -40,6 +41,7 @@ describe('presignUrl', () => {
 					...signingOptions,
 					...options,
 				};
+
 				return [name, updatedRequest, updatedOptions, expectedUrl];
 			},
 		),

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/signRequest.test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/signRequest.test.ts
@@ -3,14 +3,15 @@
 
 import { signRequest } from '../../../../../../src/clients/middleware/signing/signer/signatureV4/signRequest';
 import { HttpRequest } from '../../../../../../src/clients/types';
+import { SignRequestOptions } from '../../../../../../src/clients/middleware/signing/signer/signatureV4/types';
+import { getSignature } from '../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getSignature';
+
 import { signingTestTable } from './testUtils/signingTestTable';
 import {
 	formattedDates,
 	getDefaultRequest,
 	signingOptions,
 } from './testUtils/data';
-import { SignRequestOptions } from '../../../../../../src/clients/middleware/signing/signer/signatureV4/types';
-import { getSignature } from '../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getSignature';
 
 jest.mock(
 	'../../../../../../src/clients/middleware/signing/signer/signatureV4/utils/getSignature',
@@ -40,6 +41,7 @@ describe('signRequest', () => {
 					...signingOptions,
 					...options,
 				};
+
 				return [name, updatedRequest, updatedOptions, expectedAuthorization];
 			},
 		),

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/testUtils/signingTestTable.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/testUtils/signingTestTable.ts
@@ -3,6 +3,7 @@
 
 import { SignRequestOptions } from '../../../../../../../src/clients/middleware/signing/signer/signatureV4/types';
 import { HttpRequest } from '../../../../../../../src/clients/types';
+
 import { credentialsWithToken, signingOptions, url } from './data';
 
 interface TestCase {

--- a/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getSignature.test.ts
+++ b/packages/core/__tests__/clients/middleware/signing/signer/signatureV4/utils/getSignature.test.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-	credentials,
 	credentialScope,
+	credentials,
 	formattedDates,
 	getDefaultRequest,
 	signingRegion,

--- a/packages/core/__tests__/parseAWSExports.test.ts
+++ b/packages/core/__tests__/parseAWSExports.test.ts
@@ -243,7 +243,7 @@ describe('parseAWSExports', () => {
 					signUpVerificationMethod: undefined,
 					userAttributes: {},
 					userPoolClientId: undefined,
-					userPoolId: userPoolId,
+					userPoolId,
 				},
 			},
 		});

--- a/packages/core/__tests__/providers/pinpoint/apis/flushEvents.test.ts
+++ b/packages/core/__tests__/providers/pinpoint/apis/flushEvents.test.ts
@@ -3,7 +3,7 @@
 
 import { getEventBuffer } from '../../../../src/providers/pinpoint/utils/getEventBuffer';
 import { flushEvents } from '../../../../src/providers/pinpoint';
-import { appId, region, credentials, identityId } from '../testUtils/data';
+import { appId, credentials, identityId, region } from '../testUtils/data';
 import {
 	BUFFER_SIZE,
 	FLUSH_INTERVAL,

--- a/packages/core/__tests__/providers/pinpoint/apis/record.test.ts
+++ b/packages/core/__tests__/providers/pinpoint/apis/record.test.ts
@@ -1,4 +1,5 @@
 import { v4 } from 'uuid';
+
 import { putEvents as clientPutEvents } from '../../../../src/awsClients/pinpoint';
 import { record } from '../../../../src/providers/pinpoint/apis';
 import { updateEndpoint } from '../../../../src/providers/pinpoint/apis/updateEndpoint';
@@ -8,9 +9,9 @@ import {
 	category,
 	credentials,
 	endpointId,
-	region,
-	identityId,
 	event,
+	identityId,
+	region,
 	uuid,
 } from '../testUtils/data';
 import { getEventBuffer } from '../../../../src/providers/pinpoint/utils/getEventBuffer';

--- a/packages/core/__tests__/providers/pinpoint/apis/testUtils/getExpectedPutEventsInput.ts
+++ b/packages/core/__tests__/providers/pinpoint/apis/testUtils/getExpectedPutEventsInput.ts
@@ -4,8 +4,8 @@
 import {
 	appId,
 	endpointId as defaultEndpointId,
-	uuid,
 	event as defaultEvent,
+	uuid,
 } from '../../testUtils/data';
 
 export const getExpectedPutEventsInput = ({

--- a/packages/core/__tests__/providers/pinpoint/apis/updateEndpoint.test.ts
+++ b/packages/core/__tests__/providers/pinpoint/apis/updateEndpoint.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { v4 } from 'uuid';
+
 import { getClientInfo } from '../../../../src/utils/getClientInfo';
 import { updateEndpoint as clientUpdateEndpoint } from '../../../../src/awsClients/pinpoint';
 import { cacheEndpointId } from '../../../../src/providers/pinpoint/utils/cacheEndpointId';
@@ -18,6 +19,7 @@ import {
 	userProfile,
 	uuid,
 } from '../testUtils/data';
+
 import { getExpectedInput } from './testUtils/getExpectedInput';
 
 jest.mock('uuid');

--- a/packages/core/__tests__/storage/CookieStorage.test.ts
+++ b/packages/core/__tests__/storage/CookieStorage.test.ts
@@ -3,7 +3,7 @@ import { CookieStorage } from '../../src/storage/CookieStorage';
 const cookieStorageDomain = 'https://testdomain.com';
 
 describe('CookieStorage', () => {
-	//defining a DOM to attach a cookie to
+	// defining a DOM to attach a cookie to
 	Object.defineProperty(document, 'cookie', { writable: true });
 
 	describe('Constructor methods', () => {
@@ -17,16 +17,16 @@ describe('CookieStorage', () => {
 			const expectedError =
 				'The sameSite value of cookieStorage must be "lax", "strict" or "none"';
 			expect(() => {
-				new CookieStorage({ sameSite: undefined });
+				const _ = new CookieStorage({ sameSite: undefined });
 			}).toThrow(expectedError);
 			expect(() => {
-				new CookieStorage({ sameSite: 'foo' as any });
+				const _ = new CookieStorage({ sameSite: 'foo' as any });
 			}).toThrow(expectedError);
 		});
 
 		it('SameSite value is "none" while secure is false', () => {
 			expect(() => {
-				new CookieStorage({
+				const _ = new CookieStorage({
 					domain: cookieStorageDomain,
 					secure: false,
 					sameSite: 'none',
@@ -63,11 +63,11 @@ describe('CookieStorage', () => {
 			});
 
 			it('Clearing cookies should remove all items within the storage', async () => {
-				const cookieStore = new CookieStorage(cookieStoreData);
-				await cookieStore.setItem('testKey2', 'testValue');
-				const tempReference = await cookieStore.getItem('testKey2');
-				await cookieStore.clear();
-				expect(await cookieStore.getItem('testKey2')).not.toEqual(
+				const testCookieStore = new CookieStorage(cookieStoreData);
+				await testCookieStore.setItem('testKey2', 'testValue');
+				const tempReference = await testCookieStore.getItem('testKey2');
+				await testCookieStore.clear();
+				expect(await testCookieStore.getItem('testKey2')).not.toEqual(
 					tempReference,
 				);
 			});

--- a/packages/core/__tests__/storage/DefaultStorage.test.ts
+++ b/packages/core/__tests__/storage/DefaultStorage.test.ts
@@ -25,15 +25,14 @@ describe('DefaultStorage', () => {
 		expect(await defaultStorage.getItem(key)).toEqual(secondValue);
 	});
 
-	it('should not throw if trying to delete a non existing key', async () => {
+	it('should not throw if trying to delete a non existing key', () => {
 		const badKey = 'nonExistingKey';
-		await expect(() => {
-			defaultStorage.removeItem(badKey);
-		}).not.toThrow();
+
+		expect(defaultStorage.removeItem(badKey)).resolves.toBeUndefined();
 	});
 
 	it('should clear out storage', async () => {
 		await defaultStorage.clear();
-		expect(await defaultStorage.getItem(key)).toBeNull();
+		expect(defaultStorage.getItem(key)).resolves.toBeNull();
 	});
 });

--- a/packages/core/__tests__/storage/SessionStorage.test.ts
+++ b/packages/core/__tests__/storage/SessionStorage.test.ts
@@ -27,6 +27,7 @@ describe('sessionStorage', () => {
 
 	it('should not throw if trying to delete a non existing key', async () => {
 		const badKey = 'nonExistingKey';
+		// eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
 		await expect(() => {
 			sessionStorage.removeItem(badKey);
 		}).not.toThrow();

--- a/packages/core/__tests__/utils.test.ts
+++ b/packages/core/__tests__/utils.test.ts
@@ -1,8 +1,8 @@
 'use strict';
 
 import {
-	jitteredExponentialRetry,
 	NonRetryableError,
+	jitteredExponentialRetry,
 	urlSafeDecode,
 	urlSafeEncode,
 } from '../src/utils';
@@ -14,8 +14,6 @@ import { DateUtils } from '../src/Signer/DateUtils';
 ConsoleLogger.LOG_LEVEL = 'DEBUG';
 
 describe('Util', () => {
-	beforeEach(() => {});
-
 	describe('DateUtils', () => {
 		test('isClockSkewError', () => {
 			expect(

--- a/packages/core/__tests__/utils/generateRandomString.test.ts
+++ b/packages/core/__tests__/utils/generateRandomString.test.ts
@@ -17,6 +17,7 @@ describe('generateRandomString()', () => {
 		mathRandomSpy.mockImplementation(() => {
 			const returnValue = counter;
 			counter += 5;
+
 			return parseFloat(`0.${returnValue}`);
 		});
 

--- a/packages/core/__tests__/utils/globalHelpers/globalHelpers.native.test.ts
+++ b/packages/core/__tests__/utils/globalHelpers/globalHelpers.native.test.ts
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-const mockCrypto = { getRandomValues: jest.fn() };
+import { loadGetRandomValues } from '@aws-amplify/react-native';
 
-import { loadGetRandomValues, loadBase64 } from '@aws-amplify/react-native';
 import {
 	getAtob,
 	getBtoa,
@@ -14,7 +13,7 @@ jest.mock('react-native');
 jest.mock('@aws-amplify/react-native', () => ({
 	loadGetRandomValues: jest.fn(() => {
 		Object.defineProperty(global, 'crypto', {
-			value: mockCrypto,
+			value: { getRandomValues: jest.fn(() => 'mocked') },
 			writable: true,
 		});
 	}),
@@ -25,7 +24,6 @@ jest.mock('@aws-amplify/react-native', () => ({
 }));
 
 const mockLoadGetRandomValues = loadGetRandomValues as jest.Mock;
-const mockLoadBase64 = loadBase64 as jest.Mock;
 
 describe('getGlobal (native)', () => {
 	beforeAll(() => {
@@ -35,7 +33,7 @@ describe('getGlobal (native)', () => {
 
 	describe('getCrypto()', () => {
 		it('returns the polyfill crypto from react-native-get-random-values', () => {
-			expect(getCrypto()).toEqual(mockCrypto);
+			expect(getCrypto().getRandomValues(null)).toEqual('mocked');
 		});
 	});
 

--- a/packages/core/__tests__/utils/queuedStorage/queuedStorage.native.test.ts
+++ b/packages/core/__tests__/utils/queuedStorage/queuedStorage.native.test.ts
@@ -2,11 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { loadAsyncStorage } from '@aws-amplify/react-native';
+
 import {
 	createQueuedStorage,
 	keyPrefix,
 } from '../../../src/utils/queuedStorage/createQueuedStorage.native';
-import { ItemToAdd, QueuedItem } from '../../../src/utils/queuedStorage/types';
+import {
+	ItemToAdd,
+	QueuedItem,
+	QueuedStorage,
+} from '../../../src/utils/queuedStorage/types';
 import { getAddItemBytesSize } from '../../../src/utils/queuedStorage/getAddItemBytesSize';
 
 jest.mock('@aws-amplify/react-native', () => ({
@@ -30,7 +35,7 @@ describe('createQueuedStorage', () => {
 	const mockTimestamp = new Date('2024-01-02').toUTCString();
 
 	describe('initialization', () => {
-		let queuedStorage;
+		let queuedStorage: QueuedStorage;
 		const testBytesSize = 1;
 		const mockKeys = [`${keyPrefix}_key1`, `${keyPrefix}_key2`];
 		const mockQueuedItems = [
@@ -115,30 +120,30 @@ describe('createQueuedStorage', () => {
 			['peekAll', undefined],
 			['delete', [{}]],
 			['clear', undefined],
-		])('when invokes %s it throws', async (method, args) => {
-			const storage = createQueuedStorage();
-			await expect(storage[method](args)).rejects.toThrow(expectedError);
-		});
+		] as unknown as [keyof QueuedStorage, any])(
+			'when invokes %s it throws',
+			async (method: keyof QueuedStorage, args: any) => {
+				const storage = createQueuedStorage();
+				await expect(storage[method](args)).rejects.toThrow(expectedError);
+			},
+		);
 	});
 
 	describe('method add()', () => {
-		let queuedStorage;
-		let originalDate;
+		let queuedStorage: QueuedStorage;
+		let dateNowSpy: jest.SpyInstance;
 		const testInput: ItemToAdd = {
 			content: 'some log content',
 			timestamp: mockTimestamp,
 		};
 
 		beforeAll(() => {
-			originalDate = Date;
-			Date = {
-				now: jest.fn(() => 123),
-			} as any;
+			dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(123);
 			queuedStorage = createQueuedStorage();
 		});
 
 		afterAll(() => {
-			Date = originalDate;
+			dateNowSpy.mockRestore();
 		});
 
 		afterEach(() => {
@@ -194,7 +199,7 @@ describe('createQueuedStorage', () => {
 	});
 
 	describe('method peek() and peekAll()', () => {
-		let queuedStorage;
+		let queuedStorage: QueuedStorage;
 
 		const mockQueuedItems = [
 			{
@@ -282,7 +287,7 @@ describe('createQueuedStorage', () => {
 			},
 		];
 
-		let queuedStorage;
+		let queuedStorage: QueuedStorage;
 
 		beforeAll(() => {
 			queuedStorage = createQueuedStorage();
@@ -304,7 +309,7 @@ describe('createQueuedStorage', () => {
 	});
 
 	describe('method clear()', () => {
-		let queuedStorage;
+		let queuedStorage: QueuedStorage;
 		const testAllKeys = [
 			`${keyPrefix}_key1`,
 			`${keyPrefix}_key2`,

--- a/packages/core/__tests__/utils/queuedStorage/queuedStorage.test.ts
+++ b/packages/core/__tests__/utils/queuedStorage/queuedStorage.test.ts
@@ -14,15 +14,25 @@ import {
 } from '../../../src/utils/queuedStorage/types';
 
 describe('createQueuedStorage', () => {
-	let originalIndexedDB;
-	let originalIDBKeyRange;
+	let originalIndexedDB: IDBFactory;
+	let originalIDBKeyRange: typeof IDBKeyRange;
 	const mockTimestamp = new Date('2024-01-02').toUTCString();
 	const mockAdd = jest.fn(() => ({
 		set onsuccess(handler) {
 			handler();
 		},
+		get onsuccess() {
+			return () => {
+				// no op
+			};
+		},
 		set onerror(handler) {
 			handler();
+		},
+		get onerror() {
+			return () => {
+				// no op
+			};
 		},
 	}));
 	const mockClear = jest.fn();
@@ -30,8 +40,18 @@ describe('createQueuedStorage', () => {
 		set onsuccess(handler) {
 			handler();
 		},
+		get onsuccess() {
+			return () => {
+				// no op
+			};
+		},
 		set onerror(handler) {
 			handler();
+		},
+		get onerror() {
+			return () => {
+				// no op
+			};
 		},
 		result: [] as QueuedItem[],
 	}));
@@ -39,8 +59,18 @@ describe('createQueuedStorage', () => {
 		set onsuccess(handler) {
 			handler();
 		},
+		get onsuccess() {
+			return () => {
+				// no op
+			};
+		},
 		set onerror(handler) {
 			handler();
+		},
+		get onerror() {
+			return () => {
+				// no op
+			};
 		},
 	}));
 	const mockObjectStore = jest.fn(() => ({
@@ -63,10 +93,27 @@ describe('createQueuedStorage', () => {
 		set onupgradeneeded(handler) {
 			handler();
 		},
+		get onupgradeneeded() {
+			return () => {
+				// no op
+			};
+		},
 		set onsuccess(handler) {
 			handler();
 		},
-		set onerror(_) {},
+		get onsuccess() {
+			return () => {
+				// no op
+			};
+		},
+		set onerror(_) {
+			// no op
+		},
+		get onerror() {
+			return () => {
+				// no op
+			};
+		},
 		result: mockDB,
 	};
 	const mockIndexedDBOpen = jest.fn(() => mockIndexedDBOpenRequest);
@@ -119,7 +166,19 @@ describe('createQueuedStorage', () => {
 				set onsuccess(handler) {
 					handler();
 				},
-				set onerror(_) {},
+				get onsuccess() {
+					return () => {
+						// no op
+					};
+				},
+				set onerror(_) {
+					// no-op
+				},
+				get onerror() {
+					return () => {
+						// no op
+					};
+				},
 				result: mockQueuedItems,
 			});
 			queuedStorage = createQueuedStorage();
@@ -172,9 +231,26 @@ describe('createQueuedStorage', () => {
 				set onupgradeneeded(handler) {
 					handler();
 				},
-				set onsuccess(_) {},
+				get onupgradeneeded() {
+					return () => {
+						// no op
+					};
+				},
+				set onsuccess(_) {
+					// no-op
+				},
+				get onsuccess() {
+					return () => {
+						// no op
+					};
+				},
 				set onerror(handler) {
 					handler();
+				},
+				get onerror() {
+					return () => {
+						// no op
+					};
 				},
 				error: expectedError,
 				result: mockDB,
@@ -187,10 +263,13 @@ describe('createQueuedStorage', () => {
 			['peekAll', undefined],
 			['delete', [{}]],
 			['clear', undefined],
-		])('when invokes %s it throws', async (method, args) => {
-			const storage = createQueuedStorage();
-			await expect(storage[method](args)).rejects.toThrow(expectedError);
-		});
+		] as unknown as [keyof QueuedStorage, any])(
+			'when invokes %s it throws',
+			async (method: keyof QueuedStorage, args: any) => {
+				const storage = createQueuedStorage();
+				await expect(storage[method](args)).rejects.toThrow(expectedError);
+			},
+		);
 	});
 
 	describe('method add()', () => {
@@ -231,7 +310,19 @@ describe('createQueuedStorage', () => {
 				set onsuccess(handler) {
 					handler();
 				},
-				set onerror(_) {},
+				get onsuccess() {
+					return () => {
+						// no op
+					};
+				},
+				set onerror(_) {
+					// no op
+				},
+				get onerror() {
+					return () => {
+						// no op
+					};
+				},
 				result: mockQueuedItems,
 			});
 
@@ -273,7 +364,19 @@ describe('createQueuedStorage', () => {
 				set onsuccess(handler) {
 					handler();
 				},
-				set onerror(_) {},
+				get onsuccess() {
+					return () => {
+						// no op
+					};
+				},
+				set onerror(_) {
+					// no-op
+				},
+				get onerror() {
+					return () => {
+						// no op
+					};
+				},
 				result: [mockQueuedItems[0]],
 			});
 			const result = await queuedStorage.peek(1);
@@ -288,7 +391,19 @@ describe('createQueuedStorage', () => {
 				set onsuccess(handler) {
 					handler();
 				},
-				set onerror(_) {},
+				get onsuccess() {
+					return () => {
+						// no op
+					};
+				},
+				set onerror(_) {
+					// no op
+				},
+				get onerror() {
+					return () => {
+						// no op
+					};
+				},
 				result: mockQueuedItems,
 			});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,11 +15,12 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-amplify/data-schema-types@*", "@aws-amplify/data-schema-types@^0.7.11":
-  version "0.7.11"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/data-schema-types/-/data-schema-types-0.7.11.tgz#d6c4b5be551fa0600f6bbf2b512f19e39a20e481"
-  integrity sha512-K16p1NF1entoNBDQUnH/wK3exmOg+AtF96uFaj3SxQDOBad+wBnzVHZNWaoemlX2ISnuH/fXbuFvB5D7w76zbQ==
+"@aws-amplify/data-schema-types@*", "@aws-amplify/data-schema-types@^0.7.14":
+  version "0.7.14"
+  resolved "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-0.7.14.tgz#75504d040d7a85e1d1328e388f35e5ebd02572f4"
+  integrity sha512-zvo1j6NljHsV62KnEz560rTx9jJ1KfTz0OOqZjW/CP1AtWdlakM2ADBAn9z4AL+bKrt31CrAr55ZOAo6Uk+LTw==
   dependencies:
+    "@aws-amplify/plugin-types" "^0.9.0-beta.1"
     rxjs "^7.8.1"
 
 "@aws-amplify/data-schema@^0.14.1":
@@ -29,6 +30,11 @@
   dependencies:
     "@aws-amplify/data-schema-types" "*"
     "@types/aws-lambda" "^8.10.134"
+
+"@aws-amplify/plugin-types@^0.9.0-beta.1":
+  version "0.9.0-beta.1"
+  resolved "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-0.9.0-beta.1.tgz#066af0646b379b4c999668253e87754e67fc7427"
+  integrity sha512-5eJ2SYoXbq4ZSvBjCgStXSejNOKuBkxYVXqOXZP4xP5C9iIpUYG36s9xP+IdhWDm9K/yxklp8OUMr8YGc0g7tw==
 
 "@aws-crypto/crc32@3.0.0":
   version "3.0.0"
@@ -14199,7 +14205,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14267,7 +14282,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14280,6 +14295,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -15485,7 +15507,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15507,6 +15529,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Currently we are only setting the [OAuthInflight flag](https://github.com/aws-amplify/amplify-js/blob/main/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts#L90) and waiting for it in the [TokenOrchestrator](https://github.com/aws-amplify/amplify-js/blob/main/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts#L35) to get resolved(success/error/cancellation). This flow works well for web. However, for RN, we do not need this OAuthInflight flag to be set nor do we need to wait for it to get resolved. This fix involves removing both these actions for RN using the `isBrowser()` method.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/13191


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
