### PR TITLE
rm "username" from being parsed in amplify_outputs.json `auth.username_attributes`

### DIFF
--- a/packages/core/__tests__/parseAmplifyOutputs.test.ts
+++ b/packages/core/__tests__/parseAmplifyOutputs.test.ts
@@ -206,6 +206,14 @@ describe('parseAmplifyOutputs tests', () => {
 		expect(result.Auth?.Cognito.loginWith?.email).toBe(true);
 		expect(result.Auth?.Cognito.loginWith?.phone).toBe(true);
 		expect(result.Auth?.Cognito.loginWith?.username).toBe(false);
+
+		// Username
+		testAmplifyOutputs.auth.username_attributes = [];
+		result = parseAmplifyOutputs(testAmplifyOutputs);
+
+		expect(result.Auth?.Cognito.loginWith?.email).toBe(false);
+		expect(result.Auth?.Cognito.loginWith?.phone).toBe(false);
+		expect(result.Auth?.Cognito.loginWith?.username).toBe(true);
 	});
 
 	describe('storage tests', () => {

--- a/packages/core/src/parseAmplifyOutputs.ts
+++ b/packages/core/src/parseAmplifyOutputs.ts
@@ -141,7 +141,7 @@ function parseAuth(
 			email: username_attributes.includes('email'),
 			phone: username_attributes.includes('phone_number'),
 			// Signing in with a username is not currently supported in Gen2, this should always evaluate to false
-			username: username_attributes.includes('username'),
+			username: username_attributes.length === 0,
 		};
 	}
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

modifies `parseAmplifyOutputs` to look for an empty array in `auth.username_attributes` instead of `["username"]` to determine whether logging in with username is enabled

this is related to a similar change in the backend repo to remove `username` from the list of `username_attributes` https://github.com/aws-amplify/amplify-backend/pull/1636

valid `username_attributes` properties include `email` and `phone_number` https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cognito.CfnUserPool.html#usernameattributes

these values come from the L1 CfnUserPool property, therefore will not include `username` but the absence of attributes that can be used in place of the username
https://github.com/aws-amplify/amplify-backend/blob/main/packages/auth-construct/src/construct.ts?rgh-link-date=2024-06-19T22%3A39%3A40Z#L952


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
