### PR TITLE
fix(rtn-push-notification): wrong namespace is being used

### DIFF
--- a/packages/rtn-push-notification/android/build.gradle
+++ b/packages/rtn-push-notification/android/build.gradle
@@ -32,7 +32,7 @@ def getExtOrDefault(prop) {
 
 android {
     if (agpVersion >= 7) {
-        namespace 'com.amazonaws.amplify.pushnotification'
+        namespace 'com.amazonaws.amplify.rtnpushnotification'
     }
 
     compileSdkVersion getExtOrDefault('compileSdkVersion')


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fix wrong namespace.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-js/issues/14059

#### Description of how you validated changes

Manually build android app with installing the locally modified `@aws-amplify/rtn-push-notification` package and verify that `npm run android` can build the native Android host app with react-native versions:

1. 0.73.6 
2. 0.70.0

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
