### PR TITLE
fix(storage): internals list function not able to decide which output types to use

### DIFF
--- a/packages/storage/src/internals/apis/list.ts
+++ b/packages/storage/src/internals/apis/list.ts
@@ -4,10 +4,23 @@
 import { Amplify } from '@aws-amplify/core';
 
 import { list as listInternal } from '../../providers/s3/apis/internal/list';
-import { ListInput } from '../types/inputs';
-import { ListPaginateWithPathInput } from '../../providers/s3';
+import { ListAllInput, ListInput, ListPaginateInput } from '../types/inputs';
+import {
+	ListAllWithPathOutput,
+	ListPaginateWithPathOutput,
+} from '../../providers/s3';
 import { ListOutput } from '../types/outputs';
 
+/**
+ * @internal
+ */
+export function list(input: ListAllInput): Promise<ListAllWithPathOutput>;
+/**
+ * @internal
+ */
+export function list(
+	input: ListPaginateInput,
+): Promise<ListPaginateWithPathOutput>;
 /**
  * @internal
  */
@@ -21,8 +34,8 @@ export function list(input: ListInput): Promise<ListOutput> {
 			listAll: input.options?.listAll,
 
 			// Pagination options
-			nextToken: (input as ListPaginateWithPathInput).options?.nextToken,
-			pageSize: (input as ListPaginateWithPathInput).options?.pageSize,
+			nextToken: (input as ListPaginateInput).options?.nextToken,
+			pageSize: (input as ListPaginateInput).options?.pageSize,
 			// Advanced options
 			locationCredentialsProvider: input.options?.locationCredentialsProvider,
 		},

--- a/packages/storage/src/internals/index.ts
+++ b/packages/storage/src/internals/index.ts
@@ -16,6 +16,8 @@ export {
 	GetUrlInput,
 	CopyInput,
 	ListInput,
+	ListAllInput,
+	ListPaginateInput,
 	RemoveInput,
 	UploadDataInput,
 	DownloadDataInput,

--- a/packages/storage/src/internals/types/inputs.ts
+++ b/packages/storage/src/internals/types/inputs.ts
@@ -48,12 +48,27 @@ export interface GetDataAccessInput {
 /**
  * @internal
  */
-export type ListInput = ExtendInputWithAdvancedOptions<
-	ListAllWithPathInput | ListPaginateWithPathInput,
+export type ListAllInput = ExtendInputWithAdvancedOptions<
+	ListAllWithPathInput,
 	{
 		locationCredentialsProvider?: CredentialsProvider;
 	}
 >;
+
+/**
+ * @internal
+ */
+export type ListPaginateInput = ExtendInputWithAdvancedOptions<
+	ListPaginateWithPathInput,
+	{
+		locationCredentialsProvider?: CredentialsProvider;
+	}
+>;
+
+/**
+ * @internal
+ */
+export type ListInput = ListAllInput | ListPaginateInput;
 
 /**
  * @internal


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds function overloading to list to correct its input output typings. 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Used it in the UI repo


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
