### PR TITLE
chore: (api-rest) enable linting on __tests__ 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,7 @@ module.exports = {
 		'packages/analytics/__tests__',
 		'packages/api/__tests__',
 		'packages/api-graphql/__tests__',
-		'packages/api-rest/__tests__',
+		// 'packages/api-rest/__tests__',
 		'packages/auth/__tests__',
 		// 'packages/aws-amplify/__tests__',
 		// 'packages/core/__tests__',

--- a/packages/api-rest/__tests__/apis/common/internalPost.test.ts
+++ b/packages/api-rest/__tests__/apis/common/internalPost.test.ts
@@ -5,13 +5,13 @@ import { AmplifyClassV6 } from '@aws-amplify/core';
 import { ApiError } from '@aws-amplify/core/internals/utils';
 import {
 	authenticatedHandler,
-	unauthenticatedHandler,
 	parseJsonError,
+	unauthenticatedHandler,
 } from '@aws-amplify/core/internals/aws-client-utils';
 
 import {
-	post,
 	cancel,
+	post,
 	updateRequestToBeCancellable,
 } from '../../../src/apis/common/internalPost';
 import { RestApiError, isCancelError } from '../../../src/errors';
@@ -281,6 +281,7 @@ describe('internal post', () => {
 		mockParseJsonError.mockImplementationOnce(async response => {
 			const errorResponsePayload = await response.body?.json();
 			const error = new Error(errorResponsePayload.message);
+
 			return Object.assign(error, {
 				name: errorResponsePayload.name,
 			});
@@ -325,6 +326,7 @@ describe('internal post', () => {
 		mockParseJsonError.mockImplementationOnce(async response => {
 			const errorResponsePayload = await response.body?.json();
 			const error = new Error(errorResponsePayload.message);
+
 			return Object.assign(error, {
 				name: errorResponsePayload.name,
 			});

--- a/packages/api-rest/__tests__/apis/common/internalPost.test.ts
+++ b/packages/api-rest/__tests__/apis/common/internalPost.test.ts
@@ -234,7 +234,7 @@ describe('internal post', () => {
 		let underLyingHandlerReject;
 		mockUnauthenticatedHandler.mockReset();
 		mockUnauthenticatedHandler.mockReturnValue(
-			new Promise((_, reject) => {
+			new Promise((_resolve, reject) => {
 				underLyingHandlerReject = reject;
 			}),
 		);

--- a/packages/api-rest/__tests__/apis/common/publicApis.test.ts
+++ b/packages/api-rest/__tests__/apis/common/publicApis.test.ts
@@ -23,6 +23,7 @@ import {
 	isCancelError,
 	validationErrorMap,
 } from '../../../src/errors';
+import { RestApiResponse } from '../../../src/types';
 
 jest.mock('@aws-amplify/core/internals/aws-client-utils');
 
@@ -125,8 +126,9 @@ describe('public APIs', () => {
 				});
 				expect(response.statusCode).toBe(200);
 				if (fn !== head && fn !== del) {
-					// @ts-ignore HEAD and DELETE does not have a response body.
-					expect(await response.body.json()).toEqual({ foo: 'bar' });
+					expect(await (response as RestApiResponse).body.json()).toEqual({
+						foo: 'bar',
+					});
 				}
 			});
 
@@ -387,7 +389,7 @@ describe('public APIs', () => {
 				let underLyingHandlerReject;
 				mockAuthenticatedHandler.mockReset();
 				mockAuthenticatedHandler.mockReturnValue(
-					new Promise((_, reject) => {
+					new Promise((_resolve, reject) => {
 						underLyingHandlerReject = reject;
 					}),
 				);

--- a/packages/api-rest/__tests__/apis/common/publicApis.test.ts
+++ b/packages/api-rest/__tests__/apis/common/publicApis.test.ts
@@ -4,24 +4,24 @@
 import { AmplifyClassV6 } from '@aws-amplify/core';
 import {
 	authenticatedHandler,
-	unauthenticatedHandler,
 	parseJsonError,
+	unauthenticatedHandler,
 } from '@aws-amplify/core/internals/aws-client-utils';
 import { ApiError } from '@aws-amplify/core/internals/utils';
 
 import {
-	get,
-	post,
-	put,
 	del,
+	get,
 	head,
 	patch,
+	post,
+	put,
 } from '../../../src/apis/common/publicApis';
 import {
 	RestApiError,
+	RestApiValidationErrorCode,
 	isCancelError,
 	validationErrorMap,
-	RestApiValidationErrorCode,
 } from '../../../src/errors';
 
 jest.mock('@aws-amplify/core/internals/aws-client-utils');
@@ -29,7 +29,7 @@ jest.mock('@aws-amplify/core/internals/aws-client-utils');
 const mockAuthenticatedHandler = authenticatedHandler as jest.Mock;
 const mockUnauthenticatedHandler = unauthenticatedHandler as jest.Mock;
 const mockFetchAuthSession = jest.fn();
-let mockConfig = {
+const mockConfig = {
 	API: {
 		REST: {
 			restApi1: {
@@ -304,6 +304,7 @@ describe('public APIs', () => {
 				mockParseJsonError.mockImplementationOnce(async response => {
 					const errorResponsePayload = await response.body?.json();
 					const error = new Error(errorResponsePayload.message);
+
 					return Object.assign(error, {
 						name: errorResponsePayload.name,
 					});
@@ -349,6 +350,7 @@ describe('public APIs', () => {
 				mockParseJsonError.mockImplementationOnce(async response => {
 					const errorResponsePayload = await response.body?.json();
 					const error = new Error(errorResponsePayload.message);
+
 					return Object.assign(error, {
 						name: errorResponsePayload.name,
 					});

--- a/packages/api-rest/__tests__/index.test.ts
+++ b/packages/api-rest/__tests__/index.test.ts
@@ -3,14 +3,14 @@
 
 import { Amplify } from '@aws-amplify/core';
 
-import { get, post, put, del, patch, head } from '../src/index';
+import { del, get, head, patch, post, put } from '../src/index';
 import {
+	del as commonDel,
 	get as commonGet,
+	head as commonHead,
+	patch as commonPatch,
 	post as commonPost,
 	put as commonPut,
-	del as commonDel,
-	patch as commonPatch,
-	head as commonHead,
 } from '../src/apis/common/publicApis';
 
 jest.mock('../src/apis/common/publicApis');

--- a/packages/api-rest/__tests__/server.test.ts
+++ b/packages/api-rest/__tests__/server.test.ts
@@ -3,14 +3,14 @@
 
 import { getAmplifyServerContext } from '@aws-amplify/core/internals/adapter-core';
 
-import { get, post, put, del, patch, head } from '../src/server';
+import { del, get, head, patch, post, put } from '../src/server';
 import {
+	del as commonDel,
 	get as commonGet,
+	head as commonHead,
+	patch as commonPatch,
 	post as commonPost,
 	put as commonPut,
-	del as commonDel,
-	patch as commonPatch,
-	head as commonHead,
 } from '../src/apis/common/publicApis';
 
 jest.mock('../src/apis/common/publicApis');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

See each commit message for details.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
