### PR TITLE
feat: validate uploaded parts before completing upload

### DIFF
--- a/packages/storage/__tests__/providers/s3/apis/internal/uploadData/index.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/internal/uploadData/index.test.ts
@@ -55,12 +55,17 @@ describe('uploadData with key', () => {
 			);
 		});
 
-		it('should NOT throw if data size is unknown', async () => {
-			uploadData({
-				key: 'key',
-				data: {} as any,
-			});
-			expect(mockCreateUploadTask).toHaveBeenCalled();
+		it('should throw if data size is unknown', async () => {
+			expect(() =>
+				uploadData({
+					key: 'key',
+					data: {} as any,
+				}),
+			).toThrow(
+				expect.objectContaining(
+					validationErrorMap[StorageValidationErrorCode.InvalidUploadSource],
+				),
+			);
 		});
 	});
 
@@ -166,12 +171,17 @@ describe('uploadData with path', () => {
 			);
 		});
 
-		it('should NOT throw if data size is unknown', async () => {
-			uploadData({
-				path: testPath,
-				data: {} as any,
-			});
-			expect(mockCreateUploadTask).toHaveBeenCalled();
+		it('should throw if data size is unknown', async () => {
+			expect(() =>
+				uploadData({
+					path: testPath,
+					data: {} as any,
+				}),
+			).toThrow(
+				expect.objectContaining(
+					validationErrorMap[StorageValidationErrorCode.InvalidUploadSource],
+				),
+			);
 		});
 	});
 

--- a/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
@@ -244,7 +244,7 @@ describe('getMultipartUploadHandlers with key', () => {
 							data: twoPartsPayload,
 							options: options as StorageOptions,
 						},
-						byteLength(twoPartsPayload),
+						byteLength(twoPartsPayload)!,
 					);
 					const result = await multipartUploadJob();
 					await expect(
@@ -293,7 +293,7 @@ describe('getMultipartUploadHandlers with key', () => {
 							checksumAlgorithm: CHECKSUM_ALGORITHM_CRC32,
 						},
 					},
-					byteLength(twoPartsPayload),
+					byteLength(twoPartsPayload)!,
 				);
 				await multipartUploadJob();
 
@@ -346,10 +346,13 @@ describe('getMultipartUploadHandlers with key', () => {
 
 		it('should throw if unsupported payload type is provided', async () => {
 			mockMultipartUploadSuccess();
-			const { multipartUploadJob } = getMultipartUploadHandlers({
-				key: defaultKey,
-				data: 1 as any,
-			});
+			const { multipartUploadJob } = getMultipartUploadHandlers(
+				{
+					key: defaultKey,
+					data: 1 as any,
+				},
+				1,
+			);
 			await expect(multipartUploadJob()).rejects.toThrow(
 				expect.objectContaining(
 					validationErrorMap[StorageValidationErrorCode.InvalidUploadSource],
@@ -427,10 +430,13 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockCreateMultipartUpload.mockReset();
 			mockCreateMultipartUpload.mockRejectedValueOnce(new Error('error'));
 
-			const { multipartUploadJob } = getMultipartUploadHandlers({
-				key: defaultKey,
-				data: new ArrayBuffer(8 * MB),
-			});
+			const { multipartUploadJob } = getMultipartUploadHandlers(
+				{
+					key: defaultKey,
+					data: new ArrayBuffer(8 * MB),
+				},
+				8 * MB,
+			);
 			await expect(multipartUploadJob()).rejects.toThrow('error');
 		});
 
@@ -440,10 +446,13 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockCompleteMultipartUpload.mockReset();
 			mockCompleteMultipartUpload.mockRejectedValueOnce(new Error('error'));
 
-			const { multipartUploadJob } = getMultipartUploadHandlers({
-				key: defaultKey,
-				data: new ArrayBuffer(8 * MB),
-			});
+			const { multipartUploadJob } = getMultipartUploadHandlers(
+				{
+					key: defaultKey,
+					data: new ArrayBuffer(8 * MB),
+				},
+				8 * MB,
+			);
 			await expect(multipartUploadJob()).rejects.toThrow('error');
 		});
 
@@ -458,10 +467,13 @@ describe('getMultipartUploadHandlers with key', () => {
 			});
 			mockUploadPart.mockRejectedValueOnce(new Error('error'));
 
-			const { multipartUploadJob } = getMultipartUploadHandlers({
-				key: defaultKey,
-				data: new ArrayBuffer(8 * MB),
-			});
+			const { multipartUploadJob } = getMultipartUploadHandlers(
+				{
+					key: defaultKey,
+					data: new ArrayBuffer(8 * MB),
+				},
+				8 * MB,
+			);
 			await expect(multipartUploadJob()).rejects.toThrow('error');
 			expect(mockUploadPart).toHaveBeenCalledTimes(2);
 			expect(mockCompleteMultipartUpload).not.toHaveBeenCalled();
@@ -481,7 +493,7 @@ describe('getMultipartUploadHandlers with key', () => {
 							bucket: { bucketName: mockBucket, region: mockRegion },
 						},
 					},
-					byteLength(mockData),
+					byteLength(mockData)!,
 				);
 				await multipartUploadJob();
 				await expect(
@@ -510,7 +522,7 @@ describe('getMultipartUploadHandlers with key', () => {
 							bucket: 'default-bucket',
 						},
 					},
-					byteLength(mockData),
+					byteLength(mockData)!,
 				);
 				await multipartUploadJob();
 				await expect(
@@ -800,10 +812,13 @@ describe('getMultipartUploadHandlers with key', () => {
 
 	describe('cancel()', () => {
 		it('should abort in-flight uploadPart requests and throw if upload is canceled', async () => {
-			const { multipartUploadJob, onCancel } = getMultipartUploadHandlers({
-				key: defaultKey,
-				data: new ArrayBuffer(8 * MB),
-			});
+			const { multipartUploadJob, onCancel } = getMultipartUploadHandlers(
+				{
+					key: defaultKey,
+					data: new ArrayBuffer(8 * MB),
+				},
+				8 * MB,
+			);
 			let partCount = 0;
 			mockMultipartUploadCancellation(() => {
 				partCount++;
@@ -1007,7 +1022,7 @@ describe('getMultipartUploadHandlers with path', () => {
 							path: inputPath,
 							data: twoPartsPayload,
 						},
-						byteLength(twoPartsPayload),
+						byteLength(twoPartsPayload)!,
 					);
 					const result = await multipartUploadJob();
 					await expect(
@@ -1056,7 +1071,7 @@ describe('getMultipartUploadHandlers with path', () => {
 							checksumAlgorithm: CHECKSUM_ALGORITHM_CRC32,
 						},
 					},
-					byteLength(twoPartsPayload),
+					byteLength(twoPartsPayload)!,
 				);
 				await multipartUploadJob();
 
@@ -1109,10 +1124,13 @@ describe('getMultipartUploadHandlers with path', () => {
 
 		it('should throw if unsupported payload type is provided', async () => {
 			mockMultipartUploadSuccess();
-			const { multipartUploadJob } = getMultipartUploadHandlers({
-				path: testPath,
-				data: 1 as any,
-			});
+			const { multipartUploadJob } = getMultipartUploadHandlers(
+				{
+					path: testPath,
+					data: 1 as any,
+				},
+				1,
+			);
 			await expect(multipartUploadJob()).rejects.toThrow(
 				expect.objectContaining(
 					validationErrorMap[StorageValidationErrorCode.InvalidUploadSource],
@@ -1190,10 +1208,13 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockCreateMultipartUpload.mockReset();
 			mockCreateMultipartUpload.mockRejectedValueOnce(new Error('error'));
 
-			const { multipartUploadJob } = getMultipartUploadHandlers({
-				path: testPath,
-				data: new ArrayBuffer(8 * MB),
-			});
+			const { multipartUploadJob } = getMultipartUploadHandlers(
+				{
+					path: testPath,
+					data: new ArrayBuffer(8 * MB),
+				},
+				8 * MB,
+			);
 			await expect(multipartUploadJob()).rejects.toThrow('error');
 		});
 
@@ -1203,10 +1224,13 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockCompleteMultipartUpload.mockReset();
 			mockCompleteMultipartUpload.mockRejectedValueOnce(new Error('error'));
 
-			const { multipartUploadJob } = getMultipartUploadHandlers({
-				path: testPath,
-				data: new ArrayBuffer(8 * MB),
-			});
+			const { multipartUploadJob } = getMultipartUploadHandlers(
+				{
+					path: testPath,
+					data: new ArrayBuffer(8 * MB),
+				},
+				8 * MB,
+			);
 			await expect(multipartUploadJob()).rejects.toThrow('error');
 		});
 
@@ -1221,10 +1245,13 @@ describe('getMultipartUploadHandlers with path', () => {
 			});
 			mockUploadPart.mockRejectedValueOnce(new Error('error'));
 
-			const { multipartUploadJob } = getMultipartUploadHandlers({
-				path: testPath,
-				data: new ArrayBuffer(8 * MB),
-			});
+			const { multipartUploadJob } = getMultipartUploadHandlers(
+				{
+					path: testPath,
+					data: new ArrayBuffer(8 * MB),
+				},
+				8 * MB,
+			);
 			await expect(multipartUploadJob()).rejects.toThrow('error');
 			expect(mockUploadPart).toHaveBeenCalledTimes(2);
 			expect(mockCompleteMultipartUpload).not.toHaveBeenCalled();
@@ -1273,7 +1300,7 @@ describe('getMultipartUploadHandlers with path', () => {
 							bucket: { bucketName: mockBucket, region: mockRegion },
 						},
 					},
-					byteLength(mockData),
+					byteLength(mockData)!,
 				);
 				await multipartUploadJob();
 				await expect(
@@ -1304,7 +1331,7 @@ describe('getMultipartUploadHandlers with path', () => {
 							bucket: 'default-bucket',
 						},
 					},
-					byteLength(mockData),
+					byteLength(mockData)!,
 				);
 				await multipartUploadJob();
 				await expect(
@@ -1596,10 +1623,13 @@ describe('getMultipartUploadHandlers with path', () => {
 
 	describe('cancel()', () => {
 		it('should abort in-flight uploadPart requests and throw if upload is canceled', async () => {
-			const { multipartUploadJob, onCancel } = getMultipartUploadHandlers({
-				path: testPath,
-				data: new ArrayBuffer(8 * MB),
-			});
+			const { multipartUploadJob, onCancel } = getMultipartUploadHandlers(
+				{
+					path: testPath,
+					data: new ArrayBuffer(8 * MB),
+				},
+				8 * MB,
+			);
 			let partCount = 0;
 			mockMultipartUploadCancellation(() => {
 				partCount++;

--- a/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
@@ -115,7 +115,7 @@ const mockMultipartUploadSuccess = (disableAssertion?: boolean) => {
 		totalSize += byteLength(input.Body)!;
 
 		return {
-			Etag: `etag-${input.PartNumber}`,
+			ETag: `etag-${input.PartNumber}`,
 			PartNumber: input.PartNumber,
 		};
 	});
@@ -514,6 +514,109 @@ describe('getMultipartUploadHandlers with key', () => {
 				);
 			});
 		});
+
+		describe('cache validation', () => {
+			it.each([
+				{
+					name: 'wrong part count',
+					parts: [
+						{
+							PartNumber: 1,
+							ETag: 'mock-etag',
+							ChecksumCRC32: 'mock-checksum',
+						},
+						{
+							PartNumber: 2,
+							ETag: 'mock-etag',
+							ChecksumCRC32: 'mock-checksum',
+						},
+						{
+							PartNumber: 3,
+							ETag: 'mock-etag',
+							ChecksumCRC32: 'mock-checksum',
+						},
+					],
+				},
+				{
+					name: 'wrong part number',
+					parts: [
+						{
+							PartNumber: 1,
+							ETag: 'mock-etag',
+							ChecksumCRC32: 'mock-checksum',
+						},
+						{
+							PartNumber: 1,
+							ETag: 'mock-etag',
+							ChecksumCRC32: 'mock-checksum',
+						},
+					],
+				},
+				{
+					name: 'missing etag',
+					parts: [
+						{
+							PartNumber: 1,
+							ChecksumCRC32: 'mock-checksum',
+						},
+						{
+							PartNumber: 2,
+							ETag: 'mock-etag',
+							ChecksumCRC32: 'mock-checksum',
+						},
+					],
+				},
+				{
+					name: 'missing crc32',
+					parts: [
+						{
+							PartNumber: 1,
+							ETag: 'mock-etag',
+						},
+						{
+							PartNumber: 2,
+							ETag: 'mock-etag',
+							ChecksumCRC32: 'mock-checksum',
+						},
+					],
+				},
+			])('should throw with $name', async ({ parts }) => {
+				mockMultipartUploadSuccess();
+
+				const mockDefaultStorage = defaultStorage as jest.Mocked<
+					typeof defaultStorage
+				>;
+				mockDefaultStorage.getItem.mockResolvedValue(
+					JSON.stringify({
+						[defaultCacheKey]: {
+							uploadId: 'uploadId',
+							bucket,
+							key: defaultKey,
+							finalCrc32: 'mock-crc32',
+						},
+					}),
+				);
+				mockListParts.mockResolvedValue({
+					Parts: parts,
+					$metadata: {},
+				});
+
+				const onProgress = jest.fn();
+				const { multipartUploadJob } = getMultipartUploadHandlers(
+					{
+						key: defaultKey,
+						data: new ArrayBuffer(8 * MB),
+						options: {
+							onProgress,
+						},
+					},
+					8 * MB,
+				);
+				await expect(multipartUploadJob()).rejects.toThrow(
+					/Upload failed. Parts cache validation failed/,
+				);
+			});
+		});
 	});
 
 	describe('upload caching', () => {
@@ -845,7 +948,9 @@ describe('getMultipartUploadHandlers with key', () => {
 				}),
 			);
 			mockListParts.mockResolvedValue({
-				Parts: [{ PartNumber: 1 }],
+				Parts: [
+					{ PartNumber: 1, ETag: 'mock-etag', ChecksumCRC32: 'mock-checksum' },
+				],
 				$metadata: {},
 			});
 
@@ -1568,7 +1673,9 @@ describe('getMultipartUploadHandlers with path', () => {
 				}),
 			);
 			mockListParts.mockResolvedValue({
-				Parts: [{ PartNumber: 1 }],
+				Parts: [
+					{ PartNumber: 1, ETag: 'mock-etag', ChecksumCRC32: 'mock-checksum' },
+				],
 				$metadata: {},
 			});
 

--- a/packages/storage/__tests__/providers/s3/apis/internal/uploadData/putObjectJob.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/internal/uploadData/putObjectJob.test.ts
@@ -43,6 +43,8 @@ const mockFetchAuthSession = jest.mocked(Amplify.Auth.fetchAuthSession);
 const mockPutObject = jest.mocked(putObject);
 const bucket = 'bucket';
 const region = 'region';
+const data = 'data';
+const dataLength = data.length;
 
 mockFetchAuthSession.mockResolvedValue({
 	credentials,
@@ -78,7 +80,6 @@ describe('putObjectJob with key', () => {
 		async ({ checksumAlgorithm }) => {
 			const abortController = new AbortController();
 			const inputKey = 'key';
-			const data = 'data';
 			const mockContentType = 'contentType';
 			const contentDisposition = 'contentDisposition';
 			const contentEncoding = 'contentEncoding';
@@ -101,6 +102,7 @@ describe('putObjectJob with key', () => {
 					},
 				},
 				abortController.signal,
+				dataLength,
 			);
 			const result = await job();
 			expect(result).toEqual({
@@ -109,7 +111,7 @@ describe('putObjectJob with key', () => {
 				versionId: 'versionId',
 				contentType: 'contentType',
 				metadata: { key: 'value' },
-				size: undefined,
+				size: dataLength,
 			});
 			expect(mockPutObject).toHaveBeenCalledTimes(1);
 			await expect(mockPutObject).toBeLastCalledWithConfigAndInput(
@@ -158,6 +160,7 @@ describe('putObjectJob with key', () => {
 				data: 'data',
 			},
 			new AbortController().signal,
+			dataLength,
 		);
 		await job();
 		expect(calculateContentMd5).toHaveBeenCalledWith('data');
@@ -166,7 +169,6 @@ describe('putObjectJob with key', () => {
 	describe('bucket passed in options', () => {
 		it('should override bucket in putObject call when bucket as object', async () => {
 			const abortController = new AbortController();
-			const data = 'data';
 			const bucketName = 'bucket-1';
 			const mockRegion = 'region-1';
 
@@ -182,6 +184,7 @@ describe('putObjectJob with key', () => {
 					},
 				},
 				new AbortController().signal,
+				dataLength,
 			);
 			await job();
 
@@ -203,7 +206,6 @@ describe('putObjectJob with key', () => {
 
 		it('should override bucket in putObject call when bucket as string', async () => {
 			const abortController = new AbortController();
-			const data = 'data';
 			const job = putObjectJob(
 				{
 					key: 'key',
@@ -213,6 +215,7 @@ describe('putObjectJob with key', () => {
 					},
 				},
 				new AbortController().signal,
+				dataLength,
 			);
 			await job();
 
@@ -274,7 +277,6 @@ describe('putObjectJob with path', () => {
 		'should supply the correct parameters to putObject API handler when path is $path and checksumAlgorithm is $checksumAlgorithm',
 		async ({ path: inputPath, expectedKey, checksumAlgorithm }) => {
 			const abortController = new AbortController();
-			const data = 'data';
 			const mockContentType = 'contentType';
 			const contentDisposition = 'contentDisposition';
 			const contentEncoding = 'contentEncoding';
@@ -297,6 +299,7 @@ describe('putObjectJob with path', () => {
 					},
 				},
 				abortController.signal,
+				dataLength,
 			);
 			const result = await job();
 			expect(result).toEqual({
@@ -305,7 +308,7 @@ describe('putObjectJob with path', () => {
 				versionId: 'versionId',
 				contentType: 'contentType',
 				metadata: { key: 'value' },
-				size: undefined,
+				size: dataLength,
 			});
 			expect(mockPutObject).toHaveBeenCalledTimes(1);
 			await expect(mockPutObject).toBeLastCalledWithConfigAndInput(
@@ -351,9 +354,10 @@ describe('putObjectJob with path', () => {
 		const job = putObjectJob(
 			{
 				path: testPath,
-				data: 'data',
+				data,
 			},
 			new AbortController().signal,
+			dataLength,
 		);
 		await job();
 		expect(calculateContentMd5).toHaveBeenCalledWith('data');
@@ -364,10 +368,11 @@ describe('putObjectJob with path', () => {
 			const job = putObjectJob(
 				{
 					path: testPath,
-					data: 'data',
+					data,
 					options: { preventOverwrite: true },
 				},
 				new AbortController().signal,
+				dataLength,
 			);
 			await job();
 
@@ -383,7 +388,6 @@ describe('putObjectJob with path', () => {
 	describe('bucket passed in options', () => {
 		it('should override bucket in putObject call when bucket as object', async () => {
 			const abortController = new AbortController();
-			const data = 'data';
 			const bucketName = 'bucket-1';
 			const mockRegion = 'region-1';
 
@@ -399,6 +403,7 @@ describe('putObjectJob with path', () => {
 					},
 				},
 				new AbortController().signal,
+				dataLength,
 			);
 			await job();
 
@@ -420,7 +425,6 @@ describe('putObjectJob with path', () => {
 
 		it('should override bucket in putObject call when bucket as string', async () => {
 			const abortController = new AbortController();
-			const data = 'data';
 			const job = putObjectJob(
 				{
 					path: 'path/',
@@ -430,6 +434,7 @@ describe('putObjectJob with path', () => {
 					},
 				},
 				new AbortController().signal,
+				dataLength,
 			);
 			await job();
 

--- a/packages/storage/__tests__/providers/s3/utils/getCombinedCrc32.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/getCombinedCrc32.test.ts
@@ -103,6 +103,6 @@ describe('calculate crc32', () => {
 			expect((await getCombinedCrc32(data, byteLength(data)))!).toEqual(
 				expected.checksum,
 			);
-		});
+		}, 10_000);
 	});
 });

--- a/packages/storage/__tests__/providers/s3/utils/getCombinedCrc32.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/getCombinedCrc32.test.ts
@@ -103,6 +103,6 @@ describe('calculate crc32', () => {
 			expect((await getCombinedCrc32(data, byteLength(data)))!).toEqual(
 				expected.checksum,
 			);
-		}, 10_000);
+		});
 	});
 });

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/byteLength.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/byteLength.ts
@@ -8,16 +8,9 @@
 export const byteLength = (input?: any): number | undefined => {
 	if (input === null || input === undefined) return 0;
 	if (typeof input === 'string') {
-		let len = input.length;
+		const blob = new Blob([input]);
 
-		for (let i = len - 1; i >= 0; i--) {
-			const code = input.charCodeAt(i);
-			if (code > 0x7f && code <= 0x7ff) len++;
-			else if (code > 0x7ff && code <= 0xffff) len += 2;
-			if (code >= 0xdc00 && code <= 0xdfff) i--; // trail surrogate
-		}
-
-		return len;
+		return blob.size;
 	} else if (typeof input.byteLength === 'number') {
 		// handles Uint8Array, ArrayBuffer, Buffer, and ArrayBufferView
 		return input.byteLength;

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/byteLength.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/byteLength.ts
@@ -19,6 +19,5 @@ export const byteLength = (input?: any): number | undefined => {
 		return input.size;
 	}
 
-	// TODO: support Node.js stream size when Node.js runtime is supported out-of-box.
 	return undefined;
 };

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/index.ts
@@ -19,12 +19,18 @@ export const uploadData = (
 	const { data } = input;
 
 	const dataByteLength = byteLength(data);
+	// If the upload source sticks to the suggested types, the byteLength can be
+	// determined here.
 	assertValidationError(
-		dataByteLength === undefined || dataByteLength <= MAX_OBJECT_SIZE,
+		dataByteLength !== undefined,
+		StorageValidationErrorCode.InvalidUploadSource,
+	);
+	assertValidationError(
+		dataByteLength <= MAX_OBJECT_SIZE,
 		StorageValidationErrorCode.ObjectIsTooLarge,
 	);
 
-	if (dataByteLength !== undefined && dataByteLength <= DEFAULT_PART_SIZE) {
+	if (dataByteLength <= DEFAULT_PART_SIZE) {
 		// Single part upload
 		const abortController = new AbortController();
 

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/index.ts
@@ -19,8 +19,8 @@ export const uploadData = (
 	const { data } = input;
 
 	const dataByteLength = byteLength(data);
-	// If the upload source sticks to the suggested types, the byteLength can be
-	// determined here.
+	// Using InvalidUploadSource error code because the input data must NOT be any
+	// of permitted Blob, string, ArrayBuffer(View) if byteLength could not be determined.
 	assertValidationError(
 		dataByteLength !== undefined,
 		StorageValidationErrorCode.InvalidUploadSource,

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
@@ -43,6 +43,7 @@ import { getUploadsCacheKey, removeCachedUpload } from './uploadCache';
 import { getConcurrentUploadsProgressTracker } from './progressTracker';
 import { loadOrCreateMultipartUpload } from './initialUpload';
 import { getDataChunker } from './getDataChunker';
+import { calculatePartSize } from './calculatePartSize';
 
 type WithResumableCacheConfig<Input extends StorageOperationOptionsInput<any>> =
 	Input & {
@@ -236,6 +237,19 @@ export const getMultipartUploadHandlers = (
 
 		await Promise.all(concurrentUploadPartExecutors);
 
+		if (
+			!isValidCompletedParts(
+				inProgressUpload.completedParts,
+				size,
+				Boolean(inProgressUpload.finalCrc32),
+			)
+		) {
+			throw new StorageError({
+				name: 'Error',
+				message: `Upload failed. Parts cache validation failed`,
+			});
+		}
+
 		const { ETag: eTag } = await completeMultipartUpload(
 			{
 				...resolvedS3Config,
@@ -249,9 +263,7 @@ export const getMultipartUploadHandlers = (
 				ChecksumCRC32: inProgressUpload.finalCrc32,
 				IfNoneMatch: preventOverwrite ? '*' : undefined,
 				MultipartUpload: {
-					Parts: inProgressUpload.completedParts.sort(
-						(partA, partB) => partA.PartNumber! - partB.PartNumber!,
-					),
+					Parts: sortUploadParts(inProgressUpload.completedParts),
 				},
 				ExpectedBucketOwner: expectedBucketOwner,
 			},
@@ -355,3 +367,36 @@ const resolveAccessLevel = (accessLevel?: StorageAccessLevel) =>
 	accessLevel ??
 	Amplify.libraryOptions.Storage?.S3?.defaultAccessLevel ??
 	DEFAULT_ACCESS_LEVEL;
+
+const isValidCompletedParts = (
+	completedParts: Part[],
+	size: number | undefined,
+	useCRC32Checksum: boolean,
+) => {
+	let validPartCount = true;
+	if (size) {
+		const partsExpected = Math.ceil(size / calculatePartSize(size));
+		validPartCount = completedParts.length === partsExpected;
+	}
+
+	let validPartsContent = true;
+	const sorted = sortUploadParts(completedParts);
+	for (const [i, value] of sorted.entries()) {
+		const validPartNumber = i + 1 === value.PartNumber!;
+		const crc32Exists = !useCRC32Checksum || Boolean(value.ChecksumCRC32);
+		const etagExists = Boolean(value.ETag);
+
+		if (!(validPartNumber && crc32Exists && etagExists)) {
+			validPartsContent = false;
+			break;
+		}
+	}
+
+	return validPartCount && validPartsContent;
+};
+
+const sortUploadParts = (parts: Part[]) => {
+	return [...parts].sort(
+		(partA, partB) => partA.PartNumber! - partB.PartNumber!,
+	);
+};

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
@@ -238,7 +238,7 @@ export const getMultipartUploadHandlers = (
 
 		await Promise.all(concurrentUploadPartExecutors);
 
-		validateCompletedParts(inProgressUpload.completedParts, size!);
+		validateCompletedParts(inProgressUpload.completedParts, size);
 
 		const { ETag: eTag } = await completeMultipartUpload(
 			{

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
@@ -82,7 +82,7 @@ export type MultipartUploadDataInput = WithResumableCacheConfig<
  */
 export const getMultipartUploadHandlers = (
 	uploadDataInput: MultipartUploadDataInput,
-	size?: number,
+	size: number,
 ) => {
 	let resolveCallback:
 		| ((value: ItemWithKey | ItemWithPath) => void)

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/putObjectJob.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/putObjectJob.ts
@@ -43,7 +43,7 @@ export const putObjectJob =
 	(
 		uploadDataInput: SinglePartUploadDataInput,
 		abortSignal: AbortSignal,
-		totalLength?: number,
+		totalLength: number,
 	) =>
 	async (): Promise<ItemWithKey | ItemWithPath> => {
 		const { options: uploadDataOptions, data } = uploadDataInput;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Simplify string size evaluation in `byteLength` to align with upload part generator. When validating parts, it's required to have the same size calculation. Other data types are already aligned.
- Before sending CompleteMultipartUpload, validate that we have all expected parts based on object size.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
- New unit tests mocking cache to create invalid parts


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
