### PR TITLE
release(required): fix inflight promise on RN

### DIFF
--- a/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
@@ -191,6 +191,9 @@ describe('signInWithRedirect', () => {
 	});
 
 	describe('specifications on react-native', () => {
+		beforeAll(() => {
+			mockIsBrowser.mockReturnValue(false);
+		});
 		it('invokes `completeOAuthFlow` when `openAuthSession`completes', async () => {
 			const mockOpenAuthSessionResult = {
 				type: 'success',
@@ -258,6 +261,19 @@ describe('signInWithRedirect', () => {
 				}),
 			);
 			expect(mockHandleFailure).toHaveBeenCalledWith(expectedError);
+		});
+		it('should not set the Oauth flag on non-browser environments', async () => {
+			const mockOpenAuthSessionResult = {
+				type: 'success',
+				url: 'http://redrect-in-react-native.com',
+			};
+			mockOpenAuthSession.mockResolvedValueOnce(mockOpenAuthSessionResult);
+
+			await signInWithRedirect({
+				provider: 'Google',
+			});
+
+			expect(oAuthStore.storeOAuthInFlight).toHaveBeenCalledTimes(0);
 		});
 	});
 

--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -6,6 +6,7 @@ import {
 	AuthAction,
 	assertOAuthConfig,
 	assertTokenProviderConfig,
+	isBrowser,
 	urlSafeEncode,
 } from '@aws-amplify/core/internals/utils';
 
@@ -87,7 +88,7 @@ const oauthSignIn = async ({
 	const { value, method, toCodeChallenge } = generateCodeVerifier(128);
 	const redirectUri = getRedirectUrl(oauthConfig.redirectSignIn);
 
-	oAuthStore.storeOAuthInFlight(true);
+	if (isBrowser()) oAuthStore.storeOAuthInFlight(true);
 	oAuthStore.storeOAuthState(state);
 	oAuthStore.storePKCE(value);
 

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -383,7 +383,7 @@
 			"name": "[Auth] confirmSignIn (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmSignIn }",
-			"limit": "26.48 kB"
+			"limit": "26.49 kB"
 		},
 		{
 			"name": "[Auth] updateMFAPreference (Cognito)",
@@ -455,7 +455,7 @@
 			"name": "[Auth] OAuth Auth Flow (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ signInWithRedirect, signOut, fetchAuthSession }",
-			"limit": "19.80 kB"
+			"limit": "19.90 kB"
 		},
 		{
 			"name": "[Storage] copy (S3)",

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -383,7 +383,7 @@
 			"name": "[Auth] confirmSignIn (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmSignIn }",
-			"limit": "26.49 kB"
+			"limit": "26.50 kB"
 		},
 		{
 			"name": "[Auth] updateMFAPreference (Cognito)",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Currently we are only setting the [OAuthInflight flag](https://github.com/aws-amplify/amplify-js/blob/main/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts#L90) and waiting for it in the [TokenOrchestrator](https://github.com/aws-amplify/amplify-js/blob/main/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts#L35) to get resolved(success/error/cancellation). This flow works well for web. However, for RN, we do not need this OAuthInflight flag to be set nor do we need to wait for it to get resolved. This fix involves removing both these actions for RN using the isBrowser() method.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/13191


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
