### PR TITLE
chore(storage): add durability check for presigned urls in put object

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -497,7 +497,7 @@
 			"name": "[Storage] uploadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ uploadData }",
-			"limit": "21.68 kB"
+			"limit": "21.83 kB"
 		}
 	]
 }

--- a/packages/storage/__tests__/providers/s3/utils/client/s3Data/putObject.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/s3Data/putObject.test.ts
@@ -1,0 +1,93 @@
+import { HttpResponse } from '@aws-amplify/core/internals/aws-client-utils';
+
+import { s3TransferHandler } from '../../../../../../src/providers/s3/utils/client/runtime/s3TransferHandler/fetch';
+import { putObject } from '../../../../../../src/providers/s3/utils/client/s3data';
+import { validateObjectUrl } from '../../../../../../src/providers/s3/utils/validateObjectUrl';
+import {
+	DEFAULT_RESPONSE_HEADERS,
+	defaultConfig,
+	expectedMetadata,
+} from '../S3/cases/shared';
+import { IntegrityError } from '../../../../../../src/errors/IntegrityError';
+
+jest.mock('../../../../../../src/providers/s3/utils/validateObjectUrl');
+jest.mock(
+	'../../../../../../src/providers/s3/utils/client/runtime/s3TransferHandler/fetch',
+);
+
+const mockS3TransferHandler = s3TransferHandler as jest.Mock;
+const mockBinaryResponse = ({
+	status,
+	headers,
+	body,
+}: {
+	status: number;
+	headers: Record<string, string>;
+	body: string;
+}): HttpResponse => {
+	const responseBody = {
+		json: async (): Promise<any> => {
+			throw new Error(
+				'Parsing response to JSON is not implemented. Please use response.text() instead.',
+			);
+		},
+		blob: async () => new Blob([body], { type: 'plain/text' }),
+		text: async () => body,
+	} as HttpResponse['body'];
+
+	return {
+		statusCode: status,
+		headers,
+		body: responseBody,
+	} as any;
+};
+
+const putObjectSuccessResponse = {
+	status: 200,
+	headers: {
+		...DEFAULT_RESPONSE_HEADERS,
+		'x-amz-version-id': 'versionId',
+		etag: 'etag',
+	},
+	body: '',
+};
+
+describe('serializePutObjectRequest', () => {
+	const mockIsValidObjectUrl = jest.mocked(validateObjectUrl);
+	beforeEach(() => {
+		mockS3TransferHandler.mockReset();
+	});
+
+	it('should pass when objectUrl is durable', async () => {
+		expect.assertions(1);
+		mockS3TransferHandler.mockResolvedValue(
+			mockBinaryResponse(putObjectSuccessResponse as any),
+		);
+		const output = await putObject(defaultConfig, {
+			Bucket: 'bucket',
+			Key: 'key',
+		});
+		expect(output).toEqual({
+			$metadata: expect.objectContaining(expectedMetadata),
+			ETag: 'etag',
+			VersionId: 'versionId',
+		});
+	});
+
+	it('should fail when objectUrl is NOT durable', async () => {
+		expect.assertions(1);
+		mockS3TransferHandler.mockResolvedValue(
+			mockBinaryResponse(putObjectSuccessResponse as any),
+		);
+		const integrityError = new IntegrityError();
+		mockIsValidObjectUrl.mockImplementationOnce(() => {
+			throw integrityError;
+		});
+		expect(
+			putObject(defaultConfig, {
+				Bucket: 'bucket',
+				Key: 'key',
+			}),
+		).rejects.toThrow(integrityError);
+	});
+});

--- a/packages/storage/__tests__/providers/s3/utils/validateObjectUrl.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/validateObjectUrl.test.ts
@@ -1,0 +1,174 @@
+import { validateObjectUrl } from '../../../../src/providers/s3/utils/validateObjectUrl';
+
+describe('validateObjectUrl', () => {
+	const bucket = 'bucket';
+	const key = 'key/eresa/rre';
+	const bucketWithDots = 'bucket.with.dots';
+	const objectContainingUrl = new URL(
+		`https://bucket.s3.amz.com/${key}?params=params`,
+	);
+	const objectContainingUrlPathStyle = new URL(
+		`https://s3.amz.com/bucket/${key}?params=params`,
+	);
+	const objectContainingUrlWithDots = new URL(
+		`https://s3.amz.com/bucket.with.dots/${key}?params=params`,
+	);
+
+	test.each([
+		{
+			description: 'bucket without dots',
+			input: {
+				bucketName: bucket,
+				key,
+				objectContainingUrl,
+			},
+			success: true,
+		},
+		{
+			description: 'bucket without dots path style url',
+			input: {
+				bucketName: bucket,
+				key,
+				objectContainingUrl: objectContainingUrlPathStyle,
+			},
+			success: true,
+		},
+		{
+			description: 'bucket with dots',
+			input: {
+				bucketName: bucketWithDots,
+				key,
+				objectContainingUrl: objectContainingUrlWithDots,
+			},
+			success: true,
+		},
+		{
+			description: 'directory bucket',
+			input: {
+				bucketName: 'bucket--use1-az2--x-s3',
+				key,
+				objectContainingUrl: new URL(
+					`https://bucket--use1-az2--x-s3.s3.amz.com/${key}?params=params`,
+				),
+			},
+			success: true,
+		},
+		{
+			description: 'bucket without dots, wrong presigned url',
+			input: {
+				bucketName: bucket,
+				key,
+				objectContainingUrl: objectContainingUrlWithDots,
+			},
+			success: false,
+		},
+		{
+			description: 'bucket with dots, wrong presigned url',
+			input: {
+				bucketName: bucketWithDots,
+				key,
+				objectContainingUrl,
+			},
+			success: false,
+		},
+		{
+			description: 'bucket and key equal',
+			input: {
+				bucketName: bucket,
+				key: bucket,
+				objectContainingUrl: new URL(
+					'https://bucket.s3.amz.com/bucket?params=params',
+				),
+			},
+			success: true,
+		},
+		{
+			description: 'bucket repeated in url',
+			input: {
+				bucketName: bucket,
+				key,
+				objectContainingUrl: new URL(
+					`https://bucketbucket.s3.amz.com/${key}?params=params`,
+				),
+			},
+			success: false,
+		},
+		{
+			description: 'bucket uppercase and presigned lowercase',
+			input: {
+				bucketName: 'BUCKET',
+				key,
+				objectContainingUrl: new URL(
+					`https://bucket.s3.amz.com/${key}?params=params`,
+				),
+			},
+			success: false,
+		},
+		{
+			description: 'bucket with dots uppercase and presigned lowercase',
+			input: {
+				bucketName: 'B.U.C.K.E.T',
+				key,
+				objectContainingUrl: new URL(
+					`https://s3.amz.com/b.u.c.k.e.t/${key}?params=params`,
+				),
+			},
+			success: false,
+		},
+		{
+			description: 'key uppercase and presigned lowercase',
+			input: {
+				bucketName: bucket,
+				key: 'KEY',
+				objectContainingUrl: new URL(
+					'https://bucket.s3.amz.com/bucket?params=params',
+				),
+			},
+			success: false,
+		},
+		{
+			description: 'key lowercase and presigned uppercase',
+			input: {
+				bucketName: bucket,
+				key: 'key',
+				objectContainingUrl: new URL(
+					`https://bucket.s3.amz.com/${key.toUpperCase()}?params=params`,
+				),
+			},
+			success: false,
+		},
+		{
+			description: 'missing bucket',
+			input: { key, objectContainingUrl },
+			success: false,
+		},
+		{
+			description: 'missing key',
+			input: { bucketName: bucket, objectContainingUrl },
+			success: false,
+		},
+		{
+			description: 'missing objectContainingUrl',
+			input: { bucketName: bucket, key, objectContainingUrl: undefined },
+			success: false,
+		},
+	])(`$description`, ({ input, success }) => {
+		if (success) {
+			expect(() => {
+				validateObjectUrl({
+					bucketName: input.bucketName,
+					key: input.key,
+					objectURL: input.objectContainingUrl,
+				});
+			}).not.toThrow();
+		} else {
+			expect(() => {
+				validateObjectUrl({
+					bucketName: input.bucketName,
+					key: input.key,
+					objectURL: input.objectContainingUrl,
+				});
+			}).toThrow('An unknown error has occurred.');
+		}
+	});
+});

--- a/packages/storage/src/errors/IntegrityError.ts
+++ b/packages/storage/src/errors/IntegrityError.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import {
+	AmplifyErrorCode,
+	AmplifyErrorParams,
+} from '@aws-amplify/core/internals/utils';
+
+import { StorageError } from './StorageError';
+
+export class IntegrityError extends StorageError {
+	constructor(
+		params: AmplifyErrorParams = {
+			name: AmplifyErrorCode.Unknown,
+			message: 'An unknown error has occurred.',
+			recoverySuggestion:
+				'This may be a bug. Please reach out to library authors.',
+		},
+	) {
+		super(params);
+
+		// TODO: Delete the following 2 lines after we change the build target to >= es2015
+		this.constructor = IntegrityError;
+		Object.setPrototypeOf(this, IntegrityError.prototype);
+	}
+}

--- a/packages/storage/src/providers/s3/utils/client/s3data/putObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/putObject.ts
@@ -20,6 +20,7 @@ import {
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
 } from '../utils';
+import { validateObjectUrl } from '../../validateObjectUrl';
 
 import { defaultConfig } from './base';
 import type { PutObjectCommandInput, PutObjectCommandOutput } from './types';
@@ -63,6 +64,11 @@ const putObjectSerializer = async (
 	const url = new AmplifyUrl(endpoint.url.toString());
 	validateS3RequiredParameter(!!input.Key, 'Key');
 	url.pathname = serializePathnameObjectKey(url, input.Key);
+	validateObjectUrl({
+		bucketName: input.Bucket,
+		key: input.Key,
+		objectURL: url,
+	});
 
 	return {
 		method: 'PUT',

--- a/packages/storage/src/providers/s3/utils/validateObjectUrl.ts
+++ b/packages/storage/src/providers/s3/utils/validateObjectUrl.ts
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { extendedEncodeURIComponent } from '@aws-amplify/core/internals/aws-client-utils';
+
+import { IntegrityError } from '../../../errors/IntegrityError';
+
+export function validateObjectUrl({
+	bucketName,
+	key,
+	objectURL,
+}: {
+	bucketName?: string;
+	key?: string;
+	objectURL?: URL;
+}): void {
+	if (!bucketName || !key || !objectURL) {
+		throw new IntegrityError();
+	}
+	const bucketWithDots = bucketName.includes('.');
+	const encodedBucketName = extendedEncodeURIComponent(bucketName);
+	const encodedKey = key.split('/').map(extendedEncodeURIComponent).join('/');
+	const isPathStyleUrl =
+		objectURL.pathname === `/${encodedBucketName}/${encodedKey}`;
+	const isSubdomainUrl =
+		objectURL.hostname.startsWith(`${encodedBucketName}.`) &&
+		objectURL.pathname === `/${encodedKey}`;
+
+	if (!(isPathStyleUrl || (!bucketWithDots && isSubdomainUrl))) {
+		throw new IntegrityError();
+	}
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
- Implementing a common error for Durability Issues
- Function to check durability between a presigned url and the source bucket and key.
- Add logic inside PutObject operation to check the durability status.



#### Description of how you validated changes
- Executed environment with `yarn dev`
- Executed unit tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
