### PR TITLE
chore: Fix misleading error string mapping in XHR client

### DIFF
--- a/packages/datastore/__tests__/mutation.test.ts
+++ b/packages/datastore/__tests__/mutation.test.ts
@@ -464,5 +464,5 @@ const timeoutError = {
 			region: 'us-west-2',
 		},
 	},
-	code: 'ECONNABORTED',
+	code: 'ERR_NETWORK',
 };

--- a/packages/datastore/src/sync/processors/mutation.ts
+++ b/packages/datastore/src/sync/processors/mutation.ts
@@ -384,7 +384,7 @@ class MutationProcessor {
 
 							if (
 								error.message === 'Network Error' ||
-								code === 'ECONNABORTED' // refers to axios timeout error caused by device's bad network condition
+								code === 'ERR_NETWORK' // refers to axios timeout error caused by device's bad network condition
 							) {
 								if (!this.processing) {
 									throw new NonRetryableError('Offline');

--- a/packages/storage/__tests__/providers/s3/utils/client/xhrTransferHandler-util.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/xhrTransferHandler-util.test.ts
@@ -197,7 +197,7 @@ describe('xhrTransferHandler', () => {
 		await expect(requestPromise).rejects.toThrow(
 			expect.objectContaining({
 				message: 'Network Error',
-				name: 'ECONNABORTED',
+				name: 'ERR_NETWORK',
 			}),
 		);
 	});
@@ -211,7 +211,7 @@ describe('xhrTransferHandler', () => {
 		await expect(requestPromise).rejects.toThrow(
 			expect.objectContaining({
 				message: 'Network Error',
-				name: 'ECONNABORTED',
+				name: 'ERR_NETWORK',
 			}),
 		);
 		// Should be no-op if the xhr is already cleared

--- a/packages/storage/src/providers/s3/utils/client/runtime/constants.ts
+++ b/packages/storage/src/providers/s3/utils/client/runtime/constants.ts
@@ -5,7 +5,7 @@ export const SEND_UPLOAD_PROGRESS_EVENT = 'sendUploadProgress';
 export const SEND_DOWNLOAD_PROGRESS_EVENT = 'sendDownloadProgress';
 
 export const NETWORK_ERROR_MESSAGE = 'Network Error';
-export const NETWORK_ERROR_CODE = 'ECONNABORTED';
+export const NETWORK_ERROR_CODE = 'ERR_NETWORK';
 
 export const ABORT_ERROR_MESSAGE = 'Request aborted';
 export const ABORT_ERROR_CODE = 'ERR_ABORTED';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fixed the constant mapped for network failure to say network error, not connection abort

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
