### PR TITLE
fix(core): build in CookieSerializeOptions def

### DIFF
--- a/packages/adapter-nextjs/package.json
+++ b/packages/adapter-nextjs/package.json
@@ -8,11 +8,9 @@
 		"next": ">=13.5.0 <16.0.0"
 	},
 	"dependencies": {
-		"aws-jwt-verify": "^4.0.1",
-		"cookie": "^0.7.0"
+		"aws-jwt-verify": "^4.0.1"
 	},
 	"devDependencies": {
-		"@types/cookie": "^0.5.1",
 		"@types/node": "^20.3.1",
 		"@types/react": "^18.2.13",
 		"@types/react-dom": "^18.2.6",

--- a/packages/adapter-nextjs/package.json
+++ b/packages/adapter-nextjs/package.json
@@ -4,7 +4,7 @@
 	"version": "1.5.0",
 	"description": "The adapter for the supporting of using Amplify APIs in Next.js.",
 	"peerDependencies": {
-		"aws-amplify": "^6.13.0",
+		"aws-amplify": "^6.13.1",
 		"next": ">=13.5.0 <16.0.0"
 	},
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,6 @@
 		"@aws-sdk/types": "3.398.0",
 		"@smithy/util-hex-encoding": "2.0.0",
 		"@types/uuid": "^9.0.0",
-		"cookie": "^0.7.0",
 		"js-cookie": "^3.0.5",
 		"rxjs": "^7.8.1",
 		"tslib": "^2.5.0",

--- a/packages/core/src/adapterCore/serverContext/types/cookieStorage.ts
+++ b/packages/core/src/adapterCore/serverContext/types/cookieStorage.ts
@@ -1,7 +1,104 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { CookieSerializeOptions } from 'cookie';
+interface CookieSerializeOptions {
+	/**
+	 * Specifies the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.3|Domain Set-Cookie attribute}. By default, no
+	 * domain is set, and most clients will consider the cookie to apply to only
+	 * the current domain.
+	 */
+	domain?: string | undefined;
+
+	/**
+	 * Specifies a function that will be used to encode a cookie's value. Since
+	 * value of a cookie has a limited character set (and must be a simple
+	 * string), this function can be used to encode a value into a string suited
+	 * for a cookie's value.
+	 *
+	 * The default function is the global `encodeURIComponent`, which will
+	 * encode a JavaScript string into UTF-8 byte sequences and then URL-encode
+	 * any that fall outside of the cookie range.
+	 */
+	encode?(value: string): string;
+
+	/**
+	 * Specifies the `Date` object to be the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.1|`Expires` `Set-Cookie` attribute}. By default,
+	 * no expiration is set, and most clients will consider this a "non-persistent cookie" and will delete
+	 * it on a condition like exiting a web browser application.
+	 *
+	 * *Note* the {@link https://tools.ietf.org/html/rfc6265#section-5.3|cookie storage model specification}
+	 * states that if both `expires` and `maxAge` are set, then `maxAge` takes precedence, but it is
+	 * possible not all clients by obey this, so if both are set, they should
+	 * point to the same date and time.
+	 */
+	expires?: Date | undefined;
+	/**
+	 * Specifies the boolean value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.6|`HttpOnly` `Set-Cookie` attribute}.
+	 * When truthy, the `HttpOnly` attribute is set, otherwise it is not. By
+	 * default, the `HttpOnly` attribute is not set.
+	 *
+	 * *Note* be careful when setting this to true, as compliant clients will
+	 * not allow client-side JavaScript to see the cookie in `document.cookie`.
+	 */
+	httpOnly?: boolean | undefined;
+	/**
+	 * Specifies the number (in seconds) to be the value for the `Max-Age`
+	 * `Set-Cookie` attribute. The given number will be converted to an integer
+	 * by rounding down. By default, no maximum age is set.
+	 *
+	 * *Note* the {@link https://tools.ietf.org/html/rfc6265#section-5.3|cookie storage model specification}
+	 * states that if both `expires` and `maxAge` are set, then `maxAge` takes precedence, but it is
+	 * possible not all clients by obey this, so if both are set, they should
+	 * point to the same date and time.
+	 */
+	maxAge?: number | undefined;
+	/**
+	 * Specifies the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.4|`Path` `Set-Cookie` attribute}.
+	 * By default, the path is considered the "default path".
+	 */
+	path?: string | undefined;
+	/**
+	 * Specifies the `string` to be the value for the [`Priority` `Set-Cookie` attribute][rfc-west-cookie-priority-00-4.1].
+	 *
+	 * - `'low'` will set the `Priority` attribute to `Low`.
+	 * - `'medium'` will set the `Priority` attribute to `Medium`, the default priority when not set.
+	 * - `'high'` will set the `Priority` attribute to `High`.
+	 *
+	 * More information about the different priority levels can be found in
+	 * [the specification][rfc-west-cookie-priority-00-4.1].
+	 *
+	 * **note** This is an attribute that has not yet been fully standardized, and may change in the future.
+	 * This also means many clients may ignore this attribute until they understand it.
+	 */
+	priority?: 'low' | 'medium' | 'high' | undefined;
+	/**
+	 * Specifies the boolean or string to be the value for the {@link https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7|`SameSite` `Set-Cookie` attribute}.
+	 *
+	 * - `true` will set the `SameSite` attribute to `Strict` for strict same
+	 * site enforcement.
+	 * - `false` will not set the `SameSite` attribute.
+	 * - `'lax'` will set the `SameSite` attribute to Lax for lax same site
+	 * enforcement.
+	 * - `'strict'` will set the `SameSite` attribute to Strict for strict same
+	 * site enforcement.
+	 *  - `'none'` will set the SameSite attribute to None for an explicit
+	 *  cross-site cookie.
+	 *
+	 * More information about the different enforcement levels can be found in {@link https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7|the specification}.
+	 *
+	 * *note* This is an attribute that has not yet been fully standardized, and may change in the future. This also means many clients may ignore this attribute until they understand it.
+	 */
+	sameSite?: true | false | 'lax' | 'strict' | 'none' | undefined;
+	/**
+	 * Specifies the boolean value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.5|`Secure` `Set-Cookie` attribute}. When truthy, the
+	 * `Secure` attribute is set, otherwise it is not. By default, the `Secure` attribute is not set.
+	 *
+	 * *Note* be careful when setting this to `true`, as compliant clients will
+	 * not send the cookie back to the server in the future if the browser does
+	 * not have an HTTPS connection.
+	 */
+	secure?: boolean | undefined;
+}
 
 export declare namespace CookieStorage {
 	export type SetCookieOptions = Partial<

--- a/yarn.lock
+++ b/yarn.lock
@@ -5023,11 +5023,6 @@
   resolved "https://registry.yarnpkg.com/@types/base-64/-/base-64-1.0.0.tgz#de9c6070ea457fbd65a1b5ebf13976b3ac0bdad0"
   integrity sha512-AvCJx/HrfYHmOQRFdVvgKMplXfzTUizmh0tz9GFTpDePWgCY4uoKll84zKlaRoeiYiCr7c9ZnqSTzkl0BUVD6g==
 
-"@types/cookie@^0.5.1":
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.5.4.tgz#7e70a20cd695bc48d46b08c2505874cd68b760e0"
-  integrity sha512-7z/eR6O859gyWIAjuvBWFzNURmf2oPBmJlfVWkwehU5nzIyjwBsTh7WMmEEV4JFnHuQ3ex4oyTvfKzcyJVDBNA==
-
 "@types/estree@1.0.6", "@types/estree@^1.0.0", "@types/estree@^1.0.5", "@types/estree@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
@@ -6920,11 +6915,6 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
-
-cookie@^0.7.0:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
-  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 core-js-compat@^3.38.0, core-js-compat@^3.38.1:
   version "3.38.1"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Remove the `cookie` and `@types/cookie` (has been deprecated) dependencies and build-in the `CookieSerializeOptions` type definition.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-js/issues/14212

#### Description of how you validated changes

- Run codebase build
- Publish the package to local registry and test with a next.js sample app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
