### PR TITLE
fix(core): assign the correct keys for Apple and Amazon providers

### DIFF
--- a/packages/core/__mocks__/configMocks/amplify_outputs.json
+++ b/packages/core/__mocks__/configMocks/amplify_outputs.json
@@ -7,7 +7,7 @@
 		"user_pool_client_id": "mock-cup-client-id",
 		"identity_pool_id": "mock-idp-id",
 		"oauth": {
-			"identity_providers": ["FACEBOOK", "SIGN_IN_WITH_APPLE", "GOOGLE"],
+			"identity_providers": ["FACEBOOK", "APPLE", "GOOGLE", "AMAZON"],
 			"domain": "mock-oauth-domain",
 			"scopes": ["phone"],
 			"redirect_sign_in_uri": ["mock-sign-in-uri"],

--- a/packages/core/__mocks__/configMocks/amplifyconfiguration.json
+++ b/packages/core/__mocks__/configMocks/amplifyconfiguration.json
@@ -22,7 +22,7 @@
 		"responseType": "token"
 	},
 	"aws_cognito_verification_mechanisms": ["EMAIL"],
-	"aws_cognito_social_providers": ["FACEBOOK", "APPLE", "GOOGLE"],
+	"aws_cognito_social_providers": ["FACEBOOK", "APPLE", "GOOGLE", "AMAZON"],
 	"aws_mobile_analytics_app_id": "mock-pinpoint-app-id",
 	"aws_mobile_analytics_app_region": "us-west-2",
 	"aws_user_files_s3_bucket": "mock-storage-bucket",

--- a/packages/core/__tests__/parseAmplifyOutputs.test.ts
+++ b/packages/core/__tests__/parseAmplifyOutputs.test.ts
@@ -25,7 +25,7 @@ describe('parseAmplifyOutputs tests', () => {
 							email: true,
 							oauth: {
 								domain: 'mock-oauth-domain',
-								providers: ['Facebook', 'Apple', 'Google'],
+								providers: ['Facebook', 'Apple', 'Google', 'Amazon'],
 								redirectSignIn: ['mock-sign-in-uri'],
 								redirectSignOut: ['mock-sign-out-uri'],
 								responseType: 'token',

--- a/packages/core/src/parseAmplifyOutputs.ts
+++ b/packages/core/src/parseAmplifyOutputs.ts
@@ -310,9 +310,9 @@ function getGraphQLAuthMode(authType: string): GraphQLAuthMode {
 
 const providerNames: Record<string, OAuthProvider> = {
 	GOOGLE: 'Google',
-	LOGIN_WITH_AMAZON: 'Amazon',
+	AMAZON: 'Amazon',
 	FACEBOOK: 'Facebook',
-	SIGN_IN_WITH_APPLE: 'Apple',
+	APPLE: 'Apple',
 };
 
 function getOAuthProviders(providers: string[] = []): OAuthProvider[] {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Currently there is a key miss match present in the Amazon and Apple social providers generated by `amplifyOutputs`. This PR matches the returned keys in the `parseAmplifyOutputs` helper.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
