### PR TITLE
fix(ssr-adapter): refreshToken may return the same tokens across requests

### DIFF
--- a/packages/auth/src/providers/cognito/index.ts
+++ b/packages/auth/src/providers/cognito/index.ts
@@ -80,4 +80,5 @@ export {
 	TokenOrchestrator,
 	DefaultTokenStore,
 	refreshAuthTokens,
+	refreshAuthTokensWithoutDedupe,
 } from './tokenProvider';

--- a/packages/auth/src/providers/cognito/tokenProvider/index.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/index.ts
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export { refreshAuthTokens } from '../utils/refreshAuthTokens';
+export {
+	refreshAuthTokens,
+	refreshAuthTokensWithoutDedupe,
+} from '../utils/refreshAuthTokens';
 export { DefaultTokenStore } from './TokenStore';
 export { TokenOrchestrator } from './TokenOrchestrator';
 export { CognitoUserPoolTokenProviderType } from './types';

--- a/packages/auth/src/providers/cognito/utils/refreshAuthTokens.ts
+++ b/packages/auth/src/providers/cognito/utils/refreshAuthTokens.ts
@@ -77,3 +77,4 @@ const refreshAuthTokensFunction: TokenRefresher = async ({
 };
 
 export const refreshAuthTokens = deDupeAsyncFunction(refreshAuthTokensFunction);
+export const refreshAuthTokensWithoutDedupe = refreshAuthTokensFunction;

--- a/packages/aws-amplify/__tests__/adapterCore/authProvidersFactories/cognito/createUserPoolsTokenProvider.test.ts
+++ b/packages/aws-amplify/__tests__/adapterCore/authProvidersFactories/cognito/createUserPoolsTokenProvider.test.ts
@@ -4,7 +4,7 @@
 import {
 	DefaultTokenStore,
 	TokenOrchestrator,
-	refreshAuthTokens,
+	refreshAuthTokensWithoutDedupe,
 } from '@aws-amplify/auth/cognito';
 import { AuthConfig, KeyValueStorageInterface } from '@aws-amplify/core';
 
@@ -27,7 +27,7 @@ const mockAuthConfig: AuthConfig = {
 };
 const MockDefaultTokenStore = DefaultTokenStore as jest.Mock;
 const MockTokenOrchestrator = TokenOrchestrator as jest.Mock;
-const mockRefreshAuthTokens = refreshAuthTokens as jest.Mock;
+const mockRefreshAuthTokens = refreshAuthTokensWithoutDedupe as jest.Mock;
 
 describe('createUserPoolsTokenProvider', () => {
 	beforeEach(() => {

--- a/packages/aws-amplify/__tests__/exports.test.ts
+++ b/packages/aws-amplify/__tests__/exports.test.ts
@@ -219,6 +219,7 @@ describe('aws-amplify Exports', () => {
 					'TokenOrchestrator',
 					'DefaultTokenStore',
 					'refreshAuthTokens',
+					'refreshAuthTokensWithoutDedupe',
 				].sort(),
 			);
 		});

--- a/packages/aws-amplify/src/adapter-core/authProvidersFactories/cognito/createUserPoolsTokenProvider.ts
+++ b/packages/aws-amplify/src/adapter-core/authProvidersFactories/cognito/createUserPoolsTokenProvider.ts
@@ -4,7 +4,7 @@
 import {
 	DefaultTokenStore,
 	TokenOrchestrator,
-	refreshAuthTokens,
+	refreshAuthTokensWithoutDedupe,
 } from '@aws-amplify/auth/cognito';
 import {
 	AuthConfig,
@@ -28,7 +28,7 @@ export const createUserPoolsTokenProvider = (
 	const tokenOrchestrator = new TokenOrchestrator();
 	tokenOrchestrator.setAuthConfig(authConfig);
 	tokenOrchestrator.setAuthTokenStore(authTokenStore);
-	tokenOrchestrator.setTokenRefresher(refreshAuthTokens);
+	tokenOrchestrator.setTokenRefresher(refreshAuthTokensWithoutDedupe);
 
 	return {
 		getTokens: ({ forceRefresh } = { forceRefresh: false }) =>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

1. Exported a non-deduped token refresher function 
2. Updated the SSR adapter to use the non-deduped token refresher function to create context
3. Fixed that in a `getServerSideProps` context, refresh tokens were not being sent back to client cookie store


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

1. unit tests
2. manual testing with Next.js sample apps


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
