### PR TITLE
chore(aws-amplify/adapter-nextjs): remove extraneous deps

### DIFF
--- a/packages/adapter-nextjs/__tests__/api/generateServerClient.test.ts
+++ b/packages/adapter-nextjs/__tests__/api/generateServerClient.test.ts
@@ -1,5 +1,5 @@
-import { ResourcesConfig } from '@aws-amplify/core';
-import { parseAmplifyConfig } from '@aws-amplify/core/internals/utils';
+import { ResourcesConfig } from 'aws-amplify';
+import { parseAmplifyConfig } from 'aws-amplify/utils';
 
 import {
 	generateServerClientUsingCookies,
@@ -34,8 +34,8 @@ jest.mock('../../src/utils', () => ({
 	createRunWithAmplifyServerContext: jest.fn(() => jest.fn()),
 	createCookieStorageAdapterFromNextServerContext: jest.fn(),
 }));
-jest.mock('@aws-amplify/core/internals/utils', () => ({
-	...jest.requireActual('@aws-amplify/core/internals/utils'),
+jest.mock('aws-amplify/utils', () => ({
+	...jest.requireActual('aws-amplify/utils'),
 	parseAmplifyConfig: jest.fn(() => mockAmplifyConfig),
 }));
 
@@ -95,7 +95,7 @@ describe('generateServerClient', () => {
 			graphql: mockGraphql,
 		}));
 
-		jest.mock('@aws-amplify/core/internals/adapter-core', () => ({
+		jest.mock('aws-amplify/adapter-core/internals', () => ({
 			getAmplifyServerContext: jest.fn(),
 		}));
 

--- a/packages/adapter-nextjs/__tests__/auth/createAuthRouteHandlersFactory.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/createAuthRouteHandlersFactory.test.ts
@@ -2,7 +2,7 @@ import { ResourcesConfig } from 'aws-amplify';
 import {
 	assertOAuthConfig,
 	assertTokenProviderConfig,
-} from '@aws-amplify/core/internals/utils';
+} from 'aws-amplify/adapter-core/internals';
 
 import { createAuthRouteHandlersFactory } from '../../src/auth/createAuthRouteHandlersFactory';
 import { handleAuthApiRouteRequestForAppRouter } from '../../src/auth/handleAuthApiRouteRequestForAppRouter';
@@ -21,7 +21,11 @@ import {
 	isValidOrigin,
 } from '../../src/auth/utils';
 
-jest.mock('@aws-amplify/core/internals/utils');
+jest.mock('aws-amplify/adapter-core/internals', () => ({
+	...jest.requireActual('aws-amplify/adapter-core/internals'),
+	assertOAuthConfig: jest.fn(),
+	assertTokenProviderConfig: jest.fn(),
+}));
 jest.mock('../../src/auth/handleAuthApiRouteRequestForAppRouter');
 jest.mock('../../src/auth/handleAuthApiRouteRequestForPagesRouter');
 jest.mock('../../src/auth/utils');

--- a/packages/adapter-nextjs/__tests__/auth/handleAuthApiRouteRequestForAppRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handleAuthApiRouteRequestForAppRouter.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 import { NextRequest } from 'next/server';
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 
 import { handleAuthApiRouteRequestForAppRouter } from '../../src/auth/handleAuthApiRouteRequestForAppRouter';
 import { CreateAuthRoutesHandlersInput } from '../../src/auth/types';

--- a/packages/adapter-nextjs/__tests__/auth/handleAuthApiRouteRequestForPagesRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handleAuthApiRouteRequestForPagesRouter.test.ts
@@ -1,4 +1,4 @@
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 import { NextApiRequest } from 'next';
 
 import { handleAuthApiRouteRequestForPagesRouter } from '../../src/auth/handleAuthApiRouteRequestForPagesRouter';

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInCallbackRequest.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInCallbackRequest.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 import { NextRequest } from 'next/server.js';
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 import { CookieStorage } from 'aws-amplify/adapter-core';
 
 import { handleSignInCallbackRequest } from '../../../src/auth/handlers/handleSignInCallbackRequest';

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInCallbackRequestForPagesRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInCallbackRequestForPagesRouter.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 import { CookieStorage } from 'aws-amplify/adapter-core';
 import { NextApiRequest } from 'next';
 

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInSignUpRequest.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInSignUpRequest.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 import { CookieStorage } from 'aws-amplify/adapter-core';
 
 import { handleSignInSignUpRequest } from '../../../src/auth/handlers/handleSignInSignUpRequest';

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInSignUpRequestForPagesRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInSignUpRequestForPagesRouter.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 import { CookieStorage } from 'aws-amplify/adapter-core';
 import { NextApiRequest } from 'next';
 

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutCallbackRequest.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutCallbackRequest.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 import {
 	AUTH_KEY_PREFIX,
 	CookieStorage,

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutCallbackRequestForPagesRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutCallbackRequestForPagesRouter.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 import {
 	AUTH_KEY_PREFIX,
 	CookieStorage,

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutRequest.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutRequest.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 
 import { handleSignOutRequest } from '../../../src/auth/handlers/handleSignOutRequest';
 import {

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutRequestForPagesRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutRequestForPagesRouter.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 
 import { handleSignOutRequestForPagesRouter } from '../../../src/auth/handlers/handleSignOutRequestForPagesRouter';
 import {

--- a/packages/adapter-nextjs/__tests__/auth/utils/authNTokens.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/utils/authNTokens.test.ts
@@ -1,4 +1,4 @@
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 
 import { OAuthTokenExchangeResult } from '../../../src/auth/types';
 import {

--- a/packages/adapter-nextjs/__tests__/auth/utils/createAuthFlowProofs.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/utils/createAuthFlowProofs.test.ts
@@ -1,9 +1,9 @@
-import { urlSafeEncode } from '@aws-amplify/core/internals/utils';
+import { urlSafeEncode } from 'aws-amplify/adapter-core/internals';
 import { generateCodeVerifier, generateState } from 'aws-amplify/adapter-core';
 
 import { createAuthFlowProofs } from '../../../src/auth/utils';
 
-jest.mock('@aws-amplify/core/internals/utils');
+jest.mock('aws-amplify/adapter-core/internals');
 jest.mock('aws-amplify/adapter-core');
 
 const mockUrlSafeEncode = jest.mocked(urlSafeEncode);

--- a/packages/adapter-nextjs/__tests__/auth/utils/getAccessTokenUsername.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/utils/getAccessTokenUsername.test.ts
@@ -1,8 +1,8 @@
-import { decodeJWT } from '@aws-amplify/core';
+import { decodeJWT } from 'aws-amplify/adapter-core/internals';
 
 import { getAccessTokenUsername } from '../../../src/auth/utils/getAccessTokenUsername';
 
-jest.mock('@aws-amplify/core');
+jest.mock('aws-amplify/adapter-core/internals');
 
 const mockDecodeJWT = jest.mocked(decodeJWT);
 

--- a/packages/adapter-nextjs/__tests__/auth/utils/hasActiveUserSession.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/utils/hasActiveUserSession.test.ts
@@ -3,7 +3,7 @@
  */
 import { getCurrentUser } from 'aws-amplify/auth/server';
 import { NextRequest } from 'next/server';
-import { AuthUser } from '@aws-amplify/auth/cognito';
+import { AuthUser } from 'aws-amplify/auth';
 import { NextApiRequest } from 'next';
 
 import {

--- a/packages/adapter-nextjs/__tests__/auth/utils/resolveRedirectUrl.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/utils/resolveRedirectUrl.test.ts
@@ -1,4 +1,4 @@
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 
 import {
 	resolveRedirectSignInUrl,

--- a/packages/adapter-nextjs/__tests__/createServerRunner.test.ts
+++ b/packages/adapter-nextjs/__tests__/createServerRunner.test.ts
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ResourcesConfig, sharedInMemoryStorage } from '@aws-amplify/core';
+import { ResourcesConfig } from 'aws-amplify';
+import { sharedInMemoryStorage } from 'aws-amplify/utils';
 
 import { NextServer } from '../src/types';
 
@@ -68,7 +69,8 @@ describe('createServerRunner', () => {
 			createUserPoolsTokenProvider: mockCreateUserPoolsTokenProvider,
 			runWithAmplifyServerContext: mockRunWithAmplifyServerContextCore,
 		}));
-		jest.doMock('@aws-amplify/core/internals/utils', () => ({
+		jest.doMock('aws-amplify/utils', () => ({
+			...jest.requireActual('aws-amplify/utils'),
 			parseAmplifyConfig: mockParseAmplifyConfig,
 		}));
 		createRunWithAmplifyServerContextSpy = jest.spyOn(

--- a/packages/adapter-nextjs/src/api/createServerRunnerForAPI.ts
+++ b/packages/adapter-nextjs/src/api/createServerRunnerForAPI.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ResourcesConfig } from '@aws-amplify/core';
-import { parseAmplifyConfig } from '@aws-amplify/core/internals/utils';
+import { ResourcesConfig } from 'aws-amplify';
+import { parseAmplifyConfig } from 'aws-amplify/utils';
 
 import { createRunWithAmplifyServerContext } from '../utils';
 import { NextServer } from '../types';

--- a/packages/adapter-nextjs/src/api/generateServerClient.ts
+++ b/packages/adapter-nextjs/src/api/generateServerClient.ts
@@ -1,21 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { generateClientWithAmplifyInstance } from '@aws-amplify/api/internals';
+import {
+	CommonPublicClientOptions,
+	DefaultCommonClientOptions,
+	V6ClientSSRCookies,
+	V6ClientSSRRequest,
+	generateClientWithAmplifyInstance,
+} from 'aws-amplify/api/internals';
 import { generateClient } from 'aws-amplify/api/server';
 import {
 	AmplifyServerContextError,
 	getAmplifyServerContext,
-} from '@aws-amplify/core/internals/adapter-core';
-import {
-	V6ClientSSRCookies,
-	V6ClientSSRRequest,
-} from '@aws-amplify/api-graphql';
-import {
-	CommonPublicClientOptions,
-	DefaultCommonClientOptions,
-} from '@aws-amplify/api-graphql/internals';
-import { parseAmplifyConfig } from '@aws-amplify/core/internals/utils';
+} from 'aws-amplify/adapter-core/internals';
+import { parseAmplifyConfig } from 'aws-amplify/utils';
 
 import { NextServer } from '../types';
 

--- a/packages/adapter-nextjs/src/api/index.ts
+++ b/packages/adapter-nextjs/src/api/index.ts
@@ -4,7 +4,7 @@
 import {
 	V6ClientSSRCookies,
 	V6ClientSSRRequest,
-} from '@aws-amplify/api-graphql';
+} from 'aws-amplify/api/internals';
 
 export {
 	generateServerClientUsingReqRes,

--- a/packages/adapter-nextjs/src/auth/createAuthRouteHandlersFactory.ts
+++ b/packages/adapter-nextjs/src/auth/createAuthRouteHandlersFactory.ts
@@ -3,15 +3,13 @@
 
 import { NextRequest } from 'next/server';
 import {
-	assertOAuthConfig,
-	assertTokenProviderConfig,
-} from '@aws-amplify/core/internals/utils';
-import { NextApiRequest, NextApiResponse } from 'next';
-import {
 	AmplifyServerContextError,
 	CookieStorage,
-} from '@aws-amplify/core/internals/adapter-core';
-import { OAuthConfig } from '@aws-amplify/core';
+	OAuthConfig,
+	assertOAuthConfig,
+	assertTokenProviderConfig,
+} from 'aws-amplify/adapter-core/internals';
+import { NextApiRequest, NextApiResponse } from 'next';
 
 import {
 	AuthRoutesHandlerContext,

--- a/packages/adapter-nextjs/src/auth/handlers/types.ts
+++ b/packages/adapter-nextjs/src/auth/handlers/types.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { CookieStorage } from 'aws-amplify/adapter-core';
 

--- a/packages/adapter-nextjs/src/auth/types.ts
+++ b/packages/adapter-nextjs/src/auth/types.ts
@@ -4,7 +4,7 @@
 import { ResourcesConfig } from 'aws-amplify';
 import { NextRequest } from 'next/server';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 import { CookieStorage } from 'aws-amplify/adapter-core';
 
 import { NextServer } from '../types';

--- a/packages/adapter-nextjs/src/auth/utils/authNTokens.ts
+++ b/packages/adapter-nextjs/src/auth/utils/authNTokens.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 
 import { OAUTH_GRANT_TYPE } from '../constant';
 import { OAuthTokenExchangeResult, OAuthTokenRevocationResult } from '../types';

--- a/packages/adapter-nextjs/src/auth/utils/createAuthFlowProofs.ts
+++ b/packages/adapter-nextjs/src/auth/utils/createAuthFlowProofs.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { urlSafeEncode } from '@aws-amplify/core/internals/utils';
+import { urlSafeEncode } from 'aws-amplify/adapter-core/internals';
 import { generateCodeVerifier, generateState } from 'aws-amplify/adapter-core';
 
 export const createAuthFlowProofs = ({

--- a/packages/adapter-nextjs/src/auth/utils/createUrlSearchParams.ts
+++ b/packages/adapter-nextjs/src/auth/utils/createUrlSearchParams.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { OAuthConfig } from '@aws-amplify/core';
+import { OAuthConfig } from 'aws-amplify/adapter-core/internals';
 import { generateCodeVerifier } from 'aws-amplify/adapter-core';
 
 import { resolveIdentityProviderFromUrl } from './resolveIdentityProviderFromUrl';

--- a/packages/adapter-nextjs/src/auth/utils/getAccessTokenUsername.ts
+++ b/packages/adapter-nextjs/src/auth/utils/getAccessTokenUsername.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { decodeJWT } from '@aws-amplify/core';
+import { decodeJWT } from 'aws-amplify/adapter-core/internals';
 
 export const getAccessTokenUsername = (accessToken: string): string =>
 	decodeJWT(accessToken).payload.username as string;

--- a/packages/adapter-nextjs/src/auth/utils/resolveRedirectUrl.ts
+++ b/packages/adapter-nextjs/src/auth/utils/resolveRedirectUrl.ts
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { OAuthConfig } from '@aws-amplify/core';
-import { AmplifyServerContextError } from '@aws-amplify/core/internals/adapter-core';
+import {
+	AmplifyServerContextError,
+	OAuthConfig,
+} from 'aws-amplify/adapter-core/internals';
 
 export const resolveRedirectSignInUrl = (
 	origin: string,

--- a/packages/adapter-nextjs/src/createServerRunner.ts
+++ b/packages/adapter-nextjs/src/createServerRunner.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ResourcesConfig } from 'aws-amplify';
-import { KeyValueStorageMethodValidator } from '@aws-amplify/core/internals/adapter-core';
-import { parseAmplifyConfig } from '@aws-amplify/core/internals/utils';
+import { KeyValueStorageMethodValidator } from 'aws-amplify/adapter-core/internals';
+import { parseAmplifyConfig } from 'aws-amplify/utils';
 
 import { createRunWithAmplifyServerContext } from './utils';
 import { NextServer } from './types';

--- a/packages/adapter-nextjs/src/types/NextServer.ts
+++ b/packages/adapter-nextjs/src/types/NextServer.ts
@@ -8,8 +8,8 @@ import { AmplifyOutputs, LegacyConfig } from 'aws-amplify/adapter-core';
 import {
 	AmplifyServer,
 	CookieStorage,
-} from '@aws-amplify/core/internals/adapter-core';
-import { ResourcesConfig } from '@aws-amplify/core';
+} from 'aws-amplify/adapter-core/internals';
+import { ResourcesConfig } from 'aws-amplify';
 
 import { CreateAuthRouteHandlers } from '../auth/types';
 

--- a/packages/adapter-nextjs/src/utils/createCookieStorageAdapterFromNextServerContext.ts
+++ b/packages/adapter-nextjs/src/utils/createCookieStorageAdapterFromNextServerContext.ts
@@ -5,7 +5,7 @@ import { NextRequest, NextResponse } from 'next/server.js';
 import {
 	AmplifyServerContextError,
 	CookieStorage,
-} from '@aws-amplify/core/internals/adapter-core';
+} from 'aws-amplify/adapter-core/internals';
 
 import { NextServer } from '../types';
 

--- a/packages/adapter-nextjs/src/utils/createRunWithAmplifyServerContext.ts
+++ b/packages/adapter-nextjs/src/utils/createRunWithAmplifyServerContext.ts
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ResourcesConfig, sharedInMemoryStorage } from '@aws-amplify/core';
-import { KeyValueStorageMethodValidator } from '@aws-amplify/core/internals/adapter-core';
+import { ResourcesConfig } from 'aws-amplify';
+import { sharedInMemoryStorage } from 'aws-amplify/utils';
+import { KeyValueStorageMethodValidator } from 'aws-amplify/adapter-core/internals';
 import {
 	createAWSCredentialsAndIdentityIdProvider,
 	createKeyValueStorageFromCookieStorageAdapter,

--- a/packages/adapter-nextjs/src/utils/createTokenValidator.ts
+++ b/packages/adapter-nextjs/src/utils/createTokenValidator.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { KeyValueStorageMethodValidator } from '@aws-amplify/core/internals/adapter-core';
+import { KeyValueStorageMethodValidator } from 'aws-amplify/adapter-core/internals';
 import { CognitoJwtVerifier } from 'aws-jwt-verify';
 
 import { JwtVerifier } from '../types';

--- a/packages/aws-amplify/adapter-core/internals/package.json
+++ b/packages/aws-amplify/adapter-core/internals/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "aws-amplify/adapter-core/internals",
+	"types": "../../dist/esm/adapter-core/internals.d.ts",
+	"main": "../../dist/cjs/adapter-core/internals.js",
+	"module": "../../dist/esm/adapter-core/internals.mjs",
+	"sideEffects": false
+}

--- a/packages/aws-amplify/api/internals/package.json
+++ b/packages/aws-amplify/api/internals/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "aws-amplify/api/internals",
+	"main": "../../dist/cjs/api/internals.js",
+	"browser": "../../dist/esm/api/internals.mjs",
+	"module": "../../dist/esm/api/internals.mjs",
+	"typings": "../../dist/esm/api/internals.d.ts"
+}

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -31,6 +31,12 @@
 			"require": "./dist/cjs/api/index.js",
 			"react-native": "./src/api/index.ts"
 		},
+		"./api/internals": {
+			"types": "./dist/esm/api/internals.d.ts",
+			"import": "./dist/esm/api/internals.mjs",
+			"require": "./dist/cjs/api/internals.js",
+			"react-native": "./src/api/internals.ts"
+		},
 		"./api/server": {
 			"types": "./dist/esm/api/server.d.ts",
 			"import": "./dist/esm/api/server.mjs",
@@ -155,6 +161,11 @@
 			"import": "./dist/esm/adapter-core/index.mjs",
 			"require": "./dist/cjs/adapter-core/index.js"
 		},
+		"./adapter-core/internals": {
+			"types": "./dist/esm/adapter-core/internals.d.ts",
+			"import": "./dist/esm/adapter-core/internals.mjs",
+			"require": "./dist/cjs/adapter-core/internals.js"
+		},
 		"./package.json": "./package.json"
 	},
 	"typesVersions": {
@@ -167,6 +178,9 @@
 			],
 			"api/server": [
 				"./dist/esm/api/server.d.ts"
+			],
+			"api/server/internals": [
+				"./dist/esm/api/internals.d.ts"
 			],
 			"utils": [
 				"./dist/esm/utils/index.d.ts"
@@ -227,6 +241,9 @@
 			],
 			"adapter-core": [
 				"./dist/esm/adapter-core/index.d.ts"
+			],
+			"adapter-core/internals": [
+				"./dist/esm/adapter-core/internals.d.ts"
 			]
 		}
 	},

--- a/packages/aws-amplify/src/adapter-core/internals.ts
+++ b/packages/aws-amplify/src/adapter-core/internals.ts
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export {
+	KeyValueStorageMethodValidator,
+	AmplifyServerContextError,
+	getAmplifyServerContext,
+	AmplifyServer,
+	CookieStorage,
+} from '@aws-amplify/core/internals/adapter-core';
+export { OAuthConfig } from '@aws-amplify/core';
+export {
+	assertOAuthConfig,
+	assertTokenProviderConfig,
+	urlSafeEncode,
+	decodeJWT,
+} from '@aws-amplify/core/internals/utils';

--- a/packages/aws-amplify/src/api/internals.ts
+++ b/packages/aws-amplify/src/api/internals.ts
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { generateClientWithAmplifyInstance } from '@aws-amplify/api/internals';
+export {
+	V6ClientSSRCookies,
+	V6ClientSSRRequest,
+} from '@aws-amplify/api-graphql';
+export {
+	CommonPublicClientOptions,
+	DefaultCommonClientOptions,
+} from '@aws-amplify/api-graphql/internals';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adjusted import/export paths to remove extraneous dependencies from the `adapter-nextjs` package, to ensure this package only needs `aws-amplify` as a peer dependency.

NOTE: When we publish the packages from after merging the feature branch, we need to bump the lower bond of the aws-amplify peer dependency version.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

- build distribution artifacts
- unit tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
