### PR TITLE
release(required): network error has not been properly detected

### DIFF
--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
@@ -1,11 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+	AmplifyError,
+	AmplifyErrorCode,
+} from '@aws-amplify/core/internals/utils';
+
 import { tokenOrchestrator } from '../../../../src/providers/cognito/tokenProvider';
 import { CognitoAuthTokens } from '../../../../src/providers/cognito/tokenProvider/types';
 import { oAuthStore } from '../../../../src/providers/cognito/utils/oauth/oAuthStore';
 
-jest.mock('@aws-amplify/core/internals/utils');
 jest.mock('@aws-amplify/core', () => ({
 	...jest.requireActual('@aws-amplify/core'),
 	Hub: {
@@ -88,6 +92,22 @@ describe('tokenOrchestrator', () => {
 			// ensure the result is correct
 			expect(newTokens).toEqual(mockTokens);
 			expect(newTokens?.signInDetails).toEqual(testSignInDetails);
+		});
+	});
+
+	describe('handleErrors method', () => {
+		it('does not call clearTokens() if the error is a network error thrown from fetch handler', () => {
+			const clearTokensSpy = jest.spyOn(tokenOrchestrator, 'clearTokens');
+			const error = new AmplifyError({
+				name: AmplifyErrorCode.NetworkError,
+				message: 'Network Error',
+			});
+
+			expect(() => {
+				(tokenOrchestrator as any).handleErrors(error);
+			}).toThrow(error);
+
+			expect(clearTokensSpy).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -9,6 +9,7 @@ import {
 } from '@aws-amplify/core';
 import {
 	AMPLIFY_SYMBOL,
+	AmplifyErrorCode,
 	assertTokenProviderConfig,
 	isBrowser,
 	isTokenExpired,
@@ -169,7 +170,7 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 
 	private handleErrors(err: unknown) {
 		assertServiceError(err);
-		if (err.message !== 'Network error') {
+		if (err.name !== AmplifyErrorCode.NetworkError) {
 			// TODO(v6): Check errors on client
 			this.clearTokens();
 		}

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -485,7 +485,7 @@
 			"name": "[Storage] list (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ list }",
-			"limit": "15.41 kB"
+			"limit": "15.50 kB"
 		},
 		{
 			"name": "[Storage] remove (S3)",

--- a/packages/core/__tests__/clients/middleware/retry/defaultRetryDecider.test.ts
+++ b/packages/core/__tests__/clients/middleware/retry/defaultRetryDecider.test.ts
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { HttpResponse } from '../../../../src/clients';
+import { getRetryDecider } from '../../../../src/clients/middleware/retry/defaultRetryDecider';
+import { AmplifyError } from '../../../../src/errors';
+import { AmplifyErrorCode } from '../../../../src/types';
+
+describe('getRetryDecider', () => {
+	const mockErrorParser = jest.fn();
+
+	describe('created retryDecider', () => {
+		const mockNetworkErrorThrownFromFetch = new AmplifyError({
+			name: AmplifyErrorCode.NetworkError,
+			message: 'Network Error',
+		});
+		const mockNetworkErrorThrownFromXHRInStorage = new Error('Network Error');
+		mockNetworkErrorThrownFromXHRInStorage.name = 'ERR_NETWORK';
+		mockNetworkErrorThrownFromXHRInStorage.message = 'Network Error';
+
+		test.each([
+			[
+				'a network error from the fetch handler',
+				true,
+				mockNetworkErrorThrownFromFetch,
+			],
+			[
+				'a network error from the XHR handler defined in Storage',
+				true,
+				mockNetworkErrorThrownFromXHRInStorage,
+			],
+		])('when receives %p returns %p', (_, expected, error) => {
+			const mockResponse = {} as unknown as HttpResponse;
+			mockErrorParser.mockReturnValueOnce(error);
+			const retryDecider = getRetryDecider(mockErrorParser);
+
+			expect(retryDecider(mockResponse, error)).resolves.toBe(expected);
+		});
+	});
+});

--- a/packages/core/src/clients/middleware/retry/defaultRetryDecider.ts
+++ b/packages/core/src/clients/middleware/retry/defaultRetryDecider.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyErrorCode } from '../../../types';
 import { ErrorParser, HttpResponse } from '../../types';
 
 import { isClockSkewError } from './isClockSkewError';
@@ -55,7 +56,11 @@ const isThrottlingError = (statusCode?: number, errorCode?: string) =>
 	(!!errorCode && THROTTLING_ERROR_CODES.includes(errorCode));
 
 const isConnectionError = (error?: unknown) =>
-	(error as Error)?.name === 'Network error';
+	[
+		AmplifyErrorCode.NetworkError,
+		// TODO(vNext): unify the error code `ERR_NETWORK` used by the Storage XHR handler
+		'ERR_NETWORK',
+	].includes((error as Error)?.name);
 
 const isServerSideError = (statusCode?: number, errorCode?: string) =>
 	(!!statusCode && [500, 502, 503, 504].includes(statusCode)) ||


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

1. the `isConnectionError` of the `defaultRetryDecider` now detects network errors by looking up the `name` property to match either one of the `[NetworkError, ERR_NETWORK]`
    * `NetworkError` is thrown from the fetch transfer handler Core
    * `ERR_NETWORK` is thrown from the XHR transfer handler resides in Storage 
2. the `tokenOrchestrator.handleErrors` method now detects network errors by looking up the `name` property to match `NetworkError`, `clearTokens()` shall not be called when the error is a network error


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

* https://github.com/aws-amplify/amplify-js/issues/13930 (over clearing auth tokens on network error)
* https://github.com/aws-amplify/amplify-js/issues/13908 (retry is not being applied on network errors)


#### Description of how you validated changes

1. manual testing with a Next.js app and a react-native app
2. unit tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
