### PR TITLE
Fix: Attach Authorization Token Only When Available 

### DIFF
--- a/packages/api-graphql/src/internals/graphqlAuth.ts
+++ b/packages/api-graphql/src/internals/graphqlAuth.ts
@@ -56,13 +56,12 @@ export async function headerBasedAuth(
 			// `fetchAuthSession()` succeeded but didn't return `tokens`.
 			// This may happen when unauthenticated access is enabled and there is
 			// no user signed in.
-			if (!token) {
-				throw new GraphQLApiError(NO_VALID_AUTH_TOKEN);
+			if (token) {
+				headers = {
+					Authorization: token,
+				};
 			}
-
-			headers = {
-				Authorization: token,
-			};
+			
 			break;
 		}
 		case 'lambda':


### PR DESCRIPTION
Attach the Authorization header only when a token is available, preventing app-level header attachment issues with multiple client configurations.

#### Description of how you validated changes

1. Create multiple Amplify Clients in a single app 
2. Send request from different clients 
3. It will throw `NoValidAuthTokens`  

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)

#### Checklist for repo maintainers

- [x] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [x] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
