### PR TITLE
refactor(adapter-nextjs): use maxAge attribute to set cookie from server to avoid clock drift

### DIFF
--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInCallbackRequest.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInCallbackRequest.test.ts
@@ -218,6 +218,7 @@ describe('handleSignInCallbackRequest', () => {
 				httpOnly: true,
 				sameSite: 'strict' as const,
 				expires: new Date('2024-9-17'),
+				maxAge: 3600,
 			};
 			mockCreateTokenCookiesSetOptions.mockReturnValueOnce(
 				mockCreateTokenCookiesSetOptionsResult,
@@ -231,7 +232,7 @@ describe('handleSignInCallbackRequest', () => {
 			const mockCreateAuthFlowProofCookiesRemoveOptionsResult = {
 				domain: 'example.com',
 				path: '/',
-				expires: new Date('1970-1-1'),
+				maxAge: -1,
 			};
 			mockCreateAuthFlowProofCookiesRemoveOptions.mockReturnValueOnce(
 				mockCreateAuthFlowProofCookiesRemoveOptionsResult,

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInCallbackRequestForPagesRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInCallbackRequestForPagesRouter.test.ts
@@ -249,6 +249,7 @@ describe('handleSignInCallbackRequest', () => {
 				httpOnly: true,
 				sameSite: 'strict' as const,
 				expires: new Date('2024-9-17'),
+				maxAge: 3600,
 			};
 			mockCreateTokenCookiesSetOptions.mockReturnValueOnce(
 				mockCreateTokenCookiesSetOptionsResult,
@@ -262,7 +263,7 @@ describe('handleSignInCallbackRequest', () => {
 			const mockCreateAuthFlowProofCookiesRemoveOptionsResult = {
 				domain: 'example.com',
 				path: '/',
-				expires: new Date('1970-1-1'),
+				maxAge: -1,
 			};
 			mockCreateAuthFlowProofCookiesRemoveOptions.mockReturnValueOnce(
 				mockCreateAuthFlowProofCookiesRemoveOptionsResult,

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInSignUpRequest.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInSignUpRequest.test.ts
@@ -97,6 +97,7 @@ describe('handleSignInSignUpRequest', () => {
 				secure: true,
 				sameSite: 'lax' as const,
 				expires: new Date(),
+				maxAge: 3600,
 			};
 			mockCreateAuthFlowProofCookiesSetOptions.mockReturnValueOnce(
 				mockCreateAuthFlowProofCookiesSetOptionsResult,

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInSignUpRequestForPagesRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInSignUpRequestForPagesRouter.test.ts
@@ -116,6 +116,7 @@ describe('handleSignInSignUpRequest', () => {
 				secure: true,
 				sameSite: 'lax' as const,
 				expires: new Date(),
+				maxAge: 3600,
 			};
 			mockCreateAuthFlowProofCookiesSetOptions.mockReturnValueOnce(
 				mockCreateAuthFlowProofCookiesSetOptionsResult,

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutCallbackRequest.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutCallbackRequest.test.ts
@@ -225,7 +225,7 @@ describe('handleSignOutCallbackRequest', () => {
 			const mockCreateTokenCookiesRemoveOptionsResult = {
 				domain: mockSetCookieOptions.domain,
 				path: '/',
-				expires: new Date('1970-01-01'),
+				maxAge: -1,
 			};
 			mockCreateTokenCookiesRemoveOptions.mockReturnValueOnce(
 				mockCreateTokenCookiesRemoveOptionsResult,

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutCallbackRequestForPagesRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutCallbackRequestForPagesRouter.test.ts
@@ -257,7 +257,7 @@ describe('handleSignOutCallbackRequest', () => {
 			const mockCreateTokenCookiesRemoveOptionsResult = {
 				domain: mockSetCookieOptions.domain,
 				path: '/',
-				expires: new Date('1970-01-01'),
+				maxAge: -1,
 			};
 			mockCreateTokenCookiesRemoveOptions.mockReturnValueOnce(
 				mockCreateTokenCookiesRemoveOptionsResult,

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutRequest.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutRequest.test.ts
@@ -68,6 +68,7 @@ describe('handleSignOutRequest', () => {
 			secure: true,
 			sameSite: 'lax' as const,
 			expires: new Date('2024-09-18'),
+			maxAge: 3600,
 		};
 		mockCreateAuthFlowProofCookiesSetOptions.mockReturnValueOnce(
 			mockCreateAuthFlowProofCookiesSetOptionsResult,

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutRequestForPagesRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutRequestForPagesRouter.test.ts
@@ -85,6 +85,7 @@ describe('handleSignOutRequest', () => {
 			secure: true,
 			sameSite: 'lax' as const,
 			expires: new Date('2024-09-18'),
+			maxAge: 3600,
 		};
 		mockCreateAuthFlowProofCookiesSetOptions.mockReturnValueOnce(
 			mockCreateAuthFlowProofCookiesSetOptionsResult,

--- a/packages/adapter-nextjs/__tests__/auth/utils/authFlowProofCookies.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/utils/authFlowProofCookies.test.ts
@@ -1,7 +1,7 @@
 import { CookieStorage } from 'aws-amplify/adapter-core';
 
 import {
-	AUTH_FLOW_PROOF_COOKIE_EXPIRY,
+	AUTH_FLOW_PROOF_MAX_AGE,
 	IS_SIGNING_OUT_COOKIE_NAME,
 	PKCE_COOKIE_NAME,
 	STATE_COOKIE_NAME,
@@ -37,16 +37,6 @@ describe('createSignOutFlowProofCookies', () => {
 });
 
 describe('createAuthFlowProofCookiesSetOptions', () => {
-	let nowSpy: jest.SpyInstance;
-
-	beforeAll(() => {
-		nowSpy = jest.spyOn(Date, 'now').mockReturnValue(0);
-	});
-
-	afterAll(() => {
-		jest.restoreAllMocks();
-	});
-
 	it('returns expected cookie serialization options with specified parameters', () => {
 		const setCookieOptions: CookieStorage.SetCookieOptions = {
 			domain: '.example.com',
@@ -55,14 +45,13 @@ describe('createAuthFlowProofCookiesSetOptions', () => {
 
 		const options = createAuthFlowProofCookiesSetOptions(setCookieOptions);
 
-		expect(nowSpy).toHaveBeenCalled();
 		expect(options).toEqual({
 			domain: setCookieOptions?.domain,
 			path: '/',
 			httpOnly: true,
 			secure: true,
 			sameSite: 'lax' as const,
-			expires: new Date(0 + AUTH_FLOW_PROOF_COOKIE_EXPIRY),
+			maxAge: AUTH_FLOW_PROOF_MAX_AGE,
 		});
 	});
 
@@ -76,14 +65,13 @@ describe('createAuthFlowProofCookiesSetOptions', () => {
 			secure: false,
 		});
 
-		expect(nowSpy).toHaveBeenCalled();
 		expect(options).toEqual({
 			domain: setCookieOptions?.domain,
 			path: '/',
 			httpOnly: true,
 			secure: false,
 			sameSite: 'lax' as const,
-			expires: new Date(0 + AUTH_FLOW_PROOF_COOKIE_EXPIRY),
+			maxAge: AUTH_FLOW_PROOF_MAX_AGE,
 		});
 	});
 });
@@ -99,7 +87,7 @@ describe('createAuthFlowProofCookiesRemoveOptions', () => {
 		expect(options).toEqual({
 			domain: setCookieOptions?.domain,
 			path: '/',
-			expires: new Date('1970-01-01'),
+			maxAge: -1,
 		});
 	});
 });

--- a/packages/adapter-nextjs/__tests__/auth/utils/tokenCookies.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/utils/tokenCookies.test.ts
@@ -1,7 +1,7 @@
 import {
 	AUTH_KEY_PREFIX,
 	CookieStorage,
-	DEFAULT_COOKIE_EXPIRY,
+	DEFAULT_AUTH_TOKEN_COOKIES_MAX_AGE,
 } from 'aws-amplify/adapter-core';
 
 import { OAuthTokenResponsePayload } from '../../../src/auth/types';
@@ -113,7 +113,7 @@ describe('createTokenCookiesSetOptions', () => {
 			httpOnly: true,
 			secure: true,
 			sameSite: 'strict',
-			expires: new Date(0 + DEFAULT_COOKIE_EXPIRY),
+			maxAge: DEFAULT_AUTH_TOKEN_COOKIES_MAX_AGE,
 		});
 
 		dateNowSpy.mockRestore();
@@ -154,7 +154,7 @@ describe('createTokenCookiesRemoveOptions', () => {
 		expect(result).toEqual({
 			domain: mockSetCookieOptions?.domain,
 			path: '/',
-			expires: new Date('1970-01-01'),
+			maxAge: -1,
 		});
 	});
 });

--- a/packages/adapter-nextjs/__tests__/utils/createCookieStorageAdapterFromNextServerContext.test.ts
+++ b/packages/adapter-nextjs/__tests__/utils/createCookieStorageAdapterFromNextServerContext.test.ts
@@ -158,6 +158,7 @@ describe('createCookieStorageAdapterFromNextServerContext', () => {
 			httpOnly: true,
 			secure: true,
 			path: '/a-path',
+			maxAge: 3600,
 		};
 
 		it('gets cookie by calling `get` method of the underlying cookie store', () => {
@@ -185,7 +186,7 @@ describe('createCookieStorageAdapterFromNextServerContext', () => {
 					mockSerializeOptions.domain
 				};Expires=${mockSerializeOptions.expires.toUTCString()};HttpOnly;SameSite=${
 					mockSerializeOptions.sameSite
-				};Secure;Path=${mockSerializeOptions.path}`,
+				};Secure;Path=${mockSerializeOptions.path};Max-Age=${mockSerializeOptions.maxAge}`,
 			);
 		});
 
@@ -197,7 +198,7 @@ describe('createCookieStorageAdapterFromNextServerContext', () => {
 					mockSerializeOptions.domain
 				};Expires=${mockSerializeOptions.expires.toUTCString()};HttpOnly;SameSite=${
 					mockSerializeOptions.sameSite
-				};Secure;Path=${mockSerializeOptions.path}`,
+				};Secure;Path=${mockSerializeOptions.path};Max-Age=${mockSerializeOptions.maxAge}`,
 			);
 		});
 

--- a/packages/adapter-nextjs/src/auth/constant.ts
+++ b/packages/adapter-nextjs/src/auth/constant.ts
@@ -22,5 +22,6 @@ export const PKCE_COOKIE_NAME = 'com.amplify.server_auth.pkce';
 export const STATE_COOKIE_NAME = 'com.amplify.server_auth.state';
 export const IS_SIGNING_OUT_COOKIE_NAME =
 	'com.amplify.server_auth.isSigningOut';
-export const AUTH_FLOW_PROOF_COOKIE_EXPIRY = 10 * 60 * 1000; // 10 mins
+export const AUTH_FLOW_PROOF_MAX_AGE = 10 * 60; // 10 mins in seconds
+export const REMOVE_COOKIE_MAX_AGE = -1; // -1 to remove the cookie immediately (0 ==> session cookie)
 export const OAUTH_GRANT_TYPE = 'authorization_code';

--- a/packages/adapter-nextjs/src/auth/utils/authFlowProofCookies.ts
+++ b/packages/adapter-nextjs/src/auth/utils/authFlowProofCookies.ts
@@ -4,9 +4,10 @@
 import { CookieStorage } from 'aws-amplify/adapter-core';
 
 import {
-	AUTH_FLOW_PROOF_COOKIE_EXPIRY,
+	AUTH_FLOW_PROOF_MAX_AGE,
 	IS_SIGNING_OUT_COOKIE_NAME,
 	PKCE_COOKIE_NAME,
+	REMOVE_COOKIE_MAX_AGE,
 	STATE_COOKIE_NAME,
 } from '../constant';
 
@@ -43,7 +44,7 @@ export const createAuthFlowProofCookiesSetOptions = (
 	httpOnly: true,
 	secure: overrides?.secure ?? true,
 	sameSite: 'lax' as const,
-	expires: new Date(Date.now() + AUTH_FLOW_PROOF_COOKIE_EXPIRY),
+	maxAge: AUTH_FLOW_PROOF_MAX_AGE,
 });
 
 export const createAuthFlowProofCookiesRemoveOptions = (
@@ -51,5 +52,5 @@ export const createAuthFlowProofCookiesRemoveOptions = (
 ) => ({
 	domain: setCookieOptions?.domain,
 	path: '/',
-	expires: new Date('1970-01-01'),
+	maxAge: REMOVE_COOKIE_MAX_AGE,
 });

--- a/packages/adapter-nextjs/src/types/NextServer.ts
+++ b/packages/adapter-nextjs/src/types/NextServer.ts
@@ -81,7 +81,7 @@ export declare namespace NextServer {
 	export interface CreateServerRunnerRuntimeOptions {
 		cookies?: Pick<
 			CookieStorage.SetCookieOptions,
-			'domain' | 'expires' | 'sameSite'
+			'domain' | 'expires' | 'sameSite' | 'maxAge'
 		>;
 	}
 

--- a/packages/adapter-nextjs/src/utils/cookie/serializeCookie.ts
+++ b/packages/adapter-nextjs/src/utils/cookie/serializeCookie.ts
@@ -13,7 +13,7 @@ export const serializeCookie = (
 const serializeSetCookieOptions = (
 	options: CookieStorage.SetCookieOptions,
 ): string => {
-	const { expires, domain, httpOnly, sameSite, secure, path } = options;
+	const { expires, domain, httpOnly, sameSite, secure, path, maxAge } = options;
 	const serializedOptions: string[] = [];
 	if (domain) {
 		serializedOptions.push(`Domain=${domain}`);
@@ -32,6 +32,9 @@ const serializeSetCookieOptions = (
 	}
 	if (path) {
 		serializedOptions.push(`Path=${path}`);
+	}
+	if (maxAge) {
+		serializedOptions.push(`Max-Age=${maxAge}`);
 	}
 
 	return serializedOptions.join(';');

--- a/packages/aws-amplify/__tests__/adapterCore/storageFactories/createKeyValueStorageFromCookieStorageAdapter.test.ts
+++ b/packages/aws-amplify/__tests__/adapterCore/storageFactories/createKeyValueStorageFromCookieStorageAdapter.test.ts
@@ -3,6 +3,7 @@
 
 import {
 	CookieStorage,
+	DEFAULT_AUTH_TOKEN_COOKIES_MAX_AGE,
 	createKeyValueStorageFromCookieStorageAdapter,
 } from '../../../src/adapter-core';
 import { defaultSetCookieOptions } from '../../../src/adapter-core/storageFactories/createKeyValueStorageFromCookieStorageAdapter';
@@ -45,7 +46,7 @@ describe('keyValueStorage', () => {
 					testValue,
 					{
 						...defaultSetCookieOptions,
-						expires: expect.any(Date),
+						maxAge: DEFAULT_AUTH_TOKEN_COOKIES_MAX_AGE,
 					},
 				);
 			});
@@ -60,7 +61,7 @@ describe('keyValueStorage', () => {
 					testValue,
 					{
 						...defaultSetCookieOptions,
-						expires: expect.any(Date),
+						maxAge: DEFAULT_AUTH_TOKEN_COOKIES_MAX_AGE,
 					},
 				);
 			});
@@ -74,7 +75,7 @@ describe('keyValueStorage', () => {
 					testValue,
 					{
 						...defaultSetCookieOptions,
-						expires: expect.any(Date),
+						maxAge: DEFAULT_AUTH_TOKEN_COOKIES_MAX_AGE,
 					},
 				);
 			});
@@ -111,18 +112,18 @@ describe('keyValueStorage', () => {
 		});
 
 		describe('passing setCookieOptions parameter', () => {
-			const testSetCookieOptions: CookieStorage.SetCookieOptions = {
-				httpOnly: true,
-				sameSite: 'strict',
-				expires: new Date('2024-09-05'),
-			};
-			const keyValueStorage = createKeyValueStorageFromCookieStorageAdapter(
-				mockCookiesStorageAdapter,
-				undefined,
-				testSetCookieOptions,
-			);
-
 			it('sets item with specified setCookieOptions', async () => {
+				const testSetCookieOptions: CookieStorage.SetCookieOptions = {
+					httpOnly: true,
+					sameSite: 'strict',
+					maxAge: 3600,
+				};
+				const keyValueStorage = createKeyValueStorageFromCookieStorageAdapter(
+					mockCookiesStorageAdapter,
+					undefined,
+					testSetCookieOptions,
+				);
+
 				keyValueStorage.setItem('testKey', 'testValue');
 				expect(mockCookiesStorageAdapter.set).toHaveBeenCalledWith(
 					'testKey',
@@ -130,6 +131,29 @@ describe('keyValueStorage', () => {
 					{
 						...defaultSetCookieOptions,
 						...testSetCookieOptions,
+					},
+				);
+			});
+
+			it('sets default maxAge when expires and maxAges are not provided', async () => {
+				const testSetCookieOptions: CookieStorage.SetCookieOptions = {
+					httpOnly: true,
+					sameSite: 'strict',
+				};
+				const keyValueStorage = createKeyValueStorageFromCookieStorageAdapter(
+					mockCookiesStorageAdapter,
+					undefined,
+					testSetCookieOptions,
+				);
+
+				keyValueStorage.setItem('testKey', 'testValue');
+				expect(mockCookiesStorageAdapter.set).toHaveBeenCalledWith(
+					'testKey',
+					'testValue',
+					{
+						...defaultSetCookieOptions,
+						...testSetCookieOptions,
+						maxAge: DEFAULT_AUTH_TOKEN_COOKIES_MAX_AGE,
 					},
 				);
 			});

--- a/packages/aws-amplify/src/adapter-core/constants.ts
+++ b/packages/aws-amplify/src/adapter-core/constants.ts
@@ -1,4 +1,4 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export const DEFAULT_COOKIE_EXPIRY = 365 * 24 * 60 * 60 * 1000; // 1 year in milliseconds
+export const DEFAULT_AUTH_TOKEN_COOKIES_MAX_AGE = 365 * 24 * 60 * 60; // 1 year in seconds

--- a/packages/aws-amplify/src/adapter-core/index.ts
+++ b/packages/aws-amplify/src/adapter-core/index.ts
@@ -23,4 +23,4 @@ export {
 	createKeysForAuthStorage,
 	AUTH_KEY_PREFIX,
 } from '@aws-amplify/auth/cognito';
-export { DEFAULT_COOKIE_EXPIRY } from './constants';
+export { DEFAULT_AUTH_TOKEN_COOKIES_MAX_AGE } from './constants';

--- a/packages/aws-amplify/src/adapter-core/storageFactories/createKeyValueStorageFromCookieStorageAdapter.ts
+++ b/packages/aws-amplify/src/adapter-core/storageFactories/createKeyValueStorageFromCookieStorageAdapter.ts
@@ -7,7 +7,7 @@ import {
 	KeyValueStorageMethodValidator,
 } from '@aws-amplify/core/internals/adapter-core';
 
-import { DEFAULT_COOKIE_EXPIRY } from '../constants';
+import { DEFAULT_AUTH_TOKEN_COOKIES_MAX_AGE } from '../constants';
 
 export const defaultSetCookieOptions: CookieStorage.SetCookieOptions = {
 	// TODO: allow configure with a public interface
@@ -34,12 +34,17 @@ export const createKeyValueStorageFromCookieStorageAdapter = (
 			// SetCookie: key=value;expires=Date.now() + 365 days;path=/;secure=true
 			cookieStorageAdapter.delete(key);
 
-			// TODO(HuiSF): follow up the default CookieSerializeOptions values
-			cookieStorageAdapter.set(key, value, {
+			const mergedCookieOptions = {
 				...defaultSetCookieOptions,
-				expires: new Date(Date.now() + DEFAULT_COOKIE_EXPIRY),
 				...setCookieOptions,
-			});
+			};
+
+			// when expires and maxAge both are not specified, we set a default maxAge
+			if (!mergedCookieOptions.expires && !mergedCookieOptions.maxAge) {
+				mergedCookieOptions.maxAge = DEFAULT_AUTH_TOKEN_COOKIES_MAX_AGE;
+			}
+
+			cookieStorageAdapter.set(key, value, mergedCookieOptions);
 
 			return Promise.resolve();
 		},


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Use `maxAge` cookie attribute to set cookies from the server side to avoid clock drift issues.

Since the access token usage are carried onto the server-side, and tokens expiries check and refresh are all performed on the server side of a Next.js app, the client-side incorrect system time becomes irrelevant. 


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* unit tests
* manual tests with a Next.js sample app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
