### PR TITLE
chore(auth): add oauth metadata into token orchestrator

### DIFF
--- a/packages/auth/__tests__/providers/cognito/signOut.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signOut.test.ts
@@ -220,6 +220,7 @@ describe('signOut', () => {
 			expect(mockHandleOAuthSignOut).toHaveBeenCalledWith(
 				cognitoConfigWithOauth,
 				mockDefaultOAuthStoreInstance,
+				mockTokenOrchestrator,
 			);
 			// In cases of OAuth, token removal and Hub dispatch should be performed by the OAuth handling since
 			// these actions can be deferred or canceled out of altogether.

--- a/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
@@ -25,6 +25,8 @@ const mockAuthTokenStore = {
 	setKeyValueStorage: jest.fn(),
 	getDeviceMetadata: jest.fn(),
 	clearDeviceMetadata: jest.fn(),
+	setOAuthMetadata: jest.fn(),
+	getOAuthMetadata: jest.fn(),
 };
 const mockTokenRefresher = jest.fn();
 const validAuthConfig: ResourcesConfig = {

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
@@ -24,6 +24,8 @@ describe('tokenOrchestrator', () => {
 		setKeyValueStorage: jest.fn(),
 		getDeviceMetadata: jest.fn(),
 		clearDeviceMetadata: jest.fn(),
+		getOAuthMetadata: jest.fn(),
+		setOAuthMetadata: jest.fn(),
 	};
 
 	beforeAll(() => {

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
@@ -13,6 +13,7 @@ import { AuthErrorTypes } from '../../../../../src/types/Auth';
 import { OAuthStore } from '../../../../../src/providers/cognito/utils/types';
 import { completeOAuthFlow } from '../../../../../src/providers/cognito/utils/oauth/completeOAuthFlow';
 
+jest.mock('../../../../../src/providers/cognito/tokenProvider');
 jest.mock('@aws-amplify/core', () => ({
 	Hub: {
 		dispatch: jest.fn(),

--- a/packages/auth/src/providers/cognito/apis/signOut.ts
+++ b/packages/auth/src/providers/cognito/apis/signOut.ts
@@ -65,7 +65,11 @@ export async function signOut(input?: SignOutInput): Promise<void> {
 		const oAuthStore = new DefaultOAuthStore(defaultStorage);
 		oAuthStore.setAuthConfig(cognitoConfig);
 		const { type } =
-			(await handleOAuthSignOut(cognitoConfig, oAuthStore)) ?? {};
+			(await handleOAuthSignOut(
+				cognitoConfig,
+				oAuthStore,
+				tokenOrchestrator,
+			)) ?? {};
 		if (type === 'error') {
 			throw new AuthError({
 				name: OAUTH_SIGNOUT_EXCEPTION,

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -25,6 +25,7 @@ import {
 	AuthTokenStore,
 	CognitoAuthTokens,
 	DeviceMetadata,
+	OAuthMetadata,
 	TokenRefresher,
 } from './types';
 
@@ -202,5 +203,13 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 
 	clearDeviceMetadata(username?: string): Promise<void> {
 		return this.getTokenStore().clearDeviceMetadata(username);
+	}
+
+	setOAuthMetadata(metadata: OAuthMetadata): Promise<void> {
+		return this.getTokenStore().setOAuthMetadata(metadata);
+	}
+
+	getOAuthMetadata(): Promise<OAuthMetadata | null> {
+		return this.getTokenStore().getOAuthMetadata();
 	}
 }

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
@@ -14,6 +14,7 @@ import {
 	AuthTokenStore,
 	CognitoAuthTokens,
 	DeviceMetadata,
+	OAuthMetadata,
 } from './types';
 import { TokenProviderErrorCode, assert } from './errorHelpers';
 
@@ -163,6 +164,7 @@ export class DefaultTokenStore implements AuthTokenStore {
 			this.getKeyValueStorage().removeItem(authKeys.refreshToken),
 			this.getKeyValueStorage().removeItem(authKeys.signInDetails),
 			this.getKeyValueStorage().removeItem(this.getLastAuthUserKey()),
+			this.getKeyValueStorage().removeItem(authKeys.oauthMetadata),
 		]);
 	}
 
@@ -221,6 +223,22 @@ export class DefaultTokenStore implements AuthTokenStore {
 			'username';
 
 		return lastAuthUser;
+	}
+
+	async setOAuthMetadata(metadata: OAuthMetadata): Promise<void> {
+		const { oauthMetadata: oauthMetadataKey } = await this.getAuthKeys();
+		await this.getKeyValueStorage().setItem(
+			oauthMetadataKey,
+			JSON.stringify(metadata),
+		);
+	}
+
+	async getOAuthMetadata(): Promise<OAuthMetadata | null> {
+		const { oauthMetadata: oauthMetadataKey } = await this.getAuthKeys();
+		const oauthMetadata =
+			await this.getKeyValueStorage().getItem(oauthMetadataKey);
+
+		return oauthMetadata && JSON.parse(oauthMetadata);
 	}
 }
 

--- a/packages/auth/src/providers/cognito/tokenProvider/types.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/types.ts
@@ -34,6 +34,7 @@ export const AuthTokenStorageKeys = {
 	randomPasswordKey: 'randomPasswordKey',
 	deviceGroupKey: 'deviceGroupKey',
 	signInDetails: 'signInDetails',
+	oauthMetadata: 'oauthMetadata',
 };
 
 export interface AuthTokenStore {
@@ -44,6 +45,8 @@ export interface AuthTokenStore {
 	setKeyValueStorage(keyValueStorage: KeyValueStorageInterface): void;
 	getDeviceMetadata(username?: string): Promise<DeviceMetadata | null>;
 	clearDeviceMetadata(username?: string): Promise<void>;
+	setOAuthMetadata(metadata: OAuthMetadata): Promise<void>;
+	getOAuthMetadata(): Promise<OAuthMetadata | null>;
 }
 
 export interface AuthTokenOrchestrator {
@@ -58,6 +61,8 @@ export interface AuthTokenOrchestrator {
 	clearTokens(): Promise<void>;
 	getDeviceMetadata(username?: string): Promise<DeviceMetadata | null>;
 	clearDeviceMetadata(username?: string): Promise<void>;
+	setOAuthMetadata(metadata: OAuthMetadata): Promise<void>;
+	getOAuthMetadata(): Promise<OAuthMetadata | null>;
 }
 
 export interface CognitoUserPoolTokenProviderType extends TokenProvider {
@@ -77,4 +82,8 @@ export interface DeviceMetadata {
 	deviceKey?: string;
 	deviceGroupKey?: string;
 	randomPassword: string;
+}
+
+export interface OAuthMetadata {
+	oauthSignIn: boolean;
 }

--- a/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
@@ -11,6 +11,7 @@ import { Hub, decodeJWT } from '@aws-amplify/core';
 
 import { cacheCognitoTokens } from '../../tokenProvider/cacheTokens';
 import { dispatchSignedInHubEvent } from '../dispatchSignedInHubEvent';
+import { tokenOrchestrator } from '../../tokenProvider';
 
 import { createOAuthError } from './createOAuthError';
 import { resolveAndClearInflightPromises } from './inflightPromise';
@@ -148,6 +149,9 @@ const handleCodeFlow = async ({
 		TokenType: token_type,
 		ExpiresIn: expires_in,
 	});
+	await tokenOrchestrator.setOAuthMetadata({
+		oauthSignIn: true,
+	});
 
 	return completeFlow({
 		redirectUri,
@@ -209,6 +213,9 @@ const handleImplicitFlow = async ({
 		IdToken: id_token,
 		TokenType: token_type,
 		ExpiresIn: expires_in,
+	});
+	await tokenOrchestrator.setOAuthMetadata({
+		oauthSignIn: true,
 	});
 
 	return completeFlow({

--- a/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
@@ -149,9 +149,6 @@ const handleCodeFlow = async ({
 		TokenType: token_type,
 		ExpiresIn: expires_in,
 	});
-	await tokenOrchestrator.setOAuthMetadata({
-		oauthSignIn: true,
-	});
 
 	return completeFlow({
 		redirectUri,
@@ -214,9 +211,6 @@ const handleImplicitFlow = async ({
 		TokenType: token_type,
 		ExpiresIn: expires_in,
 	});
-	await tokenOrchestrator.setOAuthMetadata({
-		oauthSignIn: true,
-	});
 
 	return completeFlow({
 		redirectUri,
@@ -234,6 +228,9 @@ const completeFlow = async ({
 	redirectUri: string;
 	state: string;
 }) => {
+	await tokenOrchestrator.setOAuthMetadata({
+		oauthSignIn: true,
+	});
 	await oAuthStore.clearOAuthData();
 	await oAuthStore.storeOAuthSignIn(true, preferPrivateSession);
 

--- a/packages/auth/src/providers/cognito/utils/oauth/handleOAuthSignOut.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/handleOAuthSignOut.ts
@@ -5,6 +5,7 @@ import { CognitoUserPoolConfig } from '@aws-amplify/core';
 
 import { OpenAuthSessionResult } from '../../../../utils/types';
 import { DefaultOAuthStore } from '../../utils/signInWithRedirectStore';
+import { TokenOrchestrator } from '../../tokenProvider';
 
 import { completeOAuthSignOut } from './completeOAuthSignOut';
 import { oAuthSignOutRedirect } from './oAuthSignOutRedirect';
@@ -12,14 +13,16 @@ import { oAuthSignOutRedirect } from './oAuthSignOutRedirect';
 export const handleOAuthSignOut = async (
 	cognitoConfig: CognitoUserPoolConfig,
 	store: DefaultOAuthStore,
+	tokenOrchestrator: TokenOrchestrator,
 ): Promise<void | OpenAuthSessionResult> => {
 	const { isOAuthSignIn } = await store.loadOAuthSignIn();
+	const oauthMetadata = await tokenOrchestrator.getOAuthMetadata();
 
 	// Clear everything before attempting to visted logout endpoint since the current application
 	// state could be wiped away on redirect
 	await completeOAuthSignOut(store);
 
-	if (isOAuthSignIn) {
+	if (isOAuthSignIn || oauthMetadata?.oauthSignIn) {
 		// On web, this will always end up being a void action
 		return oAuthSignOutRedirect(cognitoConfig);
 	}

--- a/packages/auth/src/providers/cognito/utils/oauth/handleOAuthSignOut.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/handleOAuthSignOut.ts
@@ -22,6 +22,12 @@ export const handleOAuthSignOut = async (
 	// state could be wiped away on redirect
 	await completeOAuthSignOut(store);
 
+	// The isOAuthSignIn flag is propagated by the oAuthToken store which manages oauth keys in local storage only.
+	// These keys are used to determine if a user is in an inflight or signedIn oauth states.
+	// However, this behavior represents an issue when 2 apps share the same set of tokens in Cookie storage because the app that didn't
+	// start the OAuth will not have access to the oauth keys.
+	// A heuristic solution is to add oauth metadata to the tokenOrchestrator which will have access to the underlying
+	// storage mechanism that is used by Amplify.
 	if (isOAuthSignIn || oauthMetadata?.oauthSignIn) {
 		// On web, this will always end up being a void action
 		return oAuthSignOutRedirect(cognitoConfig);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change adds oauth metadata into the token orchestrator. This metadata is set after the user has authenticated via OAuth, and it can be accessed from the current `KeyValueStorage` (LocalStorage, SessionStorage, CookieStorage, etc).

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
