### PR TITLE
chore: reschedule canary

### DIFF
--- a/.github/workflows/on-schedule-canary-test.yml
+++ b/.github/workflows/on-schedule-canary-test.yml
@@ -1,8 +1,8 @@
 on:
-  # Tests scheduled at 4pm(UTC) / 9am(PDT) everyday
+  # Tests scheduled at 3pm(UTC) / 8am(PDT) everyday
   # default supported timezone is UTC
   schedule:
-    - cron: '0 16 * * *'
+    - cron: '0 15 * * *'
 
 jobs:
   canaries:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The purpose of this PR is reschedule canary to run 1 hour earlier to determine whether installation failures due to server errors are caused by GH action throttling.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
