### PR TITLE
fix(adapter-nextjs): wrong spot for checking app origin and auth config

### DIFF
--- a/packages/adapter-nextjs/__tests__/auth/createAuthRouteHandlersFactory.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/createAuthRouteHandlersFactory.test.ts
@@ -75,45 +75,49 @@ describe('createAuthRoutesHandlersFactory', () => {
 		mockIsValidOrigin.mockReturnValue(true);
 	});
 
-	it('throws an error if the `amplifyAppOrigin` param has value of `undefined`', () => {
-		expect(() =>
-			createAuthRouteHandlersFactory({
+	describe('the created createAuthRouteHandlers function', () => {
+		it('throws an error if the AMPLIFY_APP_ORIGIN environment variable is not defined', () => {
+			const throwingFunc = createAuthRouteHandlersFactory({
 				config: mockAmplifyConfig,
 				runtimeOptions: mockRuntimeOptions,
 				amplifyAppOrigin: undefined,
 				runWithAmplifyServerContext: mockRunWithAmplifyServerContext,
-			}),
-		).toThrow('Could not find the AMPLIFY_APP_ORIGIN environment variable.');
-	});
+			});
+			expect(() => throwingFunc()).toThrow(
+				'Could not find the AMPLIFY_APP_ORIGIN environment variable.',
+			);
+		});
 
-	it('throws an error if the AMPLIFY_APP_ORIGIN environment variable is invalid', () => {
-		mockIsValidOrigin.mockReturnValueOnce(false);
-		expect(() =>
-			createAuthRouteHandlersFactory({
+		it('throws an error if the AMPLIFY_APP_ORIGIN environment variable is invalid', () => {
+			mockIsValidOrigin.mockReturnValueOnce(false);
+			const throwingFunc = createAuthRouteHandlersFactory({
 				config: mockAmplifyConfig,
 				runtimeOptions: mockRuntimeOptions,
 				amplifyAppOrigin: 'domain-without-protocol.com',
 				runWithAmplifyServerContext: mockRunWithAmplifyServerContext,
-			}),
-		).toThrow(
-			'AMPLIFY_APP_ORIGIN environment variable contains an invalid origin string.',
-		);
-	});
-
-	it('calls config assertion functions to validate the Auth configuration', () => {
-		createAuthRouteHandlersFactory({
-			config: mockAmplifyConfig,
-			runtimeOptions: mockRuntimeOptions,
-			amplifyAppOrigin: AMPLIFY_APP_ORIGIN,
-			runWithAmplifyServerContext: mockRunWithAmplifyServerContext,
+			});
+			expect(() => throwingFunc()).toThrow(
+				'AMPLIFY_APP_ORIGIN environment variable contains an invalid origin string.',
+			);
 		});
 
-		expect(mockAssertTokenProviderConfig).toHaveBeenCalledWith(
-			mockAmplifyConfig.Auth?.Cognito,
-		);
-		expect(mockAssertOAuthConfig).toHaveBeenCalledWith(
-			mockAmplifyConfig.Auth!.Cognito,
-		);
+		it('calls config assertion functions to validate the Auth configuration', () => {
+			const func = createAuthRouteHandlersFactory({
+				config: mockAmplifyConfig,
+				runtimeOptions: mockRuntimeOptions,
+				amplifyAppOrigin: AMPLIFY_APP_ORIGIN,
+				runWithAmplifyServerContext: mockRunWithAmplifyServerContext,
+			});
+
+			func();
+
+			expect(mockAssertTokenProviderConfig).toHaveBeenCalledWith(
+				mockAmplifyConfig.Auth?.Cognito,
+			);
+			expect(mockAssertOAuthConfig).toHaveBeenCalledWith(
+				mockAmplifyConfig.Auth!.Cognito,
+			);
+		});
 	});
 
 	describe('the created route handler function', () => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Check app origin env var and required auth configuration only when the `createAuthRouteHandlers` function gets called to create the Auth API routes. 

The original spot for checking these was too early and breaks `createServerRunner` function call during build step.

With this change - if app origin env var is not provided, or Auth config is incorrect, the error can still be surfaced during the build step (when `createAuthRouteHandlers` is actually used).


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

- unit tets
- manual test with a sample app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
