### PR TITLE
chore: Store NPM logs as artifacts in CI

### DIFF
--- a/.github/actions/load-verdaccio-with-amplify-js/action.yml
+++ b/.github/actions/load-verdaccio-with-amplify-js/action.yml
@@ -48,3 +48,11 @@ runs:
         scripts/retry-yarn-script.sh -s publish:verdaccio -n 5 -r true
         yarn info aws-amplify@unstable description
         npm info aws-amplify@unstable version
+    - name: Upload artifact
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2 https://github.com/actions/upload-artifact/commit/0b7f8abb1508181956e8e162db84b466c27e18ce
+      if: failure()
+      with:
+        name: ${{ inputs.test_name }}-npm-log
+        if-no-files-found: ignore
+        path: /Users/runner/.npm/_logs/
+        retention-days: 3


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Stores NPM logs as artifacts in the event of a test failure.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
