### PR TITLE
fix(rtn-push-notification): wrong completion handler key

### DIFF
--- a/packages/rtn-push-notification/ios/AmplifyRTNPushNotificationManager.swift
+++ b/packages/rtn-push-notification/ios/AmplifyRTNPushNotificationManager.swift
@@ -172,7 +172,7 @@ class AmplifyRTNPushNotificationManager  {
                 let completionHandlerId = UUID().uuidString
                 var userInfoCopy = userInfo
 
-                remoteNotificationCompletionHandlers[completionHandlerIdKey] = completionHandler
+                remoteNotificationCompletionHandlers[completionHandlerId] = completionHandler
                 userInfoCopy[completionHandlerIdKey] = completionHandlerId
 
                 sharedEventManager.sendEventToJS(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fix: wrong key was use in the dictionary that holds remote notification completion handlers.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
