### PR TITLE
fix(adapter-nextjs): not await params async API in Next.js 15

### DIFF
--- a/packages/adapter-nextjs/__tests__/auth/utils/predicates.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/utils/predicates.test.ts
@@ -13,8 +13,9 @@ import {
 describe('isAuthRoutesHandlersContext', () => {
 	test.each([
 		[{}, false],
-		[{ params: {} }, false],
+		[{ params: {} }, true],
 		[{ params: { slug: 'sign-in' } }, true],
+		[{ params: Promise.resolve({ slug: 'sign-in' }) }, true],
 	] as [object, boolean][])(
 		'when call with %o it returns %s',
 		(input, expectedResult) => {

--- a/packages/adapter-nextjs/src/auth/handleAuthApiRouteRequestForAppRouter.ts
+++ b/packages/adapter-nextjs/src/auth/handleAuthApiRouteRequestForAppRouter.ts
@@ -29,7 +29,7 @@ export const handleAuthApiRouteRequestForAppRouter: HandleAuthApiRouteRequestFor
 			return new Response(null, { status: 405 });
 		}
 
-		const { slug } = handlerContext.params;
+		const { slug } = await handlerContext.params;
 		// don't support [...slug] here
 		if (slug === undefined || Array.isArray(slug)) {
 			return new Response(null, { status: 400 });

--- a/packages/adapter-nextjs/src/auth/types.ts
+++ b/packages/adapter-nextjs/src/auth/types.ts
@@ -24,7 +24,8 @@ export interface AuthRouteHandlerParams {
 }
 
 export interface AuthRoutesHandlerContext {
-	params: AuthRouteHandlerParams;
+	// In Next.js 15 params is an async API, so it can be a promise.
+	params: AuthRouteHandlerParams | Promise<AuthRouteHandlerParams>;
 }
 
 /**

--- a/packages/adapter-nextjs/src/auth/utils/predicates.ts
+++ b/packages/adapter-nextjs/src/auth/utils/predicates.ts
@@ -4,7 +4,7 @@
 import { NextRequest } from 'next/server';
 import { NextApiRequest, NextApiResponse } from 'next';
 
-import { AuthRouteHandlerParams, AuthRoutesHandlerContext } from '../types';
+import { AuthRoutesHandlerContext } from '../types';
 
 // NextRequest is the 1st parameter type for the API route handlers in the App Router
 export function isNextRequest(request: object): request is NextRequest {
@@ -20,15 +20,8 @@ export function isAuthRoutesHandlersContext(
 	return (
 		'params' in context &&
 		context.params !== undefined &&
-		context.params !== null &&
-		isAuthRouteHandlerParams(context.params)
+		context.params !== null
 	);
-}
-
-function isAuthRouteHandlerParams(
-	params: object,
-): params is AuthRouteHandlerParams {
-	return 'slug' in params && typeof params.slug === 'string';
 }
 
 // NextApiRequest is the 1st parameter type for the API route handlers in the Pages Router


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Removed the actual callsite of the Next.js `params` API that turned into async since Next.js 15. The callsite was a type assertion, which was actually unnecessary as we expected the `slug` is a property of the `params`.

Also updated the necessary callsite of `params` with `await`.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

- unit tests
- manual test with a Next.js v15/v14 sample app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
