### PR TITLE
fix(adapter-nextjs): make createAuthRouteHandlers interface work in both App and Pages routers

### DIFF
--- a/packages/adapter-nextjs/src/auth/createAuthRouteHandlersFactory.ts
+++ b/packages/adapter-nextjs/src/auth/createAuthRouteHandlersFactory.ts
@@ -11,9 +11,9 @@ import { AmplifyServerContextError } from '@aws-amplify/core/internals/adapter-c
 
 import {
 	AuthRoutesHandlerContext,
-	CreateAuthRouteHandlers,
 	CreateAuthRouteHandlersFactoryInput,
 	CreateAuthRoutesHandlersInput,
+	InternalCreateAuthRouteHandlers,
 } from './types';
 import {
 	isAuthRoutesHandlersContext,
@@ -29,7 +29,7 @@ export const createAuthRouteHandlersFactory = ({
 	runtimeOptions = {},
 	amplifyAppOrigin,
 	runWithAmplifyServerContext,
-}: CreateAuthRouteHandlersFactoryInput): CreateAuthRouteHandlers => {
+}: CreateAuthRouteHandlersFactoryInput): InternalCreateAuthRouteHandlers => {
 	if (!amplifyAppOrigin)
 		throw new AmplifyServerContextError({
 			message: 'Could not find the AMPLIFY_APP_ORIGIN environment variable.',

--- a/packages/adapter-nextjs/src/auth/types.ts
+++ b/packages/adapter-nextjs/src/auth/types.ts
@@ -66,9 +66,19 @@ export interface CreateAuthRoutesHandlersInput {
 	redirectOnSignOutComplete?: string;
 }
 
-export type CreateAuthRouteHandlers = (
+export type InternalCreateAuthRouteHandlers = (
 	input?: CreateAuthRoutesHandlersInput,
 ) => AuthRouteHandlers;
+
+export type CreateAuthRouteHandlers = (
+	input?: CreateAuthRoutesHandlersInput,
+) =>
+	| AuthRouteHandlers
+	// Forcing the handler interface to be any to ensure the single handler can
+	// work in both App Router `routes.ts` and Pages router. The former has a
+	// restrict handler function interface type check. The parameters types are
+	// properly typed internally, and runtime validation is place.
+	| any;
 
 export interface CreateAuthRouteHandlersFactoryInput {
 	config: ResourcesConfig;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Make the public handler function type as any to let the single function to be compatible with the type checks that happens in both the App router and Pages router.
* Runtime validation on the handler parameters are enforced.

#### Description of how you validated changes

* `npx next build`


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
