### PR TITLE
feat(storage): add remaining copy changes for internals

### DIFF
--- a/packages/storage/__tests__/internals/apis/copy.test.ts
+++ b/packages/storage/__tests__/internals/apis/copy.test.ts
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { AmplifyClassV6 } from '@aws-amplify/core';
+
+import { copy as advancedCopy } from '../../../src/internals';
+import { copy as copyInternal } from '../../../src/providers/s3/apis/internal/copy';
+
+jest.mock('../../../src/providers/s3/apis/internal/copy');
+const mockedCopyInternal = jest.mocked(copyInternal);
+
+describe('copy (internals)', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockedCopyInternal.mockResolvedValue({
+			path: 'output/path/to/mock/object',
+		});
+	});
+
+	it('should pass advanced option locationCredentialsProvider to internal list', async () => {
+		const locationCredentialsProvider = async () => ({
+			credentials: {
+				accessKeyId: 'akid',
+				secretAccessKey: 'secret',
+				sessionToken: 'token',
+				expiration: new Date(),
+			},
+		});
+		const copyInputWithAdvancedOptions = {
+			source: {
+				path: 'path/to/object',
+			},
+			destination: {
+				path: 'path/to/object',
+			},
+			options: {
+				locationCredentialsProvider,
+			},
+		};
+		const result = await advancedCopy(copyInputWithAdvancedOptions);
+		expect(mockedCopyInternal).toHaveBeenCalledTimes(1);
+		expect(mockedCopyInternal).toHaveBeenCalledWith(
+			expect.any(AmplifyClassV6),
+			copyInputWithAdvancedOptions,
+		);
+		expect(result).toEqual({
+			path: 'output/path/to/mock/object',
+		});
+	});
+});

--- a/packages/storage/__tests__/internals/apis/copy.test.ts
+++ b/packages/storage/__tests__/internals/apis/copy.test.ts
@@ -28,9 +28,13 @@ describe('copy (internals)', () => {
 		const copyInputWithAdvancedOptions = {
 			source: {
 				path: 'path/to/object',
+				bucket: 'bucket',
+				eTag: 'eTag',
+				notModifiedSince: new Date(),
 			},
 			destination: {
 				path: 'path/to/object',
+				bucket: 'bucket',
 			},
 			options: {
 				locationCredentialsProvider,

--- a/packages/storage/__tests__/internals/apis/list.test.ts
+++ b/packages/storage/__tests__/internals/apis/list.test.ts
@@ -4,7 +4,6 @@ import { AmplifyClassV6 } from '@aws-amplify/core';
 
 import { list as advancedList } from '../../../src/internals';
 import { list as listInternal } from '../../../src/providers/s3/apis/internal/list';
-import { ListAllWithPathOutput } from '../../../src';
 
 jest.mock('../../../src/providers/s3/apis/internal/list');
 const mockedListInternal = jest.mocked(listInternal);
@@ -14,7 +13,7 @@ describe('list (internals)', () => {
 		jest.clearAllMocks();
 		mockedListInternal.mockResolvedValue({
 			items: [],
-		} as ListAllWithPathOutput);
+		});
 	});
 
 	it('should pass advanced option locationCredentialsProvider to internal list', async () => {

--- a/packages/storage/src/internals/apis/copy.ts
+++ b/packages/storage/src/internals/apis/copy.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+
+import { copy as copyInternal } from '../../providers/s3/apis/internal/copy';
+import { CopyInput } from '../types/inputs';
+
+/**
+ * @internal
+ * Copy an object from a source to a destination object within the same bucket.
+ *
+ * @param input - The `CopyInput` object.
+ * @returns Output containing the destination object path.
+ * @throws service: `S3Exception` - Thrown when checking for existence of the object
+ * @throws validation: `StorageValidationErrorCode` - Thrown when
+ * source or destination path is not defined.
+ */
+export function copy(input: CopyInput) {
+	return copyInternal(Amplify, input);
+}

--- a/packages/storage/src/internals/apis/copy.ts
+++ b/packages/storage/src/internals/apis/copy.ts
@@ -9,18 +9,19 @@ import { CopyOutput } from '../types/outputs';
 
 /**
  * @internal
- * Copy an object from a source to a destination object within the same bucket.
- *
- * @param input - The `CopyInput` object.
- * @returns Output containing the destination object path.
- * @throws service: `S3Exception` - Thrown when checking for existence of the object
- * @throws validation: `StorageValidationErrorCode` - Thrown when
- * source or destination path is not defined.
  */
-export function copy(input: CopyInput) {
-	return copyInternal(Amplify, {
-		source: input.source,
-		destination: input.destination,
+export const copy = (input: CopyInput) =>
+	copyInternal(Amplify, {
+		source: {
+			path: input.source.path,
+			bucket: input.source.bucket,
+			eTag: input.source.eTag,
+			notModifiedSince: input.source.notModifiedSince,
+		},
+		destination: {
+			path: input.destination.path,
+			bucket: input.destination.bucket,
+		},
 		options: {
 			// Advanced options
 			locationCredentialsProvider: input.options?.locationCredentialsProvider,
@@ -28,4 +29,3 @@ export function copy(input: CopyInput) {
 		// Type casting is necessary because `copyInternal` supports both Gen1 and Gen2 signatures, but here
 		// given in input can only be Gen2 signature, the return can only ben Gen2 signature.
 	}) as Promise<CopyOutput>;
-}

--- a/packages/storage/src/internals/apis/copy.ts
+++ b/packages/storage/src/internals/apis/copy.ts
@@ -5,7 +5,7 @@ import { Amplify } from '@aws-amplify/core';
 
 import { copy as copyInternal } from '../../providers/s3/apis/internal/copy';
 import { CopyInput } from '../types/inputs';
-import { CopyWithPathOutput } from '../../providers/s3';
+import { CopyOutput } from '../types/outputs';
 
 /**
  * @internal
@@ -27,5 +27,5 @@ export function copy(input: CopyInput) {
 		},
 		// Type casting is necessary because `copyInternal` supports both Gen1 and Gen2 signatures, but here
 		// given in input can only be Gen2 signature, the return can only ben Gen2 signature.
-	}) as Promise<CopyWithPathOutput>;
+	}) as Promise<CopyOutput>;
 }

--- a/packages/storage/src/internals/apis/copy.ts
+++ b/packages/storage/src/internals/apis/copy.ts
@@ -5,6 +5,7 @@ import { Amplify } from '@aws-amplify/core';
 
 import { copy as copyInternal } from '../../providers/s3/apis/internal/copy';
 import { CopyInput } from '../types/inputs';
+import { CopyWithPathOutput } from '../../providers/s3';
 
 /**
  * @internal
@@ -17,5 +18,14 @@ import { CopyInput } from '../types/inputs';
  * source or destination path is not defined.
  */
 export function copy(input: CopyInput) {
-	return copyInternal(Amplify, input);
+	return copyInternal(Amplify, {
+		source: input.source,
+		destination: input.destination,
+		options: {
+			// Advanced options
+			locationCredentialsProvider: input.options?.locationCredentialsProvider,
+		},
+		// Type casting is necessary because `copyInternal` supports both Gen1 and Gen2 signatures, but here
+		// given in input can only be Gen2 signature, the return can only ben Gen2 signature.
+	}) as Promise<CopyWithPathOutput>;
 }

--- a/packages/storage/src/internals/apis/list.ts
+++ b/packages/storage/src/internals/apis/list.ts
@@ -4,7 +4,8 @@
 import { Amplify } from '@aws-amplify/core';
 
 import { list as listInternal } from '../../providers/s3/apis/internal/list';
-import { ListInputWithPath } from '../types/inputs';
+import { ListAllInput, ListPaginateInput } from '../types/inputs';
+import { ListAllOutput, ListPaginateOutput } from '../types/outputs';
 
 /**
  * @internal
@@ -14,6 +15,46 @@ import { ListInputWithPath } from '../types/inputs';
  * @throws service: `S3Exception` - S3 service errors thrown when checking for existence of bucket
  * @throws validation: `StorageValidationErrorCode`  - thrown when there are issues with credentials
  */
-export function list(input?: ListInputWithPath) {
-	return listInternal(Amplify, input ?? {});
+export function list(input?: ListPaginateInput | ListAllInput) {
+	if (!input) return listInternal(Amplify, {});
+	if (isListAllInputWithPath(input))
+		return listInternal(Amplify, {
+			path: input.path,
+			options: {
+				bucket: input.options?.bucket,
+				subpathStrategy: input.options?.subpathStrategy,
+				useAccelerateEndpoint: input.options?.useAccelerateEndpoint,
+				listAll: input.options?.listAll,
+
+				// Advanced options
+				locationCredentialsProvider: input.options?.locationCredentialsProvider,
+			},
+			// Type casting is necessary because `copyInternal` supports both Gen1 and Gen2 signatures, but here
+			// given in input can only be Gen2 signature, the return can only ben Gen2 signature.
+		} as ListAllInput) as Promise<ListAllOutput>;
+
+	return listInternal(Amplify, {
+		path: input.path,
+		options: {
+			bucket: input.options?.bucket,
+			subpathStrategy: input.options?.subpathStrategy,
+			useAccelerateEndpoint: input.options?.useAccelerateEndpoint,
+			listAll: input.options?.listAll,
+
+			// Pagination options
+			nextToken: input.options?.nextToken,
+			pageSize: input.options?.pageSize,
+
+			// Advanced options
+			locationCredentialsProvider: input.options?.locationCredentialsProvider,
+		},
+		// Type casting is necessary because `copyInternal` supports both Gen1 and Gen2 signatures, but here
+		// given in input can only be Gen2 signature, the return can only ben Gen2 signature.
+	} as ListPaginateInput) as Promise<ListPaginateOutput>;
+}
+
+function isListAllInputWithPath(
+	input?: ListPaginateInput | ListAllInput,
+): input is ListAllInput {
+	return !!input;
 }

--- a/packages/storage/src/internals/index.ts
+++ b/packages/storage/src/internals/index.ts
@@ -34,6 +34,7 @@ export { getProperties } from './apis/getProperties';
 export { getUrl } from './apis/getUrl';
 export { remove } from './apis/remove';
 export { downloadData } from './apis/downloadData';
+export { copy } from './apis/copy';
 
 /*
 CredentialsStore exports

--- a/packages/storage/src/internals/index.ts
+++ b/packages/storage/src/internals/index.ts
@@ -14,8 +14,7 @@ export {
 	GetPropertiesInput,
 	GetUrlInput,
 	CopyInput,
-	ListAllInput,
-	ListPaginateInput,
+	ListInput,
 	RemoveInput,
 	DownloadDataInput,
 } from './types/inputs';
@@ -26,8 +25,7 @@ export {
 	GetUrlOutput,
 	RemoveOutput,
 	DownloadDataOutput,
-	ListAllOutput,
-	ListPaginateOutput,
+	ListOutput,
 	CopyOutput,
 } from './types/outputs';
 

--- a/packages/storage/src/internals/index.ts
+++ b/packages/storage/src/internals/index.ts
@@ -14,7 +14,8 @@ export {
 	GetPropertiesInput,
 	GetUrlInput,
 	CopyInput,
-	ListInputWithPath,
+	ListAllInput,
+	ListPaginateInput,
 	RemoveInput,
 	DownloadDataInput,
 } from './types/inputs';
@@ -25,6 +26,9 @@ export {
 	GetUrlOutput,
 	RemoveOutput,
 	DownloadDataOutput,
+	ListAllOutput,
+	ListPaginateOutput,
+	CopyOutput,
 } from './types/outputs';
 
 export { getDataAccess } from './apis/getDataAccess';

--- a/packages/storage/src/internals/types/inputs.ts
+++ b/packages/storage/src/internals/types/inputs.ts
@@ -47,8 +47,18 @@ export interface GetDataAccessInput {
 /**
  * @internal
  */
-export type ListInputWithPath = ExtendInputWithAdvancedOptions<
-	ListAllWithPathInput | ListPaginateWithPathInput,
+export type ListAllInput = ExtendInputWithAdvancedOptions<
+	ListAllWithPathInput,
+	{
+		locationCredentialsProvider?: CredentialsProvider;
+	}
+>;
+
+/**
+ * @internal
+ */
+export type ListPaginateInput = ExtendInputWithAdvancedOptions<
+	ListPaginateWithPathInput,
 	{
 		locationCredentialsProvider?: CredentialsProvider;
 	}

--- a/packages/storage/src/internals/types/inputs.ts
+++ b/packages/storage/src/internals/types/inputs.ts
@@ -47,18 +47,8 @@ export interface GetDataAccessInput {
 /**
  * @internal
  */
-export type ListAllInput = ExtendInputWithAdvancedOptions<
-	ListAllWithPathInput,
-	{
-		locationCredentialsProvider?: CredentialsProvider;
-	}
->;
-
-/**
- * @internal
- */
-export type ListPaginateInput = ExtendInputWithAdvancedOptions<
-	ListPaginateWithPathInput,
+export type ListInput = ExtendInputWithAdvancedOptions<
+	ListAllWithPathInput | ListPaginateWithPathInput,
 	{
 		locationCredentialsProvider?: CredentialsProvider;
 	}

--- a/packages/storage/src/internals/types/outputs.ts
+++ b/packages/storage/src/internals/types/outputs.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-	DownloadDataWithPathOutput,
 	CopyWithPathOutput,
+	DownloadDataWithPathOutput,
 	GetPropertiesWithPathOutput,
 	GetUrlWithPathOutput,
 	ListAllWithPathOutput,
@@ -16,7 +16,12 @@ import { ListLocationsOutput, LocationCredentials } from './credentials';
 /**
  * @internal
  */
-export type ListCallerAccessGrantsOutput = ListLocationsOutput;
+export type CopyOutput = CopyWithPathOutput;
+
+/**
+ * @internal
+ */
+export type DownloadDataOutput = DownloadDataWithPathOutput;
 
 /**
  * @internal
@@ -41,19 +46,9 @@ export type RemoveOutput = RemoveWithPathOutput;
 /**
  * @internal
  */
-export type DownloadDataOutput = DownloadDataWithPathOutput;
+export type ListOutput = ListAllWithPathOutput | ListPaginateWithPathOutput;
 
 /**
  * @internal
  */
-export type ListAllOutput = ListAllWithPathOutput;
-
-/**
- * @internal
- */
-export type ListPaginateOutput = ListPaginateWithPathOutput;
-
-/**
- * @internal
- */
-export type CopyOutput = CopyWithPathOutput;
+export type ListCallerAccessGrantsOutput = ListLocationsOutput;

--- a/packages/storage/src/internals/types/outputs.ts
+++ b/packages/storage/src/internals/types/outputs.ts
@@ -3,8 +3,11 @@
 
 import {
 	DownloadDataWithPathOutput,
+	CopyWithPathOutput,
 	GetPropertiesWithPathOutput,
 	GetUrlWithPathOutput,
+	ListAllWithPathOutput,
+	ListPaginateWithPathOutput,
 	RemoveWithPathOutput,
 } from '../../providers/s3/types';
 
@@ -39,3 +42,18 @@ export type RemoveOutput = RemoveWithPathOutput;
  * @internal
  */
 export type DownloadDataOutput = DownloadDataWithPathOutput;
+
+/**
+ * @internal
+ */
+export type ListAllOutput = ListAllWithPathOutput;
+
+/**
+ * @internal
+ */
+export type ListPaginateOutput = ListPaginateWithPathOutput;
+
+/**
+ * @internal
+ */
+export type CopyOutput = CopyWithPathOutput;

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -33,10 +33,7 @@ import { CommonPrefix } from '../../utils/client/s3data/types';
 import { IntegrityError } from '../../../../errors/IntegrityError';
 import { ListAllInput, ListPaginateInput } from '../../types/inputs';
 // TODO: Remove this interface when we move to public advanced APIs.
-import {
-	ListAllInput as ListAllWithPathInputAndAdvancedOptions,
-	ListPaginateInput as ListPaginateWithPathInputAndAdvancedOptions,
-} from '../../../../internals/types/inputs';
+import { ListInput as ListWithPathInputAndAdvancedOptions } from '../../../../internals/types/inputs';
 
 const MAX_PAGE_SIZE = 1000;
 
@@ -48,11 +45,7 @@ interface ListInputArgs {
 
 export const list = async (
 	amplify: AmplifyClassV6,
-	input:
-		| ListAllInput
-		| ListPaginateInput
-		| ListAllWithPathInputAndAdvancedOptions
-		| ListPaginateWithPathInputAndAdvancedOptions,
+	input: ListAllInput | ListPaginateInput | ListWithPathInputAndAdvancedOptions,
 ): Promise<
 	| ListAllOutput
 	| ListPaginateOutput

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -33,7 +33,10 @@ import { CommonPrefix } from '../../utils/client/s3data/types';
 import { IntegrityError } from '../../../../errors/IntegrityError';
 import { ListAllInput, ListPaginateInput } from '../../types/inputs';
 // TODO: Remove this interface when we move to public advanced APIs.
-import { ListInputWithPath as ListWithPathInputAndAdvancedOptions } from '../../../../internals/types/inputs';
+import {
+	ListAllInput as ListAllWithPathInputAndAdvancedOptions,
+	ListPaginateInput as ListPaginateWithPathInputAndAdvancedOptions,
+} from '../../../../internals/types/inputs';
 
 const MAX_PAGE_SIZE = 1000;
 
@@ -45,7 +48,11 @@ interface ListInputArgs {
 
 export const list = async (
 	amplify: AmplifyClassV6,
-	input: ListAllInput | ListPaginateInput | ListWithPathInputAndAdvancedOptions,
+	input:
+		| ListAllInput
+		| ListPaginateInput
+		| ListAllWithPathInputAndAdvancedOptions
+		| ListPaginateWithPathInputAndAdvancedOptions,
 ): Promise<
 	| ListAllOutput
 	| ListPaginateOutput


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds an internal wrapper copy function with the new Input type. Type updates were already in place from an earlier PR.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
