### PR TITLE
chore: fix lerna package bump issue

### DIFF
--- a/.github/workflows/callable-npm-publish-lts-release.yml
+++ b/.github/workflows/callable-npm-publish-lts-release.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           path: amplify-js
           token: ${{ secrets.GH_TOKEN_AMPLIFY_JS_WRITE }}
+          # Minimal depth 0 so we can fetch all git tags.
+          fetch-depth: 0
 
       - name: Setup node and build the repository
         uses: ./amplify-js/.github/actions/node-and-build

--- a/.github/workflows/callable-npm-publish-release.yml
+++ b/.github/workflows/callable-npm-publish-release.yml
@@ -12,6 +12,8 @@ jobs:
         with:
           path: amplify-js
           token: ${{ secrets.GH_TOKEN_AMPLIFY_JS_WRITE }}
+          # Minimal depth 0 so we can fetch all git tags.
+          fetch-depth: 0
 
       - name: Setup node and build the repository
         uses: ./amplify-js/.github/actions/node-and-build


### PR DESCRIPTION
### Description of changes

#### Current behavior 
- Lerna causes a patch version bump on all packages irrespective of the packages that have changed. 
- package [CHANGELOG](https://github.com/aws-amplify/amplify-js/blob/main/packages/api-graphql/CHANGELOG.md#4027-2024-04-02) does not capture changes
- lerna publish log: ["lerna info Assuming all packages changed"](https://github.com/aws-amplify/amplify-js/actions/runs/8427545861/job/23079687360#step:4:41).

#### Expected behavior
- Lerna only bumps the version of the packages that are changed and their dependent packages
- Example a feat commit on auth causes a minor version bump on auth, patch version bump on aws-amplify
(auth is a dependency in aws-amplify) 

#### Fix
before `lerna publish` checkout with `fetch-depth: 0`see [Lerna issue on GH actions](https://github.com/lerna/lerna/issues/2542)


### Description of how you validated changes
[Current behavior](https://github.com/aws-amplify/amplify-js/actions/runs/8427545861/job/23079687360#step:4:41)
(all packages get a patch bump irrespective of files changed)
```
lerna info Assuming all packages changed
lerna info getChangelogConfig Successfully resolved preset "conventional-changelog-angular"

lerna info auto-confirmed 
Changes:
lerna info execute Skipping releases
 - @aws-amplify/adapter-nextjs: 1.0.22 => 1.0.23
 - @aws-amplify/analytics: 7.0.22 => 7.0.23
 - @aws-amplify/api: 6.0.22 => 6.0.23
 - @aws-amplify/api-graphql: 4.0.22 => 4.0.23
 - @aws-amplify/api-rest: 4.0.22 => 4.0.23
 - @aws-amplify/auth: 6.0.22 => 6.0.23
 - aws-amplify: 6.0.22 => 6.0.23
 - @aws-amplify/core: 6.0.22 => 6.0.23
 - @aws-amplify/datastore: 5.0.22 => 5.0.23
 - @aws-amplify/datastore-storage-adapter: 2.1.22 => 2.1.23
 - @aws-amplify/geo: 3.0.22 => 3.0.23
 - @aws-amplify/interactions: 6.0.22 => 6.0.23
 - @aws-amplify/notifications: 2.0.22 => 2.0.23
 - @aws-amplify/predictions: 6.0.22 => 6.0.23
 - @aws-amplify/pubsub: 6.0.22 => 6.0.23
 - @aws-amplify/react-native: 1.0.23 => 1.0.24
 - @aws-amplify/react-native-example: 0.0.23 => 0.0.24 (private)
 - @aws-amplify/rtn-push-notification: 1.2.23 => 1.2.24
 - @aws-amplify/rtn-web-browser: 1.0.23 => 1.0.24
 - @aws-amplify/storage: 6.0.22 => 6.0.23
 - tsc-compliance-test: 0.1.22 => 0.1.23 (private)
```

[Behavior after fix](https://github.com/aws-amplify/amplify-js/actions/runs/8608372537/job/23590614933#step:4:41)
(a feat commit on storage) 
```
lerna info Looking for changed packages since @aws-amplify/auth@6.2.0
lerna info getChangelogConfig Successfully resolved preset "conventional-changelog-angular"
Changes:
lerna info auto-confirmed 
 - @aws-amplify/adapter-nextjs: 1.1.2 => 1.1.3
 - aws-amplify: 6.1.2 => 6.1.3
 - @aws-amplify/predictions: 6.1.1 => 6.1.2
 - @aws-amplify/storage: 6.2.0 => 6.3.0
 - tsc-compliance-test: 0.2.2 => 0.2.3 (private)
 ```
storage get's a minor bump and other dependent packages get a patch version bump

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
