### PR TITLE
 chore: expose path storage-browser from scoped package

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -95,6 +95,11 @@
 			"import": "./dist/esm/providers/s3/server.mjs",
 			"require": "./dist/cjs/providers/s3/server.js"
 		},
+		"./storage-browser": {
+			"types": "./dist/esm/storageBrowser/index.d.ts",
+			"import": "./dist/esm/storageBrowser/index.mjs",
+			"require": "./dist/cjs/storageBrowser/index.js"
+		},
 		"./package.json": "./package.json"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
#### Description of changes
Expose path `@aws-amplify/storage/storage-browser` on Storage package

#### Description of how you validated changes
Tested on sampleApp


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)


#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
