### PR TITLE
fix: pin node version in gh actions

### DIFF
--- a/.github/actions/node-and-build/action.yml
+++ b/.github/actions/node-and-build/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Setup Node.js 18
       uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
       with:
-        node-version: 18
+        node-version: 18.20.2
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
     - uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Pins the version of Node expected in e2e integ test setup. npm-cli-adduser fails with node version 18.20.3.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Reproduced error locally with node version 18.20.3 and validated that the error did not show up when using earlier versions of node. Pinned node version in my forked repository resulting in this test run in which e2e tests are failing: https://github.com/erinleigh90/amplify-js/actions/runs/9309095374

Note that in the test run above there is an unrelated unit test failure which was not impacted by this change: it was failing before and after pinning node and is not failing in the main repository, so I believe this is unrelated. `yarn test` passes locally.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
