### PR TITLE
feat(api-graphql): AppSync realtime - include custom headers as query string params

### DIFF
--- a/packages/api-graphql/__tests__/AWSAppSyncRealTimeProvider.test.ts
+++ b/packages/api-graphql/__tests__/AWSAppSyncRealTimeProvider.test.ts
@@ -276,38 +276,6 @@ describe('AWSAppSyncRealTimeProvider', () => {
 					);
 				});
 
-				test('custom headers are applied in query string', async () => {
-					expect.assertions(1);
-
-					const newSocketSpy = jest
-						.spyOn(provider, 'getNewWebSocket')
-						.mockImplementation(() => {
-							fakeWebSocketInterface.newWebSocket();
-							return fakeWebSocketInterface.webSocket as WebSocket;
-						});
-
-					provider
-						.subscribe({
-							appSyncGraphqlEndpoint: 'http://localhost:8080',
-							additionalHeaders: {
-								'x-amz-user-agent': 'aws-amplify/6.4.0 api/1 framework/2',
-								'ex-machina': 'is a good movie',
-								// This should NOT get included in the querystring
-								Authorization: 'abc12345',
-							},
-						})
-						.subscribe({ error: () => {} });
-
-					// Wait for the socket to be initialize
-					await fakeWebSocketInterface.readyForUse;
-
-					expect(newSocketSpy).toHaveBeenNthCalledWith(
-						1,
-						'wss://localhost:8080/realtime?header=&payload=e30=&x-amz-user-agent=aws-amplify%2F6.4.0%20api%2F1%20framework%2F2&ex-machina=is%20a%20good%20movie',
-						'graphql-ws',
-					);
-				});
-
 				test('subscription waiting for onopen with https://testaccounturl123456789123.appsync-api.us-east-1.amazonaws.com/graphql" translates to wss', async () => {
 					expect.assertions(1);
 

--- a/packages/api-graphql/__tests__/AWSAppSyncRealTimeProvider.test.ts
+++ b/packages/api-graphql/__tests__/AWSAppSyncRealTimeProvider.test.ts
@@ -276,6 +276,38 @@ describe('AWSAppSyncRealTimeProvider', () => {
 					);
 				});
 
+				test('custom headers are applied in query string', async () => {
+					expect.assertions(1);
+
+					const newSocketSpy = jest
+						.spyOn(provider, 'getNewWebSocket')
+						.mockImplementation(() => {
+							fakeWebSocketInterface.newWebSocket();
+							return fakeWebSocketInterface.webSocket as WebSocket;
+						});
+
+					provider
+						.subscribe({
+							appSyncGraphqlEndpoint: 'http://localhost:8080',
+							additionalHeaders: {
+								'x-amz-user-agent': 'aws-amplify/6.4.0 api/1 framework/2',
+								'ex-machina': 'is a good movie',
+								// This should NOT get included in the querystring
+								Authorization: 'abc12345',
+							},
+						})
+						.subscribe({ error: () => {} });
+
+					// Wait for the socket to be initialize
+					await fakeWebSocketInterface.readyForUse;
+
+					expect(newSocketSpy).toHaveBeenNthCalledWith(
+						1,
+						'wss://localhost:8080/realtime?header=&payload=e30=&x-amz-user-agent=aws-amplify%2F6.4.0%20api%2F1%20framework%2F2&ex-machina=is%20a%20good%20movie',
+						'graphql-ws',
+					);
+				});
+
 				test('subscription waiting for onopen with https://testaccounturl123456789123.appsync-api.us-east-1.amazonaws.com/graphql" translates to wss', async () => {
 					expect.assertions(1);
 

--- a/packages/api-graphql/__tests__/GraphQLAPI.test.ts
+++ b/packages/api-graphql/__tests__/GraphQLAPI.test.ts
@@ -1558,4 +1558,60 @@ describe('API test', () => {
 			);
 		});
 	});
+
+	test('request level custom headers are applied to query string', async () => {
+		Amplify.configure({
+			API: {
+				GraphQL: {
+					defaultAuthMode: 'lambda',
+					endpoint:
+						'https://testaccounturl123456789123.appsync-api.us-east-1.amazonaws.com/graphql',
+					region: 'local-host-h4x',
+				},
+			},
+		});
+
+		let done: Function;
+		const mockedFnHasBeenCalled = new Promise(res => (done = res));
+
+		const spyon_appsync_realtime = jest
+			.spyOn(
+				AWSAppSyncRealTimeProvider.prototype as any,
+				'_initializeRetryableHandshake',
+			)
+			.mockImplementation(
+				jest.fn(() => {
+					done(); // resolve promise when called
+				}) as any,
+			);
+
+		const query = /* GraphQL */ `
+			subscription SubscribeToEventComments {
+				subscribeToEventComments {
+					eventId
+				}
+			}
+		`;
+
+		const resolvedUrl =
+			'wss://testaccounturl123456789123.appsync-realtime-api.us-east-1.amazonaws.com/graphql?header=eyJBdXRob3JpemF0aW9uIjoiYWJjMTIzNDUiLCJob3N0IjoidGVzdGFjY291bnR1cmwxMjM0NTY3ODkxMjMuYXBwc3luYy1hcGkudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20ifQ==&payload=e30=&x-amz-user-agent=aws-amplify%2F6.4.0%20api%2F1%20framework%2F2&ex-machina=is%20a%20good%20movie';
+
+		(
+			client.graphql(
+				{ query },
+				{
+					'x-amz-user-agent': 'aws-amplify/6.4.0 api/1 framework/2',
+					'ex-machina': 'is a good movie',
+					// This should NOT get included in the querystring
+					Authorization: 'abc12345',
+				},
+			) as unknown as Observable<object>
+		).subscribe();
+
+		await mockedFnHasBeenCalled;
+
+		expect(spyon_appsync_realtime).toHaveBeenCalledTimes(1);
+		const subscribeOptions = spyon_appsync_realtime.mock.calls[0][0];
+		expect(subscribeOptions).toBe(resolvedUrl);
+	});
 });

--- a/packages/api-graphql/__tests__/internals/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/internals/generateClient.test.ts
@@ -333,6 +333,30 @@ describe('generateClient', () => {
 				expect(normalizePostGraphqlCalls(spy)).toMatchSnapshot();
 			});
 
+			test('with custom client headers - graphql', async () => {
+				const headers = {
+					'client-header': 'should exist',
+				};
+
+				const client = generateClient<Schema>({
+					amplify: Amplify,
+					headers,
+				});
+
+				await client.graphql({
+					query: /* GraphQL */ `
+						query listPosts {
+							id
+						}
+					`,
+				});
+
+				const receivedArgs = normalizePostGraphqlCalls(spy)[0][1];
+				const receivedHeaders = receivedArgs.options.headers;
+
+				expect(receivedHeaders).toEqual(expect.objectContaining(headers));
+			});
+
 			test('with custom client header functions', async () => {
 				const client = generateClient<Schema>({
 					amplify: Amplify,

--- a/packages/api-graphql/src/Providers/AWSAppSyncRealTimeProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSAppSyncRealTimeProvider/index.ts
@@ -739,8 +739,6 @@ export class AWSAppSyncRealTimeProvider {
 	private _queryStringFromCustomHeaders(
 		headers?: AWSAppSyncRealTimeProviderOptions['additionalCustomHeaders'],
 	): string {
-		console.log('_queryStringFromCustomHeaders', headers);
-
 		const nonAuthHeaders = this._extractNonAuthHeaders(headers);
 
 		const queryParams: string[] = Object.entries(nonAuthHeaders).map(

--- a/packages/api-graphql/src/Providers/AWSAppSyncRealTimeProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSAppSyncRealTimeProvider/index.ts
@@ -712,6 +712,46 @@ export class AWSAppSyncRealTimeProvider {
 		}
 	}
 
+	/**
+	 * Strips out `Authorization` header if present
+	 */
+	private _extractNonAuthHeaders(
+		headers?: AWSAppSyncRealTimeProviderOptions['additionalCustomHeaders'],
+	): Record<string, string> {
+		if (!headers) {
+			return {};
+		}
+
+		if ('Authorization' in headers) {
+			const { Authorization: _, ...nonAuthHeaders } = headers;
+
+			return nonAuthHeaders;
+		}
+
+		return headers;
+	}
+
+	/**
+	 *
+	 * @param headers - http headers
+	 * @returns query string of uri-encoded parameters derived from custom headers
+	 */
+	private _queryStringFromCustomHeaders(
+		headers?: AWSAppSyncRealTimeProviderOptions['additionalCustomHeaders'],
+	): string {
+		console.log('_queryStringFromCustomHeaders', headers);
+
+		const nonAuthHeaders = this._extractNonAuthHeaders(headers);
+
+		const queryParams: string[] = Object.entries(nonAuthHeaders).map(
+			([key, val]) => `${encodeURIComponent(key)}=${encodeURIComponent(val)}`,
+		);
+
+		const queryString = queryParams.join('&');
+
+		return queryString;
+	}
+
 	private _initializeWebSocketConnection({
 		appSyncGraphqlEndpoint,
 		authenticationType,
@@ -749,6 +789,10 @@ export class AWSAppSyncRealTimeProvider {
 
 					const payloadQs = base64Encoder.convert(payloadString);
 
+					const queryString = this._queryStringFromCustomHeaders(
+						additionalCustomHeaders,
+					);
+
 					let discoverableEndpoint = appSyncGraphqlEndpoint ?? '';
 
 					if (this.isCustomDomain(discoverableEndpoint)) {
@@ -766,7 +810,11 @@ export class AWSAppSyncRealTimeProvider {
 						.replace('https://', protocol)
 						.replace('http://', protocol);
 
-					const awsRealTimeUrl = `${discoverableEndpoint}?header=${headerQs}&payload=${payloadQs}`;
+					let awsRealTimeUrl = `${discoverableEndpoint}?header=${headerQs}&payload=${payloadQs}`;
+
+					if (queryString !== '') {
+						awsRealTimeUrl += `&${queryString}`;
+					}
 
 					await this._initializeRetryableHandshake(awsRealTimeUrl);
 

--- a/packages/api-graphql/src/internals/v6.ts
+++ b/packages/api-graphql/src/internals/v6.ts
@@ -106,6 +106,7 @@ export function graphql<
 	const internals = getInternals(this as any);
 	options.authMode = options.authMode || internals.authMode;
 	options.authToken = options.authToken || internals.authToken;
+	const headers = additionalHeaders || internals.headers;
 
 	/**
 	 * The correctness of these typings depends on correct string branding or overrides.
@@ -116,7 +117,7 @@ export function graphql<
 		// TODO: move V6Client back into this package?
 		internals.amplify as any,
 		options,
-		additionalHeaders,
+		headers,
 	);
 
 	return result as any;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Today custom request headers set via:
```ts
// client level
generateClient<Schema>({
  headers: {
    'My-Custom-Header': 'my value',
  },
});

// OR

// request level
await client.models.Blog.get(
  { id: 'myBlogId' },
  {
    headers: {
      'My-Custom-Header': 'my value',
    },
  }
);
```
Get applied to GraphQL requests for queries and mutations. ([Docs link](https://docs.amplify.aws/react/build-a-backend/data/connect-to-API/#set-custom-request-headers))

However, the headers are ignored for subscription connection requests to AppSync, becuase the WebSocket API does not support setting headers directly.

The AppSync team is asking us to give customers a way to pass these through as query string params instead.

E.g.
```ts
await client.models.Blog.onCreate(
  {
    headers: {
      'My-Custom-Header': 'my value',
    },
  }
);
```
Should produce this query string that's added to the subscription connect url: `"&My-Custom-Header=my%20value"`

> [!NOTE]  
> The service will ignore any query params it does not recognize. So including additional params will not cause any unwanted side effects

#### Description of how you validated changes
* Unit tests
* Manual testing


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
