### PR TITLE
chore: update node version in contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Our work is done directly on Github and PR's are sent to the GitHub repo by core
 
 This section should get you running with **Amplify JS** and get you familiar with the basics of the codebase. You will need [Node.js](https://nodejs.org/en/) on your system and developing locally also requires `yarn` workspaces. You can install it [here](https://classic.yarnpkg.com/en/docs/install#mac-stable).
 
-The recommended version of Node JS to work with this project is [`16.19.0`](https://nodejs.org/en/blog/release/v16.19.0/) with Yarn version [`1.22.x`](https://github.com/yarnpkg/yarn/blob/master/CHANGELOG.md).
+The recommended version of Node JS to work with this project is [`18.18.0`](https://nodejs.org/en/blog/release/v18.18.0/) with Yarn version [`1.22.x`](https://github.com/yarnpkg/yarn/blob/master/CHANGELOG.md).
 
 > Note: newer versions of Yarn (2+) remove support for lerna's `--mutex` flag
 > so be sure to use Yarn v1.22.x


### PR DESCRIPTION
#### Description of changes

Update the recommended node version in contributing.md

Currently the recommended version is `16.19.0` which throws the following error.
```
error @eslint/compat@1.2.0: The engine "node" is incompatible with this module. Expected version "^18.18.0 || ^20.9.0 || >=21.1.0". Got "16.19.0"
error Found incompatible module.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
