### PR TITLE
release(required): an expired token that has valid signature is not considered a valid token

### DIFF
--- a/packages/adapter-nextjs/__tests__/utils/isValidCognitoToken.test.ts
+++ b/packages/adapter-nextjs/__tests__/utils/isValidCognitoToken.test.ts
@@ -1,4 +1,5 @@
 import { CognitoJwtVerifier } from 'aws-jwt-verify';
+import { JwtExpiredError } from 'aws-jwt-verify/error';
 
 import { isValidCognitoToken } from '../../src/utils/isValidCognitoToken';
 
@@ -27,6 +28,31 @@ describe('isValidCognitoToken', () => {
 	it('should return true for a valid token', async () => {
 		const mockVerifier: any = {
 			verify: jest.fn().mockResolvedValue({}),
+		};
+		mockedCreate.mockReturnValue(mockVerifier);
+
+		const isValid = await isValidCognitoToken({
+			token,
+			userPoolId,
+			clientId,
+			tokenType,
+		});
+		expect(isValid).toBe(true);
+		expect(CognitoJwtVerifier.create).toHaveBeenCalledWith({
+			userPoolId,
+			clientId,
+			tokenUse: tokenType,
+		});
+		expect(mockVerifier.verify).toHaveBeenCalledWith(token);
+	});
+
+	it('should return true for a token that has valid signature and expired', async () => {
+		const mockVerifier: any = {
+			verify: jest
+				.fn()
+				.mockRejectedValue(
+					new JwtExpiredError('Token expired', 'mocked-token'),
+				),
 		};
 		mockedCreate.mockReturnValue(mockVerifier);
 

--- a/packages/adapter-nextjs/src/utils/isValidCognitoToken.ts
+++ b/packages/adapter-nextjs/src/utils/isValidCognitoToken.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { CognitoJwtVerifier } from 'aws-jwt-verify';
+import { JwtExpiredError } from 'aws-jwt-verify/error';
 
 /**
  * Verifies a Cognito JWT token for its validity.
@@ -30,6 +31,13 @@ export const isValidCognitoToken = async (input: {
 
 		return true;
 	} catch (error) {
+		// When `JwtExpiredError` is thrown, the token should have valid signature
+		// but expired. So, we can consider it as a valid token.
+		// Reference https://github.com/awslabs/aws-jwt-verify/blob/8d8f714d7281913ecd660147f5c30311479601c1/src/jwt-rsa.ts#L290-L301
+		if (error instanceof JwtExpiredError) {
+			return true;
+		}
+
 		// TODO (ashwinkumar6): surface invalid cognito token error to customer
 		// TODO: clear invalid tokens from Storage
 		return false;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

When a token has valid signature but expired, it should be considered a valid token.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-js/issues/13456

#### Description of how you validated changes

* Next.js sample app testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
