### PR TITLE
fix(auth): call logout endpoint when `signInDetails` is defined

### DIFF
--- a/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
@@ -67,6 +67,8 @@ jest.mock('../../../src/providers/cognito/utils/oauth/oAuthStore', () => ({
 		loadPKCE: jest.fn(),
 		clearOAuthData: jest.fn(),
 		clearOAuthInflightData: jest.fn(),
+		storeAuthProvider: jest.fn(),
+		loadAuthProvider: jest.fn(),
 	} as OAuthStore,
 }));
 jest.mock('../../../src/providers/cognito/utils/oauth/handleFailure');

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/attemptCompleteOAuthFlow.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/attemptCompleteOAuthFlow.test.ts
@@ -31,6 +31,8 @@ jest.mock(
 			loadPKCE: jest.fn(),
 			clearOAuthData: jest.fn(),
 			clearOAuthInflightData: jest.fn(),
+			storeAuthProvider: jest.fn(),
+			loadAuthProvider: jest.fn(),
 		} as OAuthStore,
 	}),
 );

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
@@ -40,6 +40,8 @@ jest.mock(
 			loadPKCE: jest.fn(),
 			clearOAuthData: jest.fn(),
 			clearOAuthInflightData: jest.fn(),
+			storeAuthProvider: jest.fn(),
+			loadAuthProvider: jest.fn(),
 		} as OAuthStore,
 	}),
 );
@@ -107,6 +109,7 @@ describe('completeOAuthFlow', () => {
 			redirectUri: 'http://localhost:3000/',
 			responseType: 'code',
 			domain: 'oauth.domain.com',
+			authProvider: 'Cognito',
 		};
 
 		it('throws when `code` is not presented in the redirect url', () => {
@@ -178,6 +181,9 @@ describe('completeOAuthFlow', () => {
 				RefreshToken: expectedTokens.refresh_token,
 				TokenType: expectedTokens.token_type,
 				ExpiresIn: expectedTokens.expires_in,
+				signInDetails: {
+					provider: 'Cognito',
+				},
 			});
 			expect(mockReplaceState).toHaveBeenCalledWith(
 				'http://localhost:3000/?code=aaaa-111-222&state=aaaaa',
@@ -216,6 +222,7 @@ describe('completeOAuthFlow', () => {
 			redirectUri: 'http://localhost:3000/',
 			responseType: 'non-code',
 			domain: 'oauth.domain.com',
+			authProvider: 'Cognito',
 		};
 
 		it('throws when error and error_description are presented in the redirect url', () => {
@@ -274,6 +281,9 @@ describe('completeOAuthFlow', () => {
 				IdToken: expectedIdToken,
 				TokenType: expectedTokenType,
 				ExpiresIn: expectedExpiresIn,
+				signInDetails: {
+					provider: 'Cognito',
+				},
 			});
 
 			expect(oAuthStore.clearOAuthData).toHaveBeenCalledTimes(1);

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/handleOAuthSignOut.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/handleOAuthSignOut.test.ts
@@ -55,4 +55,13 @@ describe('handleOAuthSignOut', () => {
 		expect(mockCompleteOAuthSignOut).toHaveBeenCalledWith(mockStore);
 		expect(mockOAuthSignOutRedirect).not.toHaveBeenCalled();
 	});
+
+	it('should complete OAuth sign out and redirect when signInDetails is defined.', async () => {
+		mockStore.loadOAuthSignIn.mockResolvedValue({
+			isOAuthSignIn: false,
+			preferPrivateSession: false,
+		});
+		await handleOAuthSignOut(cognitoConfig, mockStore, { provider: 'Cognito' });
+		expect(mockOAuthSignOutRedirect).toHaveBeenCalledWith(cognitoConfig);
+	});
 });

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/validateState.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/validateState.test.ts
@@ -27,6 +27,8 @@ jest.mock(
 			loadPKCE: jest.fn(),
 			clearOAuthData: jest.fn(),
 			clearOAuthInflightData: jest.fn(),
+			storeAuthProvider: jest.fn(),
+			loadAuthProvider: jest.fn(),
 		} as OAuthStore,
 	}),
 );

--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -25,6 +25,7 @@ import {
 } from '../utils/oauth';
 import { createOAuthError } from '../utils/oauth/createOAuthError';
 import { listenForOAuthFlowCancellation } from '../utils/oauth/cancelOAuthFlow';
+import { getCognitoAuthProvider } from '../utils/oauth/getAuthProvider';
 
 /**
  * Signs in a user with OAuth. Redirects the application to an Identity Provider.
@@ -41,6 +42,7 @@ export async function signInWithRedirect(
 	assertTokenProviderConfig(authConfig);
 	assertOAuthConfig(authConfig);
 	oAuthStore.setAuthConfig(authConfig);
+	oAuthStore.storeAuthProvider(getCognitoAuthProvider(input?.provider));
 	await assertUserNotAuthenticated();
 
 	let provider = 'COGNITO'; // Default

--- a/packages/auth/src/providers/cognito/apis/signOut.ts
+++ b/packages/auth/src/providers/cognito/apis/signOut.ts
@@ -34,6 +34,8 @@ import { DefaultOAuthStore } from '../utils/signInWithRedirectStore';
 import { AuthError } from '../../../errors/AuthError';
 import { OAUTH_SIGNOUT_EXCEPTION } from '../../../errors/constants';
 
+import { getCurrentUser } from './getCurrentUser';
+
 const logger = new ConsoleLogger('Auth');
 
 /**
@@ -64,8 +66,10 @@ export async function signOut(input?: SignOutInput): Promise<void> {
 	if (hasOAuthConfig) {
 		const oAuthStore = new DefaultOAuthStore(defaultStorage);
 		oAuthStore.setAuthConfig(cognitoConfig);
+		const { signInDetails } = await getCurrentUser();
 		const { type } =
-			(await handleOAuthSignOut(cognitoConfig, oAuthStore)) ?? {};
+			(await handleOAuthSignOut(cognitoConfig, oAuthStore, signInDetails)) ??
+			{};
 		if (type === 'error') {
 			throw new AuthError({
 				name: OAUTH_SIGNOUT_EXCEPTION,

--- a/packages/auth/src/providers/cognito/types/index.ts
+++ b/packages/auth/src/providers/cognito/types/index.ts
@@ -12,6 +12,7 @@ export {
 	AuthUser,
 	CognitoAuthSignInDetails,
 	CodeDeliveryDetails,
+	CognitoAuthProvider,
 } from './models';
 
 export {

--- a/packages/auth/src/providers/cognito/types/models.ts
+++ b/packages/auth/src/providers/cognito/types/models.ts
@@ -86,14 +86,18 @@ export type AWSAuthDevice = AuthDevice & {
 	lastModifiedDate?: Date;
 };
 
+type CustomAuthProvider = string;
+
+export type CognitoAuthProvider = AuthProvider | 'Cognito' | CustomAuthProvider;
+
 /**
  * Holds the sign in details of the user.
  */
 export interface CognitoAuthSignInDetails {
 	loginId?: string;
 	authFlowType?: AuthFlowType;
+	provider?: CognitoAuthProvider;
 }
-
 /**
  * Holds the user information along with the sign in details.
  */

--- a/packages/auth/src/providers/cognito/utils/oauth/attemptCompleteOAuthFlow.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/attemptCompleteOAuthFlow.ts
@@ -39,6 +39,7 @@ export const attemptCompleteOAuthFlow = async (
 		const { loginWith, userPoolClientId } = authConfig;
 		const { domain, redirectSignIn, responseType } = loginWith.oauth;
 		const redirectUri = getRedirectUrl(redirectSignIn);
+		const authProvider = (await oAuthStore.loadAuthProvider()) ?? undefined;
 
 		await completeOAuthFlow({
 			currentUrl,
@@ -47,6 +48,7 @@ export const attemptCompleteOAuthFlow = async (
 			redirectUri,
 			responseType,
 			userAgentValue: getAuthUserAgentValue(AuthAction.SignInWithRedirect),
+			authProvider,
 		});
 	} catch (err) {
 		await handleFailure(err);

--- a/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
@@ -25,6 +25,7 @@ export const completeOAuthFlow = async ({
 	responseType,
 	domain,
 	preferPrivateSession,
+	authProvider,
 }: {
 	currentUrl: string;
 	userAgentValue: string;
@@ -33,6 +34,7 @@ export const completeOAuthFlow = async ({
 	responseType: string;
 	domain: string;
 	preferPrivateSession?: boolean;
+	authProvider?: string;
 }): Promise<void> => {
 	const urlParams = new AmplifyUrl(currentUrl);
 	const error = urlParams.searchParams.get('error');
@@ -50,6 +52,7 @@ export const completeOAuthFlow = async ({
 			redirectUri,
 			domain,
 			preferPrivateSession,
+			authProvider,
 		});
 	}
 
@@ -57,6 +60,7 @@ export const completeOAuthFlow = async ({
 		currentUrl,
 		redirectUri,
 		preferPrivateSession,
+		authProvider,
 	});
 };
 
@@ -67,6 +71,7 @@ const handleCodeFlow = async ({
 	redirectUri,
 	domain,
 	preferPrivateSession,
+	authProvider,
 }: {
 	currentUrl: string;
 	userAgentValue: string;
@@ -74,6 +79,7 @@ const handleCodeFlow = async ({
 	redirectUri: string;
 	domain: string;
 	preferPrivateSession?: boolean;
+	authProvider?: string;
 }) => {
 	/* Convert URL into an object with parameters as keys
 { redirect_uri: 'http://localhost:3000/', response_type: 'code', ...} */
@@ -147,6 +153,9 @@ const handleCodeFlow = async ({
 		RefreshToken: refreshToken,
 		TokenType: token_type,
 		ExpiresIn: expires_in,
+		signInDetails: {
+			provider: authProvider,
+		},
 	});
 
 	return completeFlow({
@@ -160,10 +169,12 @@ const handleImplicitFlow = async ({
 	currentUrl,
 	redirectUri,
 	preferPrivateSession,
+	authProvider,
 }: {
 	currentUrl: string;
 	redirectUri: string;
 	preferPrivateSession?: boolean;
+	authProvider?: string;
 }) => {
 	// hash is `null` if `#` doesn't exist on URL
 	const url = new AmplifyUrl(currentUrl);
@@ -209,6 +220,9 @@ const handleImplicitFlow = async ({
 		IdToken: id_token,
 		TokenType: token_type,
 		ExpiresIn: expires_in,
+		signInDetails: {
+			provider: authProvider,
+		},
 	});
 
 	return completeFlow({

--- a/packages/auth/src/providers/cognito/utils/oauth/getAuthProvider.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/getAuthProvider.ts
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CognitoAuthProvider, SignInWithRedirectInput } from '../../types';
+
+export const getCognitoAuthProvider = (
+	provider?: SignInWithRedirectInput['provider'],
+): CognitoAuthProvider => {
+	const defaultProvider = 'Cognito';
+	if (typeof provider === 'string') return provider;
+	else if (provider?.custom) return provider.custom;
+
+	return defaultProvider;
+};

--- a/packages/auth/src/providers/cognito/utils/oauth/handleOAuthSignOut.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/handleOAuthSignOut.ts
@@ -5,6 +5,7 @@ import { CognitoUserPoolConfig } from '@aws-amplify/core';
 
 import { OpenAuthSessionResult } from '../../../../utils/types';
 import { DefaultOAuthStore } from '../../utils/signInWithRedirectStore';
+import { CognitoAuthSignInDetails } from '../../types';
 
 import { completeOAuthSignOut } from './completeOAuthSignOut';
 import { oAuthSignOutRedirect } from './oAuthSignOutRedirect';
@@ -12,6 +13,7 @@ import { oAuthSignOutRedirect } from './oAuthSignOutRedirect';
 export const handleOAuthSignOut = async (
 	cognitoConfig: CognitoUserPoolConfig,
 	store: DefaultOAuthStore,
+	signInDetails?: CognitoAuthSignInDetails,
 ): Promise<void | OpenAuthSessionResult> => {
 	const { isOAuthSignIn } = await store.loadOAuthSignIn();
 
@@ -19,7 +21,7 @@ export const handleOAuthSignOut = async (
 	// state could be wiped away on redirect
 	await completeOAuthSignOut(store);
 
-	if (isOAuthSignIn) {
+	if (isOAuthSignIn || signInDetails?.provider) {
 		// On web, this will always end up being a void action
 		return oAuthSignOutRedirect(cognitoConfig);
 	}

--- a/packages/auth/src/providers/cognito/utils/signInWithRedirectStore.ts
+++ b/packages/auth/src/providers/cognito/utils/signInWithRedirectStore.ts
@@ -22,6 +22,26 @@ export class DefaultOAuthStore implements OAuthStore {
 		this.keyValueStorage = keyValueStorage;
 	}
 
+	storeAuthProvider(authProvider: string): Promise<void> {
+		assertTokenProviderConfig(this.cognitoConfig);
+		const authKeys = createKeysForAuthStorage(
+			name,
+			this.cognitoConfig.userPoolClientId,
+		);
+
+		return this.keyValueStorage.setItem(authKeys.authProvider, authProvider);
+	}
+
+	async loadAuthProvider(): Promise<string | null> {
+		assertTokenProviderConfig(this.cognitoConfig);
+		const { authProvider: authProviderKey } = createKeysForAuthStorage(
+			name,
+			this.cognitoConfig.userPoolClientId,
+		);
+
+		return this.keyValueStorage.getItem(authProviderKey);
+	}
+
 	async clearOAuthInflightData(): Promise<void> {
 		assertTokenProviderConfig(this.cognitoConfig);
 
@@ -33,6 +53,7 @@ export class DefaultOAuthStore implements OAuthStore {
 			this.keyValueStorage.removeItem(authKeys.inflightOAuth),
 			this.keyValueStorage.removeItem(authKeys.oauthPKCE),
 			this.keyValueStorage.removeItem(authKeys.oauthState),
+			this.keyValueStorage.removeItem(authKeys.authProvider),
 		]);
 	}
 
@@ -44,6 +65,7 @@ export class DefaultOAuthStore implements OAuthStore {
 		);
 		await this.clearOAuthInflightData();
 		await this.keyValueStorage.removeItem(V5_HOSTED_UI_KEY); // remove in case a customer migrated an App from v5 to v6
+		await this.keyValueStorage.removeItem(authKeys.authProvider);
 
 		return this.keyValueStorage.removeItem(authKeys.oauthSignIn);
 	}

--- a/packages/auth/src/providers/cognito/utils/types.ts
+++ b/packages/auth/src/providers/cognito/utils/types.ts
@@ -106,6 +106,7 @@ export const OAuthStorageKeys = {
 	oauthSignIn: 'oauthSignIn',
 	oauthPKCE: 'oauthPKCE',
 	oauthState: 'oauthState',
+	authProvider: 'authProvider',
 };
 
 export interface OAuthStore {
@@ -126,6 +127,8 @@ export interface OAuthStore {
 	storePKCE(pkce: string): Promise<void>;
 	clearOAuthInflightData(): Promise<void>;
 	clearOAuthData(): Promise<void>;
+	storeAuthProvider(authProvider: string): Promise<void>;
+	loadAuthProvider(): Promise<string | null>;
 }
 function isAuthenticated(tokens?: CognitoAuthTokens | null) {
 	return tokens?.accessToken || tokens?.idToken;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- The following changes will add an additional condition in the `signOut` API to call the Cognito `logout` endpoint

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
