### PR TITLE
fix(api-graphql): events ws connect sig

### DIFF
--- a/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
@@ -43,6 +43,7 @@ interface DataResponse {
 
 const PROVIDER_NAME = 'AWSAppSyncEventsProvider';
 const WS_PROTOCOL_NAME = 'aws-appsync-event-ws';
+const CONNECT_URI = ''; // events does not expect a connect uri
 
 export class AWSAppSyncEventProvider extends AWSWebSocketProvider {
 	constructor() {
@@ -90,7 +91,7 @@ export class AWSAppSyncEventProvider extends AWSWebSocketProvider {
 			appSyncGraphqlEndpoint,
 			authenticationType,
 			query,
-			variables,
+			// variables,
 			apiKey,
 			region,
 		} = options;
@@ -100,7 +101,7 @@ export class AWSAppSyncEventProvider extends AWSWebSocketProvider {
 		// 	events: [variables],
 		// };
 
-		const serializedData = JSON.stringify([variables]);
+		const serializedData = JSON.stringify({ channel: query });
 
 		const headers = {
 			...(await awsRealTimeHeaderBasedAuth({
@@ -201,6 +202,10 @@ export class AWSAppSyncEventProvider extends AWSWebSocketProvider {
 		const { errors: [{ errorType = '', errorCode = 0 } = {}] = [] } = data;
 
 		return { errorCode, errorType };
+	}
+
+	protected _getConnectUri(): string {
+		return CONNECT_URI;
 	}
 }
 

--- a/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
@@ -95,7 +95,6 @@ export class AWSAppSyncEventProvider extends AWSWebSocketProvider {
 			appSyncGraphqlEndpoint,
 			authenticationType,
 			query,
-			// variables,
 			apiKey,
 			region,
 		} = options;

--- a/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
@@ -47,7 +47,11 @@ const CONNECT_URI = ''; // events does not expect a connect uri
 
 export class AWSAppSyncEventProvider extends AWSWebSocketProvider {
 	constructor() {
-		super({ providerName: PROVIDER_NAME, wsProtocolName: WS_PROTOCOL_NAME });
+		super({
+			providerName: PROVIDER_NAME,
+			wsProtocolName: WS_PROTOCOL_NAME,
+			connectUri: CONNECT_URI,
+		});
 	}
 
 	getProviderName() {
@@ -202,10 +206,6 @@ export class AWSAppSyncEventProvider extends AWSWebSocketProvider {
 		const { errors: [{ errorType = '', errorCode = 0 } = {}] = [] } = data;
 
 		return { errorCode, errorType };
-	}
-
-	protected _getConnectUri(): string {
-		return CONNECT_URI;
 	}
 }
 

--- a/packages/api-graphql/src/Providers/AWSAppSyncRealTimeProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSAppSyncRealTimeProvider/index.ts
@@ -42,6 +42,7 @@ interface DataPayload {
 
 const PROVIDER_NAME = 'AWSAppSyncRealTimeProvider';
 const WS_PROTOCOL_NAME = 'graphql-ws';
+const CONNECT_URI = '/connect';
 
 export class AWSAppSyncRealTimeProvider extends AWSWebSocketProvider {
 	constructor() {
@@ -176,5 +177,9 @@ export class AWSAppSyncRealTimeProvider extends AWSWebSocketProvider {
 		} = data;
 
 		return { errorCode, errorType };
+	}
+
+	protected _getConnectUri(): string {
+		return CONNECT_URI;
 	}
 }

--- a/packages/api-graphql/src/Providers/AWSAppSyncRealTimeProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSAppSyncRealTimeProvider/index.ts
@@ -46,7 +46,11 @@ const CONNECT_URI = '/connect';
 
 export class AWSAppSyncRealTimeProvider extends AWSWebSocketProvider {
 	constructor() {
-		super({ providerName: PROVIDER_NAME, wsProtocolName: WS_PROTOCOL_NAME });
+		super({
+			providerName: PROVIDER_NAME,
+			wsProtocolName: WS_PROTOCOL_NAME,
+			connectUri: CONNECT_URI,
+		});
 	}
 
 	getProviderName() {
@@ -177,9 +181,5 @@ export class AWSAppSyncRealTimeProvider extends AWSWebSocketProvider {
 		} = data;
 
 		return { errorCode, errorType };
-	}
-
-	protected _getConnectUri(): string {
-		return CONNECT_URI;
 	}
 }

--- a/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
@@ -74,6 +74,7 @@ interface ParsedMessagePayload {
 interface AWSWebSocketProviderArgs {
 	providerName: string;
 	wsProtocolName: string;
+	connectUri: string;
 }
 
 export abstract class AWSWebSocketProvider {
@@ -91,10 +92,12 @@ export abstract class AWSWebSocketProvider {
 	private readonly reconnectionMonitor = new ReconnectionMonitor();
 	private connectionStateMonitorSubscription: SubscriptionLike;
 	private readonly wsProtocolName: string;
+	private readonly wsConnectUri: string;
 
 	constructor(args: AWSWebSocketProviderArgs) {
 		this.logger = new ConsoleLogger(args.providerName);
 		this.wsProtocolName = args.wsProtocolName;
+		this.wsConnectUri = args.connectUri;
 
 		this.connectionStateMonitorSubscription =
 			this._startConnectionStateMonitoring();
@@ -574,8 +577,6 @@ export abstract class AWSWebSocketProvider {
 		errorType: string;
 	};
 
-	protected abstract _getConnectUri(): string;
-
 	private _handleIncomingSubscriptionMessage(message: MessageEvent) {
 		if (typeof message.data !== 'string') {
 			return;
@@ -741,7 +742,7 @@ export abstract class AWSWebSocketProvider {
 					const authHeader = await awsRealTimeHeaderBasedAuth({
 						authenticationType,
 						payload: payloadString,
-						canonicalUri: this._getConnectUri(),
+						canonicalUri: this.wsConnectUri,
 						apiKey,
 						appSyncGraphqlEndpoint,
 						region,

--- a/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
@@ -574,6 +574,8 @@ export abstract class AWSWebSocketProvider {
 		errorType: string;
 	};
 
+	protected abstract _getConnectUri(): string;
+
 	private _handleIncomingSubscriptionMessage(message: MessageEvent) {
 		if (typeof message.data !== 'string') {
 			return;
@@ -739,7 +741,7 @@ export abstract class AWSWebSocketProvider {
 					const authHeader = await awsRealTimeHeaderBasedAuth({
 						authenticationType,
 						payload: payloadString,
-						canonicalUri: '/connect',
+						canonicalUri: this._getConnectUri(),
 						apiKey,
 						appSyncGraphqlEndpoint,
 						region,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Sigv4 calculation for Event API WS Connect was incorrectly appending a `/connect` path to the request URL. This is required for GQL Realtime WS Connect, but breaks for Event API. 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/14001


#### Description of how you validated changes
* Manual - events & graphql realtime WS connect & sub with IAM/IdP
* E2Es: https://github.com/aws-amplify/amplify-js/actions/runs/11804564727


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)