### PR TITLE
chore: Add internal getUrl API

### DIFF
--- a/packages/storage/__tests__/internals/apis/getUrl.test.ts
+++ b/packages/storage/__tests__/internals/apis/getUrl.test.ts
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { AmplifyClassV6 } from '@aws-amplify/core';
+
+import { getUrl as advancedGetUrl } from '../../../src/internals';
+import { getUrl as getUrlInternal } from '../../../src/providers/s3/apis/internal/getUrl';
+
+jest.mock('../../../src/providers/s3/apis/internal/getUrl');
+const mockedGetUrlInternal = jest.mocked(getUrlInternal);
+
+const MOCK_URL = new URL('https://s3.aws/mock-presigned-url');
+const MOCK_DATE = new Date();
+MOCK_DATE.setMonth(MOCK_DATE.getMonth() + 1);
+
+describe('getUrl (internal)', () => {
+	beforeEach(() => {
+		mockedGetUrlInternal.mockResolvedValue({
+			url: MOCK_URL,
+			expiresAt: MOCK_DATE,
+		});
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should pass through advanced options to the internal getUrl', async () => {
+		const useAccelerateEndpoint = true;
+		const validateObjectExistence = false;
+		const expiresIn = 300; // seconds
+		const contentDisposition = 'inline; filename="example.jpg"';
+		const contentType = 'image/jpeg';
+		const bucket = { bucketName: 'bucket', region: 'us-east-1' };
+		const locationCredentialsProvider = async () => ({
+			credentials: {
+				accessKeyId: 'akid',
+				secretAccessKey: 'secret',
+				sessionToken: 'token',
+				expiration: new Date(),
+			},
+		});
+		const result = await advancedGetUrl({
+			path: 'input/path/to/mock/object',
+			options: {
+				useAccelerateEndpoint,
+				bucket,
+				validateObjectExistence,
+				expiresIn,
+				contentDisposition,
+				contentType,
+				locationCredentialsProvider,
+			},
+		});
+		expect(mockedGetUrlInternal).toHaveBeenCalledTimes(1);
+		expect(mockedGetUrlInternal).toHaveBeenCalledWith(
+			expect.any(AmplifyClassV6),
+			{
+				path: 'input/path/to/mock/object',
+				options: {
+					useAccelerateEndpoint,
+					bucket,
+					validateObjectExistence,
+					expiresIn,
+					contentDisposition,
+					contentType,
+					locationCredentialsProvider,
+				},
+			},
+		);
+		expect(result).toEqual({
+			url: MOCK_URL,
+			expiresAt: MOCK_DATE,
+		});
+	});
+});

--- a/packages/storage/src/internals/apis/getUrl.ts
+++ b/packages/storage/src/internals/apis/getUrl.ts
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+
+import { getUrl as getUrlInternal } from '../../providers/s3/apis/internal/getUrl';
+import { GetUrlInput } from '../types/inputs';
+import { GetUrlOutput } from '../types/outputs';
+
+/**
+ * Get a temporary presigned URL to download the specified S3 object.
+ * The presigned URL expires when the associated role used to sign the request expires or
+ * the option  `expiresIn` is reached. The `expiresAt` property in the output object indicates when the URL MAY expire.
+ *
+ * By default, it will not validate the object that exists in S3. If you set the `options.validateObjectExistence`
+ * to true, this method will verify the given object already exists in S3 before returning a presigned
+ * URL, and will throw `StorageError` if the object does not exist.
+ *
+ * @param input - The `GetUrlWithPathInput` object.
+ * @returns Presigned URL and timestamp when the URL may expire.
+ * @throws service: `S3Exception` - thrown when checking for existence of the object
+ * @throws validation: `StorageValidationErrorCode` - Validation errors
+ * thrown either username or key are not defined.
+ *
+ * @internal
+ */
+export function getUrl(input: GetUrlInput) {
+	return getUrlInternal(Amplify, {
+		path: input.path,
+		options: {
+			useAccelerateEndpoint: input?.options?.useAccelerateEndpoint,
+			bucket: input?.options?.bucket,
+			validateObjectExistence: input?.options?.validateObjectExistence,
+			expiresIn: input?.options?.expiresIn,
+			contentDisposition: input?.options?.contentDisposition,
+			contentType: input?.options?.contentType,
+
+			// Advanced options
+			locationCredentialsProvider: input?.options?.locationCredentialsProvider,
+		},
+		// Type casting is necessary because `getPropertiesInternal` supports both Gen1 and Gen2 signatures, but here
+		// given in input can only be Gen2 signature, the return can only ben Gen2 signature.
+	}) as Promise<GetUrlOutput>;
+}

--- a/packages/storage/src/internals/apis/getUrl.ts
+++ b/packages/storage/src/internals/apis/getUrl.ts
@@ -8,20 +8,6 @@ import { GetUrlInput } from '../types/inputs';
 import { GetUrlOutput } from '../types/outputs';
 
 /**
- * Get a temporary presigned URL to download the specified S3 object.
- * The presigned URL expires when the associated role used to sign the request expires or
- * the option  `expiresIn` is reached. The `expiresAt` property in the output object indicates when the URL MAY expire.
- *
- * By default, it will not validate the object that exists in S3. If you set the `options.validateObjectExistence`
- * to true, this method will verify the given object already exists in S3 before returning a presigned
- * URL, and will throw `StorageError` if the object does not exist.
- *
- * @param input - The `GetUrlWithPathInput` object.
- * @returns Presigned URL and timestamp when the URL may expire.
- * @throws service: `S3Exception` - thrown when checking for existence of the object
- * @throws validation: `StorageValidationErrorCode` - Validation errors
- * thrown either username or key are not defined.
- *
  * @internal
  */
 export function getUrl(input: GetUrlInput) {

--- a/packages/storage/src/internals/index.ts
+++ b/packages/storage/src/internals/index.ts
@@ -12,17 +12,20 @@ export {
 	GetDataAccessInput,
 	ListCallerAccessGrantsInput,
 	GetPropertiesInput,
+	GetUrlInput,
 	CopyInput,
 } from './types/inputs';
 export {
 	GetDataAccessOutput,
 	ListCallerAccessGrantsOutput,
 	GetPropertiesOutput,
+	GetUrlOutput,
 } from './types/outputs';
 
 export { getDataAccess } from './apis/getDataAccess';
 export { listCallerAccessGrants } from './apis/listCallerAccessGrants';
 export { getProperties } from './apis/getProperties';
+export { getUrl } from './apis/getUrl';
 
 /*
 CredentialsStore exports

--- a/packages/storage/src/internals/types/inputs.ts
+++ b/packages/storage/src/internals/types/inputs.ts
@@ -9,6 +9,7 @@ import {
 import {
 	CopyWithPathInput,
 	GetPropertiesWithPathInput,
+	GetUrlWithPathInput,
 } from '../../providers/s3';
 
 import { CredentialsProvider, ListLocationsInput } from './credentials';
@@ -42,6 +43,16 @@ export interface GetDataAccessInput {
  */
 export type GetPropertiesInput = ExtendInputWithAdvancedOptions<
 	GetPropertiesWithPathInput,
+	{
+		locationCredentialsProvider?: CredentialsProvider;
+	}
+>;
+
+/**
+ * @internal
+ */
+export type GetUrlInput = ExtendInputWithAdvancedOptions<
+	GetUrlWithPathInput,
 	{
 		locationCredentialsProvider?: CredentialsProvider;
 	}

--- a/packages/storage/src/internals/types/outputs.ts
+++ b/packages/storage/src/internals/types/outputs.ts
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { GetPropertiesWithPathOutput } from '../../providers/s3/types';
+import {
+	GetPropertiesWithPathOutput,
+	GetUrlWithPathOutput,
+} from '../../providers/s3/types';
 
 import { ListLocationsOutput, LocationCredentials } from './credentials';
 
@@ -19,3 +22,8 @@ export type GetDataAccessOutput = LocationCredentials;
  * @internal
  */
 export type GetPropertiesOutput = GetPropertiesWithPathOutput;
+
+/**
+ * @internal
+ */
+export type GetUrlOutput = GetUrlWithPathOutput;

--- a/packages/storage/src/providers/s3/apis/internal/getUrl.ts
+++ b/packages/storage/src/providers/s3/apis/internal/getUrl.ts
@@ -4,12 +4,7 @@
 import { AmplifyClassV6 } from '@aws-amplify/core';
 import { StorageAction } from '@aws-amplify/core/internals/utils';
 
-import {
-	GetUrlInput,
-	GetUrlOutput,
-	GetUrlWithPathInput,
-	GetUrlWithPathOutput,
-} from '../../types';
+import { GetUrlInput, GetUrlOutput, GetUrlWithPathOutput } from '../../types';
 import { StorageValidationErrorCode } from '../../../../errors/types/validation';
 import { getPresignedGetObjectUrl } from '../../utils/client/s3data';
 import {
@@ -23,12 +18,14 @@ import {
 	STORAGE_INPUT_KEY,
 } from '../../utils/constants';
 import { constructContentDisposition } from '../../utils/constructContentDisposition';
+// TODO: Remove this interface when we move to public advanced APIs.
+import { GetUrlInput as GetUrlWithPathInputWithAdvancedOptions } from '../../../../internals';
 
 import { getProperties } from './getProperties';
 
 export const getUrl = async (
 	amplify: AmplifyClassV6,
-	input: GetUrlInput | GetUrlWithPathInput,
+	input: GetUrlInput | GetUrlWithPathInputWithAdvancedOptions,
 ): Promise<GetUrlOutput | GetUrlWithPathOutput> => {
 	const { options: getUrlOptions } = input;
 	const { s3Config, keyPrefix, bucket, identityId } =


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds the internal `getUrl` API with credential provider support.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
