### PR TITLE
fix: move package exports for react native

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -43,33 +43,33 @@
 	"exports": {
 		".": {
 			"types": "./dist/esm/index.d.ts",
+			"react-native": "./src/index.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./pinpoint": {
 			"types": "./dist/esm/providers/pinpoint/index.d.ts",
+			"react-native": "./src/providers/pinpoint/index.ts",
 			"import": "./dist/esm/providers/pinpoint/index.mjs",
-			"require": "./dist/cjs/providers/pinpoint/index.js",
-			"react-native": "./src/providers/pinpoint/index.ts"
+			"require": "./dist/cjs/providers/pinpoint/index.js"
 		},
 		"./kinesis": {
 			"types": "./dist/esm/providers/kinesis/index.d.ts",
+			"react-native": "./src/providers/kinesis/index.ts",
 			"import": "./dist/esm/providers/kinesis/index.mjs",
-			"require": "./dist/cjs/providers/kinesis/index.js",
-			"react-native": "./src/providers/kinesis/index.ts"
+			"require": "./dist/cjs/providers/kinesis/index.js"
 		},
 		"./kinesis-firehose": {
 			"types": "./dist/esm/providers/kinesis-firehose/index.d.ts",
+			"react-native": "./src/providers/kinesis-firehose/index.ts",
 			"import": "./dist/esm/providers/kinesis-firehose/index.mjs",
-			"require": "./dist/cjs/providers/kinesis-firehose/index.js",
-			"react-native": "./src/providers/kinesis-firehose/index.ts"
+			"require": "./dist/cjs/providers/kinesis-firehose/index.js"
 		},
 		"./personalize": {
 			"types": "./dist/esm/providers/personalize/index.d.ts",
+			"react-native": "./src/providers/personalize/index.ts",
 			"import": "./dist/esm/providers/personalize/index.mjs",
-			"require": "./dist/cjs/providers/personalize/index.js",
-			"react-native": "./src/providers/personalize/index.ts"
+			"require": "./dist/cjs/providers/personalize/index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -31,21 +31,21 @@
 	"exports": {
 		".": {
 			"types": "./dist/esm/index.d.ts",
+			"react-native": "./src/index.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./internals": {
 			"types": "./dist/esm/internals/index.d.ts",
+			"react-native": "./src/internals/index.ts",
 			"import": "./dist/esm/internals/index.mjs",
-			"require": "./dist/cjs/internals/index.js",
-			"react-native": "./src/internals/index.ts"
+			"require": "./dist/cjs/internals/index.js"
 		},
 		"./internals/server": {
 			"types": "./dist/esm/internals/server/index.d.ts",
+			"react-native": "./src/internals/server/index.ts",
 			"import": "./dist/esm/internals/server/index.mjs",
-			"require": "./dist/cjs/internals/server/index.js",
-			"react-native": "./src/internals/server/index.ts"
+			"require": "./dist/cjs/internals/server/index.js"
 		},
 		"./server": {
 			"types": "./dist/esm/server/index.d.ts",

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -28,9 +28,9 @@
 	"exports": {
 		".": {
 			"types": "./dist/esm/index.d.ts",
+			"react-native": "./src/index.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./server": {
 			"types": "./dist/esm/server.d.ts",
@@ -39,9 +39,9 @@
 		},
 		"./internals": {
 			"types": "./dist/esm/internals/index.d.ts",
+			"react-native": "./src/internals/index.ts",
 			"import": "./dist/esm/internals/index.mjs",
-			"require": "./dist/cjs/internals/index.js",
-			"react-native": "./src/internals/index.ts"
+			"require": "./dist/cjs/internals/index.js"
 		},
 		"./internals/server": {
 			"types": "./dist/esm/internals/server.d.ts",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -30,15 +30,15 @@
 	"exports": {
 		".": {
 			"types": "./dist/esm/index.d.ts",
+			"react-native": "./src/index.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./internals": {
 			"types": "./dist/esm/internals/index.d.ts",
+			"react-native": "./src/internals/index.ts",
 			"import": "./dist/esm/internals/index.mjs",
-			"require": "./dist/cjs/internals/index.js",
-			"react-native": "./src/internals/index.ts"
+			"require": "./dist/cjs/internals/index.js"
 		},
 		"./server": {
 			"types": "./dist/esm/server.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -45,15 +45,15 @@
 	"exports": {
 		".": {
 			"types": "./dist/esm/index.d.ts",
+			"react-native": "./src/index.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./cognito": {
 			"types": "./dist/esm/providers/cognito/index.d.ts",
+			"react-native": "./src/providers/cognito/index.ts",
 			"import": "./dist/esm/providers/cognito/index.mjs",
-			"require": "./dist/cjs/providers/cognito/index.js",
-			"react-native": "./src/providers/cognito/index.ts"
+			"require": "./dist/cjs/providers/cognito/index.js"
 		},
 		"./cognito/server": {
 			"types": "./dist/esm/providers/cognito/apis/server/index.d.ts",

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -9,27 +9,27 @@
 	"exports": {
 		".": {
 			"types": "./dist/esm/index.d.ts",
+			"react-native": "./src/index.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./utils": {
 			"types": "./dist/esm/utils/index.d.ts",
+			"react-native": "./src/utils/index.ts",
 			"import": "./dist/esm/utils/index.mjs",
-			"require": "./dist/cjs/utils/index.js",
-			"react-native": "./src/utils/index.ts"
+			"require": "./dist/cjs/utils/index.js"
 		},
 		"./auth": {
 			"types": "./dist/esm/auth/index.d.ts",
+			"react-native": "./src/auth/index.ts",
 			"import": "./dist/esm/auth/index.mjs",
-			"require": "./dist/cjs/auth/index.js",
-			"react-native": "./src/auth/index.ts"
+			"require": "./dist/cjs/auth/index.js"
 		},
 		"./api": {
 			"types": "./dist/esm/api/index.d.ts",
+			"react-native": "./src/api/index.ts",
 			"import": "./dist/esm/api/index.mjs",
-			"require": "./dist/cjs/api/index.js",
-			"react-native": "./src/api/index.ts"
+			"require": "./dist/cjs/api/index.js"
 		},
 		"./api/server": {
 			"types": "./dist/esm/api/server.d.ts",
@@ -38,9 +38,9 @@
 		},
 		"./data": {
 			"types": "./dist/esm/api/index.d.ts",
+			"react-native": "./src/api/index.ts",
 			"import": "./dist/esm/api/index.mjs",
-			"require": "./dist/cjs/api/index.js",
-			"react-native": "./src/api/index.ts"
+			"require": "./dist/cjs/api/index.js"
 		},
 		"./data/server": {
 			"types": "./dist/esm/api/server.d.ts",
@@ -49,15 +49,15 @@
 		},
 		"./datastore": {
 			"types": "./dist/esm/datastore/index.d.ts",
+			"react-native": "./src/datastore/index.ts",
 			"import": "./dist/esm/datastore/index.mjs",
-			"require": "./dist/cjs/datastore/index.js",
-			"react-native": "./src/datastore/index.ts"
+			"require": "./dist/cjs/datastore/index.js"
 		},
 		"./auth/cognito": {
 			"types": "./dist/esm/auth/cognito/index.d.ts",
+			"react-native": "./src/auth/cognito/index.ts",
 			"import": "./dist/esm/auth/cognito/index.mjs",
-			"require": "./dist/cjs/auth/cognito/index.js",
-			"react-native": "./src/auth/cognito/index.ts"
+			"require": "./dist/cjs/auth/cognito/index.js"
 		},
 		"./auth/cognito/server": {
 			"types": "./dist/esm/auth/cognito/server/index.d.ts",
@@ -76,45 +76,45 @@
 		},
 		"./analytics": {
 			"types": "./dist/esm/analytics/index.d.ts",
+			"react-native": "./src/analytics/index.ts",
 			"import": "./dist/esm/analytics/index.mjs",
-			"require": "./dist/cjs/analytics/index.js",
-			"react-native": "./src/analytics/index.ts"
+			"require": "./dist/cjs/analytics/index.js"
 		},
 		"./analytics/pinpoint": {
 			"types": "./dist/esm/analytics/pinpoint/index.d.ts",
+			"react-native": "./src/analytics/pinpoint/index.ts",
 			"import": "./dist/esm/analytics/pinpoint/index.mjs",
-			"require": "./dist/cjs/analytics/pinpoint/index.js",
-			"react-native": "./src/analytics/pinpoint/index.ts"
+			"require": "./dist/cjs/analytics/pinpoint/index.js"
 		},
 		"./analytics/kinesis": {
 			"types": "./dist/esm/analytics/kinesis/index.d.ts",
+			"react-native": "./src/analytics/kinesis/index.ts",
 			"import": "./dist/esm/analytics/kinesis/index.mjs",
-			"require": "./dist/cjs/analytics/kinesis/index.js",
-			"react-native": "./src/analytics/kinesis/index.ts"
+			"require": "./dist/cjs/analytics/kinesis/index.js"
 		},
 		"./analytics/kinesis-firehose": {
 			"types": "./dist/esm/analytics/kinesis-firehose/index.d.ts",
+			"react-native": "./src/analytics/kinesis-firehose/index.ts",
 			"import": "./dist/esm/analytics/kinesis-firehose/index.mjs",
-			"require": "./dist/cjs/analytics/kinesis-firehose/index.js",
-			"react-native": "./src/analytics/kinesis-firehose/index.ts"
+			"require": "./dist/cjs/analytics/kinesis-firehose/index.js"
 		},
 		"./analytics/personalize": {
 			"types": "./dist/esm/analytics/personalize/index.d.ts",
+			"react-native": "./src/analytics/personalize/index.ts",
 			"import": "./dist/esm/analytics/personalize/index.mjs",
-			"require": "./dist/cjs/analytics/personalize/index.js",
-			"react-native": "./src/analytics/personalize/index.ts"
+			"require": "./dist/cjs/analytics/personalize/index.js"
 		},
 		"./storage": {
 			"types": "./dist/esm/storage/index.d.ts",
+			"react-native": "./src/storage/index.ts",
 			"import": "./dist/esm/storage/index.mjs",
-			"require": "./dist/cjs/storage/index.js",
-			"react-native": "./src/storage/index.ts"
+			"require": "./dist/cjs/storage/index.js"
 		},
 		"./storage/s3": {
 			"types": "./dist/esm/storage/s3/index.d.ts",
+			"react-native": "./src/storage/s3/index.ts",
 			"import": "./dist/esm/storage/s3/index.mjs",
-			"require": "./dist/cjs/storage/s3/index.js",
-			"react-native": "./src/storage/s3/index.ts"
+			"require": "./dist/cjs/storage/s3/index.js"
 		},
 		"./storage/server": {
 			"types": "./dist/esm/storage/server.d.ts",
@@ -128,27 +128,27 @@
 		},
 		"./in-app-messaging": {
 			"types": "./dist/esm/in-app-messaging/index.d.ts",
+			"react-native": "./src/in-app-messaging/index.ts",
 			"import": "./dist/esm/in-app-messaging/index.mjs",
-			"require": "./dist/cjs/in-app-messaging/index.js",
-			"react-native": "./src/in-app-messaging/index.ts"
+			"require": "./dist/cjs/in-app-messaging/index.js"
 		},
 		"./push-notifications": {
 			"types": "./dist/esm/push-notifications/index.d.ts",
+			"react-native": "./src/push-notifications/index.ts",
 			"import": "./dist/esm/push-notifications/index.mjs",
-			"require": "./dist/cjs/push-notifications/index.js",
-			"react-native": "./src/push-notifications/index.ts"
+			"require": "./dist/cjs/push-notifications/index.js"
 		},
 		"./in-app-messaging/pinpoint": {
 			"types": "./dist/esm/in-app-messaging/pinpoint/index.d.ts",
+			"react-native": "./src/in-app-messaging/pinpoint/index.ts",
 			"import": "./dist/esm/in-app-messaging/pinpoint/index.mjs",
-			"require": "./dist/cjs/in-app-messaging/pinpoint/index.js",
-			"react-native": "./src/in-app-messaging/pinpoint/index.ts"
+			"require": "./dist/cjs/in-app-messaging/pinpoint/index.js"
 		},
 		"./push-notifications/pinpoint": {
 			"types": "./dist/esm/push-notifications/pinpoint/index.d.ts",
+			"react-native": "./src/push-notifications/pinpoint/index.ts",
 			"import": "./dist/esm/push-notifications/pinpoint/index.mjs",
-			"require": "./dist/cjs/push-notifications/pinpoint/index.js",
-			"react-native": "./src/push-notifications/pinpoint/index.ts"
+			"require": "./dist/cjs/push-notifications/pinpoint/index.js"
 		},
 		"./adapter-core": {
 			"types": "./dist/esm/adapter-core/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -112,9 +112,9 @@
 	"exports": {
 		".": {
 			"types": "./dist/esm/index.d.ts",
+			"react-native": "./src/index.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./server": {
 			"types": "./dist/esm/server.d.ts",
@@ -128,39 +128,39 @@
 		},
 		"./internals/aws-client-utils": {
 			"types": "./dist/esm/clients/index.d.ts",
+			"react-native": "./src/clients/index.ts",
 			"import": "./dist/esm/clients/index.mjs",
-			"require": "./dist/cjs/clients/index.js",
-			"react-native": "./src/clients/index.ts"
+			"require": "./dist/cjs/clients/index.js"
 		},
 		"./internals/aws-client-utils/composers": {
 			"types": "./dist/esm/clients/internal/index.d.ts",
+			"react-native": "./src/clients/internal/index.ts",
 			"import": "./dist/esm/clients/internal/index.mjs",
-			"require": "./dist/cjs/clients/internal/index.js",
-			"react-native": "./src/clients/internal/index.ts"
+			"require": "./dist/cjs/clients/internal/index.js"
 		},
 		"./internals/aws-clients/cognitoIdentity": {
 			"types": "./dist/esm/awsClients/cognitoIdentity/index.d.ts",
+			"react-native": "./src/awsClients/cognitoIdentity/index.ts",
 			"import": "./dist/esm/awsClients/cognitoIdentity/index.mjs",
-			"require": "./dist/cjs/awsClients/cognitoIdentity/index.js",
-			"react-native": "./src/awsClients/cognitoIdentity/index.ts"
+			"require": "./dist/cjs/awsClients/cognitoIdentity/index.js"
 		},
 		"./internals/aws-clients/pinpoint": {
 			"types": "./dist/esm/awsClients/pinpoint/index.d.ts",
+			"react-native": "./src/awsClients/pinpoint/index.ts",
 			"import": "./dist/esm/awsClients/pinpoint/index.mjs",
-			"require": "./dist/cjs/awsClients/pinpoint/index.js",
-			"react-native": "./src/awsClients/pinpoint/index.ts"
+			"require": "./dist/cjs/awsClients/pinpoint/index.js"
 		},
 		"./internals/providers/pinpoint": {
 			"types": "./dist/esm/providers/pinpoint/index.d.ts",
+			"react-native": "./src/providers/pinpoint/index.ts",
 			"import": "./dist/esm/providers/pinpoint/index.mjs",
-			"require": "./dist/cjs/providers/pinpoint/index.js",
-			"react-native": "./src/providers/pinpoint/index.ts"
+			"require": "./dist/cjs/providers/pinpoint/index.js"
 		},
 		"./internals/utils": {
 			"types": "./dist/esm/libraryUtils.d.ts",
+			"react-native": "./src/libraryUtils.ts",
 			"import": "./dist/esm/libraryUtils.mjs",
-			"require": "./dist/cjs/libraryUtils.js",
-			"react-native": "./src/libraryUtils.ts"
+			"require": "./dist/cjs/libraryUtils.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -31,15 +31,15 @@
 	"exports": {
 		".": {
 			"types": "./dist/esm/index.d.ts",
+			"react-native": "./src/index.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./location-service": {
 			"types": "./dist/esm/providers/location-service/AmazonLocationServiceProvider.d.ts",
+			"react-native": "./src/providers/location-service/AmazonLocationServiceProvider.ts",
 			"import": "./dist/esm/providers/location-service/AmazonLocationServiceProvider.mjs",
-			"require": "./dist/cjs/providers/location-service/AmazonLocationServiceProvider.js",
-			"react-native": "./src/providers/location-service/AmazonLocationServiceProvider.ts"
+			"require": "./dist/cjs/providers/location-service/AmazonLocationServiceProvider.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -43,15 +43,15 @@
 		},
 		"./lex-v1": {
 			"types": "./dist/esm/lex-v1/index.d.ts",
+			"react-native": "./src/lex-v1/index.ts",
 			"import": "./dist/esm/lex-v1/index.mjs",
-			"require": "./dist/cjs/lex-v1/index.js",
-			"react-native": "./src/lex-v1/index.ts"
+			"require": "./dist/cjs/lex-v1/index.js"
 		},
 		"./lex-v2": {
 			"types": "./dist/esm/lex-v2/index.d.ts",
+			"react-native": "./src/lex-v2/index.ts",
 			"import": "./dist/esm/lex-v2/index.mjs",
-			"require": "./dist/cjs/lex-v2/index.js",
-			"react-native": "./src/lex-v2/index.ts"
+			"require": "./dist/cjs/lex-v2/index.js"
 		}
 	},
 	"repository": {

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -43,33 +43,33 @@
 	},
 	"exports": {
 		".": {
+			"react-native": "./src/index.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./in-app-messaging": {
 			"types": "./dist/esm/inAppMessaging/index.d.ts",
+			"react-native": "./src/inAppMessaging/index.ts",
 			"import": "./dist/esm/inAppMessaging/index.mjs",
-			"require": "./dist/cjs/inAppMessaging/index.js",
-			"react-native": "./src/inAppMessaging/index.ts"
+			"require": "./dist/cjs/inAppMessaging/index.js"
 		},
 		"./push-notifications": {
 			"types": "./dist/esm/pushNotifications/index.d.ts",
+			"react-native": "./src/pushNotifications/index.ts",
 			"import": "./dist/esm/pushNotifications/index.mjs",
-			"require": "./dist/cjs/pushNotifications/index.js",
-			"react-native": "./src/pushNotifications/index.ts"
+			"require": "./dist/cjs/pushNotifications/index.js"
 		},
 		"./in-app-messaging/pinpoint": {
 			"types": "./dist/esm/inAppMessaging/providers/pinpoint/index.d.ts",
+			"react-native": "./src/inAppMessaging/providers/pinpoint/index.ts",
 			"import": "./dist/esm/inAppMessaging/providers/pinpoint/index.mjs",
-			"require": "./dist/cjs/inAppMessaging/providers/pinpoint/index.js",
-			"react-native": "./src/inAppMessaging/providers/pinpoint/index.ts"
+			"require": "./dist/cjs/inAppMessaging/providers/pinpoint/index.js"
 		},
 		"./push-notifications/pinpoint": {
 			"types": "./dist/esm/pushNotifications/providers/pinpoint/index.d.ts",
+			"react-native": "./src/pushNotifications/providers/pinpoint/index.ts",
 			"import": "./dist/esm/pushNotifications/providers/pinpoint/index.mjs",
-			"require": "./dist/cjs/pushNotifications/providers/pinpoint/index.js",
-			"react-native": "./src/pushNotifications/providers/pinpoint/index.ts"
+			"require": "./dist/cjs/pushNotifications/providers/pinpoint/index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -38,21 +38,21 @@
 	"exports": {
 		".": {
 			"types": "./dist/esm/index.d.ts",
+			"react-native": "./src/index.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./iot": {
 			"types": "./dist/esm/clients/iot.d.ts",
+			"react-native": "./src/clients/iot.ts",
 			"import": "./dist/esm/clients/iot.mjs",
-			"require": "./dist/cjs/clients/iot.js",
-			"react-native": "./src/clients/iot.ts"
+			"require": "./dist/cjs/clients/iot.js"
 		},
 		"./mqtt": {
 			"types": "./dist/esm/clients/mqtt.d.ts",
+			"react-native": "./src/clients/mqtt.ts",
 			"import": "./dist/esm/clients/mqtt.mjs",
-			"require": "./dist/cjs/clients/mqtt.js",
-			"react-native": "./src/clients/mqtt.ts"
+			"require": "./dist/cjs/clients/mqtt.js"
 		}
 	},
 	"repository": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -80,9 +80,9 @@
 	"exports": {
 		".": {
 			"types": "./dist/esm/index.d.ts",
+			"react-native": "./src/index.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./internals": {
 			"types": "./dist/esm/internals/index.d.ts",
@@ -96,9 +96,9 @@
 		},
 		"./s3": {
 			"types": "./dist/esm/providers/s3/index.d.ts",
+			"react-native": "./src/providers/s3/index.ts",
 			"import": "./dist/esm/providers/s3/index.mjs",
-			"require": "./dist/cjs/providers/s3/index.js",
-			"react-native": "./src/providers/s3/index.ts"
+			"require": "./dist/cjs/providers/s3/index.js"
 		},
 		"./s3/server": {
 			"types": "./dist/esm/providers/s3/server.d.ts",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Currently the `react-native` package exports are incorrectly order. The `react-native` package export should come before the `require` and `import` exports, since the condition names are resolved in order and [default](https://metrobundler.dev/docs/configuration/#unstable_conditionnames-experimental) to `['require', 'react-native']`.

#### Description of how you validated changes

I've only validated the changes by adjusting the exports using yarn patch in our repo.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included

#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
