### PR TITLE
release(required): fix retryStrategy parameter location

### DIFF
--- a/packages/api-rest/__tests__/apis/common/publicApis.test.ts
+++ b/packages/api-rest/__tests__/apis/common/publicApis.test.ts
@@ -435,8 +435,10 @@ describe('public APIs', () => {
 					await fn(mockAmplifyInstance, {
 						apiName: 'restApi1',
 						path: '/items',
-						retryStrategy: {
-							strategy: 'no-retry',
+						options: {
+							retryStrategy: {
+								strategy: 'no-retry',
+							},
 						},
 					}).response;
 					expect(mockAuthenticatedHandler).toHaveBeenCalledWith(
@@ -454,8 +456,10 @@ describe('public APIs', () => {
 					await fn(mockAmplifyInstance, {
 						apiName: 'restApi1',
 						path: '/items',
-						retryStrategy: {
-							strategy: 'jittered-exponential-backoff',
+						options: {
+							retryStrategy: {
+								strategy: 'jittered-exponential-backoff',
+							},
 						},
 					}).response;
 					expect(mockAuthenticatedHandler).toHaveBeenCalledWith(
@@ -501,8 +505,10 @@ describe('public APIs', () => {
 					await fn(mockAmplifyInstanceWithNoRetry, {
 						apiName: 'restApi1',
 						path: 'items',
-						retryStrategy: {
-							strategy: 'jittered-exponential-backoff',
+						options: {
+							retryStrategy: {
+								strategy: 'jittered-exponential-backoff',
+							},
 						},
 					}).response;
 
@@ -533,8 +539,10 @@ describe('public APIs', () => {
 					await fn(mockAmplifyInstanceWithRetry, {
 						apiName: 'restApi1',
 						path: 'items',
-						retryStrategy: {
-							strategy: 'no-retry',
+						options: {
+							retryStrategy: {
+								strategy: 'no-retry',
+							},
 						},
 					}).response;
 

--- a/packages/api-rest/__tests__/apis/common/publicApis.test.ts
+++ b/packages/api-rest/__tests__/apis/common/publicApis.test.ts
@@ -80,7 +80,6 @@ const mockSuccessResponse = {
 };
 const mockGetRetryDecider = getRetryDecider as jest.Mock;
 const mockRetryResponse = { retryable: true };
-const mockNoRetryResponse = { retryable: false };
 const mockRetryDeciderResponse = () => Promise.resolve(mockRetryResponse);
 
 describe('public APIs', () => {
@@ -431,7 +430,7 @@ describe('public APIs', () => {
 				});
 
 				it('should not retry when retry is set to "no-retry"', async () => {
-					expect.assertions(2);
+					expect.assertions(3);
 					await fn(mockAmplifyInstance, {
 						apiName: 'restApi1',
 						path: '/items',
@@ -446,13 +445,14 @@ describe('public APIs', () => {
 						expect.objectContaining({ retryDecider: expect.any(Function) }),
 					);
 					const callArgs = mockAuthenticatedHandler.mock.calls[0];
+					expect(getRetryDecider).not.toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
-					expect(result).toEqual(mockNoRetryResponse);
+					expect(result).toEqual({ retryable: false });
 				});
 
 				it('should retry when retry is set to "jittered-exponential-backoff"', async () => {
-					expect.assertions(2);
+					expect.assertions(3);
 					await fn(mockAmplifyInstance, {
 						apiName: 'restApi1',
 						path: '/items',
@@ -467,13 +467,14 @@ describe('public APIs', () => {
 						expect.objectContaining({ retryDecider: expect.any(Function) }),
 					);
 					const callArgs = mockAuthenticatedHandler.mock.calls[0];
+					expect(getRetryDecider).toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
 					expect(result).toEqual(mockRetryResponse);
 				});
 
 				it('should retry when retry strategy is not provided', async () => {
-					expect.assertions(2);
+					expect.assertions(3);
 					await fn(mockAmplifyInstance, {
 						apiName: 'restApi1',
 						path: '/items',
@@ -483,13 +484,14 @@ describe('public APIs', () => {
 						expect.objectContaining({ retryDecider: expect.any(Function) }),
 					);
 					const callArgs = mockAuthenticatedHandler.mock.calls[0];
+					expect(getRetryDecider).toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
 					expect(result).toEqual(mockRetryResponse);
 				});
 
 				it('should retry and prefer the individual retry strategy over the library options', async () => {
-					expect.assertions(2);
+					expect.assertions(3);
 					const mockAmplifyInstanceWithNoRetry = {
 						...mockAmplifyInstance,
 						libraryOptions: {
@@ -517,13 +519,14 @@ describe('public APIs', () => {
 						expect.objectContaining({ retryDecider: expect.any(Function) }),
 					);
 					const callArgs = mockAuthenticatedHandler.mock.calls[0];
+					expect(getRetryDecider).toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
 					expect(result).toEqual(mockRetryResponse);
 				});
 
 				it('should not retry and prefer the individual retry strategy over the library options', async () => {
-					expect.assertions(2);
+					expect.assertions(3);
 					const mockAmplifyInstanceWithRetry = {
 						...mockAmplifyInstance,
 						libraryOptions: {
@@ -551,13 +554,14 @@ describe('public APIs', () => {
 						expect.objectContaining({ retryDecider: expect.any(Function) }),
 					);
 					const callArgs = mockAuthenticatedHandler.mock.calls[0];
+					expect(getRetryDecider).not.toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
-					expect(result).toEqual(mockNoRetryResponse);
+					expect(result).toEqual({ retryable: false });
 				});
 
 				it('should not retry when configured through library options', async () => {
-					expect.assertions(2);
+					expect.assertions(3);
 					const mockAmplifyInstanceWithRetry = {
 						...mockAmplifyInstance,
 						libraryOptions: {
@@ -580,9 +584,10 @@ describe('public APIs', () => {
 						expect.objectContaining({ retryDecider: expect.any(Function) }),
 					);
 					const callArgs = mockAuthenticatedHandler.mock.calls[0];
+					expect(getRetryDecider).not.toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
-					expect(result).toEqual(mockNoRetryResponse);
+					expect(result).toEqual({ retryable: false });
 				});
 			});
 		});

--- a/packages/api-rest/__tests__/apis/common/publicApis.test.ts
+++ b/packages/api-rest/__tests__/apis/common/publicApis.test.ts
@@ -78,7 +78,7 @@ const mockSuccessResponse = {
 		text: jest.fn(),
 	},
 };
-const mockGetRetryDecider = getRetryDecider as jest.Mock;
+const mockGetRetryDecider = jest.mocked(getRetryDecider);
 const mockRetryDeciderResponse = () => Promise.resolve({ retryable: true });
 
 describe('public APIs', () => {
@@ -444,7 +444,7 @@ describe('public APIs', () => {
 						expect.objectContaining({ retryDecider: expect.any(Function) }),
 					);
 					const callArgs = mockAuthenticatedHandler.mock.calls[0];
-					expect(getRetryDecider).not.toHaveBeenCalled();
+					expect(mockGetRetryDecider).not.toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
 					expect(result).toEqual({ retryable: false });
@@ -466,7 +466,7 @@ describe('public APIs', () => {
 						expect.objectContaining({ retryDecider: expect.any(Function) }),
 					);
 					const callArgs = mockAuthenticatedHandler.mock.calls[0];
-					expect(getRetryDecider).toHaveBeenCalled();
+					expect(mockGetRetryDecider).toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
 					expect(result).toEqual({ retryable: true });
@@ -483,7 +483,7 @@ describe('public APIs', () => {
 						expect.objectContaining({ retryDecider: expect.any(Function) }),
 					);
 					const callArgs = mockAuthenticatedHandler.mock.calls[0];
-					expect(getRetryDecider).toHaveBeenCalled();
+					expect(mockGetRetryDecider).toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
 					expect(result).toEqual({ retryable: true });
@@ -518,7 +518,7 @@ describe('public APIs', () => {
 						expect.objectContaining({ retryDecider: expect.any(Function) }),
 					);
 					const callArgs = mockAuthenticatedHandler.mock.calls[0];
-					expect(getRetryDecider).toHaveBeenCalled();
+					expect(mockGetRetryDecider).toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
 					expect(result).toEqual({ retryable: true });
@@ -553,7 +553,7 @@ describe('public APIs', () => {
 						expect.objectContaining({ retryDecider: expect.any(Function) }),
 					);
 					const callArgs = mockAuthenticatedHandler.mock.calls[0];
-					expect(getRetryDecider).not.toHaveBeenCalled();
+					expect(mockGetRetryDecider).not.toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
 					expect(result).toEqual({ retryable: false });
@@ -583,7 +583,7 @@ describe('public APIs', () => {
 						expect.objectContaining({ retryDecider: expect.any(Function) }),
 					);
 					const callArgs = mockAuthenticatedHandler.mock.calls[0];
-					expect(getRetryDecider).not.toHaveBeenCalled();
+					expect(mockGetRetryDecider).not.toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
 					expect(result).toEqual({ retryable: false });

--- a/packages/api-rest/__tests__/apis/common/publicApis.test.ts
+++ b/packages/api-rest/__tests__/apis/common/publicApis.test.ts
@@ -79,8 +79,7 @@ const mockSuccessResponse = {
 	},
 };
 const mockGetRetryDecider = getRetryDecider as jest.Mock;
-const mockRetryResponse = { retryable: true };
-const mockRetryDeciderResponse = () => Promise.resolve(mockRetryResponse);
+const mockRetryDeciderResponse = () => Promise.resolve({ retryable: true });
 
 describe('public APIs', () => {
 	beforeEach(() => {
@@ -470,7 +469,7 @@ describe('public APIs', () => {
 					expect(getRetryDecider).toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
-					expect(result).toEqual(mockRetryResponse);
+					expect(result).toEqual({ retryable: true });
 				});
 
 				it('should retry when retry strategy is not provided', async () => {
@@ -487,7 +486,7 @@ describe('public APIs', () => {
 					expect(getRetryDecider).toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
-					expect(result).toEqual(mockRetryResponse);
+					expect(result).toEqual({ retryable: true });
 				});
 
 				it('should retry and prefer the individual retry strategy over the library options', async () => {
@@ -522,7 +521,7 @@ describe('public APIs', () => {
 					expect(getRetryDecider).toHaveBeenCalled();
 					const { retryDecider } = callArgs[1];
 					const result = await retryDecider();
-					expect(result).toEqual(mockRetryResponse);
+					expect(result).toEqual({ retryable: true });
 				});
 
 				it('should not retry and prefer the individual retry strategy over the library options', async () => {

--- a/packages/api-rest/src/apis/common/publicApis.ts
+++ b/packages/api-rest/src/apis/common/publicApis.ts
@@ -35,12 +35,7 @@ const publicHandler = (
 	method: string,
 ) =>
 	createCancellableOperation(async abortSignal => {
-		const {
-			apiName,
-			options: apiOptions = {},
-			path: apiPath,
-			retryStrategy,
-		} = options;
+		const { apiName, options: apiOptions = {}, path: apiPath } = options;
 		const url = resolveApiUrl(
 			amplify,
 			apiName,
@@ -76,7 +71,6 @@ const publicHandler = (
 				method,
 				headers,
 				abortSignal,
-				retryStrategy,
 			},
 			isIamAuthApplicableForRest,
 			signingServiceInfo,

--- a/packages/api-rest/src/types/index.ts
+++ b/packages/api-rest/src/types/index.ts
@@ -35,6 +35,12 @@ export interface RestApiOptionsBase {
 	 * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials}
 	 */
 	withCredentials?: boolean;
+	/**
+	 * Retry strategy for the REST API calls. It will take precedence over REST `retryStrategy` in Amplify configuration libraryOptions.
+	 *
+	 * @default ` { strategy: 'jittered-exponential-backoff' } `
+	 */
+	retryStrategy?: RetryStrategy;
 }
 
 type Headers = Record<string, string>;
@@ -82,12 +88,6 @@ export interface ApiInput<Options> {
 	 * Options to overwrite the REST API call behavior.
 	 */
 	options?: Options;
-	/**
-	 * Retry strategy for the REST API calls. It will take precedence over REST `retryStrategy` in Amplify configuration libraryOptions.
-	 *
-	 * @default ` { strategy: 'jittered-exponential-backoff' } `
-	 */
-	retryStrategy?: RetryStrategy;
 }
 
 /**

--- a/packages/api-rest/src/types/index.ts
+++ b/packages/api-rest/src/types/index.ts
@@ -97,7 +97,7 @@ export interface ApiInput<Options> {
 export interface InternalPostInput {
 	// Resolved GraphQl endpoint url
 	url: URL;
-	options?: RestApiOptionsBase & {
+	options?: Omit<RestApiOptionsBase, 'retryStrategy'> & {
 		/**
 		 * Internal-only option for GraphQL client to provide the IAM signing service and region.
 		 * * If auth mode is 'iam', you MUST set this value.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR changes the placement of `retryStrategy` within the individual `api` calls. 

Before: 

```
get(amplify, {
  apiName: 'restApi1',
  path: 'items',
  retryStrategy: {
    strategy: 'no-retry',
  }
}
```

After: 

```
get(amplify, {
  apiName: 'restApi1',
  path: 'items',
  options: {
    retryStrategy: {
     strategy: 'no-retry',
    }
  }
}
```


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
