### PR TITLE
chore: add deprecation notice to DataStore exported Schemaa type

### DIFF
--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -22,10 +22,18 @@ import { GraphQLAuthMode } from '@aws-amplify/core/internals/utils';
 export type Scalar<T> = T extends Array<infer InnerType> ? InnerType : T;
 
 //#region Schema types
-export type Schema = UserSchema & {
+/**
+ * @deprecated If you intended to use the Schema for `generateClient`, then you've imported the wrong Schema type.
+ * Use `import { type Schema } from '../amplify/data/resource' instead. If you intended to import the type for DataStore
+ * Schemas, then import "DataStoreSchema" instead.
+ */
+export type Schema = DataStoreSchema;
+
+export type DataStoreSchema = UserSchema & {
 	version: string;
 	codegenVersion: string;
 };
+
 export type UserSchema = {
 	models: SchemaModels;
 	nonModels?: SchemaNonModels;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adds deprecation flag and docstring to the `Schema` type exported from `DataStore`. Customers should not be using this type directly. And, it shows up in autocompletion when customers are looking for the `Schema` type exported from gen2 API's, which can lead to some confusion.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

The primary concern is whether any lint rules might prohibit an app from using a deprecated type. To alleviate that concern:

1. Ran e2e's in a tagged release to confirm no failed builds.
2. Manually created a nextjs app with default eslint rules and built. (No errors or warnings emitted.)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
