### PR TITLE
fix(ci): canary test failure on npm install

### DIFF
--- a/.github/workflows/callable-canary-sampleapp-tests.yml
+++ b/.github/workflows/callable-canary-sampleapp-tests.yml
@@ -124,6 +124,9 @@ jobs:
       - name: Install dependencies
         run: npm install
         working-directory: amplify-js-samples-staging/samples/next/auth/new-next-app
+      - name: Install latest stable amplify version
+        run: npm install aws-amplify@latest @aws-amplify/adapter-nextjs@latest
+        working-directory: amplify-js-samples-staging/samples/next/auth/new-next-app
       - name: Start application and run test
         run: |
           ../amplify-js/scripts/retry-yarn-script.sh -s \

--- a/.github/workflows/callable-canary-sampleapp-tests.yml
+++ b/.github/workflows/callable-canary-sampleapp-tests.yml
@@ -48,8 +48,8 @@ jobs:
         run: |
           cp credentials-auth.spec.js new-react-app.spec.js
         working-directory: amplify-js-samples-staging/cypress/integration/auth
-      - name: Install amplify
-        run: npm install amplify
+      - name: Install dependencies
+        run: npm install
         working-directory: amplify-js-samples-staging/samples/react/auth/new-react-app
       - name: Start new application and run test
         run: |
@@ -114,7 +114,7 @@ jobs:
         working-directory: amplify-js-samples-staging/samples/next/auth/new-next-app
       - name: Copy files from samples staging repo
         run: |
-          rm -r ./samples/next/auth/new-next-app 
+          rm -r ./samples/next/auth/new-next-app
           cp -r ./samples/next/auth/auth-rsc ./samples/next/auth/new-next-app
         working-directory: amplify-js-samples-staging
       - name: Copy test file from samples staging repo
@@ -123,11 +123,6 @@ jobs:
         working-directory: amplify-js-samples-staging/cypress/integration/auth
       - name: Install dependencies
         run: npm install
-        working-directory: amplify-js-samples-staging/samples/next/auth/new-next-app
-      - name: Install amplify
-        run: |
-          npm install -g npm@latest
-          npm install aws-amplify -legacy-peer-deps
         working-directory: amplify-js-samples-staging/samples/next/auth/new-next-app
       - name: Start application and run test
         run: |
@@ -194,7 +189,7 @@ jobs:
         working-directory: amplify-js-samples-staging/samples/javascript/datastore/new-javascript-app
       - name: Copy files from samples staging repo
         run: |
-          rm -r ./samples/javascript/datastore/new-javascript-app 
+          rm -r ./samples/javascript/datastore/new-javascript-app
           cp -r ./samples/javascript/datastore/basic-crud ./samples/javascript/datastore/new-javascript-app
         working-directory: amplify-js-samples-staging
       - name: Copy test file from samples staging repo

--- a/.github/workflows/callable-canary-sampleapp-tests.yml
+++ b/.github/workflows/callable-canary-sampleapp-tests.yml
@@ -48,8 +48,8 @@ jobs:
         run: |
           cp credentials-auth.spec.js new-react-app.spec.js
         working-directory: amplify-js-samples-staging/cypress/integration/auth
-      - name: Install dependencies
-        run: npm install
+      - name: Install amplify
+        run: npm install amplify
         working-directory: amplify-js-samples-staging/samples/react/auth/new-react-app
       - name: Start new application and run test
         run: |


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

With the release of[ npm 11.0.0](https://github.com/npm/cli/releases/tag/v11.0.0), canary builds started failing with 

```Run npm install -g npm@latest
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: npm@11.0.0
npm ERR! notsup Not compatible with your version of node/npm: npm@11.0.0
npm ERR! notsup Required: {"node":"^20.17.0 || >=22.9.0"}
npm ERR! notsup Actual:   {"npm":"[10](https://github.com/aws-amplify/amplify-js/actions/runs/12356454590/job/34494840473#step:16:11).5.0","node":"v18.20.2"}
```

We don't need to install the latest version of npm, as we're setting up required node/npm versions earlier in the action. Removing `npm install -g npm@latest` fixes the issue.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

- Run build script locally
- Run tests locally

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
