### PR TITLE
fix(singleton): allow oauth listener to be called with the latest config

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -293,31 +293,31 @@
 			"name": "[Analytics] record (Pinpoint)",
 			"path": "./dist/esm/analytics/index.mjs",
 			"import": "{ record }",
-			"limit": "17.09 kB"
+			"limit": "17.15 kB"
 		},
 		{
 			"name": "[Analytics] record (Kinesis)",
 			"path": "./dist/esm/analytics/kinesis/index.mjs",
 			"import": "{ record }",
-			"limit": "48.56 kB"
+			"limit": "48.59 kB"
 		},
 		{
 			"name": "[Analytics] record (Kinesis Firehose)",
 			"path": "./dist/esm/analytics/kinesis-firehose/index.mjs",
 			"import": "{ record }",
-			"limit": "45.68 kB"
+			"limit": "45.72 kB"
 		},
 		{
 			"name": "[Analytics] record (Personalize)",
 			"path": "./dist/esm/analytics/personalize/index.mjs",
 			"import": "{ record }",
-			"limit": "49.50 kB"
+			"limit": "49.54 kB"
 		},
 		{
 			"name": "[Analytics] identifyUser (Pinpoint)",
 			"path": "./dist/esm/analytics/index.mjs",
 			"import": "{ identifyUser }",
-			"limit": "15.59 kB"
+			"limit": "15.65 kB"
 		},
 		{
 			"name": "[Analytics] enable",
@@ -335,7 +335,7 @@
 			"name": "[API] generateClient (AppSync)",
 			"path": "./dist/esm/api/index.mjs",
 			"import": "{ generateClient }",
-			"limit": "40.09 kB"
+			"limit": "40.11 kB"
 		},
 		{
 			"name": "[API] REST API handlers",
@@ -353,13 +353,13 @@
 			"name": "[Auth] resetPassword (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ resetPassword }",
-			"limit": "12.44 kB"
+			"limit": "12.48 kB"
 		},
 		{
 			"name": "[Auth] confirmResetPassword (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmResetPassword }",
-			"limit": "12.39 kB"
+			"limit": "12.43 kB"
 		},
 		{
 			"name": "[Auth] signIn (Cognito)",
@@ -371,7 +371,7 @@
 			"name": "[Auth] resendSignUpCode (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ resendSignUpCode }",
-			"limit": "12.40 kB"
+			"limit": "12.44 kB"
 		},
 		{
 			"name": "[Auth] confirmSignUp (Cognito)",
@@ -383,31 +383,31 @@
 			"name": "[Auth] confirmSignIn (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmSignIn }",
-			"limit": "28.27 kB"
+			"limit": "28.33 kB"
 		},
 		{
 			"name": "[Auth] updateMFAPreference (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ updateMFAPreference }",
-			"limit": "11.74 kB"
+			"limit": "11.78 kB"
 		},
 		{
 			"name": "[Auth] fetchMFAPreference (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ fetchMFAPreference }",
-			"limit": "11.78 kB"
+			"limit": "11.82 kB"
 		},
 		{
 			"name": "[Auth] verifyTOTPSetup (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ verifyTOTPSetup }",
-			"limit": "12.6 kB"
+			"limit": "12.65 kB"
 		},
 		{
 			"name": "[Auth] updatePassword (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ updatePassword }",
-			"limit": "12.63 kB"
+			"limit": "12.67 kB"
 		},
 		{
 			"name": "[Auth] setUpTOTP (Cognito)",
@@ -419,19 +419,19 @@
 			"name": "[Auth] updateUserAttributes (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ updateUserAttributes }",
-			"limit": "11.87 kB"
+			"limit": "11.90 kB"
 		},
 		{
 			"name": "[Auth] getCurrentUser (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ getCurrentUser }",
-			"limit": "7.75 kB"
+			"limit": "7.80 kB"
 		},
 		{
 			"name": "[Auth] confirmUserAttribute (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ confirmUserAttribute }",
-			"limit": "12.61 kB"
+			"limit": "12.65 kB"
 		},
 		{
 			"name": "[Auth] signInWithRedirect (Cognito)",
@@ -443,55 +443,55 @@
 			"name": "[Auth] fetchUserAttributes (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ fetchUserAttributes }",
-			"limit": "11.69 kB"
+			"limit": "11.73 kB"
 		},
 		{
 			"name": "[Auth] Basic Auth Flow (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ signIn, signOut, fetchAuthSession, confirmSignIn }",
-			"limit": "30.06 kB"
+			"limit": "30.12 kB"
 		},
 		{
 			"name": "[Auth] OAuth Auth Flow (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ signInWithRedirect, signOut, fetchAuthSession }",
-			"limit": "21.47 kB"
+			"limit": "21.53 kB"
 		},
 		{
 			"name": "[Storage] copy (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ copy }",
-			"limit": "14.54 kB"
+			"limit": "14.57 kB"
 		},
 		{
 			"name": "[Storage] downloadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ downloadData }",
-			"limit": "15.17 kB"
+			"limit": "15.20 kB"
 		},
 		{
 			"name": "[Storage] getProperties (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getProperties }",
-			"limit": "14.43 kB"
+			"limit": "14.47 kB"
 		},
 		{
 			"name": "[Storage] getUrl (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getUrl }",
-			"limit": "15.51 kB"
+			"limit": "15.55 kB"
 		},
 		{
 			"name": "[Storage] list (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ list }",
-			"limit": "15.04 kB"
+			"limit": "15.08 kB"
 		},
 		{
 			"name": "[Storage] remove (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ remove }",
-			"limit": "14.29 kB"
+			"limit": "14.33 kB"
 		},
 		{
 			"name": "[Storage] uploadData (S3)",

--- a/packages/core/__tests__/singleton/Singleton.test.ts
+++ b/packages/core/__tests__/singleton/Singleton.test.ts
@@ -260,7 +260,7 @@ describe('Amplify.configure() and Amplify.getConfig()', () => {
 		expect(config3).not.toBe(config2);
 	});
 
-	describe.only('with oAuthListener', () => {
+	describe('with oAuthListener', () => {
 		const mockCognitoConfig: CognitoUserPoolConfig = {
 			userPoolId: 'xxxxxxxx',
 			userPoolClientId: 'xxxxxxx',

--- a/packages/core/src/singleton/Auth/types.ts
+++ b/packages/core/src/singleton/Auth/types.ts
@@ -259,3 +259,5 @@ type AuthFlowType =
 	| 'CUSTOM_WITH_SRP'
 	| 'CUSTOM_WITHOUT_SRP'
 	| 'USER_PASSWORD_AUTH';
+
+export type OAuthListener = (authConfig: AuthConfig['Cognito']) => void;

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -89,19 +89,19 @@
 			"name": "Interactions (default to Lex v2)",
 			"path": "./dist/esm/index.mjs",
 			"import": "{ Interactions }",
-			"limit": "52.52 kB"
+			"limit": "52.57 kB"
 		},
 		{
 			"name": "Interactions (Lex v2)",
 			"path": "./dist/esm/lex-v2/index.mjs",
 			"import": "{ Interactions }",
-			"limit": "52.52 kB"
+			"limit": "52.57 kB"
 		},
 		{
 			"name": "Interactions (Lex v1)",
 			"path": "./dist/esm/lex-v1/index.mjs",
 			"import": "{ Interactions }",
-			"limit": "47.33 kB"
+			"limit": "47.38 kB"
 		}
 	]
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

`Amplify.configure` will call `oAuthListener` and it will pass the Auth config. This `oAuthListener` is responsable for completing an OAuth flow. However when `Amplify.configure` is called more than 1 time, the `oAuthListener` will be called only with the first Auth config.

This fix makes sure the `oAuthListener` is called only and only if a valid OAuth `config` and `oAuthListener` are already defined. And ensures the `oAuthListener` is called with the latest config of Amplify.

- Before
`Amplify.configure` with **config1** -> `Amplify.configure` with config2 -> call `oAuthListener` with **config1**

- After
`Amplify.configure` with config1 -> `Amplify.configure` with **config2** -> call `oAuthListener` with **config2**


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/12849


#### Description of how you validated changes
- smoke testing
- unit tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
