### PR TITLE
feat(auth): throw extended AuthError for service errors from user pool & id pool

### DIFF
--- a/packages/auth/__tests__/foundation/factories/serviceClients/cognitoIdentityProvider/shared/serde/createUserPoolDeserializer.test.ts
+++ b/packages/auth/__tests__/foundation/factories/serviceClients/cognitoIdentityProvider/shared/serde/createUserPoolDeserializer.test.ts
@@ -3,6 +3,7 @@ import {
 	parseJsonBody,
 	parseJsonError,
 } from '@aws-amplify/core/internals/aws-client-utils';
+import { ErrorParser } from '@aws-amplify/core/src/clients';
 
 import { createUserPoolDeserializer } from '../../../../../../../src/foundation/factories/serviceClients/cognitoIdentityProvider/shared/serde/createUserPoolDeserializer';
 import { AuthError } from '../../../../../../../src/errors/AuthError';
@@ -33,10 +34,18 @@ describe('buildUserPoolDeserializer created response deserializer', () => {
 	});
 
 	it('throws AuthError for 4xx status code', async () => {
+		expect.assertions(2);
 		const expectedErrorName = 'TestError';
 		const expectedErrorMessage = 'TestErrorMessage';
-		const expectedError = new Error(expectedErrorMessage);
-		expectedError.name = expectedErrorName;
+		const expectedError: Awaited<ReturnType<ErrorParser>> = Object.assign(
+			new Error(expectedErrorMessage),
+			{
+				name: expectedErrorName,
+				metadata: {
+					httpStatusCode: 400,
+				},
+			},
+		);
 
 		mockParseJsonError.mockReturnValueOnce(expectedError as any);
 		const response: HttpResponse = {
@@ -49,11 +58,17 @@ describe('buildUserPoolDeserializer created response deserializer', () => {
 			headers: {},
 		};
 
-		expect(deserializer(response as any)).rejects.toThrow(
-			new AuthError({
+		try {
+			await deserializer(response as any);
+		} catch (e) {
+			expect(e).toBeInstanceOf(AuthError);
+			expect(e).toMatchObject({
 				name: expectedErrorName,
 				message: expectedErrorMessage,
-			}),
-		);
+				metadata: expect.objectContaining({
+					httpStatusCode: 400,
+				}),
+			});
+		}
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/credentialsProvider.test.ts
+++ b/packages/auth/__tests__/providers/cognito/credentialsProvider.test.ts
@@ -7,12 +7,13 @@ import {
 	getCredentialsForIdentity,
 	sharedInMemoryStorage,
 } from '@aws-amplify/core';
+import { AmplifyError } from '@aws-amplify/core/internals/utils';
 
+import { AuthError } from '../../../src';
 import {
 	CognitoAWSCredentialsAndIdentityIdProvider,
 	DefaultIdentityIdStore,
 } from '../../../src/providers/cognito';
-import { AuthError } from '../../../src/errors/AuthError';
 
 import { authAPITestParams } from './testUtils/authApiTestParams';
 
@@ -65,227 +66,256 @@ const disallowGuestAccessConfig: ResourcesConfig = {
 
 const credentialsForIdentityIdSpy = getCredentialsForIdentity as jest.Mock;
 
-describe('Guest Credentials', () => {
-	let cognitoCredentialsProvider: CognitoAWSCredentialsAndIdentityIdProvider;
-
-	describe('Happy Path Cases:', () => {
-		beforeEach(() => {
-			cognitoCredentialsProvider =
-				new CognitoAWSCredentialsAndIdentityIdProvider(
-					new DefaultIdentityIdStore(sharedInMemoryStorage),
-				);
-			credentialsForIdentityIdSpy.mockImplementationOnce(async () => {
-				return authAPITestParams.CredentialsForIdentityIdResult as GetCredentialsForIdentityOutput;
-			});
-		});
-		afterEach(() => {
-			cognitoCredentialsProvider.clearCredentials();
-			credentialsForIdentityIdSpy?.mockReset();
-		});
-		test('Should call identityIdClient with no logins to obtain guest creds', async () => {
-			const res = await cognitoCredentialsProvider.getCredentialsAndIdentityId({
-				authenticated: false,
-				authConfig: validAuthConfig.Auth!,
-			});
-			expect(res?.credentials.accessKeyId).toEqual(
-				authAPITestParams.CredentialsForIdentityIdResult.Credentials
-					.AccessKeyId,
+describe('credentialsProvider', () => {
+	test('Should throw AuthError when there is a service error', async () => {
+		const cognitoCredentialsProvider =
+			new CognitoAWSCredentialsAndIdentityIdProvider(
+				new DefaultIdentityIdStore(sharedInMemoryStorage),
 			);
-
-			expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
-			expect(credentialsForIdentityIdSpy).toHaveBeenCalledWith(
-				{ region: 'us-east-1' },
-				{ IdentityId: 'identity-id-test' },
-			);
-			expect(
-				(cognitoCredentialsProvider as any)._nextCredentialsRefresh,
-			).toBeGreaterThan(0);
-		});
-
-		test('in-memory guest creds are returned if not expired and not past TTL', async () => {
+		expect.assertions(2);
+		const mockServiceErrorParams = {
+			name: 'ServiceUnavailable',
+			message: '',
+			metadata: {
+				httpStatusCode: 500,
+				requestId: '123',
+			},
+		};
+		credentialsForIdentityIdSpy.mockReset();
+		credentialsForIdentityIdSpy.mockRejectedValue(mockServiceErrorParams);
+		try {
 			await cognitoCredentialsProvider.getCredentialsAndIdentityId({
 				authenticated: false,
 				authConfig: validAuthConfig.Auth!,
 			});
-			expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
-			const res = await cognitoCredentialsProvider.getCredentialsAndIdentityId({
-				authenticated: false,
-				authConfig: validAuthConfig.Auth!,
-			});
-			expect(res?.credentials.accessKeyId).toEqual(
-				authAPITestParams.CredentialsForIdentityIdResult.Credentials
-					.AccessKeyId,
-			);
-			// expecting to be called only once becasue in-memory creds should be returned
-			expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
-		});
+		} catch (e) {
+			expect(e).toBeInstanceOf(AmplifyError);
+			expect(e).toMatchObject(mockServiceErrorParams);
+		}
 	});
 
-	describe('Error Path Cases:', () => {
-		beforeEach(() => {
-			cognitoCredentialsProvider =
-				new CognitoAWSCredentialsAndIdentityIdProvider(
-					new DefaultIdentityIdStore(sharedInMemoryStorage),
-				);
-			credentialsForIdentityIdSpy.mockImplementationOnce(async () => {
-				return authAPITestParams.NoAccessKeyCredentialsForIdentityIdResult as GetCredentialsForIdentityOutput;
-			});
-		});
+	describe('Guest Credentials', () => {
+		let cognitoCredentialsProvider: CognitoAWSCredentialsAndIdentityIdProvider;
 
-		afterEach(() => {
-			cognitoCredentialsProvider.clearCredentials();
-		});
-		afterAll(() => {
-			credentialsForIdentityIdSpy?.mockReset();
-		});
-		test('Should not throw AuthError when allowGuestAccess is false in the config', async () => {
-			expect(
+		describe('Happy Path Cases:', () => {
+			beforeEach(() => {
+				cognitoCredentialsProvider =
+					new CognitoAWSCredentialsAndIdentityIdProvider(
+						new DefaultIdentityIdStore(sharedInMemoryStorage),
+					);
+				credentialsForIdentityIdSpy?.mockReset();
+				credentialsForIdentityIdSpy.mockImplementationOnce(async () => {
+					return authAPITestParams.CredentialsForIdentityIdResult as GetCredentialsForIdentityOutput;
+				});
+			});
+
+			test('Should call identityIdClient with no logins to obtain guest creds', async () => {
+				const res =
+					await cognitoCredentialsProvider.getCredentialsAndIdentityId({
+						authenticated: false,
+						authConfig: validAuthConfig.Auth!,
+					});
+				expect(res?.credentials.accessKeyId).toEqual(
+					authAPITestParams.CredentialsForIdentityIdResult.Credentials
+						.AccessKeyId,
+				);
+
+				expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
+				expect(credentialsForIdentityIdSpy).toHaveBeenCalledWith(
+					{ region: 'us-east-1' },
+					{ IdentityId: 'identity-id-test' },
+				);
+				expect(
+					(cognitoCredentialsProvider as any)._nextCredentialsRefresh,
+				).toBeGreaterThan(0);
+			});
+
+			test('in-memory guest creds are returned if not expired and not past TTL', async () => {
 				await cognitoCredentialsProvider.getCredentialsAndIdentityId({
 					authenticated: false,
-					authConfig: disallowGuestAccessConfig.Auth!,
-				}),
-			).toBe(undefined);
+					authConfig: validAuthConfig.Auth!,
+				});
+				expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
+				const res =
+					await cognitoCredentialsProvider.getCredentialsAndIdentityId({
+						authenticated: false,
+						authConfig: validAuthConfig.Auth!,
+					});
+				expect(res?.credentials.accessKeyId).toEqual(
+					authAPITestParams.CredentialsForIdentityIdResult.Credentials
+						.AccessKeyId,
+				);
+				// expecting to be called only once becasue in-memory creds should be returned
+				expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
+			});
 		});
-		test('Should not throw AuthError when there is no Cognito object in the config', async () => {
-			expect(
+
+		describe('Error Path Cases:', () => {
+			beforeEach(() => {
+				cognitoCredentialsProvider =
+					new CognitoAWSCredentialsAndIdentityIdProvider(
+						new DefaultIdentityIdStore(sharedInMemoryStorage),
+					);
+				credentialsForIdentityIdSpy.mockImplementationOnce(async () => {
+					return authAPITestParams.NoAccessKeyCredentialsForIdentityIdResult;
+				});
+			});
+
+			afterEach(() => {
+				cognitoCredentialsProvider.clearCredentials();
+			});
+			afterAll(() => {
+				credentialsForIdentityIdSpy?.mockReset();
+			});
+			test('Should not throw AuthError when allowGuestAccess is false in the config', async () => {
+				expect(
+					await cognitoCredentialsProvider.getCredentialsAndIdentityId({
+						authenticated: false,
+						authConfig: disallowGuestAccessConfig.Auth!,
+					}),
+				).toBe(undefined);
+			});
+			test('Should not throw AuthError when there is no Cognito object in the config', async () => {
+				expect(
+					await cognitoCredentialsProvider.getCredentialsAndIdentityId({
+						authenticated: false,
+						authConfig: inValidAuthConfig.Auth!,
+					}),
+				).toBe(undefined);
+			});
+		});
+	});
+
+	describe('Primary Credentials', () => {
+		let cognitoCredentialsProvider: CognitoAWSCredentialsAndIdentityIdProvider;
+		describe('Happy Path Cases:', () => {
+			beforeEach(() => {
+				cognitoCredentialsProvider =
+					new CognitoAWSCredentialsAndIdentityIdProvider(
+						new DefaultIdentityIdStore(sharedInMemoryStorage),
+					);
+				credentialsForIdentityIdSpy?.mockReset();
+				credentialsForIdentityIdSpy.mockImplementation(async () => {
+					return authAPITestParams.CredentialsForIdentityIdResult as GetCredentialsForIdentityOutput;
+				});
+			});
+
+			test('Should call identityIdClient with the logins map to obtain primary creds', async () => {
+				const res =
+					await cognitoCredentialsProvider.getCredentialsAndIdentityId({
+						authenticated: true,
+						authConfig: validAuthConfig.Auth!,
+						tokens: authAPITestParams.ValidAuthTokens,
+					});
+				expect(res?.credentials.accessKeyId).toEqual(
+					authAPITestParams.CredentialsForIdentityIdResult.Credentials
+						.AccessKeyId,
+				);
+
+				expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
+			});
+			test('in-memory primary creds are returned if not expired and not past TTL', async () => {
 				await cognitoCredentialsProvider.getCredentialsAndIdentityId({
-					authenticated: false,
-					authConfig: inValidAuthConfig.Auth!,
-				}),
-			).toBe(undefined);
-		});
-	});
-});
-
-describe('Primary Credentials', () => {
-	let cognitoCredentialsProvider: CognitoAWSCredentialsAndIdentityIdProvider;
-	describe('Happy Path Cases:', () => {
-		beforeEach(() => {
-			cognitoCredentialsProvider =
-				new CognitoAWSCredentialsAndIdentityIdProvider(
-					new DefaultIdentityIdStore(sharedInMemoryStorage),
+					authenticated: true,
+					authConfig: validAuthConfig.Auth!,
+					tokens: authAPITestParams.ValidAuthTokens,
+				});
+				expect(credentialsForIdentityIdSpy).toHaveBeenCalledWith(
+					{
+						region: authAPITestParams.CredentialsClientRequest.region,
+					},
+					authAPITestParams.CredentialsClientRequest.withValidAuthToken,
 				);
-			credentialsForIdentityIdSpy.mockImplementation(async () => {
-				return authAPITestParams.CredentialsForIdentityIdResult as GetCredentialsForIdentityOutput;
-			});
-		});
-		afterEach(() => {
-			cognitoCredentialsProvider.clearCredentials();
-			credentialsForIdentityIdSpy?.mockReset();
-		});
-		test('Should call identityIdClient with the logins map to obtain primary creds', async () => {
-			const res = await cognitoCredentialsProvider.getCredentialsAndIdentityId({
-				authenticated: true,
-				authConfig: validAuthConfig.Auth!,
-				tokens: authAPITestParams.ValidAuthTokens,
-			});
-			expect(res?.credentials.accessKeyId).toEqual(
-				authAPITestParams.CredentialsForIdentityIdResult.Credentials
-					.AccessKeyId,
-			);
+				expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
 
-			expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
-		});
-		test('in-memory primary creds are returned if not expired and not past TTL', async () => {
-			await cognitoCredentialsProvider.getCredentialsAndIdentityId({
-				authenticated: true,
-				authConfig: validAuthConfig.Auth!,
-				tokens: authAPITestParams.ValidAuthTokens,
-			});
-			expect(credentialsForIdentityIdSpy).toHaveBeenCalledWith(
-				{
-					region: authAPITestParams.CredentialsClientRequest.region,
-				},
-				authAPITestParams.CredentialsClientRequest.withValidAuthToken,
-			);
-			expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
-
-			const res = await cognitoCredentialsProvider.getCredentialsAndIdentityId({
-				authenticated: true,
-				authConfig: validAuthConfig.Auth!,
-				tokens: authAPITestParams.ValidAuthTokens,
-			});
-			expect(res?.credentials.accessKeyId).toEqual(
-				authAPITestParams.CredentialsForIdentityIdResult.Credentials
-					.AccessKeyId,
-			);
-			// expecting to be called only once becasue in-memory creds should be returned
-			expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
-		});
-		test('Should get new credentials when tokens have changed', async () => {
-			await cognitoCredentialsProvider.getCredentialsAndIdentityId({
-				authenticated: true,
-				authConfig: validAuthConfig.Auth!,
-				tokens: authAPITestParams.ValidAuthTokens,
-			});
-			expect(credentialsForIdentityIdSpy).toHaveBeenCalledWith(
-				{
-					region: authAPITestParams.CredentialsClientRequest.region,
-				},
-				authAPITestParams.CredentialsClientRequest.withValidAuthToken,
-			);
-			expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
-
-			await cognitoCredentialsProvider.getCredentialsAndIdentityId({
-				authenticated: true,
-				authConfig: validAuthConfig.Auth!,
-				tokens: authAPITestParams.NewValidAuthTokens,
-			});
-			expect(credentialsForIdentityIdSpy).toHaveBeenCalledWith(
-				{
-					region: authAPITestParams.CredentialsClientRequest.region,
-				},
-				authAPITestParams.CredentialsClientRequest.withNewValidAuthToken,
-			);
-			expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(2);
-		});
-	});
-	describe('Error Path Cases:', () => {
-		beforeEach(() => {
-			cognitoCredentialsProvider =
-				new CognitoAWSCredentialsAndIdentityIdProvider(
-					new DefaultIdentityIdStore(sharedInMemoryStorage),
+				const res =
+					await cognitoCredentialsProvider.getCredentialsAndIdentityId({
+						authenticated: true,
+						authConfig: validAuthConfig.Auth!,
+						tokens: authAPITestParams.ValidAuthTokens,
+					});
+				expect(res?.credentials.accessKeyId).toEqual(
+					authAPITestParams.CredentialsForIdentityIdResult.Credentials
+						.AccessKeyId,
 				);
-		});
-		afterEach(() => {
-			cognitoCredentialsProvider.clearCredentials();
-		});
-		afterAll(() => {
-			credentialsForIdentityIdSpy?.mockReset();
-		});
-		test('Should throw AuthError if either Credentials, accessKeyId or secretKey is absent in the response', async () => {
-			credentialsForIdentityIdSpy.mockImplementationOnce(async () => {
-				return authAPITestParams.NoAccessKeyCredentialsForIdentityIdResult as GetCredentialsForIdentityOutput;
+				// expecting to be called only once becasue in-memory creds should be returned
+				expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
 			});
-			expect(
-				cognitoCredentialsProvider.getCredentialsAndIdentityId({
+			test('Should get new credentials when tokens have changed', async () => {
+				await cognitoCredentialsProvider.getCredentialsAndIdentityId({
 					authenticated: true,
 					authConfig: validAuthConfig.Auth!,
 					tokens: authAPITestParams.ValidAuthTokens,
-				}),
-			).rejects.toThrow(AuthError);
-			credentialsForIdentityIdSpy.mockClear();
-			credentialsForIdentityIdSpy.mockImplementationOnce(async () => {
-				return authAPITestParams.NoCredentialsForIdentityIdResult as GetCredentialsForIdentityOutput;
-			});
-			expect(
-				cognitoCredentialsProvider.getCredentialsAndIdentityId({
+				});
+				expect(credentialsForIdentityIdSpy).toHaveBeenCalledWith(
+					{
+						region: authAPITestParams.CredentialsClientRequest.region,
+					},
+					authAPITestParams.CredentialsClientRequest.withValidAuthToken,
+				);
+				expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(1);
+
+				await cognitoCredentialsProvider.getCredentialsAndIdentityId({
 					authenticated: true,
 					authConfig: validAuthConfig.Auth!,
-					tokens: authAPITestParams.ValidAuthTokens,
-				}),
-			).rejects.toThrow(AuthError);
-			credentialsForIdentityIdSpy.mockClear();
-			credentialsForIdentityIdSpy.mockImplementationOnce(async () => {
-				return authAPITestParams.NoSecretKeyInCredentialsForIdentityIdResult as GetCredentialsForIdentityOutput;
+					tokens: authAPITestParams.NewValidAuthTokens,
+				});
+				expect(credentialsForIdentityIdSpy).toHaveBeenCalledWith(
+					{
+						region: authAPITestParams.CredentialsClientRequest.region,
+					},
+					authAPITestParams.CredentialsClientRequest.withNewValidAuthToken,
+				);
+				expect(credentialsForIdentityIdSpy).toHaveBeenCalledTimes(2);
 			});
-			expect(
-				cognitoCredentialsProvider.getCredentialsAndIdentityId({
-					authenticated: true,
-					authConfig: validAuthConfig.Auth!,
-					tokens: authAPITestParams.ValidAuthTokens,
-				}),
-			).rejects.toThrow(AuthError);
+		});
+		describe('Error Path Cases:', () => {
+			beforeEach(() => {
+				cognitoCredentialsProvider =
+					new CognitoAWSCredentialsAndIdentityIdProvider(
+						new DefaultIdentityIdStore(sharedInMemoryStorage),
+					);
+			});
+			afterEach(() => {
+				cognitoCredentialsProvider.clearCredentials();
+			});
+			afterAll(() => {
+				credentialsForIdentityIdSpy?.mockReset();
+			});
+			test('Should throw AuthError if either Credentials, accessKeyId or secretKey is absent in the response', async () => {
+				credentialsForIdentityIdSpy.mockImplementationOnce(async () => {
+					return authAPITestParams.NoAccessKeyCredentialsForIdentityIdResult;
+				});
+				expect(
+					cognitoCredentialsProvider.getCredentialsAndIdentityId({
+						authenticated: true,
+						authConfig: validAuthConfig.Auth!,
+						tokens: authAPITestParams.ValidAuthTokens,
+					}),
+				).rejects.toThrow(AuthError);
+				credentialsForIdentityIdSpy.mockClear();
+				credentialsForIdentityIdSpy.mockImplementationOnce(async () => {
+					return authAPITestParams.NoCredentialsForIdentityIdResult as GetCredentialsForIdentityOutput;
+				});
+				expect(
+					cognitoCredentialsProvider.getCredentialsAndIdentityId({
+						authenticated: true,
+						authConfig: validAuthConfig.Auth!,
+						tokens: authAPITestParams.ValidAuthTokens,
+					}),
+				).rejects.toThrow(AuthError);
+				credentialsForIdentityIdSpy.mockClear();
+				credentialsForIdentityIdSpy.mockImplementationOnce(async () => {
+					return authAPITestParams.NoSecretKeyInCredentialsForIdentityIdResult;
+				});
+				expect(
+					cognitoCredentialsProvider.getCredentialsAndIdentityId({
+						authenticated: true,
+						authConfig: validAuthConfig.Auth!,
+						tokens: authAPITestParams.ValidAuthTokens,
+					}),
+				).rejects.toThrow(AuthError);
+			});
 		});
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/identityIdProvider.test.ts
+++ b/packages/auth/__tests__/providers/cognito/identityIdProvider.test.ts
@@ -6,8 +6,12 @@ import {
 	GetIdInput,
 	GetIdOutput,
 } from '@aws-amplify/core/internals/aws-clients/cognitoIdentity';
-import { CognitoIdentityPoolConfig } from '@aws-amplify/core/internals/utils';
+import {
+	AmplifyError,
+	CognitoIdentityPoolConfig,
+} from '@aws-amplify/core/internals/utils';
 
+import { AuthError } from '../../../src';
 import { DefaultIdentityIdStore } from '../../../src/providers/cognito/credentialsProvider/IdentityIdStore';
 import { cognitoIdentityIdProvider } from '../../../src/providers/cognito/credentialsProvider/IdentityIdProvider';
 
@@ -39,105 +43,138 @@ const mockKeyValueStorage = {
 };
 const MockDefaultIdentityIdStore = DefaultIdentityIdStore as jest.Mock;
 
-describe('Cognito IdentityId Provider Happy Path Cases:', () => {
+describe('Cognito IdentityId Provider', () => {
 	const _ = new DefaultIdentityIdStore(mockKeyValueStorage);
 	const mockDefaultIdentityIdStoreInstance =
 		MockDefaultIdentityIdStore.mock.instances[0];
+	describe('Happy Path Cases:', () => {
+		beforeAll(() => {
+			jest.spyOn(Amplify, 'getConfig').mockImplementationOnce(() => ampConfig);
 
-	beforeAll(() => {
-		jest.spyOn(Amplify, 'getConfig').mockImplementationOnce(() => ampConfig);
-
-		mockGetId.mockImplementation(
-			async (_config: object, params: GetIdInput) => {
-				if (params.Logins && Object.keys(params.Logins).length === 0) {
-					return {
-						IdentityId: authAPITestParams.GuestIdentityId.id,
-					} as GetIdOutput;
-				} else {
-					return {
-						IdentityId: authAPITestParams.PrimaryIdentityId.id,
-					} as GetIdOutput;
-				}
-			},
-		);
-	});
-
-	afterEach(() => {
-		mockGetId.mockClear();
-	});
-
-	test('Should return stored guest identityId', async () => {
-		mockDefaultIdentityIdStoreInstance.loadIdentityId.mockImplementationOnce(
-			async () => {
-				return authAPITestParams.GuestIdentityId as Identity;
-			},
-		);
-		expect(
-			await cognitoIdentityIdProvider({
-				authConfig: ampConfig.Auth!.Cognito as CognitoIdentityPoolConfig,
-				identityIdStore: mockDefaultIdentityIdStoreInstance,
-			}),
-		).toBe(authAPITestParams.GuestIdentityId.id);
-		expect(mockGetId).toHaveBeenCalledTimes(0);
-	});
-	test('Should generate a guest identityId and return it', async () => {
-		mockDefaultIdentityIdStoreInstance.loadIdentityId.mockImplementationOnce(
-			async () => {
-				return undefined;
-			},
-		);
-		mockDefaultIdentityIdStoreInstance.storeIdentityId.mockImplementationOnce(
-			async (identity: Identity) => {
-				expect(identity.id).toBe(authAPITestParams.GuestIdentityId.id);
-				expect(identity.type).toBe(authAPITestParams.GuestIdentityId.type);
-			},
-		);
-		expect(
-			await cognitoIdentityIdProvider({
-				authConfig: {
-					identityPoolId: 'us-east-1:test-id',
+			mockGetId.mockImplementation(
+				async (_config: object, params: GetIdInput) => {
+					if (params.Logins && Object.keys(params.Logins).length === 0) {
+						return {
+							IdentityId: authAPITestParams.GuestIdentityId.id,
+						} as GetIdOutput;
+					} else {
+						return {
+							IdentityId: authAPITestParams.PrimaryIdentityId.id,
+						} as GetIdOutput;
+					}
 				},
-				identityIdStore: mockDefaultIdentityIdStoreInstance,
-			}),
-		).toBe(authAPITestParams.GuestIdentityId.id);
-		expect(mockGetId).toHaveBeenCalledTimes(1);
-	});
-	test('Should return stored primary identityId', async () => {
-		mockDefaultIdentityIdStoreInstance.loadIdentityId.mockImplementationOnce(
-			async () => {
-				return authAPITestParams.PrimaryIdentityId as Identity;
-			},
-		);
-		expect(
-			await cognitoIdentityIdProvider({
-				authConfig: ampConfig.Auth!.Cognito as CognitoIdentityPoolConfig,
-				tokens: authAPITestParams.ValidAuthTokens,
-				identityIdStore: mockDefaultIdentityIdStoreInstance,
-			}),
-		).toBe(authAPITestParams.PrimaryIdentityId.id);
-		expect(mockGetId).toHaveBeenCalledTimes(0);
-	});
-	test('Should generate a primary identityId and return it', async () => {
-		mockDefaultIdentityIdStoreInstance.loadIdentityId.mockImplementationOnce(
-			async () => {
-				return undefined;
-			},
-		);
-		mockDefaultIdentityIdStoreInstance.storeIdentityId.mockImplementationOnce(
-			async (identity: Identity) => {
-				expect(identity.id).toBe(authAPITestParams.PrimaryIdentityId.id);
-				expect(identity.type).toBe(authAPITestParams.PrimaryIdentityId.type);
-			},
-		);
-		expect(
-			await cognitoIdentityIdProvider({
-				tokens: authAPITestParams.ValidAuthTokens,
-				authConfig: {
-					identityPoolId: 'us-east-1:test-id',
+			);
+		});
+
+		afterEach(() => {
+			mockGetId.mockClear();
+		});
+
+		test('Should return stored guest identityId', async () => {
+			mockDefaultIdentityIdStoreInstance.loadIdentityId.mockImplementationOnce(
+				async () => {
+					return authAPITestParams.GuestIdentityId as Identity;
 				},
-				identityIdStore: mockDefaultIdentityIdStoreInstance,
-			}),
-		).toBe(authAPITestParams.PrimaryIdentityId.id);
-		expect(mockGetId).toHaveBeenCalledTimes(1);
+			);
+			expect(
+				await cognitoIdentityIdProvider({
+					authConfig: ampConfig.Auth!.Cognito as CognitoIdentityPoolConfig,
+					identityIdStore: mockDefaultIdentityIdStoreInstance,
+				}),
+			).toBe(authAPITestParams.GuestIdentityId.id);
+			expect(mockGetId).toHaveBeenCalledTimes(0);
+		});
+		test('Should generate a guest identityId and return it', async () => {
+			mockDefaultIdentityIdStoreInstance.loadIdentityId.mockImplementationOnce(
+				async () => {
+					return undefined;
+				},
+			);
+			mockDefaultIdentityIdStoreInstance.storeIdentityId.mockImplementationOnce(
+				async (identity: Identity) => {
+					expect(identity.id).toBe(authAPITestParams.GuestIdentityId.id);
+					expect(identity.type).toBe(authAPITestParams.GuestIdentityId.type);
+				},
+			);
+			expect(
+				await cognitoIdentityIdProvider({
+					authConfig: {
+						identityPoolId: 'us-east-1:test-id',
+					},
+					identityIdStore: mockDefaultIdentityIdStoreInstance,
+				}),
+			).toBe(authAPITestParams.GuestIdentityId.id);
+			expect(mockGetId).toHaveBeenCalledTimes(1);
+		});
+		test('Should return stored primary identityId', async () => {
+			mockDefaultIdentityIdStoreInstance.loadIdentityId.mockImplementationOnce(
+				async () => {
+					return authAPITestParams.PrimaryIdentityId as Identity;
+				},
+			);
+			expect(
+				await cognitoIdentityIdProvider({
+					authConfig: ampConfig.Auth!.Cognito as CognitoIdentityPoolConfig,
+					tokens: authAPITestParams.ValidAuthTokens,
+					identityIdStore: mockDefaultIdentityIdStoreInstance,
+				}),
+			).toBe(authAPITestParams.PrimaryIdentityId.id);
+			expect(mockGetId).toHaveBeenCalledTimes(0);
+		});
+		test('Should generate a primary identityId and return it', async () => {
+			mockDefaultIdentityIdStoreInstance.loadIdentityId.mockImplementationOnce(
+				async () => {
+					return undefined;
+				},
+			);
+			mockDefaultIdentityIdStoreInstance.storeIdentityId.mockImplementationOnce(
+				async (identity: Identity) => {
+					expect(identity.id).toBe(authAPITestParams.PrimaryIdentityId.id);
+					expect(identity.type).toBe(authAPITestParams.PrimaryIdentityId.type);
+				},
+			);
+			expect(
+				await cognitoIdentityIdProvider({
+					tokens: authAPITestParams.ValidAuthTokens,
+					authConfig: {
+						identityPoolId: 'us-east-1:test-id',
+					},
+					identityIdStore: mockDefaultIdentityIdStoreInstance,
+				}),
+			).toBe(authAPITestParams.PrimaryIdentityId.id);
+			expect(mockGetId).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('Error Path Cases', () => {
+		const mockServiceErrorParams = {
+			name: 'ServiceError',
+			message: '',
+			metadata: {
+				httpStatusCode: 500,
+				requestId: '123',
+			},
+		};
+		beforeEach(() => {
+			mockGetId.mockRejectedValue(new AmplifyError(mockServiceErrorParams));
+		});
+
+		test('Should throw AuthError when there is a service error', async () => {
+			expect.assertions(2);
+			mockDefaultIdentityIdStoreInstance.loadIdentityId.mockImplementationOnce(
+				async () => {
+					return undefined;
+				},
+			);
+			try {
+				await cognitoIdentityIdProvider({
+					authConfig: ampConfig.Auth!.Cognito as CognitoIdentityPoolConfig,
+					identityIdStore: mockDefaultIdentityIdStoreInstance,
+				});
+			} catch (e) {
+				expect(e).toBeInstanceOf(AuthError);
+				expect(e).toMatchObject(mockServiceErrorParams);
+			}
+		});
 	});
 });

--- a/packages/auth/src/foundation/factories/serviceClients/cognitoIdentityProvider/shared/serde/createUserPoolDeserializer.ts
+++ b/packages/auth/src/foundation/factories/serviceClients/cognitoIdentityProvider/shared/serde/createUserPoolDeserializer.ts
@@ -16,7 +16,11 @@ export const createUserPoolDeserializer =
 		if (response.statusCode >= 300) {
 			const error = await parseJsonError(response);
 			assertServiceError(error);
-			throw new AuthError({ name: error.name, message: error.message });
+			throw new AuthError({
+				name: error.name,
+				message: error.message,
+				metadata: error.metadata,
+			});
 		}
 
 		return parseJsonBody(response);

--- a/packages/auth/src/providers/cognito/credentialsProvider/IdentityIdProvider.ts
+++ b/packages/auth/src/providers/cognito/credentialsProvider/IdentityIdProvider.ts
@@ -5,6 +5,7 @@ import { AuthTokens, ConsoleLogger, Identity, getId } from '@aws-amplify/core';
 import { CognitoIdentityPoolConfig } from '@aws-amplify/core/internals/utils';
 
 import { AuthError } from '../../../errors/AuthError';
+import { assertServiceError } from '../../../errors/utils/assertServiceError';
 import { getRegionFromIdentityPoolId } from '../../../foundation/parsers';
 import { GetIdException } from '../types/errors';
 
@@ -83,10 +84,11 @@ async function generateIdentityId(
 	const region = getRegionFromIdentityPoolId(identityPoolId);
 
 	// IdentityId is absent so get it using IdentityPoolId with Cognito's GetId API
-	const idResult =
-		// for a first-time user, this will return a brand new identity
-		// for a returning user, this will retrieve the previous identity assocaited with the logins
-		(
+	let idResult: string | undefined;
+	// for a first-time user, this will return a brand new identity
+	// for a returning user, this will retrieve the previous identity assocaited with the logins
+	try {
+		idResult = (
 			await getId(
 				{
 					region,
@@ -97,6 +99,10 @@ async function generateIdentityId(
 				},
 			)
 		).IdentityId;
+	} catch (e) {
+		assertServiceError(e);
+		throw new AuthError(e);
+	}
 	if (!idResult) {
 		throw new AuthError({
 			name: 'GetIdResponseException',

--- a/packages/auth/src/providers/cognito/credentialsProvider/credentialsProvider.ts
+++ b/packages/auth/src/providers/cognito/credentialsProvider/credentialsProvider.ts
@@ -15,6 +15,7 @@ import {
 } from '@aws-amplify/core/internals/utils';
 
 import { AuthError } from '../../../errors/AuthError';
+import { assertServiceError } from '../../../errors/utils/assertServiceError';
 import { getRegionFromIdentityPoolId } from '../../../foundation/parsers';
 import { assertIdTokenInAuthTokens } from '../utils/types';
 
@@ -116,14 +117,23 @@ export class CognitoAWSCredentialsAndIdentityIdProvider
 		// save credentials in-memory
 		// No logins params should be passed for guest creds:
 		// https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetCredentialsForIdentity.html
-		const clientResult = await getCredentialsForIdentity(
-			{ region },
-			{
-				IdentityId: identityId,
-			},
-		);
+		let clientResult:
+			| Awaited<ReturnType<typeof getCredentialsForIdentity>>
+			| undefined;
+		try {
+			clientResult = await getCredentialsForIdentity(
+				{ region },
+				{
+					IdentityId: identityId,
+				},
+			);
+		} catch (e) {
+			assertServiceError(e);
+			throw new AuthError(e);
+		}
 
 		if (
+			clientResult &&
 			clientResult.Credentials &&
 			clientResult.Credentials.AccessKeyId &&
 			clientResult.Credentials.SecretKey

--- a/packages/core/__tests__/awsClients/cognitoIdentity/getCredentialsForIdentity.test.ts
+++ b/packages/core/__tests__/awsClients/cognitoIdentity/getCredentialsForIdentity.test.ts
@@ -86,6 +86,10 @@ describe('CognitoIdentity - getCredentialsForIdentity', () => {
 		const expectedError = {
 			name: 'NotAuthorizedException',
 			message: failureResponse.body.message,
+			metadata: expect.objectContaining({
+				requestId: mockRequestId,
+				httpStatusCode: failureResponse.status,
+			}),
 		};
 		(fetchTransferHandler as jest.Mock).mockResolvedValue(
 			mockJsonResponse(failureResponse),

--- a/packages/core/__tests__/awsClients/cognitoIdentity/getId.test.ts
+++ b/packages/core/__tests__/awsClients/cognitoIdentity/getId.test.ts
@@ -80,6 +80,10 @@ describe('CognitoIdentity - getId', () => {
 		const expectedError = {
 			name: 'NotAuthorizedException',
 			message: failureResponse.body.message,
+			metadata: expect.objectContaining({
+				httpStatusCode: 400,
+				requestId: mockRequestId,
+			}),
 		};
 		(fetchTransferHandler as jest.Mock).mockResolvedValue(
 			mockJsonResponse(failureResponse),

--- a/packages/core/src/clients/serde/json.ts
+++ b/packages/core/src/clients/serde/json.ts
@@ -36,7 +36,7 @@ export const parseJsonError: ErrorParser = async (response?: HttpResponse) => {
 
 	return Object.assign(error, {
 		name: code,
-		$metadata: parseMetadata(response),
+		metadata: parseMetadata(response),
 	});
 };
 

--- a/packages/core/src/clients/types/aws.ts
+++ b/packages/core/src/clients/types/aws.ts
@@ -1,15 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-import { MetadataBearer } from '@aws-sdk/types';
-
 import { Endpoint } from './core';
 import { HttpResponse } from './http';
 
-export type {
-	AwsCredentialIdentity as Credentials,
-	MetadataBearer,
-} from '@aws-sdk/types';
+export interface ResponseMetadata {
+	/**
+	 * The status code of the last HTTP response received for this operation, if the error
+	 * is caused by erroneous server response.
+	 */
+	httpStatusCode?: number;
+	/**
+	 * A unique identifier for the last request sent for this operation. Often
+	 * requested by AWS service teams to aid in debugging.
+	 */
+	requestId?: string;
+	/**
+	 * A secondary identifier for the last request sent. Often requested by AWS
+	 * service teams to aid in debugging.
+	 */
+	extendedRequestId?: string;
+}
+
+export type { AwsCredentialIdentity as Credentials } from '@aws-sdk/types';
 
 export type SourceData = string | ArrayBuffer | ArrayBufferView;
 
@@ -31,4 +43,4 @@ export interface ServiceClientOptions {
  */
 export type ErrorParser = (
 	response?: HttpResponse,
-) => Promise<(Error & MetadataBearer) | undefined>;
+) => Promise<(Error & { metadata: ResponseMetadata }) | undefined>;

--- a/packages/core/src/clients/types/index.ts
+++ b/packages/core/src/clients/types/index.ts
@@ -23,4 +23,5 @@ export {
 	EndpointResolverOptions,
 	ErrorParser,
 	ServiceClientOptions,
+	ResponseMetadata,
 } from './aws';

--- a/packages/core/src/errors/AmplifyError.ts
+++ b/packages/core/src/errors/AmplifyError.ts
@@ -1,11 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 import { AmplifyErrorParams } from '../types/errors';
+import { ResponseMetadata } from '../clients';
 
 export class AmplifyError extends Error {
-	underlyingError?: Error | unknown;
-	recoverySuggestion?: string;
+	readonly underlyingError?: Error | unknown;
+	readonly recoverySuggestion?: string;
+	/**
+	 * Additional metadata that can be used to provide more context to the error.
+	 */
+	readonly metadata?: ResponseMetadata;
 	/**
 	 *  Constructs an AmplifyError.
 	 *
@@ -19,12 +23,14 @@ export class AmplifyError extends Error {
 		name,
 		recoverySuggestion,
 		underlyingError,
+		metadata,
 	}: AmplifyErrorParams) {
 		super(message);
 
 		this.name = name;
 		this.underlyingError = underlyingError;
 		this.recoverySuggestion = recoverySuggestion;
+		this.metadata = metadata;
 
 		// Hack for making the custom error class work when transpiled to es5
 		// TODO: Delete the following 2 lines after we change the build target to >= es2015

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { ResponseMetadata } from '../clients';
 
 export enum AmplifyErrorCode {
 	NoEndpointId = 'NoEndpointId',
@@ -13,6 +14,7 @@ export interface AmplifyErrorParams<ErrorCode extends string = string> {
 	name: ErrorCode;
 	recoverySuggestion?: string;
 	underlyingError?: Error | unknown;
+	metadata?: ResponseMetadata;
 }
 
 export type AmplifyErrorMap<ErrorCode extends string = string> = {


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
* Add an optional `metadata` property to the base `AmplifyError` class and `AuthError` class. So customers can inspect the requestId if an AuthError is caused by a service error response.
* Update the error parser to populate the `metadata` property when parsing error responses from services. Previously it sets  purely internal`$metadata` property. 
* Fix the 2 identity pool APIs(`GetId`, `GetCredentialsForId`) to throw AuthError. Previously, the 2 APIs throw the base `Error` instance.
* Update the unit test for identity pool and user pool APIs to verify they all throw `AuthError`.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Unit tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
