### PR TITLE
feat(auth): enable auth gen2

### DIFF
--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -512,6 +512,72 @@ tests:
     spec: sign-in-with-oauth
     browser: [chrome]
 
+  # AUTH GEN2
+  - test_name: integ_react_javascript_authentication
+    desc: 'React Authentication'
+    framework: react
+    category: auth
+    sample_name: [javascript-auth]
+    spec: functional-auth
+    browser: *minimal_browser_list
+    backend: gen2
+  - test_name: integ_react_auth_1_guest_to_authenticated_user
+    desc: 'Guest to Authenticated User'
+    framework: react
+    category: auth
+    sample_name: [guest-to-auth-user]
+    spec: guest-to-auth-user
+    browser: *minimal_browser_list
+    backend: gen2
+  - test_name: integ_react_typescript_authentication
+    desc: 'React Typescript Authentication'
+    framework: react
+    category: auth
+    sample_name: [typescript-auth]
+    spec: functional-auth
+    browser: *minimal_browser_list
+    backend: gen2
+  - test_name: integ_react_auth_2_sign_in_after_sign_up
+    desc: 'Sign In after Sign Up'
+    framework: react
+    category: auth
+    sample_name: [auto-signin-after-signup]
+    spec: auto-signin-after-signup
+    browser: *minimal_browser_list
+    backend: gen2
+  - test_name: integ_react_device_tracking
+    desc: 'cognito-device-tracking'
+    framework: react
+    category: auth
+    sample_name: [device-tracking]
+    spec: device-tracking
+    browser: *minimal_browser_list
+    backend: gen2
+  - test_name: integ_react_delete_user
+    desc: 'delete-user'
+    framework: react
+    category: auth
+    sample_name: [delete-user]
+    spec: delete-user
+    browser: *minimal_browser_list
+    backend: gen2
+  - test_name: integ_next_auth_authenticator_and_ssr_page
+    desc: 'Authenticator and SSR page'
+    framework: next
+    category: auth
+    sample_name: [auth-ssr]
+    spec: auth-ssr
+    browser: [chrome]
+    backend: gen2
+  - test_name: integ_next_auth_authenticator_and_rsc_page
+    desc: 'Authenticator and RSC page'
+    framework: next
+    category: auth
+    sample_name: [auth-rsc]
+    spec: auth-rsc
+    browser: [chrome]
+    backend: gen2
+
   # DISABLED Angular/Vue tests:
   # TODO: delete tests or add custom ui logic to support them.
 

--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -513,7 +513,7 @@ tests:
     browser: [chrome]
 
   # AUTH GEN2
-  - test_name: integ_react_javascript_authentication
+  - test_name: integ_react_javascript_authentication_gen2
     desc: 'React Authentication'
     framework: react
     category: auth
@@ -521,7 +521,7 @@ tests:
     spec: functional-auth
     browser: *minimal_browser_list
     backend: gen2
-  - test_name: integ_react_auth_1_guest_to_authenticated_user
+  - test_name: integ_react_auth_1_guest_to_authenticated_user_gen2
     desc: 'Guest to Authenticated User'
     framework: react
     category: auth
@@ -529,7 +529,7 @@ tests:
     spec: guest-to-auth-user
     browser: *minimal_browser_list
     backend: gen2
-  - test_name: integ_react_typescript_authentication
+  - test_name: integ_react_typescript_authentication_gen2
     desc: 'React Typescript Authentication'
     framework: react
     category: auth
@@ -537,7 +537,7 @@ tests:
     spec: functional-auth
     browser: *minimal_browser_list
     backend: gen2
-  - test_name: integ_react_auth_2_sign_in_after_sign_up
+  - test_name: integ_react_auth_2_sign_in_after_sign_up_gen2
     desc: 'Sign In after Sign Up'
     framework: react
     category: auth
@@ -545,7 +545,7 @@ tests:
     spec: auto-signin-after-signup
     browser: *minimal_browser_list
     backend: gen2
-  - test_name: integ_react_device_tracking
+  - test_name: integ_react_device_tracking_gen2
     desc: 'cognito-device-tracking'
     framework: react
     category: auth
@@ -553,7 +553,7 @@ tests:
     spec: device-tracking
     browser: *minimal_browser_list
     backend: gen2
-  - test_name: integ_react_delete_user
+  - test_name: integ_react_delete_user_gen2
     desc: 'delete-user'
     framework: react
     category: auth
@@ -561,7 +561,7 @@ tests:
     spec: delete-user
     browser: *minimal_browser_list
     backend: gen2
-  - test_name: integ_next_auth_authenticator_and_ssr_page
+  - test_name: integ_next_auth_authenticator_and_ssr_page_gen2
     desc: 'Authenticator and SSR page'
     framework: next
     category: auth
@@ -569,7 +569,7 @@ tests:
     spec: auth-ssr
     browser: [chrome]
     backend: gen2
-  - test_name: integ_next_auth_authenticator_and_rsc_page
+  - test_name: integ_next_auth_authenticator_and_rsc_page_gen2
     desc: 'Authenticator and RSC page'
     framework: next
     category: auth
@@ -577,6 +577,15 @@ tests:
     spec: auth-rsc
     browser: [chrome]
     backend: gen2
+  - test_name: integ_next_sign_in_with_oauth_gen2
+    desc: 'Sign-in with the OAuth flow'
+    framework: next
+    category: auth
+    sample_name: [sign-in-with-oauth]
+    spec: sign-in-with-oauth
+    browser: [chrome]
+    backend: gen2
+    
 
   # DISABLED Angular/Vue tests:
   # TODO: delete tests or add custom ui logic to support them.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
enables web auth gen2 e2e tests on CI with the exception of  `integ_react_credentials_different_region` . This test doesn't have a gen2 config. Gen2 doesn't support setting an identity pool in a different region yet.

#### Verification
Enabled auth tests running on CI:

https://github.com/aws-amplify/amplify-js/actions/runs/8901181083

<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
