### PR TITLE
feat(storage): sync multibucket to storagebrowser

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -293,31 +293,31 @@
 			"name": "[Analytics] record (Pinpoint)",
 			"path": "./dist/esm/analytics/index.mjs",
 			"import": "{ record }",
-			"limit": "17.18 kB"
+			"limit": "17.23 kB"
 		},
 		{
 			"name": "[Analytics] record (Kinesis)",
 			"path": "./dist/esm/analytics/kinesis/index.mjs",
 			"import": "{ record }",
-			"limit": "48.61 kB"
+			"limit": "48.65 kB"
 		},
 		{
 			"name": "[Analytics] record (Kinesis Firehose)",
 			"path": "./dist/esm/analytics/kinesis-firehose/index.mjs",
 			"import": "{ record }",
-			"limit": "45.76 kB"
+			"limit": "45.81 kB"
 		},
 		{
 			"name": "[Analytics] record (Personalize)",
 			"path": "./dist/esm/analytics/personalize/index.mjs",
 			"import": "{ record }",
-			"limit": "49.58 kB"
+			"limit": "49.63 kB"
 		},
 		{
 			"name": "[Analytics] identifyUser (Pinpoint)",
 			"path": "./dist/esm/analytics/index.mjs",
 			"import": "{ identifyUser }",
-			"limit": "15.68 kB"
+			"limit": "15.73 kB"
 		},
 		{
 			"name": "[Analytics] enable",
@@ -335,7 +335,7 @@
 			"name": "[API] generateClient (AppSync)",
 			"path": "./dist/esm/api/index.mjs",
 			"import": "{ generateClient }",
-			"limit": "40.14 kB"
+			"limit": "40.19 kB"
 		},
 		{
 			"name": "[API] REST API handlers",
@@ -353,13 +353,13 @@
 			"name": "[Auth] resetPassword (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ resetPassword }",
-			"limit": "12.53 kB"
+			"limit": "12.58 kB"
 		},
 		{
 			"name": "[Auth] confirmResetPassword (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmResetPassword }",
-			"limit": "12.47 kB"
+			"limit": "12.52 kB"
 		},
 		{
 			"name": "[Auth] signIn (Cognito)",
@@ -371,7 +371,7 @@
 			"name": "[Auth] resendSignUpCode (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ resendSignUpCode }",
-			"limit": "12.49 kB"
+			"limit": "12.53 kB"
 		},
 		{
 			"name": "[Auth] confirmSignUp (Cognito)",
@@ -383,31 +383,31 @@
 			"name": "[Auth] confirmSignIn (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmSignIn }",
-			"limit": "28.38 kB"
+			"limit": "28.42 kB"
 		},
 		{
 			"name": "[Auth] updateMFAPreference (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ updateMFAPreference }",
-			"limit": "11.83 kB"
+			"limit": "11.87 kB"
 		},
 		{
 			"name": "[Auth] fetchMFAPreference (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ fetchMFAPreference }",
-			"limit": "11.86 kB"
+			"limit": "11.91 kB"
 		},
 		{
 			"name": "[Auth] verifyTOTPSetup (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ verifyTOTPSetup }",
-			"limit": "12.71 kB"
+			"limit": "12.75 kB"
 		},
 		{
 			"name": "[Auth] updatePassword (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ updatePassword }",
-			"limit": "12.73 kB"
+			"limit": "12.76 kB"
 		},
 		{
 			"name": "[Auth] setUpTOTP (Cognito)",
@@ -419,7 +419,7 @@
 			"name": "[Auth] updateUserAttributes (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ updateUserAttributes }",
-			"limit": "11.95 kB"
+			"limit": "11.99 kB"
 		},
 		{
 			"name": "[Auth] getCurrentUser (Cognito)",
@@ -431,73 +431,73 @@
 			"name": "[Auth] confirmUserAttribute (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmUserAttribute }",
-			"limit": "12.71 kB"
+			"limit": "12.75 kB"
 		},
 		{
 			"name": "[Auth] signInWithRedirect (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ signInWithRedirect }",
-			"limit": "21.15 kB"
+			"limit": "21.19 kB"
 		},
 		{
 			"name": "[Auth] fetchUserAttributes (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ fetchUserAttributes }",
-			"limit": "11.77 kB"
+			"limit": "11.82 kB"
 		},
 		{
 			"name": "[Auth] Basic Auth Flow (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ signIn, signOut, fetchAuthSession, confirmSignIn }",
-			"limit": "30.15 kB"
+			"limit": "30.20 kB"
 		},
 		{
 			"name": "[Auth] OAuth Auth Flow (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ signInWithRedirect, signOut, fetchAuthSession }",
-			"limit": "21.58 kB"
+			"limit": "21.62 kB"
 		},
 		{
 			"name": "[Storage] copy (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ copy }",
-			"limit": "14.86 kB"
+			"limit": "15.24 kB"
 		},
 		{
 			"name": "[Storage] downloadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ downloadData }",
-			"limit": "15.45 kB"
+			"limit": "15.76 kB"
 		},
 		{
 			"name": "[Storage] getProperties (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getProperties }",
-			"limit": "14.70 kB"
+			"limit": "15.03 kB"
 		},
 		{
 			"name": "[Storage] getUrl (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getUrl }",
-			"limit": "15.79 kB"
+			"limit": "16.09 kB"
 		},
 		{
 			"name": "[Storage] list (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ list }",
-			"limit": "15.30 kB"
+			"limit": "15.65 kB"
 		},
 		{
 			"name": "[Storage] remove (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ remove }",
-			"limit": "14.56 kB"
+			"limit": "14.88 kB"
 		},
 		{
 			"name": "[Storage] uploadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ uploadData }",
-			"limit": "19.85 kB"
+			"limit": "20.18 kB"
 		}
 	]
 }

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -293,31 +293,31 @@
 			"name": "[Analytics] record (Pinpoint)",
 			"path": "./dist/esm/analytics/index.mjs",
 			"import": "{ record }",
-			"limit": "17.14 kB"
+			"limit": "17.18 kB"
 		},
 		{
 			"name": "[Analytics] record (Kinesis)",
 			"path": "./dist/esm/analytics/kinesis/index.mjs",
 			"import": "{ record }",
-			"limit": "48.56 kB"
+			"limit": "48.61 kB"
 		},
 		{
 			"name": "[Analytics] record (Kinesis Firehose)",
 			"path": "./dist/esm/analytics/kinesis-firehose/index.mjs",
 			"import": "{ record }",
-			"limit": "45.71 kB"
+			"limit": "45.76 kB"
 		},
 		{
 			"name": "[Analytics] record (Personalize)",
 			"path": "./dist/esm/analytics/personalize/index.mjs",
 			"import": "{ record }",
-			"limit": "49.53 kB"
+			"limit": "49.58 kB"
 		},
 		{
 			"name": "[Analytics] identifyUser (Pinpoint)",
 			"path": "./dist/esm/analytics/index.mjs",
 			"import": "{ identifyUser }",
-			"limit": "15.64 kB"
+			"limit": "15.68 kB"
 		},
 		{
 			"name": "[Analytics] enable",
@@ -335,7 +335,7 @@
 			"name": "[API] generateClient (AppSync)",
 			"path": "./dist/esm/api/index.mjs",
 			"import": "{ generateClient }",
-			"limit": "40.09 kB"
+			"limit": "40.14 kB"
 		},
 		{
 			"name": "[API] REST API handlers",
@@ -353,13 +353,13 @@
 			"name": "[Auth] resetPassword (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ resetPassword }",
-			"limit": "12.48 kB"
+			"limit": "12.53 kB"
 		},
 		{
 			"name": "[Auth] confirmResetPassword (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmResetPassword }",
-			"limit": "12.42 kB"
+			"limit": "12.47 kB"
 		},
 		{
 			"name": "[Auth] signIn (Cognito)",
@@ -371,7 +371,7 @@
 			"name": "[Auth] resendSignUpCode (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ resendSignUpCode }",
-			"limit": "12.44 kB"
+			"limit": "12.49 kB"
 		},
 		{
 			"name": "[Auth] confirmSignUp (Cognito)",
@@ -383,31 +383,31 @@
 			"name": "[Auth] confirmSignIn (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmSignIn }",
-			"limit": "28.32 kB"
+			"limit": "28.38 kB"
 		},
 		{
 			"name": "[Auth] updateMFAPreference (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ updateMFAPreference }",
-			"limit": "11.78 kB"
+			"limit": "11.83 kB"
 		},
 		{
 			"name": "[Auth] fetchMFAPreference (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ fetchMFAPreference }",
-			"limit": "11.81 kB"
+			"limit": "11.86 kB"
 		},
 		{
 			"name": "[Auth] verifyTOTPSetup (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ verifyTOTPSetup }",
-			"limit": "12.7 kB"
+			"limit": "12.71 kB"
 		},
 		{
 			"name": "[Auth] updatePassword (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ updatePassword }",
-			"limit": "12.67 kB"
+			"limit": "12.73 kB"
 		},
 		{
 			"name": "[Auth] setUpTOTP (Cognito)",
@@ -419,85 +419,85 @@
 			"name": "[Auth] updateUserAttributes (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ updateUserAttributes }",
-			"limit": "11.87 kB"
+			"limit": "11.95 kB"
 		},
 		{
 			"name": "[Auth] getCurrentUser (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ getCurrentUser }",
-			"limit": "7.75 kB"
+			"limit": "7.85 kB"
 		},
 		{
 			"name": "[Auth] confirmUserAttribute (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmUserAttribute }",
-			"limit": "12.64 kB"
+			"limit": "12.71 kB"
 		},
 		{
 			"name": "[Auth] signInWithRedirect (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ signInWithRedirect }",
-			"limit": "21.10 kB"
+			"limit": "21.15 kB"
 		},
 		{
 			"name": "[Auth] fetchUserAttributes (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ fetchUserAttributes }",
-			"limit": "11.72 kB"
+			"limit": "11.77 kB"
 		},
 		{
 			"name": "[Auth] Basic Auth Flow (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ signIn, signOut, fetchAuthSession, confirmSignIn }",
-			"limit": "30.11 kB"
+			"limit": "30.15 kB"
 		},
 		{
 			"name": "[Auth] OAuth Auth Flow (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ signInWithRedirect, signOut, fetchAuthSession }",
-			"limit": "21.52 kB"
+			"limit": "21.58 kB"
 		},
 		{
 			"name": "[Storage] copy (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ copy }",
-			"limit": "14.9 kB"
+			"limit": "14.86 kB"
 		},
 		{
 			"name": "[Storage] downloadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ downloadData }",
-			"limit": "15.49 kB"
+			"limit": "15.45 kB"
 		},
 		{
 			"name": "[Storage] getProperties (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getProperties }",
-			"limit": "14.77 kB"
+			"limit": "14.70 kB"
 		},
 		{
 			"name": "[Storage] getUrl (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getUrl }",
-			"limit": "15.87 kB"
+			"limit": "15.79 kB"
 		},
 		{
 			"name": "[Storage] list (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ list }",
-			"limit": "15.39 kB"
+			"limit": "15.30 kB"
 		},
 		{
 			"name": "[Storage] remove (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ remove }",
-			"limit": "14.63 kB"
+			"limit": "14.56 kB"
 		},
 		{
 			"name": "[Storage] uploadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ uploadData }",
-			"limit": "19.94 kB"
+			"limit": "19.85 kB"
 		}
 	]
 }

--- a/packages/core/__tests__/parseAmplifyOutputs.test.ts
+++ b/packages/core/__tests__/parseAmplifyOutputs.test.ts
@@ -229,6 +229,71 @@ describe('parseAmplifyOutputs tests', () => {
 				},
 			});
 		});
+		it('should parse storage multi bucket', () => {
+			const amplifyOutputs: AmplifyOutputs = {
+				version: '1',
+				storage: {
+					aws_region: 'us-west-2',
+					bucket_name: 'storage-bucket-test',
+					buckets: [
+						{
+							name: 'default-bucket',
+							bucket_name: 'storage-bucket-test',
+							aws_region: 'us-west-2',
+						},
+						{
+							name: 'bucket-2',
+							bucket_name: 'storage-bucket-test-2',
+							aws_region: 'us-west-2',
+						},
+					],
+				},
+			};
+
+			const result = parseAmplifyOutputs(amplifyOutputs);
+
+			expect(result).toEqual({
+				Storage: {
+					S3: {
+						bucket: 'storage-bucket-test',
+						region: 'us-west-2',
+						buckets: {
+							'bucket-2': {
+								bucketName: 'storage-bucket-test-2',
+								region: 'us-west-2',
+							},
+							'default-bucket': {
+								bucketName: 'storage-bucket-test',
+								region: 'us-west-2',
+							},
+						},
+					},
+				},
+			});
+		});
+		it('should throw for storage multi bucket parsing with same friendly name', () => {
+			const amplifyOutputs: AmplifyOutputs = {
+				version: '1',
+				storage: {
+					aws_region: 'us-west-2',
+					bucket_name: 'storage-bucket-test',
+					buckets: [
+						{
+							name: 'default-bucket',
+							bucket_name: 'storage-bucket-test',
+							aws_region: 'us-west-2',
+						},
+						{
+							name: 'default-bucket',
+							bucket_name: 'storage-bucket-test-2',
+							aws_region: 'us-west-2',
+						},
+					],
+				},
+			};
+
+			expect(() => parseAmplifyOutputs(amplifyOutputs)).toThrow();
+		});
 	});
 
 	describe('analytics tests', () => {

--- a/packages/core/src/parseAmplifyOutputs.ts
+++ b/packages/core/src/parseAmplifyOutputs.ts
@@ -4,7 +4,7 @@
 /* This is because JSON schema contains keys with snake_case */
 /* eslint-disable camelcase */
 
-/* Does not like exahaustive checks */
+/* Does not like exhaustive checks */
 /* eslint-disable no-case-declarations */
 
 import {
@@ -25,11 +25,13 @@ import {
 	AmplifyOutputsDataProperties,
 	AmplifyOutputsGeoProperties,
 	AmplifyOutputsNotificationsProperties,
+	AmplifyOutputsStorageBucketProperties,
 	AmplifyOutputsStorageProperties,
 } from './singleton/AmplifyOutputs/types';
 import {
 	AnalyticsConfig,
 	AuthConfig,
+	BucketInfo,
 	GeoConfig,
 	LegacyConfig,
 	ResourcesConfig,
@@ -56,12 +58,13 @@ function parseStorage(
 		return undefined;
 	}
 
-	const { bucket_name, aws_region } = amplifyOutputsStorageProperties;
+	const { bucket_name, aws_region, buckets } = amplifyOutputsStorageProperties;
 
 	return {
 		S3: {
 			bucket: bucket_name,
 			region: aws_region,
+			buckets: buckets && createBucketInfoMap(buckets),
 		},
 	};
 }
@@ -332,4 +335,25 @@ function getMfaStatus(
 	if (mfaConfiguration === 'REQUIRED') return 'on';
 
 	return 'off';
+}
+
+function createBucketInfoMap(
+	buckets: AmplifyOutputsStorageBucketProperties[],
+): Record<string, BucketInfo> {
+	const mappedBuckets: Record<string, BucketInfo> = {};
+
+	buckets.forEach(({ name, bucket_name: bucketName, aws_region: region }) => {
+		if (name in mappedBuckets) {
+			throw new Error(
+				`Duplicate friendly name found: ${name}. Name must be unique.`,
+			);
+		}
+
+		mappedBuckets[name] = {
+			bucketName,
+			region,
+		};
+	});
+
+	return mappedBuckets;
 }

--- a/packages/core/src/singleton/AmplifyOutputs/types.ts
+++ b/packages/core/src/singleton/AmplifyOutputs/types.ts
@@ -43,9 +43,21 @@ export interface AmplifyOutputsAuthProperties {
 	mfa_methods?: string[];
 }
 
-export interface AmplifyOutputsStorageProperties {
-	aws_region: string;
+export interface AmplifyOutputsStorageBucketProperties {
+	/** Friendly bucket name provided in Amplify Outputs */
+	name: string;
+	/** Actual S3 bucket name given */
 	bucket_name: string;
+	/** Region for the bucket */
+	aws_region: string;
+}
+export interface AmplifyOutputsStorageProperties {
+	/** Default region for Storage */
+	aws_region: string;
+	/** Default bucket for Storage */
+	bucket_name: string;
+	/** List of buckets for Storage */
+	buckets?: AmplifyOutputsStorageBucketProperties[];
 }
 
 export interface AmplifyOutputsGeoProperties {

--- a/packages/core/src/singleton/Storage/types.ts
+++ b/packages/core/src/singleton/Storage/types.ts
@@ -6,6 +6,13 @@ import { AtLeastOne } from '../types';
 /** @deprecated This may be removed in the next major version. */
 export type StorageAccessLevel = 'guest' | 'protected' | 'private';
 
+/** Information on bucket used to store files/objects */
+export interface BucketInfo {
+	/** Actual bucket name */
+	bucketName: string;
+	/** Region of the bucket */
+	region: string;
+}
 export interface S3ProviderConfig {
 	S3: {
 		bucket?: string;
@@ -16,6 +23,8 @@ export interface S3ProviderConfig {
 		 * @internal
 		 */
 		dangerouslyConnectToHttpEndpointForTesting?: string;
+		/** Map of friendly name for bucket to its information  */
+		buckets?: Record<string, BucketInfo>;
 	};
 }
 

--- a/packages/core/src/singleton/types.ts
+++ b/packages/core/src/singleton/types.ts
@@ -19,6 +19,7 @@ import {
 import { GeoConfig } from './Geo/types';
 import { PredictionsConfig } from './Predictions/types';
 import {
+	BucketInfo,
 	LibraryStorageOptions,
 	StorageAccessLevel,
 	StorageConfig,
@@ -77,6 +78,7 @@ export {
 	PredictionsConfig,
 	StorageAccessLevel,
 	StorageConfig,
+	BucketInfo,
 	AnalyticsConfig,
 	CognitoIdentityPoolConfig,
 	GeoConfig,

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -89,19 +89,19 @@
 			"name": "Interactions (default to Lex v2)",
 			"path": "./dist/esm/index.mjs",
 			"import": "{ Interactions }",
-			"limit": "52.55 kB"
+			"limit": "52.61 kB"
 		},
 		{
 			"name": "Interactions (Lex v2)",
 			"path": "./dist/esm/lex-v2/index.mjs",
 			"import": "{ Interactions }",
-			"limit": "52.55 kB"
+			"limit": "52.61 kB"
 		},
 		{
 			"name": "Interactions (Lex v1)",
 			"path": "./dist/esm/lex-v1/index.mjs",
 			"import": "{ Interactions }",
-			"limit": "47.37 kB"
+			"limit": "47.41 kB"
 		}
 	]
 }

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -89,19 +89,19 @@
 			"name": "Interactions (default to Lex v2)",
 			"path": "./dist/esm/index.mjs",
 			"import": "{ Interactions }",
-			"limit": "52.61 kB"
+			"limit": "52.66 kB"
 		},
 		{
 			"name": "Interactions (Lex v2)",
 			"path": "./dist/esm/lex-v2/index.mjs",
 			"import": "{ Interactions }",
-			"limit": "52.61 kB"
+			"limit": "52.66 kB"
 		},
 		{
 			"name": "Interactions (Lex v1)",
 			"path": "./dist/esm/lex-v1/index.mjs",
 			"import": "{ Interactions }",
-			"limit": "47.41 kB"
+			"limit": "47.46 kB"
 		}
 	]
 }

--- a/packages/storage/__tests__/providers/s3/apis/copy.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/copy.test.ts
@@ -15,6 +15,7 @@ import {
 	CopyWithPathOutput,
 } from '../../../../src/providers/s3/types';
 import './testUtils';
+import { BucketInfo } from '../../../../src/providers/s3/types/options';
 
 jest.mock('../../../../src/providers/s3/utils/client/s3data');
 jest.mock('@aws-amplify/core', () => ({
@@ -64,6 +65,7 @@ describe('copy API', () => {
 				S3: {
 					bucket,
 					region,
+					buckets: { 'bucket-1': { bucketName: bucket, region } },
 				},
 			},
 		});
@@ -198,6 +200,34 @@ describe('copy API', () => {
 					});
 				},
 			);
+
+			it('should override bucket in copyObject call when bucket option is passed', async () => {
+				const bucketInfo: BucketInfo = {
+					bucketName: 'bucket-2',
+					region: 'region-2',
+				};
+				await copyWrapper({
+					source: { key: 'sourceKey', bucket: 'bucket-1' },
+					destination: {
+						key: 'destinationKey',
+						bucket: bucketInfo,
+					},
+				});
+				expect(copyObject).toHaveBeenCalledTimes(1);
+				await expect(copyObject).toBeLastCalledWithConfigAndInput(
+					{
+						credentials,
+						region: bucketInfo.region,
+						userAgentValue: expect.any(String),
+					},
+					{
+						Bucket: bucketInfo.bucketName,
+						MetadataDirective: 'COPY',
+						CopySource: `${bucket}/public/sourceKey`,
+						Key: 'public/destinationKey',
+					},
+				);
+			});
 		});
 
 		describe('With path', () => {
@@ -253,6 +283,33 @@ describe('copy API', () => {
 					);
 				},
 			);
+			it('should override bucket in copyObject call when bucket option is passed', async () => {
+				const bucketInfo: BucketInfo = {
+					bucketName: 'bucket-2',
+					region: 'region-2',
+				};
+				await copyWrapper({
+					source: { path: 'sourcePath', bucket: 'bucket-1' },
+					destination: {
+						path: 'destinationPath',
+						bucket: bucketInfo,
+					},
+				});
+				expect(copyObject).toHaveBeenCalledTimes(1);
+				await expect(copyObject).toBeLastCalledWithConfigAndInput(
+					{
+						credentials,
+						region: bucketInfo.region,
+						userAgentValue: expect.any(String),
+					},
+					{
+						Bucket: bucketInfo.bucketName,
+						MetadataDirective: 'COPY',
+						CopySource: `${bucket}/sourcePath`,
+						Key: 'destinationPath',
+					},
+				);
+			});
 		});
 	});
 
@@ -314,6 +371,43 @@ describe('copy API', () => {
 			} catch (error: any) {
 				expect(error).toBeInstanceOf(StorageError);
 				expect(error.name).toBe(StorageValidationErrorCode.NoDestinationKey);
+			}
+		});
+
+		it('should throw an error when only source has bucket option', async () => {
+			expect.assertions(2);
+			try {
+				await copy({
+					source: { path: 'source', bucket: 'bucket-1' },
+					destination: {
+						path: 'destination',
+					},
+				});
+			} catch (error: any) {
+				console.log(error);
+				expect(error).toBeInstanceOf(StorageError);
+				expect(error.name).toBe(
+					StorageValidationErrorCode.InvalidCopyOperationStorageBucket,
+				);
+			}
+		});
+
+		it('should throw an error when only one destination has bucket option', async () => {
+			expect.assertions(2);
+			try {
+				await copy({
+					source: { key: 'source' },
+					destination: {
+						key: 'destination',
+						bucket: 'bucket-1',
+					},
+				});
+			} catch (error: any) {
+				console.log(error);
+				expect(error).toBeInstanceOf(StorageError);
+				expect(error.name).toBe(
+					StorageValidationErrorCode.InvalidCopyOperationStorageBucket,
+				);
 			}
 		});
 	});

--- a/packages/storage/__tests__/providers/s3/apis/downloadData.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/downloadData.test.ts
@@ -24,6 +24,7 @@ import {
 	ItemWithPath,
 } from '../../../../src/providers/s3/types/outputs';
 import './testUtils';
+import { BucketInfo } from '../../../../src/providers/s3/types/options';
 
 jest.mock('../../../../src/providers/s3/utils/client/s3data');
 jest.mock('../../../../src/providers/s3/utils');
@@ -62,7 +63,7 @@ const mockDownloadResultBase = {
 const mockFetchAuthSession = Amplify.Auth.fetchAuthSession as jest.Mock;
 const mockCreateDownloadTask = createDownloadTask as jest.Mock;
 const mockValidateStorageInput = validateStorageOperationInput as jest.Mock;
-const mockGetConfig = Amplify.getConfig as jest.Mock;
+const mockGetConfig = jest.mocked(Amplify.getConfig);
 
 describe('downloadData with key', () => {
 	beforeAll(() => {
@@ -75,6 +76,7 @@ describe('downloadData with key', () => {
 				S3: {
 					bucket,
 					region,
+					buckets: { 'default-bucket': { bucketName: bucket, region } },
 				},
 			},
 		});
@@ -220,6 +222,70 @@ describe('downloadData with key', () => {
 			}),
 		);
 	});
+
+	describe('bucket passed in options', () => {
+		it('should override bucket in getObject call when bucket is object', async () => {
+			(getObject as jest.Mock).mockResolvedValueOnce({ Body: 'body' });
+			const abortController = new AbortController();
+			const bucketInfo: BucketInfo = {
+				bucketName: 'bucket-1',
+				region: 'region-1',
+			};
+
+			downloadData({
+				key: inputKey,
+				options: {
+					bucket: bucketInfo,
+				},
+			});
+
+			const { job } = mockCreateDownloadTask.mock.calls[0][0];
+			await job();
+
+			expect(getObject).toHaveBeenCalledTimes(1);
+			await expect(getObject).toBeLastCalledWithConfigAndInput(
+				{
+					credentials,
+					region: bucketInfo.region,
+					abortSignal: abortController.signal,
+					userAgentValue: expect.any(String),
+				},
+				{
+					Bucket: bucketInfo.bucketName,
+					Key: `public/${inputKey}`,
+				},
+			);
+		});
+
+		it('should override bucket in getObject call when bucket is string', async () => {
+			(getObject as jest.Mock).mockResolvedValueOnce({ Body: 'body' });
+			const abortController = new AbortController();
+
+			downloadData({
+				key: inputKey,
+				options: {
+					bucket: 'default-bucket',
+				},
+			});
+
+			const { job } = mockCreateDownloadTask.mock.calls[0][0];
+			await job();
+
+			expect(getObject).toHaveBeenCalledTimes(1);
+			await expect(getObject).toBeLastCalledWithConfigAndInput(
+				{
+					credentials,
+					region,
+					abortSignal: abortController.signal,
+					userAgentValue: expect.any(String),
+				},
+				{
+					Bucket: bucket,
+					Key: `public/${inputKey}`,
+				},
+			);
+		});
+	});
 });
 
 describe('downloadData with path', () => {
@@ -233,6 +299,7 @@ describe('downloadData with path', () => {
 				S3: {
 					bucket,
 					region,
+					buckets: { 'default-bucket': { bucketName: bucket, region } },
 				},
 			},
 		});
@@ -365,5 +432,69 @@ describe('downloadData with path', () => {
 				Range: `bytes=${start}-${end}`,
 			}),
 		);
+	});
+
+	describe('bucket passed in options', () => {
+		it('should override bucket in getObject call when bucket is object', async () => {
+			(getObject as jest.Mock).mockResolvedValueOnce({ Body: 'body' });
+			const abortController = new AbortController();
+			const bucketInfo: BucketInfo = {
+				bucketName: 'bucket-1',
+				region: 'region-1',
+			};
+
+			downloadData({
+				path: inputPath,
+				options: {
+					bucket: bucketInfo,
+				},
+			});
+
+			const { job } = mockCreateDownloadTask.mock.calls[0][0];
+			await job();
+
+			expect(getObject).toHaveBeenCalledTimes(1);
+			await expect(getObject).toBeLastCalledWithConfigAndInput(
+				{
+					credentials,
+					region: bucketInfo.region,
+					abortSignal: abortController.signal,
+					userAgentValue: expect.any(String),
+				},
+				{
+					Bucket: bucketInfo.bucketName,
+					Key: inputPath,
+				},
+			);
+		});
+
+		it('should override bucket in getObject call when bucket is string', async () => {
+			(getObject as jest.Mock).mockResolvedValueOnce({ Body: 'body' });
+			const abortController = new AbortController();
+
+			downloadData({
+				path: inputPath,
+				options: {
+					bucket: 'default-bucket',
+				},
+			});
+
+			const { job } = mockCreateDownloadTask.mock.calls[0][0];
+			await job();
+
+			expect(getObject).toHaveBeenCalledTimes(1);
+			await expect(getObject).toBeLastCalledWithConfigAndInput(
+				{
+					credentials,
+					region,
+					abortSignal: abortController.signal,
+					userAgentValue: expect.any(String),
+				},
+				{
+					Bucket: bucket,
+					Key: inputPath,
+				},
+			);
+		});
 	});
 });

--- a/packages/storage/__tests__/providers/s3/apis/getProperties.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/getProperties.test.ts
@@ -13,6 +13,7 @@ import {
 	GetPropertiesWithPathOutput,
 } from '../../../../src/providers/s3/types';
 import './testUtils';
+import { BucketInfo } from '../../../../src/providers/s3/types/options';
 
 jest.mock('../../../../src/providers/s3/utils/client/s3data');
 jest.mock('@aws-amplify/core', () => ({
@@ -28,7 +29,7 @@ jest.mock('@aws-amplify/core', () => ({
 }));
 const mockHeadObject = headObject as jest.MockedFunction<typeof headObject>;
 const mockFetchAuthSession = Amplify.Auth.fetchAuthSession as jest.Mock;
-const mockGetConfig = Amplify.getConfig as jest.Mock;
+const mockGetConfig = jest.mocked(Amplify.getConfig);
 
 const bucket = 'bucket';
 const region = 'region';
@@ -65,14 +66,16 @@ describe('getProperties with key', () => {
 				S3: {
 					bucket,
 					region,
+					buckets: { 'default-bucket': { bucketName: bucket, region } },
 				},
 			},
 		});
 	});
+
 	describe('Happy cases: With key', () => {
 		const config = {
 			credentials,
-			region: 'region',
+			region,
 			userAgentValue: expect.any(String),
 		};
 		beforeEach(() => {
@@ -152,6 +155,56 @@ describe('getProperties with key', () => {
 				);
 			},
 		);
+
+		describe('bucket passed in options', () => {
+			it('should override bucket in headObject call when bucket is object', async () => {
+				const bucketInfo: BucketInfo = {
+					bucketName: 'bucket-1',
+					region: 'region-1',
+				};
+				const headObjectOptions = {
+					Bucket: bucketInfo.bucketName,
+					Key: `public/${inputKey}`,
+				};
+
+				await getPropertiesWrapper({
+					key: inputKey,
+					options: {
+						bucket: bucketInfo,
+					},
+				});
+				expect(headObject).toHaveBeenCalledTimes(1);
+				await expect(headObject).toBeLastCalledWithConfigAndInput(
+					{
+						credentials,
+						region: bucketInfo.region,
+
+						userAgentValue: expect.any(String),
+					},
+					headObjectOptions,
+				);
+			});
+			it('should override bucket in headObject call when bucket is string', async () => {
+				await getPropertiesWrapper({
+					key: inputKey,
+					options: {
+						bucket: 'default-bucket',
+					},
+				});
+				expect(headObject).toHaveBeenCalledTimes(1);
+				await expect(headObject).toBeLastCalledWithConfigAndInput(
+					{
+						credentials,
+						region,
+						userAgentValue: expect.any(String),
+					},
+					{
+						Bucket: bucket,
+						Key: `public/${inputKey}`,
+					},
+				);
+			});
+		});
 	});
 
 	describe('Error cases :  With key', () => {
@@ -201,6 +254,7 @@ describe('Happy cases: With path', () => {
 				S3: {
 					bucket,
 					region,
+					buckets: { 'default-bucket': { bucketName: bucket, region } },
 				},
 			},
 		});
@@ -275,6 +329,55 @@ describe('Happy cases: With path', () => {
 				);
 			},
 		);
+		describe('bucket passed in options', () => {
+			it('should override bucket in headObject call when bucket is object', async () => {
+				const bucketInfo: BucketInfo = {
+					bucketName: 'bucket-1',
+					region: 'region-1',
+				};
+				const headObjectOptions = {
+					Bucket: bucketInfo.bucketName,
+					Key: inputPath,
+				};
+
+				await getPropertiesWrapper({
+					path: inputPath,
+					options: {
+						bucket: bucketInfo,
+					},
+				});
+				expect(headObject).toHaveBeenCalledTimes(1);
+				await expect(headObject).toBeLastCalledWithConfigAndInput(
+					{
+						credentials,
+						region: bucketInfo.region,
+
+						userAgentValue: expect.any(String),
+					},
+					headObjectOptions,
+				);
+			});
+			it('should override bucket in headObject call when bucket is string', async () => {
+				await getPropertiesWrapper({
+					path: inputPath,
+					options: {
+						bucket: 'default-bucket',
+					},
+				});
+				expect(headObject).toHaveBeenCalledTimes(1);
+				await expect(headObject).toBeLastCalledWithConfigAndInput(
+					{
+						credentials,
+						region,
+						userAgentValue: expect.any(String),
+					},
+					{
+						Bucket: bucket,
+						Key: inputPath,
+					},
+				);
+			});
+		});
 	});
 
 	describe('Error cases :  With path', () => {

--- a/packages/storage/__tests__/providers/s3/apis/getUrl.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/getUrl.test.ts
@@ -16,6 +16,7 @@ import {
 	GetUrlWithPathOutput,
 } from '../../../../src/providers/s3/types';
 import './testUtils';
+import { BucketInfo } from '../../../../src/providers/s3/types/options';
 
 jest.mock('../../../../src/providers/s3/utils/client/s3data');
 jest.mock('@aws-amplify/core', () => ({
@@ -56,6 +57,7 @@ describe('getUrl test with key', () => {
 				S3: {
 					bucket,
 					region,
+					buckets: { 'default-bucket': { bucketName: bucket, region } },
 				},
 			},
 		});
@@ -135,6 +137,52 @@ describe('getUrl test with key', () => {
 				expect({ url, expiresAt }).toEqual(expectedResult);
 			},
 		);
+		describe('bucket passed in options', () => {
+			it('should override bucket in getPresignedGetObjectUrl call when bucket is object', async () => {
+				const bucketInfo: BucketInfo = {
+					bucketName: 'bucket-1',
+					region: 'region-1',
+				};
+				await getUrlWrapper({
+					key: 'key',
+					options: {
+						bucket: bucketInfo,
+					},
+				});
+				expect(getPresignedGetObjectUrl).toHaveBeenCalledTimes(1);
+				await expect(getPresignedGetObjectUrl).toBeLastCalledWithConfigAndInput(
+					{
+						credentials,
+						region: bucketInfo.region,
+						expiration: expect.any(Number),
+					},
+					{
+						Bucket: bucketInfo.bucketName,
+						Key: 'public/key',
+					},
+				);
+			});
+			it('should override bucket in getPresignedGetObjectUrl call when bucket is string', async () => {
+				await getUrlWrapper({
+					key: 'key',
+					options: {
+						bucket: 'default-bucket',
+					},
+				});
+				expect(getPresignedGetObjectUrl).toHaveBeenCalledTimes(1);
+				await expect(getPresignedGetObjectUrl).toBeLastCalledWithConfigAndInput(
+					{
+						credentials,
+						region,
+						expiration: expect.any(Number),
+					},
+					{
+						Bucket: bucket,
+						Key: 'public/key',
+					},
+				);
+			});
+		});
 	});
 	describe('Error cases :  With key', () => {
 		afterAll(() => {
@@ -175,6 +223,7 @@ describe('getUrl test with path', () => {
 				S3: {
 					bucket,
 					region,
+					buckets: { 'default-bucket': { bucketName: bucket, region } },
 				},
 			},
 		});
@@ -235,7 +284,57 @@ describe('getUrl test with path', () => {
 				});
 			},
 		);
+
+		describe('bucket passed in options', () => {
+			it('should override bucket in getPresignedGetObjectUrl call when bucket is object', async () => {
+				const inputPath = 'path/';
+				const bucketInfo: BucketInfo = {
+					bucketName: 'bucket-1',
+					region: 'region-1',
+				};
+				await getUrlWrapper({
+					path: inputPath,
+					options: {
+						bucket: bucketInfo,
+					},
+				});
+				expect(getPresignedGetObjectUrl).toHaveBeenCalledTimes(1);
+				await expect(getPresignedGetObjectUrl).toBeLastCalledWithConfigAndInput(
+					{
+						credentials,
+						region: bucketInfo.region,
+						expiration: expect.any(Number),
+					},
+					{
+						Bucket: bucketInfo.bucketName,
+						Key: inputPath,
+					},
+				);
+			});
+			it('should override bucket in getPresignedGetObjectUrl call when bucket is string', async () => {
+				const inputPath = 'path/';
+				await getUrlWrapper({
+					path: inputPath,
+					options: {
+						bucket: 'default-bucket',
+					},
+				});
+				expect(getPresignedGetObjectUrl).toHaveBeenCalledTimes(1);
+				await expect(getPresignedGetObjectUrl).toBeLastCalledWithConfigAndInput(
+					{
+						credentials,
+						region,
+						expiration: expect.any(Number),
+					},
+					{
+						Bucket: bucket,
+						Key: inputPath,
+					},
+				);
+			});
+		});
 	});
+
 	describe('Error cases :  With path', () => {
 		afterAll(() => {
 			jest.clearAllMocks();

--- a/packages/storage/__tests__/providers/s3/apis/uploadData/multipartHandlers.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/uploadData/multipartHandlers.test.ts
@@ -143,6 +143,7 @@ describe('getMultipartUploadHandlers with key', () => {
 				S3: {
 					bucket,
 					region,
+					buckets: { 'default-bucket': { bucketName: bucket, region } },
 				},
 			},
 		});
@@ -346,6 +347,69 @@ describe('getMultipartUploadHandlers with key', () => {
 			await expect(multipartUploadJob()).rejects.toThrow('error');
 			expect(mockUploadPart).toHaveBeenCalledTimes(2);
 			expect(mockCompleteMultipartUpload).not.toHaveBeenCalled();
+		});
+
+		describe('bucket passed in options', () => {
+			const mockData = 'Ü'.repeat(4 * MB);
+			it('should override bucket in putObject call when bucket as object', async () => {
+				const mockBucket = 'bucket-1';
+				const mockRegion = 'region-1';
+				mockMultipartUploadSuccess();
+				const { multipartUploadJob } = getMultipartUploadHandlers({
+					key: 'key',
+					data: mockData,
+					options: {
+						bucket: { bucketName: mockBucket, region: mockRegion },
+					},
+				});
+				await multipartUploadJob();
+				await expect(
+					mockCreateMultipartUpload,
+				).toBeLastCalledWithConfigAndInput(
+					expect.objectContaining({
+						credentials,
+						region: mockRegion,
+						abortSignal: expect.any(AbortSignal),
+					}),
+					expect.objectContaining({
+						Bucket: mockBucket,
+						Key: 'public/key',
+						ContentType: defaultContentType,
+					}),
+				);
+				expect(mockCreateMultipartUpload).toHaveBeenCalledTimes(1);
+				expect(mockUploadPart).toHaveBeenCalledTimes(2);
+				expect(mockCompleteMultipartUpload).toHaveBeenCalledTimes(1);
+			});
+
+			it('should override bucket in putObject call when bucket as string', async () => {
+				mockMultipartUploadSuccess();
+				const { multipartUploadJob } = getMultipartUploadHandlers({
+					key: 'key',
+					data: mockData,
+					options: {
+						bucket: 'default-bucket',
+					},
+				});
+				await multipartUploadJob();
+				await expect(
+					mockCreateMultipartUpload,
+				).toBeLastCalledWithConfigAndInput(
+					expect.objectContaining({
+						credentials,
+						region,
+						abortSignal: expect.any(AbortSignal),
+					}),
+					expect.objectContaining({
+						Bucket: bucket,
+						Key: 'public/key',
+						ContentType: defaultContentType,
+					}),
+				);
+				expect(mockCreateMultipartUpload).toHaveBeenCalledTimes(1);
+				expect(mockUploadPart).toHaveBeenCalledTimes(2);
+				expect(mockCompleteMultipartUpload).toHaveBeenCalledTimes(1);
+			});
 		});
 	});
 
@@ -665,6 +729,7 @@ describe('getMultipartUploadHandlers with path', () => {
 				S3: {
 					bucket,
 					region,
+					buckets: { 'default-bucket': { bucketName: bucket, region } },
 				},
 			},
 		});
@@ -860,6 +925,68 @@ describe('getMultipartUploadHandlers with path', () => {
 			await expect(multipartUploadJob()).rejects.toThrow('error');
 			expect(mockUploadPart).toHaveBeenCalledTimes(2);
 			expect(mockCompleteMultipartUpload).not.toHaveBeenCalled();
+		});
+
+		describe('bucket passed in options', () => {
+			const mockData = 'Ü'.repeat(4 * MB);
+			it('should override bucket in putObject call when bucket as object', async () => {
+				const mockBucket = 'bucket-1';
+				const mockRegion = 'region-1';
+				mockMultipartUploadSuccess();
+				const { multipartUploadJob } = getMultipartUploadHandlers({
+					path: 'path/',
+					data: mockData,
+					options: {
+						bucket: { bucketName: mockBucket, region: mockRegion },
+					},
+				});
+				await multipartUploadJob();
+				await expect(
+					mockCreateMultipartUpload,
+				).toBeLastCalledWithConfigAndInput(
+					expect.objectContaining({
+						credentials,
+						region: mockRegion,
+						abortSignal: expect.any(AbortSignal),
+					}),
+					expect.objectContaining({
+						Bucket: mockBucket,
+						Key: 'path/',
+						ContentType: defaultContentType,
+					}),
+				);
+				expect(mockCreateMultipartUpload).toHaveBeenCalledTimes(1);
+				expect(mockUploadPart).toHaveBeenCalledTimes(2);
+				expect(mockCompleteMultipartUpload).toHaveBeenCalledTimes(1);
+			});
+			it('should override bucket in putObject call when bucket as string', async () => {
+				mockMultipartUploadSuccess();
+				const { multipartUploadJob } = getMultipartUploadHandlers({
+					path: 'path/',
+					data: mockData,
+					options: {
+						bucket: 'default-bucket',
+					},
+				});
+				await multipartUploadJob();
+				await expect(
+					mockCreateMultipartUpload,
+				).toBeLastCalledWithConfigAndInput(
+					expect.objectContaining({
+						credentials,
+						region,
+						abortSignal: expect.any(AbortSignal),
+					}),
+					expect.objectContaining({
+						Bucket: bucket,
+						Key: 'path/',
+						ContentType: defaultContentType,
+					}),
+				);
+				expect(mockCreateMultipartUpload).toHaveBeenCalledTimes(1);
+				expect(mockUploadPart).toHaveBeenCalledTimes(2);
+				expect(mockCompleteMultipartUpload).toHaveBeenCalledTimes(1);
+			});
 		});
 	});
 

--- a/packages/storage/src/errors/types/validation.ts
+++ b/packages/storage/src/errors/types/validation.ts
@@ -13,6 +13,8 @@ export enum StorageValidationErrorCode {
 	NoDestinationPath = 'NoDestinationPath',
 	NoBucket = 'NoBucket',
 	NoRegion = 'NoRegion',
+	InvalidStorageBucket = 'InvalidStorageBucket',
+	InvalidCopyOperationStorageBucket = 'InvalidCopyOperationStorageBucket',
 	InvalidStorageOperationPrefixInput = 'InvalidStorageOperationPrefixInput',
 	InvalidStorageOperationInput = 'InvalidStorageOperationInput',
 	InvalidStoragePathInput = 'InvalidStoragePathInput',
@@ -81,5 +83,12 @@ export const validationErrorMap: AmplifyErrorMap<StorageValidationErrorCode> = {
 	},
 	[StorageValidationErrorCode.InvalidS3Uri]: {
 		message: 'Invalid S3 URI.',
+	},
+	[StorageValidationErrorCode.InvalidStorageBucket]: {
+		message:
+			'Unable to lookup bucket from provided name in Amplify configuration.',
+	},
+	[StorageValidationErrorCode.InvalidCopyOperationStorageBucket]: {
+		message: 'Missing bucket option in either source or destination.',
 	},
 };

--- a/packages/storage/src/providers/s3/apis/internal/copy.ts
+++ b/packages/storage/src/providers/s3/apis/internal/copy.ts
@@ -61,7 +61,10 @@ const copyWithPath = async (
 
 	const { bucket: sourceBucket } = await resolveS3ConfigAndInput(amplify, {
 		path: input.source.path,
-		options: { ...input.source },
+		options: {
+			locationCredentialsProvider: input.options?.locationCredentialsProvider,
+			...input.source,
+		},
 	});
 
 	// The bucket, region, credentials of s3 client are resolved from destination.
@@ -125,7 +128,12 @@ export const copyWithKey = async (
 	const { bucket: sourceBucket, keyPrefix: sourceKeyPrefix } =
 		await resolveS3ConfigAndInput(amplify, {
 			...input,
-			options: input.source,
+			options: {
+				// @ts-expect-error: 'options' does not exist on type 'CopyInput'. In case of JS users set the location
+				// credentials provider option, resolveS3ConfigAndInput will throw validation error.
+				locationCredentialsProvider: input.options?.locationCredentialsProvider,
+				...input.source,
+			},
 		});
 
 	// The bucket, region, credentials of s3 client are resolved from destination.
@@ -136,7 +144,12 @@ export const copyWithKey = async (
 		keyPrefix: destinationKeyPrefix,
 	} = await resolveS3ConfigAndInput(amplify, {
 		...input,
-		options: input.destination,
+		options: {
+			// @ts-expect-error: 'options' does not exist on type 'CopyInput'. In case of JS users set the location
+			// credentials provider option, resolveS3ConfigAndInput will throw validation error.
+			locationCredentialsProvider: input.options?.locationCredentialsProvider,
+			...input.destination,
+		},
 	}); // resolveS3ConfigAndInput does not make extra API calls or storage access if called repeatedly.
 
 	// TODO(ashwinkumar6) V6-logger: warn `You may copy files from another user if the source level is "protected", currently it's ${srcLevel}`

--- a/packages/storage/src/providers/s3/types/index.ts
+++ b/packages/storage/src/providers/s3/types/index.ts
@@ -17,6 +17,8 @@ export {
 	DownloadDataOptionsWithKey,
 	CopyDestinationOptionsWithKey,
 	CopySourceOptionsWithKey,
+	CopyWithPathSourceOptions,
+	CopyWithPathDestinationOptions,
 } from './options';
 export {
 	UploadDataOutput,

--- a/packages/storage/src/providers/s3/types/inputs.ts
+++ b/packages/storage/src/providers/s3/types/inputs.ts
@@ -20,6 +20,8 @@ import {
 import {
 	CopyDestinationOptionsWithKey,
 	CopySourceOptionsWithKey,
+	CopyWithPathDestinationOptions,
+	CopyWithPathSourceOptions,
 	DownloadDataOptionsWithKey,
 	DownloadDataOptionsWithPath,
 	GetPropertiesOptionsWithKey,
@@ -49,9 +51,13 @@ export type CopyInput = StorageCopyInputWithKey<
 /**
  * Input type with path for S3 copy API.
  */
-export type CopyWithPathInput = StorageCopyInputWithPath<{
-	locationCredentialsProvider?: LocationCredentialsProvider;
-}>;
+export type CopyWithPathInput = StorageCopyInputWithPath<
+	CopyWithPathSourceOptions,
+	CopyWithPathDestinationOptions,
+	{
+		locationCredentialsProvider?: LocationCredentialsProvider;
+	}
+>;
 
 /**
  * @deprecated Use {@link GetPropertiesWithPathInput} instead.

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -19,6 +19,12 @@ export type LocationCredentialsProvider = (options?: {
 	forceRefresh?: boolean;
 }) => Promise<{ credentials: AWSCredentials }>;
 
+export interface BucketInfo {
+	bucketName: string;
+	region: string;
+}
+
+export type StorageBucket = string | BucketInfo;
 interface CommonOptions {
 	/**
 	 * Whether to use accelerate endpoint.
@@ -33,6 +39,7 @@ interface CommonOptions {
 	 * would be used.
 	 */
 	locationCredentialsProvider?: LocationCredentialsProvider;
+	bucket?: StorageBucket;
 }
 
 /** @deprecated This may be removed in the next major version. */
@@ -184,13 +191,22 @@ export type UploadDataOptionsWithPath = UploadDataOptions;
 export type CopySourceOptionsWithKey = ReadOptions & {
 	/** @deprecated This may be removed in the next major version. */
 	key: string;
+	bucket?: StorageBucket;
 };
 
 /** @deprecated This may be removed in the next major version. */
 export type CopyDestinationOptionsWithKey = WriteOptions & {
 	/** @deprecated This may be removed in the next major version. */
 	key: string;
+	bucket?: StorageBucket;
 };
+
+export interface CopyWithPathSourceOptions {
+	bucket?: StorageBucket;
+}
+export interface CopyWithPathDestinationOptions {
+	bucket?: StorageBucket;
+}
 
 /**
  * Internal only type for S3 API handlers' config parameter.

--- a/packages/storage/src/types/inputs.ts
+++ b/packages/storage/src/types/inputs.ts
@@ -90,10 +90,13 @@ export interface StorageCopyInputWithKey<
 	destination: DestinationOptions;
 }
 
-export interface StorageCopyInputWithPath<Options = unknown>
-	extends StorageOperationOptionsInput<Options> {
-	source: StorageOperationInputWithPath;
-	destination: StorageOperationInputWithPath;
+export interface StorageCopyInputWithPath<
+	SourceOptions,
+	DestinationOptions,
+	Options = unknown,
+> extends StorageOperationOptionsInput<Options> {
+	source: StorageOperationInputWithPath & SourceOptions;
+	destination: StorageOperationInputWithPath & DestinationOptions;
 }
 
 /**


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Merge the multibucket support to the storagebrowser branch. The only manual change is: https://github.com/aws-amplify/amplify-js/pull/13635/commits/6e5b3c58fe2d1c3e01eed99fd53036ddeb075a35


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Unit test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
