### PR TITLE
feat(adapter-nextjs): support sending lang param to managed login

### DIFF
--- a/packages/adapter-nextjs/__tests__/auth/utils/createUrlSearchParams.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/utils/createUrlSearchParams.test.ts
@@ -54,6 +54,23 @@ describe('createUrlSearchParamsForSignInSignUp', () => {
 			'redirect_uri=https%3A%2F%2Fexample.com%2Fsignin&response_type=code&client_id=userPoolClientId&scope=openid&state=state&code_challenge=code_challenge&code_challenge_method=S256&identity_provider=Google',
 		);
 	});
+
+	it('returns URLSearchParams with the correct values when lang query parameter is supplied', () => {
+		const url = 'https://example.com?lang=es';
+
+		const result = createUrlSearchParamsForSignInSignUp({
+			url,
+			oAuthConfig,
+			userPoolClientId,
+			state,
+			origin,
+			codeVerifier,
+		});
+
+		expect(result.toString()).toBe(
+			'redirect_uri=https%3A%2F%2Fexample.com%2Fsignin&response_type=code&client_id=userPoolClientId&scope=openid&state=state&code_challenge=code_challenge&code_challenge_method=S256&lang=es',
+		);
+	});
 });
 
 describe('createUrlSearchParamsForTokenExchange', () => {

--- a/packages/adapter-nextjs/src/auth/utils/createUrlSearchParams.ts
+++ b/packages/adapter-nextjs/src/auth/utils/createUrlSearchParams.ts
@@ -6,6 +6,7 @@ import { generateCodeVerifier } from 'aws-amplify/adapter-core';
 
 import { resolveIdentityProviderFromUrl } from './resolveIdentityProviderFromUrl';
 import { resolveRedirectSignInUrl } from './resolveRedirectUrl';
+import { getSearchParamValueFromUrl } from './getSearchParamValueFromUrl';
 
 export const createUrlSearchParamsForSignInSignUp = ({
 	url,
@@ -23,6 +24,7 @@ export const createUrlSearchParamsForSignInSignUp = ({
 	codeVerifier: ReturnType<typeof generateCodeVerifier>;
 }): URLSearchParams => {
 	const resolvedProvider = resolveIdentityProviderFromUrl(url);
+	const lang = getSearchParamValueFromUrl(url, 'lang');
 
 	const redirectUrlSearchParams = new URLSearchParams({
 		redirect_uri: resolveRedirectSignInUrl(origin, oAuthConfig),
@@ -36,6 +38,10 @@ export const createUrlSearchParamsForSignInSignUp = ({
 
 	if (resolvedProvider) {
 		redirectUrlSearchParams.append('identity_provider', resolvedProvider);
+	}
+
+	if (lang) {
+		redirectUrlSearchParams.append('lang', lang);
 	}
 
 	return redirectUrlSearchParams;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Now support appending a `lang` query parameter to the generated `/sign-in` and `sign-up` routes for changing [the localization of the Amazon Cognito Managed Login page](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-managed-login.html). 


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-js/issues/14316

#### Description of how you validated changes

- unit tests
- manual testing with Next.js sample apps built with App Router and Pages Router respectively


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
