### PR TITLE
[Multi-bucket] fix - disable firefox browser test for nextjs auth

### DIFF
--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -828,8 +828,8 @@ tests:
     category: storage
     sample_name: [guest-access]
     spec: storage-client-server
-    browser: *minimal_browser_list
-  
+    browser: [chrome] # firefox issues with secure cookies in cypress, manual testing works fine
+
   # INAPPMESSAGING
   - test_name: integ_in_app_messaging
     desc: 'React InApp Messaging'


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The purpose of this pull request is to disable the firefox Next.js storage integration test. There exists several issues between Firefox and Cypress that cause issues when testing using secure cookies (which are required in the Next.js context). These issues can be mitigated locally but not in CI without additional effort.

Failing on Firefox and succeeding on Chrome in CI.
https://github.com/jjarvisp/amplify-js/actions/runs/10113370892

Cypress / Firefox issues:
https://github.com/cypress-io/cypress/issues/18690
https://github.com/cypress-io/cypress/issues/18217


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
https://github.com/jjarvisp/amplify-js/actions/runs/10148754990


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
