### PR TITLE
fix(storage): browser module resoltuion is not picked up by metro web

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -6,7 +6,7 @@
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
   "browser": {
-    "./lib-esm/AwsClients/S3/runtime/index": "./lib-esm/AwsClients/S3/runtime/index.browser.js"
+    "./lib-esm/AwsClients/S3/runtime/index.js": "./lib-esm/AwsClients/S3/runtime/index.browser.js"
   },
   "sideEffects": [
     "./lib/Storage.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -6,7 +6,8 @@
   "module": "./lib-esm/index.js",
   "typings": "./lib-esm/index.d.ts",
   "browser": {
-    "./lib-esm/AwsClients/S3/runtime/index.js": "./lib-esm/AwsClients/S3/runtime/index.browser.js"
+    "./lib-esm/AwsClients/S3/runtime/index.js": "./lib-esm/AwsClients/S3/runtime/index.browser.js",
+    "./lib/AwsClients/S3/runtime/index.js": "./lib/AwsClients/S3/runtime/index.browser.js"
   },
   "sideEffects": [
     "./lib/Storage.js",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-js/issues/13853

#### Description of how you validated changes

When using the library with Expo, and run `npx expo start`, observed that the Storage uses `fetch` instead of `xhr` for making network requests. This caused that the `Storage.get()` returns a non `Blob`, `response.Body`. 

The metro bundler respect the `browser` module in `package.json`, but observed it didn't pick up the resolution during testing. The cause is that the module entry doesn't contain an extension name.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
