### PR TITLE
feat(storage): integrate locationCredentialsProvider

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -461,43 +461,43 @@
 			"name": "[Storage] copy (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ copy }",
-			"limit": "15.15 kB"
+			"limit": "15.28 kB"
 		},
 		{
 			"name": "[Storage] downloadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ downloadData }",
-			"limit": "15.77 kB"
+			"limit": "15.89 kB"
 		},
 		{
 			"name": "[Storage] getProperties (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getProperties }",
-			"limit": "15.03 kB"
+			"limit": "15.14 kB"
 		},
 		{
 			"name": "[Storage] getUrl (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getUrl }",
-			"limit": "16.13 kB"
+			"limit": "16.27 kB"
 		},
 		{
 			"name": "[Storage] list (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ list }",
-			"limit": "15.60 kB"
+			"limit": "15.74 kB"
 		},
 		{
 			"name": "[Storage] remove (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ remove }",
-			"limit": "14.90 kB"
+			"limit": "15.2 kB"
 		},
 		{
 			"name": "[Storage] uploadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ uploadData }",
-			"limit": "20.17 kB"
+			"limit": "20.30 kB"
 		}
 	]
 }

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -461,43 +461,43 @@
 			"name": "[Storage] copy (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ copy }",
-			"limit": "14.9 kB"
+			"limit": "15.15 kB"
 		},
 		{
 			"name": "[Storage] downloadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ downloadData }",
-			"limit": "15.49 kB"
+			"limit": "15.77 kB"
 		},
 		{
 			"name": "[Storage] getProperties (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getProperties }",
-			"limit": "14.77 kB"
+			"limit": "15.03 kB"
 		},
 		{
 			"name": "[Storage] getUrl (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getUrl }",
-			"limit": "15.87 kB"
+			"limit": "16.13 kB"
 		},
 		{
 			"name": "[Storage] list (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ list }",
-			"limit": "15.36 kB"
+			"limit": "15.60 kB"
 		},
 		{
 			"name": "[Storage] remove (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ remove }",
-			"limit": "14.63 kB"
+			"limit": "14.90 kB"
 		},
 		{
 			"name": "[Storage] uploadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ uploadData }",
-			"limit": "19.94 kB"
+			"limit": "20.17 kB"
 		}
 	]
 }

--- a/packages/storage/__tests__/providers/s3/apis/downloadData.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/downloadData.test.ts
@@ -25,7 +25,7 @@ import {
 } from '../../../../src/providers/s3/types/outputs';
 import './testUtils';
 
-jest.mock('../../../../src/providers/s3/utils/client');
+jest.mock('../../../../src/providers/s3/utils/client/s3data');
 jest.mock('../../../../src/providers/s3/utils', () => {
 	const utils = jest.requireActual('../../../../src/providers/s3/utils');
 

--- a/packages/storage/__tests__/providers/s3/apis/downloadData.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/downloadData.test.ts
@@ -25,8 +25,16 @@ import {
 } from '../../../../src/providers/s3/types/outputs';
 import './testUtils';
 
-jest.mock('../../../../src/providers/s3/utils/client/s3data');
-jest.mock('../../../../src/providers/s3/utils');
+jest.mock('../../../../src/providers/s3/utils/client');
+jest.mock('../../../../src/providers/s3/utils', () => {
+	const utils = jest.requireActual('../../../../src/providers/s3/utils');
+
+	return {
+		...utils,
+		createDownloadTask: jest.fn(),
+		validateStorageOperationInput: jest.fn(),
+	};
+});
 jest.mock('@aws-amplify/core', () => ({
 	ConsoleLogger: jest.fn().mockImplementation(function ConsoleLogger() {
 		return { debug: jest.fn() };

--- a/packages/storage/__tests__/providers/s3/apis/uploadData/index.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/uploadData/index.test.ts
@@ -50,7 +50,6 @@ const mockGetMultipartUploadHandlers = (
 const mockGetConfig = Amplify.getConfig as jest.Mock;
 const bucket = 'bucket';
 const region = 'region';
-// const mockFetchAuthSession = Amplify.Auth.fetchAuthSession as jest.Mock;
 /* TODO Remove suite when `key` parameter is removed */
 describe('uploadData with key', () => {
 	beforeAll(() => {

--- a/packages/storage/__tests__/providers/s3/apis/uploadData/multipartHandlers.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/uploadData/multipartHandlers.test.ts
@@ -141,8 +141,8 @@ describe('getMultipartUploadHandlers with key', () => {
 	const mockS3Config: S3InternalConfig = {
 		credentialsProvider: mockCredentialsProvider,
 		identityIdProvider: mockIdentityIdProvider,
-		serviceOptions: mockServiceOptions,
-		libraryOptions: mockLibraryOptions,
+		...mockServiceOptions,
+		...mockLibraryOptions,
 	};
 	beforeAll(() => {
 		mockCredentialsProvider.mockImplementation(async () => credentials);
@@ -692,8 +692,8 @@ describe('getMultipartUploadHandlers with path', () => {
 	const mockS3Config: S3InternalConfig = {
 		credentialsProvider: mockCredentialsProvider,
 		identityIdProvider: mockIdentityIdProvider,
-		serviceOptions: mockServiceOptions,
-		libraryOptions: mockLibraryOptions,
+		...mockServiceOptions,
+		...mockLibraryOptions,
 	};
 	beforeAll(() => {
 		mockCredentialsProvider.mockImplementation(async () => credentials);

--- a/packages/storage/__tests__/providers/s3/apis/uploadData/putObjectJob.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/uploadData/putObjectJob.test.ts
@@ -47,8 +47,8 @@ mockPutObject.mockResolvedValue({
 const config: S3InternalConfig = {
 	credentialsProvider: mockCredentialsProvider,
 	identityIdProvider: mockIdentityIdProvider,
-	serviceOptions: mockServiceOptions,
-	libraryOptions: mockLibraryOptions,
+	...mockServiceOptions,
+	...mockLibraryOptions,
 };
 
 /* TODO Remove suite when `key` parameter is removed */
@@ -124,9 +124,7 @@ describe('putObjectJob with key', () => {
 		const job = putObjectJob({
 			config: {
 				...config,
-				libraryOptions: {
-					isObjectLockEnabled: true,
-				},
+				isObjectLockEnabled: true,
 			},
 			input: {
 				key: 'key',
@@ -220,9 +218,7 @@ describe('putObjectJob with path', () => {
 		const job = putObjectJob({
 			config: {
 				...config,
-				libraryOptions: {
-					isObjectLockEnabled: true,
-				},
+				isObjectLockEnabled: true,
 			},
 			input: {
 				path: testPath,

--- a/packages/storage/__tests__/providers/s3/apis/utils/config.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/config.test.ts
@@ -1,0 +1,216 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+
+import { createStorageConfiguration } from '../../../../../src/providers/s3/utils';
+
+jest.mock('@aws-amplify/core', () => ({
+	ConsoleLogger: jest.fn().mockImplementation(function ConsoleLogger() {
+		return { debug: jest.fn() };
+	}),
+	Amplify: {
+		getConfig: jest.fn(),
+		Auth: {
+			fetchAuthSession: jest.fn(),
+		},
+	},
+}));
+const mockedBucket = 'mock-bucket';
+const mockedRegion = 'mock-region';
+const mockPermission = 'READ';
+const mockedPath = 'path';
+const mockGetConfig = jest.mocked(Amplify.getConfig);
+const mockLocationCredentialsProvider = jest.fn();
+const STORAGE_CONFIG_ERROR_MESSAGE = 'Storage configuration is required.';
+const STORAGE_PATH_ERROR_MESSAGE = 'path option needs to be a string';
+
+describe('createStorageConfiguration', () => {
+	const mockAmplify = Amplify;
+
+	beforeEach(() => {
+		mockGetConfig.mockReturnValue({
+			Storage: {
+				S3: {
+					bucket: mockedBucket,
+					region: mockedRegion,
+				},
+			},
+		});
+	});
+
+	afterEach(() => {
+		mockGetConfig.mockReset();
+	});
+
+	it('should resolve Storage service options from API input', () => {
+		const apiInput = {
+			options: {
+				bucket: mockedBucket,
+				region: mockedRegion,
+			},
+		};
+		const config = createStorageConfiguration(
+			mockAmplify,
+			apiInput,
+			mockPermission,
+		);
+		expect(config).toMatchObject({
+			bucket: mockedBucket,
+			region: mockedRegion,
+			credentialsProvider: expect.any(Function),
+			identityIdProvider: expect.any(Function),
+		});
+	});
+
+	it('should resolve Storage service options from Amplify singleton', () => {
+		const config = createStorageConfiguration(mockAmplify, {}, mockPermission);
+		expect(config).toMatchObject({
+			bucket: mockedBucket,
+			region: mockedRegion,
+			credentialsProvider: expect.any(Function),
+			identityIdProvider: expect.any(Function),
+		});
+	});
+
+	it('should throw if Storage service options are not resolved from API input and Amplify singleton', () => {
+		mockGetConfig.mockReturnValue({});
+		expect(() =>
+			createStorageConfiguration(mockAmplify, {}, mockPermission),
+		).toThrow(STORAGE_CONFIG_ERROR_MESSAGE);
+	});
+
+	it('should create a custom credentials provider if locationCredentialsProvider is defined', () => {
+		const apiInput = {
+			path: mockedPath,
+			options: {
+				bucket: mockedBucket,
+				region: mockedRegion,
+				locationCredentialsProvider: mockLocationCredentialsProvider,
+			},
+		};
+		const config = createStorageConfiguration(
+			mockAmplify,
+			apiInput,
+			mockPermission,
+		);
+		expect(config.credentialsProvider).not.toBe(expect.any(Function));
+	});
+
+	it('should throw if bucket is undefined when creating a custom credentials provider', () => {
+		mockGetConfig.mockReturnValue({
+			Storage: {
+				S3: {
+					bucket: undefined,
+					region: mockedRegion,
+				},
+			},
+		});
+		const apiInput = {
+			path: mockedPath,
+			options: {
+				region: mockedRegion,
+				locationCredentialsProvider: mockLocationCredentialsProvider,
+			},
+		};
+		expect(() =>
+			createStorageConfiguration(mockAmplify, apiInput, mockPermission),
+		).toThrow(STORAGE_CONFIG_ERROR_MESSAGE);
+	});
+
+	it('should throw if path is undefined when creating a custom credentials provider', () => {
+		const apiInput = {
+			options: {
+				bucket: mockedBucket,
+				region: mockedRegion,
+				locationCredentialsProvider: jest.fn(),
+			},
+		};
+		expect(() =>
+			createStorageConfiguration(mockAmplify, apiInput, mockPermission),
+		).toThrow(STORAGE_PATH_ERROR_MESSAGE);
+	});
+
+	it('should throw if path is a function when creating a custom credentials provider', () => {
+		const apiInput = {
+			path: jest.fn(),
+			options: {
+				bucket: mockedBucket,
+				region: mockedRegion,
+				locationCredentialsProvider: jest.fn(),
+			},
+		};
+		expect(() =>
+			createStorageConfiguration(mockAmplify, apiInput, mockPermission),
+		).toThrow(STORAGE_PATH_ERROR_MESSAGE);
+	});
+
+	it('should create paths if API input has a path when creating a custom credentials provider', () => {
+		const apiInput = {
+			path: 'mock-path',
+			options: {
+				bucket: mockedBucket,
+				region: mockedRegion,
+				locationCredentialsProvider: mockLocationCredentialsProvider,
+			},
+		};
+		const config = createStorageConfiguration(
+			mockAmplify,
+			apiInput,
+			mockPermission,
+		);
+		expect(config.credentialsProvider).toBeInstanceOf(Function);
+	});
+
+	it('should create paths if API input has source and destination when creating a custom credentials provider', () => {
+		const apiInput = {
+			source: { path: 'source-path' },
+			destination: { path: 'destination-path' },
+			options: {
+				bucket: mockedBucket,
+				region: mockedRegion,
+				locationCredentialsProvider: mockLocationCredentialsProvider,
+			},
+		};
+		const config = createStorageConfiguration(
+			mockAmplify,
+			apiInput,
+			mockPermission,
+		);
+		expect(config.credentialsProvider).toBeInstanceOf(Function);
+	});
+
+	it('should create a default credentials provider if locationCredentialsProvider is not defined and Storage config is passed in the input', () => {
+		const apiInput = {
+			options: {
+				bucket: mockedBucket,
+				region: mockedRegion,
+			},
+		};
+		const config = createStorageConfiguration(
+			mockAmplify,
+			apiInput,
+			mockPermission,
+		);
+		expect(config.credentialsProvider).toBeInstanceOf(Function);
+	});
+
+	it('should create a default credentials provider if locationCredentialsProvider is not defined and Storage config is not passed in the input', () => {
+		const apiInput = {};
+		const config = createStorageConfiguration(
+			mockAmplify,
+			apiInput,
+			mockPermission,
+		);
+		expect(config.credentialsProvider).toBeInstanceOf(Function);
+	});
+
+	it('should not throw if path is a function when creating a default credentials provider', () => {
+		const apiInput = {
+			path: jest.fn(),
+		};
+		expect(() =>
+			createStorageConfiguration(mockAmplify, apiInput, mockPermission),
+		).not.toThrow();
+	});
+});

--- a/packages/storage/__tests__/providers/s3/apis/utils/resolveS3ConfigAndInput.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/resolveS3ConfigAndInput.test.ts
@@ -32,8 +32,8 @@ describe('resolveS3ConfigAndInput', () => {
 	const config: S3InternalConfig = {
 		credentialsProvider: mockCredentialsProvider,
 		identityIdProvider: mockIdentityIdProvider,
-		serviceOptions: mockServiceOptions,
-		libraryOptions: mockLibraryOptions,
+		...mockServiceOptions,
+		...mockLibraryOptions,
 	};
 	beforeEach(() => {
 		mockCredentialsProvider.mockImplementation(async () => credentials);
@@ -88,9 +88,7 @@ describe('resolveS3ConfigAndInput', () => {
 			resolveS3ConfigAndInput({
 				config: {
 					...config,
-					serviceOptions: {
-						bucket: undefined,
-					},
+					bucket: undefined,
 				},
 			}),
 		).rejects.toMatchObject(
@@ -108,9 +106,7 @@ describe('resolveS3ConfigAndInput', () => {
 			resolveS3ConfigAndInput({
 				config: {
 					...config,
-					serviceOptions: {
-						bucket,
-					},
+					region: undefined,
 				},
 			}),
 		).rejects.toMatchObject(
@@ -126,7 +122,7 @@ describe('resolveS3ConfigAndInput', () => {
 		};
 
 		const { s3Config } = await resolveS3ConfigAndInput({
-			config: { ...config, serviceOptions },
+			config: { ...config, ...serviceOptions },
 		});
 		expect(s3Config.customEndpoint).toEqual('http://localhost:20005');
 		expect(s3Config.forcePathStyle).toEqual(true);
@@ -136,7 +132,7 @@ describe('resolveS3ConfigAndInput', () => {
 		const { isObjectLockEnabled } = await resolveS3ConfigAndInput({
 			config: {
 				...config,
-				libraryOptions: { isObjectLockEnabled: true },
+				isObjectLockEnabled: true,
 			},
 		});
 		expect(isObjectLockEnabled).toEqual(true);
@@ -154,9 +150,7 @@ describe('resolveS3ConfigAndInput', () => {
 		const { keyPrefix } = await resolveS3ConfigAndInput({
 			config: {
 				...config,
-				libraryOptions: {
-					prefixResolver: customResolvePrefix,
-				},
+				prefixResolver: customResolvePrefix,
 			},
 		});
 		expect(customResolvePrefix).toHaveBeenCalled();
@@ -184,9 +178,7 @@ describe('resolveS3ConfigAndInput', () => {
 		const { keyPrefix } = await resolveS3ConfigAndInput({
 			config: {
 				...config,
-				libraryOptions: {
-					defaultAccessLevel: 'someLevel' as any,
-				},
+				defaultAccessLevel: 'someLevel' as any,
 			},
 		});
 		expect(mockDefaultResolvePrefix).toHaveBeenCalledWith({

--- a/packages/storage/src/errors/constants.ts
+++ b/packages/storage/src/errors/constants.ts
@@ -1,0 +1,2 @@
+export const NO_STORAGE_CONFIG = 'NoStorageConfig';
+export const INVALID_STORAGE_PATH = 'InvalidStoragePath';

--- a/packages/storage/src/errors/constants.ts
+++ b/packages/storage/src/errors/constants.ts
@@ -1,2 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 export const NO_STORAGE_CONFIG = 'NoStorageConfig';
 export const INVALID_STORAGE_PATH = 'InvalidStoragePath';

--- a/packages/storage/src/providers/s3/apis/copy.ts
+++ b/packages/storage/src/providers/s3/apis/copy.ts
@@ -9,6 +9,7 @@ import {
 	CopyWithPathInput,
 	CopyWithPathOutput,
 } from '../types';
+import { createStorageConfiguration } from '../utils';
 
 import { copy as copyInternal } from './internal/copy';
 
@@ -38,5 +39,7 @@ export function copy(input: CopyWithPathInput): Promise<CopyWithPathOutput>;
 export function copy(input: CopyInput): Promise<CopyOutput>;
 
 export function copy(input: CopyInput | CopyWithPathInput) {
-	return copyInternal(Amplify, input);
+	const config = createStorageConfiguration(Amplify, input, 'READWRITE');
+
+	return copyInternal(config, input);
 }

--- a/packages/storage/src/providers/s3/apis/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/downloadData.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Amplify } from '@aws-amplify/core';
-import { StorageAction } from '@aws-amplify/core/internals/utils';
 
 import {
 	DownloadDataInput,
@@ -10,18 +9,9 @@ import {
 	DownloadDataWithPathInput,
 	DownloadDataWithPathOutput,
 } from '../types';
-import { resolveS3ConfigAndInput } from '../utils/resolveS3ConfigAndInput';
-import { createDownloadTask, validateStorageOperationInput } from '../utils';
-import { getObject } from '../utils/client/s3data';
-import { createStorageConfiguration } from '../utils/config';
-import { getStorageUserAgentValue } from '../utils/userAgent';
-import { logger } from '../../../utils';
-import {
-	StorageDownloadDataOutput,
-	StorageItemWithKey,
-	StorageItemWithPath,
-} from '../../../types';
-import { STORAGE_INPUT_KEY } from '../utils/constants';
+import { createStorageConfiguration } from '../utils';
+
+import { internalDownloadData } from './internal/downloadData';
 
 /**
  * Download S3 object data to memory
@@ -94,78 +84,7 @@ export function downloadData(input: DownloadDataInput): DownloadDataOutput;
 export function downloadData(
 	input: DownloadDataInput | DownloadDataWithPathInput,
 ) {
-	const abortController = new AbortController();
+	const config = createStorageConfiguration(Amplify, input, 'READ');
 
-	const downloadTask = createDownloadTask({
-		job: downloadDataJob(input, abortController.signal),
-		onCancel: (message?: string) => {
-			abortController.abort(message);
-		},
-	});
-
-	return downloadTask;
+	return internalDownloadData(input, config);
 }
-
-const downloadDataJob =
-	(
-		downloadDataInput: DownloadDataInput | DownloadDataWithPathInput,
-		abortSignal: AbortSignal,
-	) =>
-	async (): Promise<
-		StorageDownloadDataOutput<StorageItemWithKey | StorageItemWithPath>
-	> => {
-		const { options: downloadDataOptions } = downloadDataInput;
-		const config = createStorageConfiguration(Amplify);
-
-		const { bucket, keyPrefix, s3Config, identityId } =
-			await resolveS3ConfigAndInput({
-				config,
-				apiOptions: downloadDataOptions,
-			});
-		const { inputType, objectKey } = validateStorageOperationInput(
-			downloadDataInput,
-			identityId,
-		);
-		const finalKey =
-			inputType === STORAGE_INPUT_KEY ? keyPrefix + objectKey : objectKey;
-
-		logger.debug(`download ${objectKey} from ${finalKey}.`);
-
-		const {
-			Body: body,
-			LastModified: lastModified,
-			ContentLength: size,
-			ETag: eTag,
-			Metadata: metadata,
-			VersionId: versionId,
-			ContentType: contentType,
-		} = await getObject(
-			{
-				...s3Config,
-				abortSignal,
-				onDownloadProgress: downloadDataOptions?.onProgress,
-				userAgentValue: getStorageUserAgentValue(StorageAction.DownloadData),
-			},
-			{
-				Bucket: bucket,
-				Key: finalKey,
-				...(downloadDataOptions?.bytesRange && {
-					Range: `bytes=${downloadDataOptions.bytesRange.start}-${downloadDataOptions.bytesRange.end}`,
-				}),
-			},
-		);
-
-		const result = {
-			body,
-			lastModified,
-			size,
-			contentType,
-			eTag,
-			metadata,
-			versionId,
-		};
-
-		return inputType === STORAGE_INPUT_KEY
-			? { key: objectKey, ...result }
-			: { path: objectKey, ...result };
-	};

--- a/packages/storage/src/providers/s3/apis/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/getProperties.ts
@@ -9,6 +9,7 @@ import {
 	GetPropertiesWithPathInput,
 	GetPropertiesWithPathOutput,
 } from '../types';
+import { createStorageConfiguration } from '../utils';
 
 import { getProperties as getPropertiesInternal } from './internal/getProperties';
 
@@ -43,5 +44,7 @@ export function getProperties(
 export function getProperties(
 	input: GetPropertiesInput | GetPropertiesWithPathInput,
 ) {
-	return getPropertiesInternal(Amplify, input);
+	const config = createStorageConfiguration(Amplify, input, 'READ');
+
+	return getPropertiesInternal(config, input);
 }

--- a/packages/storage/src/providers/s3/apis/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/getUrl.ts
@@ -9,6 +9,7 @@ import {
 	GetUrlWithPathInput,
 	GetUrlWithPathOutput,
 } from '../types';
+import { createStorageConfiguration } from '../utils';
 
 import { getUrl as getUrlInternal } from './internal/getUrl';
 
@@ -53,5 +54,7 @@ export function getUrl(
 export function getUrl(input: GetUrlInput): Promise<GetUrlOutput>;
 
 export function getUrl(input: GetUrlInput | GetUrlWithPathInput) {
-	return getUrlInternal(Amplify, input);
+	const config = createStorageConfiguration(Amplify, input, 'READ');
+
+	return getUrlInternal(config, input);
 }

--- a/packages/storage/src/providers/s3/apis/internal/copy.ts
+++ b/packages/storage/src/providers/s3/apis/internal/copy.ts
@@ -36,15 +36,6 @@ export const copy = async (
 		: copyWithKey(config, input);
 };
 
-export const copyV2 = async (
-	config: S3InternalConfig,
-	input: CopyInput | CopyWithPathInput,
-): Promise<CopyOutput | CopyWithPathOutput> => {
-	return isCopyInputWithPath(input)
-		? copyWithPath(config, input)
-		: copyWithKey(config, input);
-};
-
 const copyWithPath = async (
 	config: S3InternalConfig,
 	input: CopyWithPathInput,

--- a/packages/storage/src/providers/s3/apis/internal/copy.ts
+++ b/packages/storage/src/providers/s3/apis/internal/copy.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
 import { StorageAction } from '@aws-amplify/core/internals/utils';
 
 import {
@@ -12,7 +11,6 @@ import {
 } from '../../types';
 import { ResolvedS3Config } from '../../types/options';
 import {
-	createStorageConfiguration,
 	isInputWithPath,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInput,
@@ -23,25 +21,27 @@ import { copyObject } from '../../utils/client/s3data';
 import { getStorageUserAgentValue } from '../../utils/userAgent';
 import { logger } from '../../../../utils';
 
+import { S3InternalConfig } from './types';
+
 const isCopyInputWithPath = (
 	input: CopyInput | CopyWithPathInput,
 ): input is CopyWithPathInput => isInputWithPath(input.source);
 
 export const copy = async (
-	amplify: AmplifyClassV6,
+	config: S3InternalConfig,
 	input: CopyInput | CopyWithPathInput,
 ): Promise<CopyOutput | CopyWithPathOutput> => {
 	return isCopyInputWithPath(input)
-		? copyWithPath(amplify, input)
-		: copyWithKey(amplify, input);
+		? copyWithPath(config, input)
+		: copyWithKey(config, input);
 };
 
 const copyWithPath = async (
-	amplify: AmplifyClassV6,
+	config: S3InternalConfig,
 	input: CopyWithPathInput,
 ): Promise<CopyWithPathOutput> => {
 	const { source, destination } = input;
-	const config = createStorageConfiguration(amplify);
+
 	const { s3Config, bucket, identityId } = await resolveS3ConfigAndInput({
 		config,
 	});
@@ -77,7 +77,7 @@ const copyWithPath = async (
 
 /** @deprecated Use {@link copyWithPath} instead. */
 export const copyWithKey = async (
-	amplify: AmplifyClassV6,
+	config: S3InternalConfig,
 	input: CopyInput,
 ): Promise<CopyOutput> => {
 	const {
@@ -90,7 +90,6 @@ export const copyWithKey = async (
 		!!destinationKey,
 		StorageValidationErrorCode.NoDestinationKey,
 	);
-	const config = createStorageConfiguration(amplify);
 	const {
 		s3Config,
 		bucket,

--- a/packages/storage/src/providers/s3/apis/internal/copy.ts
+++ b/packages/storage/src/providers/s3/apis/internal/copy.ts
@@ -36,6 +36,15 @@ export const copy = async (
 		: copyWithKey(config, input);
 };
 
+export const copyV2 = async (
+	config: S3InternalConfig,
+	input: CopyInput | CopyWithPathInput,
+): Promise<CopyOutput | CopyWithPathOutput> => {
+	return isCopyInputWithPath(input)
+		? copyWithPath(config, input)
+		: copyWithKey(config, input);
+};
+
 const copyWithPath = async (
 	config: S3InternalConfig,
 	input: CopyWithPathInput,

--- a/packages/storage/src/providers/s3/apis/internal/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/internal/downloadData.ts
@@ -1,0 +1,99 @@
+import { StorageAction } from '@aws-amplify/core/internals/utils';
+
+import {
+	StorageDownloadDataOutput,
+	StorageItemWithKey,
+	StorageItemWithPath,
+} from '../../../../types';
+import { logger } from '../../../../utils';
+import { DownloadDataInput, DownloadDataWithPathInput } from '../../types';
+import {
+	createDownloadTask,
+	resolveS3ConfigAndInput,
+	validateStorageOperationInput,
+} from '../../utils';
+import { getObject } from '../../utils/client';
+import { STORAGE_INPUT_KEY } from '../../utils/constants';
+import { getStorageUserAgentValue } from '../../utils/userAgent';
+
+import { S3InternalConfig } from './types';
+
+export function internalDownloadData(
+	input: DownloadDataInput | DownloadDataWithPathInput,
+	config: S3InternalConfig,
+) {
+	const abortController = new AbortController();
+
+	const downloadTask = createDownloadTask({
+		job: downloadDataJob(input, abortController.signal, config),
+		onCancel: (message?: string) => {
+			abortController.abort(message);
+		},
+	});
+
+	return downloadTask;
+}
+
+const downloadDataJob =
+	(
+		downloadDataInput: DownloadDataInput | DownloadDataWithPathInput,
+		abortSignal: AbortSignal,
+		config: S3InternalConfig,
+	) =>
+	async (): Promise<
+		StorageDownloadDataOutput<StorageItemWithKey | StorageItemWithPath>
+	> => {
+		const { options: downloadDataOptions } = downloadDataInput;
+
+		const { bucket, keyPrefix, s3Config, identityId } =
+			await resolveS3ConfigAndInput({
+				config,
+				apiOptions: downloadDataOptions,
+			});
+		const { inputType, objectKey } = validateStorageOperationInput(
+			downloadDataInput,
+			identityId,
+		);
+		const finalKey =
+			inputType === STORAGE_INPUT_KEY ? keyPrefix + objectKey : objectKey;
+
+		logger.debug(`download ${objectKey} from ${finalKey}.`);
+
+		const {
+			Body: body,
+			LastModified: lastModified,
+			ContentLength: size,
+			ETag: eTag,
+			Metadata: metadata,
+			VersionId: versionId,
+			ContentType: contentType,
+		} = await getObject(
+			{
+				...s3Config,
+				abortSignal,
+				onDownloadProgress: downloadDataOptions?.onProgress,
+				userAgentValue: getStorageUserAgentValue(StorageAction.DownloadData),
+			},
+			{
+				Bucket: bucket,
+				Key: finalKey,
+				...(downloadDataOptions?.bytesRange && {
+					Range: `bytes=${downloadDataOptions.bytesRange.start}-${downloadDataOptions.bytesRange.end}`,
+				}),
+			},
+		);
+
+		const result = {
+			body,
+			lastModified,
+			size,
+			contentType,
+			eTag,
+			metadata,
+			versionId,
+		};
+
+		return inputType === STORAGE_INPUT_KEY
+			? { key: objectKey, ...result }
+			: { path: objectKey, ...result };
+	};

--- a/packages/storage/src/providers/s3/apis/internal/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/internal/downloadData.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 import { StorageAction } from '@aws-amplify/core/internals/utils';
 
 import {

--- a/packages/storage/src/providers/s3/apis/internal/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/internal/downloadData.ts
@@ -15,7 +15,7 @@ import {
 	resolveS3ConfigAndInput,
 	validateStorageOperationInput,
 } from '../../utils';
-import { getObject } from '../../utils/client';
+import { getObject } from '../../utils/client/s3data';
 import { STORAGE_INPUT_KEY } from '../../utils/constants';
 import { getStorageUserAgentValue } from '../../utils/userAgent';
 

--- a/packages/storage/src/providers/s3/apis/internal/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getProperties.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
 import { StorageAction } from '@aws-amplify/core/internals/utils';
 
 import {
@@ -11,7 +10,6 @@ import {
 	GetPropertiesWithPathOutput,
 } from '../../types';
 import {
-	createStorageConfiguration,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInput,
 } from '../../utils';
@@ -20,13 +18,14 @@ import { getStorageUserAgentValue } from '../../utils/userAgent';
 import { logger } from '../../../../utils';
 import { STORAGE_INPUT_KEY } from '../../utils/constants';
 
+import { S3InternalConfig } from './types';
+
 export const getProperties = async (
-	amplify: AmplifyClassV6,
+	config: S3InternalConfig,
 	input: GetPropertiesInput | GetPropertiesWithPathInput,
 	action?: StorageAction,
 ): Promise<GetPropertiesOutput | GetPropertiesWithPathOutput> => {
 	const { options: getPropertiesOptions } = input;
-	const config = createStorageConfiguration(amplify);
 	const { s3Config, bucket, keyPrefix, identityId } =
 		await resolveS3ConfigAndInput({
 			config,

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
 import { StorageAction } from '@aws-amplify/core/internals/utils';
 
 import {
@@ -13,7 +12,6 @@ import {
 import { StorageValidationErrorCode } from '../../../../errors/types/validation';
 import { getPresignedGetObjectUrl } from '../../utils/client/s3data';
 import {
-	createStorageConfiguration,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInput,
 } from '../../utils';
@@ -25,13 +23,13 @@ import {
 } from '../../utils/constants';
 
 import { getProperties } from './getProperties';
+import { S3InternalConfig } from './types';
 
 export const getUrl = async (
-	amplify: AmplifyClassV6,
+	config: S3InternalConfig,
 	input: GetUrlInput | GetUrlWithPathInput,
 ): Promise<GetUrlOutput | GetUrlWithPathOutput> => {
 	const { options: getUrlOptions } = input;
-	const config = createStorageConfiguration(amplify);
 	const { s3Config, keyPrefix, bucket, identityId } =
 		await resolveS3ConfigAndInput({
 			config,
@@ -46,7 +44,7 @@ export const getUrl = async (
 		inputType === STORAGE_INPUT_KEY ? keyPrefix + objectKey : objectKey;
 
 	if (getUrlOptions?.validateObjectExistence) {
-		await getProperties(amplify, input, StorageAction.GetUrl);
+		await getProperties(config, input, StorageAction.GetUrl);
 	}
 
 	let urlExpirationInSec =

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
 import { StorageAction } from '@aws-amplify/core/internals/utils';
 
 import {
@@ -17,7 +16,6 @@ import {
 	ListPaginateWithPathOutput,
 } from '../../types';
 import {
-	createStorageConfiguration,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInputWithPrefix,
 } from '../../utils';
@@ -32,6 +30,8 @@ import { logger } from '../../../../utils';
 import { STORAGE_INPUT_PREFIX } from '../../utils/constants';
 import { CommonPrefix } from '../../utils/client/s3data/types';
 
+import { S3InternalConfig } from './types';
+
 const MAX_PAGE_SIZE = 1000;
 
 interface ListInputArgs {
@@ -41,7 +41,7 @@ interface ListInputArgs {
 }
 
 export const list = async (
-	amplify: AmplifyClassV6,
+	config: S3InternalConfig,
 	input:
 		| ListAllInput
 		| ListPaginateInput
@@ -55,7 +55,6 @@ export const list = async (
 > => {
 	const { options = {} } = input;
 
-	const config = createStorageConfiguration(amplify);
 	const {
 		s3Config,
 		bucket,

--- a/packages/storage/src/providers/s3/apis/internal/remove.ts
+++ b/packages/storage/src/providers/s3/apis/internal/remove.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
 import { StorageAction } from '@aws-amplify/core/internals/utils';
 
 import {
@@ -11,7 +10,6 @@ import {
 	RemoveWithPathOutput,
 } from '../../types';
 import {
-	createStorageConfiguration,
 	resolveS3ConfigAndInput,
 	validateStorageOperationInput,
 } from '../../utils';
@@ -20,12 +18,13 @@ import { getStorageUserAgentValue } from '../../utils/userAgent';
 import { logger } from '../../../../utils';
 import { STORAGE_INPUT_KEY } from '../../utils/constants';
 
+import { S3InternalConfig } from './types';
+
 export const remove = async (
-	amplify: AmplifyClassV6,
+	config: S3InternalConfig,
 	input: RemoveInput | RemoveWithPathInput,
 ): Promise<RemoveOutput | RemoveWithPathOutput> => {
 	const { options = {} } = input ?? {};
-	const config = createStorageConfiguration(amplify);
 	const { s3Config, keyPrefix, bucket, identityId } =
 		await resolveS3ConfigAndInput({
 			config,

--- a/packages/storage/src/providers/s3/apis/internal/types/index.ts
+++ b/packages/storage/src/providers/s3/apis/internal/types/index.ts
@@ -4,6 +4,12 @@
 import { LibraryOptions, StorageConfig } from '@aws-amplify/core';
 import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 
+import {
+	StorageOperationInput,
+	StorageOperationOptionsInput,
+} from '../../../../../types/inputs';
+import { CommonOptions } from '../../../types/options';
+
 /**
  * Internal S3 service options.
  *
@@ -23,9 +29,25 @@ type S3LibraryOptions = NonNullable<LibraryOptions['Storage']>['S3'];
  *
  * @internal
  */
-export interface S3InternalConfig {
-	serviceOptions: S3ServiceOptions;
-	libraryOptions: S3LibraryOptions;
+export interface S3InternalConfig extends S3ServiceOptions, S3LibraryOptions {
 	credentialsProvider(): Promise<AWSCredentials>;
 	identityIdProvider(): Promise<string>;
+}
+
+export type StorageCredentialsProvider = () => Promise<AWSCredentials>;
+export type StorageIdentityIdProvider = () => Promise<string>;
+
+/**
+ * This interface is used to resolve the main options for the locationCredentialsProvider
+ *
+ * @internal
+ */
+export interface InternalStorageAPIConfig
+	extends StorageOperationOptionsInput<
+		CommonOptions & {
+			bucket?: string;
+			region?: string;
+		}
+	> {
+	paths: StorageOperationInput['path'][];
 }

--- a/packages/storage/src/providers/s3/apis/internal/types/index.ts
+++ b/packages/storage/src/providers/s3/apis/internal/types/index.ts
@@ -4,10 +4,7 @@
 import { LibraryOptions, StorageConfig } from '@aws-amplify/core';
 import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 
-import {
-	StorageOperationInput,
-	StorageOperationOptionsInput,
-} from '../../../../../types/inputs';
+import { StorageOperationOptionsInput } from '../../../../../types/inputs';
 import { CommonOptions } from '../../../types/options';
 
 /**
@@ -49,5 +46,5 @@ export interface InternalStorageAPIConfig
 			region?: string;
 		}
 	> {
-	paths: StorageOperationInput['path'][];
+	paths?: string[];
 }

--- a/packages/storage/src/providers/s3/apis/internal/types/index.ts
+++ b/packages/storage/src/providers/s3/apis/internal/types/index.ts
@@ -9,7 +9,7 @@ import { AWSCredentials } from '@aws-amplify/core/internals/utils';
  *
  * @internal
  */
-type S3ServiceOptions = StorageConfig['S3'];
+export type S3ServiceOptions = StorageConfig['S3'];
 
 /**
  * Internal S3 library options.

--- a/packages/storage/src/providers/s3/apis/list.ts
+++ b/packages/storage/src/providers/s3/apis/list.ts
@@ -12,6 +12,7 @@ import {
 	ListPaginateWithPathInput,
 	ListPaginateWithPathOutput,
 } from '../types';
+import { createStorageConfiguration } from '../utils';
 
 import { list as listInternal } from './internal/list';
 
@@ -65,5 +66,7 @@ export function list(
 		| ListAllWithPathInput
 		| ListPaginateWithPathInput,
 ) {
-	return listInternal(Amplify, input ?? {});
+	const config = createStorageConfiguration(Amplify, input, 'READ');
+
+	return listInternal(config, input ?? {});
 }

--- a/packages/storage/src/providers/s3/apis/remove.ts
+++ b/packages/storage/src/providers/s3/apis/remove.ts
@@ -9,6 +9,7 @@ import {
 	RemoveWithPathInput,
 	RemoveWithPathOutput,
 } from '../types';
+import { createStorageConfiguration } from '../utils';
 
 import { remove as removeInternal } from './internal/remove';
 
@@ -37,5 +38,7 @@ export function remove(
 export function remove(input: RemoveInput): Promise<RemoveOutput>;
 
 export function remove(input: RemoveInput | RemoveWithPathInput) {
-	return removeInternal(Amplify, input);
+	const config = createStorageConfiguration(Amplify, input, 'WRITE');
+
+	return removeInternal(config, input);
 }

--- a/packages/storage/src/providers/s3/apis/server/copy.ts
+++ b/packages/storage/src/providers/s3/apis/server/copy.ts
@@ -12,6 +12,7 @@ import {
 	CopyWithPathOutput,
 } from '../../types';
 import { copy as copyInternal } from '../internal/copy';
+import { createServerStorageConfiguration } from '../../utils/config';
 
 /**
  * Copy an object from a source to a destination object within the same bucket.
@@ -50,5 +51,9 @@ export function copy(
 	contextSpec: AmplifyServer.ContextSpec,
 	input: CopyInput | CopyWithPathInput,
 ) {
-	return copyInternal(getAmplifyServerContext(contextSpec).amplify, input);
+	const config = createServerStorageConfiguration(
+		getAmplifyServerContext(contextSpec).amplify,
+	);
+
+	return copyInternal(config, input);
 }

--- a/packages/storage/src/providers/s3/apis/server/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/server/getProperties.ts
@@ -13,6 +13,7 @@ import {
 	GetPropertiesWithPathOutput,
 } from '../../types';
 import { getProperties as getPropertiesInternal } from '../internal/getProperties';
+import { createServerStorageConfiguration } from '../../utils';
 
 /**
  * Gets the properties of a file. The properties include S3 system metadata and
@@ -50,8 +51,9 @@ export function getProperties(
 	contextSpec: AmplifyServer.ContextSpec,
 	input: GetPropertiesInput | GetPropertiesWithPathInput,
 ) {
-	return getPropertiesInternal(
+	const config = createServerStorageConfiguration(
 		getAmplifyServerContext(contextSpec).amplify,
-		input,
 	);
+
+	return getPropertiesInternal(config, input);
 }

--- a/packages/storage/src/providers/s3/apis/server/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/server/getUrl.ts
@@ -13,6 +13,7 @@ import {
 	GetUrlWithPathOutput,
 } from '../../types';
 import { getUrl as getUrlInternal } from '../internal/getUrl';
+import { createServerStorageConfiguration } from '../../utils';
 
 /**
  * Get a temporary presigned URL to download the specified S3 object.
@@ -64,5 +65,9 @@ export function getUrl(
 	contextSpec: AmplifyServer.ContextSpec,
 	input: GetUrlInput | GetUrlWithPathInput,
 ) {
-	return getUrlInternal(getAmplifyServerContext(contextSpec).amplify, input);
+	const config = createServerStorageConfiguration(
+		getAmplifyServerContext(contextSpec).amplify,
+	);
+
+	return getUrlInternal(config, input);
 }

--- a/packages/storage/src/providers/s3/apis/server/list.ts
+++ b/packages/storage/src/providers/s3/apis/server/list.ts
@@ -16,6 +16,7 @@ import {
 	ListPaginateWithPathOutput,
 } from '../../types';
 import { list as listInternal } from '../internal/list';
+import { createServerStorageConfiguration } from '../../utils';
 
 /**
  * List files in pages with the given `path`.
@@ -78,8 +79,9 @@ export function list(
 		| ListAllWithPathInput
 		| ListPaginateWithPathInput,
 ) {
-	return listInternal(
+	const config = createServerStorageConfiguration(
 		getAmplifyServerContext(contextSpec).amplify,
-		input ?? {},
 	);
+
+	return listInternal(config, input ?? {});
 }

--- a/packages/storage/src/providers/s3/apis/server/remove.ts
+++ b/packages/storage/src/providers/s3/apis/server/remove.ts
@@ -13,6 +13,7 @@ import {
 	RemoveWithPathOutput,
 } from '../../types';
 import { remove as removeInternal } from '../internal/remove';
+import { createServerStorageConfiguration } from '../../utils';
 
 /**
  * Remove a file from your S3 bucket.
@@ -48,5 +49,9 @@ export function remove(
 	contextSpec: AmplifyServer.ContextSpec,
 	input: RemoveInput | RemoveWithPathInput,
 ) {
-	return removeInternal(getAmplifyServerContext(contextSpec).amplify, input);
+	const config = createServerStorageConfiguration(
+		getAmplifyServerContext(contextSpec).amplify,
+	);
+
+	return removeInternal(config, input);
 }

--- a/packages/storage/src/providers/s3/apis/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/index.ts
@@ -123,7 +123,7 @@ export function uploadData(
 export function uploadData(input: UploadDataInput): UploadDataOutput;
 
 export function uploadData(input: UploadDataInput | UploadDataWithPathInput) {
-	const config = createStorageConfiguration(Amplify);
+	const config = createStorageConfiguration(Amplify, input, 'WRITE');
 
 	return internalUploadData(config, input);
 }

--- a/packages/storage/src/providers/s3/types/inputs.ts
+++ b/packages/storage/src/providers/s3/types/inputs.ts
@@ -35,6 +35,8 @@ import {
 	UploadDataOptionsWithPath,
 } from '../types';
 
+import { CommonOptions } from './options';
+
 // TODO: support use accelerate endpoint option
 /**
  * @deprecated Use {@link CopyWithPathInput} instead.
@@ -42,12 +44,15 @@ import {
  */
 export type CopyInput = StorageCopyInputWithKey<
 	CopySourceOptionsWithKey,
-	CopyDestinationOptionsWithKey
+	CopyDestinationOptionsWithKey,
+	Pick<CommonOptions, 'locationCredentialsProvider'>
 >;
 /**
  * Input type with path for S3 copy API.
  */
-export type CopyWithPathInput = StorageCopyInputWithPath;
+export type CopyWithPathInput = StorageCopyInputWithPath<
+	Pick<CommonOptions, 'locationCredentialsProvider'>
+>;
 
 /**
  * @deprecated Use {@link GetPropertiesWithPathInput} instead.

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -33,7 +33,7 @@ export type LocationCredentialsProvider = (options: {
 	permission: Permission;
 }) => Promise<{ credentials: AWSCredentials }>;
 
-interface CommonOptions {
+export interface CommonOptions {
 	/**
 	 * Whether to use accelerate endpoint.
 	 * @default false

--- a/packages/storage/src/providers/s3/utils/config.ts
+++ b/packages/storage/src/providers/s3/utils/config.ts
@@ -229,7 +229,7 @@ const createCustomCredentialsProvider = ({
 	locationCredentialsProvider,
 }: CreateCustomCredentialsProviderParams): StorageCredentialsProvider => {
 	return async () => {
-		const locations = await getLocations({ bucket, paths });
+		const locations = getLocations({ bucket, paths });
 		const { credentials } = await locationCredentialsProvider({
 			locations,
 			permission,
@@ -257,9 +257,10 @@ type GetLocationsParams = Pick<
 	CreateCustomCredentialsProviderParams,
 	'paths' | 'bucket'
 >;
-const getLocations: (
-	params: GetLocationsParams,
-) => Promise<BucketLocation[]> = async ({ paths, bucket }) => {
+const getLocations: (params: GetLocationsParams) => BucketLocation[] = ({
+	paths,
+	bucket,
+}) => {
 	assertValidationError(!!bucket, StorageValidationErrorCode.NoBucket);
 
 	return paths.map(path => ({ bucket, path: resolvePath({ path }) }));

--- a/packages/storage/src/providers/s3/utils/config.ts
+++ b/packages/storage/src/providers/s3/utils/config.ts
@@ -2,12 +2,34 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 
 import { StorageValidationErrorCode } from '../../../errors/types/validation';
 import { assertValidationError } from '../../../errors/utils/assertValidationError';
-import { S3InternalConfig } from '../apis/internal/types';
+import { S3InternalConfig, S3ServiceOptions } from '../apis/internal/types';
+import {
+	BucketLocation,
+	CommonOptions,
+	LocationCredentialsProvider,
+	Permission,
+} from '../types/options';
+import {
+	StorageOperationInput,
+	StorageOperationInputWithPath,
+	StorageOperationOptionsInput,
+} from '../../../types/inputs';
+import { StorageError } from '../../../errors/StorageError';
+import {
+	INVALID_STORAGE_PATH,
+	NO_STORAGE_CONFIG,
+} from '../../../errors/constants';
 
-const createDefaultCredentialsProvider = (amplify: AmplifyClassV6) => {
+type StorageCredentialsProvider = () => Promise<AWSCredentials>;
+type StorageIdentityIdProvider = () => Promise<string>;
+
+const createDefaultCredentialsProvider = (
+	amplify: AmplifyClassV6,
+): StorageCredentialsProvider => {
 	/**
 	 * A credentials provider function instead of a static credentials object is
 	 * used because the long-running tasks like multipart upload may span over the
@@ -25,7 +47,9 @@ const createDefaultCredentialsProvider = (amplify: AmplifyClassV6) => {
 	};
 };
 
-const createDefaultIdentityIdProvider = (amplify: AmplifyClassV6) => {
+const createDefaultIdentityIdProvider = (
+	amplify: AmplifyClassV6,
+): StorageIdentityIdProvider => {
 	return async () => {
 		const { identityId } = await amplify.Auth.fetchAuthSession();
 		assertValidationError(
@@ -37,12 +61,133 @@ const createDefaultIdentityIdProvider = (amplify: AmplifyClassV6) => {
 	};
 };
 
+const isInputWithOptions = (
+	input: unknown,
+): input is { options: InternalStorageAPIConfig['options'] } => {
+	return !!input && (input as any).options;
+};
+const isInputWithPath = (
+	input: unknown,
+): input is StorageOperationInputWithPath => {
+	return !!input && (input as any).path;
+};
+
+const isInputWithSourceAndDestination = (
+	input: unknown,
+): input is {
+	source: StorageOperationInputWithPath;
+	destination: StorageOperationInputWithPath;
+} => {
+	return !!input && (input as any).destination && (input as any).source;
+};
+
+interface InternalStorageAPIConfig
+	extends StorageOperationOptionsInput<
+		CommonOptions & {
+			bucket?: string;
+			region?: string;
+		}
+	> {
+	paths: StorageOperationInput['path'][];
+}
+
+/**
+ * This function is independent from the different input permutations and is used mainly to resolve the
+ * the main storage options.
+ *
+ * @internal
+ */
+export const createInternalStorageAPIConfig = (
+	input: unknown,
+): InternalStorageAPIConfig => {
+	let options: NonNullable<InternalStorageAPIConfig['options']> = {};
+	let paths: InternalStorageAPIConfig['paths'] = [];
+
+	if (isInputWithPath(input)) {
+		const { path } = input;
+		paths = [path];
+	} else if (isInputWithSourceAndDestination(input)) {
+		const {
+			destination: { path: destinationPath },
+			source: { path: sourcePath },
+		} = input;
+		paths = [destinationPath, sourcePath];
+	}
+
+	if (isInputWithOptions(input)) {
+		const { options: apiOptions } = input;
+		options = { ...apiOptions };
+	}
+
+	return {
+		paths,
+		options,
+	};
+};
+
 /**
  * It will return a Storage configuration used by lower level utils and APIs.
  *
  * @internal
  */
 export const createStorageConfiguration = (
+	amplify: AmplifyClassV6,
+	apiInput: unknown,
+	permission: Permission,
+): S3InternalConfig => {
+	const { paths, options } = createInternalStorageAPIConfig(apiInput);
+	const { locationCredentialsProvider } = options ?? {};
+
+	const libraryOptions = amplify.libraryOptions?.Storage?.S3 ?? {};
+	const serviceOptions = getServiceOptions(amplify, options);
+	const identityIdProvider = createDefaultIdentityIdProvider(amplify);
+	const { bucket } = serviceOptions;
+
+	const credentialsProvider = locationCredentialsProvider
+		? createCustomCredentialsProvider({
+				bucket,
+				paths,
+				locationCredentialsProvider,
+				permission,
+			})
+		: createDefaultCredentialsProvider(amplify);
+
+	return {
+		libraryOptions,
+		serviceOptions,
+		credentialsProvider,
+		identityIdProvider,
+	};
+};
+
+const getServiceOptions = (
+	amplify: AmplifyClassV6,
+	options: InternalStorageAPIConfig['options'],
+): S3ServiceOptions => {
+	const { Storage } = amplify.getConfig() ?? {};
+	const { dangerouslyConnectToHttpEndpointForTesting } = Storage?.S3 ?? {};
+
+	if (isConfigFromApiInput(options)) {
+		return {
+			bucket: options?.bucket,
+			region: options?.region,
+			dangerouslyConnectToHttpEndpointForTesting,
+		};
+	} else if (isConfigFromAmplifySingleton(Storage?.S3)) {
+		return {
+			bucket: Storage?.S3.bucket,
+			region: Storage?.S3.region,
+			dangerouslyConnectToHttpEndpointForTesting,
+		};
+	}
+
+	throw new StorageError({
+		name: NO_STORAGE_CONFIG,
+		message: 'Storage configuration is required.',
+	});
+};
+
+export const createServerStorageConfiguration = (
 	amplify: AmplifyClassV6,
 ): S3InternalConfig => {
 	const libraryOptions = amplify.libraryOptions?.Storage?.S3 ?? {};
@@ -56,4 +201,66 @@ export const createStorageConfiguration = (
 		credentialsProvider,
 		identityIdProvider,
 	};
+};
+
+interface CreateCustomCredentialsProviderParams {
+	paths: InternalStorageAPIConfig['paths'];
+	bucket?: string;
+	locationCredentialsProvider: LocationCredentialsProvider;
+	permission: Permission;
+}
+
+const createCustomCredentialsProvider = ({
+	bucket,
+	paths,
+	permission,
+	locationCredentialsProvider,
+}: CreateCustomCredentialsProviderParams): StorageCredentialsProvider => {
+	return async () => {
+		const locations = await getLocations({ bucket, paths });
+		const { credentials } = await locationCredentialsProvider({
+			locations,
+			permission,
+		});
+
+		return credentials;
+	};
+};
+
+interface ResolvePathProps {
+	path: StorageOperationInput['path'];
+}
+const resolvePath = ({ path }: ResolvePathProps): string => {
+	if (!path || typeof path === 'function') {
+		throw new StorageError({
+			name: INVALID_STORAGE_PATH,
+			message: 'path option needs to be a string',
+		});
+	}
+
+	return path;
+};
+
+type GetLocationsParams = Pick<
+	CreateCustomCredentialsProviderParams,
+	'paths' | 'bucket'
+>;
+const getLocations: (
+	params: GetLocationsParams,
+) => Promise<BucketLocation[]> = async ({ paths, bucket }) => {
+	assertValidationError(!!bucket, StorageValidationErrorCode.NoBucket);
+
+	return paths.map(path => ({ bucket, path: resolvePath({ path }) }));
+};
+
+const isConfigFromApiInput = (
+	options: InternalStorageAPIConfig['options'],
+): boolean => {
+	return !!(options?.bucket && options?.region);
+};
+
+const isConfigFromAmplifySingleton = (
+	s3Options?: S3ServiceOptions,
+): s3Options is S3ServiceOptions => {
+	return !!(s3Options && s3Options.bucket && s3Options.region);
 };

--- a/packages/storage/src/providers/s3/utils/index.ts
+++ b/packages/storage/src/providers/s3/utils/index.ts
@@ -7,4 +7,8 @@ export { createDownloadTask, createUploadTask } from './transferTask';
 export { validateStorageOperationInput } from './validateStorageOperationInput';
 export { validateStorageOperationInputWithPrefix } from './validateStorageOperationInputWithPrefix';
 export { isInputWithPath } from './isInputWithPath';
-export { createStorageConfiguration } from './config';
+export {
+	createStorageConfiguration,
+	createServerStorageConfiguration,
+	createInternalStorageAPIConfig,
+} from './config';

--- a/packages/storage/src/providers/s3/utils/index.ts
+++ b/packages/storage/src/providers/s3/utils/index.ts
@@ -10,5 +10,4 @@ export { isInputWithPath } from './isInputWithPath';
 export {
 	createStorageConfiguration,
 	createServerStorageConfiguration,
-	createInternalStorageAPIConfig,
 } from './config';

--- a/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
+++ b/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
@@ -38,20 +38,19 @@ export const resolveS3ConfigAndInput = async ({
 }: ResolveS3ConfigAndInputParams): Promise<ResolvedS3ConfigAndInput> => {
 	const {
 		credentialsProvider,
-		serviceOptions,
-		libraryOptions,
-		identityIdProvider,
-	} = config;
-	const { bucket, region, dangerouslyConnectToHttpEndpointForTesting } =
-		serviceOptions ?? {};
-	assertValidationError(!!bucket, StorageValidationErrorCode.NoBucket);
-	assertValidationError(!!region, StorageValidationErrorCode.NoRegion);
-	const identityId = await identityIdProvider();
-	const {
+		bucket,
+		region,
+		dangerouslyConnectToHttpEndpointForTesting,
 		defaultAccessLevel,
 		prefixResolver = defaultPrefixResolver,
 		isObjectLockEnabled,
-	} = libraryOptions ?? {};
+		identityIdProvider,
+	} = config;
+
+	assertValidationError(!!bucket, StorageValidationErrorCode.NoBucket);
+	assertValidationError(!!region, StorageValidationErrorCode.NoRegion);
+	const identityId = await identityIdProvider();
+
 	const keyPrefix = await prefixResolver({
 		accessLevel:
 			apiOptions?.accessLevel ?? defaultAccessLevel ?? DEFAULT_ACCESS_LEVEL,

--- a/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
+++ b/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
@@ -42,6 +42,7 @@ export const resolveS3ConfigAndInput = async ({
 		libraryOptions,
 		identityIdProvider,
 	} = config;
+	console.log(serviceOptions);
 	const { bucket, region, dangerouslyConnectToHttpEndpointForTesting } =
 		serviceOptions ?? {};
 	assertValidationError(!!bucket, StorageValidationErrorCode.NoBucket);

--- a/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
+++ b/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
@@ -42,7 +42,6 @@ export const resolveS3ConfigAndInput = async ({
 		libraryOptions,
 		identityIdProvider,
 	} = config;
-	console.log(serviceOptions);
 	const { bucket, region, dangerouslyConnectToHttpEndpointForTesting } =
 		serviceOptions ?? {};
 	assertValidationError(!!bucket, StorageValidationErrorCode.NoBucket);

--- a/packages/storage/src/types/inputs.ts
+++ b/packages/storage/src/types/inputs.ts
@@ -85,12 +85,14 @@ export type StorageUploadDataInputWithPath<Options> =
 export interface StorageCopyInputWithKey<
 	SourceOptions extends StorageOptions,
 	DestinationOptions extends StorageOptions,
-> {
+	Options,
+> extends StorageOperationOptionsInput<Options> {
 	source: SourceOptions;
 	destination: DestinationOptions;
 }
 
-export interface StorageCopyInputWithPath {
+export interface StorageCopyInputWithPath<Options>
+	extends StorageOperationOptionsInput<Options> {
 	source: StorageOperationInputWithPath;
 	destination: StorageOperationInputWithPath;
 }


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Integrates the `locationCredentialsProvider` into the Storage APIs

The following changes will throw an exception,
 - if and only if `locationCredentialsProvider` is defined, and
 	- `path` is not a string;
 	- `bucket` is an empty `string` or is not defined;
 - if `bucket` and `region` are not defined from the Amplify singleton or API input

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
