### PR TITLE
fix(amazon-cognito-identity-js): not using latest tag

### DIFF
--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -2,9 +2,6 @@
   "name": "amazon-cognito-identity-js",
   "description": "Amazon Cognito Identity Provider JavaScript SDK",
   "version": "6.3.14",
-	"publishConfig": {
-    "tag": "latest"
-  },
   "author": {
     "name": "Amazon Web Services",
     "email": "aws@amazon.com",
@@ -49,7 +46,8 @@
     "generate-version": "genversion src/Platform/version.ts --es6 --semi",
     "test": "jest --config ./jest.config.js",
     "format": "echo \"Not implemented\"",
-    "ts-coverage": "typescript-coverage-report -p ./tsconfig.build.json"
+    "ts-coverage": "typescript-coverage-report -p ./tsconfig.build.json",
+    "postpublish": "npm dist-tag add $npm_package_name@$npm_package_version latest"
   },
   "main": "lib/index.js",
   "react-native": {

--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -2,6 +2,9 @@
   "name": "amazon-cognito-identity-js",
   "description": "Amazon Cognito Identity Provider JavaScript SDK",
   "version": "6.3.14",
+	"publishConfig": {
+    "tag": "latest"
+  },
   "author": {
     "name": "Amazon Web Services",
     "email": "aws@amazon.com",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Currently all packages published from the `v5-stable` branch are using the `--dist-tag v5-stable`, however, for the legacy `amazon-cognito-identity-js` package, the newly published version should use `--dist-tag latest`. 

Added a `postpublish` script to point the last released version to the `latest` tag.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
