### PR TITLE
fix(storage): omit subPathStrategy when prefix is defined

### DIFF
--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -81,7 +81,9 @@ export const list = async (
 		Prefix: isInputWithPrefix ? `${generatedPrefix}${objectKey}` : objectKey,
 		MaxKeys: options?.listAll ? undefined : options?.pageSize,
 		ContinuationToken: options?.listAll ? undefined : options?.nextToken,
-		Delimiter: getDelimiter(options.subpathStrategy),
+		Delimiter: getDelimiter(
+			(options as ListAllWithPathInput['options'])?.subpathStrategy,
+		),
 	};
 	logger.debug(`listing items from "${listParams.Prefix}"`);
 

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -70,7 +70,10 @@ export type RemoveOptions = WriteOptions & CommonOptions;
  * @deprecated Use {@link ListAllOptionsWithPath} instead.
  * Input options type with prefix for S3 list all API.
  */
-export type ListAllOptionsWithPrefix = StorageListAllOptions &
+export type ListAllOptionsWithPrefix = Omit<
+	StorageListAllOptions,
+	'subpathStrategy'
+> &
 	ReadOptions &
 	CommonOptions;
 
@@ -78,7 +81,10 @@ export type ListAllOptionsWithPrefix = StorageListAllOptions &
  * @deprecated Use {@link ListPaginateOptionsWithPath} instead.
  * Input options type with prefix for S3 list API to paginate items.
  */
-export type ListPaginateOptionsWithPrefix = StorageListPaginateOptions &
+export type ListPaginateOptionsWithPrefix = Omit<
+	StorageListAllOptions,
+	'subpathStrategy'
+> &
 	ReadOptions &
 	CommonOptions;
 

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -71,22 +71,18 @@ export type RemoveOptions = WriteOptions & CommonOptions;
  * Input options type with prefix for S3 list all API.
  */
 export type ListAllOptionsWithPrefix = Omit<
-	StorageListAllOptions,
+	StorageListAllOptions & ReadOptions & CommonOptions,
 	'subpathStrategy'
-> &
-	ReadOptions &
-	CommonOptions;
+>;
 
 /**
  * @deprecated Use {@link ListPaginateOptionsWithPath} instead.
  * Input options type with prefix for S3 list API to paginate items.
  */
 export type ListPaginateOptionsWithPrefix = Omit<
-	StorageListAllOptions,
+	StorageListPaginateOptions & ReadOptions & CommonOptions,
 	'subpathStrategy'
-> &
-	ReadOptions &
-	CommonOptions;
+>;
 
 /**
  * Input options type with path for S3 list all API.

--- a/packages/storage/src/providers/s3/types/outputs.ts
+++ b/packages/storage/src/providers/s3/types/outputs.ts
@@ -94,7 +94,10 @@ export type GetPropertiesWithPathOutput = ItemBase & StorageItemWithPath;
  * @deprecated Use {@link ListAllWithPathOutput} instead.
  * Output type for S3 list API. Lists all bucket objects.
  */
-export type ListAllOutput = StorageListOutput<ListOutputItem>;
+export type ListAllOutput = Omit<
+	StorageListOutput<ListOutputItem>,
+	'excludedSubpaths'
+>;
 
 /**
  * Output type with path for S3 list API. Lists all bucket objects.
@@ -105,7 +108,10 @@ export type ListAllWithPathOutput = StorageListOutput<ListOutputItemWithPath>;
  * @deprecated Use {@link ListPaginateWithPathOutput} instead.
  * Output type for S3 list API. Lists bucket objects with pagination.
  */
-export type ListPaginateOutput = StorageListOutput<ListOutputItem> & {
+export type ListPaginateOutput = Omit<
+	StorageListOutput<ListOutputItem>,
+	'excludedSubpaths'
+> & {
 	nextToken?: string;
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The `subpathStrategy` option is currently added to the `prefix` input of the `list`, which is deprecated already. This change is excluding the `subpathStrategy` key when the `list` API has `prefix` as part of the input.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
- smoke test
***before***:
<img width="468" alt="Screenshot 2024-07-17 at 3 31 31 PM" src="https://github.com/user-attachments/assets/2708b642-ecaa-4eb5-b831-886bb4f9b598">

***after***:
<img width="286" alt="Screenshot 2024-07-17 at 3 38 35 PM" src="https://github.com/user-attachments/assets/abf62e30-91d2-4f1a-907f-af41bb1ffabb">




#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
