### PR TITLE
chore: downgrade to macos-13 runner to let test passing with older detox version

### DIFF
--- a/.github/workflows/callable-canary-e2e.yml
+++ b/.github/workflows/callable-canary-e2e.yml
@@ -15,7 +15,7 @@ jobs:
   prebuild-macos:
     uses: ./.github/workflows/callable-prebuild-amplify-js.yml
     with:
-      runs_on: macos-latest
+      runs_on: macos-13
   prebuild-samples-staging:
     secrets: inherit
     uses: ./.github/workflows/callable-prebuild-samples-staging.yml

--- a/.github/workflows/callable-e2e-test-detox.yml
+++ b/.github/workflows/callable-e2e-test-detox.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   e2e-test:
     name: E2E-Detox ${{ inputs.test_name }}
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
     steps:

--- a/.github/workflows/callable-release-verification.yml
+++ b/.github/workflows/callable-release-verification.yml
@@ -10,7 +10,7 @@ jobs:
   prebuild-macos:
     uses: ./.github/workflows/callable-prebuild-amplify-js.yml
     with:
-      runs_on: macos-latest
+      runs_on: macos-13
   prebuild-samples-staging:
     secrets: inherit
     uses: ./.github/workflows/callable-prebuild-samples-staging.yml


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
