### PR TITLE
fix(auth): fall back to user agent if deviceName resolves to empty st…

### DIFF
--- a/packages/core/__tests__/utils/deviceName/getDeviceName.test.ts
+++ b/packages/core/__tests__/utils/deviceName/getDeviceName.test.ts
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { getDeviceName } from '../../../src/utils/deviceName';
+
+describe('getDeviceName()', () => {
+	const userAgentData = {
+		platform: 'device-platform',
+		platformVersion: 'device-platform-version',
+		architecture: 'device-architecture',
+		model: 'device-model',
+		fullVersionList: [
+			{ brand: 'device-brand-1', version: 'device-version-1' },
+			{ brand: 'device-brand-2', version: 'device-version-2' },
+		],
+	};
+	const userAgent = `product/version`;
+
+	const mockGetHighEntropyValues = jest.fn();
+	const navigatorSpy = jest.spyOn(window, 'navigator', 'get');
+
+	afterEach(() => {
+		mockGetHighEntropyValues.mockReset();
+		navigatorSpy.mockReset();
+	});
+
+	it('should return a device name based on user agent data', async () => {
+		mockGetHighEntropyValues.mockResolvedValue(userAgentData);
+		navigatorSpy.mockReturnValue({
+			userAgentData: {
+				getHighEntropyValues: mockGetHighEntropyValues,
+			},
+		} as any);
+
+		const { architecture, fullVersionList, model, platform, platformVersion } =
+			userAgentData;
+		const [brand1, brand2] = fullVersionList;
+		expect(await getDeviceName()).toBe(
+			`${platform} ` +
+				`${platformVersion} ` +
+				`${architecture} ` +
+				`${model} ` +
+				`${platform} ` +
+				`${brand1.brand}/${brand1.version};` +
+				`${brand2.brand}/${brand2.version}`,
+		);
+	});
+
+	it('should fall back to user agent if no user agent data', async () => {
+		navigatorSpy.mockReturnValue({ userAgent } as any);
+
+		expect(await getDeviceName()).toBe(userAgent);
+	});
+
+	it('should fall back to user agent if deviceName resolves to empty string', async () => {
+		// simulated devices in Chrome can return empty strings
+		mockGetHighEntropyValues.mockResolvedValue({
+			platform: '',
+			platformVersion: '',
+			architecture: '',
+			model: '',
+			fullVersionList: [],
+		});
+		navigatorSpy.mockReturnValue({
+			userAgentData: {
+				getHighEntropyValues: mockGetHighEntropyValues,
+			},
+			userAgent,
+		} as any);
+
+		expect(await getDeviceName()).toBe(userAgent);
+	});
+});

--- a/packages/core/src/utils/deviceName/getDeviceName.ts
+++ b/packages/core/src/utils/deviceName/getDeviceName.ts
@@ -48,5 +48,5 @@ export const getDeviceName = async (): Promise<string> => {
 		.filter(value => value)
 		.join(' ');
 
-	return deviceName;
+	return deviceName || navigator.userAgent;
 };


### PR DESCRIPTION
…ring

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR updates the device name resolution to fall back to using the user agent if it resolves to `''`. This might happen when the `userAgentData` returns empty values for the requested information - something that happens when simulating devices in Chrome, for example.

Currently, the device name already falls back to user agent in the case `userAgentData` is not supported on the platform so this PR only applies the same fallback logic to the case where `userAgentData` is supported but is reporting empty values.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
https://github.com/aws-amplify/amplify-js/issues/14100


#### Description of how you validated changes
Reproduced issue using Chrome browser and validated that DeviceName is no longer sent with empty string when device tracking is enabled.

Manually tested against Firefox and Safari.

Added unit tests.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
