### PR TITLE
feat(Auth): Allow sending login_hint, lang and nonce on signInWithRedirects

### DIFF
--- a/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
@@ -295,6 +295,7 @@ describe('signInWithRedirect', () => {
 			);
 			expect(mockHandleFailure).toHaveBeenCalledWith(expectedError);
 		});
+
 		it('should not set the Oauth flag on non-browser environments', async () => {
 			const mockOpenAuthSessionResult = {
 				type: 'success',
@@ -307,6 +308,28 @@ describe('signInWithRedirect', () => {
 			});
 
 			expect(oAuthStore.storeOAuthInFlight).toHaveBeenCalledTimes(0);
+		});
+
+		it('should send the login_hint, lang and nonce in the query string if provided', async () => {
+			await signInWithRedirect({
+				provider: 'Google',
+				options: {
+					loginHint: 'someone@gmail.com',
+					lang: 'en',
+					nonce: '88388838883',
+				},
+			});
+
+			const [oauthUrl, redirectSignIn, preferPrivateSession] =
+				mockOpenAuthSession.mock.calls[0];
+
+			expect(oauthUrl).toStrictEqual(
+				'https://oauth.domain.com/oauth2/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F&response_type=code&client_id=userPoolClientId&identity_provider=Google&scope=phone%20email%20openid%20profile%20aws.cognito.signin.user.admin&login_hint=someone%40gmail.com&lang=en&nonce=88388838883&state=oauth_state&code_challenge=code_challenge&code_challenge_method=S256',
+			);
+			expect(redirectSignIn).toEqual(
+				mockAuthConfigWithOAuth.Auth.Cognito.loginWith.oauth.redirectSignIn,
+			);
+			expect(preferPrivateSession).toBeUndefined();
 		});
 	});
 

--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -57,9 +57,11 @@ export async function signInWithRedirect(
 		provider,
 		customState: input?.customState,
 		preferPrivateSession: input?.options?.preferPrivateSession,
-		loginHint: input?.options?.loginHint,
-		lang: input?.options?.lang,
-		nonce: input?.options?.nonce,
+		options: {
+			loginHint: input?.options?.loginHint,
+			lang: input?.options?.lang,
+			nonce: input?.options?.nonce,
+		},
 	});
 }
 
@@ -69,20 +71,17 @@ const oauthSignIn = async ({
 	clientId,
 	customState,
 	preferPrivateSession,
-	loginHint,
-	lang,
-	nonce,
+	options,
 }: {
 	oauthConfig: OAuthConfig;
 	provider: string;
 	clientId: string;
 	customState?: string;
 	preferPrivateSession?: boolean;
-	loginHint?: string;
-	lang?: string;
-	nonce?: string;
+	options?: SignInWithRedirectInput['options'];
 }) => {
 	const { domain, redirectSignIn, responseType, scopes } = oauthConfig;
+	const { loginHint, lang, nonce } = options ?? {};
 	const randomState = generateState();
 
 	/* encodeURIComponent is not URL safe, use urlSafeEncode instead. Cognito

--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -57,6 +57,9 @@ export async function signInWithRedirect(
 		provider,
 		customState: input?.customState,
 		preferPrivateSession: input?.options?.preferPrivateSession,
+		loginHint: input?.options?.loginHint,
+		lang: input?.options?.lang,
+		nonce: input?.options?.nonce,
 	});
 }
 
@@ -66,12 +69,18 @@ const oauthSignIn = async ({
 	clientId,
 	customState,
 	preferPrivateSession,
+	loginHint,
+	lang,
+	nonce,
 }: {
 	oauthConfig: OAuthConfig;
 	provider: string;
 	clientId: string;
 	customState?: string;
 	preferPrivateSession?: boolean;
+	loginHint?: string;
+	lang?: string;
+	nonce?: string;
 }) => {
 	const { domain, redirectSignIn, responseType, scopes } = oauthConfig;
 	const randomState = generateState();
@@ -99,6 +108,10 @@ const oauthSignIn = async ({
 		client_id: clientId,
 		identity_provider: provider,
 		scope: scopes.join(' '),
+		// eslint-disable-next-line camelcase
+		...(loginHint && { login_hint: loginHint }),
+		...(lang && { lang }),
+		...(nonce && { nonce }),
 		state,
 		...(responseType === 'code' && {
 			code_challenge: toCodeChallenge(),

--- a/packages/auth/src/types/inputs.ts
+++ b/packages/auth/src/types/inputs.ts
@@ -68,6 +68,9 @@ export interface AuthSignInWithRedirectInput {
 		 * On all other platforms, this flag is ignored.
 		 */
 		preferPrivateSession?: boolean;
+		loginHint?: string;
+		lang?: string;
+		nonce?: string;
 	};
 }
 

--- a/packages/auth/src/types/inputs.ts
+++ b/packages/auth/src/types/inputs.ts
@@ -68,8 +68,32 @@ export interface AuthSignInWithRedirectInput {
 		 * On all other platforms, this flag is ignored.
 		 */
 		preferPrivateSession?: boolean;
+		/**
+		 * A username prompt that you want to pass to the authorization server. You can collect a username, email address or phone number from your user and allow the destination provider to pre-populate the user's sign-in name. When you submit a `login_hint` parameter and no `idp_identifier` or `identity_provider` parameters to the `/oauth2/authorize` endpoint, managed login fills the username field with your hint value. You can also pass this parameter to the Login endpoint and automatically fill the username value.
+		 * @see https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html
+		 */
 		loginHint?: string;
-		lang?: string;
+		/**
+		 * The language that you want to display user-interactive pages in. Managed login pages can be localized, but hosted UI (classic) pages can not
+		 * @see https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html
+		 */
+		lang?:
+			| 'de'
+			| 'en'
+			| 'es'
+			| 'fr'
+			| 'id'
+			| 'it'
+			| 'ja'
+			| 'ko'
+			| 'pt-BR'
+			| 'zh-CN'
+			| 'zh-TW'
+			| (string & NonNullable<unknown>);
+		/**
+		 * A random value that you can add to the request. The nonce value that you provide is included in the ID token that Amazon Cognito issues. To guard against replay attacks, your app can inspect the `nonce` claim in the ID token and compare it to the one you generated.
+		 * @see https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html
+		 */
 		nonce?: string;
 	};
 }


### PR DESCRIPTION
#### Description of changes
This adds support for the login_hint, lang and nonce parameters, which are supported by cognito as of the official documentation https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html 

The way to pass them is by adding them as extra options under the input parameters on the `signInWithRedirect` function

```js
await signInWithRedirect({
	provider: 'Google',
	options: {
		loginHint: 'someone@gmail.com',
		lang: 'en',
		nonce: '88388838883',
	},
});
```

#### Issue #, if available
Adding login_hint would fix #8951
Possible fix by adding nonce #4998
Support lang attribute #14040 

#### Description of how you validated changes
- I added a unit tests to verify that when the parameters are passed they end up in the URL
- I created a sample app to test the changes and verified that they are working against 2 providers, Okta and Azure.


#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
