### PR TITLE
feat(auth): add option to disable idp oauth flow

### DIFF
--- a/packages/auth/__tests__/auth-unit-test.ts
+++ b/packages/auth/__tests__/auth-unit-test.ts
@@ -3820,36 +3820,18 @@ describe('auth unit test', () => {
 
 		test('should call urlListener by default', async () => {
 			const urlListenerSpy = jest.spyOn(urlListener, 'default');
-			const options: AuthOptions = {
-				region: 'region',
-				userPoolId: 'userPoolId',
-				oauth: {
-					domain: 'mydomain.auth.us-east-1.amazoncognito.com',
-					scope: ['aws.cognito.signin.user.admin'],
-					redirectSignIn: 'http://localhost:3000/',
-					redirectSignOut: 'http://localhost:3000/',
-					responseType: 'code',
-				},
-				identityPoolId: 'awsCognitoIdentityPoolId',
-			};
-			new Auth(options);
+			new Auth(authOptionsWithHostedUIConfig);
 			expect(urlListenerSpy).toHaveBeenCalledTimes(1);
 		});
 
 		test('should not call urlListener when IDP initiated oauth is disabled', async () => {
 			const urlListenerSpy = jest.spyOn(urlListener, 'default');
 			const options: AuthOptions = {
-				region: 'region',
-				userPoolId: 'userPoolId',
+				...authOptionsWithHostedUIConfig,
 				oauth: {
-					domain: 'mydomain.auth.us-east-1.amazoncognito.com',
-					scope: ['aws.cognito.signin.user.admin'],
-					redirectSignIn: 'http://localhost:3000/',
-					redirectSignOut: 'http://localhost:3000/',
-					responseType: 'code',
+					...authOptionsWithHostedUIConfig.oauth!,
 					idpEnabled: false,
 				},
-				identityPoolId: 'awsCognitoIdentityPoolId',
 			};
 			new Auth(options);
 			expect(urlListenerSpy).not.toHaveBeenCalled();
@@ -3865,17 +3847,11 @@ describe('auth unit test', () => {
 			const urlListenerSpy = jest.spyOn(urlListener, 'default');
 
 			const options: AuthOptions = {
-				region: 'region',
-				userPoolId: 'userPoolId',
+				...authOptionsWithHostedUIConfig,
 				oauth: {
-					domain: 'mydomain.auth.us-east-1.amazoncognito.com',
-					scope: ['aws.cognito.signin.user.admin'],
-					redirectSignIn: 'http://localhost:3000/',
-					redirectSignOut: 'http://localhost:3000/',
-					responseType: 'code',
+					...authOptionsWithHostedUIConfig.oauth!,
 					idpEnabled: false,
 				},
-				identityPoolId: 'awsCognitoIdentityPoolId',
 			};
 			new Auth(options);
 			expect(urlListenerSpy).toHaveBeenCalledTimes(1);

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -60,7 +60,7 @@
       "name": "Auth (top-level class)",
       "path": "./lib-esm/index.js",
       "import": "{ Amplify, Auth }",
-      "limit": "55.12 kB"
+      "limit": "55.21 kB"
     }
   ],
   "jest": {

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -127,6 +127,7 @@ export interface AwsCognitoOAuthOpts {
 	redirectSignOut: string;
 	responseType: string;
 	options?: object;
+	idpEnabled?: boolean;
 	urlOpener?: (url: string, redirectUrl: string) => Promise<any>;
 }
 


### PR DESCRIPTION
#### Description of changes
Amplify supports two types of oauth flows in V5 **"IDP (initiated by provider)"** and **"SP (initiated by client)"**.  Since IDP flow is initiated outside of Amplify we uses a [global urlListener](https://github.com/aws-amplify/amplify-js/blob/v5-stable/packages/auth/src/Auth.ts#L256) to handle the oauth response when the url query params contain `code`,`access_token` or `error`.

However even if the app isn't redirected from HostedUI but contains the the url query params `code`,`access_token` or `error`, the global urlListener is hit and the url is replaced with the redirectSignIn url

**Solution** 
- Add an option to `Amplify.configure()` to optionally disable IDP initiated flow to avoid calling the global urlListener 
- Detect if a SP initiated flow is in flight using a `amplify-sp-initiated-oauth-inFlight` flag in local storage
- If SP initiated flow is in flight OR IDP initiated flow is enabled call the global urlListener to handle oauth response

#### Issue #, if available

#### Description of how you validated changes

```
// on sampleApp
import { Amplify } from "aws-amplify";
import awsconfig from "./aws-exports";

Amplify.configure({
  ...awsconfig,
  oauth: {
    ...awsconfig.oauth,
    idpEnabled: false, // defaults to true to avoid breaking change
  },
});
```
Tested the following flows
- SP flow works as expected irrespective of setting `idpEnabled` in Amplify.configure
- IDP flow works by default, `idpEnabled: true` and ignored when `idpEnabled: false`
- The url query params aren't swallowed when `idpEnabled: false`

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
