### PR TITLE
feat: Add expectedBucketOwner to remaining internal APIs

### DIFF
--- a/packages/storage/__tests__/internals/apis/copy.test.ts
+++ b/packages/storage/__tests__/internals/apis/copy.test.ts
@@ -31,10 +31,12 @@ describe('copy (internals)', () => {
 				bucket: 'bucket',
 				eTag: 'eTag',
 				notModifiedSince: new Date(),
+				expectedBucketOwner: '012345678901',
 			},
 			destination: {
 				path: 'path/to/object',
 				bucket: 'bucket',
+				expectedBucketOwner: '212345678901',
 			},
 			options: {
 				locationCredentialsProvider,

--- a/packages/storage/__tests__/internals/apis/downloadData.test.ts
+++ b/packages/storage/__tests__/internals/apis/downloadData.test.ts
@@ -29,6 +29,7 @@ describe('downloadData (internal)', () => {
 
 	it('should pass advanced option locationCredentialsProvider to internal downloadData', async () => {
 		const useAccelerateEndpoint = true;
+		const expectedBucketOwner = '012345678901';
 		const bucket = { bucketName: 'bucket', region: 'us-east-1' };
 		const locationCredentialsProvider = async () => ({
 			credentials: {
@@ -49,6 +50,7 @@ describe('downloadData (internal)', () => {
 				locationCredentialsProvider,
 				onProgress,
 				bytesRange,
+				expectedBucketOwner,
 			},
 		});
 
@@ -61,6 +63,7 @@ describe('downloadData (internal)', () => {
 				locationCredentialsProvider,
 				onProgress,
 				bytesRange,
+				expectedBucketOwner,
 			},
 		});
 

--- a/packages/storage/__tests__/internals/apis/getProperties.test.ts
+++ b/packages/storage/__tests__/internals/apis/getProperties.test.ts
@@ -21,6 +21,7 @@ describe('getProperties (internal)', () => {
 
 	it('should pass advanced option locationCredentialsProvider to internal getProperties', async () => {
 		const useAccelerateEndpoint = true;
+		const expectedBucketOwner = '012345678901';
 		const bucket = { bucketName: 'bucket', region: 'us-east-1' };
 		const locationCredentialsProvider = async () => ({
 			credentials: {
@@ -35,6 +36,7 @@ describe('getProperties (internal)', () => {
 			options: {
 				useAccelerateEndpoint,
 				bucket,
+				expectedBucketOwner,
 				locationCredentialsProvider,
 			},
 		});
@@ -46,6 +48,7 @@ describe('getProperties (internal)', () => {
 				options: {
 					useAccelerateEndpoint,
 					bucket,
+					expectedBucketOwner,
 					locationCredentialsProvider,
 				},
 			},

--- a/packages/storage/__tests__/internals/apis/getUrl.test.ts
+++ b/packages/storage/__tests__/internals/apis/getUrl.test.ts
@@ -27,6 +27,7 @@ describe('getUrl (internal)', () => {
 	it('should pass through advanced options to the internal getUrl', async () => {
 		const useAccelerateEndpoint = true;
 		const validateObjectExistence = false;
+		const expectedBucketOwner = '012345678901';
 		const expiresIn = 300; // seconds
 		const contentDisposition = 'inline; filename="example.jpg"';
 		const contentType = 'image/jpeg';
@@ -48,6 +49,7 @@ describe('getUrl (internal)', () => {
 				expiresIn,
 				contentDisposition,
 				contentType,
+				expectedBucketOwner,
 				locationCredentialsProvider,
 			},
 		});
@@ -63,6 +65,7 @@ describe('getUrl (internal)', () => {
 					expiresIn,
 					contentDisposition,
 					contentType,
+					expectedBucketOwner,
 					locationCredentialsProvider,
 				},
 			},

--- a/packages/storage/__tests__/internals/apis/list.test.ts
+++ b/packages/storage/__tests__/internals/apis/list.test.ts
@@ -18,6 +18,7 @@ describe('list (internals)', () => {
 
 	it('should pass advanced option locationCredentialsProvider to internal list', async () => {
 		const useAccelerateEndpoint = true;
+		const expectedBucketOwner = '012345678901';
 		const bucket = { bucketName: 'bucket', region: 'us-east-1' };
 		const locationCredentialsProvider = async () => ({
 			credentials: {
@@ -32,6 +33,7 @@ describe('list (internals)', () => {
 			options: {
 				useAccelerateEndpoint,
 				bucket,
+				expectedBucketOwner,
 				locationCredentialsProvider,
 			},
 		});
@@ -43,6 +45,7 @@ describe('list (internals)', () => {
 				options: {
 					useAccelerateEndpoint,
 					bucket,
+					expectedBucketOwner,
 					locationCredentialsProvider,
 				},
 			},

--- a/packages/storage/__tests__/internals/apis/remove.test.ts
+++ b/packages/storage/__tests__/internals/apis/remove.test.ts
@@ -21,6 +21,7 @@ describe('remove (internal)', () => {
 
 	it('should pass advanced option locationCredentialsProvider to internal remove', async () => {
 		const useAccelerateEndpoint = true;
+		const expectedBucketOwner = '012345678901';
 		const bucket = { bucketName: 'bucket', region: 'us-east-1' };
 		const locationCredentialsProvider = async () => ({
 			credentials: {
@@ -36,6 +37,7 @@ describe('remove (internal)', () => {
 			options: {
 				useAccelerateEndpoint,
 				bucket,
+				expectedBucketOwner,
 				locationCredentialsProvider,
 			},
 		});
@@ -48,6 +50,7 @@ describe('remove (internal)', () => {
 				options: {
 					useAccelerateEndpoint,
 					bucket,
+					expectedBucketOwner,
 					locationCredentialsProvider,
 				},
 			},

--- a/packages/storage/__tests__/internals/apis/uploadData.test.ts
+++ b/packages/storage/__tests__/internals/apis/uploadData.test.ts
@@ -19,6 +19,7 @@ describe('uploadData (internal)', () => {
 
 	it('should pass advanced option locationCredentialsProvider to internal remove', async () => {
 		const useAccelerateEndpoint = true;
+		const expectedBucketOwner = '012345678901';
 		const bucket = { bucketName: 'bucket', region: 'us-east-1' };
 		const locationCredentialsProvider = async () => ({
 			credentials: {
@@ -44,6 +45,7 @@ describe('uploadData (internal)', () => {
 				contentType: 'text/html',
 				onProgress,
 				metadata,
+				expectedBucketOwner,
 			},
 		});
 
@@ -60,6 +62,7 @@ describe('uploadData (internal)', () => {
 				contentType: 'text/html',
 				onProgress,
 				metadata,
+				expectedBucketOwner,
 			},
 		});
 		expect(result).toEqual(mockedUploadTask);

--- a/packages/storage/src/internals/apis/copy.ts
+++ b/packages/storage/src/internals/apis/copy.ts
@@ -17,10 +17,12 @@ export const copy = (input: CopyInput) =>
 			bucket: input.source.bucket,
 			eTag: input.source.eTag,
 			notModifiedSince: input.source.notModifiedSince,
+			expectedBucketOwner: input.source.expectedBucketOwner,
 		},
 		destination: {
 			path: input.destination.path,
 			bucket: input.destination.bucket,
+			expectedBucketOwner: input.destination.expectedBucketOwner,
 		},
 		options: {
 			// Advanced options

--- a/packages/storage/src/internals/apis/downloadData.ts
+++ b/packages/storage/src/internals/apis/downloadData.ts
@@ -6,35 +6,6 @@ import { DownloadDataInput } from '../types/inputs';
 import { DownloadDataOutput } from '../types/outputs';
 
 /**
- * Download S3 object data to memory
- *
- * @param input - The `DownloadDataInput` object.
- * @returns A cancelable task exposing result promise from `result` property.
- * @throws service: `S3Exception` - thrown when checking for existence of the object
- * @throws validation: `StorageValidationErrorCode` - Validation errors
- *
- * @example
- * ```ts
- * // Download a file from s3 bucket
- * const { body, eTag } = await downloadData({ path, options: {
- *   onProgress, // Optional progress callback.
- * } }).result;
- * ```
- * @example
- * ```ts
- * // Cancel a task
- * const downloadTask = downloadData({ path });
- * //...
- * downloadTask.cancel();
- * try {
- * 	await downloadTask.result;
- * } catch (error) {
- * 	if(isCancelError(error)) {
- *    // Handle error thrown by task cancelation.
- * 	}
- * }
- *```
- *
  * @internal
  */
 export const downloadData = (input: DownloadDataInput): DownloadDataOutput =>
@@ -46,6 +17,7 @@ export const downloadData = (input: DownloadDataInput): DownloadDataOutput =>
 			locationCredentialsProvider: input?.options?.locationCredentialsProvider,
 			bytesRange: input?.options?.bytesRange,
 			onProgress: input?.options?.onProgress,
+			expectedBucketOwner: input?.options?.expectedBucketOwner,
 		},
 		// Type casting is necessary because `downloadDataInternal` supports both Gen1 and Gen2 signatures, but here
 		// given in input can only be Gen2 signature, the return can only ben Gen2 signature.

--- a/packages/storage/src/internals/apis/getProperties.ts
+++ b/packages/storage/src/internals/apis/getProperties.ts
@@ -8,13 +8,6 @@ import { GetPropertiesInput } from '../types/inputs';
 import { GetPropertiesOutput } from '../types/outputs';
 
 /**
- * Gets the properties of a file. The properties include S3 system metadata and
- * the user metadata that was provided when uploading the file.
- * @param input - The `GetPropertiesInput` object.
- * @returns Requested object properties.
- * @throws An `S3Exception` when the underlying S3 service returned error.
- * @throws A `StorageValidationErrorCode` when API call parameters are invalid.
- *
  * @internal
  */
 export const getProperties = (

--- a/packages/storage/src/internals/apis/getUrl.ts
+++ b/packages/storage/src/internals/apis/getUrl.ts
@@ -20,6 +20,7 @@ export const getUrl = (input: GetUrlInput) =>
 			expiresIn: input?.options?.expiresIn,
 			contentDisposition: input?.options?.contentDisposition,
 			contentType: input?.options?.contentType,
+			expectedBucketOwner: input?.options?.expectedBucketOwner,
 
 			// Advanced options
 			locationCredentialsProvider: input?.options?.locationCredentialsProvider,

--- a/packages/storage/src/internals/apis/list.ts
+++ b/packages/storage/src/internals/apis/list.ts
@@ -32,6 +32,7 @@ export function list(input: ListInput): Promise<ListOutput> {
 			subpathStrategy: input.options?.subpathStrategy,
 			useAccelerateEndpoint: input.options?.useAccelerateEndpoint,
 			listAll: input.options?.listAll,
+			expectedBucketOwner: input.options?.expectedBucketOwner,
 
 			// Pagination options
 			nextToken: (input as ListPaginateInput).options?.nextToken,

--- a/packages/storage/src/internals/apis/remove.ts
+++ b/packages/storage/src/internals/apis/remove.ts
@@ -8,13 +8,6 @@ import { RemoveInput } from '../types/inputs';
 import { RemoveOutput } from '../types/outputs';
 
 /**
- * Remove a file from your S3 bucket.
- * @param input - The `RemoveInput` object.
- * @return Output containing the removed object path.
- * @throws service: `S3Exception` - S3 service errors thrown while while removing the object.
- * @throws validation: `StorageValidationErrorCode` - Validation errors thrown
- * when there is no path or path is empty or path has a leading slash.
- *
  * @internal
  */
 export const remove = (input: RemoveInput): Promise<RemoveOutput> =>
@@ -23,6 +16,7 @@ export const remove = (input: RemoveInput): Promise<RemoveOutput> =>
 		options: {
 			useAccelerateEndpoint: input?.options?.useAccelerateEndpoint,
 			bucket: input?.options?.bucket,
+			expectedBucketOwner: input?.options?.expectedBucketOwner,
 			locationCredentialsProvider: input?.options?.locationCredentialsProvider,
 		},
 		// Type casting is necessary because `removeInternal` supports both Gen1 and Gen2 signatures, but here

--- a/packages/storage/src/internals/apis/uploadData.ts
+++ b/packages/storage/src/internals/apis/uploadData.ts
@@ -23,6 +23,7 @@ export const uploadData = (input: UploadDataInput) => {
 			contentType: options?.contentType,
 			metadata: options?.metadata,
 			preventOverwrite: options?.preventOverwrite,
+			expectedBucketOwner: options?.expectedBucketOwner,
 
 			// Advanced options
 			locationCredentialsProvider: options?.locationCredentialsProvider,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds the expected bucket owner option to the remaining internal APIs. Also removes doc-strings from some internal APIs to discourage use.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Local testing.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
