### PR TITLE
[Chore] Enable Integ test and tagged release on Multi-bucket work

### DIFF
--- a/.github/workflows/push-preid-release.yml
+++ b/.github/workflows/push-preid-release.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       # Change this to your branch name where "example-preid" corresponds to the preid you want your changes released on
-      - feat/example-preid-branch/main
+      - feat/multi-bucket
 
 jobs:
   e2e:

--- a/packages/storage/src/providers/s3/apis/internal/copy.ts
+++ b/packages/storage/src/providers/s3/apis/internal/copy.ts
@@ -29,15 +29,18 @@ const isCopyInputWithPath = (
 const storageBucketAssertion = (
 	sourceBucket?: StorageBucket,
 	destBucket?: StorageBucket,
-) =>
-	// Throw assertion error when either one of bucket options is empty
-	{
-		assertValidationError(
-			(sourceBucket !== undefined && destBucket !== undefined) ||
-				(!destBucket && !sourceBucket),
-			StorageValidationErrorCode.InvalidCopyOperationStorageBucket,
-		);
-	};
+) => {
+	/**  For multi-bucket, both source and destination bucket needs to be passed in
+	 *   or both can be undefined and we fallback to singleton's default value
+	 */
+	assertValidationError(
+		// Both src & dest bucket option is present is acceptable
+		(sourceBucket !== undefined && destBucket !== undefined) ||
+			// or both are undefined is also acceptable
+			(!destBucket && !sourceBucket),
+		StorageValidationErrorCode.InvalidCopyOperationStorageBucket,
+	);
+};
 
 export const copy = async (
 	amplify: AmplifyClassV6,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- This PR enables integ test and tagged release on Multi-bucket branch
- Also adds minor comment improvement on copy assertion to make it clear



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
