### PR TITLE
feat(storage): emit response metadata in applicable error throw sites

### DIFF
--- a/packages/storage/__tests__/providers/s3/utils/client/S3/cases/completeMultipartUpload.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/S3/cases/completeMultipartUpload.ts
@@ -167,6 +167,10 @@ const completeMultipartUploadErrorCase: ApiFunctionalTestCase<
 	{
 		message: 'Access Denied',
 		name: 'AccessDenied',
+		metadata: expect.objectContaining({
+			...expectedMetadata,
+			httpStatusCode: 403,
+		}),
 	},
 ];
 
@@ -199,6 +203,7 @@ const completeMultipartUploadErrorWith200CodeCase: ApiFunctionalTestCase<
 	{
 		message: 'We encountered an internal error. Please try again.',
 		name: 'InternalError',
+		metadata: expect.objectContaining(expectedMetadata),
 	},
 ];
 

--- a/packages/storage/__tests__/providers/s3/utils/client/S3/cases/getDataAccess.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/S3/cases/getDataAccess.ts
@@ -128,6 +128,10 @@ const getDataAccessErrorCase: ApiFunctionalTestCase<typeof getDataAccess> = [
 	{
 		message: 'Access Denied',
 		name: 'AccessDenied',
+		metadata: expect.objectContaining({
+			...expectedMetadata,
+			httpStatusCode: 403,
+		}),
 	},
 ];
 

--- a/packages/storage/__tests__/providers/s3/utils/client/S3/cases/listCallerAccessGrants.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/S3/cases/listCallerAccessGrants.ts
@@ -195,6 +195,10 @@ const listCallerAccessGrantsErrorCase: ApiFunctionalTestCase<
 	{
 		message: 'Access Denied',
 		name: 'AccessDenied',
+		metadata: expect.objectContaining({
+			...expectedMetadata,
+			httpStatusCode: 403,
+		}),
 	},
 ];
 

--- a/packages/storage/__tests__/providers/s3/utils/client/S3/cases/listObjectsV2.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/S3/cases/listObjectsV2.ts
@@ -224,6 +224,10 @@ const listObjectsV2ErrorCase403: ApiFunctionalTestCase<typeof listObjectsV2> = [
 	{
 		message: 'The resource you requested does not exist',
 		name: 'NoSuchKey',
+		metadata: expect.objectContaining({
+			...expectedMetadata,
+			httpStatusCode: 403,
+		}),
 	},
 ];
 
@@ -586,6 +590,7 @@ const listObjectsV2ErrorCaseNoEncoding: ApiFunctionalTestCase<
 	{
 		message: 'An unknown error has occurred.',
 		name: 'Unknown',
+		metadata: expect.objectContaining(expectedMetadata),
 	},
 ];
 

--- a/packages/storage/__tests__/providers/s3/utils/client/s3Data/createMultipartUpload.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/s3Data/createMultipartUpload.test.ts
@@ -67,7 +67,6 @@ describe('createMultipartUploadSerializer', () => {
 			Bucket: 'bucket',
 			Key: 'key',
 		});
-		console.log(output);
 		expect(output).toEqual({
 			$metadata: expect.objectContaining(expectedMetadata),
 		});

--- a/packages/storage/__tests__/providers/s3/utils/client/testUtils/types.ts
+++ b/packages/storage/__tests__/providers/s3/utils/client/testUtils/types.ts
@@ -31,7 +31,7 @@ type ApiFunctionalTestErrorCase<ApiHandler extends (...args: any) => any> = [
 	Parameters<ApiHandler>[1], // input
 	HttpRequest, // expected request
 	MockFetchResponse, // response
-	{ name: string; message: string }, // error
+	{ name: string; message: string; metadata?: Record<string, any> }, // error
 ];
 
 /**

--- a/packages/storage/src/errors/IntegrityError.ts
+++ b/packages/storage/src/errors/IntegrityError.ts
@@ -8,15 +8,14 @@ import {
 import { StorageError } from './StorageError';
 
 export class IntegrityError extends StorageError {
-	constructor(
-		params: AmplifyErrorParams = {
+	constructor(params?: Pick<AmplifyErrorParams, 'metadata'>) {
+		super({
 			name: AmplifyErrorCode.Unknown,
 			message: 'An unknown error has occurred.',
 			recoverySuggestion:
 				'This may be a bug. Please reach out to library authors.',
-		},
-	) {
-		super(params);
+			metadata: params?.metadata,
+		});
 
 		// TODO: Delete the following 2 lines after we change the build target to >= es2015
 		this.constructor = IntegrityError;

--- a/packages/storage/src/internals/apis/getDataAccess.ts
+++ b/packages/storage/src/internals/apis/getDataAccess.ts
@@ -59,6 +59,7 @@ export const getDataAccess = async (
 		throw new StorageError({
 			name: AmplifyErrorCode.Unknown,
 			message: 'Service did not return valid temporary credentials.',
+			metadata: result.$metadata,
 		});
 	} else {
 		logger.debug(`Retrieved credentials for: ${result.MatchedGrantTarget}`);

--- a/packages/storage/src/providers/s3/apis/internal/list.ts
+++ b/packages/storage/src/providers/s3/apis/internal/list.ts
@@ -298,7 +298,7 @@ const validateEchoedElements = (
 		listInput.ContinuationToken === listOutput.ContinuationToken;
 
 	if (!validEchoedParameters) {
-		throw new IntegrityError();
+		throw new IntegrityError({ metadata: listOutput.$metadata });
 	}
 };
 

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
@@ -264,7 +264,7 @@ export const getMultipartUploadHandlers = (
 		);
 
 		if (size) {
-			const { ContentLength: uploadedObjectSize } = await headObject(
+			const { ContentLength: uploadedObjectSize, $metadata } = await headObject(
 				resolvedS3Config,
 				{
 					Bucket: resolvedBucket,
@@ -276,6 +276,7 @@ export const getMultipartUploadHandlers = (
 				throw new StorageError({
 					name: 'Error',
 					message: `Upload failed. Expected object size ${size}, but got ${uploadedObjectSize}.`,
+					metadata: $metadata,
 				});
 			}
 		}

--- a/packages/storage/src/providers/s3/utils/client/s3control/getDataAccess.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3control/getDataAccess.ts
@@ -64,8 +64,8 @@ const getDataAccessDeserializer = async (
 ): Promise<GetDataAccessCommandOutput> => {
 	if (response.statusCode >= 300) {
 		// error is always set when statusCode >= 300
-		const error = (await parseXmlError(response)) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		const error = await parseXmlError(response);
+		throw buildStorageServiceError(error!, error?.$metadata);
 	} else {
 		const parsed = await parseXmlBody(response);
 		const contents = map(parsed, {

--- a/packages/storage/src/providers/s3/utils/client/s3control/getDataAccess.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3control/getDataAccess.ts
@@ -64,8 +64,7 @@ const getDataAccessDeserializer = async (
 ): Promise<GetDataAccessCommandOutput> => {
 	if (response.statusCode >= 300) {
 		// error is always set when statusCode >= 300
-		const error = await parseXmlError(response);
-		throw buildStorageServiceError(error!, error?.$metadata);
+		throw buildStorageServiceError((await parseXmlError(response))!);
 	} else {
 		const parsed = await parseXmlBody(response);
 		const contents = map(parsed, {

--- a/packages/storage/src/providers/s3/utils/client/s3control/listCallerAccessGrants.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3control/listCallerAccessGrants.ts
@@ -71,8 +71,8 @@ const listCallerAccessGrantsDeserializer = async (
 ): Promise<ListCallerAccessGrantsOutput> => {
 	if (response.statusCode >= 300) {
 		// error is always set when statusCode >= 300
-		const error = (await parseXmlError(response)) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		const error = await parseXmlError(response);
+		throw buildStorageServiceError(error!, error?.$metadata);
 	} else {
 		const parsed = await parseXmlBody(response);
 		const contents = map(parsed, {

--- a/packages/storage/src/providers/s3/utils/client/s3control/listCallerAccessGrants.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3control/listCallerAccessGrants.ts
@@ -71,8 +71,7 @@ const listCallerAccessGrantsDeserializer = async (
 ): Promise<ListCallerAccessGrantsOutput> => {
 	if (response.statusCode >= 300) {
 		// error is always set when statusCode >= 300
-		const error = await parseXmlError(response);
-		throw buildStorageServiceError(error!, error?.$metadata);
+		throw buildStorageServiceError((await parseXmlError(response))!);
 	} else {
 		const parsed = await parseXmlBody(response);
 		const contents = map(parsed, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/abortMultipartUpload.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/abortMultipartUpload.ts
@@ -66,8 +66,8 @@ const abortMultipartUploadDeserializer = async (
 	response: HttpResponse,
 ): Promise<AbortMultipartUploadOutput> => {
 	if (response.statusCode >= 300) {
-		const error = (await parseXmlError(response)) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		const error = await parseXmlError(response);
+		throw buildStorageServiceError(error!, error?.$metadata);
 	} else {
 		return {
 			$metadata: parseMetadata(response),

--- a/packages/storage/src/providers/s3/utils/client/s3data/abortMultipartUpload.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/abortMultipartUpload.ts
@@ -66,8 +66,8 @@ const abortMultipartUploadDeserializer = async (
 	response: HttpResponse,
 ): Promise<AbortMultipartUploadOutput> => {
 	if (response.statusCode >= 300) {
-		const error = await parseXmlError(response);
-		throw buildStorageServiceError(error!, error?.$metadata);
+		// error is always set when statusCode >= 300
+		throw buildStorageServiceError((await parseXmlError(response))!);
 	} else {
 		return {
 			$metadata: parseMetadata(response),

--- a/packages/storage/src/providers/s3/utils/client/s3data/completeMultipartUpload.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/completeMultipartUpload.ts
@@ -139,7 +139,8 @@ const parseXmlBodyOrThrow = async (response: HttpResponse): Promise<any> => {
 			...response,
 			statusCode: 500, // To workaround the >=300 status code check common to other APIs.
 		});
-		throw buildStorageServiceError(error!, error?.$metadata);
+		error!.$metadata.httpStatusCode = response.statusCode;
+		throw buildStorageServiceError(error!);
 	}
 
 	return parsed;
@@ -149,8 +150,8 @@ const completeMultipartUploadDeserializer = async (
 	response: HttpResponse,
 ): Promise<CompleteMultipartUploadOutput> => {
 	if (response.statusCode >= 300) {
-		const error = await parseXmlError(response);
-		throw buildStorageServiceError(error!, error?.$metadata);
+		// error is always set when statusCode >= 300
+		throw buildStorageServiceError((await parseXmlError(response))!);
 	} else {
 		const parsed = await parseXmlBodyOrThrow(response);
 		const contents = map(parsed, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/completeMultipartUpload.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/completeMultipartUpload.ts
@@ -135,11 +135,11 @@ const serializeCompletedPartList = (input: CompletedPart): string => {
 const parseXmlBodyOrThrow = async (response: HttpResponse): Promise<any> => {
 	const parsed = await parseXmlBody(response); // Handles empty body case
 	if (parsed.Code !== undefined && parsed.Message !== undefined) {
-		const error = (await parseXmlError({
+		const error = await parseXmlError({
 			...response,
 			statusCode: 500, // To workaround the >=300 status code check common to other APIs.
-		})) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		});
+		throw buildStorageServiceError(error!, error?.$metadata);
 	}
 
 	return parsed;
@@ -149,8 +149,8 @@ const completeMultipartUploadDeserializer = async (
 	response: HttpResponse,
 ): Promise<CompleteMultipartUploadOutput> => {
 	if (response.statusCode >= 300) {
-		const error = (await parseXmlError(response)) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		const error = await parseXmlError(response);
+		throw buildStorageServiceError(error!, error?.$metadata);
 	} else {
 		const parsed = await parseXmlBodyOrThrow(response);
 		const contents = map(parsed, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/copyObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/copyObject.ts
@@ -110,8 +110,8 @@ const copyObjectDeserializer = async (
 	response: HttpResponse,
 ): Promise<CopyObjectOutput> => {
 	if (response.statusCode >= 300) {
-		const error = await parseXmlError(response);
-		throw buildStorageServiceError(error!, error?.$metadata);
+		// error is always set when statusCode >= 300
+		throw buildStorageServiceError((await parseXmlError(response))!);
 	} else {
 		await parseXmlBody(response);
 

--- a/packages/storage/src/providers/s3/utils/client/s3data/copyObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/copyObject.ts
@@ -110,8 +110,8 @@ const copyObjectDeserializer = async (
 	response: HttpResponse,
 ): Promise<CopyObjectOutput> => {
 	if (response.statusCode >= 300) {
-		const error = (await parseXmlError(response)) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		const error = await parseXmlError(response);
+		throw buildStorageServiceError(error!, error?.$metadata);
 	} else {
 		await parseXmlBody(response);
 

--- a/packages/storage/src/providers/s3/utils/client/s3data/createMultipartUpload.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/createMultipartUpload.ts
@@ -71,8 +71,8 @@ const createMultipartUploadDeserializer = async (
 	response: HttpResponse,
 ): Promise<CreateMultipartUploadOutput> => {
 	if (response.statusCode >= 300) {
-		const error = await parseXmlError(response);
-		throw buildStorageServiceError(error!, error?.$metadata);
+		// error is always set when statusCode >= 300
+		throw buildStorageServiceError((await parseXmlError(response))!);
 	} else {
 		const parsed = await parseXmlBody(response);
 		const contents = map(parsed, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/createMultipartUpload.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/createMultipartUpload.ts
@@ -71,8 +71,8 @@ const createMultipartUploadDeserializer = async (
 	response: HttpResponse,
 ): Promise<CreateMultipartUploadOutput> => {
 	if (response.statusCode >= 300) {
-		const error = (await parseXmlError(response)) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		const error = await parseXmlError(response);
+		throw buildStorageServiceError(error!, error?.$metadata);
 	} else {
 		const parsed = await parseXmlBody(response);
 		const contents = map(parsed, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/deleteObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/deleteObject.ts
@@ -62,8 +62,8 @@ const deleteObjectDeserializer = async (
 ): Promise<DeleteObjectOutput> => {
 	if (response.statusCode >= 300) {
 		// error is always set when statusCode >= 300
-		const error = (await parseXmlError(response)) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		const error = await parseXmlError(response);
+		throw buildStorageServiceError(error!, error?.$metadata);
 	} else {
 		const content = map(response.headers, {
 			DeleteMarker: ['x-amz-delete-marker', deserializeBoolean],

--- a/packages/storage/src/providers/s3/utils/client/s3data/deleteObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/deleteObject.ts
@@ -62,8 +62,7 @@ const deleteObjectDeserializer = async (
 ): Promise<DeleteObjectOutput> => {
 	if (response.statusCode >= 300) {
 		// error is always set when statusCode >= 300
-		const error = await parseXmlError(response);
-		throw buildStorageServiceError(error!, error?.$metadata);
+		throw buildStorageServiceError((await parseXmlError(response))!);
 	} else {
 		const content = map(response.headers, {
 			DeleteMarker: ['x-amz-delete-marker', deserializeBoolean],

--- a/packages/storage/src/providers/s3/utils/client/s3data/getObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/getObject.ts
@@ -83,8 +83,8 @@ const getObjectDeserializer = async (
 	response: HttpResponse,
 ): Promise<GetObjectOutput> => {
 	if (response.statusCode >= 300) {
-		const error = (await parseXmlError(response)) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		const error = await parseXmlError(response);
+		throw buildStorageServiceError(error!, error?.$metadata);
 	} else {
 		return {
 			...map(response.headers, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/getObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/getObject.ts
@@ -83,8 +83,8 @@ const getObjectDeserializer = async (
 	response: HttpResponse,
 ): Promise<GetObjectOutput> => {
 	if (response.statusCode >= 300) {
-		const error = await parseXmlError(response);
-		throw buildStorageServiceError(error!, error?.$metadata);
+		// error is always set when statusCode >= 300
+		throw buildStorageServiceError((await parseXmlError(response))!);
 	} else {
 		return {
 			...map(response.headers, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/headObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/headObject.ts
@@ -70,8 +70,7 @@ const headObjectDeserializer = async (
 ): Promise<HeadObjectOutput> => {
 	if (response.statusCode >= 300) {
 		// error is always set when statusCode >= 300
-		const error = await parseXmlError(response);
-		throw buildStorageServiceError(error!, error?.$metadata);
+		throw buildStorageServiceError((await parseXmlError(response))!);
 	} else {
 		const contents = {
 			...map(response.headers, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/headObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/headObject.ts
@@ -70,8 +70,8 @@ const headObjectDeserializer = async (
 ): Promise<HeadObjectOutput> => {
 	if (response.statusCode >= 300) {
 		// error is always set when statusCode >= 300
-		const error = (await parseXmlError(response)) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		const error = await parseXmlError(response);
+		throw buildStorageServiceError(error!, error?.$metadata);
 	} else {
 		const contents = {
 			...map(response.headers, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/listObjectsV2.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/listObjectsV2.ts
@@ -69,8 +69,7 @@ const listObjectsV2Deserializer = async (
 ): Promise<ListObjectsV2Output> => {
 	if (response.statusCode >= 300) {
 		// error is always set when statusCode >= 300
-		const error = await parseXmlError(response);
-		throw buildStorageServiceError(error!, error?.$metadata);
+		throw buildStorageServiceError((await parseXmlError(response))!);
 	} else {
 		const parsed = await parseXmlBody(response);
 		const contents = map(parsed, {
@@ -152,7 +151,7 @@ const validateCorroboratingElements = (response: ListObjectsV2Output) => {
 		KeyCount === Contents.length + CommonPrefixes.length;
 
 	if (!validTruncation || !validNumberOfKeysReturned) {
-		throw new IntegrityError();
+		throw new IntegrityError({ metadata: response.$metadata });
 	}
 };
 

--- a/packages/storage/src/providers/s3/utils/client/s3data/listObjectsV2.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/listObjectsV2.ts
@@ -69,8 +69,8 @@ const listObjectsV2Deserializer = async (
 ): Promise<ListObjectsV2Output> => {
 	if (response.statusCode >= 300) {
 		// error is always set when statusCode >= 300
-		const error = (await parseXmlError(response)) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		const error = await parseXmlError(response);
+		throw buildStorageServiceError(error!, error?.$metadata);
 	} else {
 		const parsed = await parseXmlBody(response);
 		const contents = map(parsed, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/listParts.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/listParts.ts
@@ -61,8 +61,8 @@ const listPartsDeserializer = async (
 	response: HttpResponse,
 ): Promise<ListPartsOutput> => {
 	if (response.statusCode >= 300) {
-		const error = (await parseXmlError(response)) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		const error = await parseXmlError(response);
+		throw buildStorageServiceError(error!, error?.$metadata);
 	} else {
 		const parsed = await parseXmlBody(response);
 		const contents = map(parsed, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/listParts.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/listParts.ts
@@ -61,8 +61,8 @@ const listPartsDeserializer = async (
 	response: HttpResponse,
 ): Promise<ListPartsOutput> => {
 	if (response.statusCode >= 300) {
-		const error = await parseXmlError(response);
-		throw buildStorageServiceError(error!, error?.$metadata);
+		// error is always set when statusCode >= 300
+		throw buildStorageServiceError((await parseXmlError(response))!);
 	} else {
 		const parsed = await parseXmlBody(response);
 		const contents = map(parsed, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/putObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/putObject.ts
@@ -87,8 +87,8 @@ const putObjectDeserializer = async (
 	response: HttpResponse,
 ): Promise<PutObjectOutput> => {
 	if (response.statusCode >= 300) {
-		const error = await parseXmlError(response);
-		throw buildStorageServiceError(error!, error?.$metadata);
+		// error is always set when statusCode >= 300
+		throw buildStorageServiceError((await parseXmlError(response))!);
 	} else {
 		return {
 			...map(response.headers, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/putObject.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/putObject.ts
@@ -87,8 +87,8 @@ const putObjectDeserializer = async (
 	response: HttpResponse,
 ): Promise<PutObjectOutput> => {
 	if (response.statusCode >= 300) {
-		const error = (await parseXmlError(response)) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		const error = await parseXmlError(response);
+		throw buildStorageServiceError(error!, error?.$metadata);
 	} else {
 		return {
 			...map(response.headers, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/uploadPart.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/uploadPart.ts
@@ -84,8 +84,8 @@ const uploadPartDeserializer = async (
 	response: HttpResponse,
 ): Promise<UploadPartOutput> => {
 	if (response.statusCode >= 300) {
-		const error = await parseXmlError(response);
-		throw buildStorageServiceError(error!, error?.$metadata);
+		// error is always set when statusCode >= 300
+		throw buildStorageServiceError((await parseXmlError(response))!);
 	} else {
 		return {
 			...map(response.headers, {

--- a/packages/storage/src/providers/s3/utils/client/s3data/uploadPart.ts
+++ b/packages/storage/src/providers/s3/utils/client/s3data/uploadPart.ts
@@ -84,8 +84,8 @@ const uploadPartDeserializer = async (
 	response: HttpResponse,
 ): Promise<UploadPartOutput> => {
 	if (response.statusCode >= 300) {
-		const error = (await parseXmlError(response)) as Error;
-		throw buildStorageServiceError(error, response.statusCode);
+		const error = await parseXmlError(response);
+		throw buildStorageServiceError(error!, error?.$metadata);
 	} else {
 		return {
 			...map(response.headers, {

--- a/packages/storage/src/providers/s3/utils/client/utils/deserializeHelpers.ts
+++ b/packages/storage/src/providers/s3/utils/client/utils/deserializeHelpers.ts
@@ -1,9 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Headers } from '@aws-amplify/core/internals/aws-client-utils';
+import {
+	ErrorParser,
+	Headers,
+} from '@aws-amplify/core/internals/aws-client-utils';
 import { ServiceError } from '@aws-amplify/core/internals/utils';
-import { ResponseMetadata } from '@aws-amplify/core/dist/esm/types';
 
 import { StorageError } from '../../../../../errors/StorageError';
 import { CompletedPart } from '../s3data';
@@ -184,19 +186,20 @@ export const deserializeMetadata = (
 	return Object.keys(deserialized).length > 0 ? deserialized : undefined;
 };
 
+export type ParsedError = Awaited<ReturnType<ErrorParser>> & {};
+
 /**
- * Internal-only method to create a new StorageError from a service error.
+ * Internal-only method to create a new StorageError from a service error with AWS SDK-compatible interfaces
+ * @param error - The output of a service error parser, with AWS SDK-compatible interface(e.g. $metadata)
+ * @returns A new StorageError.
  *
  * @internal
  */
-export const buildStorageServiceError = (
-	error: Error,
-	responseMetadata?: ResponseMetadata,
-): ServiceError =>
+export const buildStorageServiceError = (error: ParsedError): ServiceError =>
 	new StorageError({
 		name: error.name,
 		message: error.message,
-		metadata: responseMetadata,
+		metadata: error.$metadata,
 	});
 
 /**

--- a/packages/storage/src/providers/s3/utils/client/utils/deserializeHelpers.ts
+++ b/packages/storage/src/providers/s3/utils/client/utils/deserializeHelpers.ts
@@ -3,6 +3,7 @@
 
 import { Headers } from '@aws-amplify/core/internals/aws-client-utils';
 import { ServiceError } from '@aws-amplify/core/internals/utils';
+import { ResponseMetadata } from '@aws-amplify/core/dist/esm/types';
 
 import { StorageError } from '../../../../../errors/StorageError';
 import { CompletedPart } from '../s3data';
@@ -190,17 +191,12 @@ export const deserializeMetadata = (
  */
 export const buildStorageServiceError = (
 	error: Error,
-	statusCode: number,
+	responseMetadata?: ResponseMetadata,
 ): ServiceError =>
 	new StorageError({
 		name: error.name,
 		message: error.message,
-		...(statusCode === 404
-			? {
-					recoverySuggestion:
-						'Please add the object with this key to the bucket as the key is not found.',
-				}
-			: {}),
+		metadata: responseMetadata,
 	});
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
* Add `metadata` to `StorageError`, and make sure all the error thrown caused by erroneous responses includes `metadata`.
* Remove extra `recoverySuggestion` from 404 error

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Unit test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
