### PR TITLE
docs(api-graphql): correct function name from generateServerClient to generateClient in example

### DIFF
--- a/packages/api-graphql/src/server/generateClient.ts
+++ b/packages/api-graphql/src/server/generateClient.ts
@@ -25,7 +25,7 @@ import {
  * import config from './amplifyconfiguration.json';
  * import { listPosts } from './graphql/queries';
  *
- * const client = generateServerClient({ config });
+ * const client = generateClient({ config });
  *
  * const result = await runWithAmplifyServerContext({
  *   nextServerContext: { request, response },

--- a/packages/api-graphql/src/types/index.ts
+++ b/packages/api-graphql/src/types/index.ts
@@ -498,7 +498,7 @@ export type GraphQLMethodSSR<Options extends CommonPublicClientOptions> = <
  */
 export interface ServerClientGenerationParams {
 	amplify:
-		| null // null expected when used with `generateServerClient`
+		| null // null expected when used with `generateClient`
 		// closure expected with `generateServerClientUsingCookies`
 		| ((fn: (amplify: AmplifyClassV6) => Promise<any>) => Promise<any>);
 	// global env-sourced config use for retrieving modelIntro


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Changed incorrect function name generateServerClient to correct function name generateClient in API Document.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

- Run `yarn run docs:references`
- Open `docs/api/functions/aws_amplify.api_server.generateClient.html` with browser.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
