### PR TITLE
fix(storage-browser): listCallerAccessGrantsDeserializer not parsing multiple AccessGrant instances

### DIFF
--- a/packages/storage/__tests__/providers/s3/utils/client/S3/cases/listCallerAccessGrants.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/S3/cases/listCallerAccessGrants.ts
@@ -54,6 +54,11 @@ const listCallerAccessGrantsHappyCase: ApiFunctionalTestCase<
 						<GrantScope>${MOCK_GRANT_SCOPE}</GrantScope>
 						<Permission>${MOCK_PERMISSION}</Permission>
 				</AccessGrantsInstance>
+				<AccessGrantsInstance>
+						<ApplicationArn>${MOCK_APP_ARN}</ApplicationArn>
+						<GrantScope>${MOCK_GRANT_SCOPE}</GrantScope>
+						<Permission>${MOCK_PERMISSION}</Permission>
+				</AccessGrantsInstance>
 			</CallerAccessGrantsList>
 		</ListCallerAccessGrantsResult>
 	`,
@@ -61,6 +66,11 @@ const listCallerAccessGrantsHappyCase: ApiFunctionalTestCase<
 	{
 		$metadata: expect.objectContaining(expectedMetadata),
 		CallerAccessGrantsList: [
+			{
+				ApplicationArn: MOCK_APP_ARN,
+				GrantScope: MOCK_GRANT_SCOPE,
+				Permission: MOCK_PERMISSION,
+			},
 			{
 				ApplicationArn: MOCK_APP_ARN,
 				GrantScope: MOCK_GRANT_SCOPE,

--- a/packages/storage/src/providers/s3/utils/client/s3control/listCallerAccessGrants.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3control/listCallerAccessGrants.ts
@@ -70,7 +70,11 @@ const listCallerAccessGrantsDeserializer = async (
 		const contents = map(parsed, {
 			CallerAccessGrantsList: [
 				'CallerAccessGrantsList',
-				value => emptyArrayGuard(value, deserializeAccessGrantsList),
+				value =>
+					emptyArrayGuard(
+						value.AccessGrantsInstance,
+						deserializeAccessGrantsList,
+					),
 			],
 			NextToken: 'NextToken',
 		});
@@ -86,7 +90,7 @@ const deserializeAccessGrantsList = (output: any[]) =>
 	output.map(deserializeCallerAccessGrant);
 
 const deserializeCallerAccessGrant = (output: any) =>
-	map(output.AccessGrantsInstance, {
+	map(output, {
 		ApplicationArn: 'ApplicationArn',
 		GrantScope: 'GrantScope',
 		Permission: 'Permission',


### PR DESCRIPTION
#### Description of changes
- The listCallerAccessGrantsDeserializer does not handle parsing multiple `AccessGrantsInstance`.
- When the XML response from service contains a single `AccessGrantsInstance` items it's parsed into an object; while it's parsed into an array if there are multiple items 

**Output log before fix**
xml parsed
```
// 1 item
{
  "CallerAccessGrantsList": {
    "AccessGrantsInstance": {
      "ApplicationArn": "ALL",
      "Permission": "READWRITE",
      "GrantScope": "s3://ashwin-portcullis-test1/*"
    }
  }
}

// 2 items
{
  "CallerAccessGrantsList": {
    "AccessGrantsInstance": [
      {
        "ApplicationArn": "ALL",
        "Permission": "READWRITE",
        "GrantScope": "s3://ashwin-portcullis-test1/*"
      },
      {
        "ApplicationArn": "ALL",
        "Permission": "READWRITE",
        "GrantScope": "s3://ashwin-portcullis-test2/*"
      }
    ]
  }
}
```
Deserializer output
```
// 1 item
{
  "CallerAccessGrantsList": [
    {
      "ApplicationArn": "ALL",
      "GrantScope": "s3://ashwin-portcullis-test1/*",
      "Permission": "READWRITE"
    }
  ]
}
// 2 items
{
  "CallerAccessGrantsList": [
    {} ====> ERROR
  ]
}

```
#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
- Updated unit tests
- linked lib and tested locally with AG setup in backend

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
