### PR TITLE
fix(storage-browser): missing error wrapping for s3 control responses

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -461,43 +461,43 @@
 			"name": "[Storage] copy (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ copy }",
-			"limit": "15.42 kB"
+			"limit": "15.47 kB"
 		},
 		{
 			"name": "[Storage] downloadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ downloadData }",
-			"limit": "15.93 kB"
+			"limit": "15.98 kB"
 		},
 		{
 			"name": "[Storage] getProperties (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getProperties }",
-			"limit": "15.20 kB"
+			"limit": "15.25 kB"
 		},
 		{
 			"name": "[Storage] getUrl (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ getUrl }",
-			"limit": "16.43 kB"
+			"limit": "16.47 kB"
 		},
 		{
 			"name": "[Storage] list (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ list }",
-			"limit": "15.82 kB"
+			"limit": "15.88 kB"
 		},
 		{
 			"name": "[Storage] remove (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ remove }",
-			"limit": "15.05 kB"
+			"limit": "15.10 kB"
 		},
 		{
 			"name": "[Storage] uploadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ uploadData }",
-			"limit": "21.68 kB"
+			"limit": "21.71 kB"
 		}
 	]
 }

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -491,13 +491,13 @@
 			"name": "[Storage] remove (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ remove }",
-			"limit": "15.10 kB"
+			"limit": "15.13 kB"
 		},
 		{
 			"name": "[Storage] uploadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ uploadData }",
-			"limit": "21.71 kB"
+			"limit": "21.73 kB"
 		}
 	]
 }

--- a/packages/storage/__tests__/providers/s3/utils/client/S3/cases/getDataAccess.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/S3/cases/getDataAccess.ts
@@ -83,12 +83,14 @@ const getDataAccessErrorCase: ApiFunctionalTestCase<typeof getDataAccess> = [
 		headers: DEFAULT_RESPONSE_HEADERS,
 		body: `
 		<?xml version="1.0" encoding="UTF-8"?>
-		<Error>
-			<Code>AccessDenied</Code>
-			<Message>Access Denied</Message>
+		<ErrorResponse>
+		  <Error>
+			  <Code>AccessDenied</Code>
+			  <Message>Access Denied</Message>
+			</Error>
 			<RequestId>656c76696e6727732072657175657374</RequestId>
 			<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>
-		</Error>
+		</ErrorResponse>
 		`,
 	},
 	{

--- a/packages/storage/__tests__/providers/s3/utils/client/S3/cases/listCallerAccessGrants.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/S3/cases/listCallerAccessGrants.ts
@@ -149,12 +149,14 @@ const listCallerAccessGrantsErrorCase: ApiFunctionalTestCase<
 		headers: DEFAULT_RESPONSE_HEADERS,
 		body: `
 		<?xml version="1.0" encoding="UTF-8"?>
-		<Error>
-			<Code>AccessDenied</Code>
-			<Message>Access Denied</Message>
+		<ErrorResponse>
+			<Error>
+				<Code>AccessDenied</Code>
+				<Message>Access Denied</Message>
+			</Error>
 			<RequestId>656c76696e6727732072657175657374</RequestId>
 			<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>
-		</Error>
+		</ErrorResponse>
 		`,
 	},
 	{

--- a/packages/storage/__tests__/providers/s3/utils/client/S3/utils/createRetryDecider.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/S3/utils/createRetryDecider.test.ts
@@ -5,17 +5,13 @@ import {
 	getRetryDecider as getDefaultRetryDecider,
 } from '@aws-amplify/core/internals/aws-client-utils';
 
-import { retryDecider } from '../../../../../../../src/providers/s3/utils/client/utils';
-import { parseXmlError } from '../../../../../../../src/providers/s3/utils/client/utils/parsePayload';
+import { createRetryDecider } from '../../../../../../../src/providers/s3/utils/client/utils';
 
-jest.mock(
-	'../../../../../../../src/providers/s3/utils/client/utils/parsePayload',
-);
 jest.mock('@aws-amplify/core/internals/aws-client-utils');
 
-const mockErrorParser = jest.mocked(parseXmlError);
+const mockErrorParser = jest.fn();
 
-describe('retryDecider', () => {
+describe('createRetryDecider', () => {
 	const mockHttpResponse: HttpResponse = {
 		statusCode: 200,
 		headers: {},
@@ -34,6 +30,7 @@ describe('retryDecider', () => {
 
 	it('should invoke the default retry decider', async () => {
 		expect.assertions(3);
+		const retryDecider = createRetryDecider(mockErrorParser);
 		const { retryable, isCredentialsExpiredError } = await retryDecider(
 			mockHttpResponse,
 			undefined,
@@ -56,6 +53,7 @@ describe('retryDecider', () => {
 					$metadata: {},
 				};
 				mockErrorParser.mockResolvedValue(parsedError);
+				const retryDecider = createRetryDecider(mockErrorParser);
 				const { retryable, isCredentialsExpiredError } = await retryDecider(
 					{ ...mockHttpResponse, statusCode: 400 },
 					undefined,
@@ -74,6 +72,7 @@ describe('retryDecider', () => {
 				$metadata: {},
 			};
 			mockErrorParser.mockResolvedValue(parsedError);
+			const retryDecider = createRetryDecider(mockErrorParser);
 			const { retryable, isCredentialsExpiredError } = await retryDecider(
 				{ ...mockHttpResponse, statusCode: 400 },
 				undefined,
@@ -91,6 +90,7 @@ describe('retryDecider', () => {
 				$metadata: {},
 			};
 			mockErrorParser.mockResolvedValue(parsedError);
+			const retryDecider = createRetryDecider(mockErrorParser);
 			const { retryable, isCredentialsExpiredError } = await retryDecider(
 				{ ...mockHttpResponse, statusCode: 400 },
 				undefined,

--- a/packages/storage/__tests__/providers/s3/utils/client/testUtils/types.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/testUtils/types.ts
@@ -3,7 +3,7 @@
 
 import { HttpRequest } from '@aws-amplify/core/internals/aws-client-utils';
 
-interface MockFetchResponse {
+export interface MockFetchResponse {
 	body: BodyInit;
 	headers: HeadersInit;
 	status: number;

--- a/packages/storage/src/providers/s3/utils/client/s3control/base.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3control/base.ts
@@ -11,7 +11,7 @@ import {
 	jitteredBackoff,
 } from '@aws-amplify/core/internals/aws-client-utils';
 
-import { retryDecider } from '../utils';
+import { createRetryDecider, createXmlErrorParser } from '../utils';
 
 /**
  * The service name used to sign requests if the API requires authentication.
@@ -56,6 +56,33 @@ const endpointResolver = (
 
 	return { url: endpoint };
 };
+
+/**
+ * Error parser for the XML payload of S3 control plane error response. The
+ * error's `Code` and `Message` locates at the nested `Error` element instead of
+ * the XML root element.
+ *
+ * @example
+ * ```
+ * 	<?xml version="1.0" encoding="UTF-8"?>
+ * 	<ErrorResponse>
+ * 	  <Error>
+ * 		  <Code>AccessDenied</Code>
+ * 		  <Message>Access Denied</Message>
+ * 		</Error>
+ * 		<RequestId>656c76696e6727732072657175657374</RequestId>
+ * 		<HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>
+ * 	</ErrorResponse>
+ * 	```
+ *
+ * @internal
+ */
+export const parseXmlError = createXmlErrorParser();
+
+/**
+ * @internal
+ */
+export const retryDecider = createRetryDecider(parseXmlError);
 
 /**
  * @internal

--- a/packages/storage/src/providers/s3/utils/client/s3control/getDataAccess.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3control/getDataAccess.ts
@@ -7,11 +7,11 @@ import {
 	HttpResponse,
 	parseMetadata,
 } from '@aws-amplify/core/internals/aws-client-utils';
+import { composeServiceApi } from '@aws-amplify/core/internals/aws-client-utils/composers';
 import {
 	AmplifyUrl,
 	AmplifyUrlSearchParams,
 } from '@aws-amplify/core/internals/utils';
-import { composeServiceApi } from '@aws-amplify/core/internals/aws-client-utils/composers';
 
 import {
 	assignStringVariables,
@@ -19,7 +19,6 @@ import {
 	deserializeTimestamp,
 	map,
 	parseXmlBody,
-	parseXmlError,
 	s3TransferHandler,
 } from '../utils';
 
@@ -27,7 +26,7 @@ import type {
 	GetDataAccessCommandInput,
 	GetDataAccessCommandOutput,
 } from './types';
-import { defaultConfig } from './base';
+import { defaultConfig, parseXmlError } from './base';
 
 export type GetDataAccessInput = GetDataAccessCommandInput;
 

--- a/packages/storage/src/providers/s3/utils/client/s3control/listCallerAccessGrants.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3control/listCallerAccessGrants.ts
@@ -19,7 +19,6 @@ import {
 	emptyArrayGuard,
 	map,
 	parseXmlBody,
-	parseXmlError,
 	s3TransferHandler,
 } from '../utils';
 import { createStringEnumDeserializer } from '../utils/deserializeHelpers';
@@ -28,7 +27,7 @@ import type {
 	ListCallerAccessGrantsCommandInput,
 	ListCallerAccessGrantsCommandOutput,
 } from './types';
-import { defaultConfig } from './base';
+import { defaultConfig, parseXmlError } from './base';
 
 export type ListCallerAccessGrantsInput = ListCallerAccessGrantsCommandInput;
 

--- a/packages/storage/src/providers/s3/utils/client/s3data/abortMultipartUpload.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/abortMultipartUpload.ts
@@ -16,14 +16,13 @@ import { MetadataBearer } from '@aws-sdk/types';
 
 import {
 	buildStorageServiceError,
-	parseXmlError,
 	s3TransferHandler,
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
 } from '../utils';
 
 import type { AbortMultipartUploadCommandInput } from './types';
-import { defaultConfig } from './base';
+import { defaultConfig, parseXmlError } from './base';
 
 export type AbortMultipartUploadInput = Pick<
 	AbortMultipartUploadCommandInput,

--- a/packages/storage/src/providers/s3/utils/client/s3data/base.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/base.ts
@@ -99,7 +99,6 @@ export const isDnsCompatibleBucketName = (bucketName: string): boolean =>
 	!IP_ADDRESS_PATTERN.test(bucketName) &&
 	!DOTS_PATTERN.test(bucketName);
 
-const isNoErrorWrapping = true;
 /**
  * Error parser for the XML payload of S3 data plane error response. The error's
  * `Code` and `Message` locates directly at the XML root element.
@@ -117,7 +116,7 @@ const isNoErrorWrapping = true;
  *
  * @internal
  */
-export const parseXmlError = createXmlErrorParser(isNoErrorWrapping);
+export const parseXmlError = createXmlErrorParser({ noErrorWrapping: true });
 
 /**
  * @internal

--- a/packages/storage/src/providers/s3/utils/client/s3data/completeMultipartUpload.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/completeMultipartUpload.ts
@@ -20,8 +20,6 @@ import {
 	buildStorageServiceError,
 	map,
 	parseXmlBody,
-	parseXmlError,
-	retryDecider,
 	s3TransferHandler,
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
@@ -33,7 +31,7 @@ import type {
 	CompletedMultipartUpload,
 	CompletedPart,
 } from './types';
-import { defaultConfig } from './base';
+import { defaultConfig, parseXmlError, retryDecider } from './base';
 
 const INVALID_PARAMETER_ERROR_MSG =
 	'Invalid parameter for ComplteMultipartUpload API';

--- a/packages/storage/src/providers/s3/utils/client/s3data/copyObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/copyObject.ts
@@ -14,7 +14,6 @@ import {
 	assignStringVariables,
 	buildStorageServiceError,
 	parseXmlBody,
-	parseXmlError,
 	s3TransferHandler,
 	serializeObjectConfigsToHeaders,
 	serializePathnameObjectKey,
@@ -22,7 +21,7 @@ import {
 } from '../utils';
 
 import type { CopyObjectCommandInput, CopyObjectCommandOutput } from './types';
-import { defaultConfig } from './base';
+import { defaultConfig, parseXmlError } from './base';
 
 export type CopyObjectInput = Pick<
 	CopyObjectCommandInput,

--- a/packages/storage/src/providers/s3/utils/client/s3data/createMultipartUpload.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/createMultipartUpload.ts
@@ -15,7 +15,6 @@ import {
 	buildStorageServiceError,
 	map,
 	parseXmlBody,
-	parseXmlError,
 	s3TransferHandler,
 	serializeObjectConfigsToHeaders,
 	serializePathnameObjectKey,
@@ -27,7 +26,7 @@ import type {
 	CreateMultipartUploadCommandOutput,
 } from './types';
 import type { PutObjectInput } from './putObject';
-import { defaultConfig } from './base';
+import { defaultConfig, parseXmlError } from './base';
 
 export type CreateMultipartUploadInput = Extract<
 	CreateMultipartUploadCommandInput,

--- a/packages/storage/src/providers/s3/utils/client/s3data/deleteObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/deleteObject.ts
@@ -14,7 +14,6 @@ import {
 	buildStorageServiceError,
 	deserializeBoolean,
 	map,
-	parseXmlError,
 	s3TransferHandler,
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
@@ -24,7 +23,7 @@ import type {
 	DeleteObjectCommandInput,
 	DeleteObjectCommandOutput,
 } from './types';
-import { defaultConfig } from './base';
+import { defaultConfig, parseXmlError } from './base';
 
 export type DeleteObjectInput = Pick<
 	DeleteObjectCommandInput,

--- a/packages/storage/src/providers/s3/utils/client/s3data/getObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/getObject.ts
@@ -11,8 +11,8 @@ import {
 	parseMetadata,
 	presignUrl,
 } from '@aws-amplify/core/internals/aws-client-utils';
-import { AmplifyUrl } from '@aws-amplify/core/internals/utils';
 import { composeServiceApi } from '@aws-amplify/core/internals/aws-client-utils/composers';
+import { AmplifyUrl } from '@aws-amplify/core/internals/utils';
 
 import {
 	CONTENT_SHA256_HEADER,
@@ -22,13 +22,16 @@ import {
 	deserializeNumber,
 	deserializeTimestamp,
 	map,
-	parseXmlError,
 	s3TransferHandler,
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
 } from '../utils';
 
-import { S3EndpointResolverOptions, defaultConfig } from './base';
+import {
+	S3EndpointResolverOptions,
+	defaultConfig,
+	parseXmlError,
+} from './base';
 import type {
 	CompatibleHttpResponse,
 	GetObjectCommandInput,

--- a/packages/storage/src/providers/s3/utils/client/s3data/headObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/headObject.ts
@@ -16,13 +16,12 @@ import {
 	deserializeNumber,
 	deserializeTimestamp,
 	map,
-	parseXmlError,
 	s3TransferHandler,
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
 } from '../utils';
 
-import { defaultConfig } from './base';
+import { defaultConfig, parseXmlError } from './base';
 import type { HeadObjectCommandInput, HeadObjectCommandOutput } from './types';
 
 export type HeadObjectInput = Pick<HeadObjectCommandInput, 'Bucket' | 'Key'>;

--- a/packages/storage/src/providers/s3/utils/client/s3data/listObjectsV2.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/listObjectsV2.ts
@@ -22,7 +22,6 @@ import {
 	emptyArrayGuard,
 	map,
 	parseXmlBody,
-	parseXmlError,
 	s3TransferHandler,
 } from '../utils';
 
@@ -30,7 +29,7 @@ import type {
 	ListObjectsV2CommandInput,
 	ListObjectsV2CommandOutput,
 } from './types';
-import { defaultConfig } from './base';
+import { defaultConfig, parseXmlError } from './base';
 
 export type ListObjectsV2Input = ListObjectsV2CommandInput;
 

--- a/packages/storage/src/providers/s3/utils/client/s3data/listParts.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/listParts.ts
@@ -19,7 +19,6 @@ import {
 	emptyArrayGuard,
 	map,
 	parseXmlBody,
-	parseXmlError,
 	s3TransferHandler,
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
@@ -30,7 +29,7 @@ import type {
 	ListPartsCommandInput,
 	ListPartsCommandOutput,
 } from './types';
-import { defaultConfig } from './base';
+import { defaultConfig, parseXmlError } from './base';
 
 export type ListPartsInput = Pick<
 	ListPartsCommandInput,

--- a/packages/storage/src/providers/s3/utils/client/s3data/putObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/putObject.ts
@@ -14,14 +14,13 @@ import {
 	assignStringVariables,
 	buildStorageServiceError,
 	map,
-	parseXmlError,
 	s3TransferHandler,
 	serializeObjectConfigsToHeaders,
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
 } from '../utils';
 
-import { defaultConfig } from './base';
+import { defaultConfig, parseXmlError } from './base';
 import type { PutObjectCommandInput, PutObjectCommandOutput } from './types';
 
 export type PutObjectInput = Pick<

--- a/packages/storage/src/providers/s3/utils/client/s3data/uploadPart.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/uploadPart.ts
@@ -17,13 +17,12 @@ import {
 	assignStringVariables,
 	buildStorageServiceError,
 	map,
-	parseXmlError,
 	s3TransferHandler,
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
 } from '../utils';
 
-import { defaultConfig } from './base';
+import { defaultConfig, parseXmlError } from './base';
 import type { UploadPartCommandInput, UploadPartCommandOutput } from './types';
 
 // Content-length is ignored here because it's forbidden header

--- a/packages/storage/src/providers/s3/utils/client/utils/index.ts
+++ b/packages/storage/src/providers/s3/utils/client/utils/index.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export { parseXmlBody, parseXmlError } from './parsePayload';
+export { parseXmlBody, createXmlErrorParser } from './parsePayload';
 export {
 	SEND_DOWNLOAD_PROGRESS_EVENT,
 	SEND_UPLOAD_PROGRESS_EVENT,
@@ -25,4 +25,4 @@ export {
 	serializePathnameObjectKey,
 	validateS3RequiredParameter,
 } from './serializeHelpers';
-export { retryDecider } from './retryDecider';
+export { createRetryDecider } from './createRetryDecider';

--- a/packages/storage/src/providers/s3/utils/client/utils/parsePayload.ts
+++ b/packages/storage/src/providers/s3/utils/client/utils/parsePayload.ts
@@ -9,25 +9,40 @@ import {
 
 import { parser } from '../runtime';
 
-export const parseXmlError: ErrorParser = async (response?: HttpResponse) => {
-	if (!response || response.statusCode < 300) {
-		return;
-	}
-	const { statusCode } = response;
-	const body = await parseXmlBody(response);
-	const code = body?.Code
-		? (body.Code as string)
-		: statusCode === 404
-			? 'NotFound'
-			: statusCode.toString();
-	const message = body?.message ?? body?.Message ?? code;
-	const error = new Error(message);
+/**
+ * Factory creating a parser that parses the JS Error object from the XML
+ * response payload.
+ *
+ * @param noErrorWrapping Whether the error code and message are located
+ * 	directly in the root XML element, or in a nested `<Error>` element.
+ * 	See: https://smithy.io/2.0/aws/protocols/aws-restxml-protocol.html#restxml-errors
+ *
+ * 	Default to false.
+ *
+ * @internal
+ */
+export const createXmlErrorParser =
+	(noErrorWrapping = false): ErrorParser =>
+	async (response?: HttpResponse) => {
+		if (!response || response.statusCode < 300) {
+			return;
+		}
+		const { statusCode } = response;
+		const body = await parseXmlBody(response);
+		const errorLocation = noErrorWrapping ? body : body.Error;
+		const code = errorLocation?.Code
+			? (errorLocation.Code as string)
+			: statusCode === 404
+				? 'NotFound'
+				: statusCode.toString();
+		const message = errorLocation?.message ?? errorLocation?.Message ?? code;
+		const error = new Error(message);
 
-	return Object.assign(error, {
-		name: code,
-		$metadata: parseMetadata(response),
-	});
-};
+		return Object.assign(error, {
+			name: code,
+			$metadata: parseMetadata(response),
+		});
+	};
 
 export const parseXmlBody = async (response: HttpResponse): Promise<any> => {
 	if (!response.body) {

--- a/packages/storage/src/providers/s3/utils/client/utils/parsePayload.ts
+++ b/packages/storage/src/providers/s3/utils/client/utils/parsePayload.ts
@@ -13,16 +13,19 @@ import { parser } from '../runtime';
  * Factory creating a parser that parses the JS Error object from the XML
  * response payload.
  *
- * @param noErrorWrapping Whether the error code and message are located
- * 	directly in the root XML element, or in a nested `<Error>` element.
- * 	See: https://smithy.io/2.0/aws/protocols/aws-restxml-protocol.html#restxml-errors
+ * @param input Input object
+ * @param input.noErrorWrapping Whether the error code and message are located
+ *   directly in the root XML element, or in a nested `<Error>` element.
+ *   See: https://smithy.io/2.0/aws/protocols/aws-restxml-protocol.html#restxml-errors
  *
- * 	Default to false.
+ *   Default to false.
  *
  * @internal
  */
 export const createXmlErrorParser =
-	(noErrorWrapping = false): ErrorParser =>
+	({
+		noErrorWrapping = false,
+	}: { noErrorWrapping?: boolean } = {}): ErrorParser =>
 	async (response?: HttpResponse) => {
 		if (!response || response.statusCode < 300) {
 			return;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change fixes a bug where the S3 control plane API error response not parsed correctly.

Unlike the S3 data plane API, the S3 control plane API wraps the error code and message inside an `<Error>` element. For example:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<ErrorResponse>
  <Error>
	  <Code>AccessDenied</Code>
	  <Message>Access Denied</Message>
	</Error>
	<RequestId>123</RequestId>
	<HostId>123</HostId>
</ErrorResponse>
```

Whereas the S3 data plane error response looks like this:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<Error>
  <Code>AccessDenied</Code>
  <Message>Access Denied</Message>
  <RequestId>123</RequestId>
  <HostId>123</HostId>
</Error>
```

This difference is modeled by the [`noErrorWraping` API trait](https://smithy.io/2.0/aws/protocols/aws-restxml-protocol.html#restxml-errors)

This change move the XML error parser and associated retry decider to be specific to the S3 data-plane API or S3 control-plane API.

#### Description of how you validated changes
Unit test; Manual test;


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
