### PR TITLE
fix: Prevent creating multiple endpoint ids

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -317,7 +317,7 @@
 			"name": "[Analytics] identifyUser (Pinpoint)",
 			"path": "./dist/esm/analytics/index.mjs",
 			"import": "{ identifyUser }",
-			"limit": "15.52 kB"
+			"limit": "15.53 kB"
 		},
 		{
 			"name": "[Analytics] enable",

--- a/packages/core/__tests__/providers/pinpoint/utils/createEndpointId.test.ts
+++ b/packages/core/__tests__/providers/pinpoint/utils/createEndpointId.test.ts
@@ -42,11 +42,13 @@ describe('Pinpoint Provider Util: createEndpointId', () => {
 		expect(mockAmplifyUuid).toHaveBeenCalled();
 	});
 
-	it('clears a created endpoint id for a category', () => {
-		const newUuid = `new-${uuid}`;
-		mockAmplifyUuid.mockReturnValue(newUuid);
-		clearCreatedEndpointId(appId, category);
+	describe('clearCreatedEndpointId()', () => {
+		it('can create a new endpoint id for a category after clearing', () => {
+			const newUuid = `new-${uuid}`;
+			mockAmplifyUuid.mockReturnValue(newUuid);
+			clearCreatedEndpointId(appId, category);
 
-		expect(createEndpointId(appId, category)).toBe(newUuid);
+			expect(createEndpointId(appId, category)).toBe(newUuid);
+		});
 	});
 });

--- a/packages/core/__tests__/providers/pinpoint/utils/createEndpointId.test.ts
+++ b/packages/core/__tests__/providers/pinpoint/utils/createEndpointId.test.ts
@@ -14,10 +14,15 @@ describe('Pinpoint Provider Util: createEndpointId', () => {
 	// assert mocks
 	const mockAmplifyUuid = amplifyUuid as jest.Mock;
 
+	afterEach(() => {
+		mockAmplifyUuid.mockReset();
+	});
+
 	it('returns a new endpoint id for a category', () => {
 		mockAmplifyUuid.mockReturnValue(uuid);
 
 		expect(createEndpointId(appId, category)).toBe(uuid);
+		expect(mockAmplifyUuid).toHaveBeenCalled();
 	});
 
 	it('returns the same endpoint id for a category', () => {
@@ -25,6 +30,7 @@ describe('Pinpoint Provider Util: createEndpointId', () => {
 		mockAmplifyUuid.mockReturnValue(newUuid);
 
 		expect(createEndpointId(appId, category)).toBe(uuid);
+		expect(mockAmplifyUuid).not.toHaveBeenCalled();
 	});
 
 	it('returns a new endpoint id for a different category', () => {
@@ -33,6 +39,7 @@ describe('Pinpoint Provider Util: createEndpointId', () => {
 		mockAmplifyUuid.mockReturnValue(newUuid);
 
 		expect(createEndpointId(appId, newCategory)).toBe(newUuid);
+		expect(mockAmplifyUuid).toHaveBeenCalled();
 	});
 
 	it('clears a created endpoint id for a category', () => {

--- a/packages/core/__tests__/providers/pinpoint/utils/createEndpointId.test.ts
+++ b/packages/core/__tests__/providers/pinpoint/utils/createEndpointId.test.ts
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	clearCreatedEndpointId,
+	createEndpointId,
+} from '../../../../src/providers/pinpoint/utils/createEndpointId';
+import { amplifyUuid } from '../../../../src/utils/amplifyUuid';
+import { appId, category, uuid } from '../testUtils/data';
+
+jest.mock('../../../../src/utils/amplifyUuid');
+
+describe('Pinpoint Provider Util: createEndpointId', () => {
+	// assert mocks
+	const mockAmplifyUuid = amplifyUuid as jest.Mock;
+
+	it('returns a new endpoint id for a category', () => {
+		mockAmplifyUuid.mockReturnValue(uuid);
+
+		expect(createEndpointId(appId, category)).toBe(uuid);
+	});
+
+	it('returns the same endpoint id for a category', () => {
+		const newUuid = `new-${uuid}`;
+		mockAmplifyUuid.mockReturnValue(newUuid);
+
+		expect(createEndpointId(appId, category)).toBe(uuid);
+	});
+
+	it('returns a new endpoint id for a different category', () => {
+		const newUuid = `new-${uuid}`;
+		const newCategory = 'PushNotification';
+		mockAmplifyUuid.mockReturnValue(newUuid);
+
+		expect(createEndpointId(appId, newCategory)).toBe(newUuid);
+	});
+
+	it('clears a created endpoint id for a category', () => {
+		const newUuid = `new-${uuid}`;
+		mockAmplifyUuid.mockReturnValue(newUuid);
+		clearCreatedEndpointId(appId, category);
+
+		expect(createEndpointId(appId, category)).toBe(newUuid);
+	});
+});

--- a/packages/core/src/providers/pinpoint/utils/createEndpointId.ts
+++ b/packages/core/src/providers/pinpoint/utils/createEndpointId.ts
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { amplifyUuid } from '../../../utils/amplifyUuid';
+import { SupportedCategory } from '../types';
+
+import { getCacheKey } from './getCacheKey';
+
+const createdEndpointIds: Record<string, string> = {};
+
+/**
+ * Creates an endpoint id and guarantees multiple creations for a category returns the same uuid.
+ *
+ * @internal
+ */
+export const createEndpointId = (
+	appId: string,
+	category: SupportedCategory,
+): string => {
+	const cacheKey = getCacheKey(appId, category);
+	if (!createdEndpointIds[cacheKey]) {
+		createdEndpointIds[cacheKey] = amplifyUuid();
+	}
+
+	return createdEndpointIds[cacheKey];
+};
+
+/**
+ * Clears a created endpoint id for a category.
+ *
+ * @internal
+ */
+export const clearCreatedEndpointId = (
+	appId: string,
+	category: SupportedCategory,
+): void => {
+	const cacheKey = getCacheKey(appId, category);
+	delete createdEndpointIds[cacheKey];
+};

--- a/packages/core/src/providers/pinpoint/utils/index.ts
+++ b/packages/core/src/providers/pinpoint/utils/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { cacheEndpointId } from './cacheEndpointId';
+export { createEndpointId } from './createEndpointId';
 export { getCacheKey } from './getCacheKey';
 export { getEndpointId } from './getEndpointId';
 export { resolveEndpointId } from './resolveEndpointId';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Currently, when an endpoint is created by `updateEndpoint`, it is not cached until a full network round trip to the service. This results in a large window during which additional `updateEndpoint` calls will create new endpoint ids due to none being found in the cache.

This PR adds a utility which will hold created endpoint ids in memory until it is successfully cached or if the endpoint updating has failed.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/13272

#### Description of how you validated changes
* `yarn test`
* Added thrown error expectation to original code and asserted the resulting behavior of the `updateEndpoint` function is the same (async void which throws uncaught)
* Tested in sample app and validated that network race condition was mitigated - the `updateEndpoint` calls triggered by `initializePushNotifications` and an adjacent `identifyUser` call were no longer creating separate endpoints.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
