### PR TITLE
fix(adapter-nextjs): removing only tokens and LastAuthUser cookies

### DIFF
--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutCallbackRequest.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutCallbackRequest.test.ts
@@ -213,7 +213,10 @@ describe('handleSignOutCallbackRequest', () => {
 					mock_refresh_token_cookie_name: 'mock_refresh_token',
 				});
 			const mockCreateKeysForAuthStorageResult = {
+				accessToken: 'mock_access_token_cookie_name',
+				idToken: 'mock_id_token_cookie_name',
 				refreshToken: 'mock_refresh_token_cookie_name',
+				deviceKey: 'shouldNotIncludeMe',
 			} as any;
 			mockCreateKeysForAuthStorage.mockReturnValueOnce(
 				mockCreateKeysForAuthStorageResult,
@@ -282,7 +285,9 @@ describe('handleSignOutCallbackRequest', () => {
 				endpointDomain: mockOAuthConfig.domain,
 			});
 			expect(mockCreateTokenRemoveCookies).toHaveBeenCalledWith([
-				...Object.values(mockCreateKeysForAuthStorageResult),
+				mockCreateKeysForAuthStorageResult.accessToken,
+				mockCreateKeysForAuthStorageResult.idToken,
+				mockCreateKeysForAuthStorageResult.refreshToken,
 				`${AUTH_KEY_PREFIX}.${mockUserPoolClientId}.LastAuthUser`,
 				IS_SIGNING_OUT_COOKIE_NAME,
 			]);

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutCallbackRequestForPagesRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutCallbackRequestForPagesRouter.test.ts
@@ -245,7 +245,10 @@ describe('handleSignOutCallbackRequest', () => {
 					mock_refresh_token_cookie_name: 'mock_refresh_token',
 				});
 			const mockCreateKeysForAuthStorageResult = {
+				accessToken: 'mock_access_token_cookie_name',
+				idToken: 'mock_id_token_cookie_name',
 				refreshToken: 'mock_refresh_token_cookie_name',
+				deviceKey: 'shouldNotIncludeMe',
 			} as any;
 			mockCreateKeysForAuthStorage.mockReturnValueOnce(
 				mockCreateKeysForAuthStorageResult,
@@ -330,7 +333,9 @@ describe('handleSignOutCallbackRequest', () => {
 				endpointDomain: mockOAuthConfig.domain,
 			});
 			expect(mockCreateTokenRemoveCookies).toHaveBeenCalledWith([
-				...Object.values(mockCreateKeysForAuthStorageResult),
+				mockCreateKeysForAuthStorageResult.accessToken,
+				mockCreateKeysForAuthStorageResult.idToken,
+				mockCreateKeysForAuthStorageResult.refreshToken,
 				`${AUTH_KEY_PREFIX}.${mockUserPoolClientId}.LastAuthUser`,
 				IS_SIGNING_OUT_COOKIE_NAME,
 			]);

--- a/packages/adapter-nextjs/src/auth/handlers/handleSignOutCallbackRequest.ts
+++ b/packages/adapter-nextjs/src/auth/handlers/handleSignOutCallbackRequest.ts
@@ -81,7 +81,9 @@ export const handleSignOutCallbackRequest: HandleSignOutCallbackRequest =
 			headers,
 			[
 				...createTokenRemoveCookies([
-					...Object.values(authCookiesKeys),
+					authCookiesKeys.accessToken,
+					authCookiesKeys.idToken,
+					authCookiesKeys.refreshToken,
 					lastAuthUserCookieName,
 					IS_SIGNING_OUT_COOKIE_NAME,
 				]),

--- a/packages/adapter-nextjs/src/auth/handlers/handleSignOutCallbackRequestForPagesRouter.ts
+++ b/packages/adapter-nextjs/src/auth/handlers/handleSignOutCallbackRequestForPagesRouter.ts
@@ -84,7 +84,9 @@ export const handleSignOutCallbackRequestForPagesRouter: HandleSignOutCallbackRe
 			response,
 			[
 				...createTokenRemoveCookies([
-					...Object.values(authCookiesKeys),
+					authCookiesKeys.accessToken,
+					authCookiesKeys.idToken,
+					authCookiesKeys.refreshToken,
 					lastAuthUserCookieName,
 					IS_SIGNING_OUT_COOKIE_NAME,
 				]),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Generating `Set-Cookie` headers for only previous set cookies in server-side auth signOut flow. 
In particular:

1. `.accessToken`
2. `.idToken`
3. `.refreshToken`
4. `.LastAuthUser`
5. `isSigningOut` flag


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
