### PR TITLE
fix: amplify configure with auth userGroups

### DIFF
--- a/packages/core/__tests__/parseAmplifyOutputs.test.ts
+++ b/packages/core/__tests__/parseAmplifyOutputs.test.ts
@@ -133,6 +133,7 @@ describe('parseAmplifyOutputs tests', () => {
 					unauthenticated_identities_enabled: true,
 					mfa_configuration: 'OPTIONAL',
 					mfa_methods: ['SMS'],
+					groups: [{ ADMIN: { precedence: 0 }, USER: { precedence: 0 } }],
 				},
 			};
 
@@ -174,6 +175,7 @@ describe('parseAmplifyOutputs tests', () => {
 								scopes: ['profile', '...'],
 							},
 						},
+						groups: [{ ADMIN: { precedence: 0 }, USER: { precedence: 0 } }],
 					},
 				},
 			});

--- a/packages/core/src/singleton/AmplifyOutputs/types.ts
+++ b/packages/core/src/singleton/AmplifyOutputs/types.ts
@@ -42,7 +42,7 @@ export interface AmplifyOutputsAuthProperties {
 	unauthenticated_identities_enabled?: boolean;
 	mfa_configuration?: string;
 	mfa_methods?: string[];
-	groups?: Record<UserGroupName, UserGroupPrecedence>[];
+	groups?: Partial<Record<UserGroupName, UserGroupPrecedence>>[];
 }
 
 export interface AmplifyOutputsStorageBucketProperties {


### PR DESCRIPTION
#### Description of changes
Amplify configure with auth user groups throws a type error `not assignable to type 'Record<string, UserGroupPrecedence>[]'`. This PR loosens this type to avoid this error.

#### Issue #, if available
#14045

#### Description of how you validated changes
- Tested that the following with `amplify.configure` does not throw any type error
```
  "auth": {
    "groups": [
      {
        "ADMIN": { "precedence": 0 },
        "USER": { "precedence": 1 }
      },
      {
        "USER": { "precedence": 0 }
      },
      {
        "TEST": { "precedence": 2 },
        "USER": { "precedence": 1 },
        "ADMIN": { "precedence": 0 }
      }
    ],
```
- `amplify.getConfig` returns the correct config
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
