### PR TITLE
[V5-Stable] Pin macOS version

### DIFF
--- a/.github/workflows/callable-canary-e2e.yml
+++ b/.github/workflows/callable-canary-e2e.yml
@@ -15,7 +15,7 @@ jobs:
   prebuild-macos:
     uses: ./.github/workflows/callable-prebuild-amplify-js.yml
     with:
-      runs_on: macos-latest
+      runs_on: macos-12
   prebuild-samples-staging:
     secrets: inherit
     uses: ./.github/workflows/callable-prebuild-samples-staging.yml

--- a/.github/workflows/callable-e2e-test-detox.yml
+++ b/.github/workflows/callable-e2e-test-detox.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   e2e-test:
     name: E2E-Detox ${{ inputs.test_name }}
-    runs-on: macos-latest
+    runs-on: macos-12
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
     steps:

--- a/.github/workflows/callable-e2e-tests.yml
+++ b/.github/workflows/callable-e2e-tests.yml
@@ -14,8 +14,6 @@ jobs:
       - name: Read integ config files
         id: load_config
         run: |
-          echo "INTEG_CONFIG=$(cat .github/integ-config/integ-all.yml | yq '.tests' -o=json | jq -c .)" >> $GITHUB_OUTPUT
-          echo "INTEG_CONFIG_HEADLESS=$(cat .github/integ-config/integ-all-headless.yml | yq '.tests' -o=json | jq -c .)" >> $GITHUB_OUTPUT
           echo "DETOX_INTEG_CONFIG=$(cat .github/integ-config/detox-integ-all.yml | yq -o=json | jq -c .)" >> $GITHUB_OUTPUT
         working-directory: ./amplify-js
     outputs:

--- a/.github/workflows/callable-e2e-tests.yml
+++ b/.github/workflows/callable-e2e-tests.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Read integ config files
         id: load_config
         run: |
+          echo "INTEG_CONFIG=$(cat .github/integ-config/integ-all.yml | yq '.tests' -o=json | jq -c .)" >> $GITHUB_OUTPUT
+          echo "INTEG_CONFIG_HEADLESS=$(cat .github/integ-config/integ-all-headless.yml | yq '.tests' -o=json | jq -c .)" >> $GITHUB_OUTPUT
           echo "DETOX_INTEG_CONFIG=$(cat .github/integ-config/detox-integ-all.yml | yq -o=json | jq -c .)" >> $GITHUB_OUTPUT
         working-directory: ./amplify-js
     outputs:

--- a/.github/workflows/callable-release-verification.yml
+++ b/.github/workflows/callable-release-verification.yml
@@ -10,7 +10,7 @@ jobs:
   prebuild-macos:
     uses: ./.github/workflows/callable-prebuild-amplify-js.yml
     with:
-      runs_on: macos-latest
+      runs_on: macos-12
   prebuild-samples-staging:
     secrets: inherit
     uses: ./.github/workflows/callable-prebuild-samples-staging.yml


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Pinning the version down on macOS to unblock release. 

We need to backport the detox version 20 update in v6 to v5 branch in samples staging repo as long term fix.


#### Description of how you validated changes
Successful run : https://github.com/aws-amplify/amplify-js/actions/runs/9388518491/job/25856630610


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
