### PR TITLE
fix: Open docs update PRs against next-release/main instead of merging directly to main

### DIFF
--- a/.github/workflows/callable-docs-update.yml
+++ b/.github/workflows/callable-docs-update.yml
@@ -63,4 +63,4 @@ jobs:
         run: |
           git checkout -b $TEMP_BRANCH_NAME
           git push origin $TEMP_BRANCH_NAME
-          gh pr create -B main -H $TEMP_BRANCH_NAME --title 'chore: amplify-js api references update' --body 'Merge the api references changes from the most recent release.'
+          gh pr create -B next-release/main -H $TEMP_BRANCH_NAME --title 'chore: amplify-js api references update' --body 'Merge the api references changes from the most recent release.'


### PR DESCRIPTION
#### Description of changes

The `next-release/main` branch builds a preview and can then be merged into `main`, so it is a better target for the initial PR.

#### Description of how you validated changes
I haven't


#### Checklist
- [x] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
