### PR TITLE
fix(api-graphql): close WS on events.closeAll

### DIFF
--- a/packages/api-graphql/__tests__/helpers.ts
+++ b/packages/api-graphql/__tests__/helpers.ts
@@ -258,9 +258,8 @@ export class FakeWebSocketInterface {
 	/**
 	 * Run a command and resolve to allow internal behavior to execute
 	 */
-	async runAndResolve(fn) {
+	async runAndResolve(fn: Function) {
 		await fn();
-		await Promise.resolve();
 	}
 
 	/**
@@ -310,6 +309,10 @@ class FakeWebSocket implements WebSocket {
 	close(code?: number, reason?: string): void {
 		const closeResolver = this.closeResolverFcn();
 		if (closeResolver) closeResolver(Promise.resolve(undefined));
+
+		try {
+			this.onclose(new CloseEvent('', {}));
+		} catch {}
 	}
 	send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
 		const parsedInput = JSON.parse(String(data));

--- a/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
@@ -53,6 +53,27 @@ export class AWSAppSyncEventProvider extends AWSWebSocketProvider {
 		return PROVIDER_NAME;
 	}
 
+	close() {
+		return new Promise<void>((resolve, reject) => {
+			super.close();
+			if (this.awsRealTimeSocket) {
+				this.awsRealTimeSocket.onclose = (_: CloseEvent) => {
+					this.subscriptionObserverMap = new Map();
+					this.awsRealTimeSocket = undefined;
+					resolve();
+				};
+
+				this.awsRealTimeSocket.onerror = (err: any) => {
+					reject(err);
+				};
+
+				this.awsRealTimeSocket.close();
+			} else {
+				resolve();
+			}
+		});
+	}
+
 	public async connect(options: AWSAppSyncEventProviderOptions) {
 		super.connect(options);
 	}

--- a/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
@@ -80,7 +80,7 @@ export abstract class AWSWebSocketProvider {
 	protected logger: ConsoleLogger;
 	protected subscriptionObserverMap = new Map<string, ObserverQuery>();
 
-	private awsRealTimeSocket?: WebSocket;
+	protected awsRealTimeSocket?: WebSocket;
 	private socketStatus: SOCKET_STATUS = SOCKET_STATUS.CLOSED;
 	private keepAliveTimeoutId?: ReturnType<typeof setTimeout>;
 	private keepAliveTimeout = DEFAULT_KEEP_ALIVE_TIMEOUT;

--- a/packages/api-graphql/src/internals/events/index.ts
+++ b/packages/api-graphql/src/internals/events/index.ts
@@ -154,8 +154,19 @@ async function post(
 	}
 }
 
-function closeAll(): void {
-	eventProvider.close();
+/**
+ * @experimental API may change in future versions
+ *
+ * Close WebSocket connection, disconnect listeners and reconnect observers
+ *
+ * @example
+ * await events.closeAll()
+ *
+ * @returns void on success
+ * @throws on error
+ */
+async function closeAll(): Promise<void> {
+	await eventProvider.close();
 }
 
 export { connect, post, closeAll };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
`events.closeAll()` is intended to close the WS connection, disconnect listeners and reconnect observers. However, the underlying `AWSWebSocketProvider.close()` method does all of the above, except for close the WS connection. 
To limit the blast radius of this change, this PR only modifies the `AWSAppSyncEventProvider` sub class, closing the WS connection on `close()` and leaves the AppSyncRealTimeProvider unchanged.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/13984


#### Description of how you validated changes
* Manual
* Added fn test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)