### PR TITLE
refactor(api-graphql): apply WS.close to base class

### DIFF
--- a/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
@@ -53,27 +53,6 @@ export class AWSAppSyncEventProvider extends AWSWebSocketProvider {
 		return PROVIDER_NAME;
 	}
 
-	close() {
-		return new Promise<void>((resolve, reject) => {
-			super.close();
-			if (this.awsRealTimeSocket) {
-				this.awsRealTimeSocket.onclose = (_: CloseEvent) => {
-					this.subscriptionObserverMap = new Map();
-					this.awsRealTimeSocket = undefined;
-					resolve();
-				};
-
-				this.awsRealTimeSocket.onerror = (err: any) => {
-					reject(err);
-				};
-
-				this.awsRealTimeSocket.close();
-			} else {
-				resolve();
-			}
-		});
-	}
-
 	public async connect(options: AWSAppSyncEventProviderOptions) {
 		super.connect(options);
 	}

--- a/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
@@ -112,6 +112,24 @@ export abstract class AWSWebSocketProvider {
 		this.connectionStateMonitorSubscription.unsubscribe();
 		// Complete all reconnect observers
 		this.reconnectionMonitor.close();
+
+		return new Promise<void>((resolve, reject) => {
+			if (this.awsRealTimeSocket) {
+				this.awsRealTimeSocket.onclose = (_: CloseEvent) => {
+					this.subscriptionObserverMap = new Map();
+					this.awsRealTimeSocket = undefined;
+					resolve();
+				};
+
+				this.awsRealTimeSocket.onerror = (err: any) => {
+					reject(err);
+				};
+
+				this.awsRealTimeSocket.close();
+			} else {
+				resolve();
+			}
+		});
 	}
 
 	subscribe(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Applying change from #13989 to the base class. 
Verified that this does not affect the Realtime provider. `.close()` is not accessible publicly and is not invoked internally on that provider. 


#### Description of how you validated changes
* Code review
* Unit tests pass
* E2Es pass: https://github.com/aws-amplify/amplify-js/actions/runs/11709500317


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)
