### PR TITLE
feat(auth): WebAuthN support for React-Native Android

### DIFF
--- a/packages/auth/src/client/utils/passkey/errors/index.native.ts
+++ b/packages/auth/src/client/utils/passkey/errors/index.native.ts
@@ -1,0 +1,2 @@
+export * from './shared';
+export * from './native'; // Export native-specific error handlers

--- a/packages/auth/src/client/utils/passkey/errors/index.ts
+++ b/packages/auth/src/client/utils/passkey/errors/index.ts
@@ -1,0 +1,2 @@
+export * from './shared';
+export * from './web'; // Export web-specific error handlers

--- a/packages/auth/src/client/utils/passkey/errors/native.ts
+++ b/packages/auth/src/client/utils/passkey/errors/native.ts
@@ -1,0 +1,111 @@
+import { AmplifyErrorCode } from '@aws-amplify/core/internals/utils';
+
+import { PasskeyError, PasskeyErrorCode, passkeyErrorMap } from './shared';
+
+/**
+ * Handle Passkey Authentication Errors for Native Platforms
+ * Maps native error codes to PasskeyError types
+ *
+ * @param err unknown
+ * @returns PasskeyError
+ */
+export const handlePasskeyAuthenticationError = (
+	err: unknown,
+): PasskeyError => {
+	if (err instanceof PasskeyError) {
+		return err;
+	}
+
+	if (err instanceof Error && 'code' in err) {
+		switch (err.code) {
+			case 'UserCancelled':
+				return new PasskeyError({
+					name: PasskeyErrorCode.PasskeyAuthenticationCanceled,
+					...passkeyErrorMap[PasskeyErrorCode.PasskeyAuthenticationCanceled],
+					underlyingError: err,
+				});
+			case 'NotSupported':
+				return new PasskeyError({
+					name: PasskeyErrorCode.PasskeyNotSupported,
+					...passkeyErrorMap[PasskeyErrorCode.PasskeyNotSupported],
+					underlyingError: err,
+				});
+			case 'NotConfigured':
+				return new PasskeyError({
+					name: PasskeyErrorCode.InvalidPasskeyAuthenticationOptions,
+					...passkeyErrorMap[
+						PasskeyErrorCode.InvalidPasskeyAuthenticationOptions
+					],
+					underlyingError: err,
+				});
+			case 'NoCredentials':
+				return new PasskeyError({
+					name: PasskeyErrorCode.PasskeyRetrievalFailed,
+					...passkeyErrorMap[PasskeyErrorCode.PasskeyRetrievalFailed],
+					underlyingError: err,
+				});
+			case 'Interrupted':
+				return new PasskeyError({
+					name: PasskeyErrorCode.PasskeyOperationAborted,
+					...passkeyErrorMap[PasskeyErrorCode.PasskeyOperationAborted],
+					underlyingError: err,
+				});
+		}
+	}
+
+	return new PasskeyError({
+		name: AmplifyErrorCode.Unknown,
+		message: 'An unknown error occurred during passkey authentication.',
+		underlyingError: err,
+	});
+};
+
+/**
+ * Handle Passkey Registration Errors for Native Platforms
+ * Maps native error codes to PasskeyError types
+ *
+ * @param err unknown
+ * @returns PasskeyError
+ */
+export const handlePasskeyRegistrationError = (err: unknown): PasskeyError => {
+	if (err instanceof PasskeyError) {
+		return err;
+	}
+
+	if (err instanceof Error && 'code' in err) {
+		switch (err.code) {
+			case 'UserCancelled':
+				return new PasskeyError({
+					name: PasskeyErrorCode.PasskeyRegistrationCanceled,
+					...passkeyErrorMap[PasskeyErrorCode.PasskeyRegistrationCanceled],
+					underlyingError: err,
+				});
+			case 'NotSupported':
+				return new PasskeyError({
+					name: PasskeyErrorCode.PasskeyNotSupported,
+					...passkeyErrorMap[PasskeyErrorCode.PasskeyNotSupported],
+					underlyingError: err,
+				});
+			case 'NotConfigured':
+				return new PasskeyError({
+					name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
+					...passkeyErrorMap[
+						PasskeyErrorCode.InvalidPasskeyRegistrationOptions
+					],
+					underlyingError: err,
+				});
+			case 'Interrupted':
+				return new PasskeyError({
+					name: PasskeyErrorCode.PasskeyOperationAborted,
+					...passkeyErrorMap[PasskeyErrorCode.PasskeyOperationAborted],
+					underlyingError: err,
+				});
+		}
+	}
+
+	return new PasskeyError({
+		name: AmplifyErrorCode.Unknown,
+		message: 'An unknown error occurred during passkey registration.',
+		underlyingError: err,
+	});
+};

--- a/packages/auth/src/client/utils/passkey/errors/shared.ts
+++ b/packages/auth/src/client/utils/passkey/errors/shared.ts
@@ -1,9 +1,5 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
 import {
 	AmplifyError,
-	AmplifyErrorCode,
 	AmplifyErrorMap,
 	AmplifyErrorParams,
 	AssertionFunction,
@@ -13,9 +9,6 @@ import {
 export class PasskeyError extends AmplifyError {
 	constructor(params: AmplifyErrorParams) {
 		super(params);
-
-		// Hack for making the custom error class work when transpiled to es5
-		// TODO: Delete the following 2 lines after we change the build target to >= es2015
 		this.constructor = PasskeyError;
 		Object.setPrototypeOf(this, PasskeyError.prototype);
 	}
@@ -46,7 +39,7 @@ const abortOrCancelRecoverySuggestion =
 const misconfigurationRecoverySuggestion =
 	'Ensure your user pool is configured to support the WEB_AUTHN as an authentication factor.';
 
-const passkeyErrorMap: AmplifyErrorMap<PasskeyErrorCode> = {
+export const passkeyErrorMap: AmplifyErrorMap<PasskeyErrorCode> = {
 	[PasskeyErrorCode.PasskeyNotSupported]: {
 		message: 'Passkeys may not be supported on this device.',
 		recoverySuggestion: notSupportedRecoverySuggestion,
@@ -94,121 +87,3 @@ const passkeyErrorMap: AmplifyErrorMap<PasskeyErrorCode> = {
 
 export const assertPasskeyError: AssertionFunction<PasskeyErrorCode> =
 	createAssertionFunction(passkeyErrorMap, PasskeyError);
-
-/**
- * Handle Passkey Authentication Errors
- * https://w3c.github.io/webauthn/#sctn-get-request-exceptions
- *
- * @param err unknown
- * @returns PasskeyError
- */
-
-export const handlePasskeyAuthenticationError = (
-	err: unknown,
-): PasskeyError => {
-	if (err instanceof PasskeyError) {
-		return err;
-	}
-
-	if (err instanceof Error) {
-		if (err.name === 'NotAllowedError') {
-			const { message, recoverySuggestion } =
-				passkeyErrorMap[PasskeyErrorCode.PasskeyAuthenticationCanceled];
-
-			return new PasskeyError({
-				name: PasskeyErrorCode.PasskeyAuthenticationCanceled,
-				message,
-				recoverySuggestion,
-				underlyingError: err,
-			});
-		}
-	}
-
-	return handlePasskeyError(err);
-};
-
-/**
- * Handle Passkey Registration Errors
- * https://w3c.github.io/webauthn/#sctn-create-request-exceptions
- *
- * @param err unknown
- * @returns PasskeyError
- */
-export const handlePasskeyRegistrationError = (err: unknown): PasskeyError => {
-	if (err instanceof PasskeyError) {
-		return err;
-	}
-
-	if (err instanceof Error) {
-		// Duplicate Passkey
-		if (err.name === 'InvalidStateError') {
-			const { message, recoverySuggestion } =
-				passkeyErrorMap[PasskeyErrorCode.PasskeyAlreadyExists];
-
-			return new PasskeyError({
-				name: PasskeyErrorCode.PasskeyAlreadyExists,
-				message,
-				recoverySuggestion,
-				underlyingError: err,
-			});
-		}
-
-		// User Cancels Ceremony / Generic Catch All
-		if (err.name === 'NotAllowedError') {
-			const { message, recoverySuggestion } =
-				passkeyErrorMap[PasskeyErrorCode.PasskeyRegistrationCanceled];
-
-			return new PasskeyError({
-				name: PasskeyErrorCode.PasskeyRegistrationCanceled,
-				message,
-				recoverySuggestion,
-				underlyingError: err,
-			});
-		}
-	}
-
-	return handlePasskeyError(err);
-};
-
-/**
- * Handles Overlapping Passkey Errors Between Registration & Authentication
- * https://w3c.github.io/webauthn/#sctn-create-request-exceptions
- * https://w3c.github.io/webauthn/#sctn-get-request-exceptions
- *
- * @param err unknown
- * @returns PasskeyError
- */
-const handlePasskeyError = (err: unknown): PasskeyError => {
-	if (err instanceof Error) {
-		// Passkey Operation Aborted
-		if (err.name === 'AbortError') {
-			const { message, recoverySuggestion } =
-				passkeyErrorMap[PasskeyErrorCode.PasskeyOperationAborted];
-
-			return new PasskeyError({
-				name: PasskeyErrorCode.PasskeyOperationAborted,
-				message,
-				recoverySuggestion,
-				underlyingError: err,
-			});
-		}
-		// Relying Party / Domain Mismatch
-		if (err.name === 'SecurityError') {
-			const { message, recoverySuggestion } =
-				passkeyErrorMap[PasskeyErrorCode.RelyingPartyMismatch];
-
-			return new PasskeyError({
-				name: PasskeyErrorCode.RelyingPartyMismatch,
-				message,
-				recoverySuggestion,
-				underlyingError: err,
-			});
-		}
-	}
-
-	return new PasskeyError({
-		name: AmplifyErrorCode.Unknown,
-		message: 'An unknown error has occurred.',
-		underlyingError: err,
-	});
-};

--- a/packages/auth/src/client/utils/passkey/errors/web.ts
+++ b/packages/auth/src/client/utils/passkey/errors/web.ts
@@ -1,0 +1,75 @@
+import { AmplifyErrorCode } from '@aws-amplify/core/internals/utils';
+
+import { PasskeyError, PasskeyErrorCode, passkeyErrorMap } from './shared';
+
+/**
+ * Handles Overlapping Passkey Errors Between Registration & Authentication
+ */
+const handlePasskeyError = (err: unknown): PasskeyError => {
+	if (err instanceof Error) {
+		if (err.name === 'AbortError') {
+			return new PasskeyError({
+				name: PasskeyErrorCode.PasskeyOperationAborted,
+				...passkeyErrorMap[PasskeyErrorCode.PasskeyOperationAborted],
+				underlyingError: err,
+			});
+		}
+		if (err.name === 'SecurityError') {
+			return new PasskeyError({
+				name: PasskeyErrorCode.RelyingPartyMismatch,
+				...passkeyErrorMap[PasskeyErrorCode.RelyingPartyMismatch],
+				underlyingError: err,
+			});
+		}
+	}
+
+	return new PasskeyError({
+		name: AmplifyErrorCode.Unknown,
+		message: 'An unknown error has occurred.',
+		underlyingError: err,
+	});
+};
+
+export const handlePasskeyAuthenticationError = (
+	err: unknown,
+): PasskeyError => {
+	if (err instanceof PasskeyError) {
+		return err;
+	}
+
+	if (err instanceof Error && err.name === 'NotAllowedError') {
+		return new PasskeyError({
+			name: PasskeyErrorCode.PasskeyAuthenticationCanceled,
+			...passkeyErrorMap[PasskeyErrorCode.PasskeyAuthenticationCanceled],
+			underlyingError: err,
+		});
+	}
+
+	return handlePasskeyError(err);
+};
+
+export const handlePasskeyRegistrationError = (err: unknown): PasskeyError => {
+	if (err instanceof PasskeyError) {
+		return err;
+	}
+
+	if (err instanceof Error) {
+		if (err.name === 'InvalidStateError') {
+			return new PasskeyError({
+				name: PasskeyErrorCode.PasskeyAlreadyExists,
+				...passkeyErrorMap[PasskeyErrorCode.PasskeyAlreadyExists],
+				underlyingError: err,
+			});
+		}
+
+		if (err.name === 'NotAllowedError') {
+			return new PasskeyError({
+				name: PasskeyErrorCode.PasskeyRegistrationCanceled,
+				...passkeyErrorMap[PasskeyErrorCode.PasskeyRegistrationCanceled],
+				underlyingError: err,
+			});
+		}
+	}
+
+	return handlePasskeyError(err);
+};

--- a/packages/auth/src/client/utils/passkey/getIsPasskeySupported.native.ts
+++ b/packages/auth/src/client/utils/passkey/getIsPasskeySupported.native.ts
@@ -5,4 +5,26 @@
 
 import { getIsPasskeySupported as rtnGetIsPasskeySupported } from '@aws-amplify/react-native';
 
-export const getIsPasskeySupported = () => rtnGetIsPasskeySupported();
+import { PasskeyError, PasskeyErrorCode } from './errors';
+
+/**
+ * Checks if passkey authentication is supported on the current device
+ * For Android: Checks if the device has the necessary hardware and software support
+ * @returns Promise<boolean>
+ * @throws PasskeyError if the check fails
+ */
+// export const getIsPasskeySupported = () => rtnGetIsPasskeySupported();
+export const getIsPasskeySupported = async (): Promise<boolean> => {
+	try {
+		return await rtnGetIsPasskeySupported();
+	} catch (error) {
+		// If there's an error checking support, we treat it as not supported.
+		throw new PasskeyError({
+			name: PasskeyErrorCode.PasskeyNotSupported,
+			message: 'Failed to determine passkey support status',
+			recoverySuggestion:
+				'Ensure your device is running a supported version of Android',
+			underlyingError: error,
+		});
+	}
+};

--- a/packages/auth/src/client/utils/passkey/getIsPasskeySupported.native.ts
+++ b/packages/auth/src/client/utils/passkey/getIsPasskeySupported.native.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
+// import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
 
-export const getIsPasskeySupported = () => {
-	throw new PlatformNotSupportedError();
-};
+import { getIsPasskeySupported as rtnGetIsPasskeySupported } from '@aws-amplify/react-native';
+
+export const getIsPasskeySupported = () => rtnGetIsPasskeySupported();

--- a/packages/auth/src/client/utils/passkey/getPasskey.native.ts
+++ b/packages/auth/src/client/utils/passkey/getPasskey.native.ts
@@ -1,8 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
+// import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
+import { getPasskey as rtnGetPasskey } from '@aws-amplify/react-native';
 
-export const getPasskey = async () => {
-	throw new PlatformNotSupportedError();
+import { PasskeyGetOptionsJson, PasskeyGetResultJson } from './types';
+
+export const getPasskey = async (input: PasskeyGetOptionsJson) => {
+	const result = await rtnGetPasskey(JSON.stringify(input));
+
+	return JSON.parse(result) as PasskeyGetResultJson;
 };

--- a/packages/auth/src/client/utils/passkey/getPasskey.native.ts
+++ b/packages/auth/src/client/utils/passkey/getPasskey.native.ts
@@ -4,10 +4,122 @@
 // import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
 import { getPasskey as rtnGetPasskey } from '@aws-amplify/react-native';
 
+import { PasskeyError, PasskeyErrorCode } from './errors';
 import { PasskeyGetOptionsJson, PasskeyGetResultJson } from './types';
 
-export const getPasskey = async (input: PasskeyGetOptionsJson) => {
-	const result = await rtnGetPasskey(JSON.stringify(input));
+/**
+ * Retrieves a stored passkey credential from the device
+ * @param input - Options for retrieving the passkey
+ * @returns Promise<PasskeyGetResultJson>
+ * @throws PasskeyError
+ */
+export const getPasskey = async (
+	input: PasskeyGetOptionsJson,
+): Promise<PasskeyGetResultJson> => {
+	// Input validation
+	if (!input?.challenge) {
+		throw new PasskeyError({
+			name: PasskeyErrorCode.InvalidPasskeyAuthenticationOptions,
+			message: 'Missing required challenge in input',
+			recoverySuggestion:
+				'Ensure the challenge parameter is provided in the options',
+		});
+	}
 
-	return JSON.parse(result) as PasskeyGetResultJson;
+	try {
+		// Convert input to JSON string
+		const requestJson = JSON.stringify(input);
+
+		// Call native module
+		const result = await rtnGetPasskey(requestJson);
+
+		// Validate and parse response
+		if (!result) {
+			throw new PasskeyError({
+				name: PasskeyErrorCode.PasskeyRetrievalFailed,
+				message: 'No response received from native module',
+				recoverySuggestion: 'Try the operation again',
+			});
+		}
+
+		try {
+			const parsedResult = JSON.parse(result) as PasskeyGetResultJson;
+
+			// Validate parsed result structure
+			if (!parsedResult.id || !parsedResult.response || !parsedResult.type) {
+				throw new PasskeyError({
+					name: PasskeyErrorCode.PasskeyRetrievalFailed,
+					message: 'Invalid response format from native module',
+					recoverySuggestion: 'Ensure the device supports passkey operations',
+				});
+			}
+
+			// Validate response type
+			if (parsedResult.type !== 'public-key') {
+				throw new PasskeyError({
+					name: PasskeyErrorCode.PasskeyRetrievalFailed,
+					message: 'Invalid credential type in response',
+					recoverySuggestion: 'Ensure the device supports WebAuthn credentials',
+				});
+			}
+
+			return parsedResult;
+		} catch (parseError) {
+			if (parseError instanceof PasskeyError) {
+				throw parseError;
+			}
+			throw new PasskeyError({
+				name: PasskeyErrorCode.PasskeyRetrievalFailed,
+				message: 'Failed to parse native module response',
+				recoverySuggestion: 'Try the operation again',
+				underlyingError: parseError,
+			});
+		}
+	} catch (error) {
+		// Handle native module specific errors
+		if (error instanceof Error && 'code' in error) {
+			switch (error.code) {
+				case 'UserCancelled':
+					throw new PasskeyError({
+						name: PasskeyErrorCode.PasskeyAuthenticationCanceled,
+						message: 'User cancelled the authentication',
+						recoverySuggestion: 'The user can try authenticating again',
+					});
+				case 'NotSupported':
+					throw new PasskeyError({
+						name: PasskeyErrorCode.PasskeyNotSupported,
+						message: 'Passkeys are not supported on this device',
+						recoverySuggestion:
+							'Try using a device that supports passkey authentication',
+					});
+				case 'NotConfigured':
+					throw new PasskeyError({
+						name: PasskeyErrorCode.InvalidPasskeyAuthenticationOptions,
+						message: 'Passkey authentication is not properly configured',
+						recoverySuggestion: 'Check your passkey configuration',
+					});
+				case 'NoCredentials':
+					throw new PasskeyError({
+						name: PasskeyErrorCode.PasskeyRetrievalFailed,
+						message: 'No passkey credentials found',
+						recoverySuggestion:
+							'Register a passkey before attempting authentication',
+					});
+			}
+		}
+
+		// If it's already a PasskeyError, rethrow it
+		if (error instanceof PasskeyError) {
+			throw error;
+		}
+
+		// Handle any other errors
+		throw new PasskeyError({
+			name: PasskeyErrorCode.PasskeyRetrievalFailed,
+			message: 'Failed to retrieve passkey',
+			recoverySuggestion:
+				'Try the operation again or check device compatibility',
+			underlyingError: error,
+		});
+	}
 };

--- a/packages/auth/src/client/utils/passkey/registerPasskey.native.ts
+++ b/packages/auth/src/client/utils/passkey/registerPasskey.native.ts
@@ -4,10 +4,169 @@
 // import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
 import { createPasskey as rtnCreatePasskey } from '@aws-amplify/react-native';
 
+import { PasskeyError, PasskeyErrorCode } from './errors';
 import { PasskeyCreateOptionsJson, PasskeyCreateResultJson } from './types';
 
-export const registerPasskey = async (input: PasskeyCreateOptionsJson) => {
-	const result = await rtnCreatePasskey(JSON.stringify(input));
+/**
+ * Registers a new passkey credential on the device
+ * @param input - Options for creating the passkey
+ * @returns Promise<PasskeyCreateResultJson>
+ * @throws PasskeyError for validation, registration, or parsing failures
+ */
+export const registerPasskey = async (
+	input: PasskeyCreateOptionsJson,
+): Promise<PasskeyCreateResultJson> => {
+	// Validate required input fields
+	if (!input?.rp?.name) {
+		throw new PasskeyError({
+			name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
+			message: 'Missing required relying party name',
+			recoverySuggestion:
+				'Ensure the relying party name is provided in the options',
+		});
+	}
 
-	return JSON.parse(result) as PasskeyCreateResultJson;
+	if (!input?.user?.id || !input?.user?.name || !input?.user?.displayName) {
+		throw new PasskeyError({
+			name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
+			message: 'Missing required user information',
+			recoverySuggestion: 'Ensure user id, name, and displayName are provided',
+		});
+	}
+
+	if (!input?.challenge) {
+		throw new PasskeyError({
+			name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
+			message: 'Missing required challenge',
+			recoverySuggestion: 'Ensure the challenge parameter is provided',
+		});
+	}
+
+	if (
+		!Array.isArray(input?.pubKeyCredParams) ||
+		input.pubKeyCredParams.length === 0
+	) {
+		throw new PasskeyError({
+			name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
+			message: 'Invalid or missing public key credential parameters',
+			recoverySuggestion:
+				'Ensure valid public key credential parameters are provided',
+		});
+	}
+
+	try {
+		// Convert input to JSON string
+		const requestJson = JSON.stringify(input);
+
+		// Call native module
+		const result = await rtnCreatePasskey(requestJson);
+
+		// Validate response exists
+		if (!result) {
+			throw new PasskeyError({
+				name: PasskeyErrorCode.PasskeyRegistrationFailed,
+				message: 'No response received from native module',
+				recoverySuggestion: 'Try the registration again',
+			});
+		}
+
+		try {
+			// Parse and validate response
+			const parsedResult = JSON.parse(result) as PasskeyCreateResultJson;
+
+			// Validate response structure
+			if (
+				!parsedResult.id ||
+				!parsedResult.rawId ||
+				!parsedResult.response ||
+				!parsedResult.type
+			) {
+				throw new PasskeyError({
+					name: PasskeyErrorCode.PasskeyRegistrationFailed,
+					message: 'Invalid response format from native module',
+					recoverySuggestion: 'Ensure the device supports passkey registration',
+				});
+			}
+
+			// Validate response type
+			if (parsedResult.type !== 'public-key') {
+				throw new PasskeyError({
+					name: PasskeyErrorCode.PasskeyRegistrationFailed,
+					message: 'Invalid credential type in response',
+					recoverySuggestion: 'Ensure the device supports WebAuthn credentials',
+				});
+			}
+
+			// Validate attestation response
+			if (
+				!parsedResult.response.attestationObject ||
+				!parsedResult.response.clientDataJSON
+			) {
+				throw new PasskeyError({
+					name: PasskeyErrorCode.PasskeyRegistrationFailed,
+					message: 'Missing required attestation data in response',
+					recoverySuggestion:
+						'Try registering again or check device compatibility',
+				});
+			}
+
+			return parsedResult;
+		} catch (parseError) {
+			if (parseError instanceof PasskeyError) {
+				throw parseError;
+			}
+			throw new PasskeyError({
+				name: PasskeyErrorCode.PasskeyRegistrationFailed,
+				message: 'Failed to parse native module response',
+				recoverySuggestion: 'Try the registration again',
+				underlyingError: parseError,
+			});
+		}
+	} catch (error) {
+		// Handle native module specific errors
+		if (error instanceof Error && 'code' in error) {
+			switch (error.code) {
+				case 'UserCancelled':
+					throw new PasskeyError({
+						name: PasskeyErrorCode.PasskeyRegistrationCanceled,
+						message: 'User cancelled the registration',
+						recoverySuggestion: 'The user can try registering again',
+					});
+				case 'NotSupported':
+					throw new PasskeyError({
+						name: PasskeyErrorCode.PasskeyNotSupported,
+						message: 'Passkeys are not supported on this device',
+						recoverySuggestion:
+							'Try using a device that supports passkey registration',
+					});
+				case 'NotConfigured':
+					throw new PasskeyError({
+						name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
+						message: 'Passkey registration is not properly configured',
+						recoverySuggestion: 'Check your passkey configuration',
+					});
+				case 'Interrupted':
+					throw new PasskeyError({
+						name: PasskeyErrorCode.PasskeyOperationAborted,
+						message: 'Registration was interrupted',
+						recoverySuggestion:
+							'Try registering again when the device is not in use',
+					});
+			}
+		}
+
+		// If it's already a PasskeyError, rethrow it
+		if (error instanceof PasskeyError) {
+			throw error;
+		}
+
+		// Handle any other errors
+		throw new PasskeyError({
+			name: PasskeyErrorCode.PasskeyRegistrationFailed,
+			message: 'Failed to register passkey',
+			recoverySuggestion:
+				'Try the registration again or check device compatibility',
+			underlyingError: error,
+		});
+	}
 };

--- a/packages/auth/src/client/utils/passkey/registerPasskey.native.ts
+++ b/packages/auth/src/client/utils/passkey/registerPasskey.native.ts
@@ -1,8 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
+// import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
+import { createPasskey as rtnCreatePasskey } from '@aws-amplify/react-native';
 
-export const registerPasskey = async () => {
-	throw new PlatformNotSupportedError();
+import { PasskeyCreateOptionsJson, PasskeyCreateResultJson } from './types';
+
+export const registerPasskey = async (input: PasskeyCreateOptionsJson) => {
+	const result = await rtnCreatePasskey(JSON.stringify(input));
+
+	return JSON.parse(result) as PasskeyCreateResultJson;
 };

--- a/packages/auth/src/client/utils/passkey/serde.ts
+++ b/packages/auth/src/client/utils/passkey/serde.ts
@@ -6,6 +6,7 @@ import {
 	convertBase64UrlToArrayBuffer,
 } from '../../../foundation/convert';
 
+import { PasskeyError, PasskeyErrorCode } from './errors';
 import {
 	PasskeyCreateOptionsJson,
 	PasskeyCreateResultJson,
@@ -18,134 +19,284 @@ import {
 } from './types';
 
 /**
+ * Validates base64URL string format
+ * @param input string to validate
+ * @returns boolean
+ */
+const isValidBase64Url = (input: string): boolean => {
+	const base64UrlRegex = /^[A-Za-z0-9_-]*$/;
+
+	return base64UrlRegex.test(input);
+};
+
+/**
  * Deserializes Public Key Credential Creation Options JSON
  * @param input PasskeyCreateOptionsJson
  * @returns PublicKeyCredentialCreationOptions
+ * @throws PasskeyError if validation fails
  */
 export const deserializeJsonToPkcCreationOptions = (
 	input: PasskeyCreateOptionsJson,
 ): PublicKeyCredentialCreationOptions => {
-	const userIdBuffer = convertBase64UrlToArrayBuffer(input.user.id);
-	const challengeBuffer = convertBase64UrlToArrayBuffer(input.challenge);
-	const excludeCredentialsWithBuffer = (input.excludeCredentials || []).map(
-		excludeCred => ({
-			...excludeCred,
-			id: convertBase64UrlToArrayBuffer(excludeCred.id),
-		}),
-	);
+	try {
+		// Validate required fields
+		if (!input?.user?.id || !input?.challenge) {
+			throw new PasskeyError({
+				name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
+				message: 'Missing required fields in creation options',
+				recoverySuggestion:
+					'Ensure all required fields are provided in the input options',
+			});
+		}
 
-	return {
-		...input,
-		excludeCredentials: excludeCredentialsWithBuffer,
-		challenge: challengeBuffer,
-		user: {
-			...input.user,
-			id: userIdBuffer,
-		},
-	};
+		// Validate base64URL format
+		if (
+			!isValidBase64Url(input.user.id) ||
+			!isValidBase64Url(input.challenge)
+		) {
+			throw new PasskeyError({
+				name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
+				message: 'Invalid base64URL format in input',
+				recoverySuggestion:
+					'Ensure input strings are properly base64URL encoded',
+			});
+		}
+
+		const userIdBuffer = convertBase64UrlToArrayBuffer(input.user.id);
+		const challengeBuffer = convertBase64UrlToArrayBuffer(input.challenge);
+
+		// Validate exclude credentials if present
+		const excludeCredentialsWithBuffer = (input.excludeCredentials || []).map(
+			excludeCred => {
+				if (!excludeCred.id || !isValidBase64Url(excludeCred.id)) {
+					throw new PasskeyError({
+						name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
+						message: 'Invalid credential ID in excludeCredentials',
+						recoverySuggestion:
+							'Ensure all credential IDs are properly base64URL encoded',
+					});
+				}
+
+				return {
+					...excludeCred,
+					id: convertBase64UrlToArrayBuffer(excludeCred.id),
+				};
+			},
+		);
+
+		return {
+			...input,
+			excludeCredentials: excludeCredentialsWithBuffer,
+			challenge: challengeBuffer,
+			user: {
+				...input.user,
+				id: userIdBuffer,
+			},
+		};
+	} catch (error) {
+		if (error instanceof PasskeyError) {
+			throw error;
+		}
+		throw new PasskeyError({
+			name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
+			message: 'Failed to deserialize creation options',
+			recoverySuggestion: 'Check the format of your input data',
+			underlyingError: error,
+		});
+	}
 };
 
 /**
  * Serializes a Public Key Credential With Attestation to JSON
  * @param input PasskeyCreateResult
  * @returns PasskeyCreateResultJson
+ * @throws PasskeyError if serialization fails
  */
 export const serializePkcWithAttestationToJson = (
 	input: PkcWithAuthenticatorAttestationResponse,
 ): PasskeyCreateResultJson => {
-	const response: PkcAttestationResponse<string> = {
-		clientDataJSON: convertArrayBufferToBase64Url(
-			input.response.clientDataJSON,
-		),
-		attestationObject: convertArrayBufferToBase64Url(
-			input.response.attestationObject,
-		),
-		transports: input.response.getTransports(),
-		publicKeyAlgorithm: input.response.getPublicKeyAlgorithm(),
-		authenticatorData: convertArrayBufferToBase64Url(
-			input.response.getAuthenticatorData(),
-		),
-	};
+	try {
+		if (
+			!input?.response?.clientDataJSON ||
+			!input?.response?.attestationObject
+		) {
+			throw new PasskeyError({
+				name: PasskeyErrorCode.PasskeyRegistrationFailed,
+				message: 'Missing required attestation data',
+				recoverySuggestion:
+					'Ensure the attestation response contains all required fields',
+			});
+		}
 
-	const publicKey = input.response.getPublicKey();
+		const response: PkcAttestationResponse<string> = {
+			clientDataJSON: convertArrayBufferToBase64Url(
+				input.response.clientDataJSON,
+			),
+			attestationObject: convertArrayBufferToBase64Url(
+				input.response.attestationObject,
+			),
+			transports: input.response.getTransports(),
+			publicKeyAlgorithm: input.response.getPublicKeyAlgorithm(),
+			authenticatorData: convertArrayBufferToBase64Url(
+				input.response.getAuthenticatorData(),
+			),
+		};
 
-	if (publicKey) {
-		response.publicKey = convertArrayBufferToBase64Url(publicKey);
+		const publicKey = input.response.getPublicKey();
+		if (publicKey) {
+			response.publicKey = convertArrayBufferToBase64Url(publicKey);
+		}
+
+		const resultJson: PasskeyCreateResultJson = {
+			type: input.type,
+			id: input.id,
+			rawId: convertArrayBufferToBase64Url(input.rawId),
+			clientExtensionResults: input.getClientExtensionResults(),
+			response,
+		};
+
+		if (input.authenticatorAttachment) {
+			resultJson.authenticatorAttachment = input.authenticatorAttachment;
+		}
+
+		return resultJson;
+	} catch (error) {
+		if (error instanceof PasskeyError) {
+			throw error;
+		}
+		throw new PasskeyError({
+			name: PasskeyErrorCode.PasskeyRegistrationFailed,
+			message: 'Failed to serialize attestation response',
+			recoverySuggestion: 'Check the format of the attestation response',
+			underlyingError: error,
+		});
 	}
-
-	const resultJson: PasskeyCreateResultJson = {
-		type: input.type,
-		id: input.id,
-		rawId: convertArrayBufferToBase64Url(input.rawId),
-		clientExtensionResults: input.getClientExtensionResults(),
-		response,
-	};
-
-	if (input.authenticatorAttachment) {
-		resultJson.authenticatorAttachment = input.authenticatorAttachment;
-	}
-
-	return resultJson;
 };
 
 /**
  * Deserializes Public Key Credential Get Options JSON
  * @param input PasskeyGetOptionsJson
  * @returns PublicKeyCredentialRequestOptions
+ * @throws PasskeyError if validation fails
  */
 export const deserializeJsonToPkcGetOptions = (
 	input: PasskeyGetOptionsJson,
 ): PublicKeyCredentialRequestOptions => {
-	const challengeBuffer = convertBase64UrlToArrayBuffer(input.challenge);
-	const allowedCredentialsWithBuffer = (input.allowCredentials || []).map(
-		allowedCred => ({
-			...allowedCred,
-			id: convertBase64UrlToArrayBuffer(allowedCred.id),
-		}),
-	);
+	try {
+		if (!input?.challenge) {
+			throw new PasskeyError({
+				name: PasskeyErrorCode.InvalidPasskeyAuthenticationOptions,
+				message: 'Missing challenge in get options',
+				recoverySuggestion: 'Ensure challenge is provided in the input options',
+			});
+		}
 
-	return {
-		...input,
-		challenge: challengeBuffer,
-		allowCredentials: allowedCredentialsWithBuffer,
-	};
+		if (!isValidBase64Url(input.challenge)) {
+			throw new PasskeyError({
+				name: PasskeyErrorCode.InvalidPasskeyAuthenticationOptions,
+				message: 'Invalid challenge format',
+				recoverySuggestion: 'Ensure challenge is properly base64URL encoded',
+			});
+		}
+
+		const challengeBuffer = convertBase64UrlToArrayBuffer(input.challenge);
+		const allowedCredentialsWithBuffer = (input.allowCredentials || []).map(
+			allowedCred => {
+				if (!allowedCred.id || !isValidBase64Url(allowedCred.id)) {
+					throw new PasskeyError({
+						name: PasskeyErrorCode.InvalidPasskeyAuthenticationOptions,
+						message: 'Invalid credential ID in allowCredentials',
+						recoverySuggestion:
+							'Ensure all credential IDs are properly base64URL encoded',
+					});
+				}
+
+				return {
+					...allowedCred,
+					id: convertBase64UrlToArrayBuffer(allowedCred.id),
+				};
+			},
+		);
+
+		return {
+			...input,
+			challenge: challengeBuffer,
+			allowCredentials: allowedCredentialsWithBuffer,
+		};
+	} catch (error) {
+		if (error instanceof PasskeyError) {
+			throw error;
+		}
+		throw new PasskeyError({
+			name: PasskeyErrorCode.InvalidPasskeyAuthenticationOptions,
+			message: 'Failed to deserialize get options',
+			recoverySuggestion: 'Check the format of your input data',
+			underlyingError: error,
+		});
+	}
 };
 
 /**
- * Serializes a Public Key Credential With Attestation to JSON
+ * Serializes a Public Key Credential With Assertion to JSON
  * @param input PasskeyGetResult
  * @returns PasskeyGetResultJson
+ * @throws PasskeyError if serialization fails
  */
 export const serializePkcWithAssertionToJson = (
 	input: PkcWithAuthenticatorAssertionResponse,
 ): PasskeyGetResultJson => {
-	const response: PkcAssertionResponse<string> = {
-		clientDataJSON: convertArrayBufferToBase64Url(
-			input.response.clientDataJSON,
-		),
-		authenticatorData: convertArrayBufferToBase64Url(
-			input.response.authenticatorData,
-		),
-		signature: convertArrayBufferToBase64Url(input.response.signature),
-	};
+	try {
+		if (
+			!input?.response?.clientDataJSON ||
+			!input?.response?.authenticatorData ||
+			!input?.response?.signature
+		) {
+			throw new PasskeyError({
+				name: PasskeyErrorCode.PasskeyRetrievalFailed,
+				message: 'Missing required assertion data',
+				recoverySuggestion:
+					'Ensure the assertion response contains all required fields',
+			});
+		}
 
-	if (input.response.userHandle) {
-		response.userHandle = convertArrayBufferToBase64Url(
-			input.response.userHandle,
-		);
+		const response: PkcAssertionResponse<string> = {
+			clientDataJSON: convertArrayBufferToBase64Url(
+				input.response.clientDataJSON,
+			),
+			authenticatorData: convertArrayBufferToBase64Url(
+				input.response.authenticatorData,
+			),
+			signature: convertArrayBufferToBase64Url(input.response.signature),
+		};
+
+		if (input.response.userHandle) {
+			response.userHandle = convertArrayBufferToBase64Url(
+				input.response.userHandle,
+			);
+		}
+
+		const resultJson: PasskeyGetResultJson = {
+			id: input.id,
+			rawId: convertArrayBufferToBase64Url(input.rawId),
+			type: input.type,
+			clientExtensionResults: input.getClientExtensionResults(),
+			response,
+		};
+
+		if (input.authenticatorAttachment) {
+			resultJson.authenticatorAttachment = input.authenticatorAttachment;
+		}
+
+		return resultJson;
+	} catch (error) {
+		if (error instanceof PasskeyError) {
+			throw error;
+		}
+		throw new PasskeyError({
+			name: PasskeyErrorCode.PasskeyRetrievalFailed,
+			message: 'Failed to serialize assertion response',
+			recoverySuggestion: 'Check the format of the assertion response',
+			underlyingError: error,
+		});
 	}
-
-	const resultJson: PasskeyGetResultJson = {
-		id: input.id,
-		rawId: convertArrayBufferToBase64Url(input.rawId),
-		type: input.type,
-		clientExtensionResults: input.getClientExtensionResults(),
-		response,
-	};
-
-	if (input.authenticatorAttachment) {
-		resultJson.authenticatorAttachment = input.authenticatorAttachment;
-	}
-
-	return resultJson;
 };

--- a/packages/auth/src/client/utils/passkey/serde.ts
+++ b/packages/auth/src/client/utils/passkey/serde.ts
@@ -6,7 +6,6 @@ import {
 	convertBase64UrlToArrayBuffer,
 } from '../../../foundation/convert';
 
-import { PasskeyError, PasskeyErrorCode } from './errors';
 import {
 	PasskeyCreateOptionsJson,
 	PasskeyCreateResultJson,
@@ -19,284 +18,134 @@ import {
 } from './types';
 
 /**
- * Validates base64URL string format
- * @param input string to validate
- * @returns boolean
- */
-const isValidBase64Url = (input: string): boolean => {
-	const base64UrlRegex = /^[A-Za-z0-9_-]*$/;
-
-	return base64UrlRegex.test(input);
-};
-
-/**
  * Deserializes Public Key Credential Creation Options JSON
  * @param input PasskeyCreateOptionsJson
  * @returns PublicKeyCredentialCreationOptions
- * @throws PasskeyError if validation fails
  */
 export const deserializeJsonToPkcCreationOptions = (
 	input: PasskeyCreateOptionsJson,
 ): PublicKeyCredentialCreationOptions => {
-	try {
-		// Validate required fields
-		if (!input?.user?.id || !input?.challenge) {
-			throw new PasskeyError({
-				name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
-				message: 'Missing required fields in creation options',
-				recoverySuggestion:
-					'Ensure all required fields are provided in the input options',
-			});
-		}
+	const userIdBuffer = convertBase64UrlToArrayBuffer(input.user.id);
+	const challengeBuffer = convertBase64UrlToArrayBuffer(input.challenge);
+	const excludeCredentialsWithBuffer = (input.excludeCredentials || []).map(
+		excludeCred => ({
+			...excludeCred,
+			id: convertBase64UrlToArrayBuffer(excludeCred.id),
+		}),
+	);
 
-		// Validate base64URL format
-		if (
-			!isValidBase64Url(input.user.id) ||
-			!isValidBase64Url(input.challenge)
-		) {
-			throw new PasskeyError({
-				name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
-				message: 'Invalid base64URL format in input',
-				recoverySuggestion:
-					'Ensure input strings are properly base64URL encoded',
-			});
-		}
-
-		const userIdBuffer = convertBase64UrlToArrayBuffer(input.user.id);
-		const challengeBuffer = convertBase64UrlToArrayBuffer(input.challenge);
-
-		// Validate exclude credentials if present
-		const excludeCredentialsWithBuffer = (input.excludeCredentials || []).map(
-			excludeCred => {
-				if (!excludeCred.id || !isValidBase64Url(excludeCred.id)) {
-					throw new PasskeyError({
-						name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
-						message: 'Invalid credential ID in excludeCredentials',
-						recoverySuggestion:
-							'Ensure all credential IDs are properly base64URL encoded',
-					});
-				}
-
-				return {
-					...excludeCred,
-					id: convertBase64UrlToArrayBuffer(excludeCred.id),
-				};
-			},
-		);
-
-		return {
-			...input,
-			excludeCredentials: excludeCredentialsWithBuffer,
-			challenge: challengeBuffer,
-			user: {
-				...input.user,
-				id: userIdBuffer,
-			},
-		};
-	} catch (error) {
-		if (error instanceof PasskeyError) {
-			throw error;
-		}
-		throw new PasskeyError({
-			name: PasskeyErrorCode.InvalidPasskeyRegistrationOptions,
-			message: 'Failed to deserialize creation options',
-			recoverySuggestion: 'Check the format of your input data',
-			underlyingError: error,
-		});
-	}
+	return {
+		...input,
+		excludeCredentials: excludeCredentialsWithBuffer,
+		challenge: challengeBuffer,
+		user: {
+			...input.user,
+			id: userIdBuffer,
+		},
+	};
 };
 
 /**
  * Serializes a Public Key Credential With Attestation to JSON
  * @param input PasskeyCreateResult
  * @returns PasskeyCreateResultJson
- * @throws PasskeyError if serialization fails
  */
 export const serializePkcWithAttestationToJson = (
 	input: PkcWithAuthenticatorAttestationResponse,
 ): PasskeyCreateResultJson => {
-	try {
-		if (
-			!input?.response?.clientDataJSON ||
-			!input?.response?.attestationObject
-		) {
-			throw new PasskeyError({
-				name: PasskeyErrorCode.PasskeyRegistrationFailed,
-				message: 'Missing required attestation data',
-				recoverySuggestion:
-					'Ensure the attestation response contains all required fields',
-			});
-		}
+	const response: PkcAttestationResponse<string> = {
+		clientDataJSON: convertArrayBufferToBase64Url(
+			input.response.clientDataJSON,
+		),
+		attestationObject: convertArrayBufferToBase64Url(
+			input.response.attestationObject,
+		),
+		transports: input.response.getTransports(),
+		publicKeyAlgorithm: input.response.getPublicKeyAlgorithm(),
+		authenticatorData: convertArrayBufferToBase64Url(
+			input.response.getAuthenticatorData(),
+		),
+	};
 
-		const response: PkcAttestationResponse<string> = {
-			clientDataJSON: convertArrayBufferToBase64Url(
-				input.response.clientDataJSON,
-			),
-			attestationObject: convertArrayBufferToBase64Url(
-				input.response.attestationObject,
-			),
-			transports: input.response.getTransports(),
-			publicKeyAlgorithm: input.response.getPublicKeyAlgorithm(),
-			authenticatorData: convertArrayBufferToBase64Url(
-				input.response.getAuthenticatorData(),
-			),
-		};
+	const publicKey = input.response.getPublicKey();
 
-		const publicKey = input.response.getPublicKey();
-		if (publicKey) {
-			response.publicKey = convertArrayBufferToBase64Url(publicKey);
-		}
-
-		const resultJson: PasskeyCreateResultJson = {
-			type: input.type,
-			id: input.id,
-			rawId: convertArrayBufferToBase64Url(input.rawId),
-			clientExtensionResults: input.getClientExtensionResults(),
-			response,
-		};
-
-		if (input.authenticatorAttachment) {
-			resultJson.authenticatorAttachment = input.authenticatorAttachment;
-		}
-
-		return resultJson;
-	} catch (error) {
-		if (error instanceof PasskeyError) {
-			throw error;
-		}
-		throw new PasskeyError({
-			name: PasskeyErrorCode.PasskeyRegistrationFailed,
-			message: 'Failed to serialize attestation response',
-			recoverySuggestion: 'Check the format of the attestation response',
-			underlyingError: error,
-		});
+	if (publicKey) {
+		response.publicKey = convertArrayBufferToBase64Url(publicKey);
 	}
+
+	const resultJson: PasskeyCreateResultJson = {
+		type: input.type,
+		id: input.id,
+		rawId: convertArrayBufferToBase64Url(input.rawId),
+		clientExtensionResults: input.getClientExtensionResults(),
+		response,
+	};
+
+	if (input.authenticatorAttachment) {
+		resultJson.authenticatorAttachment = input.authenticatorAttachment;
+	}
+
+	return resultJson;
 };
 
 /**
  * Deserializes Public Key Credential Get Options JSON
  * @param input PasskeyGetOptionsJson
  * @returns PublicKeyCredentialRequestOptions
- * @throws PasskeyError if validation fails
  */
 export const deserializeJsonToPkcGetOptions = (
 	input: PasskeyGetOptionsJson,
 ): PublicKeyCredentialRequestOptions => {
-	try {
-		if (!input?.challenge) {
-			throw new PasskeyError({
-				name: PasskeyErrorCode.InvalidPasskeyAuthenticationOptions,
-				message: 'Missing challenge in get options',
-				recoverySuggestion: 'Ensure challenge is provided in the input options',
-			});
-		}
+	const challengeBuffer = convertBase64UrlToArrayBuffer(input.challenge);
+	const allowedCredentialsWithBuffer = (input.allowCredentials || []).map(
+		allowedCred => ({
+			...allowedCred,
+			id: convertBase64UrlToArrayBuffer(allowedCred.id),
+		}),
+	);
 
-		if (!isValidBase64Url(input.challenge)) {
-			throw new PasskeyError({
-				name: PasskeyErrorCode.InvalidPasskeyAuthenticationOptions,
-				message: 'Invalid challenge format',
-				recoverySuggestion: 'Ensure challenge is properly base64URL encoded',
-			});
-		}
-
-		const challengeBuffer = convertBase64UrlToArrayBuffer(input.challenge);
-		const allowedCredentialsWithBuffer = (input.allowCredentials || []).map(
-			allowedCred => {
-				if (!allowedCred.id || !isValidBase64Url(allowedCred.id)) {
-					throw new PasskeyError({
-						name: PasskeyErrorCode.InvalidPasskeyAuthenticationOptions,
-						message: 'Invalid credential ID in allowCredentials',
-						recoverySuggestion:
-							'Ensure all credential IDs are properly base64URL encoded',
-					});
-				}
-
-				return {
-					...allowedCred,
-					id: convertBase64UrlToArrayBuffer(allowedCred.id),
-				};
-			},
-		);
-
-		return {
-			...input,
-			challenge: challengeBuffer,
-			allowCredentials: allowedCredentialsWithBuffer,
-		};
-	} catch (error) {
-		if (error instanceof PasskeyError) {
-			throw error;
-		}
-		throw new PasskeyError({
-			name: PasskeyErrorCode.InvalidPasskeyAuthenticationOptions,
-			message: 'Failed to deserialize get options',
-			recoverySuggestion: 'Check the format of your input data',
-			underlyingError: error,
-		});
-	}
+	return {
+		...input,
+		challenge: challengeBuffer,
+		allowCredentials: allowedCredentialsWithBuffer,
+	};
 };
 
 /**
- * Serializes a Public Key Credential With Assertion to JSON
+ * Serializes a Public Key Credential With Attestation to JSON
  * @param input PasskeyGetResult
  * @returns PasskeyGetResultJson
- * @throws PasskeyError if serialization fails
  */
 export const serializePkcWithAssertionToJson = (
 	input: PkcWithAuthenticatorAssertionResponse,
 ): PasskeyGetResultJson => {
-	try {
-		if (
-			!input?.response?.clientDataJSON ||
-			!input?.response?.authenticatorData ||
-			!input?.response?.signature
-		) {
-			throw new PasskeyError({
-				name: PasskeyErrorCode.PasskeyRetrievalFailed,
-				message: 'Missing required assertion data',
-				recoverySuggestion:
-					'Ensure the assertion response contains all required fields',
-			});
-		}
+	const response: PkcAssertionResponse<string> = {
+		clientDataJSON: convertArrayBufferToBase64Url(
+			input.response.clientDataJSON,
+		),
+		authenticatorData: convertArrayBufferToBase64Url(
+			input.response.authenticatorData,
+		),
+		signature: convertArrayBufferToBase64Url(input.response.signature),
+	};
 
-		const response: PkcAssertionResponse<string> = {
-			clientDataJSON: convertArrayBufferToBase64Url(
-				input.response.clientDataJSON,
-			),
-			authenticatorData: convertArrayBufferToBase64Url(
-				input.response.authenticatorData,
-			),
-			signature: convertArrayBufferToBase64Url(input.response.signature),
-		};
-
-		if (input.response.userHandle) {
-			response.userHandle = convertArrayBufferToBase64Url(
-				input.response.userHandle,
-			);
-		}
-
-		const resultJson: PasskeyGetResultJson = {
-			id: input.id,
-			rawId: convertArrayBufferToBase64Url(input.rawId),
-			type: input.type,
-			clientExtensionResults: input.getClientExtensionResults(),
-			response,
-		};
-
-		if (input.authenticatorAttachment) {
-			resultJson.authenticatorAttachment = input.authenticatorAttachment;
-		}
-
-		return resultJson;
-	} catch (error) {
-		if (error instanceof PasskeyError) {
-			throw error;
-		}
-		throw new PasskeyError({
-			name: PasskeyErrorCode.PasskeyRetrievalFailed,
-			message: 'Failed to serialize assertion response',
-			recoverySuggestion: 'Check the format of the assertion response',
-			underlyingError: error,
-		});
+	if (input.response.userHandle) {
+		response.userHandle = convertArrayBufferToBase64Url(
+			input.response.userHandle,
+		);
 	}
+
+	const resultJson: PasskeyGetResultJson = {
+		id: input.id,
+		rawId: convertArrayBufferToBase64Url(input.rawId),
+		type: input.type,
+		clientExtensionResults: input.getClientExtensionResults(),
+		response,
+	};
+
+	if (input.authenticatorAttachment) {
+		resultJson.authenticatorAttachment = input.authenticatorAttachment;
+	}
+
+	return resultJson;
 };

--- a/packages/auth/src/client/utils/passkey/types/index.native.ts
+++ b/packages/auth/src/client/utils/passkey/types/index.native.ts
@@ -1,0 +1,53 @@
+import { PasskeyErrorCode, assertPasskeyError } from '../errors';
+
+/**
+ * Passkey Create Types
+ */
+export {
+	PkcAttestationResponse,
+	PasskeyCreateOptionsJson,
+	PasskeyCreateResultJson,
+	assertValidCredentialCreationOptions,
+} from './shared';
+
+/**
+ * Passkey Get Types
+ */
+export {
+	PkcAssertionResponse,
+	PasskeyGetOptionsJson,
+	PasskeyGetResultJson,
+} from './shared';
+
+// Native-specific type assertions
+export function assertValidNativeResponse(response: any): void {
+	assertPasskeyError(
+		response &&
+			typeof response === 'object' &&
+			typeof response.clientDataJSON === 'string',
+		PasskeyErrorCode.PasskeyRetrievalFailed,
+	);
+}
+
+// For registration response
+export function assertValidNativeRegistrationResponse(response: any): void {
+	assertPasskeyError(
+		response &&
+			typeof response === 'object' &&
+			typeof response.clientDataJSON === 'string' &&
+			typeof response.attestationObject === 'string',
+		PasskeyErrorCode.PasskeyRegistrationFailed,
+	);
+}
+
+// For authentication response
+export function assertValidNativeAuthenticationResponse(response: any): void {
+	assertPasskeyError(
+		response &&
+			typeof response === 'object' &&
+			typeof response.clientDataJSON === 'string' &&
+			typeof response.authenticatorData === 'string' &&
+			typeof response.signature === 'string',
+		PasskeyErrorCode.PasskeyRetrievalFailed,
+	);
+}

--- a/packages/auth/src/client/utils/passkey/types/native.ts
+++ b/packages/auth/src/client/utils/passkey/types/native.ts
@@ -1,0 +1,43 @@
+import type {
+	PasskeyCreateOptionsJson,
+	PasskeyCreateResultJson,
+	PasskeyGetOptionsJson,
+	PasskeyGetResultJson,
+} from './shared';
+
+// Re-export shared types that are used in native implementation
+export type {
+	PasskeyCreateOptionsJson,
+	PasskeyCreateResultJson,
+	PasskeyGetOptionsJson,
+	PasskeyGetResultJson,
+};
+
+// Native-specific type for credential assertion response
+export interface NativeCredentialAssertionResponse {
+	authenticatorData: string;
+	clientDataJSON: string;
+	signature: string;
+	userHandle?: string;
+}
+
+// Native-specific type for credential attestation response
+export interface NativeCredentialAttestationResponse {
+	clientDataJSON: string;
+	attestationObject: string;
+	transports?: string[];
+}
+
+// Helper function to validate native response format
+export function isValidNativeResponse(response: any): boolean {
+	return (
+		response &&
+		typeof response === 'object' &&
+		typeof response.clientDataJSON === 'string' &&
+		// For attestation response
+		(typeof response.attestationObject === 'string' ||
+			// For assertion response
+			(typeof response.authenticatorData === 'string' &&
+				typeof response.signature === 'string'))
+	);
+}

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -92,6 +92,16 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
+	// for credential manager API
+	// https://developer.android.com/identity/sign-in/credential-manager#add-dependencies
+
+	implementation "androidx.credentials:credentials:1.3.0"
+
+    // optional - needed for credentials support from play services, for devices running
+    // Android 13 and below.
+    implementation "androidx.credentials:credentials-play-services-auth:1.3.0"
+
 }
 
 if (isNewArchitectureEnabled()) {

--- a/packages/react-native/android/src/main/kotlin/com/amazonaws/amplify/rtncore/AmplifyRTNCoreModule.kt
+++ b/packages/react-native/android/src/main/kotlin/com/amazonaws/amplify/rtncore/AmplifyRTNCoreModule.kt
@@ -55,6 +55,12 @@ class AmplifyRTNCoreModule(reactContext: ReactApplicationContext) :
 		private const val ERROR_TAG = "Passkey"
 		private const val REGISTRATION_RESPONSE_KEY = "androidx.credentials.BUNDLE_KEY_REGISTRATION_RESPONSE_JSON"
     	private const val AUTHENTICATION_RESPONSE_KEY = "androidx.credentials.BUNDLE_KEY_AUTHENTICATION_RESPONSE_JSON"
+		private const val ERROR_USER_CANCELLED = "UserCancelled"
+    	private const val ERROR_NOT_SUPPORTED = "NotSupported"
+    	private const val ERROR_NOT_CONFIGURED = "NotConfigured"
+    	private const val ERROR_INTERRUPTED = "Interrupted"
+    	private const val ERROR_UNKNOWN = "UnknownError"
+    	private const val ERROR_NO_CREDENTIALS = "NoCredentials"
     }
 
 	private fun isValidJson(json: String): Boolean {
@@ -94,9 +100,7 @@ class AmplifyRTNCoreModule(reactContext: ReactApplicationContext) :
 					CreatePublicKeyCredentialRequest(requestJson)
 				)
 	
-				val response = result.data.getString(
-					"androidx.credentials.BUNDLE_KEY_REGISTRATION_RESPONSE_JSON"
-				)
+				val response = result.data.getString(REGISTRATION_RESPONSE_KEY)
 				
 				if (response == null) {
 					promise.reject(ERROR_TAG, "No response received from credential manager")
@@ -114,31 +118,17 @@ class AmplifyRTNCoreModule(reactContext: ReactApplicationContext) :
 	}
 
     private fun handlePasskeyRegistrationException(e: CreateCredentialException): String {
-        e.printStackTrace()
-        when (e) {
-            is CreatePublicKeyCredentialDomException -> {
-                return e.errorMessage.toString()
-            }
-            is CreateCredentialCancellationException -> {
-                return "UserCancelled"
-            }
-            is CreateCredentialInterruptedException -> {
-                return "Interrupted"
-            }
-            is CreateCredentialProviderConfigurationException -> {
-                return "NotConfigured"
-            }
-            is CreateCredentialUnknownException -> {
-                return "UnknownError"
-            }
-            is CreateCredentialUnsupportedException -> {
-                return "NotSupported"
-            }
-            else -> {
-                return e.errorMessage.toString()
-            }
-        }
-    }
+		e.printStackTrace()
+		return when (e) {
+			is CreatePublicKeyCredentialDomException -> e.errorMessage.toString()
+			is CreateCredentialCancellationException -> ERROR_USER_CANCELLED
+			is CreateCredentialInterruptedException -> ERROR_INTERRUPTED
+			is CreateCredentialProviderConfigurationException -> ERROR_NOT_CONFIGURED
+			is CreateCredentialUnknownException -> ERROR_UNKNOWN
+			is CreateCredentialUnsupportedException -> ERROR_NOT_SUPPORTED
+			else -> e.errorMessage.toString()
+		}
+	}
 
     @ReactMethod
     fun getPasskey(requestJson: String, promise: Promise) {
@@ -168,9 +158,7 @@ class AmplifyRTNCoreModule(reactContext: ReactApplicationContext) :
 					GetCredentialRequest(listOf(GetPublicKeyCredentialOption(requestJson)))
 				)
 	
-				val response = result.credential.data.getString(
-					"androidx.credentials.BUNDLE_KEY_AUTHENTICATION_RESPONSE_JSON"
-				)
+				val response = result.credential.data.getString(AUTHENTICATION_RESPONSE_KEY)
 				
 				if (response == null) {
 					promise.reject(ERROR_TAG, "No response received from credential manager")
@@ -187,35 +175,19 @@ class AmplifyRTNCoreModule(reactContext: ReactApplicationContext) :
 		}
 	}
 
-    private fun handlePasskeyAuthenticationException(e: GetCredentialException): String {
-        e.printStackTrace()
-        when (e) {
-            is GetPublicKeyCredentialDomException -> {
-                return e.errorMessage.toString()
-            }
-            is GetCredentialCancellationException -> {
-                return "UserCancelled"
-            }
-            is GetCredentialInterruptedException -> {
-                return "Interrupted"
-            }
-            is GetCredentialProviderConfigurationException -> {
-                return "NotConfigured"
-            }
-            is GetCredentialUnknownException -> {
-                return "UnknownError"
-            }
-            is GetCredentialUnsupportedException -> {
-                return "NotSupported"
-            }
-            is NoCredentialException -> {
-                return "NoCredentials"
-            }
-            else -> {
-                return e.errorMessage.toString()
-            }
-        }
-    }
+	private fun handlePasskeyAuthenticationException(e: GetCredentialException): String {
+		e.printStackTrace()
+		return when (e) {
+			is GetPublicKeyCredentialDomException -> e.errorMessage.toString()
+			is GetCredentialCancellationException -> ERROR_USER_CANCELLED
+			is GetCredentialInterruptedException -> ERROR_INTERRUPTED
+			is GetCredentialProviderConfigurationException -> ERROR_NOT_CONFIGURED
+			is GetCredentialUnknownException -> ERROR_UNKNOWN
+			is GetCredentialUnsupportedException -> ERROR_NOT_SUPPORTED
+			is NoCredentialException -> ERROR_NO_CREDENTIALS
+			else -> e.errorMessage.toString()
+		}
+	}
 
     @ReactMethod
 	fun getIsPasskeySupported(promise: Promise) {

--- a/packages/react-native/android/src/main/kotlin/com/amazonaws/amplify/rtncore/AmplifyRTNCoreModule.kt
+++ b/packages/react-native/android/src/main/kotlin/com/amazonaws/amplify/rtncore/AmplifyRTNCoreModule.kt
@@ -10,8 +10,22 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
 
+import androidx.credentials.CredentialManager
+import androidx.credentials.CreatePublicKeyCredentialRequest
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.exceptions.*
+import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException
+import androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentialDomException
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
 class AmplifyRTNCoreModule(reactContext: ReactApplicationContext) :
 	ReactContextBaseJavaModule(reactContext) {
+	private val coroutineScope = CoroutineScope(Dispatchers.Default)
+
 	override fun getName(): String {
 		return NAME
 	}
@@ -39,5 +53,118 @@ class AmplifyRTNCoreModule(reactContext: ReactApplicationContext) :
 
 	companion object {
 		const val NAME = "AmplifyRTNCore"
+	}
+
+	@ReactMethod
+	fun createPasskey(requestJson: String, promise: Promise) {
+		val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
+		val createPublicKeyCredentialRequest = CreatePublicKeyCredentialRequest(requestJson)
+
+		coroutineScope.launch {
+			try {
+				val result = currentActivity?.let {
+					credentialManager.createCredential(
+						it,
+						createPublicKeyCredentialRequest
+					)
+				}
+
+				val response =
+					result?.data?.getString("androidx.credentials.BUNDLE_KEY_REGISTRATION_RESPONSE_JSON")
+				promise.resolve(response)
+			} catch (e: CreateCredentialException) {
+				promise.reject("Passkey", handlePasskeyRegistrationException(e))
+			}
+		}
+	}
+
+	private fun handlePasskeyRegistrationException(e: CreateCredentialException): String {
+		e.printStackTrace()
+		when (e) {
+			is CreatePublicKeyCredentialDomException -> {
+				return e.errorMessage.toString()
+			}
+
+			is CreateCredentialCancellationException -> {
+				return "UserCancelled"
+			}
+
+			is CreateCredentialInterruptedException -> {
+				return "Interrupted"
+			}
+
+			is CreateCredentialProviderConfigurationException -> {
+				return "NotConfigured"
+			}
+
+			is CreateCredentialUnknownException -> {
+				return "UnknownError"
+			}
+
+			is CreateCredentialUnsupportedException -> {
+				return "NotSupported"
+			}
+
+			else -> {
+				return e.errorMessage.toString()
+			}
+		}
+	}
+
+	@ReactMethod
+	fun getPasskey(requestJson: String, promise: Promise) {
+		val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
+		val getCredentialRequest =
+			GetCredentialRequest(listOf(GetPublicKeyCredentialOption(requestJson)))
+
+		coroutineScope.launch {
+			try {
+				val result =
+					currentActivity?.let { credentialManager.getCredential(it, getCredentialRequest) }
+
+				val response =
+					result?.credential?.data?.getString("androidx.credentials.BUNDLE_KEY_AUTHENTICATION_RESPONSE_JSON")
+				promise.resolve(response)
+			} catch (e: GetCredentialException) {
+				promise.reject("Passkey", handlePasskeyAuthenticationException(e))
+			}
+		}
+	}
+
+	private fun handlePasskeyAuthenticationException(e: GetCredentialException): String {
+		e.printStackTrace()
+		when (e) {
+			is GetPublicKeyCredentialDomException -> {
+				return e.errorMessage.toString()
+			}
+
+			is GetCredentialCancellationException -> {
+				return "UserCancelled"
+			}
+
+			is GetCredentialInterruptedException -> {
+				return "Interrupted"
+			}
+
+			is GetCredentialProviderConfigurationException -> {
+				return "NotConfigured"
+			}
+
+			is GetCredentialUnknownException -> {
+				return "UnknownError"
+			}
+
+			is GetCredentialUnsupportedException -> {
+				return "NotSupported"
+			}
+
+			is NoCredentialException -> {
+				return "NoCredentials"
+			}
+
+			else -> {
+				return e.errorMessage.toString()
+			}
+		}
 	}
 }

--- a/packages/react-native/android/src/main/kotlin/com/amazonaws/amplify/rtncore/AmplifyRTNCoreModule.kt
+++ b/packages/react-native/android/src/main/kotlin/com/amazonaws/amplify/rtncore/AmplifyRTNCoreModule.kt
@@ -4,167 +4,237 @@
 package com.amazonaws.amplify.rtncore
 
 import android.os.Build
-import com.facebook.react.bridge.Promise
-import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.ReactMethod
-import com.facebook.react.bridge.ReadableMap
-
-import androidx.credentials.CredentialManager
+import android.content.pm.PackageManager
 import androidx.credentials.CreatePublicKeyCredentialRequest
+import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetPublicKeyCredentialOption
 import androidx.credentials.exceptions.*
 import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException
 import androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentialDomException
-
-import kotlinx.coroutines.Dispatchers
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class AmplifyRTNCoreModule(reactContext: ReactApplicationContext) :
-	ReactContextBaseJavaModule(reactContext) {
-	private val coroutineScope = CoroutineScope(Dispatchers.Default)
+        ReactContextBaseJavaModule(reactContext) {
+    private val coroutineScope = CoroutineScope(Dispatchers.Default)
 
-	override fun getName(): String {
-		return NAME
+    override fun getName(): String {
+        return NAME
+    }
+
+    @ReactMethod
+    fun computeModPow(
+            payload: ReadableMap,
+            promise: Promise,
+    ) {
+        BigInteger.computeModPow(payload, promise)
+    }
+
+    @ReactMethod
+    fun computeS(
+            payload: ReadableMap,
+            promise: Promise,
+    ) {
+        BigInteger.computeS(payload, promise)
+    }
+
+    @ReactMethod
+    fun getDeviceName(promise: Promise) {
+        promise.resolve(Build.MODEL)
+    }
+
+    companion object {
+        const val NAME = "AmplifyRTNCore"
+		private const val ERROR_TAG = "Passkey"
+		private const val REGISTRATION_RESPONSE_KEY = "androidx.credentials.BUNDLE_KEY_REGISTRATION_RESPONSE_JSON"
+    	private const val AUTHENTICATION_RESPONSE_KEY = "androidx.credentials.BUNDLE_KEY_AUTHENTICATION_RESPONSE_JSON"
+    }
+
+	private fun isValidJson(json: String): Boolean {
+		return try {
+			org.json.JSONObject(json)
+			true
+		} catch (e: Exception) {
+			false
+		}
 	}
 
-	@ReactMethod
-	fun computeModPow(
-		payload: ReadableMap,
-		promise: Promise,
-	) {
-		BigInteger.computeModPow(payload, promise)
-	}
-
-	@ReactMethod
-	fun computeS(
-		payload: ReadableMap,
-		promise: Promise,
-	) {
-		BigInteger.computeS(payload, promise)
-	}
-
-	@ReactMethod
-	fun getDeviceName(promise: Promise) {
-		promise.resolve(Build.MODEL)
-	}
-
-	companion object {
-		const val NAME = "AmplifyRTNCore"
-	}
-
-	@ReactMethod
-	fun createPasskey(requestJson: String, promise: Promise) {
-		val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
-		val createPublicKeyCredentialRequest = CreatePublicKeyCredentialRequest(requestJson)
-
+    @ReactMethod
+    fun createPasskey(requestJson: String, promise: Promise) {
+		// Early validations
+		if (currentActivity == null) {
+			promise.reject(ERROR_TAG, "Activity is null")
+			return
+		}
+	
+		if (requestJson.isBlank()) {
+			promise.reject(ERROR_TAG, "Invalid request: empty input")
+			return
+		}
+	
+		if (!isValidJson(requestJson)) {
+			promise.reject(ERROR_TAG, "Invalid JSON input")
+			return
+		}
+	
 		coroutineScope.launch {
 			try {
-				val result = currentActivity?.let {
-					credentialManager.createCredential(
-						it,
-						createPublicKeyCredentialRequest
-					)
+				val credentialManager = CredentialManager
+					.create(reactApplicationContext.applicationContext)
+				
+				val result = credentialManager.createCredential(
+					currentActivity!!,
+					CreatePublicKeyCredentialRequest(requestJson)
+				)
+	
+				val response = result.data.getString(
+					"androidx.credentials.BUNDLE_KEY_REGISTRATION_RESPONSE_JSON"
+				)
+				
+				if (response == null) {
+					promise.reject(ERROR_TAG, "No response received from credential manager")
+				} else {
+					promise.resolve(response)
 				}
-
-				val response =
-					result?.data?.getString("androidx.credentials.BUNDLE_KEY_REGISTRATION_RESPONSE_JSON")
-				promise.resolve(response)
 			} catch (e: CreateCredentialException) {
-				promise.reject("Passkey", handlePasskeyRegistrationException(e))
+				promise.reject(ERROR_TAG, handlePasskeyRegistrationException(e))
+			} catch (e: IllegalStateException) {
+				promise.reject(ERROR_TAG, "Activity was destroyed during operation")
+			} catch (e: Exception) {
+				promise.reject(ERROR_TAG, "Unknown error: ${e.message}")
 			}
 		}
 	}
 
-	private fun handlePasskeyRegistrationException(e: CreateCredentialException): String {
-		e.printStackTrace()
-		when (e) {
-			is CreatePublicKeyCredentialDomException -> {
-				return e.errorMessage.toString()
-			}
+    private fun handlePasskeyRegistrationException(e: CreateCredentialException): String {
+        e.printStackTrace()
+        when (e) {
+            is CreatePublicKeyCredentialDomException -> {
+                return e.errorMessage.toString()
+            }
+            is CreateCredentialCancellationException -> {
+                return "UserCancelled"
+            }
+            is CreateCredentialInterruptedException -> {
+                return "Interrupted"
+            }
+            is CreateCredentialProviderConfigurationException -> {
+                return "NotConfigured"
+            }
+            is CreateCredentialUnknownException -> {
+                return "UnknownError"
+            }
+            is CreateCredentialUnsupportedException -> {
+                return "NotSupported"
+            }
+            else -> {
+                return e.errorMessage.toString()
+            }
+        }
+    }
 
-			is CreateCredentialCancellationException -> {
-				return "UserCancelled"
-			}
-
-			is CreateCredentialInterruptedException -> {
-				return "Interrupted"
-			}
-
-			is CreateCredentialProviderConfigurationException -> {
-				return "NotConfigured"
-			}
-
-			is CreateCredentialUnknownException -> {
-				return "UnknownError"
-			}
-
-			is CreateCredentialUnsupportedException -> {
-				return "NotSupported"
-			}
-
-			else -> {
-				return e.errorMessage.toString()
-			}
+    @ReactMethod
+    fun getPasskey(requestJson: String, promise: Promise) {
+		// Early validations
+		if (currentActivity == null) {
+			promise.reject(ERROR_TAG, "Activity is null")
+			return
 		}
-	}
-
-	@ReactMethod
-	fun getPasskey(requestJson: String, promise: Promise) {
-		val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
-		val getCredentialRequest =
-			GetCredentialRequest(listOf(GetPublicKeyCredentialOption(requestJson)))
-
+	
+		if (requestJson.isBlank()) {
+			promise.reject(ERROR_TAG, "Invalid request: empty input")
+			return
+		}
+	
+		if (!isValidJson(requestJson)) {
+			promise.reject(ERROR_TAG, "Invalid JSON input")
+			return
+		}
+	
 		coroutineScope.launch {
 			try {
-				val result =
-					currentActivity?.let { credentialManager.getCredential(it, getCredentialRequest) }
-
-				val response =
-					result?.credential?.data?.getString("androidx.credentials.BUNDLE_KEY_AUTHENTICATION_RESPONSE_JSON")
-				promise.resolve(response)
+				val credentialManager = CredentialManager
+					.create(reactApplicationContext.applicationContext)
+				
+				val result = credentialManager.getCredential(
+					currentActivity!!,
+					GetCredentialRequest(listOf(GetPublicKeyCredentialOption(requestJson)))
+				)
+	
+				val response = result.credential.data.getString(
+					"androidx.credentials.BUNDLE_KEY_AUTHENTICATION_RESPONSE_JSON"
+				)
+				
+				if (response == null) {
+					promise.reject(ERROR_TAG, "No response received from credential manager")
+				} else {
+					promise.resolve(response)
+				}
 			} catch (e: GetCredentialException) {
-				promise.reject("Passkey", handlePasskeyAuthenticationException(e))
+				promise.reject(ERROR_TAG, handlePasskeyAuthenticationException(e))
+			} catch (e: IllegalStateException) {
+				promise.reject(ERROR_TAG, "Activity was destroyed during operation")
+			} catch (e: Exception) {
+				promise.reject(ERROR_TAG, "Unknown error: ${e.message}")
 			}
 		}
 	}
 
-	private fun handlePasskeyAuthenticationException(e: GetCredentialException): String {
-		e.printStackTrace()
-		when (e) {
-			is GetPublicKeyCredentialDomException -> {
-				return e.errorMessage.toString()
-			}
+    private fun handlePasskeyAuthenticationException(e: GetCredentialException): String {
+        e.printStackTrace()
+        when (e) {
+            is GetPublicKeyCredentialDomException -> {
+                return e.errorMessage.toString()
+            }
+            is GetCredentialCancellationException -> {
+                return "UserCancelled"
+            }
+            is GetCredentialInterruptedException -> {
+                return "Interrupted"
+            }
+            is GetCredentialProviderConfigurationException -> {
+                return "NotConfigured"
+            }
+            is GetCredentialUnknownException -> {
+                return "UnknownError"
+            }
+            is GetCredentialUnsupportedException -> {
+                return "NotSupported"
+            }
+            is NoCredentialException -> {
+                return "NoCredentials"
+            }
+            else -> {
+                return e.errorMessage.toString()
+            }
+        }
+    }
 
-			is GetCredentialCancellationException -> {
-				return "UserCancelled"
-			}
+    @ReactMethod
+	fun getIsPasskeySupported(promise: Promise) {
+    	try {
+    	    val credentialManager = CredentialManager.create(reactApplicationContext.applicationContext)
 
-			is GetCredentialInterruptedException -> {
-				return "Interrupted"
-			}
+        	// Check for minimum API level that supports Credential Manager
+        	val hasMinimumApiLevel = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
 
-			is GetCredentialProviderConfigurationException -> {
-				return "NotConfigured"
-			}
+        	// Ensure the device has biometric capabilities
+        	val hasBiometricSupport = reactApplicationContext.packageManager.hasSystemFeature(
+        	    PackageManager.FEATURE_FINGERPRINT
+        	)
 
-			is GetCredentialUnknownException -> {
-				return "UnknownError"
-			}
-
-			is GetCredentialUnsupportedException -> {
-				return "NotSupported"
-			}
-
-			is NoCredentialException -> {
-				return "NoCredentials"
-			}
-
-			else -> {
-				return e.errorMessage.toString()
-			}
-		}
+        	val isSupported = hasMinimumApiLevel && hasBiometricSupport
+        	promise.resolve(isSupported)
+    	} catch (e: Exception) {
+    	    e.printStackTrace()
+    	    promise.reject("PasskeyNotSupported", "Failed to check passkey support: ${e.message}")
+    	}
 	}
 }

--- a/packages/react-native/ios/AmplifyRTNCore.mm
+++ b/packages/react-native/ios/AmplifyRTNCore.mm
@@ -3,21 +3,33 @@
 
 #import <React/RCTBridgeModule.h>
 
-@interface RCT_EXTERN_MODULE(AmplifyRTNCore, NSObject)
+@interface RCT_EXTERN_MODULE (AmplifyRTNCore, NSObject)
 
-RCT_EXTERN_METHOD(computeModPow:(NSDictionary*)payload
-                  withResolver:(RCTPromiseResolveBlock)resolve
-                  withRejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(computeModPow
+                  : (NSDictionary *)payload withResolver
+                  : (RCTPromiseResolveBlock)resolve withRejecter
+                  : (RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(computeS:(NSDictionary*)payload
-                  withResolver:(RCTPromiseResolveBlock)resolve
-                  withRejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(computeS
+                  : (NSDictionary *)payload withResolver
+                  : (RCTPromiseResolveBlock)resolve withRejecter
+                  : (RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(getDeviceName:(RCTPromiseResolveBlock)resolve
-                  withResolver:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(getDeviceName
+                  : (RCTPromiseResolveBlock)resolve withResolver
+                  : (RCTPromiseRejectBlock)reject)
 
-+ (BOOL)requiresMainQueueSetup
-{
+RCT_EXTERN_METHOD(getPasskey
+                  : (NSString)request withResolver
+                  : (RCTPromiseResolveBlock)resolve withRejecter
+                  : (RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(createPasskey
+                  : (NSString)request withResolver
+                  : (RCTPromiseResolveBlock)resolve withRejecter
+                  : (RCTPromiseRejectBlock)reject)
+
++ (BOOL)requiresMainQueueSetup {
   return NO;
 }
 

--- a/packages/react-native/ios/AmplifyRTNCore.swift
+++ b/packages/react-native/ios/AmplifyRTNCore.swift
@@ -1,16 +1,24 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import AuthenticationServices
+
 #if canImport(UIKit)
 	import UIKit
 #else
-	import Foundation	
+	import Foundation
 #endif
 
 @objc(AmplifyRTNCore)
 class AmplifyRTNCore: NSObject {
+	var passkeyHandler: RTNPasskeyHandler?
+
 	@objc(multiply:withB:withResolver:withRejecter:)
-	func multiply(a: Float, b: Float, resolve: RCTPromiseResolveBlock, reject _: RCTPromiseRejectBlock) {
+	func multiply(
+		a: Float, b: Float,
+		resolve: RCTPromiseResolveBlock,
+		reject _: RCTPromiseRejectBlock
+	) {
 		resolve(a * b)
 	}
 
@@ -33,7 +41,10 @@ class AmplifyRTNCore: NSObject {
 	}
 
 	@objc(getDeviceName:withResolver:)
-	func getDeviceName(resolve: @escaping RCTPromiseResolveBlock, reject _: @escaping RCTPromiseRejectBlock) {
+	func getDeviceName(
+		resolve: @escaping RCTPromiseResolveBlock,
+		reject _: @escaping RCTPromiseRejectBlock
+	) {
 		var deviceName: String
 		#if canImport(UIKit)
 			deviceName = UIDevice.current.name
@@ -41,5 +52,208 @@ class AmplifyRTNCore: NSObject {
 			deviceName = ProcessInfo.processInfo.hostName
 		#endif
 		resolve(deviceName)
+	}
+
+	@available(iOS 15.0, *)
+	@objc(createPasskey:withResolver:withRejecter:)
+	func createPasskey(
+		_ request: String,
+		resolve: @escaping RCTPromiseResolveBlock,
+		reject: @escaping RCTPromiseRejectBlock
+	) {
+
+		do {
+			passkeyHandler = RTNPasskeyHandler(resolve, reject)
+
+			let requestData = request.data(using: String.Encoding.utf8)!
+			let requestJson: CreatePasskeyOptions = try JSONDecoder().decode(
+				CreatePasskeyOptions.self, from: requestData)
+
+			let platformProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(
+				relyingPartyIdentifier: requestJson.rp.id)
+
+			let platformKeyRequest = platformProvider.createCredentialRegistrationRequest(
+				challenge: requestJson.challenge.decodeBase64Url()!,
+				name: requestJson.user.name,
+				userID: requestJson.user.id.decodeBase64Url()!
+			)
+
+			let authController = ASAuthorizationController(authorizationRequests: [
+				platformKeyRequest
+			])
+
+			authController.delegate = self
+			authController.presentationContextProvider = self
+			authController.performRequests()
+		} catch let error as NSError {
+			reject(error.debugDescription, "create passkey error", nil)
+		}
+
+	}
+
+	@available(iOS 15.0, *)
+	@objc(getPasskey:withResolver:withRejecter:)
+	func getPasskey(
+		_ request: String,
+		resolve: @escaping RCTPromiseResolveBlock,
+		reject: @escaping RCTPromiseRejectBlock
+	) {
+		do {
+			passkeyHandler = RTNPasskeyHandler(resolve, reject)
+
+			let requestData = request.data(using: .utf8)!
+			let requestJson = try JSONDecoder().decode(GetPasskeyOptions.self, from: requestData)
+
+			let platformProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(
+				relyingPartyIdentifier: requestJson.rpId)
+
+			let platformKeyRequest = platformProvider.createCredentialAssertionRequest(
+				challenge: requestJson.challenge.decodeBase64Url()!)
+
+			let authController = ASAuthorizationController(authorizationRequests: [
+				platformKeyRequest
+			])
+
+			authController.delegate = self
+			authController.presentationContextProvider = self
+			authController.performRequests()
+		} catch let error as NSError {
+			reject(error.debugDescription, "get passkey error", nil)
+		}
+	}
+}
+
+@available(iOS 15.0, *)
+extension AmplifyRTNCore: ASAuthorizationControllerDelegate {
+	func authorizationController(
+		controller: ASAuthorizationController,
+		didCompleteWithAuthorization authorization: ASAuthorization
+	) {
+		guard let handler = passkeyHandler else {
+			print("no handler 1")
+			return
+		}
+
+		do {
+			switch authorization.credential {
+			case let credential as ASAuthorizationPlatformPublicKeyCredentialRegistration:
+				let createResult: NSDictionary = [
+					"id": credential.credentialID.toBase64Url(),
+					"rawId": credential.credentialID.toBase64Url(),
+					"type": "public-key",
+					"response": [
+						"attestationObject": credential.rawAttestationObject!
+							.toBase64Url(),
+						"clientDataJSON": credential.rawClientDataJSON.toBase64Url(),
+						"transports": ["internal"],
+					],
+					"authenticatorAttachment": "platform",
+				]
+
+				let jsonData = try JSONSerialization.data(withJSONObject: createResult)
+
+				if let jsonString = String(data: jsonData, encoding: .utf8) {
+					handler.resolve(jsonString)
+				}
+			case let credential as ASAuthorizationPlatformPublicKeyCredentialAssertion:
+				let getResult: NSDictionary = [
+					"id": credential.credentialID.toBase64Url(),
+					"rawId": credential.credentialID.toBase64Url(),
+					"type": "public-key",
+					"response": [
+						"authenticatorData": credential.rawAuthenticatorData
+							.toBase64Url(),
+						"clientDataJSON": credential.rawClientDataJSON.toBase64Url(),
+						"signature": credential.signature.toBase64Url(),
+					],
+					"authenticatorAttachment": "platform",
+				]
+				let jsonData = try JSONSerialization.data(withJSONObject: getResult)
+
+				if let jsonString = String(data: jsonData, encoding: .utf8) {
+					handler.resolve(jsonString)
+				}
+			default:
+				handler.reject("ERROR", "not a valid credential type", nil)
+			}
+		} catch let error as NSError {
+			handler.reject("ERROR", "error in authorization controller", nil)
+		}
+	}
+	func authorizationController(
+		controller: ASAuthorizationController,
+		didCompleteWithError error: any Error
+	) {
+		guard let handler = passkeyHandler else {
+			print("no handler 2")
+			return
+		}
+		handler.reject("ERROR", "An unexpected error occurred", nil)
+	}
+}
+
+@available(iOS 15.0, *)
+extension AmplifyRTNCore: ASAuthorizationControllerPresentationContextProviding {
+	func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+		return ASPresentationAnchor()
+	}
+}
+
+@available(iOS 15.0, *)
+struct CreatePasskeyOptions: Decodable {
+	let challenge: String
+	struct RelyingParty: Decodable {
+		let id: String
+	}
+	struct User: Decodable {
+		let id: String
+		let name: String
+	}
+
+	let user: User
+	let rp: RelyingParty
+
+}
+
+struct GetPasskeyOptions: Decodable {
+	let challenge: String
+	let rpId: String
+}
+
+struct RTNPasskeyHandler {
+	var resolve: RCTPromiseResolveBlock
+	var reject: RCTPromiseRejectBlock
+
+	init(
+		_ resolve: @escaping RCTPromiseResolveBlock,
+		_ reject: @escaping RCTPromiseRejectBlock
+	) {
+		self.resolve = resolve
+		self.reject = reject
+	}
+}
+
+@available(iOS 15.0, *)
+extension Data {
+	fileprivate func toBase64Url() -> String {
+		return self.base64EncodedString()
+			.replacingOccurrences(of: "+", with: "-")
+			.replacingOccurrences(of: "/", with: "_")
+			.replacingOccurrences(of: "=", with: "")
+	}
+}
+
+@available(iOS 15.0, *)
+extension String {
+	fileprivate func decodeBase64Url() -> Data? {
+		var base64 =
+			self
+			.replacingOccurrences(of: "-", with: "+")
+			.replacingOccurrences(of: "_", with: "/")
+		if base64.count % 4 != 0 {
+			base64.append(String(repeating: "=", count: 4 - base64.count % 4))
+		}
+
+		return Data(base64Encoded: base64)
 	}
 }

--- a/packages/react-native/src/apis/createPasskey.ts
+++ b/packages/react-native/src/apis/createPasskey.ts
@@ -1,0 +1,5 @@
+import { nativeModule } from '../nativeModule';
+import { RTNCore } from '../types';
+
+export const createPasskey: RTNCore['createPasskey'] =
+	nativeModule.createPasskey;

--- a/packages/react-native/src/apis/getIsPasskeySupported.ts
+++ b/packages/react-native/src/apis/getIsPasskeySupported.ts
@@ -1,0 +1,13 @@
+import { Platform } from 'react-native';
+
+export const getIsPasskeySupported = () => {
+	if (Platform.OS === 'android') {
+		return Platform.Version > 28;
+	}
+
+	if (Platform.OS === 'ios') {
+		return parseInt(Platform.Version, 10) >= 15;
+	}
+
+	return false;
+};

--- a/packages/react-native/src/apis/getPasskey.ts
+++ b/packages/react-native/src/apis/getPasskey.ts
@@ -1,0 +1,4 @@
+import { nativeModule } from '../nativeModule';
+import { RTNCore } from '../types';
+
+export const getPasskey: RTNCore['getPasskey'] = nativeModule.getPasskey;

--- a/packages/react-native/src/apis/index.ts
+++ b/packages/react-native/src/apis/index.ts
@@ -5,3 +5,6 @@ export { computeModPow } from './computeModPow';
 export { computeS } from './computeS';
 export { getOperatingSystem } from './getOperatingSystem';
 export { getDeviceName } from './getDeviceName';
+export { getPasskey } from './getPasskey';
+export { createPasskey } from './createPasskey';
+export { getIsPasskeySupported } from './getIsPasskeySupported';

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -6,6 +6,9 @@ export {
 	computeS,
 	getOperatingSystem,
 	getDeviceName,
+	getPasskey,
+	createPasskey,
+	getIsPasskeySupported,
 } from './apis';
 export {
 	loadAmplifyPushNotification,

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -18,4 +18,7 @@ export interface RTNCore {
 	}): Promise<string>;
 
 	getDeviceName(): Promise<string>;
+
+	getPasskey(a: string): Promise<string>;
+	createPasskey(a: string): Promise<string>;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- The purpose of this PR is to add support for React Native Android to be able to use passkey (WebAuthN) to authenticate users.
- Add Platform-specific error handling for native responses and Type definitions that handle platform differences between web and native 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
