### PR TITLE
[Fix] Update API overload types

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -473,7 +473,7 @@
 			"name": "[Storage] getProperties (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getProperties }",
-			"limit": "13.55 kB"
+			"limit": "13.56 kB"
 		},
 		{
 			"name": "[Storage] getUrl (S3)",

--- a/packages/storage/src/providers/s3/apis/copy.ts
+++ b/packages/storage/src/providers/s3/apis/copy.ts
@@ -39,7 +39,7 @@ interface Copy {
 	 * source or destination key is not defined.
 	 */
 	(input: CopyInputWithKey): Promise<CopyOutputWithKey>;
-	(input: CopyInputWithPath | CopyInputWithKey): Promise<CopyOutput>;
+	(input: CopyInput): Promise<CopyOutput>;
 }
 
 export const copy: Copy = <Output extends CopyOutput>(

--- a/packages/storage/src/providers/s3/apis/copy.ts
+++ b/packages/storage/src/providers/s3/apis/copy.ts
@@ -39,6 +39,7 @@ interface Copy {
 	 * source or destination key is not defined.
 	 */
 	(input: CopyInputWithKey): Promise<CopyOutputWithKey>;
+	(input: CopyInputWithPath | CopyInputWithKey): Promise<CopyOutput>;
 }
 
 export const copy: Copy = <Output extends CopyOutput>(

--- a/packages/storage/src/providers/s3/apis/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/downloadData.ts
@@ -90,9 +90,7 @@ interface DownloadData {
 	 *```
 	 */
 	(input: DownloadDataInputWithKey): DownloadDataOutputWithKey;
-	(
-		input: DownloadDataInputWithPath | DownloadDataInputWithKey,
-	): DownloadDataOutput;
+	(input: DownloadDataInput): DownloadDataOutput;
 }
 
 export const downloadData: DownloadData = <Output extends DownloadDataOutput>(

--- a/packages/storage/src/providers/s3/apis/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/downloadData.ts
@@ -90,6 +90,9 @@ interface DownloadData {
 	 *```
 	 */
 	(input: DownloadDataInputWithKey): DownloadDataOutputWithKey;
+	(
+		input: DownloadDataInputWithPath | DownloadDataInputWithKey,
+	): DownloadDataOutput;
 }
 
 export const downloadData: DownloadData = <Output extends DownloadDataOutput>(

--- a/packages/storage/src/providers/s3/apis/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/getProperties.ts
@@ -38,9 +38,7 @@ interface GetProperties {
 	 * @throws A `StorageValidationErrorCode` when API call parameters are invalid.
 	 */
 	(input: GetPropertiesInputWithKey): Promise<GetPropertiesOutputWithKey>;
-	(
-		input: GetPropertiesInputWithPath | GetPropertiesInputWithKey,
-	): Promise<GetPropertiesOutput>;
+	(input: GetPropertiesInput): Promise<GetPropertiesOutput>;
 }
 
 export const getProperties: GetProperties = <

--- a/packages/storage/src/providers/s3/apis/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/getProperties.ts
@@ -38,6 +38,9 @@ interface GetProperties {
 	 * @throws A `StorageValidationErrorCode` when API call parameters are invalid.
 	 */
 	(input: GetPropertiesInputWithKey): Promise<GetPropertiesOutputWithKey>;
+	(
+		input: GetPropertiesInputWithPath | GetPropertiesInputWithKey,
+	): Promise<GetPropertiesOutput>;
 }
 
 export const getProperties: GetProperties = <

--- a/packages/storage/src/providers/s3/apis/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/getUrl.ts
@@ -50,6 +50,7 @@ interface GetUrl {
 	 *
 	 */
 	(input: GetUrlInputWithKey): Promise<GetUrlOutput>;
+	(input: GetUrlInputWithPath | GetUrlInputWithKey): Promise<GetUrlOutput>;
 }
 
 export const getUrl: GetUrl = (input: GetUrlInput): Promise<GetUrlOutput> =>

--- a/packages/storage/src/providers/s3/apis/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/getUrl.ts
@@ -50,7 +50,7 @@ interface GetUrl {
 	 *
 	 */
 	(input: GetUrlInputWithKey): Promise<GetUrlOutput>;
-	(input: GetUrlInputWithPath | GetUrlInputWithKey): Promise<GetUrlOutput>;
+	(input: GetUrlInput): Promise<GetUrlOutput>;
 }
 
 export const getUrl: GetUrl = (input: GetUrlInput): Promise<GetUrlOutput> =>

--- a/packages/storage/src/providers/s3/apis/list.ts
+++ b/packages/storage/src/providers/s3/apis/list.ts
@@ -58,12 +58,8 @@ interface ListApi {
 	 * @throws validation: `StorageValidationErrorCode`  - thrown when there are issues with credentials
 	 */
 	(input?: ListAllInputWithPrefix): Promise<ListAllOutputWithPrefix>;
-	(
-		input?: ListAllInputWithPath | ListAllInputWithPrefix,
-	): Promise<ListAllOutput>;
-	(
-		input?: ListPaginateInputWithPath | ListPaginateInputWithPrefix,
-	): Promise<ListPaginateOutput>;
+	(input?: ListAllInput): Promise<ListAllOutput>;
+	(input?: ListPaginateInput): Promise<ListPaginateOutput>;
 }
 
 export const list: ListApi = <

--- a/packages/storage/src/providers/s3/apis/list.ts
+++ b/packages/storage/src/providers/s3/apis/list.ts
@@ -58,6 +58,12 @@ interface ListApi {
 	 * @throws validation: `StorageValidationErrorCode`  - thrown when there are issues with credentials
 	 */
 	(input?: ListAllInputWithPrefix): Promise<ListAllOutputWithPrefix>;
+	(
+		input?: ListAllInputWithPath | ListAllInputWithPrefix,
+	): Promise<ListAllOutput>;
+	(
+		input?: ListPaginateInputWithPath | ListPaginateInputWithPrefix,
+	): Promise<ListPaginateOutput>;
 }
 
 export const list: ListApi = <

--- a/packages/storage/src/providers/s3/apis/remove.ts
+++ b/packages/storage/src/providers/s3/apis/remove.ts
@@ -36,7 +36,7 @@ interface RemoveApi {
 	 * when there is no key or its empty.
 	 */
 	(input: RemoveInputWithKey): Promise<RemoveOutputWithKey>;
-	(input: RemoveInputWithPath | RemoveInputWithKey): Promise<RemoveOutput>;
+	(input: RemoveInput): Promise<RemoveOutput>;
 }
 
 export const remove: RemoveApi = <Output extends RemoveOutput>(

--- a/packages/storage/src/providers/s3/apis/remove.ts
+++ b/packages/storage/src/providers/s3/apis/remove.ts
@@ -36,6 +36,7 @@ interface RemoveApi {
 	 * when there is no key or its empty.
 	 */
 	(input: RemoveInputWithKey): Promise<RemoveOutputWithKey>;
+	(input: RemoveInputWithPath | RemoveInputWithKey): Promise<RemoveOutput>;
 }
 
 export const remove: RemoveApi = <Output extends RemoveOutput>(

--- a/packages/storage/src/providers/s3/apis/server/copy.ts
+++ b/packages/storage/src/providers/s3/apis/server/copy.ts
@@ -51,7 +51,7 @@ interface Copy {
 
 	(
 		contextSpec: AmplifyServer.ContextSpec,
-		input: CopyInputWithPath | CopyInputWithKey,
+		input: CopyInput,
 	): Promise<CopyOutput>;
 }
 

--- a/packages/storage/src/providers/s3/apis/server/copy.ts
+++ b/packages/storage/src/providers/s3/apis/server/copy.ts
@@ -48,6 +48,11 @@ interface Copy {
 		contextSpec: AmplifyServer.ContextSpec,
 		input: CopyInputWithKey,
 	): Promise<CopyOutputWithKey>;
+
+	(
+		contextSpec: AmplifyServer.ContextSpec,
+		input: CopyInputWithPath | CopyInputWithKey,
+	): Promise<CopyOutput>;
 }
 
 export const copy: Copy = <Output extends CopyOutput>(

--- a/packages/storage/src/providers/s3/apis/server/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/server/getProperties.ts
@@ -50,7 +50,7 @@ interface GetProperties {
 	): Promise<GetPropertiesOutputWithKey>;
 	(
 		contextSpec: AmplifyServer.ContextSpec,
-		input: GetPropertiesInputWithPath | GetPropertiesInputWithKey,
+		input: GetPropertiesInput,
 	): Promise<GetPropertiesOutput>;
 }
 

--- a/packages/storage/src/providers/s3/apis/server/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/server/getProperties.ts
@@ -48,6 +48,10 @@ interface GetProperties {
 		contextSpec: AmplifyServer.ContextSpec,
 		input: GetPropertiesInputWithKey,
 	): Promise<GetPropertiesOutputWithKey>;
+	(
+		contextSpec: AmplifyServer.ContextSpec,
+		input: GetPropertiesInputWithPath | GetPropertiesInputWithKey,
+	): Promise<GetPropertiesOutput>;
 }
 
 export const getProperties: GetProperties = <

--- a/packages/storage/src/providers/s3/apis/server/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/server/getUrl.ts
@@ -60,6 +60,10 @@ interface GetUrl {
 		contextSpec: AmplifyServer.ContextSpec,
 		input: GetUrlInputWithKey,
 	): Promise<GetUrlOutput>;
+	(
+		contextSpec: AmplifyServer.ContextSpec,
+		input: GetUrlInputWithPath | GetUrlInputWithKey,
+	): Promise<GetUrlOutput>;
 }
 export const getUrl: GetUrl = async (
 	contextSpec: AmplifyServer.ContextSpec,

--- a/packages/storage/src/providers/s3/apis/server/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/server/getUrl.ts
@@ -62,7 +62,7 @@ interface GetUrl {
 	): Promise<GetUrlOutput>;
 	(
 		contextSpec: AmplifyServer.ContextSpec,
-		input: GetUrlInputWithPath | GetUrlInputWithKey,
+		input: GetUrlInput,
 	): Promise<GetUrlOutput>;
 }
 export const getUrl: GetUrl = async (

--- a/packages/storage/src/providers/s3/apis/server/list.ts
+++ b/packages/storage/src/providers/s3/apis/server/list.ts
@@ -74,6 +74,14 @@ interface ListApi {
 		contextSpec: AmplifyServer.ContextSpec,
 		input?: ListAllInputWithPrefix,
 	): Promise<ListAllOutputWithPrefix>;
+	(
+		contextSpec: AmplifyServer.ContextSpec,
+		input?: ListPaginateInputWithPath | ListPaginateInputWithPrefix,
+	): Promise<ListPaginateOutput>;
+	(
+		contextSpec: AmplifyServer.ContextSpec,
+		input?: ListAllInputWithPath | ListAllInputWithPrefix,
+	): Promise<ListAllOutput>;
 }
 
 export const list: ListApi = <

--- a/packages/storage/src/providers/s3/apis/server/list.ts
+++ b/packages/storage/src/providers/s3/apis/server/list.ts
@@ -76,11 +76,11 @@ interface ListApi {
 	): Promise<ListAllOutputWithPrefix>;
 	(
 		contextSpec: AmplifyServer.ContextSpec,
-		input?: ListPaginateInputWithPath | ListPaginateInputWithPrefix,
+		input?: ListPaginateInput,
 	): Promise<ListPaginateOutput>;
 	(
 		contextSpec: AmplifyServer.ContextSpec,
-		input?: ListAllInputWithPath | ListAllInputWithPrefix,
+		input?: ListAllInput,
 	): Promise<ListAllOutput>;
 }
 

--- a/packages/storage/src/providers/s3/apis/server/remove.ts
+++ b/packages/storage/src/providers/s3/apis/server/remove.ts
@@ -48,7 +48,7 @@ interface RemoveApi {
 	): Promise<RemoveOutputWithKey>;
 	(
 		contextSpec: AmplifyServer.ContextSpec,
-		input: RemoveInputWithPath | RemoveInputWithKey,
+		input: RemoveInput,
 	): Promise<RemoveOutput>;
 }
 

--- a/packages/storage/src/providers/s3/apis/server/remove.ts
+++ b/packages/storage/src/providers/s3/apis/server/remove.ts
@@ -46,6 +46,10 @@ interface RemoveApi {
 		contextSpec: AmplifyServer.ContextSpec,
 		input: RemoveInputWithKey,
 	): Promise<RemoveOutputWithKey>;
+	(
+		contextSpec: AmplifyServer.ContextSpec,
+		input: RemoveInputWithPath | RemoveInputWithKey,
+	): Promise<RemoveOutput>;
 }
 
 export const remove: RemoveApi = <Output extends RemoveOutput>(

--- a/packages/storage/src/providers/s3/apis/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/index.ts
@@ -126,7 +126,7 @@ interface UploadData {
 	 * ```
 	 */
 	(input: UploadDataInputWithKey): UploadDataOutputWithKey;
-	(input: UploadDataInputWithPath | UploadDataInputWithKey): UploadDataOutput;
+	(input: UploadDataInput): UploadDataOutput;
 }
 
 export const uploadData: UploadData = <Output extends UploadDataOutput>(

--- a/packages/storage/src/providers/s3/apis/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/index.ts
@@ -126,6 +126,7 @@ interface UploadData {
 	 * ```
 	 */
 	(input: UploadDataInputWithKey): UploadDataOutputWithKey;
+	(input: UploadDataInputWithPath | UploadDataInputWithKey): UploadDataOutput;
 }
 
 export const uploadData: UploadData = <Output extends UploadDataOutput>(

--- a/packages/storage/src/providers/s3/utils/isInputWithPath.ts
+++ b/packages/storage/src/providers/s3/utils/isInputWithPath.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-	StorageOperationInputType,
+	StorageOperationInput,
 	StorageOperationInputWithPath,
 } from '../../../types/inputs';
 
 export const isInputWithPath = (
-	input: StorageOperationInputType,
+	input: StorageOperationInput,
 ): input is StorageOperationInputWithPath => {
 	return input.path !== undefined;
 };

--- a/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
+++ b/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { StorageOperationInputType as Input } from '../../../types/inputs';
+import { StorageOperationInput as Input } from '../../../types/inputs';
 import { assertValidationError } from '../../../errors/utils/assertValidationError';
 import { StorageValidationErrorCode } from '../../../errors/types/validation';
 

--- a/packages/storage/src/types/index.ts
+++ b/packages/storage/src/types/index.ts
@@ -8,7 +8,6 @@ export {
 	UploadTask,
 } from './common';
 export {
-	StorageOperationInput,
 	StorageGetPropertiesInputWithKey,
 	StorageGetPropertiesInputWithPath,
 	StorageListInputWithPrefix,

--- a/packages/storage/src/types/inputs.ts
+++ b/packages/storage/src/types/inputs.ts
@@ -9,9 +9,7 @@ import {
 	StorageOptions,
 } from './options';
 
-// TODO: rename to StorageOperationInput once the other type with
-// the same named is removed
-export type StorageOperationInputType = StrictUnion<
+export type StorageOperationInput = StrictUnion<
 	StorageOperationInputWithKey | StorageOperationInputWithPath
 >;
 export type StorageOperationInputWithPrefixPath = StrictUnion<
@@ -43,15 +41,9 @@ export type StorageDownloadDataInputWithKey<Options extends StorageOptions> =
 export type StorageDownloadDataInputWithPath<Options> =
 	StorageOperationInputWithPath & StorageOperationOptionsInput<Options>;
 
-// TODO: This needs to be removed after refactor of all storage APIs
-export interface StorageOperationInput<Options extends StorageOptions> {
-	key: string;
-	options?: Options;
-}
-
 /** @deprecated Use {@link StorageGetPropertiesInputWithPath} instead. */
 export type StorageGetPropertiesInputWithKey<Options extends StorageOptions> =
-	StorageOperationInputWithKey & StorageOperationInput<Options>;
+	StorageOperationInputWithKey & StorageOperationOptionsInput<Options>;
 
 export type StorageGetPropertiesInputWithPath<Options> =
 	StorageOperationInputWithPath & StorageOperationOptionsInput<Options>;
@@ -73,7 +65,7 @@ export type StorageListInputWithPath<
 
 /** @deprecated Use {@link StorageGetUrlInputWithPath} instead. */
 export type StorageGetUrlInputWithKey<Options extends StorageOptions> =
-	StorageOperationInputWithKey & StorageOperationInput<Options>;
+	StorageOperationInputWithKey & StorageOperationOptionsInput<Options>;
 
 export type StorageGetUrlInputWithPath<Options> =
 	StorageOperationInputWithPath & StorageOperationOptionsInput<Options>;


### PR DESCRIPTION
#### Description of changes
- The overloads for the storage APIs were missing type for unionized input.
- Remove un-used type
- Refactor type name

#### Description of how you validated changes
- Unit and Integ tests were run
- Manually tested it


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
