### PR TITLE
fix: Wait for endpoint creation to identify user

### DIFF
--- a/packages/core/src/providers/pinpoint/index.ts
+++ b/packages/core/src/providers/pinpoint/index.ts
@@ -7,4 +7,4 @@ export {
 	PinpointServiceOptions,
 	UpdateEndpointException,
 } from './types';
-export { resolveEndpointId } from './utils';
+export { getEndpointId, resolveEndpointId } from './utils';

--- a/packages/notifications/__tests__/pushNotifications/providers/pinpoint/apis/identifyUser.native.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/pinpoint/apis/identifyUser.native.test.ts
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { updateEndpoint } from '@aws-amplify/core/internals/providers/pinpoint';
+import {
+	getEndpointId,
+	updateEndpoint,
+} from '@aws-amplify/core/internals/providers/pinpoint';
 import { assertIsInitialized } from '../../../../../src/pushNotifications/errors/errorHelpers';
 import { identifyUser } from '../../../../../src/pushNotifications/providers/pinpoint/apis/identifyUser.native';
 import { IdentifyUserInput } from '../../../../../src/pushNotifications/providers/pinpoint/types';
@@ -11,6 +14,7 @@ import {
 } from '../../../../../src/pushNotifications/utils';
 import {
 	getChannelType,
+	getInflightDeviceRegistration,
 	resolveConfig,
 } from '../../../../../src/pushNotifications/providers/pinpoint/utils';
 import {
@@ -32,11 +36,14 @@ describe('identifyUser (native)', () => {
 	// assert mocks
 	const mockAssertIsInitialized = assertIsInitialized as jest.Mock;
 	const mockGetChannelType = getChannelType as jest.Mock;
-	const mockUpdateEndpoint = updateEndpoint as jest.Mock;
+	const mockGetEndpointId = getEndpointId as jest.Mock;
+	const mockGetInflightDeviceRegistration =
+		getInflightDeviceRegistration as jest.Mock;
 	const mockGetPushNotificationUserAgentString =
 		getPushNotificationUserAgentString as jest.Mock;
 	const mockResolveConfig = resolveConfig as jest.Mock;
 	const mockResolveCredentials = resolveCredentials as jest.Mock;
+	const mockUpdateEndpoint = updateEndpoint as jest.Mock;
 
 	beforeAll(() => {
 		mockGetChannelType.mockReturnValue(channelType);
@@ -47,7 +54,9 @@ describe('identifyUser (native)', () => {
 
 	afterEach(() => {
 		mockAssertIsInitialized.mockReset();
+		mockGetEndpointId.mockReset();
 		mockUpdateEndpoint.mockReset();
+		mockGetInflightDeviceRegistration.mockClear();
 	});
 
 	it('must be initialized', async () => {
@@ -110,5 +119,25 @@ describe('identifyUser (native)', () => {
 			userProfile: {},
 		};
 		await expect(identifyUser(input)).rejects.toBeDefined();
+	});
+
+	it('awaits device registration promise when endpoint is not present', async () => {
+		const input: IdentifyUserInput = {
+			userId: 'user-id',
+			userProfile: {},
+		};
+		mockGetEndpointId.mockResolvedValue(undefined);
+		await identifyUser(input);
+		expect(mockGetInflightDeviceRegistration).toHaveBeenCalled();
+	});
+
+	it('does not await device registration promise when endpoint is present', async () => {
+		const input: IdentifyUserInput = {
+			userId: 'user-id',
+			userProfile: {},
+		};
+		mockGetEndpointId.mockResolvedValue('endpoint-id');
+		await identifyUser(input);
+		expect(mockGetInflightDeviceRegistration).not.toHaveBeenCalled();
 	});
 });

--- a/packages/notifications/__tests__/pushNotifications/providers/pinpoint/apis/initializePushNotifications.native.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/pinpoint/apis/initializePushNotifications.native.test.ts
@@ -13,7 +13,11 @@ import {
 	resolveCredentials,
 	setToken,
 } from '../../../../../src/pushNotifications/utils';
-import { resolveConfig } from '../../../../../src/pushNotifications//providers/pinpoint/utils';
+import {
+	rejectInflightDeviceRegistration,
+	resolveConfig,
+	resolveInflightDeviceRegistration,
+} from '../../../../../src/pushNotifications//providers/pinpoint/utils';
 import {
 	completionHandlerId,
 	credentials,
@@ -56,8 +60,12 @@ describe('initializePushNotifications (native)', () => {
 	const mockGetToken = getToken as jest.Mock;
 	const mockInitialize = initialize as jest.Mock;
 	const mockIsInitialized = isInitialized as jest.Mock;
+	const mockRejectInflightDeviceRegistration =
+		rejectInflightDeviceRegistration as jest.Mock;
 	const mockResolveCredentials = resolveCredentials as jest.Mock;
 	const mockResolveConfig = resolveConfig as jest.Mock;
+	const mockResolveInflightDeviceRegistration =
+		resolveInflightDeviceRegistration as jest.Mock;
 	const mockSetToken = setToken as jest.Mock;
 	const mockNotifyEventListeners = notifyEventListeners as jest.Mock;
 	const mockNotifyEventListenersAndAwaitHandlers =
@@ -114,6 +122,8 @@ describe('initializePushNotifications (native)', () => {
 		mockEventListenerRemover.remove.mockClear();
 		mockNotifyEventListeners.mockClear();
 		mockNotifyEventListenersAndAwaitHandlers.mockClear();
+		mockRejectInflightDeviceRegistration.mockClear();
+		mockResolveInflightDeviceRegistration.mockClear();
 	});
 
 	it('only enables once', () => {
@@ -236,29 +246,29 @@ describe('initializePushNotifications (native)', () => {
 
 	describe('token received', () => {
 		it('registers and calls token received listener', done => {
+			expect.assertions(6);
 			mockGetToken.mockReturnValue(undefined);
 			mockAddTokenEventListener.mockImplementation(
 				async (heardEvent, handler) => {
 					if (heardEvent === NativeEvent.TOKEN_RECEIVED) {
 						await handler(pushToken);
+						expect(mockAddTokenEventListener).toHaveBeenCalledWith(
+							NativeEvent.TOKEN_RECEIVED,
+							expect.any(Function),
+						);
+						expect(mockSetToken).toHaveBeenCalledWith(pushToken);
+						expect(mockNotifyEventListeners).toHaveBeenCalledWith(
+							'tokenReceived',
+							pushToken,
+						);
+						expect(mockUpdateEndpoint).toHaveBeenCalled();
+						expect(mockResolveInflightDeviceRegistration).toHaveBeenCalled();
+						expect(mockRejectInflightDeviceRegistration).not.toHaveBeenCalled();
+						done();
 					}
 				},
 			);
-			mockUpdateEndpoint.mockImplementation(() => {
-				expect(mockUpdateEndpoint).toHaveBeenCalled();
-				done();
-			});
 			initializePushNotifications();
-
-			expect(mockAddTokenEventListener).toHaveBeenCalledWith(
-				NativeEvent.TOKEN_RECEIVED,
-				expect.any(Function),
-			);
-			expect(mockSetToken).toHaveBeenCalledWith(pushToken);
-			expect(mockNotifyEventListeners).toHaveBeenCalledWith(
-				'tokenReceived',
-				pushToken,
-			);
 		});
 
 		it('should not be invoke token received listener with the same token twice', () => {
@@ -292,6 +302,7 @@ describe('initializePushNotifications (native)', () => {
 		});
 
 		it('throws if device registration fails', done => {
+			expect.assertions(3);
 			mockUpdateEndpoint.mockImplementation(() => {
 				throw new Error();
 			});
@@ -299,6 +310,10 @@ describe('initializePushNotifications (native)', () => {
 				async (heardEvent, handler) => {
 					if (heardEvent === NativeEvent.TOKEN_RECEIVED) {
 						await expect(handler(pushToken)).rejects.toThrow();
+						expect(
+							mockResolveInflightDeviceRegistration,
+						).not.toHaveBeenCalled();
+						expect(mockRejectInflightDeviceRegistration).toHaveBeenCalled();
 						done();
 					}
 				},

--- a/packages/notifications/__tests__/pushNotifications/providers/pinpoint/utils/inflightDeviceRegistration.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/pinpoint/utils/inflightDeviceRegistration.test.ts
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	getInflightDeviceRegistration,
+	rejectInflightDeviceRegistration,
+	resolveInflightDeviceRegistration,
+} from '../../../../../src/pushNotifications/providers/pinpoint/utils/inflightDeviceRegistration';
+import { InflightDeviceRegistration } from '../../../../../src/pushNotifications/providers/pinpoint/types';
+
+describe('inflightDeviceRegistration', () => {
+	describe('resolveInflightDeviceRegistration', () => {
+		let getInflightDeviceRegistration: () => InflightDeviceRegistration;
+		let resolveInflightDeviceRegistration: () => void;
+		jest.isolateModules(() => {
+			({
+				getInflightDeviceRegistration,
+				resolveInflightDeviceRegistration,
+			} = require('../../../../../src/pushNotifications/providers/pinpoint/utils/inflightDeviceRegistration'));
+		});
+
+		it('creates a pending promise on module load', () => {
+			expect(getInflightDeviceRegistration()).toBeDefined();
+		});
+
+		it('should resolve the promise', async () => {
+			const blockedFunction = jest.fn();
+			const promise = getInflightDeviceRegistration()?.then(() => {
+				blockedFunction();
+			});
+
+			expect(blockedFunction).not.toHaveBeenCalled();
+			resolveInflightDeviceRegistration();
+			await promise;
+			expect(blockedFunction).toHaveBeenCalled();
+		});
+
+		it('should have released the promise from memory', () => {
+			expect(getInflightDeviceRegistration()).toBeUndefined();
+		});
+	});
+
+	describe('rejectInflightDeviceRegistration', () => {
+		let getInflightDeviceRegistration: () => InflightDeviceRegistration;
+		let rejectInflightDeviceRegistration: (underlyingError: unknown) => void;
+		jest.isolateModules(() => {
+			({
+				getInflightDeviceRegistration,
+				rejectInflightDeviceRegistration,
+			} = require('../../../../../src/pushNotifications/providers/pinpoint/utils/inflightDeviceRegistration'));
+		});
+
+		it('creates a pending promise on module load', () => {
+			expect(getInflightDeviceRegistration()).toBeDefined();
+		});
+
+		it('should reject the promise', async () => {
+			const blockedFunction = jest.fn();
+			const promise = getInflightDeviceRegistration()?.then(() => {
+				blockedFunction();
+			});
+
+			expect(blockedFunction).not.toHaveBeenCalled();
+			rejectInflightDeviceRegistration(new Error());
+			await expect(promise).rejects.toThrow('Failed to register device');
+			expect(blockedFunction).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/notifications/__tests__/pushNotifications/providers/pinpoint/utils/inflightDeviceRegistration.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/pinpoint/utils/inflightDeviceRegistration.test.ts
@@ -55,14 +55,18 @@ describe('inflightDeviceRegistration', () => {
 		});
 
 		it('should reject the promise', async () => {
+			const underlyingError = new Error('underlying-error');
 			const blockedFunction = jest.fn();
 			const promise = getInflightDeviceRegistration()?.then(() => {
 				blockedFunction();
 			});
 
 			expect(blockedFunction).not.toHaveBeenCalled();
-			rejectInflightDeviceRegistration(new Error());
-			await expect(promise).rejects.toThrow('Failed to register device');
+			rejectInflightDeviceRegistration(underlyingError);
+			await expect(promise).rejects.toMatchObject({
+				name: 'DeviceRegistrationFailed',
+				underlyingError,
+			});
 			expect(blockedFunction).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/notifications/src/pushNotifications/providers/pinpoint/types/index.ts
+++ b/packages/notifications/src/pushNotifications/providers/pinpoint/types/index.ts
@@ -37,4 +37,8 @@ export {
 	OnTokenReceivedOutput,
 } from './outputs';
 export { IdentifyUserOptions } from './options';
-export { ChannelType } from './pushNotifications';
+export {
+	ChannelType,
+	InflightDeviceRegistration,
+	InflightDeviceRegistrationResolver,
+} from './pushNotifications';

--- a/packages/notifications/src/pushNotifications/providers/pinpoint/types/pushNotifications.ts
+++ b/packages/notifications/src/pushNotifications/providers/pinpoint/types/pushNotifications.ts
@@ -3,4 +3,13 @@
 
 import { updateEndpoint } from '@aws-amplify/core/internals/providers/pinpoint';
 
+import { PushNotificationError } from '../../../errors';
+
 export type ChannelType = Parameters<typeof updateEndpoint>[0]['channelType'];
+
+export type InflightDeviceRegistration = Promise<void> | undefined;
+
+export interface InflightDeviceRegistrationResolver {
+	resolve?(): void;
+	reject?(error: PushNotificationError): void;
+}

--- a/packages/notifications/src/pushNotifications/providers/pinpoint/utils/index.ts
+++ b/packages/notifications/src/pushNotifications/providers/pinpoint/utils/index.ts
@@ -4,4 +4,9 @@
 export { createMessageEventRecorder } from './createMessageEventRecorder';
 export { getAnalyticsEvent } from './getAnalyticsEvent';
 export { getChannelType } from './getChannelType';
+export {
+	getInflightDeviceRegistration,
+	rejectInflightDeviceRegistration,
+	resolveInflightDeviceRegistration,
+} from './inflightDeviceRegistration';
 export { resolveConfig } from './resolveConfig';

--- a/packages/notifications/src/pushNotifications/providers/pinpoint/utils/inflightDeviceRegistration.ts
+++ b/packages/notifications/src/pushNotifications/providers/pinpoint/utils/inflightDeviceRegistration.ts
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PushNotificationError } from '../../../errors';
+import {
+	InflightDeviceRegistration,
+	InflightDeviceRegistrationResolver,
+} from '../types';
+
+const inflightDeviceRegistrationResolver: InflightDeviceRegistrationResolver =
+	{};
+
+let inflightDeviceRegistration: InflightDeviceRegistration = new Promise<void>(
+	(resolve, reject) => {
+		inflightDeviceRegistrationResolver.resolve = resolve;
+		inflightDeviceRegistrationResolver.reject = reject;
+	},
+);
+
+export const getInflightDeviceRegistration = () => inflightDeviceRegistration;
+
+export const resolveInflightDeviceRegistration = () => {
+	inflightDeviceRegistrationResolver.resolve?.();
+	// release promise from memory
+	inflightDeviceRegistration = undefined;
+};
+
+export const rejectInflightDeviceRegistration = (underlyingError: unknown) => {
+	inflightDeviceRegistrationResolver.reject?.(
+		new PushNotificationError({
+			name: 'DeviceRegistrationFailed',
+			message: 'Failed to register device for push notifications.',
+			underlyingError,
+		}),
+	);
+	// release promise from memory
+	inflightDeviceRegistration = undefined;
+};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
When the Push Notification category is first creating a Pinpoint endpoint upon receiving a device token, it is possible for an `identifyUser` call to be attempting to update the endpoint to be resolved first over the network. This is troublesome for at least two known reasons:
1. The `identifyUser` call could be attempting to set the `OptOut` property to `'NONE'` and if it is resolved first by the service, the service will reject the request due to the `Address` not having yet been set.
2. The `identifyUser` call could contain `userId` or `demographic` information and if it resolved first by the service, the request made by the library to register the device token would contain default values which would unintentionally overwrite the ones set by `identifyUser`

This PR mitigates this by having `identifyUser` calls (for Push Notification channels) await the resolution of device registration during endpoint creation (i.e. this blocking does not occur during endpoint updates).

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/13174
https://github.com/aws-amplify/amplify-js/issues/13272

#### Description of how you validated changes
* Added unit tests for added use cases
* `yarn test`
* Tested in a sample React Native application to assert `identifyUser` calls were blocked on the endpoint creation triggered by device registration but not on subsequent updates

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
