### PR TITLE
fix(storage): Fix MD5 calculation

### DIFF
--- a/packages/storage/__tests__/providers/s3/utils/md5.native.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/md5.native.test.ts
@@ -1,0 +1,131 @@
+import { Buffer } from 'buffer';
+
+import { Md5 } from '@smithy/md5-js';
+
+import { calculateContentMd5 } from '../../../../src/providers/s3/utils/md5.native';
+import { toBase64 } from '../../../../src/providers/s3/utils/client/utils';
+
+jest.mock('@smithy/md5-js');
+jest.mock('../../../../src/providers/s3/utils/client/utils');
+jest.mock('buffer');
+
+interface MockFileReader {
+	error?: any;
+	result?: any;
+	onload?(): void;
+	onabort?(): void;
+	onerror?(): void;
+	readAsArrayBuffer?(): void;
+	readAsDataURL?(): void;
+}
+
+// The FileReader in React Native 0.71 did not support `readAsArrayBuffer`. This native implementation accomodates this
+// by attempting to use `readAsArrayBuffer` and changing the file reading strategy if it throws an error.
+// TODO: This file should be removable when we drop support for React Native 0.71
+describe('calculateContentMd5 (native)', () => {
+	const stringContent = 'string-content';
+	const base64data = 'base-64-data';
+	const fileReaderResult = new ArrayBuffer(8);
+	const fileReaderBase64Result = `data:foo/bar;base64,${base64data}`;
+	const fileReaderError = new Error();
+	// assert mocks
+	const mockBufferFrom = Buffer.from as jest.Mock;
+	const mockToBase64 = toBase64 as jest.Mock;
+	const mockMd5 = Md5 as jest.Mock;
+	// create mocks
+	const mockSuccessfulFileReader: MockFileReader = {
+		readAsArrayBuffer: jest.fn(() => {
+			mockSuccessfulFileReader.result = fileReaderResult;
+			mockSuccessfulFileReader.onload?.();
+		}),
+	};
+	const mockAbortedFileReader: MockFileReader = {
+		readAsArrayBuffer: jest.fn(() => {
+			mockAbortedFileReader.onabort?.();
+		}),
+	};
+	const mockFailedFileReader: MockFileReader = {
+		readAsArrayBuffer: jest.fn(() => {
+			mockFailedFileReader.error = fileReaderError;
+			mockFailedFileReader.onerror?.();
+		}),
+	};
+	const mockPartialFileReader: MockFileReader = {
+		readAsArrayBuffer: jest.fn(() => {
+			throw new Error('Not implemented');
+		}),
+		readAsDataURL: jest.fn(() => {
+			mockPartialFileReader.result = fileReaderBase64Result;
+			mockPartialFileReader.onload?.();
+		}),
+	};
+
+	beforeAll(() => {
+		mockBufferFrom.mockReturnValue(fileReaderResult);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+		mockMd5.mockReset();
+	});
+
+	it('calculates MD5 for content type: string', async () => {
+		await calculateContentMd5(stringContent);
+		const [mockMd5Instance] = mockMd5.mock.instances;
+		expect(mockMd5Instance.update.mock.calls[0][0]).toBe(stringContent);
+		expect(mockToBase64).toHaveBeenCalled();
+	});
+
+	it.each([
+		{ type: 'ArrayBuffer view', content: new Uint8Array() },
+		{ type: 'ArrayBuffer', content: new ArrayBuffer(8) },
+		{ type: 'Blob', content: new Blob([stringContent]) },
+	])('calculates MD5 for content type: $type', async ({ content }) => {
+		Object.defineProperty(global, 'FileReader', {
+			writable: true,
+			value: jest.fn(() => mockSuccessfulFileReader),
+		});
+		await calculateContentMd5(content);
+		const [mockMd5Instance] = mockMd5.mock.instances;
+		expect(mockMd5Instance.update.mock.calls[0][0]).toBe(fileReaderResult);
+		expect(mockSuccessfulFileReader.readAsArrayBuffer).toHaveBeenCalled();
+		expect(mockToBase64).toHaveBeenCalled();
+	});
+
+	it('rejects on file reader abort', async () => {
+		Object.defineProperty(global, 'FileReader', {
+			writable: true,
+			value: jest.fn(() => mockAbortedFileReader),
+		});
+		await expect(
+			calculateContentMd5(new Blob([stringContent])),
+		).rejects.toThrow('Read aborted');
+		expect(mockAbortedFileReader.readAsArrayBuffer).toHaveBeenCalled();
+		expect(mockToBase64).not.toHaveBeenCalled();
+	});
+
+	it('rejects on file reader error', async () => {
+		Object.defineProperty(global, 'FileReader', {
+			writable: true,
+			value: jest.fn(() => mockFailedFileReader),
+		});
+		await expect(
+			calculateContentMd5(new Blob([stringContent])),
+		).rejects.toThrow(fileReaderError);
+		expect(mockFailedFileReader.readAsArrayBuffer).toHaveBeenCalled();
+		expect(mockToBase64).not.toHaveBeenCalled();
+	});
+
+	it('tries again using a different strategy if readAsArrayBuffer is unavailable', async () => {
+		Object.defineProperty(global, 'FileReader', {
+			writable: true,
+			value: jest.fn(() => mockPartialFileReader),
+		});
+		await calculateContentMd5(new Blob([stringContent]));
+		const [mockMd5Instance] = mockMd5.mock.instances;
+		expect(mockMd5Instance.update.mock.calls[0][0]).toBe(fileReaderResult);
+		expect(mockPartialFileReader.readAsDataURL).toHaveBeenCalled();
+		expect(mockBufferFrom).toHaveBeenCalledWith(base64data, 'base64');
+		expect(mockToBase64).toHaveBeenCalled();
+	});
+});

--- a/packages/storage/__tests__/providers/s3/utils/md5.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/md5.test.ts
@@ -1,0 +1,95 @@
+import { Md5 } from '@smithy/md5-js';
+
+import { calculateContentMd5 } from '../../../../src/providers/s3/utils/md5';
+import { toBase64 } from '../../../../src/providers/s3/utils/client/utils';
+
+jest.mock('@smithy/md5-js');
+jest.mock('../../../../src/providers/s3/utils/client/utils');
+
+interface MockFileReader {
+	error?: any;
+	result?: any;
+	onload?(): void;
+	onabort?(): void;
+	onerror?(): void;
+	readAsArrayBuffer?(): void;
+}
+
+describe('calculateContentMd5', () => {
+	const stringContent = 'string-content';
+	const fileReaderResult = new ArrayBuffer(8);
+	const fileReaderError = new Error();
+	// assert mocks
+	const mockToBase64 = toBase64 as jest.Mock;
+	const mockMd5 = Md5 as jest.Mock;
+	// create mocks
+	const mockSuccessfulFileReader: MockFileReader = {
+		readAsArrayBuffer: jest.fn(() => {
+			mockSuccessfulFileReader.result = fileReaderResult;
+			mockSuccessfulFileReader.onload?.();
+		}),
+	};
+	const mockAbortedFileReader: MockFileReader = {
+		readAsArrayBuffer: jest.fn(() => {
+			mockAbortedFileReader.onabort?.();
+		}),
+	};
+	const mockFailedFileReader: MockFileReader = {
+		readAsArrayBuffer: jest.fn(() => {
+			mockFailedFileReader.error = fileReaderError;
+			mockFailedFileReader.onerror?.();
+		}),
+	};
+
+	afterEach(() => {
+		jest.clearAllMocks();
+		mockMd5.mockReset();
+	});
+
+	it('calculates MD5 for content type: string', async () => {
+		await calculateContentMd5(stringContent);
+		const [mockMd5Instance] = mockMd5.mock.instances;
+		expect(mockMd5Instance.update.mock.calls[0][0]).toBe(stringContent);
+		expect(mockToBase64).toHaveBeenCalled();
+	});
+
+	it.each([
+		{ type: 'ArrayBuffer view', content: new Uint8Array() },
+		{ type: 'ArrayBuffer', content: new ArrayBuffer(8) },
+		{ type: 'Blob', content: new Blob([stringContent]) },
+	])('calculates MD5 for content type: $type', async ({ content }) => {
+		Object.defineProperty(global, 'FileReader', {
+			writable: true,
+			value: jest.fn(() => mockSuccessfulFileReader),
+		});
+		await calculateContentMd5(content);
+		const [mockMd5Instance] = mockMd5.mock.instances;
+		expect(mockMd5Instance.update.mock.calls[0][0]).toBe(fileReaderResult);
+		expect(mockSuccessfulFileReader.readAsArrayBuffer).toHaveBeenCalled();
+		expect(mockToBase64).toHaveBeenCalled();
+	});
+
+	it('rejects on file reader abort', async () => {
+		Object.defineProperty(global, 'FileReader', {
+			writable: true,
+			value: jest.fn(() => mockAbortedFileReader),
+		});
+		await expect(
+			calculateContentMd5(new Blob([stringContent])),
+		).rejects.toThrow('Read aborted');
+		expect(mockAbortedFileReader.readAsArrayBuffer).toHaveBeenCalled();
+		expect(mockToBase64).not.toHaveBeenCalled();
+	});
+
+	it('rejects on file reader error', async () => {
+		Object.defineProperty(global, 'FileReader', {
+			writable: true,
+			value: jest.fn(() => mockFailedFileReader),
+		});
+		await expect(
+			calculateContentMd5(new Blob([stringContent])),
+		).rejects.toThrow(fileReaderError);
+		expect(mockFailedFileReader.readAsArrayBuffer).toHaveBeenCalled();
+		expect(mockToBase64).not.toHaveBeenCalled();
+	});
+});

--- a/packages/storage/src/providers/s3/utils/client/runtime/base64/index.browser.ts
+++ b/packages/storage/src/providers/s3/utils/client/runtime/base64/index.browser.ts
@@ -7,13 +7,9 @@ function bytesToBase64(bytes: Uint8Array): string {
 	return btoa(base64Str);
 }
 
-export function utf8Encode(input: string): Uint8Array {
-	return new TextEncoder().encode(input);
-}
-
 export function toBase64(input: string | ArrayBufferView): string {
 	if (typeof input === 'string') {
-		return bytesToBase64(utf8Encode(input));
+		return bytesToBase64(new TextEncoder().encode(input));
 	}
 
 	return bytesToBase64(

--- a/packages/storage/src/providers/s3/utils/client/runtime/base64/index.native.ts
+++ b/packages/storage/src/providers/s3/utils/client/runtime/base64/index.native.ts
@@ -3,10 +3,6 @@
 
 import { Buffer } from 'buffer';
 
-export function utf8Encode(input: string): Uint8Array {
-	return Buffer.from(input, 'utf-8');
-}
-
 export function toBase64(input: string | ArrayBufferView): string {
 	if (typeof input === 'string') {
 		return Buffer.from(input, 'utf-8').toString('base64');

--- a/packages/storage/src/providers/s3/utils/client/runtime/index.browser.ts
+++ b/packages/storage/src/providers/s3/utils/client/runtime/index.browser.ts
@@ -10,4 +10,4 @@ export {
 } from './constants';
 export { s3TransferHandler } from './s3TransferHandler/xhr';
 export { parser } from './xmlParser/dom';
-export { toBase64, utf8Encode } from './base64/index.browser';
+export { toBase64 } from './base64/index.browser';

--- a/packages/storage/src/providers/s3/utils/client/runtime/index.native.ts
+++ b/packages/storage/src/providers/s3/utils/client/runtime/index.native.ts
@@ -10,4 +10,4 @@ export {
 } from './constants';
 export { s3TransferHandler } from './s3TransferHandler/xhr';
 export { parser } from './xmlParser/pureJs';
-export { toBase64, utf8Encode } from './base64/index.native';
+export { toBase64 } from './base64/index.native';

--- a/packages/storage/src/providers/s3/utils/client/runtime/index.ts
+++ b/packages/storage/src/providers/s3/utils/client/runtime/index.ts
@@ -11,4 +11,4 @@ export {
 } from './constants';
 export { s3TransferHandler } from './s3TransferHandler/fetch';
 export { parser } from './xmlParser/pureJs';
-export { toBase64, utf8Encode } from './index.native';
+export { toBase64 } from './index.native';

--- a/packages/storage/src/providers/s3/utils/client/utils/index.ts
+++ b/packages/storage/src/providers/s3/utils/client/utils/index.ts
@@ -9,7 +9,6 @@ export {
 	CANCELED_ERROR_MESSAGE,
 	CONTENT_SHA256_HEADER,
 	toBase64,
-	utf8Encode,
 } from '../runtime';
 export {
 	buildStorageServiceError,

--- a/packages/storage/src/providers/s3/utils/md5.native.ts
+++ b/packages/storage/src/providers/s3/utils/md5.native.ts
@@ -1,10 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Buffer } from 'buffer';
+
 import { Md5 } from '@smithy/md5-js';
 
 import { toBase64 } from './client/utils';
 
+// The FileReader in React Native 0.71 did not support `readAsArrayBuffer`. This native implementation accomodates this
+// by attempting to use `readAsArrayBuffer` and changing the file reading strategy if it throws an error.
+// TODO: This file should be removable when we drop support for React Native 0.71
 export const calculateContentMd5 = async (
 	content: Blob | string | ArrayBuffer | ArrayBufferView,
 ): Promise<string> => {
@@ -24,20 +29,29 @@ export const calculateContentMd5 = async (
 	return toBase64(digest);
 };
 
-const readFile = (file: Blob): Promise<ArrayBuffer> => {
-	return new Promise((resolve, reject) => {
+const readFile = (file: Blob): Promise<ArrayBuffer> =>
+	new Promise((resolve, reject) => {
 		const reader = new FileReader();
-		reader.onloadend = () => {
-			if (reader.result) {
-				resolve(reader.result as ArrayBuffer);
-			}
-			reader.onabort = () => {
-				reject(new Error('Read aborted'));
-			};
-			reader.onerror = () => {
-				reject(reader.error);
-			};
+		reader.onload = () => {
+			resolve(reader.result as ArrayBuffer);
 		};
-		if (file !== undefined) reader.readAsArrayBuffer(file);
+		reader.onabort = () => {
+			reject(new Error('Read aborted'));
+		};
+		reader.onerror = () => {
+			reject(reader.error);
+		};
+
+		try {
+			reader.readAsArrayBuffer(file);
+		} catch (e) {
+			reader.onload = () => {
+				// reference: https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL
+				// response from readAsDataURL is always prepended with "data:*/*;base64,"
+				const [, base64Data] = (reader.result as string).split(',');
+				const arrayBuffer = Buffer.from(base64Data, 'base64');
+				resolve(arrayBuffer);
+			};
+			reader.readAsDataURL(file);
+		}
 	});
-};


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
When `isObjectLockEnabled` is set to `true` in configuration, the Amplify library calculates and appends `ContentMD5` automatically. However, as a customer discovered, this MD5 calculation was not always being performed correctly and the upload task results in a BadDigest error from the service.

Upon investigation, it appears that the category went under a refactor which saw the MD5 calculations utilities be renamed and relocated. However, during this refactor, the implementations intended for web and native were accidentally flipped:
* MD5Utils -> utils/md5.native
* MD5Utils.native -> utils/md5

After undoing this switch, the library behaved as expected on Web but the native implementations continued to fail. Upon further deep dive, it was discovered that the `readAsArrayBuffer` gap which necessitated the diverged native path in the first place is only experienced in React Native version < 0.71.

This PR:
* Unflips the web implementation for MD5 calculation
* Wraps the attempt to use `readAsArrayBuffer` in a try/catch and only invokes the `readAsDataURL` strategy as a fallback if the prior function fails
* Adds unit tests to prevent future regressions

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/13434

#### Description of how you validated changes
Validated that MD5 calculation was not working in sample apps prior to changes but now work with the proposed fix for:
* React web app
* React native 0.74 app (current)
* React native 0.71 app (latest version to not support `readAsArrayBuffer` in its FileReader)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
