### PR TITLE
fix(storage): export storage-browser types for TS v4.2+

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -45,7 +45,10 @@
 			],
 			"s3/server": [
 				"./dist/esm/providers/s3/server.d.ts"
-			]
+			],
+			"storage-browser": [
+        "./dist/esm/storageBrowser/index.d.ts"
+      ]
 		}
 	},
 	"repository": {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Expose `"storage-browser"` types for TS >= v4.2

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
NA


#### Description of how you validated changes
Build `@aws-amplify/storage`, `npm pack` tarball, install/verify types in `@aws-amplify/ui-react-storage`


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
