### PR TITLE
feat(storage): enables location credentials provider

### DIFF
--- a/packages/storage/__tests__/providers/s3/apis/utils/resolveS3ConfigAndInput.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/resolveS3ConfigAndInput.test.ts
@@ -182,7 +182,7 @@ describe('resolveS3ConfigAndInput', () => {
 	it('should resolve prefix with given access level', async () => {
 		mockDefaultResolvePrefix.mockResolvedValueOnce('prefix');
 		const { keyPrefix } = await resolveS3ConfigAndInput(Amplify, {
-			accessLevel: 'someLevel' as any,
+			options: { accessLevel: 'someLevel' as any },
 		});
 		expect(mockDefaultResolvePrefix).toHaveBeenCalledWith({
 			accessLevel: 'someLevel',
@@ -232,7 +232,9 @@ describe('resolveS3ConfigAndInput', () => {
 				},
 			});
 			const { s3Config } = await resolveS3ConfigAndInput(Amplify, {
-				locationCredentialsProvider: mockLocationCredentialsProvider,
+				options: {
+					locationCredentialsProvider: mockLocationCredentialsProvider,
+				},
 			});
 
 			if (typeof s3Config.credentials === 'function') {
@@ -267,18 +269,16 @@ describe('resolveS3ConfigAndInput', () => {
 			const testCases = [...deprecatedInputs, ...callbackPathInputs];
 
 			it.each(testCases)('should throw when input is %s', async input => {
-				const { s3Config } = await resolveS3ConfigAndInput(
-					Amplify,
-					{ locationCredentialsProvider: mockLocationCredentialsProvider },
-					input,
-				);
+				const { s3Config } = await resolveS3ConfigAndInput(Amplify, {
+					...input,
+					options: {
+						locationCredentialsProvider: mockLocationCredentialsProvider,
+					},
+				});
 				if (typeof s3Config.credentials === 'function') {
 					await expect(s3Config.credentials()).rejects.toThrow(
 						expect.objectContaining({
 							name: INVALID_STORAGE_INPUT,
-							message: 'The input needs to have a path as a string value.',
-							recoverySuggestion:
-								'Please provide a valid path as a string value for the input.',
 						}),
 					);
 				} else {

--- a/packages/storage/__tests__/providers/s3/apis/utils/resolveS3ConfigAndInput.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/resolveS3ConfigAndInput.test.ts
@@ -246,6 +246,23 @@ describe('resolveS3ConfigAndInput', () => {
 			}
 		});
 
+		it('should not throw when path is pass as a string', async () => {
+			const { s3Config } = await resolveS3ConfigAndInput(Amplify, {
+				path: 'my-path',
+				options: {
+					locationCredentialsProvider: mockLocationCredentialsProvider,
+				},
+			});
+
+			if (typeof s3Config.credentials === 'function') {
+				const result = await s3Config.credentials();
+				expect(mockLocationCredentialsProvider).toHaveBeenCalled();
+				expect(result).toEqual(credentials);
+			} else {
+				throw new Error('Expect credentials to be a function');
+			}
+		});
+
 		describe('with deprecated or callback paths as inputs', () => {
 			const key = 'mock-value';
 			const prefix = 'mock-value';

--- a/packages/storage/__tests__/providers/s3/apis/utils/resolveS3ConfigAndInput.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/utils/resolveS3ConfigAndInput.test.ts
@@ -276,7 +276,9 @@ describe('resolveS3ConfigAndInput', () => {
 					await expect(s3Config.credentials()).rejects.toThrow(
 						expect.objectContaining({
 							name: INVALID_STORAGE_INPUT,
-							message: 'The storage input needs to pass a string path.',
+							message: 'The input needs to have a path as a string value.',
+							recoverySuggestion:
+								'Please provide a valid path as a string value for the input.',
 						}),
 					);
 				} else {

--- a/packages/storage/src/errors/constants.ts
+++ b/packages/storage/src/errors/constants.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const INVALID_STORAGE_INPUT = 'InvalidStorageInput';

--- a/packages/storage/src/providers/s3/apis/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/downloadData.ts
@@ -115,7 +115,11 @@ const downloadDataJob =
 	> => {
 		const { options: downloadDataOptions } = downloadDataInput;
 		const { bucket, keyPrefix, s3Config, identityId } =
-			await resolveS3ConfigAndInput(Amplify, downloadDataOptions);
+			await resolveS3ConfigAndInput(
+				Amplify,
+				downloadDataOptions,
+				downloadDataInput as DownloadDataInput,
+			);
 		const { inputType, objectKey } = validateStorageOperationInput(
 			downloadDataInput,
 			identityId,

--- a/packages/storage/src/providers/s3/apis/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/downloadData.ts
@@ -118,7 +118,7 @@ const downloadDataJob =
 			await resolveS3ConfigAndInput(
 				Amplify,
 				downloadDataOptions,
-				downloadDataInput as DownloadDataInput,
+				downloadDataInput,
 			);
 		const { inputType, objectKey } = validateStorageOperationInput(
 			downloadDataInput,

--- a/packages/storage/src/providers/s3/apis/downloadData.ts
+++ b/packages/storage/src/providers/s3/apis/downloadData.ts
@@ -115,11 +115,7 @@ const downloadDataJob =
 	> => {
 		const { options: downloadDataOptions } = downloadDataInput;
 		const { bucket, keyPrefix, s3Config, identityId } =
-			await resolveS3ConfigAndInput(
-				Amplify,
-				downloadDataOptions,
-				downloadDataInput,
-			);
+			await resolveS3ConfigAndInput(Amplify, downloadDataInput);
 		const { inputType, objectKey } = validateStorageOperationInput(
 			downloadDataInput,
 			identityId,

--- a/packages/storage/src/providers/s3/apis/internal/copy.ts
+++ b/packages/storage/src/providers/s3/apis/internal/copy.ts
@@ -42,7 +42,6 @@ const copyWithPath = async (
 	const { source, destination } = input;
 	const { s3Config, bucket, identityId } = await resolveS3ConfigAndInput(
 		amplify,
-		{},
 		input,
 	);
 
@@ -95,11 +94,13 @@ export const copyWithKey = async (
 		s3Config,
 		bucket,
 		keyPrefix: sourceKeyPrefix,
-	} = await resolveS3ConfigAndInput(amplify, input.source, input);
+	} = await resolveS3ConfigAndInput(amplify, {
+		...input,
+		options: input.source,
+	});
 	const { keyPrefix: destinationKeyPrefix } = await resolveS3ConfigAndInput(
 		amplify,
-		input.destination,
-		input,
+		{ ...input, options: input.destination },
 	); // resolveS3ConfigAndInput does not make extra API calls or storage access if called repeatedly.
 
 	// TODO(ashwinkumar6) V6-logger: warn `You may copy files from another user if the source level is "protected", currently it's ${srcLevel}`

--- a/packages/storage/src/providers/s3/apis/internal/copy.ts
+++ b/packages/storage/src/providers/s3/apis/internal/copy.ts
@@ -40,8 +40,11 @@ const copyWithPath = async (
 	input: CopyWithPathInput,
 ): Promise<CopyWithPathOutput> => {
 	const { source, destination } = input;
-	const { s3Config, bucket, identityId } =
-		await resolveS3ConfigAndInput(amplify);
+	const { s3Config, bucket, identityId } = await resolveS3ConfigAndInput(
+		amplify,
+		{},
+		input,
+	);
 
 	assertValidationError(!!source.path, StorageValidationErrorCode.NoSourcePath);
 	assertValidationError(

--- a/packages/storage/src/providers/s3/apis/internal/copy.ts
+++ b/packages/storage/src/providers/s3/apis/internal/copy.ts
@@ -92,10 +92,11 @@ export const copyWithKey = async (
 		s3Config,
 		bucket,
 		keyPrefix: sourceKeyPrefix,
-	} = await resolveS3ConfigAndInput(amplify, input.source);
+	} = await resolveS3ConfigAndInput(amplify, input.source, input);
 	const { keyPrefix: destinationKeyPrefix } = await resolveS3ConfigAndInput(
 		amplify,
 		input.destination,
+		input,
 	); // resolveS3ConfigAndInput does not make extra API calls or storage access if called repeatedly.
 
 	// TODO(ashwinkumar6) V6-logger: warn `You may copy files from another user if the source level is "protected", currently it's ${srcLevel}`

--- a/packages/storage/src/providers/s3/apis/internal/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getProperties.ts
@@ -26,11 +26,7 @@ export const getProperties = async (
 ): Promise<GetPropertiesOutput | GetPropertiesWithPathOutput> => {
 	const { options: getPropertiesOptions } = input;
 	const { s3Config, bucket, keyPrefix, identityId } =
-		await resolveS3ConfigAndInput(
-			amplify,
-			getPropertiesOptions,
-			input as GetPropertiesInput,
-		);
+		await resolveS3ConfigAndInput(amplify, getPropertiesOptions, input);
 	const { inputType, objectKey } = validateStorageOperationInput(
 		input,
 		identityId,

--- a/packages/storage/src/providers/s3/apis/internal/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getProperties.ts
@@ -26,7 +26,11 @@ export const getProperties = async (
 ): Promise<GetPropertiesOutput | GetPropertiesWithPathOutput> => {
 	const { options: getPropertiesOptions } = input;
 	const { s3Config, bucket, keyPrefix, identityId } =
-		await resolveS3ConfigAndInput(amplify, getPropertiesOptions);
+		await resolveS3ConfigAndInput(
+			amplify,
+			getPropertiesOptions,
+			input as GetPropertiesInput,
+		);
 	const { inputType, objectKey } = validateStorageOperationInput(
 		input,
 		identityId,

--- a/packages/storage/src/providers/s3/apis/internal/getProperties.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getProperties.ts
@@ -24,9 +24,8 @@ export const getProperties = async (
 	input: GetPropertiesInput | GetPropertiesWithPathInput,
 	action?: StorageAction,
 ): Promise<GetPropertiesOutput | GetPropertiesWithPathOutput> => {
-	const { options: getPropertiesOptions } = input;
 	const { s3Config, bucket, keyPrefix, identityId } =
-		await resolveS3ConfigAndInput(amplify, getPropertiesOptions, input);
+		await resolveS3ConfigAndInput(amplify, input);
 	const { inputType, objectKey } = validateStorageOperationInput(
 		input,
 		identityId,

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -31,7 +31,7 @@ export const getUrl = async (
 ): Promise<GetUrlOutput | GetUrlWithPathOutput> => {
 	const { options: getUrlOptions } = input;
 	const { s3Config, keyPrefix, bucket, identityId } =
-		await resolveS3ConfigAndInput(amplify, getUrlOptions);
+		await resolveS3ConfigAndInput(amplify, getUrlOptions, input as GetUrlInput);
 	const { inputType, objectKey } = validateStorageOperationInput(
 		input,
 		identityId,

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -31,7 +31,7 @@ export const getUrl = async (
 ): Promise<GetUrlOutput | GetUrlWithPathOutput> => {
 	const { options: getUrlOptions } = input;
 	const { s3Config, keyPrefix, bucket, identityId } =
-		await resolveS3ConfigAndInput(amplify, getUrlOptions, input as GetUrlInput);
+		await resolveS3ConfigAndInput(amplify, getUrlOptions, input);
 	const { inputType, objectKey } = validateStorageOperationInput(
 		input,
 		identityId,

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -31,7 +31,7 @@ export const getUrl = async (
 ): Promise<GetUrlOutput | GetUrlWithPathOutput> => {
 	const { options: getUrlOptions } = input;
 	const { s3Config, keyPrefix, bucket, identityId } =
-		await resolveS3ConfigAndInput(amplify, getUrlOptions, input);
+		await resolveS3ConfigAndInput(amplify, input);
 	const { inputType, objectKey } = validateStorageOperationInput(
 		input,
 		identityId,

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -58,7 +58,7 @@ export const list = async (
 		bucket,
 		keyPrefix: generatedPrefix,
 		identityId,
-	} = await resolveS3ConfigAndInput(amplify, options);
+	} = await resolveS3ConfigAndInput(amplify, options, input as ListAllInput);
 
 	const { inputType, objectKey } = validateStorageOperationInputWithPrefix(
 		input,

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -58,7 +58,7 @@ export const list = async (
 		bucket,
 		keyPrefix: generatedPrefix,
 		identityId,
-	} = await resolveS3ConfigAndInput(amplify, options, input as ListAllInput);
+	} = await resolveS3ConfigAndInput(amplify, options, input);
 
 	const { inputType, objectKey } = validateStorageOperationInputWithPrefix(
 		input,

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -58,7 +58,7 @@ export const list = async (
 		bucket,
 		keyPrefix: generatedPrefix,
 		identityId,
-	} = await resolveS3ConfigAndInput(amplify, options, input);
+	} = await resolveS3ConfigAndInput(amplify, input);
 
 	const { inputType, objectKey } = validateStorageOperationInputWithPrefix(
 		input,

--- a/packages/storage/src/providers/s3/apis/internal/remove.ts
+++ b/packages/storage/src/providers/s3/apis/internal/remove.ts
@@ -25,7 +25,7 @@ export const remove = async (
 ): Promise<RemoveOutput | RemoveWithPathOutput> => {
 	const { options = {} } = input ?? {};
 	const { s3Config, keyPrefix, bucket, identityId } =
-		await resolveS3ConfigAndInput(amplify, options);
+		await resolveS3ConfigAndInput(amplify, options, input as RemoveInput);
 
 	const { inputType, objectKey } = validateStorageOperationInput(
 		input,

--- a/packages/storage/src/providers/s3/apis/internal/remove.ts
+++ b/packages/storage/src/providers/s3/apis/internal/remove.ts
@@ -23,9 +23,8 @@ export const remove = async (
 	amplify: AmplifyClassV6,
 	input: RemoveInput | RemoveWithPathInput,
 ): Promise<RemoveOutput | RemoveWithPathOutput> => {
-	const { options = {} } = input ?? {};
 	const { s3Config, keyPrefix, bucket, identityId } =
-		await resolveS3ConfigAndInput(amplify, options, input);
+		await resolveS3ConfigAndInput(amplify, input);
 
 	const { inputType, objectKey } = validateStorageOperationInput(
 		input,

--- a/packages/storage/src/providers/s3/apis/internal/remove.ts
+++ b/packages/storage/src/providers/s3/apis/internal/remove.ts
@@ -25,7 +25,7 @@ export const remove = async (
 ): Promise<RemoveOutput | RemoveWithPathOutput> => {
 	const { options = {} } = input ?? {};
 	const { s3Config, keyPrefix, bucket, identityId } =
-		await resolveS3ConfigAndInput(amplify, options, input as RemoveInput);
+		await resolveS3ConfigAndInput(amplify, options, input);
 
 	const { inputType, objectKey } = validateStorageOperationInput(
 		input,

--- a/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
@@ -74,7 +74,7 @@ export const getMultipartUploadHandlers = (
 		const resolvedS3Options = await resolveS3ConfigAndInput(
 			Amplify,
 			uploadDataOptions,
-			uploadDataInput as UploadDataInput,
+			uploadDataInput,
 		);
 
 		abortController = new AbortController();

--- a/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
@@ -74,6 +74,7 @@ export const getMultipartUploadHandlers = (
 		const resolvedS3Options = await resolveS3ConfigAndInput(
 			Amplify,
 			uploadDataOptions,
+			uploadDataInput as UploadDataInput,
 		);
 
 		abortController = new AbortController();

--- a/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/multipart/uploadHandlers.ts
@@ -73,7 +73,6 @@ export const getMultipartUploadHandlers = (
 		const { options: uploadDataOptions, data } = uploadDataInput;
 		const resolvedS3Options = await resolveS3ConfigAndInput(
 			Amplify,
-			uploadDataOptions,
 			uploadDataInput,
 		);
 

--- a/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
@@ -29,7 +29,11 @@ export const putObjectJob =
 	async (): Promise<ItemWithKey | ItemWithPath> => {
 		const { options: uploadDataOptions, data } = uploadDataInput;
 		const { bucket, keyPrefix, s3Config, isObjectLockEnabled, identityId } =
-			await resolveS3ConfigAndInput(Amplify, uploadDataOptions);
+			await resolveS3ConfigAndInput(
+				Amplify,
+				uploadDataOptions,
+				uploadDataInput as UploadDataInput,
+			);
 		const { inputType, objectKey } = validateStorageOperationInput(
 			uploadDataInput,
 			identityId,

--- a/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
@@ -29,11 +29,7 @@ export const putObjectJob =
 	async (): Promise<ItemWithKey | ItemWithPath> => {
 		const { options: uploadDataOptions, data } = uploadDataInput;
 		const { bucket, keyPrefix, s3Config, isObjectLockEnabled, identityId } =
-			await resolveS3ConfigAndInput(
-				Amplify,
-				uploadDataOptions,
-				uploadDataInput,
-			);
+			await resolveS3ConfigAndInput(Amplify, uploadDataInput);
 		const { inputType, objectKey } = validateStorageOperationInput(
 			uploadDataInput,
 			identityId,

--- a/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
@@ -32,7 +32,7 @@ export const putObjectJob =
 			await resolveS3ConfigAndInput(
 				Amplify,
 				uploadDataOptions,
-				uploadDataInput as UploadDataInput,
+				uploadDataInput,
 			);
 		const { inputType, objectKey } = validateStorageOperationInput(
 			uploadDataInput,

--- a/packages/storage/src/providers/s3/types/inputs.ts
+++ b/packages/storage/src/providers/s3/types/inputs.ts
@@ -35,7 +35,7 @@ import {
 	UploadDataOptionsWithPath,
 } from '../types';
 
-import { CommonOptions } from './options';
+import { LocationCredentialsProvider } from './options';
 
 // TODO: support use accelerate endpoint option
 /**
@@ -45,14 +45,14 @@ import { CommonOptions } from './options';
 export type CopyInput = StorageCopyInputWithKey<
 	CopySourceOptionsWithKey,
 	CopyDestinationOptionsWithKey,
-	Pick<CommonOptions, 'locationCredentialsProvider'>
+	{ locationCredentialsProvider?: LocationCredentialsProvider }
 >;
 /**
  * Input type with path for S3 copy API.
  */
-export type CopyWithPathInput = StorageCopyInputWithPath<
-	Pick<CommonOptions, 'locationCredentialsProvider'>
->;
+export type CopyWithPathInput = StorageCopyInputWithPath<{
+	locationCredentialsProvider?: LocationCredentialsProvider;
+}>;
 
 /**
  * @deprecated Use {@link GetPropertiesWithPathInput} instead.

--- a/packages/storage/src/providers/s3/types/inputs.ts
+++ b/packages/storage/src/providers/s3/types/inputs.ts
@@ -44,8 +44,7 @@ import { LocationCredentialsProvider } from './options';
  */
 export type CopyInput = StorageCopyInputWithKey<
 	CopySourceOptionsWithKey,
-	CopyDestinationOptionsWithKey,
-	{ locationCredentialsProvider?: LocationCredentialsProvider }
+	CopyDestinationOptionsWithKey
 >;
 /**
  * Input type with path for S3 copy API.

--- a/packages/storage/src/providers/s3/types/inputs.ts
+++ b/packages/storage/src/providers/s3/types/inputs.ts
@@ -35,6 +35,8 @@ import {
 	UploadDataOptionsWithPath,
 } from '../types';
 
+import { CommonOptions } from './options';
+
 // TODO: support use accelerate endpoint option
 /**
  * @deprecated Use {@link CopyWithPathInput} instead.
@@ -42,12 +44,15 @@ import {
  */
 export type CopyInput = StorageCopyInputWithKey<
 	CopySourceOptionsWithKey,
-	CopyDestinationOptionsWithKey
+	CopyDestinationOptionsWithKey,
+	Pick<CommonOptions, 'locationCredentialsProvider'>
 >;
 /**
  * Input type with path for S3 copy API.
  */
-export type CopyWithPathInput = StorageCopyInputWithPath;
+export type CopyWithPathInput = StorageCopyInputWithPath<
+	Pick<CommonOptions, 'locationCredentialsProvider'>
+>;
 
 /**
  * @deprecated Use {@link GetPropertiesWithPathInput} instead.

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -18,7 +18,7 @@ export type LocationCredentialsProvider = (options?: {
 	forceRefresh?: boolean;
 }) => Promise<{ credentials: AWSCredentials }>;
 
-export interface CommonOptions {
+interface CommonOptions {
 	/**
 	 * Whether to use accelerate endpoint.
 	 * @default false

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -18,7 +18,7 @@ export type LocationCredentialsProvider = (options?: {
 	forceRefresh?: boolean;
 }) => Promise<{ credentials: AWSCredentials }>;
 
-interface CommonOptions {
+export interface CommonOptions {
 	/**
 	 * Whether to use accelerate endpoint.
 	 * @default false

--- a/packages/storage/src/providers/s3/utils/resolveIdentityId.ts
+++ b/packages/storage/src/providers/s3/utils/resolveIdentityId.ts
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { StorageValidationErrorCode } from '../../../errors/types/validation';
+import { assertValidationError } from '../../../errors/utils/assertValidationError';
+
+export const resolveIdentityId = (identityId?: string): string => {
+	assertValidationError(!!identityId, StorageValidationErrorCode.NoIdentityId);
+
+	return identityId;
+};

--- a/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
+++ b/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
@@ -164,7 +164,9 @@ const assertStorageInput = (
 	if (isDeprecatedInput(input) || isInputWithCallbackPath(input)) {
 		throw new StorageError({
 			name: INVALID_STORAGE_INPUT,
-			message: 'The storage input needs to pass a string path.',
+			message: 'The input needs to have a path as a string value',
+			recoverySuggestion:
+				'Please provide a valid path as a string value for the input.',
 		});
 	}
 };

--- a/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
+++ b/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
@@ -164,7 +164,7 @@ const assertStorageInput = (
 	if (isDeprecatedInput(input) || isInputWithCallbackPath(input)) {
 		throw new StorageError({
 			name: INVALID_STORAGE_INPUT,
-			message: 'The input needs to have a path as a string value',
+			message: 'The input needs to have a path as a string value.',
 			recoverySuggestion:
 				'Please provide a valid path as a string value for the input.',
 		});

--- a/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
+++ b/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
@@ -17,7 +17,21 @@ import {
 	StorageOperationInputWithPrefix,
 } from '../../../types/inputs';
 import { StorageError } from '../../../errors/StorageError';
-import { CopyInput } from '../types';
+import {
+	CopyInput,
+	CopyWithPathInput,
+	DownloadDataInput,
+	DownloadDataWithPathInput,
+	GetPropertiesInput,
+	GetPropertiesWithPathInput,
+	GetUrlInput,
+	GetUrlWithPathInput,
+	ListAllInput,
+	ListAllWithPathInput,
+	ListPaginateInput,
+	ListPaginateWithPathInput,
+	RemoveWithPathInput,
+} from '../types';
 import { INVALID_STORAGE_INPUT } from '../../../errors/constants';
 
 import { DEFAULT_ACCESS_LEVEL, LOCAL_TESTING_S3_ENDPOINT } from './constants';
@@ -37,13 +51,29 @@ interface ResolvedS3ConfigAndInput {
 	identityId?: string;
 }
 export type DeprecatedStorageInput =
+	| DownloadDataInput
+	| GetUrlInput
 	| StorageOperationInputWithKey
 	| StorageOperationInputWithPrefix
+	| CopyInput
+	| ListAllInput
+	| ListPaginateInput
+	| GetPropertiesInput
 	| CopyInput;
 
 export type CallbackPathStorageInput =
 	| StorageOperationInputWithPath
 	| StorageCopyInputWithPath;
+
+type StorageInput =
+	| DeprecatedStorageInput
+	| DownloadDataWithPathInput
+	| RemoveWithPathInput
+	| ListAllWithPathInput
+	| ListPaginateWithPathInput
+	| GetPropertiesWithPathInput
+	| GetUrlWithPathInput
+	| CopyWithPathInput;
 
 /**
  * resolve the common input options for S3 API handlers from Amplify configuration and library options.
@@ -58,9 +88,9 @@ export type CallbackPathStorageInput =
  */
 export const resolveS3ConfigAndInput = async (
 	amplify: AmplifyClassV6,
-	apiOptions?: S3ApiOptions,
-	input?: DeprecatedStorageInput | CallbackPathStorageInput,
+	apiInput?: StorageInput & { options?: S3ApiOptions },
 ): Promise<ResolvedS3ConfigAndInput> => {
+	const { options: apiOptions } = apiInput ?? {};
 	/**
 	 * IdentityId is always cached in memory so we can safely make calls here. It
 	 * should be stable even for unauthenticated users, regardless of credentials.
@@ -75,7 +105,9 @@ export const resolveS3ConfigAndInput = async (
 	 */
 	const credentialsProvider = async () => {
 		if (isLocationCredentialsProvider(apiOptions)) {
-			assertStorageInput(input);
+			assertStorageInput(
+				apiInput as DeprecatedStorageInput | CallbackPathStorageInput,
+			);
 		}
 
 		const { credentials } = isLocationCredentialsProvider(apiOptions)

--- a/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
+++ b/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
@@ -6,7 +6,19 @@ import { AmplifyClassV6, StorageAccessLevel } from '@aws-amplify/core';
 import { assertValidationError } from '../../../errors/utils/assertValidationError';
 import { StorageValidationErrorCode } from '../../../errors/types/validation';
 import { resolvePrefix as defaultPrefixResolver } from '../../../utils/resolvePrefix';
-import { ResolvedS3Config } from '../types/options';
+import {
+	LocationCredentialsProvider,
+	ResolvedS3Config,
+} from '../types/options';
+import {
+	StorageCopyInputWithPath,
+	StorageOperationInputWithKey,
+	StorageOperationInputWithPath,
+	StorageOperationInputWithPrefix,
+} from '../../../types/inputs';
+import { StorageError } from '../../../errors/StorageError';
+import { CopyInput } from '../types';
+import { INVALID_STORAGE_INPUT } from '../../../errors/constants';
 
 import { DEFAULT_ACCESS_LEVEL, LOCAL_TESTING_S3_ENDPOINT } from './constants';
 
@@ -14,6 +26,7 @@ interface S3ApiOptions {
 	accessLevel?: StorageAccessLevel;
 	targetIdentityId?: string;
 	useAccelerateEndpoint?: boolean;
+	locationCredentialsProvider?: LocationCredentialsProvider;
 }
 
 interface ResolvedS3ConfigAndInput {
@@ -23,7 +36,10 @@ interface ResolvedS3ConfigAndInput {
 	isObjectLockEnabled?: boolean;
 	identityId?: string;
 }
-
+type DeprecatedStorageInput =
+	| StorageOperationInputWithKey
+	| StorageOperationInputWithPrefix
+	| CopyInput;
 /**
  * resolve the common input options for S3 API handlers from Amplify configuration and library options.
  *
@@ -38,13 +54,13 @@ interface ResolvedS3ConfigAndInput {
 export const resolveS3ConfigAndInput = async (
 	amplify: AmplifyClassV6,
 	apiOptions?: S3ApiOptions,
+	input?: DeprecatedStorageInput | StorageOperationInputWithPath,
 ): Promise<ResolvedS3ConfigAndInput> => {
 	/**
 	 * IdentityId is always cached in memory so we can safely make calls here. It
 	 * should be stable even for unauthenticated users, regardless of credentials.
 	 */
 	const { identityId } = await amplify.Auth.fetchAuthSession();
-	assertValidationError(!!identityId, StorageValidationErrorCode.NoIdentityId);
 
 	/**
 	 * A credentials provider function instead of a static credentials object is
@@ -53,7 +69,16 @@ export const resolveS3ConfigAndInput = async (
 	 * credentials if they are expired.
 	 */
 	const credentialsProvider = async () => {
-		const { credentials } = await amplify.Auth.fetchAuthSession();
+		if (isLocationCredentialsProvider(apiOptions)) {
+			assertStorageInput(input);
+		}
+
+		const { credentials } = isLocationCredentialsProvider(apiOptions)
+			? await apiOptions.locationCredentialsProvider({
+					locations: [],
+					permission: 'READ',
+				})
+			: await amplify.Auth.fetchAuthSession();
 		assertValidationError(
 			!!credentials,
 			StorageValidationErrorCode.NoCredentials,
@@ -100,4 +125,54 @@ export const resolveS3ConfigAndInput = async (
 		identityId,
 		isObjectLockEnabled,
 	};
+};
+
+const isLocationCredentialsProvider = (
+	options?: S3ApiOptions,
+): options is S3ApiOptions & {
+	locationCredentialsProvider: LocationCredentialsProvider;
+} => {
+	return !!options?.locationCredentialsProvider;
+};
+
+const isInputWithCallbackPath = (
+	input?: StorageOperationInputWithPath | StorageCopyInputWithPath,
+) => {
+	return (
+		((input as StorageOperationInputWithPath)?.path &&
+			typeof (input as StorageOperationInputWithPath).path === 'function') ||
+		((input as StorageCopyInputWithPath)?.destination?.path &&
+			typeof (input as StorageCopyInputWithPath).destination.path ===
+				'function') ||
+		((input as StorageCopyInputWithPath)?.source?.path &&
+			typeof (input as StorageCopyInputWithPath).source.path === 'function')
+	);
+};
+const isDeprecatedInput = (
+	input?:
+		| DeprecatedStorageInput
+		| StorageOperationInputWithPath
+		| StorageCopyInputWithPath,
+): input is DeprecatedStorageInput => {
+	return !!(
+		(input as StorageOperationInputWithKey)?.key ||
+		(input as StorageOperationInputWithPrefix)?.prefix ||
+		(input as CopyInput)?.destination.accessLevel ||
+		(input as CopyInput)?.source.accessLevel ||
+		(input as CopyInput)?.destination.key ||
+		(input as CopyInput)?.source.key
+	);
+};
+const assertStorageInput = (
+	input?:
+		| DeprecatedStorageInput
+		| StorageOperationInputWithPath
+		| StorageCopyInputWithPath,
+) => {
+	if (isDeprecatedInput(input) || isInputWithCallbackPath(input)) {
+		throw new StorageError({
+			name: INVALID_STORAGE_INPUT,
+			message: 'The storage input needs to pass a string path.',
+		});
+	}
 };

--- a/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
+++ b/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
@@ -148,16 +148,14 @@ const isInputWithCallbackPath = (input?: CallbackPathStorageInput) => {
 			typeof (input as StorageCopyInputWithPath).source?.path === 'function')
 	);
 };
+
 const isDeprecatedInput = (
 	input?: DeprecatedStorageInput | CallbackPathStorageInput,
 ): input is DeprecatedStorageInput => {
-	return !!(
-		(input as StorageOperationInputWithKey)?.key ||
-		(input as StorageOperationInputWithPrefix)?.prefix ||
-		(input as CopyInput)?.destination?.key ||
-		(input as CopyInput)?.source?.key ||
-		(input as CopyInput)?.destination?.accessLevel ||
-		(input as CopyInput)?.source?.accessLevel
+	return (
+		isInputWithKey(input) ||
+		isInputWithPrefix(input) ||
+		isInputWithCopySourceOrDestination(input)
 	);
 };
 const assertStorageInput = (
@@ -169,4 +167,31 @@ const assertStorageInput = (
 			message: 'The storage input needs to pass a string path.',
 		});
 	}
+};
+
+const isInputWithKey = (
+	input?: DeprecatedStorageInput | CallbackPathStorageInput,
+): input is StorageOperationInputWithKey => {
+	return !!(
+		(input as StorageOperationInputWithKey)?.key &&
+		typeof (input as StorageOperationInputWithKey).key === 'string'
+	);
+};
+const isInputWithPrefix = (
+	input?: DeprecatedStorageInput | CallbackPathStorageInput,
+): input is StorageOperationInputWithPrefix => {
+	return !!(
+		(input as StorageOperationInputWithPrefix)?.prefix &&
+		typeof (input as StorageOperationInputWithPrefix).prefix === 'string'
+	);
+};
+const isInputWithCopySourceOrDestination = (
+	input?: CopyInput | CallbackPathStorageInput,
+): input is CopyInput => {
+	return !!(
+		((input as CopyInput)?.source?.key &&
+			typeof (input as CopyInput).source?.key === 'string') ||
+		((input as CopyInput)?.destination?.key &&
+			typeof (input as CopyInput).destination?.key === 'string')
+	);
 };

--- a/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
+++ b/packages/storage/src/providers/s3/utils/validateStorageOperationInput.ts
@@ -7,6 +7,7 @@ import { StorageValidationErrorCode } from '../../../errors/types/validation';
 
 import { isInputWithPath } from './isInputWithPath';
 import { STORAGE_INPUT_KEY, STORAGE_INPUT_PATH } from './constants';
+import { resolveIdentityId } from './resolveIdentityId';
 
 export const validateStorageOperationInput = (
 	input: Input,
@@ -22,7 +23,10 @@ export const validateStorageOperationInput = (
 
 	if (isInputWithPath(input)) {
 		const { path } = input;
-		const objectKey = typeof path === 'string' ? path : path({ identityId });
+		const objectKey =
+			typeof path === 'string'
+				? path
+				: path({ identityId: resolveIdentityId(identityId) });
 
 		assertValidationError(
 			!objectKey.startsWith('/'),

--- a/packages/storage/src/providers/s3/utils/validateStorageOperationInputWithPrefix.ts
+++ b/packages/storage/src/providers/s3/utils/validateStorageOperationInputWithPrefix.ts
@@ -9,6 +9,7 @@ import { assertValidationError } from '../../../errors/utils/assertValidationErr
 import { StorageValidationErrorCode } from '../../../errors/types/validation';
 
 import { STORAGE_INPUT_PATH, STORAGE_INPUT_PREFIX } from './constants';
+import { resolveIdentityId } from './resolveIdentityId';
 
 // Local assertion function with StorageOperationInputWithPrefixPath as Input
 const _isInputWithPath = (
@@ -28,7 +29,10 @@ export const validateStorageOperationInputWithPrefix = (
 	);
 	if (_isInputWithPath(input)) {
 		const { path } = input;
-		const objectKey = typeof path === 'string' ? path : path({ identityId });
+		const objectKey =
+			typeof path === 'string'
+				? path
+				: path({ identityId: resolveIdentityId(identityId) });
 
 		// Assert on no leading slash in the path parameter
 		assertValidationError(

--- a/packages/storage/src/types/inputs.ts
+++ b/packages/storage/src/types/inputs.ts
@@ -85,12 +85,14 @@ export type StorageUploadDataInputWithPath<Options> =
 export interface StorageCopyInputWithKey<
 	SourceOptions extends StorageOptions,
 	DestinationOptions extends StorageOptions,
-> {
+	Options,
+> extends StorageOperationOptionsInput<Options> {
 	source: SourceOptions;
 	destination: DestinationOptions;
 }
 
-export interface StorageCopyInputWithPath {
+export interface StorageCopyInputWithPath<Options = unknown>
+	extends StorageOperationOptionsInput<Options> {
 	source: StorageOperationInputWithPath;
 	destination: StorageOperationInputWithPath;
 }

--- a/packages/storage/src/types/inputs.ts
+++ b/packages/storage/src/types/inputs.ts
@@ -85,8 +85,7 @@ export type StorageUploadDataInputWithPath<Options> =
 export interface StorageCopyInputWithKey<
 	SourceOptions extends StorageOptions,
 	DestinationOptions extends StorageOptions,
-	Options,
-> extends StorageOperationOptionsInput<Options> {
+> {
 	source: SourceOptions;
 	destination: DestinationOptions;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The following PR enables the location credentials provider on the `resolveS3ConfigAndInput` helper. This helper is used by all of the storage APIs.

##### Main changes:

- Removed `identityId` assertion in the `resolveS3ConfigAndInput` helper  — doubled check with @AllanZhengYP already. The assertion of the `identityId` is not needed by the underlying service APIs. 
- The `credentialsProvider` in the `resolveS3ConfigAndInput` function is asserting for a `deprecated` input or a callback `path` if and only if a `locationCredentialsProvider` is passed in the Storage option inputs.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
- unit tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
