### PR TITLE
Revert "fix(storage): omit subPathStrategy when prefix is defined 

### DIFF
--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -20,11 +20,7 @@ import {
 	resolveS3ConfigAndInput,
 	validateStorageOperationInputWithPrefix,
 } from '../../utils';
-import {
-	ListAllOptionsWithPath,
-	ListPaginateOptionsWithPath,
-	ResolvedS3Config,
-} from '../../types/options';
+import { ResolvedS3Config } from '../../types/options';
 import {
 	ListObjectsV2Input,
 	ListObjectsV2Output,
@@ -34,6 +30,7 @@ import { getStorageUserAgentValue } from '../../utils/userAgent';
 import { logger } from '../../../../utils';
 import { DEFAULT_DELIMITER, STORAGE_INPUT_PREFIX } from '../../utils/constants';
 import { CommonPrefix } from '../../utils/client/types';
+import { StorageSubpathStrategy } from '../../../../types';
 
 const MAX_PAGE_SIZE = 1000;
 
@@ -79,13 +76,12 @@ export const list = async (
 			} ${anyOptions?.nextToken ? `nextToken: ${anyOptions?.nextToken}` : ''}.`,
 		);
 	}
-
 	const listParams = {
 		Bucket: bucket,
 		Prefix: isInputWithPrefix ? `${generatedPrefix}${objectKey}` : objectKey,
 		MaxKeys: options?.listAll ? undefined : options?.pageSize,
 		ContinuationToken: options?.listAll ? undefined : options?.nextToken,
-		Delimiter: getDelimiter(options),
+		Delimiter: getDelimiter(options.subpathStrategy),
 	};
 	logger.debug(`listing items from "${listParams.Prefix}"`);
 
@@ -267,9 +263,9 @@ const mapCommonPrefixesToExcludedSubpaths = (
 };
 
 const getDelimiter = (
-	options?: ListAllOptionsWithPath | ListPaginateOptionsWithPath,
+	subpathStrategy?: StorageSubpathStrategy,
 ): string | undefined => {
-	if (options?.subpathStrategy?.strategy === 'exclude') {
-		return options?.subpathStrategy?.delimiter ?? DEFAULT_DELIMITER;
+	if (subpathStrategy?.strategy === 'exclude') {
+		return subpathStrategy?.delimiter ?? DEFAULT_DELIMITER;
 	}
 };

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -70,19 +70,17 @@ export type RemoveOptions = WriteOptions & CommonOptions;
  * @deprecated Use {@link ListAllOptionsWithPath} instead.
  * Input options type with prefix for S3 list all API.
  */
-export type ListAllOptionsWithPrefix = Omit<
-	StorageListAllOptions & ReadOptions & CommonOptions,
-	'subpathStrategy'
->;
+export type ListAllOptionsWithPrefix = StorageListAllOptions &
+	ReadOptions &
+	CommonOptions;
 
 /**
  * @deprecated Use {@link ListPaginateOptionsWithPath} instead.
  * Input options type with prefix for S3 list API to paginate items.
  */
-export type ListPaginateOptionsWithPrefix = Omit<
-	StorageListPaginateOptions & ReadOptions & CommonOptions,
-	'subpathStrategy'
->;
+export type ListPaginateOptionsWithPrefix = StorageListPaginateOptions &
+	ReadOptions &
+	CommonOptions;
 
 /**
  * Input options type with path for S3 list all API.

--- a/packages/storage/src/providers/s3/types/outputs.ts
+++ b/packages/storage/src/providers/s3/types/outputs.ts
@@ -94,10 +94,7 @@ export type GetPropertiesWithPathOutput = ItemBase & StorageItemWithPath;
  * @deprecated Use {@link ListAllWithPathOutput} instead.
  * Output type for S3 list API. Lists all bucket objects.
  */
-export type ListAllOutput = Omit<
-	StorageListOutput<ListOutputItem>,
-	'excludedSubpaths'
->;
+export type ListAllOutput = StorageListOutput<ListOutputItem>;
 
 /**
  * Output type with path for S3 list API. Lists all bucket objects.
@@ -108,10 +105,7 @@ export type ListAllWithPathOutput = StorageListOutput<ListOutputItemWithPath>;
  * @deprecated Use {@link ListPaginateWithPathOutput} instead.
  * Output type for S3 list API. Lists bucket objects with pagination.
  */
-export type ListPaginateOutput = Omit<
-	StorageListOutput<ListOutputItem>,
-	'excludedSubpaths'
-> & {
+export type ListPaginateOutput = StorageListOutput<ListOutputItem> & {
 	nextToken?: string;
 };
 


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

The current change is breaking a type from an e2e [test](https://github.com/aws-amplify/amplify-js/actions/runs/9996810032/job/27636498826#logs). I need to chase down the root cause 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
