### PR TITLE
fix: create jwt verifier once

### DIFF
--- a/packages/adapter-nextjs/src/types/index.ts
+++ b/packages/adapter-nextjs/src/types/index.ts
@@ -1,4 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { CognitoJwtVerifier } from 'aws-jwt-verify';
+
 export { NextServer } from './NextServer';
+
+export type JwtVerifier = ReturnType<typeof CognitoJwtVerifier.create>;
+
+export interface TokenVerifierMap {
+	id?: JwtVerifier;
+	access?: JwtVerifier;
+}

--- a/packages/adapter-nextjs/src/utils/isValidCognitoToken.ts
+++ b/packages/adapter-nextjs/src/utils/isValidCognitoToken.ts
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { CognitoJwtVerifier } from 'aws-jwt-verify';
 import { JwtExpiredError } from 'aws-jwt-verify/error';
+
+import { JwtVerifier } from '../types';
 
 /**
  * Verifies a Cognito JWT token for its validity.
@@ -15,18 +16,11 @@ import { JwtExpiredError } from 'aws-jwt-verify/error';
  */
 export const isValidCognitoToken = async (input: {
 	token: string;
-	userPoolId: string;
-	clientId: string;
-	tokenType: 'id' | 'access';
+	verifier: JwtVerifier;
 }): Promise<boolean> => {
-	const { userPoolId, clientId, tokenType, token } = input;
+	const { token, verifier } = input;
 
 	try {
-		const verifier = CognitoJwtVerifier.create({
-			userPoolId,
-			tokenUse: tokenType,
-			clientId,
-		});
 		await verifier.verify(token);
 
 		return true;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Creates the token JWT verifier during the createServerRunner process and stores in memory instead of on getItem.  This allows us to maintain the JWKS in cache instead of calling the JWKS endpoint every time tokens are retrieved from localStorage.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/13706



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
