### PR TITLE
chore(storage-browser): export store and credentials related types, update createListLocationsHandler

### DIFF
--- a/packages/storage/src/storageBrowser/index.ts
+++ b/packages/storage/src/storageBrowser/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { LocationCredentialsProvider } from '../providers/s3/types/options';
+export { StorageSubpathStrategy } from '../types/options';
 
 export { createLocationCredentialsStore } from './locationCredentialsStore';
 export {

--- a/packages/storage/src/storageBrowser/index.ts
+++ b/packages/storage/src/storageBrowser/index.ts
@@ -1,6 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+export { LocationCredentialsProvider } from '../providers/s3/types/options';
+
 export { createLocationCredentialsStore } from './locationCredentialsStore';
-export { createManagedAuthConfigAdapter } from './managedAuthConfigAdapter/createManagedAuthConfigAdapter';
-export { GetLocationCredentials, ListLocations } from './types';
+export {
+	AuthConfigAdapter,
+	createManagedAuthConfigAdapter,
+	CreateManagedAuthConfigAdapterInput,
+} from './managedAuthConfigAdapter';
+export {
+	GetLocationCredentials,
+	ListLocations,
+	LocationCredentialsStore,
+} from './types';

--- a/packages/storage/src/storageBrowser/managedAuthConfigAdapter/createListLocationsHandler.ts
+++ b/packages/storage/src/storageBrowser/managedAuthConfigAdapter/createListLocationsHandler.ts
@@ -13,21 +13,9 @@ interface CreateListLocationsHandlerInput {
 export const createListLocationsHandler = (
 	handlerInput: CreateListLocationsHandlerInput,
 ): ListLocations => {
-	return async (input = {}) => {
-		const { nextToken, pageSize } = input;
-		const { locations, nextToken: newNextToken } = await listCallerAccessGrants(
-			{
-				accountId: handlerInput.accountId,
-				credentialsProvider: handlerInput.credentialsProvider,
-				region: handlerInput.region,
-				pageSize,
-				nextToken,
-			},
-		);
+	return async function listLocations(input = {}) {
+		const result = await listCallerAccessGrants({ ...input, ...handlerInput });
 
-		return {
-			locations,
-			nextToken: newNextToken || undefined,
-		};
+		return result;
 	};
 };

--- a/packages/storage/src/storageBrowser/managedAuthConfigAdapter/createManagedAuthConfigAdapter.ts
+++ b/packages/storage/src/storageBrowser/managedAuthConfigAdapter/createManagedAuthConfigAdapter.ts
@@ -9,13 +9,13 @@ import {
 import { createListLocationsHandler } from './createListLocationsHandler';
 import { createLocationCredentialsHandler } from './createLocationCredentialsHandler';
 
-interface CreateManagedAuthConfigAdapterInput {
+export interface CreateManagedAuthConfigAdapterInput {
 	accountId: string;
 	region: string;
 	credentialsProvider: CredentialsProvider;
 }
 
-interface AuthConfigAdapter {
+export interface AuthConfigAdapter {
 	listLocations: ListLocations;
 	getLocationCredentials: GetLocationCredentials;
 	region: string;

--- a/packages/storage/src/storageBrowser/managedAuthConfigAdapter/index.ts
+++ b/packages/storage/src/storageBrowser/managedAuthConfigAdapter/index.ts
@@ -1,4 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export { createManagedAuthConfigAdapter } from './createManagedAuthConfigAdapter';
+export {
+	AuthConfigAdapter,
+	createManagedAuthConfigAdapter,
+	CreateManagedAuthConfigAdapterInput,
+} from './createManagedAuthConfigAdapter';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Return named function from `createListLocationsHandler`, export store and credentials related types from _@aws-amplify/storage/storage-browser_:
- `LocationCredentialsStore`
- `LocationCredentialsProvider`
- `CreateManagedAuthConfigAdapterInput`
- `AuthConfigAdapter`
- `SubpathStrategy`

Providing the above types prevents the need for manually declarations in consumers, e.g.:
```ts
import { ListPaginateWithPathInput } from 'aws-amplify/storage';

type ListInput = NonNullable<ListPaginateWithPathInput>;

export type LocationCredentialsProvider = NonNullable<
  NonNullable<ListInput['options']>['locationCredentialsProvider']
>;
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
NA


#### Description of how you validated changes
Build storage package, install and build Amplify UI monorepo

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
