### PR TITLE
feat(storage): use WeakMap for store registry

### DIFF
--- a/packages/storage/__tests__/storageBrowser/locationCredentialsStore/registry.test.ts
+++ b/packages/storage/__tests__/storageBrowser/locationCredentialsStore/registry.test.ts
@@ -40,7 +40,7 @@ describe('createStore', () => {
 
 	it('should return a symbol to refer the store instance', () => {
 		const storeReference = createStore(jest.fn(), 20);
-		expect(Object.prototype.toString.call(storeReference)).toBe(
+		expect(Object.prototype.toString.call(storeReference.value)).toBe(
 			'[object Symbol]',
 		);
 	});
@@ -48,12 +48,12 @@ describe('createStore', () => {
 
 describe('getValue', () => {
 	const mockCachedValue = 'CACHED_VALUE' as any as AWSCredentials;
-	let storeReference: symbol;
+	let storeSymbol: { value: symbol };
 	beforeEach(() => {
-		storeReference = createStore(jest.fn(), 20);
+		storeSymbol = createStore(jest.fn(), 20);
 	});
 	afterEach(() => {
-		removeStore(storeReference);
+		removeStore(storeSymbol);
 		jest.clearAllMocks();
 	});
 
@@ -61,7 +61,7 @@ describe('getValue', () => {
 		expect.assertions(1);
 		await expect(
 			getValue({
-				storeSymbol: Symbol('invalid'),
+				storeSymbol: { value: Symbol('invalid') },
 				location: { scope: 'abc', permission: 'READ' },
 				forceRefresh: false,
 			}),
@@ -77,7 +77,7 @@ describe('getValue', () => {
 		jest.mocked(getCacheValue).mockReturnValueOnce(mockCachedValue);
 		expect(
 			await getValue({
-				storeSymbol: storeReference,
+				storeSymbol,
 				location: { scope: 'abc', permission: 'READ' },
 				forceRefresh: false,
 			}),
@@ -95,7 +95,7 @@ describe('getValue', () => {
 		jest.mocked(getCacheValue).mockReturnValueOnce(mockCachedValue);
 		expect(
 			await getValue({
-				storeSymbol: storeReference,
+				storeSymbol,
 				location: { scope: 'abc', permission: 'READ' },
 				forceRefresh: false,
 			}),
@@ -117,7 +117,7 @@ describe('getValue', () => {
 		jest.mocked(fetchNewValue).mockResolvedValue('NEW_VALUE' as any);
 		expect(
 			await getValue({
-				storeSymbol: storeReference,
+				storeSymbol,
 				location: { scope: 'abc', permission: 'READ' },
 				forceRefresh: false,
 			}),
@@ -135,7 +135,7 @@ describe('getValue', () => {
 		jest.mocked(fetchNewValue).mockResolvedValue('NEW_VALUE' as any);
 		expect(
 			await getValue({
-				storeSymbol: storeReference,
+				storeSymbol,
 				location: { scope: 'abc', permission: 'READ' },
 				forceRefresh: true,
 			}),
@@ -154,7 +154,7 @@ describe('getValue', () => {
 			.mockRejectedValueOnce(new Error('Network error'));
 		await expect(
 			getValue({
-				storeSymbol: storeReference,
+				storeSymbol,
 				location: { scope: 'abc', permission: 'READ' },
 				forceRefresh: true,
 			}),
@@ -182,7 +182,7 @@ describe('removeStore', () => {
 
 	it('should not throw if store with given symbol does not exist', () => {
 		expect(() => {
-			removeStore(Symbol('invalid'));
+			removeStore({ value: Symbol('invalid') });
 		}).not.toThrow();
 	});
 });

--- a/packages/storage/src/storageBrowser/index.ts
+++ b/packages/storage/src/storageBrowser/index.ts
@@ -1,6 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * NOTE: The APIs exported from this file are ONLY intended for usage by
+ * Amplify UI. To use location-related features, please use
+ * @aws-amplify/ui-react-storage
+ */
+
 export {
 	listCallerAccessGrants,
 	ListCallerAccessGrantsInput,

--- a/packages/storage/src/storageBrowser/locationCredentialsStore/registry.ts
+++ b/packages/storage/src/storageBrowser/locationCredentialsStore/registry.ts
@@ -15,12 +15,19 @@ import {
 	initStore,
 } from './store';
 
+interface StoreRegistrySymbol {
+	readonly value: symbol;
+}
+
 /**
  * Keep all cache records for all instances of credentials store in a singleton
  * so we can reliably de-reference from the memory when we destroy a store
  * instance.
  */
-const storeRegistry = new Map<symbol, LruLocationCredentialsStore>();
+const storeRegistry = new WeakMap<
+	StoreRegistrySymbol,
+	LruLocationCredentialsStore
+>();
 
 /**
  * @internal
@@ -29,10 +36,10 @@ export const createStore = (
 	refreshHandler: LocationCredentialsHandler,
 	size?: number,
 ) => {
-	const storeInstanceSymbol = Symbol('LocationCredentialsStore');
-	storeRegistry.set(storeInstanceSymbol, initStore(refreshHandler, size));
+	const storeSymbol = { value: Symbol('LocationCredentialsStore') };
+	storeRegistry.set(storeSymbol, initStore(refreshHandler, size));
 
-	return storeInstanceSymbol;
+	return storeSymbol;
 };
 
 const getLookUpLocations = (location: CredentialsLocation) => {
@@ -45,7 +52,7 @@ const getLookUpLocations = (location: CredentialsLocation) => {
 	return locations;
 };
 
-const getCredentialsStore = (storeSymbol: symbol) => {
+const getCredentialsStore = (storeSymbol: StoreRegistrySymbol) => {
 	assertValidationError(
 		storeRegistry.has(storeSymbol),
 		StorageValidationErrorCode.LocationCredentialsStoreDestroyed,
@@ -58,7 +65,7 @@ const getCredentialsStore = (storeSymbol: symbol) => {
  * @internal
  */
 export const getValue = async (input: {
-	storeSymbol: symbol;
+	storeSymbol: StoreRegistrySymbol;
 	location: CredentialsLocation;
 	forceRefresh: boolean;
 }): Promise<{ credentials: AWSCredentials }> => {
@@ -77,6 +84,6 @@ export const getValue = async (input: {
 	return fetchNewValue(store, location);
 };
 
-export const removeStore = (storeSymbol: symbol) => {
+export const removeStore = (storeSymbol: StoreRegistrySymbol) => {
 	storeRegistry.delete(storeSymbol);
 };

--- a/packages/storage/storage-browser/package.json
+++ b/packages/storage/storage-browser/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "@aws-amplify/storage/storage-browser",
+	"main": "../dist/cjs/storageBrowser/index.js",
+	"browser": "../dist/esm/storageBrowser/index.mjs",
+	"module": "../dist/esm/storageBrowser/index.mjs",
+	"typings": "../dist/esm/storageBrowser/index.d.ts"
+}


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
2 changes are included in this PR:
1. Use `WeakMap` instead of `Map` for store regitry. This is inspired by the Amplify context store implemenation. The nice thing of `WeakMap` is that the entry in the WeakMap is not referred to prevent it from GC. So as long as the store is no longer referred in the code scope, it can be GC'd. Whereas with `Map`, we always depend on `destroy()` to de-reference the store. thanks @HuiSF 
2. Moving the storage browser exports to `@aws-amplify/storage/storage-browser` subpath. We are using this subpath to differentiate it from APIs will be reexported publicly in umbrella package(e.g. `/s3` subpath), and APIs that entirely internal to the library(e.g. `/internals` subpath). This subpath is called out to be only consumable by UI.

#### Description of how you validated changes
Unit test; Manual Validation of export paths


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
