### PR TITLE
release(required): Parsing custom oAuth in amplify_outputs

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -317,7 +317,7 @@
 			"name": "[Analytics] identifyUser (Pinpoint)",
 			"path": "./dist/esm/analytics/index.mjs",
 			"import": "{ identifyUser }",
-			"limit": "15.57 kB"
+			"limit": "15.58 kB"
 		},
 		{
 			"name": "[Analytics] enable",

--- a/packages/core/__mocks__/configMocks/amplify_outputs.json
+++ b/packages/core/__mocks__/configMocks/amplify_outputs.json
@@ -7,7 +7,7 @@
 		"user_pool_client_id": "mock-cup-client-id",
 		"identity_pool_id": "mock-idp-id",
 		"oauth": {
-			"identity_providers": ["FACEBOOK", "SIGN_IN_WITH_APPLE", "GOOGLE"],
+			"identity_providers": ["FACEBOOK", "SIGN_IN_WITH_APPLE", "GOOGLE", "Auth0"],
 			"domain": "mock-oauth-domain",
 			"scopes": ["phone"],
 			"redirect_sign_in_uri": ["mock-sign-in-uri"],

--- a/packages/core/__mocks__/configMocks/amplifyconfiguration.json
+++ b/packages/core/__mocks__/configMocks/amplifyconfiguration.json
@@ -22,38 +22,32 @@
 		"responseType": "token"
 	},
 	"aws_cognito_verification_mechanisms": ["EMAIL"],
-	"aws_cognito_social_providers": ["FACEBOOK", "APPLE", "GOOGLE"],
+	"aws_cognito_social_providers": ["FACEBOOK", "APPLE", "GOOGLE", "Auth0"],
 	"aws_mobile_analytics_app_id": "mock-pinpoint-app-id",
 	"aws_mobile_analytics_app_region": "us-west-2",
 	"aws_user_files_s3_bucket": "mock-storage-bucket",
 	"aws_user_files_s3_bucket_region": "us-west-2",
 	"aws_user_pools_id": "mock-cup-id",
 	"aws_user_pools_web_client_id": "mock-cup-client-id",
-	"geo": { 
+	"geo": {
 		"amazon_location_service": {
 			"search_indices": {
-				"items": [
-					"mock-geo-search-item",
-					"mock-geo-search-item-alt"
-				],
+				"items": ["mock-geo-search-item", "mock-geo-search-item-alt"],
 				"default": "mock-geo-search-item"
 			},
 			"geofenceCollections": {
-				"items": [
-					"mock-geo-fence-item",
-					"mock-geo-fence-item-alt"
-				],
+				"items": ["mock-geo-fence-item", "mock-geo-fence-item-alt"],
 				"default": "mock-geo-fence-item"
 			},
 			"region": "us-west-2"
-		} 
+		}
 	},
 	"aws_appsync_graphqlEndpoint": "mock-data-url",
 	"aws_appsync_apiKey": "mock-data-api-key",
 	"aws_appsync_region": "us-west-2",
 	"aws_appsync_authenticationType": "API_KEY",
 	"Notifications": {
-		"InAppMessaging": { 
+		"InAppMessaging": {
 			"AWSPinpoint": {
 				"appId": "mock-pinpoint-app-id",
 				"region": "us-west-2"

--- a/packages/core/__tests__/parseAWSExports.test.ts
+++ b/packages/core/__tests__/parseAWSExports.test.ts
@@ -91,7 +91,7 @@ describe('parseAWSExports', () => {
 						email: false,
 						oauth: {
 							domain: oAuthDomain,
-							providers: ['Google', 'Apple', 'Facebook', 'Amazon'],
+							providers: ['Google', 'Apple', 'Facebook', 'Amazon', 'Auth0'],
 							redirectSignIn: [oAuthSigninUrl],
 							redirectSignOut: [oAuthSignoutUrl],
 							responseType: oAuthResponseType,
@@ -172,7 +172,13 @@ describe('parseAWSExports', () => {
 					responseType: oAuthResponseType,
 				},
 				aws_cognito_verification_mechanisms: ['EMAIL'],
-				aws_cognito_social_providers: ['GOOGLE', 'APPLE', 'FACEBOOK', 'AMAZON'],
+				aws_cognito_social_providers: [
+					'GOOGLE',
+					'APPLE',
+					'FACEBOOK',
+					'AMAZON',
+					'Auth0',
+				],
 				aws_mandatory_sign_in: 'enable',
 				aws_mobile_analytics_app_id: appId,
 				aws_mobile_analytics_app_region: region,

--- a/packages/core/__tests__/parseAmplifyOutputs.test.ts
+++ b/packages/core/__tests__/parseAmplifyOutputs.test.ts
@@ -25,7 +25,7 @@ describe('parseAmplifyOutputs tests', () => {
 							email: true,
 							oauth: {
 								domain: 'mock-oauth-domain',
-								providers: ['Facebook', 'Apple', 'Google'],
+								providers: ['Facebook', 'Apple', 'Google', 'Auth0'],
 								redirectSignIn: ['mock-sign-in-uri'],
 								redirectSignOut: ['mock-sign-out-uri'],
 								responseType: 'token',

--- a/packages/core/src/parseAWSExports.ts
+++ b/packages/core/src/parseAWSExports.ts
@@ -6,7 +6,6 @@ import {
 	AuthConfigUserAttributes,
 	LegacyUserAttributeKey,
 	OAuthConfig,
-	OAuthProvider,
 } from './singleton/Auth/types';
 import { ResourcesConfig } from './singleton/types';
 
@@ -320,10 +319,12 @@ const getOAuthConfig = ({
 	responseType,
 });
 
-const parseSocialProviders = (aws_cognito_social_providers: string[]) => {
+const parseSocialProviders = (
+	aws_cognito_social_providers: string[],
+): string[] => {
 	return aws_cognito_social_providers.map((provider: string) => {
 		const updatedProvider = provider.toLowerCase();
 
 		return updatedProvider.charAt(0).toUpperCase() + updatedProvider.slice(1);
-	}) as OAuthProvider[];
+	});
 };

--- a/packages/core/src/parseAmplifyOutputs.ts
+++ b/packages/core/src/parseAmplifyOutputs.ts
@@ -315,8 +315,8 @@ const providerNames: Record<string, OAuthProvider> = {
 	SIGN_IN_WITH_APPLE: 'Apple',
 };
 
-function getOAuthProviders(providers: string[] = []): OAuthProvider[] {
-	return providers.map(provider => providerNames[provider]);
+function getOAuthProviders(providers: string[] = []): string[] {
+	return providers.map(provider => providerNames[provider] ?? provider);
 }
 
 function getMfaStatus(

--- a/packages/core/src/singleton/Auth/types.ts
+++ b/packages/core/src/singleton/Auth/types.ts
@@ -179,7 +179,7 @@ export interface OAuthConfig {
 	redirectSignIn: string[];
 	redirectSignOut: string[];
 	responseType: 'code' | 'token';
-	providers?: (OAuthProvider | CustomProvider)[];
+	providers?: (OAuthProvider | CustomProvider)[] | string[];
 }
 
 export type OAuthProvider = 'Google' | 'Facebook' | 'Amazon' | 'Apple';


### PR DESCRIPTION
#### Description of changes
The `parseAmplifyOutputs` function does not take into account any custom oAuth Provider and this lead to providers in oAuth config having undefined values breaking the UI Authenticator component.

In additon to the fix for Amplify outputs, the PR loosens up the OAuth config type.  Since looking into the issue, realized our parse utility provided for adding custom oAuth as string to list of providers outside of our `CustomProvider` in `OAuthConfig`. 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/13466


#### Description of how you validated changes
- unit tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
