### PR TITLE
fix(geo): update amplify config geo schema

### DIFF
--- a/packages/core/__tests__/parseAmplifyOutputs.test.ts
+++ b/packages/core/__tests__/parseAmplifyOutputs.test.ts
@@ -222,7 +222,7 @@ describe('parseAmplifyOutputs tests', () => {
 					aws_region: 'us-east-1',
 					maps: {
 						items: {
-							map1: { name: 'map1', style: 'color' },
+							map1: { style: 'color' },
 						},
 						default: 'map1',
 					},
@@ -249,7 +249,6 @@ describe('parseAmplifyOutputs tests', () => {
 							items: {
 								map1: {
 									style: 'color',
-									name: 'map1',
 								},
 							},
 						},

--- a/packages/core/src/singleton/AmplifyOutputs/types.ts
+++ b/packages/core/src/singleton/AmplifyOutputs/types.ts
@@ -51,7 +51,7 @@ export interface AmplifyOutputsStorageProperties {
 export interface AmplifyOutputsGeoProperties {
 	aws_region: string;
 	maps?: {
-		items: Record<string, { name: string; style: string }>;
+		items: Record<string, unknown>;
 		default: string;
 	};
 	search_indices?: { items: string[]; default: string };


### PR DESCRIPTION
#### Description of changes
below is the ref for backend schema that generates geo amplifyOutputs
```
"geo": {
    "description": "Outputs manually specified by developers for use with frontend library",
    "type": "object",
    "additionalProperties": false,
    "properties": {
    "aws_region": {
        "description": "AWS Region of Amazon Location Service resources",
        "$ref": "#/$defs/aws_region"
    },
    "maps": {
        "description": "Maps from Amazon Location Service",
        "type": "object",
        "additionalProperties": false,
        "properties": {
        "items": {
            "type": "object",
            "additionalProperties": false,
            "propertyNames": {
            "description": "Amazon Location Service Map name",
            "type": "string"
            },
            "patternProperties": {
            ".*": {
                "$ref": "#/$defs/amazon_location_service_config"
            }
            }
        },
        "default": {
            "type": "string"
        }
        },
        "required": ["items", "default"]
    },
    "search_indices": {
        "description": "Location search (search by places, addresses, coordinates)",
        "type": "object",
        "additionalProperties": false,
        "properties": {
        "items": {
            "type": "array",
            "uniqueItems": true,
            "minItems": 1,
            "items": {
            "description": "Actual search name",
            "type": "string"
            }
        },
        "default": {
            "type": "string"
        }
        },
        "required": ["items", "default"]
    },
    "geofence_collections": {
        "description": "Geofencing (visualize virtual perimeters)",
        "type": "object",
        "additionalProperties": false,
        "properties": {
            "items": {
            "type": "array",
            "uniqueItems": true,
            "minItems": 1,
            "items": {
                "description": "Geofence name",
                "type": "string"
            }
            },
            "default": {
            "type": "string"
            }
        },
        "required": ["items", "default"]
    }
    },
    "required": ["aws_region"]
},
```

Geo.map.items (`amazon_location_service_config` from the config above)
```
"amazon_location_service_config": {
    "type": "object",
    "additionalProperties": false,
    "properties": {
    "style": { // ====> only 'style' present here, no 'name'
        "description": "Map style",
        "type": "string"
    }
    }
}
```

amplify_outputs.json
```
"geo": {
  "aws_region": "us-west-2",
  "maps": {
    "items": {
      "myMap": {
        "style": "VectorEsriNavigation"
      }
    },
    "default": "myMap"
  },
  "geofence_collections": {
    "default": "myGeofenceCollection",
    "items": [
      "myGeofenceCollection"
    ]
  },
  "search_indices": {
    "default": "myPlaceIndex",
    "items": [
      "myPlaceIndex"
    ]
  }
}
```

#### Description of how you validated changes
Validated this change works with the [geo gen2 cdk construct mentioned in docs](https://docs.amplify.aws/gen2/build-a-backend/add-aws-services/geo/)


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
