### PR TITLE
fix(core): bind this context to browser-based btoa and atob utilities

### DIFF
--- a/packages/core/__tests__/utils/globalHelpers/globalHelpers.test.ts
+++ b/packages/core/__tests__/utils/globalHelpers/globalHelpers.test.ts
@@ -67,7 +67,10 @@ describe('getGlobal', () => {
 				btoa: mockBtoa,
 			}));
 
-			expect(getBtoa()).toEqual(mockBtoa);
+			const btoaFunc = getBtoa();
+			btoaFunc('test');
+
+			expect(mockBtoa).toHaveBeenCalledWith('test');
 		});
 
 		it('returns the global btoa when it is available', () => {
@@ -103,7 +106,10 @@ describe('getGlobal', () => {
 				atob: mockAtoB,
 			}));
 
-			expect(getAtob()).toEqual(mockAtoB);
+			const atobFunc = getAtob();
+			atobFunc('test');
+
+			expect(mockAtoB).toHaveBeenCalledWith('test');
 		});
 
 		it('returns the global atob when it is available', () => {

--- a/packages/core/src/utils/globalHelpers/index.ts
+++ b/packages/core/src/utils/globalHelpers/index.ts
@@ -22,7 +22,7 @@ export const getCrypto = () => {
 export const getBtoa = () => {
 	// browser
 	if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
-		return window.btoa;
+		return window.btoa.bind(window);
 	}
 
 	// Next.js global polyfill
@@ -39,7 +39,7 @@ export const getBtoa = () => {
 export const getAtob = () => {
 	// browser
 	if (typeof window !== 'undefined' && typeof window.atob === 'function') {
-		return window.atob;
+		return window.atob.bind(window);
 	}
 
 	// Next.js global polyfill


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fixes a Firefox-specific issue where `atob()` fails when called without proper Window context binding.

I received a vague error when trying to invoke the utility method `decodeJWT` inside Firefox: `Error: Invalid token payload`. After debugging, I noticed the error was coming from the `convert` method:

<img width="522" alt="Screenshot 2025-02-02 at 9 29 11 PM" src="https://github.com/user-attachments/assets/74de23e0-7155-4c4d-8745-9d2c1360e8c1" />

`TypeError: 'atob' called on an object that does not implement interface Window.`

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

I ran `yarn build`, then used the `link` instructions in the contributing guide to override my project's `@aws-amplify/core` dependency to my local, and tested the changes in both Firefox and Chrome. After the changes, the error is no longer thrown in Firefox. `decodeJWT` now works in Chrome and Firefox without error.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [x] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
