### PR TITLE
chore(storage-browser): expose additional input output types

### DIFF
--- a/packages/storage/__tests__/storageBrowser/apis/listCallerAccessGrants.test.ts
+++ b/packages/storage/__tests__/storageBrowser/apis/listCallerAccessGrants.test.ts
@@ -117,19 +117,16 @@ describe('listCallerAccessGrants', () => {
 				scope: 's3://bucket/*',
 				type: 'BUCKET',
 				permission: 'READ',
-				applicationArn: undefined,
 			},
 			{
 				scope: 's3://bucket/path/*',
 				type: 'PREFIX',
 				permission: 'READWRITE',
-				applicationArn: undefined,
 			},
 			{
 				scope: 's3://bucket/path/to/object',
 				type: 'OBJECT',
 				permission: 'READ',
-				applicationArn: 'arn:123',
 			},
 		]);
 		expect(nextToken).toBeUndefined();

--- a/packages/storage/src/storageBrowser/apis/listCallerAccessGrants.ts
+++ b/packages/storage/src/storageBrowser/apis/listCallerAccessGrants.ts
@@ -51,7 +51,6 @@ export const listCallerAccessGrants = async (
 			},
 		);
 
-	// TODO: return `applicationArn` if required
 	const accessGrants: LocationAccess[] =
 		CallerAccessGrantsList?.map(grant => {
 			// These values are correct from service mostly, but we add assertions to make TSC happy.

--- a/packages/storage/src/storageBrowser/apis/listCallerAccessGrants.ts
+++ b/packages/storage/src/storageBrowser/apis/listCallerAccessGrants.ts
@@ -6,7 +6,7 @@ import { CredentialsProviderOptions } from '@aws-amplify/core/internals/aws-clie
 
 import { logger } from '../../utils';
 import { listCallerAccessGrants as listCallerAccessGrantsClient } from '../../providers/s3/utils/client/s3control';
-import { AccessGrant, LocationType, Permission } from '../types';
+import { LocationAccess, LocationType, Permission } from '../types';
 import { StorageError } from '../../errors/StorageError';
 import { getStorageUserAgentValue } from '../../providers/s3/utils/userAgent';
 
@@ -51,7 +51,8 @@ export const listCallerAccessGrants = async (
 			},
 		);
 
-	const accessGrants: AccessGrant[] =
+	// TODO: return `applicationArn` if required
+	const accessGrants: LocationAccess[] =
 		CallerAccessGrantsList?.map(grant => {
 			// These values are correct from service mostly, but we add assertions to make TSC happy.
 			assertPermission(grant.Permission);
@@ -60,7 +61,6 @@ export const listCallerAccessGrants = async (
 			return {
 				scope: grant.GrantScope,
 				permission: grant.Permission,
-				applicationArn: grant.ApplicationArn,
 				type: parseGrantType(grant.GrantScope!),
 			};
 		}) ?? [];

--- a/packages/storage/src/storageBrowser/apis/types.ts
+++ b/packages/storage/src/storageBrowser/apis/types.ts
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-	AccessGrant,
 	CredentialsProvider,
 	ListLocationsInput,
-	ListLocationsOutputS3,
+	ListLocationsOutput,
 	LocationCredentials,
 	Permission,
 	PrefixType,
@@ -18,7 +17,7 @@ export interface ListCallerAccessGrantsInput extends ListLocationsInput {
 	region: string;
 }
 
-export type ListCallerAccessGrantsOutput = ListLocationsOutputS3<AccessGrant>;
+export type ListCallerAccessGrantsOutput = ListLocationsOutput;
 
 export interface GetDataAccessInput {
 	accountId: string;

--- a/packages/storage/src/storageBrowser/apis/types.ts
+++ b/packages/storage/src/storageBrowser/apis/types.ts
@@ -5,7 +5,7 @@ import {
 	AccessGrant,
 	CredentialsProvider,
 	ListLocationsInput,
-	ListLocationsOutput,
+	ListLocationsOutputS3,
 	LocationCredentials,
 	Permission,
 	PrefixType,
@@ -18,7 +18,7 @@ export interface ListCallerAccessGrantsInput extends ListLocationsInput {
 	region: string;
 }
 
-export type ListCallerAccessGrantsOutput = ListLocationsOutput<AccessGrant>;
+export type ListCallerAccessGrantsOutput = ListLocationsOutputS3<AccessGrant>;
 
 export interface GetDataAccessInput {
 	accountId: string;

--- a/packages/storage/src/storageBrowser/index.ts
+++ b/packages/storage/src/storageBrowser/index.ts
@@ -20,6 +20,6 @@ export {
 	ListLocationsOutput,
 	GetLocationCredentialsInput,
 	GetLocationCredentialsOutput,
-	Permission as AccessGrantPermission,
+	Permission,
 } from './types';
 export { AWSTemporaryCredentials } from '../providers/s3/types/options';

--- a/packages/storage/src/storageBrowser/index.ts
+++ b/packages/storage/src/storageBrowser/index.ts
@@ -14,4 +14,12 @@ export {
 	GetLocationCredentials,
 	ListLocations,
 	LocationCredentialsStore,
+	CreateLocationCredentialsStoreInput,
+	LocationCredentials,
+	ListLocationsInput,
+	ListLocationsOutput,
+	GetLocationCredentialsInput,
+	GetLocationCredentialsOutput,
+	Permission as AccessGrantPermission,
 } from './types';
+export { AWSTemporaryCredentials } from '../providers/s3/types/options';

--- a/packages/storage/src/storageBrowser/locationCredentialsStore/create.ts
+++ b/packages/storage/src/storageBrowser/locationCredentialsStore/create.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+	CreateLocationCredentialsStoreInput,
 	CredentialsLocation,
-	GetLocationCredentials,
 	LocationCredentialsStore,
 } from '../types';
 import { StorageValidationErrorCode } from '../../errors/types/validation';
@@ -12,9 +12,9 @@ import { LocationCredentialsProvider } from '../../providers/s3/types/options';
 
 import { createStore, getValue, removeStore } from './registry';
 
-export const createLocationCredentialsStore = (input: {
-	handler: GetLocationCredentials;
-}): LocationCredentialsStore => {
+export const createLocationCredentialsStore = (
+	input: CreateLocationCredentialsStoreInput,
+): LocationCredentialsStore => {
 	const storeSymbol = createStore(input.handler);
 
 	const store = {

--- a/packages/storage/src/storageBrowser/types.ts
+++ b/packages/storage/src/storageBrowser/types.ts
@@ -71,31 +71,18 @@ export interface LocationCredentials extends Partial<LocationScope> {
 	readonly credentials: AWSTemporaryCredentials;
 }
 
-export interface AccessGrant extends LocationAccess {
-	/**
-	 * The Amazon Resource Name (ARN) of an AWS IAM Identity Center application
-	 * associated with your Identity Center instance. If the grant includes an
-	 * application ARN, the grantee can only access the S3 data through this
-	 * application.
-	 */
-	readonly applicationArn: string | undefined;
-}
-
-/**
- * @internal
- */
-
-export interface ListLocationsOutputS3<T extends LocationAccess> {
-	locations: T[];
-	nextToken?: string;
-}
-export type ListLocationsOutput = ListLocationsOutputS3<LocationAccess>;
-
 /**
  * @internal
  */
 export interface ListLocationsInput {
 	pageSize?: number;
+	nextToken?: string;
+}
+/**
+ * @internal
+ */
+export interface ListLocationsOutput {
+	locations: LocationAccess[];
 	nextToken?: string;
 }
 

--- a/packages/storage/src/storageBrowser/types.ts
+++ b/packages/storage/src/storageBrowser/types.ts
@@ -84,10 +84,12 @@ export interface AccessGrant extends LocationAccess {
 /**
  * @internal
  */
-export interface ListLocationsOutput<T extends LocationAccess> {
+
+export interface ListLocationsOutputS3<T extends LocationAccess> {
 	locations: T[];
 	nextToken?: string;
 }
+export type ListLocationsOutput = ListLocationsOutputS3<LocationAccess>;
 
 /**
  * @internal
@@ -99,7 +101,7 @@ export interface ListLocationsInput {
 
 export type ListLocations = (
 	input?: ListLocationsInput,
-) => Promise<ListLocationsOutput<LocationAccess>>;
+) => Promise<ListLocationsOutput>;
 
 export type GetLocationCredentialsInput = CredentialsLocation;
 export type GetLocationCredentialsOutput = LocationCredentials;
@@ -107,6 +109,10 @@ export type GetLocationCredentialsOutput = LocationCredentials;
 export type GetLocationCredentials = (
 	input: GetLocationCredentialsInput,
 ) => Promise<GetLocationCredentialsOutput>;
+
+export interface CreateLocationCredentialsStoreInput {
+	handler: GetLocationCredentials;
+}
 
 export interface LocationCredentialsStore {
 	/**


### PR DESCRIPTION
#### Description of changes
Expose additional input output types on path `@aws-amplify/storage/storage-browser`.
The additional exposed types are:
```
CreateLocationCredentialsStoreInput,
LocationCredentials,
ListLocationsInput,
ListLocationsOutput,
GetLocationCredentialsInput,
GetLocationCredentialsOutput,
Permission as AccessGrantPermission,
```


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
