### PR TITLE
fix(storage): multipart upload is firing on 0 bytes data

### DIFF
--- a/packages/storage/__tests__/providers/s3/apis/uploadData/index.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/uploadData/index.test.ts
@@ -180,6 +180,22 @@ describe('uploadData with path', () => {
 			},
 		);
 
+		it('should use putObject for 0 bytes data (e.g. create a folder)', () => {
+			const testInput = {
+				path: 'test-path',
+				data: '', // 0 bytes
+			};
+
+			uploadData(testInput);
+
+			expect(mockPutObjectJob).toHaveBeenCalledWith(
+				testInput,
+				expect.any(AbortSignal),
+				expect.any(Number),
+			);
+			expect(mockGetMultipartUploadHandlers).not.toHaveBeenCalled();
+		});
+
 		it('should use uploadTask', async () => {
 			mockPutObjectJob.mockReturnValueOnce('putObjectJob');
 			mockCreateUploadTask.mockReturnValueOnce('uploadTask');

--- a/packages/storage/src/providers/s3/apis/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData/index.ts
@@ -135,7 +135,7 @@ export function uploadData(input: UploadDataInput | UploadDataWithPathInput) {
 		StorageValidationErrorCode.ObjectIsTooLarge,
 	);
 
-	if (dataByteLength && dataByteLength <= DEFAULT_PART_SIZE) {
+	if (dataByteLength !== undefined && dataByteLength <= DEFAULT_PART_SIZE) {
 		// Single part upload
 		const abortController = new AbortController();
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Check `dataByteLength !== undefined` instead of consuming the falsy 0

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

- unit tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
