### PR TITLE
fix: add expectedBucketOwner to uploadData API and configuration

### DIFF
--- a/packages/core/src/singleton/Storage/types.ts
+++ b/packages/core/src/singleton/Storage/types.ts
@@ -12,11 +12,14 @@ export interface BucketInfo {
 	bucketName: string;
 	/** Region of the bucket */
 	region: string;
+	/** Expected owner of the bucket */
+	expectedBucketOwner?: string;
 }
 export interface S3ProviderConfig {
 	S3: {
 		bucket?: string;
 		region?: string;
+		expectedBucketOwner?: string;
 		/**
 		 * Internal-only configuration for testing purpose. You should not use this.
 		 *

--- a/packages/storage/src/providers/s3/apis/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/index.ts
@@ -162,9 +162,3 @@ export function uploadData(input: UploadDataInput | UploadDataWithPathInput) {
 		});
 	}
 }
-
-uploadData({
-	path: '',
-	data: '',
-	options: { bucket: { bucketName: '', region: '', expectedBucketOwner: '' } },
-});

--- a/packages/storage/src/providers/s3/apis/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/index.ts
@@ -162,3 +162,9 @@ export function uploadData(input: UploadDataInput | UploadDataWithPathInput) {
 		});
 	}
 }
+
+uploadData({
+	path: '',
+	data: '',
+	options: { bucket: { bucketName: '', region: '', expectedBucketOwner: '' } },
+});

--- a/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/putObjectJob.ts
@@ -29,8 +29,14 @@ export const putObjectJob =
 	) =>
 	async (): Promise<ItemWithKey | ItemWithPath> => {
 		const { options: uploadDataOptions, data } = uploadDataInput;
-		const { bucket, keyPrefix, s3Config, isObjectLockEnabled, identityId } =
-			await resolveS3ConfigAndInput(Amplify, uploadDataOptions);
+		const {
+			bucket,
+			keyPrefix,
+			s3Config,
+			isObjectLockEnabled,
+			identityId,
+			expectedBucketOwner,
+		} = await resolveS3ConfigAndInput(Amplify, uploadDataOptions);
 		const { inputType, objectKey } = validateStorageOperationInput(
 			uploadDataInput,
 			identityId,
@@ -64,6 +70,7 @@ export const putObjectJob =
 				ContentMD5: isObjectLockEnabled
 					? await calculateContentMd5(data)
 					: undefined,
+				ExpectedBucketOwner: expectedBucketOwner,
 			},
 		);
 

--- a/packages/storage/src/providers/s3/types/options.ts
+++ b/packages/storage/src/providers/s3/types/options.ts
@@ -14,6 +14,7 @@ import {
 export interface BucketInfo {
 	bucketName: string;
 	region: string;
+	expectedBucketOwner?: string;
 }
 
 export type StorageBucket = string | BucketInfo;

--- a/packages/storage/src/providers/s3/utils/client/putObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/putObject.ts
@@ -37,6 +37,7 @@ export type PutObjectInput = Pick<
 	| 'Expires'
 	| 'Metadata'
 	| 'Tagging'
+	| 'ExpectedBucketOwner'
 >;
 
 export type PutObjectOutput = Pick<

--- a/packages/storage/src/providers/s3/utils/client/utils/serializeHelpers.ts
+++ b/packages/storage/src/providers/s3/utils/client/utils/serializeHelpers.ts
@@ -32,6 +32,7 @@ interface ObjectConfigs {
 	Expires?: Date;
 	Tagging?: string;
 	Metadata?: Record<string, string>;
+	ExpectedBucketOwner?: string;
 }
 
 /**
@@ -52,6 +53,7 @@ export const serializeObjectConfigsToHeaders = async (
 		'content-type': input.ContentType,
 		expires: input.Expires?.toUTCString(),
 		'x-amz-tagging': input.Tagging,
+		'x-amz-expected-bucket-owner': input.ExpectedBucketOwner,
 		...serializeMetadata(input.Metadata),
 	}),
 });

--- a/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
+++ b/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
@@ -23,6 +23,7 @@ interface ResolvedS3ConfigAndInput {
 	keyPrefix: string;
 	isObjectLockEnabled?: boolean;
 	identityId?: string;
+	expectedBucketOwner?: string;
 }
 
 /**
@@ -70,8 +71,11 @@ export const resolveS3ConfigAndInput = async (
 		buckets,
 	} = amplify.getConfig()?.Storage?.S3 ?? {};
 
-	const { bucket = defaultBucket, region = defaultRegion } =
-		(apiOptions?.bucket && resolveBucketConfig(apiOptions, buckets)) || {};
+	const {
+		bucket = defaultBucket,
+		region = defaultRegion,
+		expectedBucketOwner,
+	} = (apiOptions?.bucket && resolveBucketConfig(apiOptions, buckets)) || {};
 
 	assertValidationError(!!bucket, StorageValidationErrorCode.NoBucket);
 	assertValidationError(!!region, StorageValidationErrorCode.NoRegion);
@@ -105,6 +109,7 @@ export const resolveS3ConfigAndInput = async (
 				: {}),
 		},
 		bucket,
+		expectedBucketOwner,
 		keyPrefix,
 		identityId,
 		isObjectLockEnabled,
@@ -114,7 +119,9 @@ export const resolveS3ConfigAndInput = async (
 const resolveBucketConfig = (
 	apiOptions: S3ApiOptions,
 	buckets: Record<string, BucketInfo> | undefined,
-): { bucket: string; region: string } | undefined => {
+):
+	| { bucket: string; region: string; expectedBucketOwner?: string }
+	| undefined => {
 	if (typeof apiOptions.bucket === 'string') {
 		const bucketConfig = buckets?.[apiOptions.bucket];
 		assertValidationError(
@@ -129,6 +136,7 @@ const resolveBucketConfig = (
 		return {
 			bucket: apiOptions.bucket.bucketName,
 			region: apiOptions.bucket.region,
+			expectedBucketOwner: apiOptions.bucket.expectedBucketOwner,
 		};
 	}
 };

--- a/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
+++ b/packages/storage/src/providers/s3/utils/resolveS3ConfigAndInput.ts
@@ -67,6 +67,7 @@ export const resolveS3ConfigAndInput = async (
 	const {
 		bucket: defaultBucket,
 		region: defaultRegion,
+		expectedBucketOwner: defaultBucketOwner,
 		dangerouslyConnectToHttpEndpointForTesting,
 		buckets,
 	} = amplify.getConfig()?.Storage?.S3 ?? {};
@@ -74,7 +75,7 @@ export const resolveS3ConfigAndInput = async (
 	const {
 		bucket = defaultBucket,
 		region = defaultRegion,
-		expectedBucketOwner,
+		expectedBucketOwner = defaultBucketOwner,
 	} = (apiOptions?.bucket && resolveBucketConfig(apiOptions, buckets)) || {};
 
 	assertValidationError(!!bucket, StorageValidationErrorCode.NoBucket);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
