### PR TITLE
fix(storage): omit unserializable properties when hash uploadDataOptions

### DIFF
--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -515,7 +515,7 @@
 			"name": "[Storage] uploadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ uploadData }",
-			"limit": "22.87 kB"
+			"limit": "22.95 kB"
 		}
 	]
 }

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -515,7 +515,7 @@
 			"name": "[Storage] uploadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ uploadData }",
-			"limit": "22.95 kB"
+			"limit": "22.99 kB"
 		}
 	]
 }

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -515,7 +515,7 @@
 			"name": "[Storage] uploadData (S3)",
 			"path": "./dist/esm/storage/index.mjs",
 			"import": "{ uploadData }",
-			"limit": "22.99 kB"
+			"limit": "22.95 kB"
 		}
 	]
 }

--- a/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
@@ -44,10 +44,10 @@ const bucket = 'bucket';
 const region = 'region';
 const defaultKey = 'key';
 const defaultContentType = 'application/octet-stream';
-const defaultCacheKey =
-	'o6a/Qw==_8388608_application/octet-stream_bucket_public_key';
+const emptyOptionHash = 'o6a/Qw=='; // crc32 for '{}'
+const defaultCacheKey = `${emptyOptionHash}_8388608_application/octet-stream_bucket_public_key`;
 const testPath = 'testPath/object';
-const testPathCacheKey = `o6a/Qw==_8388608_${defaultContentType}_${bucket}_custom_${testPath}`;
+const testPathCacheKey = `${emptyOptionHash}_8388608_${defaultContentType}_${bucket}_custom_${testPath}`;
 
 const mockCreateMultipartUpload = jest.mocked(createMultipartUpload);
 const mockUploadPart = jest.mocked(uploadPart);
@@ -545,7 +545,7 @@ describe('getMultipartUploadHandlers with key', () => {
 		describe('cache validation', () => {
 			it.each([
 				{
-					name: 'mismatch part count between cached upload and actual upload',
+					name: 'mismatched part count between cached upload and actual upload',
 					parts: [{ PartNumber: 1 }, { PartNumber: 2 }, { PartNumber: 3 }],
 				},
 				{
@@ -693,7 +693,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			expect(Object.keys(cacheValue)).toEqual([
 				expect.stringMatching(
 					// \d{13} is the file lastModified property of a file
-					/someName_\d{13}_o6a\/Qw==_8388608_application\/octet-stream_bucket_public_key/,
+					new RegExp(`someName_\\d{13}_${defaultCacheKey}`),
 				),
 			]);
 		});

--- a/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
@@ -57,12 +57,6 @@ const mockListParts = jest.mocked(listParts);
 const mockHeadObject = jest.mocked(headObject);
 const mockCalculateContentCRC32 = jest.mocked(calculateContentCRC32);
 
-// Hack to make sure jest mocked defaultStorage is not serializable. So it will not change the options hash.
-Object.setPrototypeOf(
-	defaultStorage,
-	Object.getPrototypeOf(jest.requireActual('@aws-amplify/core').defaultStorage),
-);
-
 const disableAssertionFlag = true;
 
 const MB = 1024 * 1024;

--- a/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
@@ -57,6 +57,12 @@ const mockListParts = jest.mocked(listParts);
 const mockHeadObject = jest.mocked(headObject);
 const mockCalculateContentCRC32 = jest.mocked(calculateContentCRC32);
 
+// Hack to make sure jest mocked defaultStorage is not serializable. So it will not change the options hash.
+Object.setPrototypeOf(
+	defaultStorage,
+	Object.getPrototypeOf(jest.requireActual('@aws-amplify/core').defaultStorage),
+);
+
 const disableAssertionFlag = true;
 
 const MB = 1024 * 1024;

--- a/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
@@ -45,9 +45,9 @@ const region = 'region';
 const defaultKey = 'key';
 const defaultContentType = 'application/octet-stream';
 const defaultCacheKey =
-	'Jz3O2w==_8388608_application/octet-stream_bucket_public_key';
+	'o6a/Qw==_8388608_application/octet-stream_bucket_public_key';
 const testPath = 'testPath/object';
-const testPathCacheKey = `Jz3O2w==_8388608_${defaultContentType}_${bucket}_custom_${testPath}`;
+const testPathCacheKey = `o6a/Qw==_8388608_${defaultContentType}_${bucket}_custom_${testPath}`;
 
 const mockCreateMultipartUpload = jest.mocked(createMultipartUpload);
 const mockUploadPart = jest.mocked(uploadPart);
@@ -545,14 +545,14 @@ describe('getMultipartUploadHandlers with key', () => {
 		describe('cache validation', () => {
 			it.each([
 				{
-					name: 'wrong part count',
+					name: 'mismatch part count between cached upload and actual upload',
 					parts: [{ PartNumber: 1 }, { PartNumber: 2 }, { PartNumber: 3 }],
 				},
 				{
-					name: 'wrong part numbers',
+					name: 'mismatched part numbers between cached upload and actual upload',
 					parts: [{ PartNumber: 1 }, { PartNumber: 1 }],
 				},
-			])('should throw with $name', async ({ parts }) => {
+			])('should throw integrity error with $name', async ({ parts }) => {
 				mockMultipartUploadSuccess();
 
 				const mockDefaultStorage = defaultStorage as jest.Mocked<
@@ -693,7 +693,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			expect(Object.keys(cacheValue)).toEqual([
 				expect.stringMatching(
 					// \d{13} is the file lastModified property of a file
-					/someName_\d{13}_Jz3O2w==_8388608_application\/octet-stream_bucket_public_key/,
+					/someName_\d{13}_o6a\/Qw==_8388608_application\/octet-stream_bucket_public_key/,
 				),
 			]);
 		});

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadCache.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadCache.ts
@@ -10,6 +10,8 @@ import { UPLOADS_STORAGE_KEY } from '../../../../utils/constants';
 import { ResolvedS3Config } from '../../../../types/options';
 import { Part, listParts } from '../../../../utils/client/s3data';
 import { logger } from '../../../../../../utils';
+// TODO: Remove this interface when we move to public advanced APIs.
+import { UploadDataInput as UploadDataWithPathInputWithAdvancedOptions } from '../../../../../../internals/types/inputs';
 
 const ONE_HOUR = 1000 * 60 * 60;
 
@@ -94,6 +96,28 @@ const listCachedUploadTasks = async (
 
 		return {};
 	}
+};
+
+/**
+ * Serialize the uploadData API options to string so it can be hashed.
+ */
+export const serializeUploadOptions = (
+	options: UploadDataWithPathInputWithAdvancedOptions['options'] & {
+		resumableUploadsCache?: KeyValueStorageInterface;
+	} = {},
+): string => {
+	const unserializableOptionProperties: string[] = [
+		'onProgress',
+		'resumableUploadsCache', // Internally injected implementation not set by customers
+		'locationCredentialsProvider', // Internally injected implementation not set by customers
+	] satisfies (keyof typeof options)[];
+	const serializableOptions = Object.fromEntries(
+		Object.entries(options).filter(
+			([key]) => !unserializableOptionProperties.includes(key),
+		),
+	);
+
+	return JSON.stringify(serializableOptions);
 };
 
 interface UploadsCacheKeyOptions {

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadCache.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadCache.ts
@@ -99,22 +99,42 @@ const listCachedUploadTasks = async (
 };
 
 /**
- * Serialize the uploadData API options to string so it can be hashed.
+ * Serialize the uploadData API options to string so it can be hashed. The following options will be OMITTED from the
+ * result. It only checks the top-level options assuming we do not use unserializable types in nested properties by
+ * design.
+ * * undefined
+ * * bigint
+ * * function
+ * * symbol
+ * * class instances except for Array.
  */
 export const serializeUploadOptions = (
 	options: UploadDataWithPathInputWithAdvancedOptions['options'] & {
 		resumableUploadsCache?: KeyValueStorageInterface;
 	} = {},
 ): string => {
-	const unserializableOptionProperties: string[] = [
-		'onProgress',
-		'resumableUploadsCache', // Internally injected implementation not set by customers
-		'locationCredentialsProvider', // Internally injected implementation not set by customers
-	] satisfies (keyof typeof options)[];
+	const isSerializable = (value: any): boolean => {
+		const valueType = typeof value;
+		if (['bigint', 'function', 'symbol', 'undefined'].includes(valueType)) {
+			return false;
+		}
+		if (valueType === 'object') {
+			if (
+				value === null ||
+				Object.getPrototypeOf(value) === Object.prototype ||
+				Object.getPrototypeOf(value) === Array.prototype
+			) {
+				return true; // null/array/plain objects
+			}
+
+			return false;
+		}
+
+		return true; // string/number/boolean
+	};
+
 	const serializableOptions = Object.fromEntries(
-		Object.entries(options).filter(
-			([key]) => !unserializableOptionProperties.includes(key),
-		),
+		Object.entries(options).filter(([_, value]) => isSerializable(value)),
 	);
 
 	return JSON.stringify(serializableOptions);

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
@@ -40,7 +40,11 @@ import { StorageOperationOptionsInput } from '../../../../../../types/inputs';
 import { IntegrityError } from '../../../../../../errors/IntegrityError';
 
 import { uploadPartExecutor } from './uploadPartExecutor';
-import { getUploadsCacheKey, removeCachedUpload } from './uploadCache';
+import {
+	getUploadsCacheKey,
+	removeCachedUpload,
+	serializeUploadOptions,
+} from './uploadCache';
 import { getConcurrentUploadsProgressTracker } from './progressTracker';
 import { loadOrCreateMultipartUpload } from './initialUpload';
 import { getDataChunker } from './getDataChunker';
@@ -151,9 +155,9 @@ export const getMultipartUploadHandlers = (
 			resolvedAccessLevel = resolveAccessLevel(accessLevel);
 		}
 
-		const optionsHash = (
-			await calculateContentCRC32(JSON.stringify(uploadDataOptions))
-		).checksum;
+		const { checksum: optionsHash } = await calculateContentCRC32(
+			serializeUploadOptions(uploadDataOptions),
+		);
 
 		if (!inProgressUpload) {
 			const { uploadId, cachedParts, finalCrc32 } =


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
From https://github.com/aws-amplify/amplify-js/pull/13931, we added a internally-injected option `resumableUploadsCache ` for public uploadData API. However, the default value of this option `KeyValueStorage` has a reference to the `LocalStorage` instance. 

This causes that the hash value of uploadData options keeps changing, as the `LocalStorage` value keep changing. This fix adds a list of options that should NOT be hashed when calculating the options hash. Any new options will be added options hash by default.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
#14149 


#### Description of how you validated changes
Unit test; Manual integ test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
