### PR TITLE
fix(adapter-nextjs): secure: false is not set for localhost on sign-in

### DIFF
--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInCallbackRequest.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInCallbackRequest.test.ts
@@ -329,6 +329,7 @@ describe('handleSignInCallbackRequest', () => {
 			});
 			expect(mockCreateTokenCookiesSetOptions).toHaveBeenCalledWith(
 				mockSetCookieOptions,
+				mockOrigin,
 			);
 			expect(mockCreateSignInFlowProofCookies).toHaveBeenCalledWith({
 				state: '',

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInCallbackRequestForPagesRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInCallbackRequestForPagesRouter.test.ts
@@ -386,6 +386,7 @@ describe('handleSignInCallbackRequest', () => {
 			});
 			expect(mockCreateTokenCookiesSetOptions).toHaveBeenCalledWith(
 				mockSetCookieOptions,
+				mockOrigin,
 			);
 			expect(mockCreateSignInFlowProofCookies).toHaveBeenCalledWith({
 				state: '',

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInSignUpRequest.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInSignUpRequest.test.ts
@@ -10,7 +10,6 @@ import {
 	createSignInFlowProofCookies,
 	createSignUpEndpoint,
 	createUrlSearchParamsForSignInSignUp,
-	isSSLOrigin,
 } from '../../../src/auth/utils';
 
 jest.mock('../../../src/auth/utils');
@@ -28,7 +27,6 @@ const mockCreateSignUpEndpoint = jest.mocked(createSignUpEndpoint);
 const mockCreateUrlSearchParamsForSignInSignUp = jest.mocked(
 	createUrlSearchParamsForSignInSignUp,
 );
-const mockIsSSLOrigin = jest.mocked(isSSLOrigin);
 
 describe('handleSignInSignUpRequest', () => {
 	const mockCustomState = 'mockCustomState';
@@ -40,10 +38,6 @@ describe('handleSignInSignUpRequest', () => {
 	};
 	const mockToCodeChallenge = jest.fn(() => 'mockCodeChallenge');
 
-	beforeAll(() => {
-		mockIsSSLOrigin.mockReturnValue(true);
-	});
-
 	afterEach(() => {
 		mockAppendSetCookieHeaders.mockClear();
 		mockCreateAuthFlowProofCookiesSetOptions.mockClear();
@@ -53,7 +47,6 @@ describe('handleSignInSignUpRequest', () => {
 		mockCreateSignUpEndpoint.mockClear();
 		mockCreateUrlSearchParamsForSignInSignUp.mockClear();
 		mockToCodeChallenge.mockClear();
-		mockIsSSLOrigin.mockClear();
 	});
 
 	test.each(['signIn' as const, 'signUp' as const])(
@@ -152,9 +145,7 @@ describe('handleSignInSignUpRequest', () => {
 
 			expect(mockCreateAuthFlowProofCookiesSetOptions).toHaveBeenCalledWith(
 				mockSetCookieOptions,
-				{
-					secure: true,
-				},
+				mockOrigin,
 			);
 
 			expect(mockAppendSetCookieHeaders).toHaveBeenCalledWith(
@@ -162,7 +153,6 @@ describe('handleSignInSignUpRequest', () => {
 				mockCreateSignInFlowProofCookiesResult,
 				mockCreateAuthFlowProofCookiesSetOptionsResult,
 			);
-			expect(isSSLOrigin).toHaveBeenCalledWith(mockOrigin);
 		},
 	);
 });

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInSignUpRequestForPagesRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignInSignUpRequestForPagesRouter.test.ts
@@ -11,7 +11,6 @@ import {
 	createSignInFlowProofCookies,
 	createSignUpEndpoint,
 	createUrlSearchParamsForSignInSignUp,
-	isSSLOrigin,
 } from '../../../src/auth/utils';
 import { createMockNextApiResponse } from '../testUtils';
 
@@ -32,7 +31,6 @@ const mockCreateSignUpEndpoint = jest.mocked(createSignUpEndpoint);
 const mockCreateUrlSearchParamsForSignInSignUp = jest.mocked(
 	createUrlSearchParamsForSignInSignUp,
 );
-const mockIsSSLOrigin = jest.mocked(isSSLOrigin);
 
 describe('handleSignInSignUpRequest', () => {
 	const mockCustomState = 'mockCustomState';
@@ -53,10 +51,6 @@ describe('handleSignInSignUpRequest', () => {
 		mockResponse,
 	} = createMockNextApiResponse();
 
-	beforeAll(() => {
-		mockIsSSLOrigin.mockReturnValue(true);
-	});
-
 	afterEach(() => {
 		mockAppendSetCookieHeadersToNextApiResponse.mockClear();
 		mockCreateAuthFlowProofCookiesSetOptions.mockClear();
@@ -66,7 +60,6 @@ describe('handleSignInSignUpRequest', () => {
 		mockCreateSignUpEndpoint.mockClear();
 		mockCreateUrlSearchParamsForSignInSignUp.mockClear();
 		mockToCodeChallenge.mockClear();
-		mockIsSSLOrigin.mockClear();
 
 		mockResponseAppendHeader.mockClear();
 		mockResponseEnd.mockClear();
@@ -177,9 +170,7 @@ describe('handleSignInSignUpRequest', () => {
 
 			expect(mockCreateAuthFlowProofCookiesSetOptions).toHaveBeenCalledWith(
 				mockSetCookieOptions,
-				{
-					secure: true,
-				},
+				mockOrigin,
 			);
 
 			expect(mockAppendSetCookieHeadersToNextApiResponse).toHaveBeenCalledWith(
@@ -187,7 +178,6 @@ describe('handleSignInSignUpRequest', () => {
 				mockCreateSignInFlowProofCookiesResult,
 				mockCreateAuthFlowProofCookiesSetOptionsResult,
 			);
-			expect(isSSLOrigin).toHaveBeenCalledWith(mockOrigin);
 		},
 	);
 });

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutRequest.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutRequest.test.ts
@@ -6,7 +6,6 @@ import {
 	createAuthFlowProofCookiesSetOptions,
 	createLogoutEndpoint,
 	createSignOutFlowProofCookies,
-	isSSLOrigin,
 	resolveRedirectSignOutUrl,
 } from '../../../src/auth/utils';
 
@@ -21,20 +20,14 @@ const mockCreateSignOutFlowProofCookies = jest.mocked(
 	createSignOutFlowProofCookies,
 );
 const mockResolveRedirectSignOutUrl = jest.mocked(resolveRedirectSignOutUrl);
-const mockIsSSLOrigin = jest.mocked(isSSLOrigin);
 
 describe('handleSignOutRequest', () => {
-	beforeAll(() => {
-		mockIsSSLOrigin.mockReturnValue(true);
-	});
-
 	afterEach(() => {
 		mockAppendSetCookieHeaders.mockClear();
 		mockCreateAuthFlowProofCookiesSetOptions.mockClear();
 		mockCreateLogoutEndpoint.mockClear();
 		mockCreateSignOutFlowProofCookies.mockClear();
 		mockResolveRedirectSignOutUrl.mockClear();
-		mockIsSSLOrigin.mockClear();
 	});
 
 	it('returns a 302 response with the correct headers and cookies', async () => {
@@ -98,12 +91,9 @@ describe('handleSignOutRequest', () => {
 			expect.any(URLSearchParams),
 		);
 		expect(mockCreateSignOutFlowProofCookies).toHaveBeenCalled();
-		expect(mockIsSSLOrigin).toHaveBeenCalledWith(mockOrigin);
 		expect(mockCreateAuthFlowProofCookiesSetOptions).toHaveBeenCalledWith(
 			mockSetCookieOptions,
-			{
-				secure: true,
-			},
+			mockOrigin,
 		);
 		expect(mockAppendSetCookieHeaders).toHaveBeenCalledWith(
 			expect.any(Headers),

--- a/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutRequestForPagesRouter.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/handlers/handleSignOutRequestForPagesRouter.test.ts
@@ -6,7 +6,6 @@ import {
 	createAuthFlowProofCookiesSetOptions,
 	createLogoutEndpoint,
 	createSignOutFlowProofCookies,
-	isSSLOrigin,
 	resolveRedirectSignOutUrl,
 } from '../../../src/auth/utils';
 import { createMockNextApiResponse } from '../testUtils';
@@ -24,7 +23,6 @@ const mockCreateSignOutFlowProofCookies = jest.mocked(
 	createSignOutFlowProofCookies,
 );
 const mockResolveRedirectSignOutUrl = jest.mocked(resolveRedirectSignOutUrl);
-const mockIsSSLOrigin = jest.mocked(isSSLOrigin);
 
 describe('handleSignOutRequest', () => {
 	const {
@@ -35,10 +33,6 @@ describe('handleSignOutRequest', () => {
 		mockResponseRedirect,
 		mockResponse,
 	} = createMockNextApiResponse();
-
-	beforeAll(() => {
-		mockIsSSLOrigin.mockReturnValue(true);
-	});
 
 	afterEach(() => {
 		mockAppendSetCookieHeadersToNextApiResponse.mockClear();
@@ -121,12 +115,9 @@ describe('handleSignOutRequest', () => {
 			expect.any(URLSearchParams),
 		);
 		expect(mockCreateSignOutFlowProofCookies).toHaveBeenCalled();
-		expect(mockIsSSLOrigin).toHaveBeenCalledWith(mockOrigin);
 		expect(mockCreateAuthFlowProofCookiesSetOptions).toHaveBeenCalledWith(
 			mockSetCookieOptions,
-			{
-				secure: true,
-			},
+			mockOrigin,
 		);
 	});
 });

--- a/packages/adapter-nextjs/__tests__/auth/utils/authFlowProofCookies.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/utils/authFlowProofCookies.test.ts
@@ -43,7 +43,10 @@ describe('createAuthFlowProofCookiesSetOptions', () => {
 			sameSite: 'strict',
 		};
 
-		const options = createAuthFlowProofCookiesSetOptions(setCookieOptions);
+		const options = createAuthFlowProofCookiesSetOptions(
+			setCookieOptions,
+			'https://example.com',
+		);
 
 		expect(options).toEqual({
 			domain: setCookieOptions?.domain,
@@ -61,9 +64,10 @@ describe('createAuthFlowProofCookiesSetOptions', () => {
 			sameSite: 'strict',
 		};
 
-		const options = createAuthFlowProofCookiesSetOptions(setCookieOptions, {
-			secure: false,
-		});
+		const options = createAuthFlowProofCookiesSetOptions(
+			setCookieOptions,
+			'http://example.com',
+		);
 
 		expect(options).toEqual({
 			domain: setCookieOptions?.domain,

--- a/packages/adapter-nextjs/__tests__/auth/utils/tokenCookies.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/utils/tokenCookies.test.ts
@@ -83,7 +83,10 @@ describe('createTokenCookiesSetOptions', () => {
 			expires: new Date('2024-09-17'),
 		};
 
-		const result = createTokenCookiesSetOptions(mockSetCookieOptions);
+		const result = createTokenCookiesSetOptions(
+			mockSetCookieOptions,
+			'https://example.com',
+		);
 
 		expect(result).toEqual({
 			domain: mockSetCookieOptions.domain,
@@ -97,7 +100,7 @@ describe('createTokenCookiesSetOptions', () => {
 
 	it('returns an object with the default expiry and sameSite properties', () => {
 		const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(0);
-		const result = createTokenCookiesSetOptions({});
+		const result = createTokenCookiesSetOptions({}, 'https://example.com');
 
 		expect(result).toEqual({
 			domain: undefined,
@@ -118,9 +121,10 @@ describe('createTokenCookiesSetOptions', () => {
 			expires: new Date('2024-09-17'),
 		};
 
-		const result = createTokenCookiesSetOptions(mockSetCookieOptions, {
-			secure: false,
-		});
+		const result = createTokenCookiesSetOptions(
+			mockSetCookieOptions,
+			'http://example.com',
+		);
 
 		expect(result).toEqual({
 			domain: mockSetCookieOptions.domain,

--- a/packages/adapter-nextjs/src/auth/handlers/handleSignInCallbackRequest.ts
+++ b/packages/adapter-nextjs/src/auth/handlers/handleSignInCallbackRequest.ts
@@ -96,7 +96,7 @@ export const handleSignInCallbackRequest: HandleSignInCallbackRequest = async ({
 			tokensPayload,
 			userPoolClientId,
 		}),
-		createTokenCookiesSetOptions(setCookieOptions),
+		createTokenCookiesSetOptions(setCookieOptions, origin),
 	);
 	appendSetCookieHeaders(
 		headers,

--- a/packages/adapter-nextjs/src/auth/handlers/handleSignInCallbackRequestForPagesRouter.ts
+++ b/packages/adapter-nextjs/src/auth/handlers/handleSignInCallbackRequestForPagesRouter.ts
@@ -104,7 +104,7 @@ export const handleSignInCallbackRequestForPagesRouter: HandleSignInCallbackRequ
 				tokensPayload,
 				userPoolClientId,
 			}),
-			createTokenCookiesSetOptions(setCookieOptions),
+			createTokenCookiesSetOptions(setCookieOptions, origin),
 		);
 		appendSetCookieHeadersToNextApiResponse(
 			response,

--- a/packages/adapter-nextjs/src/auth/handlers/handleSignInSignUpRequest.ts
+++ b/packages/adapter-nextjs/src/auth/handlers/handleSignInSignUpRequest.ts
@@ -9,7 +9,6 @@ import {
 	createSignInFlowProofCookies,
 	createSignUpEndpoint,
 	createUrlSearchParamsForSignInSignUp,
-	isSSLOrigin,
 } from '../utils';
 
 import { HandleSignInSignUpRequest } from './types';
@@ -44,9 +43,7 @@ export const handleSignInSignUpRequest: HandleSignInSignUpRequest = ({
 	appendSetCookieHeaders(
 		headers,
 		createSignInFlowProofCookies({ state, pkce: codeVerifier.value }),
-		createAuthFlowProofCookiesSetOptions(setCookieOptions, {
-			secure: isSSLOrigin(origin),
-		}),
+		createAuthFlowProofCookiesSetOptions(setCookieOptions, origin),
 	);
 
 	return new Response(null, {

--- a/packages/adapter-nextjs/src/auth/handlers/handleSignInSignUpRequestForPagesRouter.ts
+++ b/packages/adapter-nextjs/src/auth/handlers/handleSignInSignUpRequestForPagesRouter.ts
@@ -9,7 +9,6 @@ import {
 	createSignInFlowProofCookies,
 	createSignUpEndpoint,
 	createUrlSearchParamsForSignInSignUp,
-	isSSLOrigin,
 } from '../utils';
 
 import { HandleSignInSignUpRequestForPagesRouter } from './types';
@@ -38,9 +37,7 @@ export const handleSignInSignUpRequestForPagesRouter: HandleSignInSignUpRequestF
 		appendSetCookieHeadersToNextApiResponse(
 			response,
 			createSignInFlowProofCookies({ state, pkce: codeVerifier.value }),
-			createAuthFlowProofCookiesSetOptions(setCookieOptions, {
-				secure: isSSLOrigin(origin),
-			}),
+			createAuthFlowProofCookiesSetOptions(setCookieOptions, origin),
 		);
 
 		const redirectUrl =

--- a/packages/adapter-nextjs/src/auth/handlers/handleSignOutRequest.ts
+++ b/packages/adapter-nextjs/src/auth/handlers/handleSignOutRequest.ts
@@ -6,7 +6,6 @@ import {
 	createAuthFlowProofCookiesSetOptions,
 	createLogoutEndpoint,
 	createSignOutFlowProofCookies,
-	isSSLOrigin,
 	resolveRedirectSignOutUrl,
 } from '../utils';
 
@@ -31,9 +30,7 @@ export const handleSignOutRequest: HandleSignOutRequest = ({
 	appendSetCookieHeaders(
 		headers,
 		createSignOutFlowProofCookies(),
-		createAuthFlowProofCookiesSetOptions(setCookieOptions, {
-			secure: isSSLOrigin(origin),
-		}),
+		createAuthFlowProofCookiesSetOptions(setCookieOptions, origin),
 	);
 
 	return new Response(null, {

--- a/packages/adapter-nextjs/src/auth/handlers/handleSignOutRequestForPagesRouter.ts
+++ b/packages/adapter-nextjs/src/auth/handlers/handleSignOutRequestForPagesRouter.ts
@@ -6,7 +6,6 @@ import {
 	createAuthFlowProofCookiesSetOptions,
 	createLogoutEndpoint,
 	createSignOutFlowProofCookies,
-	isSSLOrigin,
 	resolveRedirectSignOutUrl,
 } from '../utils';
 
@@ -22,9 +21,7 @@ export const handleSignOutRequestForPagesRouter: HandleSignOutRequestForPagesRou
 		appendSetCookieHeadersToNextApiResponse(
 			response,
 			createSignOutFlowProofCookies(),
-			createAuthFlowProofCookiesSetOptions(setCookieOptions, {
-				secure: isSSLOrigin(origin),
-			}),
+			createAuthFlowProofCookiesSetOptions(setCookieOptions, origin),
 		);
 
 		response.redirect(

--- a/packages/adapter-nextjs/src/auth/utils/authFlowProofCookies.ts
+++ b/packages/adapter-nextjs/src/auth/utils/authFlowProofCookies.ts
@@ -11,6 +11,8 @@ import {
 	STATE_COOKIE_NAME,
 } from '../constant';
 
+import { isSSLOrigin } from './origin';
+
 export const createSignInFlowProofCookies = ({
 	state,
 	pkce,
@@ -37,12 +39,12 @@ export const createSignOutFlowProofCookies = () => [
 
 export const createAuthFlowProofCookiesSetOptions = (
 	setCookieOptions: CookieStorage.SetCookieOptions,
-	overrides?: Pick<CookieStorage.SetCookieOptions, 'secure'>,
+	origin: string,
 ) => ({
 	domain: setCookieOptions?.domain,
 	path: '/',
 	httpOnly: true,
-	secure: overrides?.secure ?? true,
+	secure: isSSLOrigin(origin),
 	sameSite: 'lax' as const,
 	maxAge: AUTH_FLOW_PROOF_MAX_AGE,
 });

--- a/packages/adapter-nextjs/src/auth/utils/tokenCookies.ts
+++ b/packages/adapter-nextjs/src/auth/utils/tokenCookies.ts
@@ -15,6 +15,7 @@ import {
 } from '../constant';
 
 import { getAccessTokenUsername } from './getAccessTokenUsername';
+import { isSSLOrigin } from './origin';
 
 export const createTokenCookies = ({
 	tokensPayload,
@@ -55,13 +56,13 @@ export const createTokenRemoveCookies = (keys: string[]) =>
 
 export const createTokenCookiesSetOptions = (
 	{ domain, sameSite, expires, maxAge }: CookieStorage.SetCookieOptions,
-	overrides?: Pick<CookieStorage.SetCookieOptions, 'secure'>,
+	origin: string,
 ) => {
 	const result = {
 		domain,
 		path: '/',
 		httpOnly: true,
-		secure: overrides?.secure ?? true,
+		secure: isSSLOrigin(origin),
 		sameSite: sameSite ?? 'strict',
 		expires,
 		maxAge,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Move the `secure` cookie attribute value calculation into the functions that actually generate the cookie attributes to prevent misses


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

- local testing with a Next.js sample app running on localhost
- e2e test

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
