### PR TITLE
fix: ensure credentials in put

### DIFF
--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -599,6 +599,10 @@ export class AWSS3Provider implements StorageProvider {
 		object: PutObjectInput['Body'],
 		config?: T
 	): S3ProviderPutOutput<T> {
+		const credentialsOK = await this._ensureCredentials();
+		if (!credentialsOK || !this._isWithCredentials(this._config)) {
+			throw new Error(StorageErrorStrings.NO_CREDENTIALS);
+		}
 		const opt = Object.assign({}, this._config, config);
 		const { bucket, track, progressCallback, level, resumable } = opt;
 		const {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
ensure correct credentials are set in config before upload


#### Issue #, if available
This fixes a long standing issue where upload would return and expired token error even if the Credentials had more recent valid credentials.



#### Description of how you validated changes
In my current code Im calling getProperties everytime before put as a way to call ensureCredentials



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
