### PR TITLE
fix: Prevent overwriting with fallbacks when updating endpoint

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -293,7 +293,7 @@
 			"name": "[Analytics] record (Pinpoint)",
 			"path": "./dist/esm/analytics/index.mjs",
 			"import": "{ record }",
-			"limit": "17.05 kB"
+			"limit": "17.08 kB"
 		},
 		{
 			"name": "[Analytics] record (Kinesis)",
@@ -317,7 +317,7 @@
 			"name": "[Analytics] identifyUser (Pinpoint)",
 			"path": "./dist/esm/analytics/index.mjs",
 			"import": "{ identifyUser }",
-			"limit": "15.53 kB"
+			"limit": "15.57 kB"
 		},
 		{
 			"name": "[Analytics] enable",

--- a/packages/core/__tests__/providers/pinpoint/apis/testUtils/getExpectedInput.ts
+++ b/packages/core/__tests__/providers/pinpoint/apis/testUtils/getExpectedInput.ts
@@ -3,7 +3,6 @@
 
 import {
 	appId,
-	clientDemographic,
 	endpointId as defaultEndpointId,
 	uuid,
 } from '../../testUtils/data';
@@ -12,7 +11,7 @@ export const getExpectedInput = ({
 	address,
 	attributes,
 	channelType,
-	demographic = clientDemographic as any,
+	demographic,
 	endpointId = defaultEndpointId,
 	location,
 	metrics,
@@ -28,30 +27,36 @@ export const getExpectedInput = ({
 			EffectiveDate: expect.any(String),
 			ChannelType: channelType,
 			Address: address,
-			Attributes: attributes,
-			Demographic: {
-				AppVersion: demographic.appVersion,
-				Locale: demographic.locale,
-				Make: demographic.make,
-				Model: demographic.model,
-				ModelVersion: demographic.modelVersion ?? demographic.version,
-				Platform: demographic.platform,
-				PlatformVersion: demographic.platformVersion,
-				Timezone: demographic.timezone,
-			},
-			Location: {
-				City: location?.city,
-				Country: location?.country,
-				Latitude: location?.latitude,
-				Longitude: location?.longitude,
-				PostalCode: location?.postalCode,
-				Region: location?.region,
-			},
+			...(attributes && { Attributes: attributes }),
+			...(demographic && {
+				Demographic: {
+					AppVersion: demographic.appVersion,
+					Locale: demographic.locale,
+					Make: demographic.make,
+					Model: demographic.model,
+					ModelVersion: demographic.modelVersion ?? demographic.version,
+					Platform: demographic.platform,
+					PlatformVersion: demographic.platformVersion,
+					Timezone: demographic.timezone,
+				},
+			}),
+			...(location && {
+				Location: {
+					City: location?.city,
+					Country: location?.country,
+					Latitude: location?.latitude,
+					Longitude: location?.longitude,
+					PostalCode: location?.postalCode,
+					Region: location?.region,
+				},
+			}),
 			Metrics: metrics,
 			OptOut: optOut,
-			User: {
-				UserId: userId,
-				UserAttributes: userAttributes,
-			},
+			...((userId || userAttributes) && {
+				User: {
+					UserId: userId,
+					UserAttributes: userAttributes,
+				},
+			}),
 		}),
 	});

--- a/packages/core/__tests__/providers/pinpoint/testUtils/data.ts
+++ b/packages/core/__tests__/providers/pinpoint/testUtils/data.ts
@@ -27,6 +27,9 @@ export const event = {
 };
 export const identityId = 'identity-id';
 export const region = 'region';
+export const userAttributes = {
+	attr: ['attr-value-one', 'attr-value-two'],
+};
 export const userId = 'user-id';
 export const userProfile = {
 	customProperties: {

--- a/packages/core/src/providers/pinpoint/apis/updateEndpoint.ts
+++ b/packages/core/src/providers/pinpoint/apis/updateEndpoint.ts
@@ -1,12 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { amplifyUuid } from '../../../utils/amplifyUuid';
-import { getClientInfo } from '../../../utils/getClientInfo';
 import {
 	UpdateEndpointInput,
 	updateEndpoint as clientUpdateEndpoint,
 } from '../../../awsClients/pinpoint';
+import { UserProfile } from '../../../types';
+import { amplifyUuid } from '../../../utils/amplifyUuid';
+import { getClientInfo } from '../../../utils/getClientInfo';
 import { PinpointUpdateEndpointInput } from '../types';
 import { cacheEndpointId } from '../utils/cacheEndpointId';
 import {
@@ -46,22 +47,34 @@ export const updateEndpoint = async ({
 		name,
 		plan,
 	} = userProfile ?? {};
-	const clientInfo = getClientInfo();
+
+	// only automatically populate the endpoint with client info and identity id upon endpoint creation to
+	// avoid overwriting the endpoint with these values every time the endpoint is updated
+	const demographicsFromClientInfo: UserProfile['demographic'] = {};
+	const resolvedUserId = createdEndpointId ? userId ?? identityId : userId;
+	if (createdEndpointId) {
+		const clientInfo = getClientInfo();
+		demographicsFromClientInfo.appVersion = clientInfo.appVersion;
+		demographicsFromClientInfo.make = clientInfo.make;
+		demographicsFromClientInfo.model = clientInfo.model;
+		demographicsFromClientInfo.modelVersion = clientInfo.version;
+		demographicsFromClientInfo.platform = clientInfo.platform;
+	}
 	const mergedDemographic = {
-		appVersion: clientInfo.appVersion,
-		make: clientInfo.make,
-		model: clientInfo.model,
-		modelVersion: clientInfo.version,
-		platform: clientInfo.platform,
+		...demographicsFromClientInfo,
 		...demographic,
 	};
-	const shouldAddAttributes = email || customProperties || name || plan;
 	const attributes = {
 		...(email && { email: [email] }),
 		...(name && { name: [name] }),
 		...(plan && { plan: [plan] }),
 		...customProperties,
 	};
+
+	const shouldAddDemographics = createdEndpointId || demographic;
+	const shouldAddAttributes = email || customProperties || name || plan;
+	const shouldAddUser = resolvedUserId || userAttributes;
+
 	const input: UpdateEndpointInput = {
 		ApplicationId: appId,
 		EndpointId: endpointId ?? createdEndpointId,
@@ -70,31 +83,37 @@ export const updateEndpoint = async ({
 			EffectiveDate: new Date().toISOString(),
 			ChannelType: channelType,
 			Address: address,
-			Attributes: shouldAddAttributes ? attributes : undefined,
-			Demographic: {
-				AppVersion: mergedDemographic.appVersion,
-				Locale: mergedDemographic.locale,
-				Make: mergedDemographic.make,
-				Model: mergedDemographic.model,
-				ModelVersion: mergedDemographic.modelVersion,
-				Platform: mergedDemographic.platform,
-				PlatformVersion: mergedDemographic.platformVersion,
-				Timezone: mergedDemographic.timezone,
-			},
-			Location: {
-				City: location?.city,
-				Country: location?.country,
-				Latitude: location?.latitude,
-				Longitude: location?.longitude,
-				PostalCode: location?.postalCode,
-				Region: location?.region,
-			},
+			...(shouldAddAttributes && { Attributes: attributes }),
+			...(shouldAddDemographics && {
+				Demographic: {
+					AppVersion: mergedDemographic.appVersion,
+					Locale: mergedDemographic.locale,
+					Make: mergedDemographic.make,
+					Model: mergedDemographic.model,
+					ModelVersion: mergedDemographic.modelVersion,
+					Platform: mergedDemographic.platform,
+					PlatformVersion: mergedDemographic.platformVersion,
+					Timezone: mergedDemographic.timezone,
+				},
+			}),
+			...(location && {
+				Location: {
+					City: location.city,
+					Country: location.country,
+					Latitude: location.latitude,
+					Longitude: location.longitude,
+					PostalCode: location.postalCode,
+					Region: location.region,
+				},
+			}),
 			Metrics: metrics,
 			OptOut: optOut,
-			User: {
-				UserId: userId ?? identityId,
-				UserAttributes: userAttributes,
-			},
+			...(shouldAddUser && {
+				User: {
+					UserId: resolvedUserId,
+					UserAttributes: userAttributes,
+				},
+			}),
 		},
 	};
 	try {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
When calling `initializePushNotifications`, the library calls an internal `updateEndpoint` API. Anytime `updateEndpoint` is called, it automatically populates the `demographic` property with client info and the `userId` with the identity id. When calling `identifyUser`, these values can be provided explicitly but will always be pre-populated. This can have unexpected consequences since `initializePushNotifications` is typically called on every app launch - and it will opaquely overwrite existing values previously set on the endpoint.

This PR updates the `updateEndpoint` API to only pre-populate these fields when **creating** an endpoint to avoid repeatedly overwriting the endpoint with the default/fallback values.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/13174


#### Description of how you validated changes
* `yarn test`
* Added unit tests that were expected to fail prior to code changes and verified they are now passing
* Tested on sample app to see that `demographic` and `userId` are only on the network request when an endpoint has yet to be cached (endpoint creation) and subsequent calls do not.

```
// Endpoint creation
{
  "RequestId": "8808844f-5e12-440b-a914-d3ae7191b0f8",
  "EffectiveDate": "2024-05-02T19:55:22.795Z",
  "ChannelType": "APNS_SANDBOX",
  "Address": "<apns-token>",
  "Demographic": {
    "AppVersion": "ios/17.0",
    "Make": null,
    "Model": null,
    "ModelVersion": "17.0",
    "Platform": "ios"
  },
  "User": { "UserId": "<cognito-identity-id>" }
}
```

```
// Endpoint update
{
  "RequestId": "8178652f-5842-44b6-a02c-27616f4d6cb9",
  "EffectiveDate": "2024-05-02T19:57:28.751Z",
  "ChannelType": "APNS_SANDBOX",
  "Address": "<apns-token>",
}

```


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
