### PR TITLE
fix(adapter-nextjs): Set-Cookie headers incorrectly set with getServerSideProps context

### DIFF
--- a/packages/adapter-nextjs/__tests__/utils/createCookieStorageAdapterFromNextServerContext.test.ts
+++ b/packages/adapter-nextjs/__tests__/utils/createCookieStorageAdapterFromNextServerContext.test.ts
@@ -293,7 +293,7 @@ describe('createCookieStorageAdapterFromNextServerContext', () => {
 
 			const request = new IncomingMessage(new Socket());
 			const response = new ServerResponse(request);
-			const setHeaderSpy = jest.spyOn(response, 'setHeader');
+			const appendHeaderSpy = jest.spyOn(response, 'appendHeader');
 
 			Object.defineProperty(request, 'cookies', {
 				get() {
@@ -314,21 +314,30 @@ describe('createCookieStorageAdapterFromNextServerContext', () => {
 			]);
 
 			result.set('key3', 'value3');
-			expect(setHeaderSpy).toHaveBeenCalledWith('Set-Cookie', 'key3=value3;');
+			expect(appendHeaderSpy).toHaveBeenCalledWith(
+				'Set-Cookie',
+				'key3=value3;',
+			);
 
 			result.set('key4', 'value4', {
 				httpOnly: true,
 			});
-			expect(setHeaderSpy).toHaveBeenCalledWith(
+			expect(appendHeaderSpy).toHaveBeenCalledWith(
 				'Set-Cookie',
 				'key4=value4;HttpOnly',
 			);
 
 			result.delete('key3');
-			expect(setHeaderSpy).toHaveBeenCalledWith(
+			expect(appendHeaderSpy).toHaveBeenCalledWith(
 				'Set-Cookie',
 				`key3=;Expires=${DATE_IN_THE_PAST.toUTCString()}`,
 			);
+
+			expect(response.getHeader('Set-Cookie')).toEqual([
+				'key3=value3;',
+				'key4=value4;HttpOnly',
+				'key3=;Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+			]);
 		});
 
 		it('operates with the underlying cookie store with encoded cookie names', () => {
@@ -346,7 +355,7 @@ describe('createCookieStorageAdapterFromNextServerContext', () => {
 
 			const request = new IncomingMessage(new Socket());
 			const response = new ServerResponse(request);
-			const setHeaderSpy = jest.spyOn(response, 'setHeader');
+			const appendHeaderSpy = jest.spyOn(response, 'appendHeader');
 
 			Object.defineProperty(request, 'cookies', {
 				get() {
@@ -371,7 +380,10 @@ describe('createCookieStorageAdapterFromNextServerContext', () => {
 			]);
 
 			result.set('key3', 'value3');
-			expect(setHeaderSpy).toHaveBeenCalledWith('Set-Cookie', 'key3=value3;');
+			expect(appendHeaderSpy).toHaveBeenCalledWith(
+				'Set-Cookie',
+				'key3=value3;',
+			);
 
 			result.set('key4', 'value4', {
 				httpOnly: true,
@@ -381,16 +393,23 @@ describe('createCookieStorageAdapterFromNextServerContext', () => {
 				'test@email.com.somethingElse',
 			);
 			result.set(encodeURIComponent('test@email.com.somethingElse'), 'value5');
-			expect(setHeaderSpy).toHaveBeenCalledWith(
+			expect(appendHeaderSpy).toHaveBeenCalledWith(
 				'Set-Cookie',
 				`${encodeURIComponent(encodedCookieName)}=value5;`,
 			);
 
 			result.delete('key3');
-			expect(setHeaderSpy).toHaveBeenCalledWith(
+			expect(appendHeaderSpy).toHaveBeenCalledWith(
 				'Set-Cookie',
 				`key3=;Expires=${DATE_IN_THE_PAST.toUTCString()}`,
 			);
+
+			expect(response.getHeader('Set-Cookie')).toEqual([
+				'key3=value3;',
+				'key4=value4;HttpOnly',
+				'test%2540email.com.somethingElse=value5;',
+				'key3=;Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+			]);
 		});
 	});
 

--- a/packages/adapter-nextjs/src/utils/createCookieStorageAdapterFromNextServerContext.ts
+++ b/packages/adapter-nextjs/src/utils/createCookieStorageAdapterFromNextServerContext.ts
@@ -171,7 +171,7 @@ const createCookieStorageAdapterFromGetServerSidePropsContext = (
 			return allCookies;
 		},
 		set(name, value, options) {
-			response.setHeader(
+			response.appendHeader(
 				'Set-Cookie',
 				`${ensureEncodedForJSCookie(name)}=${value};${
 					options ? serializeSetCookieOptions(options) : ''
@@ -179,7 +179,7 @@ const createCookieStorageAdapterFromGetServerSidePropsContext = (
 			);
 		},
 		delete(name) {
-			response.setHeader(
+			response.appendHeader(
 				'Set-Cookie',
 				`${ensureEncodedForJSCookie(
 					name,


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Fixed to use `appendHeader` to add `Set-Cookie` header values


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
