### PR TITLE
feat: add url opener option to oauth sign in with redirect flow

### DIFF
--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -80,7 +80,8 @@ const oauthSignIn = async ({
 	preferPrivateSession?: boolean;
 	options?: SignInWithRedirectInput['options'];
 }) => {
-	const { domain, redirectSignIn, responseType, scopes } = oauthConfig;
+	const { domain, redirectSignIn, responseType, scopes, urlOpener } =
+		oauthConfig;
 	const { loginHint, lang, nonce } = options ?? {};
 	const randomState = generateState();
 
@@ -130,8 +131,12 @@ const oauthSignIn = async ({
 
 	// the following is effective only in react-native as openAuthSession resolves only in react-native
 	const { type, error, url } =
-		(await openAuthSession(oAuthUrl, redirectSignIn, preferPrivateSession)) ??
-		{};
+		(await openAuthSession(
+			oAuthUrl,
+			redirectSignIn,
+			preferPrivateSession,
+			urlOpener,
+		)) ?? {};
 
 	try {
 		if (type === 'error') {

--- a/packages/auth/src/utils/openAuthSession.ts
+++ b/packages/auth/src/utils/openAuthSession.ts
@@ -3,10 +3,21 @@
 
 import { OpenAuthSession } from './types';
 
-export const openAuthSession: OpenAuthSession = async (url: string) => {
+export const openAuthSession: OpenAuthSession = async (
+	url: string,
+	_redirectUrls: string[],
+	_preferPrivateSession?: boolean,
+	urlOpener: (_url: string) => Promise<void> = async (_url: string) => {
+		window.location.href = _url;
+	},
+) => {
 	if (!window?.location) {
 		return;
 	}
+
 	// enforce HTTPS
-	window.location.href = url.replace('http://', 'https://');
+	const secureUrl = url.replace('http://', 'https://');
+
+	// Call the provided or default urlOpener
+	await urlOpener(secureUrl);
 };

--- a/packages/auth/src/utils/types.ts
+++ b/packages/auth/src/utils/types.ts
@@ -5,6 +5,7 @@ export type OpenAuthSession = (
 	url: string,
 	redirectUrls: string[],
 	preferPrivateSession?: boolean,
+	urlOpener?: (url: string) => Promise<void>,
 ) => Promise<OpenAuthSessionResult | void>;
 
 type OpenAuthSessionResultType = 'canceled' | 'success' | 'error';

--- a/packages/core/src/singleton/Auth/types.ts
+++ b/packages/core/src/singleton/Auth/types.ts
@@ -181,6 +181,7 @@ export interface OAuthConfig {
 	redirectSignOut: string[];
 	responseType: 'code' | 'token';
 	providers?: (OAuthProvider | CustomProvider)[];
+	urlOpener?: (url: string) => Promise<void>
 }
 
 export type OAuthProvider = 'Google' | 'Facebook' | 'Amazon' | 'Apple';


### PR DESCRIPTION
#### Description of changes
Added OAuth `urlOpener` option to be used in `signInWithRedirect` flow if provided, this will allow to use in-app-browser for native applications for ionic/capacitor apps

#### Issue #10301, #13521, #12895

#### Description of how you validated changes
`yarn test` passes


#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
