### PR TITLE
[Email MFA] Add support for EMAIL_OTP during sign in flows

### DIFF
--- a/packages/auth/__tests__/providers/cognito/confirmSignInErrorCases.test.ts
+++ b/packages/auth/__tests__/providers/cognito/confirmSignInErrorCases.test.ts
@@ -51,7 +51,7 @@ describe('confirmSignIn API error path cases:', () => {
 		}
 	});
 
-	it('should throw an error when sign-in step is CONTINUE_SIGN_IN_WITH_MFA_SELECTION and challengeResponse is not "SMS" or "TOTP"', async () => {
+	it('should throw an error when sign-in step is CONTINUE_SIGN_IN_WITH_MFA_SELECTION and challengeResponse is not "SMS", "TOTP", or "EMAIL"', async () => {
 		expect.assertions(2);
 		try {
 			await confirmSignIn({ challengeResponse: 'NO_SMS' });

--- a/packages/auth/src/common/AuthErrorStrings.ts
+++ b/packages/auth/src/common/AuthErrorStrings.ts
@@ -47,8 +47,10 @@ export const validationErrorMap: AmplifyErrorMap<AuthValidationErrorCode> = {
 		recoverySuggestion: 'Do not include a password in your signIn call.',
 	},
 	[AuthValidationErrorCode.IncorrectMFAMethod]: {
-		message: 'Incorrect MFA method was chosen. It should be either SMS or TOTP',
-		recoverySuggestion: 'Try to pass TOTP or SMS as the challengeResponse',
+		message:
+			'Incorrect MFA method was chosen. It should be either SMS, TOTP, or EMAIL',
+		recoverySuggestion:
+			'Try to pass SMS, TOTP, or EMAIL as the challengeResponse',
 	},
 	[AuthValidationErrorCode.EmptyVerifyTOTPSetupCode]: {
 		message: 'code is required to verifyTotpSetup',

--- a/packages/auth/src/providers/cognito/utils/clients/CognitoIdentityProvider/types.ts
+++ b/packages/auth/src/providers/cognito/utils/clients/CognitoIdentityProvider/types.ts
@@ -8,6 +8,7 @@ import { MetadataBearer as __MetadataBearer } from '@aws-sdk/types';
 export type ChallengeName =
 	| 'SMS_MFA'
 	| 'SOFTWARE_TOKEN_MFA'
+	| 'EMAIL_OTP'
 	| 'SELECT_MFA_TYPE'
 	| 'MFA_SETUP'
 	| 'PASSWORD_VERIFIER'
@@ -28,7 +29,7 @@ export type ChallengeParameters = {
 	MFAS_CAN_SETUP?: string;
 } & Record<string, unknown>;
 
-export type CognitoMFAType = 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA';
+export type CognitoMFAType = 'SMS_MFA' | 'SOFTWARE_TOKEN_MFA' | 'EMAIL_OTP';
 
 export interface CognitoMFASettings {
 	Enabled?: boolean;
@@ -55,6 +56,7 @@ declare enum ChallengeNameType {
 	SELECT_MFA_TYPE = 'SELECT_MFA_TYPE',
 	SMS_MFA = 'SMS_MFA',
 	SOFTWARE_TOKEN_MFA = 'SOFTWARE_TOKEN_MFA',
+	EMAIL_OTP = 'EMAIL_OTP',
 }
 declare enum DeliveryMediumType {
 	EMAIL = 'EMAIL',

--- a/packages/auth/src/providers/cognito/utils/signInHelpers.ts
+++ b/packages/auth/src/providers/cognito/utils/signInHelpers.ts
@@ -1103,7 +1103,7 @@ export async function handleMFAChallenge({
 		challengeResponses.SOFTWARE_TOKEN_MFA_CODE = challengeResponse;
 	}
 
-	const UserContextData = getUserContextData({
+	const userContextData = getUserContextData({
 		username,
 		userPoolId,
 		userPoolClientId,
@@ -1115,7 +1115,7 @@ export async function handleMFAChallenge({
 		Session: session,
 		ClientMetadata: clientMetadata,
 		ClientId: userPoolClientId,
-		UserContextData,
+		UserContextData: userContextData,
 	};
 
 	return respondToAuthChallenge(

--- a/packages/auth/src/types/models.ts
+++ b/packages/auth/src/types/models.ts
@@ -152,7 +152,7 @@ export interface ConfirmSignInWithEmailCode {
 	 *
 	 * @example
 	 * ```typescript
-	 * // Code retrieved from cellphone
+	 * // Code retrieved from email
 	 * const emailCode = '112233'
 	 * await confirmSignIn({challengeResponse: emailCode})
 	 * ```

--- a/packages/auth/src/types/models.ts
+++ b/packages/auth/src/types/models.ts
@@ -146,6 +146,21 @@ export interface ConfirmSignInWithSMSCode {
 	codeDeliveryDetails?: AuthCodeDeliveryDetails;
 }
 
+export interface ConfirmSignInWithEmailCode {
+	/**
+	 * Auth step requires user to use EMAIL as multifactor authentication by retrieving a code sent to inbox.
+	 *
+	 * @example
+	 * ```typescript
+	 * // Code retrieved from cellphone
+	 * const emailCode = '112233'
+	 * await confirmSignIn({challengeResponse: emailCode})
+	 * ```
+	 */
+	signInStep: 'CONFIRM_SIGN_IN_WITH_EMAIL_CODE';
+	codeDeliveryDetails?: AuthCodeDeliveryDetails;
+}
+
 export interface ConfirmSignUpStep {
 	/**
 	 * Auth step requires to confirm user's sign-up.
@@ -181,6 +196,7 @@ export type AuthNextSignInStep<
 	| ConfirmSignInWithNewPasswordRequired<UserAttributeKey>
 	| ConfirmSignInWithSMSCode
 	| ConfirmSignInWithTOTPCode
+	| ConfirmSignInWithEmailCode
 	| ContinueSignInWithTOTPSetup
 	| ConfirmSignUpStep
 	| ResetPasswordStep


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The purpose of this pull request is to add support for the `CONFIRM_SIGN_IN_WITH_EMAIL_CODE` challenge and selecting `EMAIL` as the delivery destination during the `CONTINUE_SIGN_IN_WITH_MFA_SELECTION` challenge. 

MFA_SETUP challenge will be handled separately.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
- Manual testing
- Unit tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [X] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
