### PR TITLE
fix(api-graphql): incorrect list sk arg type

### DIFF
--- a/packages/api-graphql/__tests__/internals/APIClient.test.ts
+++ b/packages/api-graphql/__tests__/internals/APIClient.test.ts
@@ -563,7 +563,7 @@ describe('generateGraphQLDocument()', () => {
 					modelOperation
 				);
 
-				expect(document.includes(expectedArgs)).toBe(true);
+				expect(document).toEqual(expect.stringContaining(expectedArgs))
 			}
 		);
 	});

--- a/packages/api-graphql/__tests__/internals/__snapshots__/generateClient.test.ts.snap
+++ b/packages/api-graphql/__tests__/internals/__snapshots__/generateClient.test.ts.snap
@@ -4092,11 +4092,11 @@ exports[`generateClient basic model operations can list() with sortDirection (AS
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($cpk_cluster_key: String, $cpk_sort_key: ModelStringKeyConditionInput, $sortDirection: ModelSortDirection, $filter: ModelThingWithCustomPkFilterInput, $limit: Int, $nextToken: String) {
+          "query": "query ($cpk_cluster_key: String, $sortDirection: ModelSortDirection, $cpk_sort_key: ModelStringKeyConditionInput, $filter: ModelThingWithCustomPkFilterInput, $limit: Int, $nextToken: String) {
   listThingWithCustomPks(
     cpk_cluster_key: $cpk_cluster_key
-    cpk_sort_key: $cpk_sort_key
     sortDirection: $sortDirection
+    cpk_sort_key: $cpk_sort_key
     filter: $filter
     limit: $limit
     nextToken: $nextToken
@@ -4139,11 +4139,11 @@ exports[`generateClient basic model operations can list() with sortDirection (DE
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($cpk_cluster_key: String, $cpk_sort_key: ModelStringKeyConditionInput, $sortDirection: ModelSortDirection, $filter: ModelThingWithCustomPkFilterInput, $limit: Int, $nextToken: String) {
+          "query": "query ($cpk_cluster_key: String, $sortDirection: ModelSortDirection, $cpk_sort_key: ModelStringKeyConditionInput, $filter: ModelThingWithCustomPkFilterInput, $limit: Int, $nextToken: String) {
   listThingWithCustomPks(
     cpk_cluster_key: $cpk_cluster_key
-    cpk_sort_key: $cpk_sort_key
     sortDirection: $sortDirection
+    cpk_sort_key: $cpk_sort_key
     filter: $filter
     limit: $limit
     nextToken: $nextToken

--- a/packages/api-graphql/__tests__/internals/__snapshots__/generateClient.test.ts.snap
+++ b/packages/api-graphql/__tests__/internals/__snapshots__/generateClient.test.ts.snap
@@ -4092,12 +4092,12 @@ exports[`generateClient basic model operations can list() with sortDirection (AS
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelThingWithCustomPkFilterInput, $sortDirection: ModelSortDirection, $cpk_cluster_key: String, $cpk_sort_key: String, $limit: Int, $nextToken: String) {
+          "query": "query ($cpk_cluster_key: String, $cpk_sort_key: ModelStringKeyConditionInput, $sortDirection: ModelSortDirection, $filter: ModelThingWithCustomPkFilterInput, $limit: Int, $nextToken: String) {
   listThingWithCustomPks(
-    filter: $filter
-    sortDirection: $sortDirection
     cpk_cluster_key: $cpk_cluster_key
     cpk_sort_key: $cpk_sort_key
+    sortDirection: $sortDirection
+    filter: $filter
     limit: $limit
     nextToken: $nextToken
   ) {
@@ -4139,12 +4139,12 @@ exports[`generateClient basic model operations can list() with sortDirection (DE
       "abortController": AbortController {},
       "options": {
         "body": {
-          "query": "query ($filter: ModelThingWithCustomPkFilterInput, $sortDirection: ModelSortDirection, $cpk_cluster_key: String, $cpk_sort_key: String, $limit: Int, $nextToken: String) {
+          "query": "query ($cpk_cluster_key: String, $cpk_sort_key: ModelStringKeyConditionInput, $sortDirection: ModelSortDirection, $filter: ModelThingWithCustomPkFilterInput, $limit: Int, $nextToken: String) {
   listThingWithCustomPks(
-    filter: $filter
-    sortDirection: $sortDirection
     cpk_cluster_key: $cpk_cluster_key
     cpk_sort_key: $cpk_sort_key
+    sortDirection: $sortDirection
+    filter: $filter
     limit: $limit
     nextToken: $nextToken
   ) {

--- a/packages/api-graphql/src/internals/APIClient.ts
+++ b/packages/api-graphql/src/internals/APIClient.ts
@@ -746,17 +746,18 @@ export function generateGraphQLDocument(
 	};
 
 	if (isCustomPrimaryKey) {
-		Object.assign(getPkArgs, {
-			...generateSkArgs('get'),
-		});
+		Object.assign(getPkArgs, generateSkArgs('get'));
 
-		Object.assign(listPkArgs, {
-			// PK is only included in list query field args in the generated GQL
-			// when explicitly specifying PK with .identifier(['fieldName']) or @primaryKey in the schema definition
-			[primaryKeyFieldName]: `${fields[primaryKeyFieldName].type}`, // PK is always a nullable arg for list (no `!` after the type)
-			...generateSkArgs('list'),
-			sortDirection: 'ModelSortDirection',
-		});
+		Object.assign(
+			listPkArgs,
+			{
+				// PK is only included in list query field args in the generated GQL
+				// when explicitly specifying PK with .identifier(['fieldName']) or @primaryKey in the schema definition
+				[primaryKeyFieldName]: `${fields[primaryKeyFieldName].type}`, // PK is always a nullable arg for list (no `!` after the type)
+				sortDirection: 'ModelSortDirection',
+			},
+			generateSkArgs('list'),
+		);
 	}
 
 	switch (modelOperation) {

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -335,7 +335,7 @@
 			"name": "[API] generateClient (AppSync)",
 			"path": "./dist/esm/api/index.mjs",
 			"import": "{ generateClient }",
-			"limit": "38.5 kB"
+			"limit": "39.0 kB"
 		},
 		{
 			"name": "[API] REST API handlers",


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

We were generating list query arguments for sort keys using the underlying field's primitive type as the argument type.

List queries on models with composite primary keys expect a _condition_ input argument type for the sort key(s).

See this diff for current vs expected behavior: https://github.com/aws-amplify/amplify-js/compare/data-fix-sk-args?expand=1#diff-fa24101f776e07b54f8416746bbed348b96dd7e855c0eed2e5609bcb501a9b46L4095-R4095


#### Description of how you validated changes
* updated e2e test to include this use case - https://github.com/aws-amplify/amplify-js-samples-staging/pull/845


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
