### PR TITLE
feat(storage): require temporary credentials for storage browser interfaces

### DIFF
--- a/packages/storage/__tests__/storageBrowser/apis/getDataAccess.test.ts
+++ b/packages/storage/__tests__/storageBrowser/apis/getDataAccess.test.ts
@@ -97,7 +97,7 @@ describe('getDataAccess', () => {
 		});
 
 		expect(getDataAccess(sharedGetDataAccessParams)).rejects.toThrow(
-			'Service did not return credentials.',
+			'Service did not return valid temporary credentials.',
 		);
 	});
 

--- a/packages/storage/__tests__/storageBrowser/locationCredentialsStore/create.test.ts
+++ b/packages/storage/__tests__/storageBrowser/locationCredentialsStore/create.test.ts
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 
 import { createLocationCredentialsStore } from '../../../src/storageBrowser/locationCredentialsStore/create';
 import {
@@ -13,10 +12,11 @@ import {
 	StorageValidationErrorCode,
 	validationErrorMap,
 } from '../../../src/errors/types/validation';
+import { AWSTemporaryCredentials } from '../../../src/providers/s3/types/options';
 
 jest.mock('../../../src/storageBrowser/locationCredentialsStore/registry');
 
-const mockedCredentials = 'MOCK_CREDS' as any as AWSCredentials;
+const mockedCredentials = 'MOCK_CREDS' as any as AWSTemporaryCredentials;
 
 describe('createLocationCredentialsStore', () => {
 	it('should create a store', () => {

--- a/packages/storage/__tests__/storageBrowser/locationCredentialsStore/registry.test.ts
+++ b/packages/storage/__tests__/storageBrowser/locationCredentialsStore/registry.test.ts
@@ -1,12 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AWSCredentials } from '@aws-amplify/core/internals/utils';
-
 import {
 	StorageValidationErrorCode,
 	validationErrorMap,
 } from '../../../src/errors/types/validation';
+import { AWSTemporaryCredentials } from '../../../src/providers/s3/types/options';
 import {
 	createStore,
 	getValue,
@@ -47,7 +46,7 @@ describe('createStore', () => {
 });
 
 describe('getValue', () => {
-	const mockCachedValue = 'CACHED_VALUE' as any as AWSCredentials;
+	const mockCachedValue = 'CACHED_VALUE' as any as AWSTemporaryCredentials;
 	let storeSymbol: { value: symbol };
 	beforeEach(() => {
 		storeSymbol = createStore(jest.fn(), 20);

--- a/packages/storage/__tests__/storageBrowser/locationCredentialsStore/store.test.ts
+++ b/packages/storage/__tests__/storageBrowser/locationCredentialsStore/store.test.ts
@@ -12,6 +12,10 @@ import {
 } from '../../../src/storageBrowser/locationCredentialsStore/store';
 import { CredentialsLocation } from '../../../src/storageBrowser/types';
 
+const mockCredentials = {
+	expiration: new Date(Date.now() + 60 * 60_1000),
+};
+
 describe('initStore', () => {
 	it('should create a store with given capacity, refresh Handler and values', () => {
 		const refreshHandler = jest.fn();
@@ -42,7 +46,7 @@ describe('initStore', () => {
 describe('getCacheValue', () => {
 	it('should return a cache value for given location and permission', () => {
 		const cachedValue = {
-			credentials: 'MOCK_CREDS',
+			credentials: mockCredentials,
 			scope: 'abc',
 			permission: 'READ',
 		} as any;
@@ -114,7 +118,6 @@ describe('fetchNewValue', () => {
 
 	it('should fetch new value from remote source', async () => {
 		expect.assertions(2);
-		const mockCredentials = 'MOCK_CREDS';
 		const refreshHandler = jest.fn().mockResolvedValue({
 			credentials: mockCredentials,
 		});
@@ -143,7 +146,6 @@ describe('fetchNewValue', () => {
 
 	it('should update cache with new value', async () => {
 		expect.assertions(1);
-		const mockCredentials = 'MOCK_CREDS';
 		const refreshHandler = jest.fn().mockResolvedValue({
 			credentials: mockCredentials,
 		});
@@ -159,7 +161,6 @@ describe('fetchNewValue', () => {
 
 	it('should invoke refresh handler only once if multiple fetches for same location is called', async () => {
 		expect.assertions(1);
-		const mockCredentials = 'MOCK_CREDS';
 		const refreshHandler = jest.fn().mockResolvedValue({
 			credentials: mockCredentials,
 		});
@@ -174,7 +175,6 @@ describe('fetchNewValue', () => {
 
 	it('should invoke the refresh handler if the refresh handler previously fails', async () => {
 		expect.assertions(4);
-		const mockCredentials = 'MOCK_CREDS';
 		const refreshHandler = jest
 			.fn()
 			.mockRejectedValueOnce(new Error('Network error'))
@@ -199,7 +199,6 @@ describe('fetchNewValue', () => {
 
 	it('should call refresh handler for new cache entry if the cache is full', async () => {
 		expect.assertions(4);
-		const mockCredentials = 'MOCK_CREDS';
 		const refreshHandler = jest.fn().mockResolvedValue({
 			credentials: mockCredentials,
 		});

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -18,9 +18,19 @@ import {
 /**
  * @internal
  */
+export type AWSTemporaryCredentials = Required<
+	Pick<
+		AWSCredentials,
+		'accessKeyId' | 'secretAccessKey' | 'sessionToken' | 'expiration'
+	>
+>;
+
+/**
+ * @internal
+ */
 export type LocationCredentialsProvider = (
-	input?: CredentialsProviderOptions,
-) => Promise<{ credentials: AWSCredentials }>;
+	options?: CredentialsProviderOptions,
+) => Promise<{ credentials: AWSTemporaryCredentials }>;
 
 export interface BucketInfo {
 	bucketName: string;

--- a/packages/storage/src/storageBrowser/apis/getDataAccess.ts
+++ b/packages/storage/src/storageBrowser/apis/getDataAccess.ts
@@ -45,10 +45,16 @@ export const getDataAccess = async (
 	const grantCredentials = result.Credentials;
 
 	// Ensure that S3 returned credentials (this shouldn't happen)
-	if (!grantCredentials) {
+	if (
+		!grantCredentials ||
+		!grantCredentials.AccessKeyId ||
+		!grantCredentials.SecretAccessKey ||
+		!grantCredentials.SessionToken ||
+		!grantCredentials.Expiration
+	) {
 		throw new StorageError({
 			name: AmplifyErrorCode.Unknown,
-			message: 'Service did not return credentials.',
+			message: 'Service did not return valid temporary credentials.',
 		});
 	} else {
 		logger.debug(`Retrieved credentials for: ${result.MatchedGrantTarget}`);
@@ -63,8 +69,8 @@ export const getDataAccess = async (
 
 	return {
 		credentials: {
-			accessKeyId: accessKeyId!,
-			secretAccessKey: secretAccessKey!,
+			accessKeyId,
+			secretAccessKey,
 			sessionToken,
 			expiration,
 		},

--- a/packages/storage/src/storageBrowser/locationCredentialsStore/registry.ts
+++ b/packages/storage/src/storageBrowser/locationCredentialsStore/registry.ts
@@ -2,8 +2,7 @@
 
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { AWSCredentials } from '@aws-amplify/core/internals/utils';
-
+import { AWSTemporaryCredentials } from '../../providers/s3/types/options';
 import { CredentialsLocation, GetLocationCredentials } from '../types';
 import { assertValidationError } from '../../errors/utils/assertValidationError';
 import { StorageValidationErrorCode } from '../../errors/types/validation';
@@ -68,7 +67,7 @@ export const getValue = async (input: {
 	storeSymbol: StoreRegistrySymbol;
 	location: CredentialsLocation;
 	forceRefresh: boolean;
-}): Promise<{ credentials: AWSCredentials }> => {
+}): Promise<{ credentials: AWSTemporaryCredentials }> => {
 	const { storeSymbol: storeReference, location, forceRefresh } = input;
 	const store = getCredentialsStore(storeReference);
 	if (!forceRefresh) {

--- a/packages/storage/src/storageBrowser/types.ts
+++ b/packages/storage/src/storageBrowser/types.ts
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AWSCredentials } from '@aws-amplify/core/internals/utils';
-import { CredentialsProviderOptions } from '@aws-amplify/core/internals/aws-client-utils';
-
-import { LocationCredentialsProvider } from '../providers/s3/types/options';
+import {
+	AWSTemporaryCredentials,
+	LocationCredentialsProvider,
+} from '../providers/s3/types/options';
 
 /**
  * @internal
@@ -14,9 +14,7 @@ export type Permission = 'READ' | 'READWRITE' | 'WRITE';
 /**
  * @internal
  */
-export type CredentialsProvider = (
-	options?: CredentialsProviderOptions,
-) => Promise<{ credentials: AWSCredentials }>;
+export type CredentialsProvider = LocationCredentialsProvider;
 
 /**
  * @internal
@@ -70,7 +68,7 @@ export interface LocationCredentials extends Partial<LocationScope> {
 	/**
 	 * AWS credentials which can be used to access the specified location.
 	 */
-	readonly credentials: AWSCredentials;
+	readonly credentials: AWSTemporaryCredentials;
 }
 
 export interface AccessGrant extends LocationAccess {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Following interface changes are made:
1. `locationCredentialsProvider` is required to return temperary credentials with `expiration` and `sessionToken`.
2. location-specific credentials from getLocationCredentials is required to be temperary credentials with `expiration` and `sessionToken`.
3. credentials used by managed auth adpater is required to be temperary credentials with `expiration` and `sessionToken`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
