### PR TITLE
Fix api-graphql lambda auth

### DIFF
--- a/packages/api-graphql/__tests__/events.test.ts
+++ b/packages/api-graphql/__tests__/events.test.ts
@@ -132,6 +132,17 @@ describe('Events client', () => {
 							expect.objectContaining({ authenticationType: authMode }),
 						);
 					});
+
+					test(`auth token override: ${authMode}`, async () => {
+						await events.connect('/', { authMode, authToken: 'TOKEN' });
+
+						expect(mockProvider.connect).toHaveBeenCalledWith(
+							expect.objectContaining({
+								authenticationType: authMode,
+								authToken: 'TOKEN',
+							}),
+						);
+					});
 				}
 			});
 		});
@@ -167,6 +178,63 @@ describe('Events client', () => {
 
 						expect(mockSubscribeObservable).toHaveBeenCalledWith(
 							expect.objectContaining({ authenticationType: authMode }),
+						);
+					});
+
+					test(`auth token override from connect: ${authMode}`, async () => {
+						const channel = await events.connect('/', { authToken: 'TOKEN' });
+
+						channel.subscribe(
+							{
+								next: data => void data,
+								error: error => void error,
+							},
+							{ authMode },
+						);
+
+						expect(mockSubscribeObservable).toHaveBeenCalledWith(
+							expect.objectContaining({
+								authenticationType: authMode,
+								authToken: 'TOKEN',
+							}),
+						);
+					});
+
+					test(`auth token override: ${authMode}`, async () => {
+						const channel = await events.connect('/');
+
+						channel.subscribe(
+							{
+								next: data => void data,
+								error: error => void error,
+							},
+							{ authMode, authToken: 'TOKEN' },
+						);
+
+						expect(mockSubscribeObservable).toHaveBeenCalledWith(
+							expect.objectContaining({
+								authenticationType: authMode,
+								authToken: 'TOKEN',
+							}),
+						);
+					});
+
+					test(`auth token override subscribe has precedence: ${authMode}`, async () => {
+						const channel = await events.connect('/', { authToken: 'TOKEN1' });
+
+						channel.subscribe(
+							{
+								next: data => void data,
+								error: error => void error,
+							},
+							{ authMode, authToken: 'TOKEN2' },
+						);
+
+						expect(mockSubscribeObservable).toHaveBeenCalledWith(
+							expect.objectContaining({
+								authenticationType: authMode,
+								authToken: 'TOKEN2',
+							}),
 						);
 					});
 				}

--- a/packages/api-graphql/src/internals/events/index.ts
+++ b/packages/api-graphql/src/internals/events/index.ts
@@ -41,19 +41,19 @@ async function connect(
 	channel: string,
 	options?: EventsOptions,
 ): Promise<EventsChannel> {
-	const providerOptions = configure();
+	const configureOptions = configure();
 
-	providerOptions.authenticationType = normalizeAuth(
+	configureOptions.authenticationType = normalizeAuth(
 		options?.authMode,
-		providerOptions.authenticationType,
+		configureOptions.authenticationType,
 	);
 
-	const connectOptions = {
-		...providerOptions, 
-		authToken: options?.authToken
+	const providerOptions = {
+		...configureOptions,
+		authToken: options?.authToken,
 	};
 
-	await eventProvider.connect(connectOptions);
+	await eventProvider.connect(providerOptions);
 
 	let _subscription: Subscription;
 
@@ -66,6 +66,9 @@ async function connect(
 			subOptions?.authMode,
 			subscribeOptions.authenticationType,
 		);
+		if (subOptions?.authToken) {
+			subscribeOptions.authToken = subOptions.authToken;
+		}
 
 		_subscription = eventProvider
 			.subscribe(subscribeOptions)

--- a/packages/api-graphql/src/internals/events/index.ts
+++ b/packages/api-graphql/src/internals/events/index.ts
@@ -48,7 +48,12 @@ async function connect(
 		providerOptions.authenticationType,
 	);
 
-	await eventProvider.connect(providerOptions);
+	const connectOptions = {
+		...providerOptions, 
+		authToken: options?.authToken
+	};
+
+	await eventProvider.connect(connectOptions);
 
 	let _subscription: Subscription;
 


### PR DESCRIPTION
#### Description of changes

In the connect call of events, the `authToken` is not passed to the subsequent connect calls, resulting in no `Authorization` header being added, and an error `'No auth token specified'` thrown.

```js
const channel = await events.connect('/test/channel', {
      authToken: "TOKEN"
});
```

This PR makes sure, the `authToken` is properly dispatched to the subsequent connect calls.

#### Issue #14124


#### Description of how you validated changes

- created a sample vuejs project: `yarn create vue`
- added amplify: `yarn add aws-amplify`. 
- follow the contribution guide to build and link the changes from core and api-graphql
- setup a aws AppSync Event, lambda function and connect them in the aws console

    ```py
    def lambda_handler(event, context):
        token: str | None = event.get("authorizationToken")
        headers: dict[str, str] = event.get("requestHeaders", {})
        print(f"{token=} {headers=}")
        return {"isAuthorized": True}
    ```

- get `amplify_outputs.json` from the console, make sure to have `"defaultAuthMode": "lambda"` set
- in the vue project, add to main.ts:

    ```ts
    import { Amplify } from 'aws-amplify';
    import config from './amplify_outputs.json';
    Amplify.configure(config);
    ```

- in the vue project, add to App.vue:

    ```vue
    import { events } from "aws-amplify/data";
    
    async function connect() {
      const channel = await events.connect("/default/*", { authToken: "TOKEN" });
      channel.subscribe({
        next: (d) => {
          console.log("received", d);
        },
        error: (err) => console.error("error", err),
      });
    
    }
    ```

- running the vue app and observe console

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [~changed or~ added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
