### PR TITLE
refactor(storage): decouple utils from Amplify singleton

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -461,43 +461,43 @@
 			"name": "[Storage] copy (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ copy }",
-			"limit": "14.64 kB"
+			"limit": "14.71 kB"
 		},
 		{
 			"name": "[Storage] downloadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ downloadData }",
-			"limit": "15.27 kB"
+			"limit": "15.30 kB"
 		},
 		{
 			"name": "[Storage] getProperties (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getProperties }",
-			"limit": "14.52 kB"
+			"limit": "14.58 kB"
 		},
 		{
 			"name": "[Storage] getUrl (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getUrl }",
-			"limit": "15.62 kB"
+			"limit": "15.68 kB"
 		},
 		{
 			"name": "[Storage] list (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ list }",
-			"limit": "15.12 kB"
+			"limit": "15.16 kB"
 		},
 		{
 			"name": "[Storage] remove (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ remove }",
-			"limit": "14.38 kB"
+			"limit": "14.43 kB"
 		},
 		{
 			"name": "[Storage] uploadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ uploadData }",
-			"limit": "19.69 kB"
+			"limit": "19.77 kB"
 		}
 	]
 }

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -467,7 +467,7 @@
 			"name": "[Storage] downloadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ downloadData }",
-			"limit": "15.30 kB"
+			"limit": "15.31 kB"
 		},
 		{
 			"name": "[Storage] getProperties (S3)",
@@ -485,13 +485,13 @@
 			"name": "[Storage] list (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ list }",
-			"limit": "15.16 kB"
+			"limit": "15.18 kB"
 		},
 		{
 			"name": "[Storage] remove (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ remove }",
-			"limit": "14.43 kB"
+			"limit": "14.45 kB"
 		},
 		{
 			"name": "[Storage] uploadData (S3)",

--- a/packages/storage/__tests__/providers/s3/apis/uploadData/index.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/uploadData/index.test.ts
@@ -172,9 +172,12 @@ describe('uploadData with path', () => {
 				uploadData(testInput);
 
 				expect(mockPutObjectJob).toHaveBeenCalledWith(
-					testInput,
-					expect.any(AbortSignal),
-					expect.any(Number),
+					expect.objectContaining({
+						input: testInput,
+						totalLength: expect.any(Number),
+						abortSignal: expect.any(AbortSignal),
+						config: expect.any(Object),
+					}),
 				);
 				expect(mockGetMultipartUploadHandlers).not.toHaveBeenCalled();
 			},
@@ -212,8 +215,11 @@ describe('uploadData with path', () => {
 
 			expect(mockPutObjectJob).not.toHaveBeenCalled();
 			expect(mockGetMultipartUploadHandlers).toHaveBeenCalledWith(
-				testInput,
-				expect.any(Number),
+				expect.objectContaining({
+					config: expect.any(Object),
+					input: testInput,
+					size: expect.any(Number),
+				}),
 			);
 		});
 

--- a/packages/storage/__tests__/providers/s3/apis/uploadData/multipartHandlers.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/uploadData/multipartHandlers.test.ts
@@ -22,7 +22,7 @@ import { byteLength } from '../../../../../src/providers/s3/apis/uploadData/byte
 import { CanceledError } from '../../../../../src/errors/CanceledError';
 import { StorageOptions } from '../../../../../src/types';
 import '../testUtils';
-import { S3Configuration } from '../../../../../src/providers/s3/apis/internal/types';
+import { S3InternalConfig } from '../../../../../src/providers/s3/apis/internal/types';
 
 jest.mock('@aws-amplify/core');
 jest.mock('../../../../../src/providers/s3/utils/client');
@@ -138,7 +138,7 @@ const mockLibraryOptions = {};
 
 /* TODO Remove suite when `key` parameter is removed */
 describe('getMultipartUploadHandlers with key', () => {
-	const mockS3Config: S3Configuration = {
+	const mockS3Config: S3InternalConfig = {
 		credentialsProvider: mockCredentialsProvider,
 		identityIdProvider: mockIdentityIdProvider,
 		serviceOptions: mockServiceOptions,
@@ -689,7 +689,7 @@ describe('getMultipartUploadHandlers with key', () => {
 });
 
 describe('getMultipartUploadHandlers with path', () => {
-	const mockS3Config: S3Configuration = {
+	const mockS3Config: S3InternalConfig = {
 		credentialsProvider: mockCredentialsProvider,
 		identityIdProvider: mockIdentityIdProvider,
 		serviceOptions: mockServiceOptions,

--- a/packages/storage/__tests__/providers/s3/apis/uploadData/multipartHandlers.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/uploadData/multipartHandlers.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AWSCredentials } from '@aws-amplify/core/internals/utils';
-import { Amplify, defaultStorage } from '@aws-amplify/core';
+import { defaultStorage } from '@aws-amplify/core';
 
 import {
 	abortMultipartUpload,
@@ -22,7 +22,6 @@ import { byteLength } from '../../../../../src/providers/s3/apis/uploadData/byte
 import { CanceledError } from '../../../../../src/errors/CanceledError';
 import { StorageOptions } from '../../../../../src/types';
 import '../testUtils';
-import { createStorageConfiguration } from '../../../../../src/providers/s3/utils';
 import { S3Configuration } from '../../../../../src/providers/s3/apis/internal/types';
 
 jest.mock('@aws-amplify/core');
@@ -34,7 +33,6 @@ const credentials: AWSCredentials = {
 	secretAccessKey: 'secretAccessKey',
 };
 const defaultIdentityId = 'defaultIdentityId';
-const mockFetchAuthSession = Amplify.Auth.fetchAuthSession as jest.Mock;
 const bucket = 'bucket';
 const region = 'region';
 const defaultKey = 'key';
@@ -133,24 +131,22 @@ const resetS3Mocks = () => {
 	mockListParts.mockReset();
 };
 
+const mockCredentialsProvider = jest.fn();
+const mockIdentityIdProvider = jest.fn();
+const mockServiceOptions = { bucket, region };
+const mockLibraryOptions = {};
+
 /* TODO Remove suite when `key` parameter is removed */
 describe('getMultipartUploadHandlers with key', () => {
-	let mockS3Config: S3Configuration;
+	const mockS3Config: S3Configuration = {
+		credentialsProvider: mockCredentialsProvider,
+		identityIdProvider: mockIdentityIdProvider,
+		serviceOptions: mockServiceOptions,
+		libraryOptions: mockLibraryOptions,
+	};
 	beforeAll(() => {
-		mockFetchAuthSession.mockResolvedValue({
-			credentials,
-			identityId: defaultIdentityId,
-		});
-		(Amplify.getConfig as jest.Mock).mockReturnValue({
-			Storage: {
-				S3: {
-					bucket,
-					region,
-				},
-			},
-		});
-
-		mockS3Config = createStorageConfiguration(Amplify);
+		mockCredentialsProvider.mockImplementation(async () => credentials);
+		mockIdentityIdProvider.mockImplementation(async () => defaultIdentityId);
 	});
 
 	afterEach(() => {
@@ -693,22 +689,15 @@ describe('getMultipartUploadHandlers with key', () => {
 });
 
 describe('getMultipartUploadHandlers with path', () => {
-	let mockS3Config: S3Configuration;
+	const mockS3Config: S3Configuration = {
+		credentialsProvider: mockCredentialsProvider,
+		identityIdProvider: mockIdentityIdProvider,
+		serviceOptions: mockServiceOptions,
+		libraryOptions: mockLibraryOptions,
+	};
 	beforeAll(() => {
-		mockFetchAuthSession.mockResolvedValue({
-			credentials,
-			identityId: defaultIdentityId,
-		});
-		(Amplify.getConfig as jest.Mock).mockReturnValue({
-			Storage: {
-				S3: {
-					bucket,
-					region,
-				},
-			},
-		});
-
-		mockS3Config = createStorageConfiguration(Amplify);
+		mockCredentialsProvider.mockImplementation(async () => credentials);
+		mockIdentityIdProvider.mockImplementation(async () => defaultIdentityId);
 	});
 
 	afterEach(() => {

--- a/packages/storage/__tests__/providers/s3/apis/uploadData/putObjectJob.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/uploadData/putObjectJob.test.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AWSCredentials } from '@aws-amplify/core/internals/utils';
-import { Amplify } from '@aws-amplify/core';
 
 import { putObject } from '../../../../../src/providers/s3/utils/client';
 import { calculateContentMd5 } from '../../../../../src/providers/s3/utils';
 import { putObjectJob } from '../../../../../src/providers/s3/apis/uploadData/putObjectJob';
 import '../testUtils';
+import { S3Configuration } from '../../../../../src/providers/s3/apis/internal/types';
 
 jest.mock('../../../../../src/providers/s3/utils/client');
 jest.mock('../../../../../src/providers/s3/utils', () => {
@@ -20,13 +20,6 @@ jest.mock('../../../../../src/providers/s3/utils', () => {
 });
 jest.mock('@aws-amplify/core', () => ({
 	ConsoleLogger: jest.fn(),
-	fetchAuthSession: jest.fn(),
-	Amplify: {
-		getConfig: jest.fn(),
-		Auth: {
-			fetchAuthSession: jest.fn(),
-		},
-	},
 }));
 
 const testPath = 'testPath/object';
@@ -36,31 +29,35 @@ const credentials: AWSCredentials = {
 	secretAccessKey: 'secretAccessKey',
 };
 const identityId = 'identityId';
-const mockFetchAuthSession = jest.mocked(Amplify.Auth.fetchAuthSession);
+const bucket = 'bucket';
+const region = 'region';
+
+const mockCredentialsProvider = jest.fn();
+const mockIdentityIdProvider = jest.fn();
+const mockServiceOptions = { bucket, region };
+const mockLibraryOptions = {};
 const mockPutObject = jest.mocked(putObject);
 
-mockFetchAuthSession.mockResolvedValue({
-	credentials,
-	identityId,
-});
-jest.mocked(Amplify.getConfig).mockReturnValue({
-	Storage: {
-		S3: {
-			bucket: 'bucket',
-			region: 'region',
-		},
-	},
-});
 mockPutObject.mockResolvedValue({
 	ETag: 'eTag',
 	VersionId: 'versionId',
 	$metadata: {},
 });
 
+const config: S3Configuration = {
+	credentialsProvider: mockCredentialsProvider,
+	identityIdProvider: mockIdentityIdProvider,
+	serviceOptions: mockServiceOptions,
+	libraryOptions: mockLibraryOptions,
+};
+
 /* TODO Remove suite when `key` parameter is removed */
 describe('putObjectJob with key', () => {
 	beforeEach(() => {
+		mockCredentialsProvider.mockImplementation(async () => credentials);
+		mockIdentityIdProvider.mockImplementation(async () => identityId);
 		mockPutObject.mockClear();
+		jest.clearAllMocks();
 	});
 
 	it('should supply the correct parameters to putObject API handler', async () => {
@@ -74,8 +71,9 @@ describe('putObjectJob with key', () => {
 		const onProgress = jest.fn();
 		const useAccelerateEndpoint = true;
 
-		const job = putObjectJob(
-			{
+		const job = putObjectJob({
+			config,
+			input: {
 				key: inputKey,
 				data,
 				options: {
@@ -87,8 +85,8 @@ describe('putObjectJob with key', () => {
 					useAccelerateEndpoint,
 				},
 			},
-			abortController.signal,
-		);
+			abortSignal: abortController.signal,
+		});
 		const result = await job();
 		expect(result).toEqual({
 			key: inputKey,
@@ -99,6 +97,7 @@ describe('putObjectJob with key', () => {
 			size: undefined,
 		});
 		expect(mockPutObject).toHaveBeenCalledTimes(1);
+
 		await expect(mockPutObject).toBeLastCalledWithConfigAndInput(
 			{
 				credentials,
@@ -122,20 +121,19 @@ describe('putObjectJob with key', () => {
 	});
 
 	it('should set ContentMD5 if object lock is enabled', async () => {
-		Amplify.libraryOptions = {
-			Storage: {
-				S3: {
+		const job = putObjectJob({
+			config: {
+				...config,
+				libraryOptions: {
 					isObjectLockEnabled: true,
 				},
 			},
-		};
-		const job = putObjectJob(
-			{
+			input: {
 				key: 'key',
 				data: 'data',
 			},
-			new AbortController().signal,
-		);
+			abortSignal: new AbortController().signal,
+		});
 		await job();
 		expect(calculateContentMd5).toHaveBeenCalledWith('data');
 	});
@@ -143,6 +141,8 @@ describe('putObjectJob with key', () => {
 
 describe('putObjectJob with path', () => {
 	beforeEach(() => {
+		mockCredentialsProvider.mockImplementation(async () => credentials);
+		mockIdentityIdProvider.mockImplementation(async () => identityId);
 		mockPutObject.mockClear();
 	});
 
@@ -167,8 +167,9 @@ describe('putObjectJob with path', () => {
 			const onProgress = jest.fn();
 			const useAccelerateEndpoint = true;
 
-			const job = putObjectJob(
-				{
+			const job = putObjectJob({
+				config,
+				input: {
 					path: inputPath,
 					data,
 					options: {
@@ -180,8 +181,8 @@ describe('putObjectJob with path', () => {
 						useAccelerateEndpoint,
 					},
 				},
-				abortController.signal,
-			);
+				abortSignal: abortController.signal,
+			});
 			const result = await job();
 			expect(result).toEqual({
 				path: expectedKey,
@@ -216,20 +217,19 @@ describe('putObjectJob with path', () => {
 	);
 
 	it('should set ContentMD5 if object lock is enabled', async () => {
-		Amplify.libraryOptions = {
-			Storage: {
-				S3: {
+		const job = putObjectJob({
+			config: {
+				...config,
+				libraryOptions: {
 					isObjectLockEnabled: true,
 				},
 			},
-		};
-		const job = putObjectJob(
-			{
+			input: {
 				path: testPath,
 				data: 'data',
 			},
-			new AbortController().signal,
-		);
+			abortSignal: new AbortController().signal,
+		});
 		await job();
 		expect(calculateContentMd5).toHaveBeenCalledWith('data');
 	});

--- a/packages/storage/__tests__/providers/s3/apis/uploadData/putObjectJob.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/uploadData/putObjectJob.test.ts
@@ -7,7 +7,7 @@ import { putObject } from '../../../../../src/providers/s3/utils/client';
 import { calculateContentMd5 } from '../../../../../src/providers/s3/utils';
 import { putObjectJob } from '../../../../../src/providers/s3/apis/uploadData/putObjectJob';
 import '../testUtils';
-import { S3Configuration } from '../../../../../src/providers/s3/apis/internal/types';
+import { S3InternalConfig } from '../../../../../src/providers/s3/apis/internal/types';
 
 jest.mock('../../../../../src/providers/s3/utils/client');
 jest.mock('../../../../../src/providers/s3/utils', () => {
@@ -44,7 +44,7 @@ mockPutObject.mockResolvedValue({
 	$metadata: {},
 });
 
-const config: S3Configuration = {
+const config: S3InternalConfig = {
 	credentialsProvider: mockCredentialsProvider,
 	identityIdProvider: mockIdentityIdProvider,
 	serviceOptions: mockServiceOptions,

--- a/packages/storage/__tests__/providers/s3/apis/utils/resolveS3ConfigAndInput.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/resolveS3ConfigAndInput.test.ts
@@ -1,29 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
-
 import { resolveS3ConfigAndInput } from '../../../../../src/providers/s3/utils';
 import { resolvePrefix } from '../../../../../src/utils/resolvePrefix';
 import {
 	StorageValidationErrorCode,
 	validationErrorMap,
 } from '../../../../../src/errors/types/validation';
+import { S3Configuration } from '../../../../../src/providers/s3/apis/internal/types';
+import { assertValidationError } from '../../../../../src/errors/utils/assertValidationError';
 
-jest.mock('@aws-amplify/core', () => ({
-	ConsoleLogger: jest.fn(),
-	Amplify: {
-		getConfig: jest.fn(),
-		Auth: {
-			fetchAuthSession: jest.fn(),
-		},
-	},
-}));
 jest.mock('../../../../../src/utils/resolvePrefix');
 
-const mockGetConfig = Amplify.getConfig as jest.Mock;
 const mockDefaultResolvePrefix = resolvePrefix as jest.Mock;
-const mockFetchAuthSession = Amplify.Auth.fetchAuthSession as jest.Mock;
 
 const bucket = 'bucket';
 const region = 'region';
@@ -34,39 +23,41 @@ const credentials = {
 };
 const targetIdentityId = 'targetIdentityId';
 
-describe('resolveS3ConfigAndInput', () => {
-	beforeEach(() => {
-		jest.clearAllMocks();
-		Amplify.libraryOptions = {};
-	});
-	mockFetchAuthSession.mockResolvedValue({
-		credentials,
-		identityId: targetIdentityId,
-	});
+const mockCredentialsProvider = jest.fn();
+const mockIdentityIdProvider = jest.fn();
+const mockServiceOptions = { bucket, region };
+const mockLibraryOptions = {};
 
-	mockGetConfig.mockReturnValue({
-		Storage: {
-			S3: {
-				bucket,
-				region,
-			},
-		},
+describe('resolveS3ConfigAndInput', () => {
+	const config: S3Configuration = {
+		credentialsProvider: mockCredentialsProvider,
+		identityIdProvider: mockIdentityIdProvider,
+		serviceOptions: mockServiceOptions,
+		libraryOptions: mockLibraryOptions,
+	};
+	beforeEach(() => {
+		mockCredentialsProvider.mockImplementation(async () => credentials);
+		mockIdentityIdProvider.mockImplementation(async () => targetIdentityId);
+		jest.clearAllMocks();
 	});
 
 	it('should call fetchAuthSession for credentials and identityId', async () => {
 		expect.assertions(1);
-		await resolveS3ConfigAndInput(Amplify, {});
-		expect(mockFetchAuthSession).toHaveBeenCalled();
+		await resolveS3ConfigAndInput({ ...config });
+		expect(mockIdentityIdProvider).toHaveBeenCalled();
 	});
 
 	it('should throw if credentials are not available', async () => {
 		expect.assertions(1);
-		mockFetchAuthSession.mockResolvedValue({
-			identityId: targetIdentityId,
+		mockCredentialsProvider.mockImplementation(async () => {
+			assertValidationError(
+				!!undefined,
+				StorageValidationErrorCode.NoCredentials,
+			);
 		});
 		const {
 			s3Config: { credentials: credentialsProvider },
-		} = await resolveS3ConfigAndInput(Amplify, {});
+		} = await resolveS3ConfigAndInput({ ...config });
 		if (typeof credentialsProvider === 'function') {
 			await expect(credentialsProvider()).rejects.toMatchObject(
 				validationErrorMap[StorageValidationErrorCode.NoCredentials],
@@ -77,100 +68,90 @@ describe('resolveS3ConfigAndInput', () => {
 	});
 
 	it('should throw if identityId is not available', async () => {
-		mockFetchAuthSession.mockResolvedValueOnce({
-			credentials,
+		mockIdentityIdProvider.mockImplementation(async () => {
+			assertValidationError(!!'', StorageValidationErrorCode.NoIdentityId);
 		});
-		await expect(resolveS3ConfigAndInput(Amplify, {})).rejects.toMatchObject(
+		await expect(resolveS3ConfigAndInput({ ...config })).rejects.toMatchObject(
 			validationErrorMap[StorageValidationErrorCode.NoIdentityId],
 		);
 	});
 
 	it('should resolve bucket from S3 config', async () => {
-		const { bucket: resolvedBucket } = await resolveS3ConfigAndInput(
-			Amplify,
-			{},
-		);
+		const { bucket: resolvedBucket } = await resolveS3ConfigAndInput({
+			...config,
+		});
 		expect(resolvedBucket).toEqual(bucket);
-		expect(mockGetConfig).toHaveBeenCalled();
 	});
 
 	it('should throw if bucket is not available', async () => {
-		mockGetConfig.mockReturnValueOnce({
-			Storage: {
-				S3: {
-					region,
+		await expect(
+			resolveS3ConfigAndInput({
+				...config,
+				serviceOptions: {
+					bucket: undefined,
 				},
-			},
-		});
-		await expect(resolveS3ConfigAndInput(Amplify, {})).rejects.toMatchObject(
+			}),
+		).rejects.toMatchObject(
 			validationErrorMap[StorageValidationErrorCode.NoBucket],
 		);
 	});
 
 	it('should resolve region from S3 config', async () => {
-		const { s3Config } = await resolveS3ConfigAndInput(Amplify, {});
+		const { s3Config } = await resolveS3ConfigAndInput({ ...config });
 		expect(s3Config.region).toEqual(region);
-		expect(mockGetConfig).toHaveBeenCalled();
 	});
 
 	it('should throw if region is not available', async () => {
-		mockGetConfig.mockReturnValueOnce({
-			Storage: {
-				S3: {
+		await expect(
+			resolveS3ConfigAndInput({
+				...config,
+				serviceOptions: {
 					bucket,
 				},
-			},
-		});
-		await expect(resolveS3ConfigAndInput(Amplify, {})).rejects.toMatchObject(
+			}),
+		).rejects.toMatchObject(
 			validationErrorMap[StorageValidationErrorCode.NoRegion],
 		);
 	});
 
 	it('should set customEndpoint and forcePathStyle to true if dangerouslyConnectToHttpEndpointForTesting is set from S3 config', async () => {
-		mockGetConfig.mockReturnValueOnce({
-			Storage: {
-				S3: {
-					bucket,
-					region,
-					dangerouslyConnectToHttpEndpointForTesting: true,
-				},
-			},
+		const serviceOptions = {
+			bucket,
+			region,
+			dangerouslyConnectToHttpEndpointForTesting: 'true',
+		};
+
+		const { s3Config } = await resolveS3ConfigAndInput({
+			...config,
+			serviceOptions,
 		});
-		const { s3Config } = await resolveS3ConfigAndInput(Amplify, {});
 		expect(s3Config.customEndpoint).toEqual('http://localhost:20005');
 		expect(s3Config.forcePathStyle).toEqual(true);
-		expect(mockGetConfig).toHaveBeenCalled();
 	});
 
 	it('should resolve isObjectLockEnabled from S3 library options', async () => {
-		Amplify.libraryOptions = {
-			Storage: {
-				S3: {
-					isObjectLockEnabled: true,
-				},
-			},
-		};
-		const { isObjectLockEnabled } = await resolveS3ConfigAndInput(Amplify, {});
+		const { isObjectLockEnabled } = await resolveS3ConfigAndInput({
+			...config,
+			libraryOptions: { isObjectLockEnabled: true },
+		});
 		expect(isObjectLockEnabled).toEqual(true);
 	});
 
 	it('should use default prefix resolver', async () => {
 		mockDefaultResolvePrefix.mockResolvedValueOnce('prefix');
-		const { keyPrefix } = await resolveS3ConfigAndInput(Amplify, {});
+		const { keyPrefix } = await resolveS3ConfigAndInput({ ...config });
 		expect(mockDefaultResolvePrefix).toHaveBeenCalled();
 		expect(keyPrefix).toEqual('prefix');
 	});
 
 	it('should use prefix resolver from S3 library options if supplied', async () => {
 		const customResolvePrefix = jest.fn().mockResolvedValueOnce('prefix');
-		Amplify.libraryOptions = {
-			Storage: {
-				S3: {
-					prefixResolver: customResolvePrefix,
-				},
+		const { keyPrefix } = await resolveS3ConfigAndInput({
+			...config,
+			libraryOptions: {
+				prefixResolver: customResolvePrefix,
 			},
-		};
-		const { keyPrefix } = await resolveS3ConfigAndInput(Amplify, {});
+		});
 		expect(customResolvePrefix).toHaveBeenCalled();
 		expect(keyPrefix).toEqual('prefix');
 		expect(mockDefaultResolvePrefix).not.toHaveBeenCalled();
@@ -178,8 +159,11 @@ describe('resolveS3ConfigAndInput', () => {
 
 	it('should resolve prefix with given access level', async () => {
 		mockDefaultResolvePrefix.mockResolvedValueOnce('prefix');
-		const { keyPrefix } = await resolveS3ConfigAndInput(Amplify, {
-			accessLevel: 'someLevel' as any,
+		const { keyPrefix } = await resolveS3ConfigAndInput({
+			...config,
+			apiOptions: {
+				accessLevel: 'someLevel' as any,
+			},
 		});
 		expect(mockDefaultResolvePrefix).toHaveBeenCalledWith({
 			accessLevel: 'someLevel',
@@ -190,14 +174,12 @@ describe('resolveS3ConfigAndInput', () => {
 
 	it('should resolve prefix with default access level from S3 library options', async () => {
 		mockDefaultResolvePrefix.mockResolvedValueOnce('prefix');
-		Amplify.libraryOptions = {
-			Storage: {
-				S3: {
-					defaultAccessLevel: 'someLevel' as any,
-				},
+		const { keyPrefix } = await resolveS3ConfigAndInput({
+			...config,
+			libraryOptions: {
+				defaultAccessLevel: 'someLevel' as any,
 			},
-		};
-		const { keyPrefix } = await resolveS3ConfigAndInput(Amplify, {});
+		});
 		expect(mockDefaultResolvePrefix).toHaveBeenCalledWith({
 			accessLevel: 'someLevel',
 			targetIdentityId,
@@ -207,7 +189,7 @@ describe('resolveS3ConfigAndInput', () => {
 
 	it('should resolve prefix with `guest` access level if no access level is given', async () => {
 		mockDefaultResolvePrefix.mockResolvedValueOnce('prefix');
-		const { keyPrefix } = await resolveS3ConfigAndInput(Amplify, {});
+		const { keyPrefix } = await resolveS3ConfigAndInput({ ...config });
 		expect(mockDefaultResolvePrefix).toHaveBeenCalledWith({
 			accessLevel: 'guest', // default access level
 			targetIdentityId,

--- a/packages/storage/src/providers/s3/apis/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/downloadData.ts
@@ -11,7 +11,11 @@ import {
 	DownloadDataWithPathOutput,
 } from '../types';
 import { resolveS3ConfigAndInput } from '../utils/resolveS3ConfigAndInput';
-import { createDownloadTask, validateStorageOperationInput } from '../utils';
+import {
+	constructStorageConfiguration,
+	createDownloadTask,
+	validateStorageOperationInput,
+} from '../utils';
 import { getObject } from '../utils/client';
 import { getStorageUserAgentValue } from '../utils/userAgent';
 import { logger } from '../../../utils';
@@ -114,8 +118,12 @@ const downloadDataJob =
 		StorageDownloadDataOutput<StorageItemWithKey | StorageItemWithPath>
 	> => {
 		const { options: downloadDataOptions } = downloadDataInput;
+		const configuration = constructStorageConfiguration(Amplify);
 		const { bucket, keyPrefix, s3Config, identityId } =
-			await resolveS3ConfigAndInput(Amplify, downloadDataOptions);
+			await resolveS3ConfigAndInput({
+				...configuration,
+				apiOptions: downloadDataOptions,
+			});
 		const { inputType, objectKey } = validateStorageOperationInput(
 			downloadDataInput,
 			identityId,

--- a/packages/storage/src/providers/s3/apis/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/downloadData.ts
@@ -11,11 +11,8 @@ import {
 	DownloadDataWithPathOutput,
 } from '../types';
 import { resolveS3ConfigAndInput } from '../utils/resolveS3ConfigAndInput';
-import {
-	constructStorageConfiguration,
-	createDownloadTask,
-	validateStorageOperationInput,
-} from '../utils';
+import { createDownloadTask, validateStorageOperationInput } from '../utils';
+import { createStorageConfiguration } from '../utils/config';
 import { getObject } from '../utils/client';
 import { getStorageUserAgentValue } from '../utils/userAgent';
 import { logger } from '../../../utils';
@@ -118,7 +115,8 @@ const downloadDataJob =
 		StorageDownloadDataOutput<StorageItemWithKey | StorageItemWithPath>
 	> => {
 		const { options: downloadDataOptions } = downloadDataInput;
-		const configuration = constructStorageConfiguration(Amplify);
+		const configuration = createStorageConfiguration(Amplify);
+
 		const { bucket, keyPrefix, s3Config, identityId } =
 			await resolveS3ConfigAndInput({
 				...configuration,

--- a/packages/storage/src/providers/s3/apis/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/downloadData.ts
@@ -115,11 +115,11 @@ const downloadDataJob =
 		StorageDownloadDataOutput<StorageItemWithKey | StorageItemWithPath>
 	> => {
 		const { options: downloadDataOptions } = downloadDataInput;
-		const configuration = createStorageConfiguration(Amplify);
+		const config = createStorageConfiguration(Amplify);
 
 		const { bucket, keyPrefix, s3Config, identityId } =
 			await resolveS3ConfigAndInput({
-				...configuration,
+				config,
 				apiOptions: downloadDataOptions,
 			});
 		const { inputType, objectKey } = validateStorageOperationInput(

--- a/packages/storage/src/providers/s3/apis/internal/copy.ts
+++ b/packages/storage/src/providers/s3/apis/internal/copy.ts
@@ -41,9 +41,9 @@ const copyWithPath = async (
 	input: CopyWithPathInput,
 ): Promise<CopyWithPathOutput> => {
 	const { source, destination } = input;
-	const configuration = createStorageConfiguration(amplify);
+	const config = createStorageConfiguration(amplify);
 	const { s3Config, bucket, identityId } = await resolveS3ConfigAndInput({
-		...configuration,
+		config,
 	});
 
 	assertValidationError(!!source.path, StorageValidationErrorCode.NoSourcePath);
@@ -90,17 +90,17 @@ export const copyWithKey = async (
 		!!destinationKey,
 		StorageValidationErrorCode.NoDestinationKey,
 	);
-	const configuration = createStorageConfiguration(amplify);
+	const config = createStorageConfiguration(amplify);
 	const {
 		s3Config,
 		bucket,
 		keyPrefix: sourceKeyPrefix,
 	} = await resolveS3ConfigAndInput({
-		...configuration,
+		config,
 		apiOptions: input.source,
 	});
 	const { keyPrefix: destinationKeyPrefix } = await resolveS3ConfigAndInput({
-		...configuration,
+		config,
 		apiOptions: input.destination,
 	}); // resolveS3ConfigAndInput does not make extra API calls or storage access if called repeatedly.
 

--- a/packages/storage/src/providers/s3/apis/internal/copy.ts
+++ b/packages/storage/src/providers/s3/apis/internal/copy.ts
@@ -12,7 +12,7 @@ import {
 } from '../../types';
 import { ResolvedS3Config } from '../../types/options';
 import {
-	constructStorageConfiguration,
+	createStorageConfiguration,
 	isInputWithPath,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInput,
@@ -41,7 +41,7 @@ const copyWithPath = async (
 	input: CopyWithPathInput,
 ): Promise<CopyWithPathOutput> => {
 	const { source, destination } = input;
-	const configuration = constructStorageConfiguration(amplify);
+	const configuration = createStorageConfiguration(amplify);
 	const { s3Config, bucket, identityId } = await resolveS3ConfigAndInput({
 		...configuration,
 	});
@@ -90,7 +90,7 @@ export const copyWithKey = async (
 		!!destinationKey,
 		StorageValidationErrorCode.NoDestinationKey,
 	);
-	const configuration = constructStorageConfiguration(amplify);
+	const configuration = createStorageConfiguration(amplify);
 	const {
 		s3Config,
 		bucket,

--- a/packages/storage/src/providers/s3/apis/internal/copy.ts
+++ b/packages/storage/src/providers/s3/apis/internal/copy.ts
@@ -12,6 +12,7 @@ import {
 } from '../../types';
 import { ResolvedS3Config } from '../../types/options';
 import {
+	constructStorageConfiguration,
 	isInputWithPath,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInput,
@@ -40,8 +41,10 @@ const copyWithPath = async (
 	input: CopyWithPathInput,
 ): Promise<CopyWithPathOutput> => {
 	const { source, destination } = input;
-	const { s3Config, bucket, identityId } =
-		await resolveS3ConfigAndInput(amplify);
+	const configuration = constructStorageConfiguration(amplify);
+	const { s3Config, bucket, identityId } = await resolveS3ConfigAndInput({
+		...configuration,
+	});
 
 	assertValidationError(!!source.path, StorageValidationErrorCode.NoSourcePath);
 	assertValidationError(
@@ -87,16 +90,19 @@ export const copyWithKey = async (
 		!!destinationKey,
 		StorageValidationErrorCode.NoDestinationKey,
 	);
-
+	const configuration = constructStorageConfiguration(amplify);
 	const {
 		s3Config,
 		bucket,
 		keyPrefix: sourceKeyPrefix,
-	} = await resolveS3ConfigAndInput(amplify, input.source);
-	const { keyPrefix: destinationKeyPrefix } = await resolveS3ConfigAndInput(
-		amplify,
-		input.destination,
-	); // resolveS3ConfigAndInput does not make extra API calls or storage access if called repeatedly.
+	} = await resolveS3ConfigAndInput({
+		...configuration,
+		apiOptions: input.source,
+	});
+	const { keyPrefix: destinationKeyPrefix } = await resolveS3ConfigAndInput({
+		...configuration,
+		apiOptions: input.destination,
+	}); // resolveS3ConfigAndInput does not make extra API calls or storage access if called repeatedly.
 
 	// TODO(ashwinkumar6) V6-logger: warn `You may copy files from another user if the source level is "protected", currently it's ${srcLevel}`
 	const finalCopySource = `${bucket}/${sourceKeyPrefix}${sourceKey}`;

--- a/packages/storage/src/providers/s3/apis/internal/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getProperties.ts
@@ -11,7 +11,7 @@ import {
 	GetPropertiesWithPathOutput,
 } from '../../types';
 import {
-	constructStorageConfiguration,
+	createStorageConfiguration,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInput,
 } from '../../utils';
@@ -26,7 +26,7 @@ export const getProperties = async (
 	action?: StorageAction,
 ): Promise<GetPropertiesOutput | GetPropertiesWithPathOutput> => {
 	const { options: getPropertiesOptions } = input;
-	const configuration = constructStorageConfiguration(amplify);
+	const configuration = createStorageConfiguration(amplify);
 	const { s3Config, bucket, keyPrefix, identityId } =
 		await resolveS3ConfigAndInput({
 			...configuration,

--- a/packages/storage/src/providers/s3/apis/internal/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getProperties.ts
@@ -11,6 +11,7 @@ import {
 	GetPropertiesWithPathOutput,
 } from '../../types';
 import {
+	constructStorageConfiguration,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInput,
 } from '../../utils';
@@ -25,8 +26,12 @@ export const getProperties = async (
 	action?: StorageAction,
 ): Promise<GetPropertiesOutput | GetPropertiesWithPathOutput> => {
 	const { options: getPropertiesOptions } = input;
+	const configuration = constructStorageConfiguration(amplify);
 	const { s3Config, bucket, keyPrefix, identityId } =
-		await resolveS3ConfigAndInput(amplify, getPropertiesOptions);
+		await resolveS3ConfigAndInput({
+			...configuration,
+			apiOptions: getPropertiesOptions,
+		});
 	const { inputType, objectKey } = validateStorageOperationInput(
 		input,
 		identityId,

--- a/packages/storage/src/providers/s3/apis/internal/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getProperties.ts
@@ -26,10 +26,10 @@ export const getProperties = async (
 	action?: StorageAction,
 ): Promise<GetPropertiesOutput | GetPropertiesWithPathOutput> => {
 	const { options: getPropertiesOptions } = input;
-	const configuration = createStorageConfiguration(amplify);
+	const config = createStorageConfiguration(amplify);
 	const { s3Config, bucket, keyPrefix, identityId } =
 		await resolveS3ConfigAndInput({
-			...configuration,
+			config,
 			apiOptions: getPropertiesOptions,
 		});
 	const { inputType, objectKey } = validateStorageOperationInput(

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -13,6 +13,7 @@ import {
 import { StorageValidationErrorCode } from '../../../../errors/types/validation';
 import { getPresignedGetObjectUrl } from '../../utils/client';
 import {
+	constructStorageConfiguration,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInput,
 } from '../../utils';
@@ -30,8 +31,12 @@ export const getUrl = async (
 	input: GetUrlInput | GetUrlWithPathInput,
 ): Promise<GetUrlOutput | GetUrlWithPathOutput> => {
 	const { options: getUrlOptions } = input;
+	const configuration = constructStorageConfiguration(amplify);
 	const { s3Config, keyPrefix, bucket, identityId } =
-		await resolveS3ConfigAndInput(amplify, getUrlOptions);
+		await resolveS3ConfigAndInput({
+			...configuration,
+			apiOptions: getUrlOptions,
+		});
 	const { inputType, objectKey } = validateStorageOperationInput(
 		input,
 		identityId,

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -13,7 +13,7 @@ import {
 import { StorageValidationErrorCode } from '../../../../errors/types/validation';
 import { getPresignedGetObjectUrl } from '../../utils/client';
 import {
-	constructStorageConfiguration,
+	createStorageConfiguration,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInput,
 } from '../../utils';
@@ -31,7 +31,7 @@ export const getUrl = async (
 	input: GetUrlInput | GetUrlWithPathInput,
 ): Promise<GetUrlOutput | GetUrlWithPathOutput> => {
 	const { options: getUrlOptions } = input;
-	const configuration = constructStorageConfiguration(amplify);
+	const configuration = createStorageConfiguration(amplify);
 	const { s3Config, keyPrefix, bucket, identityId } =
 		await resolveS3ConfigAndInput({
 			...configuration,

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -31,10 +31,10 @@ export const getUrl = async (
 	input: GetUrlInput | GetUrlWithPathInput,
 ): Promise<GetUrlOutput | GetUrlWithPathOutput> => {
 	const { options: getUrlOptions } = input;
-	const configuration = createStorageConfiguration(amplify);
+	const config = createStorageConfiguration(amplify);
 	const { s3Config, keyPrefix, bucket, identityId } =
 		await resolveS3ConfigAndInput({
-			...configuration,
+			config,
 			apiOptions: getUrlOptions,
 		});
 	const { inputType, objectKey } = validateStorageOperationInput(

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -17,7 +17,7 @@ import {
 	ListPaginateWithPathOutput,
 } from '../../types';
 import {
-	constructStorageConfiguration,
+	createStorageConfiguration,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInputWithPrefix,
 } from '../../utils';
@@ -55,7 +55,7 @@ export const list = async (
 > => {
 	const { options = {} } = input;
 
-	const configuration = constructStorageConfiguration(amplify);
+	const configuration = createStorageConfiguration(amplify);
 	const {
 		s3Config,
 		bucket,

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -17,6 +17,7 @@ import {
 	ListPaginateWithPathOutput,
 } from '../../types';
 import {
+	constructStorageConfiguration,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInputWithPrefix,
 } from '../../utils';
@@ -53,12 +54,17 @@ export const list = async (
 	| ListPaginateWithPathOutput
 > => {
 	const { options = {} } = input;
+
+	const configuration = constructStorageConfiguration(amplify);
 	const {
 		s3Config,
 		bucket,
 		keyPrefix: generatedPrefix,
 		identityId,
-	} = await resolveS3ConfigAndInput(amplify, options);
+	} = await resolveS3ConfigAndInput({
+		...configuration,
+		apiOptions: options,
+	});
 
 	const { inputType, objectKey } = validateStorageOperationInputWithPrefix(
 		input,

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -55,14 +55,14 @@ export const list = async (
 > => {
 	const { options = {} } = input;
 
-	const configuration = createStorageConfiguration(amplify);
+	const config = createStorageConfiguration(amplify);
 	const {
 		s3Config,
 		bucket,
 		keyPrefix: generatedPrefix,
 		identityId,
 	} = await resolveS3ConfigAndInput({
-		...configuration,
+		config,
 		apiOptions: options,
 	});
 

--- a/packages/storage/src/providers/s3/apis/internal/remove.ts
+++ b/packages/storage/src/providers/s3/apis/internal/remove.ts
@@ -25,10 +25,10 @@ export const remove = async (
 	input: RemoveInput | RemoveWithPathInput,
 ): Promise<RemoveOutput | RemoveWithPathOutput> => {
 	const { options = {} } = input ?? {};
-	const configuration = createStorageConfiguration(amplify);
+	const config = createStorageConfiguration(amplify);
 	const { s3Config, keyPrefix, bucket, identityId } =
 		await resolveS3ConfigAndInput({
-			...configuration,
+			config,
 			apiOptions: options,
 		});
 

--- a/packages/storage/src/providers/s3/apis/internal/remove.ts
+++ b/packages/storage/src/providers/s3/apis/internal/remove.ts
@@ -11,7 +11,7 @@ import {
 	RemoveWithPathOutput,
 } from '../../types';
 import {
-	constructStorageConfiguration,
+	createStorageConfiguration,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInput,
 } from '../../utils';
@@ -25,7 +25,7 @@ export const remove = async (
 	input: RemoveInput | RemoveWithPathInput,
 ): Promise<RemoveOutput | RemoveWithPathOutput> => {
 	const { options = {} } = input ?? {};
-	const configuration = constructStorageConfiguration(amplify);
+	const configuration = createStorageConfiguration(amplify);
 	const { s3Config, keyPrefix, bucket, identityId } =
 		await resolveS3ConfigAndInput({
 			...configuration,

--- a/packages/storage/src/providers/s3/apis/internal/remove.ts
+++ b/packages/storage/src/providers/s3/apis/internal/remove.ts
@@ -11,6 +11,7 @@ import {
 	RemoveWithPathOutput,
 } from '../../types';
 import {
+	constructStorageConfiguration,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInput,
 } from '../../utils';
@@ -24,8 +25,12 @@ export const remove = async (
 	input: RemoveInput | RemoveWithPathInput,
 ): Promise<RemoveOutput | RemoveWithPathOutput> => {
 	const { options = {} } = input ?? {};
+	const configuration = constructStorageConfiguration(amplify);
 	const { s3Config, keyPrefix, bucket, identityId } =
-		await resolveS3ConfigAndInput(amplify, options);
+		await resolveS3ConfigAndInput({
+			...configuration,
+			apiOptions: options,
+		});
 
 	const { inputType, objectKey } = validateStorageOperationInput(
 		input,

--- a/packages/storage/src/providers/s3/apis/internal/types/index.ts
+++ b/packages/storage/src/providers/s3/apis/internal/types/index.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 
 import { S3LibraryOptions, S3ServiceOptions } from '../../../types/options';

--- a/packages/storage/src/providers/s3/apis/internal/types/index.ts
+++ b/packages/storage/src/providers/s3/apis/internal/types/index.ts
@@ -1,16 +1,29 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { LibraryOptions, StorageConfig } from '@aws-amplify/core';
 import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 
-import { S3LibraryOptions, S3ServiceOptions } from '../../../types/options';
+/**
+ * Internal S3 service options.
+ *
+ * @internal
+ */
+type S3ServiceOptions = StorageConfig['S3'];
+
+/**
+ * Internal S3 library options.
+ *
+ * @internal
+ */
+type S3LibraryOptions = NonNullable<LibraryOptions['Storage']>['S3'];
 
 /**
  * S3 storage config input
  *
  * @internal
  */
-export interface S3Configuration {
+export interface S3InternalConfig {
 	serviceOptions: S3ServiceOptions;
 	libraryOptions: S3LibraryOptions;
 	credentialsProvider(): Promise<AWSCredentials>;

--- a/packages/storage/src/providers/s3/apis/internal/types/index.ts
+++ b/packages/storage/src/providers/s3/apis/internal/types/index.ts
@@ -1,0 +1,15 @@
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
+
+import { S3LibraryOptions, S3ServiceOptions } from '../../../types/options';
+
+/**
+ * Storage config input
+ *
+ * @internal
+ */
+export interface StorageConfiguration {
+	serviceOptions: S3ServiceOptions;
+	libraryOptions: S3LibraryOptions;
+	credentialsProvider(): Promise<AWSCredentials>;
+	identityIdProvider(): Promise<string>;
+}

--- a/packages/storage/src/providers/s3/apis/internal/types/index.ts
+++ b/packages/storage/src/providers/s3/apis/internal/types/index.ts
@@ -3,11 +3,11 @@ import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 import { S3LibraryOptions, S3ServiceOptions } from '../../../types/options';
 
 /**
- * Storage config input
+ * S3 storage config input
  *
  * @internal
  */
-export interface StorageConfiguration {
+export interface S3Configuration {
 	serviceOptions: S3ServiceOptions;
 	libraryOptions: S3LibraryOptions;
 	credentialsProvider(): Promise<AWSCredentials>;

--- a/packages/storage/src/providers/s3/apis/internal/uploadData.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData.ts
@@ -1,0 +1,64 @@
+import { UploadDataInput, UploadDataWithPathInput } from '../../types';
+import { createUploadTask } from '../../utils';
+import { assertValidationError } from '../../../../errors/utils/assertValidationError';
+import { StorageValidationErrorCode } from '../../../../errors/types/validation';
+import { DEFAULT_PART_SIZE, MAX_OBJECT_SIZE } from '../../utils/constants';
+import { byteLength } from '../uploadData/byteLength';
+import { putObjectJob } from '../uploadData/putObjectJob';
+import { getMultipartUploadHandlers } from '../uploadData/multipart';
+
+import { StorageConfiguration } from './types';
+
+export function internalUploadData(
+	config: StorageConfiguration,
+	input: UploadDataInput | UploadDataWithPathInput,
+) {
+	const {
+		serviceOptions,
+		libraryOptions,
+		credentialsProvider,
+		identityIdProvider,
+	} = config;
+	const { data } = input;
+
+	const dataByteLength = byteLength(data);
+	assertValidationError(
+		dataByteLength === undefined || dataByteLength <= MAX_OBJECT_SIZE,
+		StorageValidationErrorCode.ObjectIsTooLarge,
+	);
+
+	if (dataByteLength && dataByteLength <= DEFAULT_PART_SIZE) {
+		// Single part upload
+		const abortController = new AbortController();
+
+		return createUploadTask({
+			isMultipartUpload: false,
+			job: putObjectJob({
+				libraryOptions,
+				serviceOptions,
+				credentialsProvider,
+				identityIdProvider,
+				uploadDataInput: input,
+				abortSignal: abortController.signal,
+				totalLength: dataByteLength,
+			}),
+			onCancel: (message?: string) => {
+				abortController.abort(message);
+			},
+		});
+	} else {
+		// Multipart upload
+		const { multipartUploadJob, onPause, onResume, onCancel } =
+			getMultipartUploadHandlers(config, input, dataByteLength);
+
+		return createUploadTask({
+			isMultipartUpload: true,
+			job: multipartUploadJob,
+			onCancel: (message?: string) => {
+				onCancel(message);
+			},
+			onPause,
+			onResume,
+		});
+	}
+}

--- a/packages/storage/src/providers/s3/apis/internal/uploadData.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { UploadDataInput, UploadDataWithPathInput } from '../../types';
 import { createUploadTask } from '../../utils';
 import { assertValidationError } from '../../../../errors/utils/assertValidationError';

--- a/packages/storage/src/providers/s3/apis/internal/uploadData.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData.ts
@@ -10,10 +10,10 @@ import { byteLength } from '../uploadData/byteLength';
 import { putObjectJob } from '../uploadData/putObjectJob';
 import { getMultipartUploadHandlers } from '../uploadData/multipart';
 
-import { S3Configuration } from './types';
+import { S3InternalConfig } from './types';
 
 export function internalUploadData(
-	config: S3Configuration,
+	config: S3InternalConfig,
 	input: UploadDataInput | UploadDataWithPathInput,
 ) {
 	const { data } = input;

--- a/packages/storage/src/providers/s3/apis/internal/uploadData.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData.ts
@@ -13,12 +13,6 @@ export function internalUploadData(
 	config: StorageConfiguration,
 	input: UploadDataInput | UploadDataWithPathInput,
 ) {
-	const {
-		serviceOptions,
-		libraryOptions,
-		credentialsProvider,
-		identityIdProvider,
-	} = config;
 	const { data } = input;
 
 	const dataByteLength = byteLength(data);
@@ -34,10 +28,7 @@ export function internalUploadData(
 		return createUploadTask({
 			isMultipartUpload: false,
 			job: putObjectJob({
-				libraryOptions,
-				serviceOptions,
-				credentialsProvider,
-				identityIdProvider,
+				...config,
 				uploadDataInput: input,
 				abortSignal: abortController.signal,
 				totalLength: dataByteLength,

--- a/packages/storage/src/providers/s3/apis/internal/uploadData.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData.ts
@@ -7,10 +7,10 @@ import { byteLength } from '../uploadData/byteLength';
 import { putObjectJob } from '../uploadData/putObjectJob';
 import { getMultipartUploadHandlers } from '../uploadData/multipart';
 
-import { StorageConfiguration } from './types';
+import { S3Configuration } from './types';
 
 export function internalUploadData(
-	config: StorageConfiguration,
+	config: S3Configuration,
 	input: UploadDataInput | UploadDataWithPathInput,
 ) {
 	const { data } = input;
@@ -28,8 +28,8 @@ export function internalUploadData(
 		return createUploadTask({
 			isMultipartUpload: false,
 			job: putObjectJob({
-				...config,
-				uploadDataInput: input,
+				config,
+				input,
 				abortSignal: abortController.signal,
 				totalLength: dataByteLength,
 			}),
@@ -40,7 +40,7 @@ export function internalUploadData(
 	} else {
 		// Multipart upload
 		const { multipartUploadJob, onPause, onResume, onCancel } =
-			getMultipartUploadHandlers(config, input, dataByteLength);
+			getMultipartUploadHandlers({ config, input, size: dataByteLength });
 
 		return createUploadTask({
 			isMultipartUpload: true,

--- a/packages/storage/src/providers/s3/apis/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/index.ts
@@ -1,20 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Amplify } from '@aws-amplify/core';
+
 import {
 	UploadDataInput,
 	UploadDataOutput,
 	UploadDataWithPathInput,
 	UploadDataWithPathOutput,
 } from '../../types';
-import { createUploadTask } from '../../utils';
-import { assertValidationError } from '../../../../errors/utils/assertValidationError';
-import { StorageValidationErrorCode } from '../../../../errors/types/validation';
-import { DEFAULT_PART_SIZE, MAX_OBJECT_SIZE } from '../../utils/constants';
-
-import { byteLength } from './byteLength';
-import { putObjectJob } from './putObjectJob';
-import { getMultipartUploadHandlers } from './multipart';
+import { internalUploadData } from '../internal/uploadData';
+import { constructStorageConfiguration } from '../../utils/constructors';
 
 /**
  * Upload data to the specified S3 object path. By default uses single PUT operation to upload if the payload is less than 5MB.
@@ -127,38 +123,7 @@ export function uploadData(
 export function uploadData(input: UploadDataInput): UploadDataOutput;
 
 export function uploadData(input: UploadDataInput | UploadDataWithPathInput) {
-	const { data } = input;
+	const config = constructStorageConfiguration(Amplify);
 
-	const dataByteLength = byteLength(data);
-	assertValidationError(
-		dataByteLength === undefined || dataByteLength <= MAX_OBJECT_SIZE,
-		StorageValidationErrorCode.ObjectIsTooLarge,
-	);
-
-	if (dataByteLength && dataByteLength <= DEFAULT_PART_SIZE) {
-		// Single part upload
-		const abortController = new AbortController();
-
-		return createUploadTask({
-			isMultipartUpload: false,
-			job: putObjectJob(input, abortController.signal, dataByteLength),
-			onCancel: (message?: string) => {
-				abortController.abort(message);
-			},
-		});
-	} else {
-		// Multipart upload
-		const { multipartUploadJob, onPause, onResume, onCancel } =
-			getMultipartUploadHandlers(input, dataByteLength);
-
-		return createUploadTask({
-			isMultipartUpload: true,
-			job: multipartUploadJob,
-			onCancel: (message?: string) => {
-				onCancel(message);
-			},
-			onPause,
-			onResume,
-		});
-	}
+	return internalUploadData(config, input);
 }

--- a/packages/storage/src/providers/s3/apis/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/index.ts
@@ -10,7 +10,7 @@ import {
 	UploadDataWithPathOutput,
 } from '../../types';
 import { internalUploadData } from '../internal/uploadData';
-import { constructStorageConfiguration } from '../../utils/constructors';
+import { createStorageConfiguration } from '../../utils/config';
 
 /**
  * Upload data to the specified S3 object path. By default uses single PUT operation to upload if the payload is less than 5MB.
@@ -123,7 +123,7 @@ export function uploadData(
 export function uploadData(input: UploadDataInput): UploadDataOutput;
 
 export function uploadData(input: UploadDataInput | UploadDataWithPathInput) {
-	const config = constructStorageConfiguration(Amplify);
+	const config = createStorageConfiguration(Amplify);
 
 	return internalUploadData(config, input);
 }

--- a/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
@@ -29,7 +29,7 @@ import {
 } from '../../../utils/client';
 import { getStorageUserAgentValue } from '../../../utils/userAgent';
 import { logger } from '../../../../../utils';
-import { S3Configuration } from '../../internal/types';
+import { S3InternalConfig } from '../../internal/types';
 
 import { uploadPartExecutor } from './uploadPartExecutor';
 import { getUploadsCacheKey, removeCachedUpload } from './uploadCache';
@@ -45,7 +45,7 @@ import { getDataChunker } from './getDataChunker';
  */
 
 interface GetMultipartUploadHandlersProps {
-	config: S3Configuration;
+	config: S3InternalConfig;
 	input: UploadDataInput | UploadDataWithPathInput;
 	size?: number;
 }
@@ -80,7 +80,7 @@ export const getMultipartUploadHandlers = ({
 	const startUpload = async (): Promise<ItemWithKey | ItemWithPath> => {
 		const { options: uploadDataOptions, data } = input;
 		const resolvedS3Options = await resolveS3ConfigAndInput({
-			...config,
+			config,
 			apiOptions: uploadDataOptions,
 		});
 

--- a/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
@@ -29,6 +29,7 @@ import {
 } from '../../../utils/client';
 import { getStorageUserAgentValue } from '../../../utils/userAgent';
 import { logger } from '../../../../../utils';
+import { StorageConfiguration } from '../../internal/types';
 
 import { uploadPartExecutor } from './uploadPartExecutor';
 import { getUploadsCacheKey, removeCachedUpload } from './uploadCache';
@@ -43,6 +44,7 @@ import { getDataChunker } from './getDataChunker';
  * @internal
  */
 export const getMultipartUploadHandlers = (
+	config: StorageConfiguration,
 	uploadDataInput: UploadDataInput | UploadDataWithPathInput,
 	size?: number,
 ) => {
@@ -68,13 +70,21 @@ export const getMultipartUploadHandlers = (
 	// The former one should NOT cause the upload job to throw, but cancels any pending HTTP requests.
 	// This should be replaced by a special abort reason. However,the support of this API is lagged behind.
 	let isAbortSignalFromPause = false;
-
+	const {
+		serviceOptions,
+		libraryOptions,
+		credentialsProvider,
+		identityIdProvider,
+	} = config;
 	const startUpload = async (): Promise<ItemWithKey | ItemWithPath> => {
 		const { options: uploadDataOptions, data } = uploadDataInput;
-		const resolvedS3Options = await resolveS3ConfigAndInput(
-			Amplify,
-			uploadDataOptions,
-		);
+		const resolvedS3Options = await resolveS3ConfigAndInput({
+			serviceOptions,
+			libraryOptions,
+			apiOptions: uploadDataOptions,
+			credentialsProvider,
+			identityIdProvider,
+		});
 
 		abortController = new AbortController();
 		isAbortSignalFromPause = false;

--- a/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
@@ -70,20 +70,12 @@ export const getMultipartUploadHandlers = (
 	// The former one should NOT cause the upload job to throw, but cancels any pending HTTP requests.
 	// This should be replaced by a special abort reason. However,the support of this API is lagged behind.
 	let isAbortSignalFromPause = false;
-	const {
-		serviceOptions,
-		libraryOptions,
-		credentialsProvider,
-		identityIdProvider,
-	} = config;
+
 	const startUpload = async (): Promise<ItemWithKey | ItemWithPath> => {
 		const { options: uploadDataOptions, data } = uploadDataInput;
 		const resolvedS3Options = await resolveS3ConfigAndInput({
-			serviceOptions,
-			libraryOptions,
+			...config,
 			apiOptions: uploadDataOptions,
-			credentialsProvider,
-			identityIdProvider,
 		});
 
 		abortController = new AbortController();

--- a/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
@@ -29,7 +29,7 @@ import {
 } from '../../../utils/client';
 import { getStorageUserAgentValue } from '../../../utils/userAgent';
 import { logger } from '../../../../../utils';
-import { StorageConfiguration } from '../../internal/types';
+import { S3Configuration } from '../../internal/types';
 
 import { uploadPartExecutor } from './uploadPartExecutor';
 import { getUploadsCacheKey, removeCachedUpload } from './uploadCache';
@@ -43,11 +43,17 @@ import { getDataChunker } from './getDataChunker';
  *
  * @internal
  */
-export const getMultipartUploadHandlers = (
-	config: StorageConfiguration,
-	uploadDataInput: UploadDataInput | UploadDataWithPathInput,
-	size?: number,
-) => {
+
+interface GetMultipartUploadHandlersProps {
+	config: S3Configuration;
+	input: UploadDataInput | UploadDataWithPathInput;
+	size?: number;
+}
+export const getMultipartUploadHandlers = ({
+	config,
+	input,
+	size,
+}: GetMultipartUploadHandlersProps) => {
 	let resolveCallback:
 		| ((value: ItemWithKey | ItemWithPath) => void)
 		| undefined;
@@ -72,7 +78,7 @@ export const getMultipartUploadHandlers = (
 	let isAbortSignalFromPause = false;
 
 	const startUpload = async (): Promise<ItemWithKey | ItemWithPath> => {
-		const { options: uploadDataOptions, data } = uploadDataInput;
+		const { options: uploadDataOptions, data } = input;
 		const resolvedS3Options = await resolveS3ConfigAndInput({
 			...config,
 			apiOptions: uploadDataOptions,
@@ -85,7 +91,7 @@ export const getMultipartUploadHandlers = (
 		resolvedIdentityId = resolvedS3Options.identityId;
 
 		const { inputType, objectKey } = validateStorageOperationInput(
-			uploadDataInput,
+			input,
 			resolvedIdentityId,
 		);
 

--- a/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
@@ -1,10 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-	AWSCredentials,
-	StorageAction,
-} from '@aws-amplify/core/internals/utils';
+import { StorageAction } from '@aws-amplify/core/internals/utils';
 
 import { UploadDataInput, UploadDataWithPathInput } from '../../types';
 import {
@@ -16,15 +13,12 @@ import { ItemWithKey, ItemWithPath } from '../../types/outputs';
 import { putObject } from '../../utils/client';
 import { getStorageUserAgentValue } from '../../utils/userAgent';
 import { STORAGE_INPUT_KEY } from '../../utils/constants';
-import { S3LibraryOptions, S3ServiceOptions } from '../../types/options';
+import { S3Configuration } from '../internal/types';
 
 interface PutObjectJobProps {
-	uploadDataInput: UploadDataInput | UploadDataWithPathInput;
+	config: S3Configuration;
+	input: UploadDataInput | UploadDataWithPathInput;
 	abortSignal: AbortSignal;
-	credentialsProvider(): Promise<AWSCredentials>;
-	identityIdProvider(): Promise<string>;
-	serviceOptions: S3ServiceOptions;
-	libraryOptions: S3LibraryOptions;
 	totalLength?: number;
 }
 
@@ -34,18 +28,15 @@ interface PutObjectJobProps {
  * @internal
  */
 export const putObjectJob =
-	({
-		uploadDataInput,
-		abortSignal,
-		credentialsProvider,
-		identityIdProvider,
-		serviceOptions,
-		libraryOptions,
-		totalLength,
-	}: PutObjectJobProps) =>
+	({ config, input, abortSignal, totalLength }: PutObjectJobProps) =>
 	async (): Promise<ItemWithKey | ItemWithPath> => {
-		const { options: uploadDataOptions, data } = uploadDataInput;
-
+		const { options: uploadDataOptions, data } = input;
+		const {
+			credentialsProvider,
+			identityIdProvider,
+			serviceOptions,
+			libraryOptions,
+		} = config;
 		const { bucket, keyPrefix, s3Config, isObjectLockEnabled, identityId } =
 			await resolveS3ConfigAndInput({
 				credentialsProvider,
@@ -55,7 +46,7 @@ export const putObjectJob =
 				apiOptions: uploadDataOptions,
 			});
 		const { inputType, objectKey } = validateStorageOperationInput(
-			uploadDataInput,
+			input,
 			identityId,
 		);
 

--- a/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
@@ -13,10 +13,10 @@ import { ItemWithKey, ItemWithPath } from '../../types/outputs';
 import { putObject } from '../../utils/client';
 import { getStorageUserAgentValue } from '../../utils/userAgent';
 import { STORAGE_INPUT_KEY } from '../../utils/constants';
-import { S3Configuration } from '../internal/types';
+import { S3InternalConfig } from '../internal/types';
 
 interface PutObjectJobProps {
-	config: S3Configuration;
+	config: S3InternalConfig;
 	input: UploadDataInput | UploadDataWithPathInput;
 	abortSignal: AbortSignal;
 	totalLength?: number;
@@ -31,18 +31,10 @@ export const putObjectJob =
 	({ config, input, abortSignal, totalLength }: PutObjectJobProps) =>
 	async (): Promise<ItemWithKey | ItemWithPath> => {
 		const { options: uploadDataOptions, data } = input;
-		const {
-			credentialsProvider,
-			identityIdProvider,
-			serviceOptions,
-			libraryOptions,
-		} = config;
+
 		const { bucket, keyPrefix, s3Config, isObjectLockEnabled, identityId } =
 			await resolveS3ConfigAndInput({
-				credentialsProvider,
-				identityIdProvider,
-				serviceOptions,
-				libraryOptions,
+				config,
 				apiOptions: uploadDataOptions,
 			});
 		const { inputType, objectKey } = validateStorageOperationInput(

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -1,11 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-	LibraryOptions,
-	StorageAccessLevel,
-	StorageConfig,
-} from '@aws-amplify/core';
+import { StorageAccessLevel } from '@aws-amplify/core';
 import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 import { SigningOptions } from '@aws-amplify/core/internals/aws-client-utils';
 
@@ -217,20 +213,6 @@ export interface ResolvedS3Config
 	forcePathStyle?: boolean;
 	useAccelerateEndpoint?: boolean;
 }
-
-/**
- * Internal S3 service options.
- *
- * @internal
- */
-export type S3ServiceOptions = StorageConfig['S3'];
-
-/**
- * Internal S3 library options.
- *
- * @internal
- */
-export type S3LibraryOptions = NonNullable<LibraryOptions['Storage']>['S3'];
 
 /**
  * Internal S3 API options.

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { StorageAccessLevel } from '@aws-amplify/core';
+import {
+	LibraryOptions,
+	StorageAccessLevel,
+	StorageConfig,
+} from '@aws-amplify/core';
 import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 import { SigningOptions } from '@aws-amplify/core/internals/aws-client-utils';
 
@@ -211,5 +215,30 @@ export interface ResolvedS3Config
 	extends Pick<SigningOptions, 'credentials' | 'region'> {
 	customEndpoint?: string;
 	forcePathStyle?: boolean;
+	useAccelerateEndpoint?: boolean;
+}
+
+/**
+ * Internal S3 service options.
+ *
+ * @internal
+ */
+export type S3ServiceOptions = StorageConfig['S3'];
+
+/**
+ * Internal S3 library options.
+ *
+ * @internal
+ */
+export type S3LibraryOptions = NonNullable<LibraryOptions['Storage']>['S3'];
+
+/**
+ * Internal S3 API options.
+ *
+ * @internal
+ */
+export interface S3ApiOptions {
+	accessLevel?: StorageAccessLevel;
+	targetIdentityId?: string;
 	useAccelerateEndpoint?: boolean;
 }

--- a/packages/storage/src/providers/s3/utils/config.ts
+++ b/packages/storage/src/providers/s3/utils/config.ts
@@ -5,7 +5,7 @@ import { AmplifyClassV6 } from '@aws-amplify/core';
 
 import { StorageValidationErrorCode } from '../../../errors/types/validation';
 import { assertValidationError } from '../../../errors/utils/assertValidationError';
-import { S3Configuration } from '../apis/internal/types';
+import { S3InternalConfig } from '../apis/internal/types';
 
 const createDefaultCredentialsProvider = (amplify: AmplifyClassV6) => {
 	/**
@@ -44,7 +44,7 @@ const createDefaultIdentityIdProvider = (amplify: AmplifyClassV6) => {
  */
 export const createStorageConfiguration = (
 	amplify: AmplifyClassV6,
-): S3Configuration => {
+): S3InternalConfig => {
 	const libraryOptions = amplify.libraryOptions?.Storage?.S3 ?? {};
 	const serviceOptions = amplify.getConfig()?.Storage?.S3 ?? {};
 	const credentialsProvider = createDefaultCredentialsProvider(amplify);

--- a/packages/storage/src/providers/s3/utils/config.ts
+++ b/packages/storage/src/providers/s3/utils/config.ts
@@ -38,8 +38,7 @@ const createDefaultIdentityIdProvider = (amplify: AmplifyClassV6) => {
 };
 
 /**
- * This createor will return a storage configuration
- * that is independent from the Amplify singleton.
+ * It will return a Storage configuration used by lower level utils and APIs.
  *
  * @internal
  */
@@ -48,7 +47,6 @@ export const createStorageConfiguration = (
 ): S3Configuration => {
 	const libraryOptions = amplify.libraryOptions?.Storage?.S3 ?? {};
 	const serviceOptions = amplify.getConfig()?.Storage?.S3 ?? {};
-	console.log(serviceOptions);
 	const credentialsProvider = createDefaultCredentialsProvider(amplify);
 	const identityIdProvider = createDefaultIdentityIdProvider(amplify);
 

--- a/packages/storage/src/providers/s3/utils/config.ts
+++ b/packages/storage/src/providers/s3/utils/config.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { AmplifyClassV6 } from '@aws-amplify/core';
 
 import { StorageValidationErrorCode } from '../../../errors/types/validation';

--- a/packages/storage/src/providers/s3/utils/config.ts
+++ b/packages/storage/src/providers/s3/utils/config.ts
@@ -2,9 +2,9 @@ import { AmplifyClassV6 } from '@aws-amplify/core';
 
 import { StorageValidationErrorCode } from '../../../errors/types/validation';
 import { assertValidationError } from '../../../errors/utils/assertValidationError';
-import { StorageConfiguration } from '../apis/internal/types';
+import { S3Configuration } from '../apis/internal/types';
 
-const constructDefaultCredentialsProvider = (amplify: AmplifyClassV6) => {
+const createDefaultCredentialsProvider = (amplify: AmplifyClassV6) => {
 	/**
 	 * A credentials provider function instead of a static credentials object is
 	 * used because the long-running tasks like multipart upload may span over the
@@ -22,7 +22,7 @@ const constructDefaultCredentialsProvider = (amplify: AmplifyClassV6) => {
 	};
 };
 
-const constructDefaultIdentityIdProvider = (amplify: AmplifyClassV6) => {
+const createDefaultIdentityIdProvider = (amplify: AmplifyClassV6) => {
 	return async () => {
 		const { identityId } = await amplify.Auth.fetchAuthSession();
 		assertValidationError(
@@ -35,18 +35,19 @@ const constructDefaultIdentityIdProvider = (amplify: AmplifyClassV6) => {
 };
 
 /**
- * This constructor will return a storage configuration
+ * This createor will return a storage configuration
  * that is independent from the Amplify singleton.
  *
  * @internal
  */
-export const constructStorageConfiguration = (
+export const createStorageConfiguration = (
 	amplify: AmplifyClassV6,
-): StorageConfiguration => {
-	const libraryOptions = amplify.libraryOptions.Storage?.S3 ?? {};
+): S3Configuration => {
+	const libraryOptions = amplify.libraryOptions?.Storage?.S3 ?? {};
 	const serviceOptions = amplify.getConfig()?.Storage?.S3 ?? {};
-	const credentialsProvider = constructDefaultCredentialsProvider(amplify);
-	const identityIdProvider = constructDefaultIdentityIdProvider(amplify);
+	console.log(serviceOptions);
+	const credentialsProvider = createDefaultCredentialsProvider(amplify);
+	const identityIdProvider = createDefaultIdentityIdProvider(amplify);
 
 	return {
 		libraryOptions,

--- a/packages/storage/src/providers/s3/utils/constructors.ts
+++ b/packages/storage/src/providers/s3/utils/constructors.ts
@@ -1,0 +1,57 @@
+import { AmplifyClassV6 } from '@aws-amplify/core';
+
+import { StorageValidationErrorCode } from '../../../errors/types/validation';
+import { assertValidationError } from '../../../errors/utils/assertValidationError';
+import { StorageConfiguration } from '../apis/internal/types';
+
+const constructDefaultCredentialsProvider = (amplify: AmplifyClassV6) => {
+	/**
+	 * A credentials provider function instead of a static credentials object is
+	 * used because the long-running tasks like multipart upload may span over the
+	 * credentials expiry. Auth.fetchAuthSession() automatically refreshes the
+	 * credentials if they are expired.
+	 */
+	return async () => {
+		const { credentials } = await amplify.Auth.fetchAuthSession();
+		assertValidationError(
+			!!credentials,
+			StorageValidationErrorCode.NoCredentials,
+		);
+
+		return credentials;
+	};
+};
+
+const constructDefaultIdentityIdProvider = (amplify: AmplifyClassV6) => {
+	return async () => {
+		const { identityId } = await amplify.Auth.fetchAuthSession();
+		assertValidationError(
+			!!identityId,
+			StorageValidationErrorCode.NoIdentityId,
+		);
+
+		return identityId;
+	};
+};
+
+/**
+ * This constructor will return a storage configuration
+ * that is independent from the Amplify singleton.
+ *
+ * @internal
+ */
+export const constructStorageConfiguration = (
+	amplify: AmplifyClassV6,
+): StorageConfiguration => {
+	const libraryOptions = amplify.libraryOptions.Storage?.S3 ?? {};
+	const serviceOptions = amplify.getConfig()?.Storage?.S3 ?? {};
+	const credentialsProvider = constructDefaultCredentialsProvider(amplify);
+	const identityIdProvider = constructDefaultIdentityIdProvider(amplify);
+
+	return {
+		libraryOptions,
+		serviceOptions,
+		credentialsProvider,
+		identityIdProvider,
+	};
+};

--- a/packages/storage/src/providers/s3/utils/index.ts
+++ b/packages/storage/src/providers/s3/utils/index.ts
@@ -7,4 +7,4 @@ export { createDownloadTask, createUploadTask } from './transferTask';
 export { validateStorageOperationInput } from './validateStorageOperationInput';
 export { validateStorageOperationInputWithPrefix } from './validateStorageOperationInputWithPrefix';
 export { isInputWithPath } from './isInputWithPath';
-export { constructStorageConfiguration } from './constructors';
+export { createStorageConfiguration } from './config';

--- a/packages/storage/src/providers/s3/utils/index.ts
+++ b/packages/storage/src/providers/s3/utils/index.ts
@@ -7,3 +7,4 @@ export { createDownloadTask, createUploadTask } from './transferTask';
 export { validateStorageOperationInput } from './validateStorageOperationInput';
 export { validateStorageOperationInputWithPrefix } from './validateStorageOperationInputWithPrefix';
 export { isInputWithPath } from './isInputWithPath';
+export { constructStorageConfiguration } from './constructors';

--- a/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
+++ b/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
@@ -1,20 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6, StorageAccessLevel } from '@aws-amplify/core';
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 
 import { assertValidationError } from '../../../errors/utils/assertValidationError';
 import { StorageValidationErrorCode } from '../../../errors/types/validation';
 import { resolvePrefix as defaultPrefixResolver } from '../../../utils/resolvePrefix';
-import { ResolvedS3Config } from '../types/options';
+import {
+	ResolvedS3Config,
+	S3ApiOptions,
+	S3LibraryOptions,
+	S3ServiceOptions,
+} from '../types/options';
 
 import { DEFAULT_ACCESS_LEVEL, LOCAL_TESTING_S3_ENDPOINT } from './constants';
-
-interface S3ApiOptions {
-	accessLevel?: StorageAccessLevel;
-	targetIdentityId?: string;
-	useAccelerateEndpoint?: boolean;
-}
 
 interface ResolvedS3ConfigAndInput {
 	s3Config: ResolvedS3Config;
@@ -24,6 +23,13 @@ interface ResolvedS3ConfigAndInput {
 	identityId?: string;
 }
 
+interface ResolveS3ConfigAndInputParams {
+	credentialsProvider(): Promise<AWSCredentials>;
+	identityIdProvider(): Promise<string>;
+	serviceOptions?: S3ServiceOptions;
+	libraryOptions?: S3LibraryOptions;
+	apiOptions?: S3ApiOptions;
+}
 /**
  * resolve the common input options for S3 API handlers from Amplify configuration and library options.
  *
@@ -35,44 +41,23 @@ interface ResolvedS3ConfigAndInput {
  *
  * @internal
  */
-export const resolveS3ConfigAndInput = async (
-	amplify: AmplifyClassV6,
-	apiOptions?: S3ApiOptions,
-): Promise<ResolvedS3ConfigAndInput> => {
-	/**
-	 * IdentityId is always cached in memory so we can safely make calls here. It
-	 * should be stable even for unauthenticated users, regardless of credentials.
-	 */
-	const { identityId } = await amplify.Auth.fetchAuthSession();
-	assertValidationError(!!identityId, StorageValidationErrorCode.NoIdentityId);
-
-	/**
-	 * A credentials provider function instead of a static credentials object is
-	 * used because the long-running tasks like multipart upload may span over the
-	 * credentials expiry. Auth.fetchAuthSession() automatically refreshes the
-	 * credentials if they are expired.
-	 */
-	const credentialsProvider = async () => {
-		const { credentials } = await amplify.Auth.fetchAuthSession();
-		assertValidationError(
-			!!credentials,
-			StorageValidationErrorCode.NoCredentials,
-		);
-
-		return credentials;
-	};
-
+export const resolveS3ConfigAndInput = async ({
+	credentialsProvider,
+	identityIdProvider,
+	serviceOptions,
+	libraryOptions,
+	apiOptions,
+}: ResolveS3ConfigAndInputParams): Promise<ResolvedS3ConfigAndInput> => {
 	const { bucket, region, dangerouslyConnectToHttpEndpointForTesting } =
-		amplify.getConfig()?.Storage?.S3 ?? {};
+		serviceOptions ?? {};
 	assertValidationError(!!bucket, StorageValidationErrorCode.NoBucket);
 	assertValidationError(!!region, StorageValidationErrorCode.NoRegion);
-
+	const identityId = await identityIdProvider();
 	const {
 		defaultAccessLevel,
 		prefixResolver = defaultPrefixResolver,
 		isObjectLockEnabled,
-	} = amplify.libraryOptions?.Storage?.S3 ?? {};
-
+	} = libraryOptions ?? {};
 	const keyPrefix = await prefixResolver({
 		accessLevel:
 			apiOptions?.accessLevel ?? defaultAccessLevel ?? DEFAULT_ACCESS_LEVEL,
@@ -97,7 +82,6 @@ export const resolveS3ConfigAndInput = async (
 		},
 		bucket,
 		keyPrefix,
-		identityId,
 		isObjectLockEnabled,
 	};
 };

--- a/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
+++ b/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
@@ -83,5 +83,6 @@ export const resolveS3ConfigAndInput = async ({
 		bucket,
 		keyPrefix,
 		isObjectLockEnabled,
+		identityId,
 	};
 };

--- a/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
+++ b/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
@@ -1,17 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AWSCredentials } from '@aws-amplify/core/internals/utils';
-
 import { assertValidationError } from '../../../errors/utils/assertValidationError';
 import { StorageValidationErrorCode } from '../../../errors/types/validation';
 import { resolvePrefix as defaultPrefixResolver } from '../../../utils/resolvePrefix';
-import {
-	ResolvedS3Config,
-	S3ApiOptions,
-	S3LibraryOptions,
-	S3ServiceOptions,
-} from '../types/options';
+import { ResolvedS3Config, S3ApiOptions } from '../types/options';
+import { S3InternalConfig } from '../apis/internal/types';
 
 import { DEFAULT_ACCESS_LEVEL, LOCAL_TESTING_S3_ENDPOINT } from './constants';
 
@@ -24,10 +18,7 @@ interface ResolvedS3ConfigAndInput {
 }
 
 interface ResolveS3ConfigAndInputParams {
-	credentialsProvider(): Promise<AWSCredentials>;
-	identityIdProvider(): Promise<string>;
-	serviceOptions?: S3ServiceOptions;
-	libraryOptions?: S3LibraryOptions;
+	config: S3InternalConfig;
 	apiOptions?: S3ApiOptions;
 }
 /**
@@ -42,12 +33,15 @@ interface ResolveS3ConfigAndInputParams {
  * @internal
  */
 export const resolveS3ConfigAndInput = async ({
-	credentialsProvider,
-	identityIdProvider,
-	serviceOptions,
-	libraryOptions,
+	config,
 	apiOptions,
 }: ResolveS3ConfigAndInputParams): Promise<ResolvedS3ConfigAndInput> => {
+	const {
+		credentialsProvider,
+		serviceOptions,
+		libraryOptions,
+		identityIdProvider,
+	} = config;
 	const { bucket, region, dangerouslyConnectToHttpEndpointForTesting } =
 		serviceOptions ?? {};
 	assertValidationError(!!bucket, StorageValidationErrorCode.NoBucket);


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The following changes decouple internal Storage `utils` and the `uploadData` API from the Amplify singleton. This refactor will allow the high-level APIs, the ones exposed to customers, to manage and create a Storage configuration based on an API input or Amplify configuration. Then the obtained config will be accessed by the low level implementation functionalities, e.g `putObjectJob`, `getMultipartUploadHandlers`, and `resolveS3ConfigAndInput` utils.

#### Out of the scope 

- PR doesn't refactor the functionality of the internal Storage utils
- Decouple additional Storage APIs other than `uploadData` 

#### Arch Diagram
All of the storage APIs will follow this pattern

![StorageAPIStructure](https://github.com/aws-amplify/amplify-js/assets/70438514/1df38287-2edf-4e21-b510-5a1b6cf6d3d7)


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
