### PR TITLE
release(required): fix react-native exports condition order

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,5 +144,6 @@
 	"overrides": {
 		"tar": "6.2.1",
 		"cross-spawn": "7.0.5"
-	}
+	},
+	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -42,34 +42,34 @@
 	},
 	"exports": {
 		".": {
+			"react-native": "./src/index.ts",
 			"types": "./dist/esm/index.d.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./pinpoint": {
+			"react-native": "./src/providers/pinpoint/index.ts",
 			"types": "./dist/esm/providers/pinpoint/index.d.ts",
 			"import": "./dist/esm/providers/pinpoint/index.mjs",
-			"require": "./dist/cjs/providers/pinpoint/index.js",
-			"react-native": "./src/providers/pinpoint/index.ts"
+			"require": "./dist/cjs/providers/pinpoint/index.js"
 		},
 		"./kinesis": {
+			"react-native": "./src/providers/kinesis/index.ts",
 			"types": "./dist/esm/providers/kinesis/index.d.ts",
 			"import": "./dist/esm/providers/kinesis/index.mjs",
-			"require": "./dist/cjs/providers/kinesis/index.js",
-			"react-native": "./src/providers/kinesis/index.ts"
+			"require": "./dist/cjs/providers/kinesis/index.js"
 		},
 		"./kinesis-firehose": {
+			"react-native": "./src/providers/kinesis-firehose/index.ts",
 			"types": "./dist/esm/providers/kinesis-firehose/index.d.ts",
 			"import": "./dist/esm/providers/kinesis-firehose/index.mjs",
-			"require": "./dist/cjs/providers/kinesis-firehose/index.js",
-			"react-native": "./src/providers/kinesis-firehose/index.ts"
+			"require": "./dist/cjs/providers/kinesis-firehose/index.js"
 		},
 		"./personalize": {
+			"react-native": "./src/providers/personalize/index.ts",
 			"types": "./dist/esm/providers/personalize/index.d.ts",
 			"import": "./dist/esm/providers/personalize/index.mjs",
-			"require": "./dist/cjs/providers/personalize/index.js",
-			"react-native": "./src/providers/personalize/index.ts"
+			"require": "./dist/cjs/providers/personalize/index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -30,22 +30,22 @@
 	},
 	"exports": {
 		".": {
+			"react-native": "./src/index.ts",
 			"types": "./dist/esm/index.d.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./internals": {
+			"react-native": "./src/internals/index.ts",
 			"types": "./dist/esm/internals/index.d.ts",
 			"import": "./dist/esm/internals/index.mjs",
-			"require": "./dist/cjs/internals/index.js",
-			"react-native": "./src/internals/index.ts"
+			"require": "./dist/cjs/internals/index.js"
 		},
 		"./internals/server": {
+			"react-native": "./src/internals/server/index.ts",
 			"types": "./dist/esm/internals/server/index.d.ts",
 			"import": "./dist/esm/internals/server/index.mjs",
-			"require": "./dist/cjs/internals/server/index.js",
-			"react-native": "./src/internals/server/index.ts"
+			"require": "./dist/cjs/internals/server/index.js"
 		},
 		"./server": {
 			"types": "./dist/esm/server/index.d.ts",

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -27,10 +27,10 @@
 	},
 	"exports": {
 		".": {
+			"react-native": "./src/index.ts",
 			"types": "./dist/esm/index.d.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./server": {
 			"types": "./dist/esm/server.d.ts",
@@ -38,10 +38,10 @@
 			"require": "./dist/cjs/server.js"
 		},
 		"./internals": {
+			"react-native": "./src/internals/index.ts",
 			"types": "./dist/esm/internals/index.d.ts",
 			"import": "./dist/esm/internals/index.mjs",
-			"require": "./dist/cjs/internals/index.js",
-			"react-native": "./src/internals/index.ts"
+			"require": "./dist/cjs/internals/index.js"
 		},
 		"./internals/server": {
 			"types": "./dist/esm/internals/server.d.ts",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,16 +29,16 @@
 	},
 	"exports": {
 		".": {
+			"react-native": "./src/index.ts",
 			"types": "./dist/esm/index.d.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./internals": {
+			"react-native": "./src/internals/index.ts",
 			"types": "./dist/esm/internals/index.d.ts",
 			"import": "./dist/esm/internals/index.mjs",
-			"require": "./dist/cjs/internals/index.js",
-			"react-native": "./src/internals/index.ts"
+			"require": "./dist/cjs/internals/index.js"
 		},
 		"./server": {
 			"types": "./dist/esm/server.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -44,16 +44,16 @@
 	},
 	"exports": {
 		".": {
+			"react-native": "./src/index.ts",
 			"types": "./dist/esm/index.d.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./cognito": {
+			"react-native": "./src/providers/cognito/index.ts",
 			"types": "./dist/esm/providers/cognito/index.d.ts",
 			"import": "./dist/esm/providers/cognito/index.mjs",
-			"require": "./dist/cjs/providers/cognito/index.js",
-			"react-native": "./src/providers/cognito/index.ts"
+			"require": "./dist/cjs/providers/cognito/index.js"
 		},
 		"./cognito/server": {
 			"types": "./dist/esm/providers/cognito/apis/server/index.d.ts",

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -8,34 +8,34 @@
 	"react-native": "./src/index.ts",
 	"exports": {
 		".": {
+			"react-native": "./src/index.ts",
 			"types": "./dist/esm/index.d.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./utils": {
+			"react-native": "./src/utils/index.ts",
 			"types": "./dist/esm/utils/index.d.ts",
 			"import": "./dist/esm/utils/index.mjs",
-			"require": "./dist/cjs/utils/index.js",
-			"react-native": "./src/utils/index.ts"
+			"require": "./dist/cjs/utils/index.js"
 		},
 		"./auth": {
+			"react-native": "./src/auth/index.ts",
 			"types": "./dist/esm/auth/index.d.ts",
 			"import": "./dist/esm/auth/index.mjs",
-			"require": "./dist/cjs/auth/index.js",
-			"react-native": "./src/auth/index.ts"
+			"require": "./dist/cjs/auth/index.js"
 		},
 		"./api": {
+			"react-native": "./src/api/index.ts",
 			"types": "./dist/esm/api/index.d.ts",
 			"import": "./dist/esm/api/index.mjs",
-			"require": "./dist/cjs/api/index.js",
-			"react-native": "./src/api/index.ts"
+			"require": "./dist/cjs/api/index.js"
 		},
 		"./api/internals": {
+			"react-native": "./src/api/internals.ts",
 			"types": "./dist/esm/api/internals.d.ts",
 			"import": "./dist/esm/api/internals.mjs",
-			"require": "./dist/cjs/api/internals.js",
-			"react-native": "./src/api/internals.ts"
+			"require": "./dist/cjs/api/internals.js"
 		},
 		"./api/server": {
 			"types": "./dist/esm/api/server.d.ts",
@@ -43,10 +43,10 @@
 			"require": "./dist/cjs/api/server.js"
 		},
 		"./data": {
+			"react-native": "./src/api/index.ts",
 			"types": "./dist/esm/api/index.d.ts",
 			"import": "./dist/esm/api/index.mjs",
-			"require": "./dist/cjs/api/index.js",
-			"react-native": "./src/api/index.ts"
+			"require": "./dist/cjs/api/index.js"
 		},
 		"./data/server": {
 			"types": "./dist/esm/api/server.d.ts",
@@ -54,16 +54,16 @@
 			"require": "./dist/cjs/api/server.js"
 		},
 		"./datastore": {
+			"react-native": "./src/datastore/index.ts",
 			"types": "./dist/esm/datastore/index.d.ts",
 			"import": "./dist/esm/datastore/index.mjs",
-			"require": "./dist/cjs/datastore/index.js",
-			"react-native": "./src/datastore/index.ts"
+			"require": "./dist/cjs/datastore/index.js"
 		},
 		"./auth/cognito": {
+			"react-native": "./src/auth/cognito/index.ts",
 			"types": "./dist/esm/auth/cognito/index.d.ts",
 			"import": "./dist/esm/auth/cognito/index.mjs",
-			"require": "./dist/cjs/auth/cognito/index.js",
-			"react-native": "./src/auth/cognito/index.ts"
+			"require": "./dist/cjs/auth/cognito/index.js"
 		},
 		"./auth/cognito/server": {
 			"types": "./dist/esm/auth/cognito/server/index.d.ts",
@@ -81,46 +81,46 @@
 			"require": "./dist/cjs/auth/enableOAuthListener.js"
 		},
 		"./analytics": {
+			"react-native": "./src/analytics/index.ts",
 			"types": "./dist/esm/analytics/index.d.ts",
 			"import": "./dist/esm/analytics/index.mjs",
-			"require": "./dist/cjs/analytics/index.js",
-			"react-native": "./src/analytics/index.ts"
+			"require": "./dist/cjs/analytics/index.js"
 		},
 		"./analytics/pinpoint": {
+			"react-native": "./src/analytics/pinpoint/index.ts",
 			"types": "./dist/esm/analytics/pinpoint/index.d.ts",
 			"import": "./dist/esm/analytics/pinpoint/index.mjs",
-			"require": "./dist/cjs/analytics/pinpoint/index.js",
-			"react-native": "./src/analytics/pinpoint/index.ts"
+			"require": "./dist/cjs/analytics/pinpoint/index.js"
 		},
 		"./analytics/kinesis": {
+			"react-native": "./src/analytics/kinesis/index.ts",
 			"types": "./dist/esm/analytics/kinesis/index.d.ts",
 			"import": "./dist/esm/analytics/kinesis/index.mjs",
-			"require": "./dist/cjs/analytics/kinesis/index.js",
-			"react-native": "./src/analytics/kinesis/index.ts"
+			"require": "./dist/cjs/analytics/kinesis/index.js"
 		},
 		"./analytics/kinesis-firehose": {
+			"react-native": "./src/analytics/kinesis-firehose/index.ts",
 			"types": "./dist/esm/analytics/kinesis-firehose/index.d.ts",
 			"import": "./dist/esm/analytics/kinesis-firehose/index.mjs",
-			"require": "./dist/cjs/analytics/kinesis-firehose/index.js",
-			"react-native": "./src/analytics/kinesis-firehose/index.ts"
+			"require": "./dist/cjs/analytics/kinesis-firehose/index.js"
 		},
 		"./analytics/personalize": {
+			"react-native": "./src/analytics/personalize/index.ts",
 			"types": "./dist/esm/analytics/personalize/index.d.ts",
 			"import": "./dist/esm/analytics/personalize/index.mjs",
-			"require": "./dist/cjs/analytics/personalize/index.js",
-			"react-native": "./src/analytics/personalize/index.ts"
+			"require": "./dist/cjs/analytics/personalize/index.js"
 		},
 		"./storage": {
+			"react-native": "./src/storage/index.ts",
 			"types": "./dist/esm/storage/index.d.ts",
 			"import": "./dist/esm/storage/index.mjs",
-			"require": "./dist/cjs/storage/index.js",
-			"react-native": "./src/storage/index.ts"
+			"require": "./dist/cjs/storage/index.js"
 		},
 		"./storage/s3": {
+			"react-native": "./src/storage/s3/index.ts",
 			"types": "./dist/esm/storage/s3/index.d.ts",
 			"import": "./dist/esm/storage/s3/index.mjs",
-			"require": "./dist/cjs/storage/s3/index.js",
-			"react-native": "./src/storage/s3/index.ts"
+			"require": "./dist/cjs/storage/s3/index.js"
 		},
 		"./storage/server": {
 			"types": "./dist/esm/storage/server.d.ts",
@@ -133,28 +133,28 @@
 			"require": "./dist/cjs/storage/s3/server.js"
 		},
 		"./in-app-messaging": {
+			"react-native": "./src/in-app-messaging/index.ts",
 			"types": "./dist/esm/in-app-messaging/index.d.ts",
 			"import": "./dist/esm/in-app-messaging/index.mjs",
-			"require": "./dist/cjs/in-app-messaging/index.js",
-			"react-native": "./src/in-app-messaging/index.ts"
+			"require": "./dist/cjs/in-app-messaging/index.js"
 		},
 		"./push-notifications": {
+			"react-native": "./src/push-notifications/index.ts",
 			"types": "./dist/esm/push-notifications/index.d.ts",
 			"import": "./dist/esm/push-notifications/index.mjs",
-			"require": "./dist/cjs/push-notifications/index.js",
-			"react-native": "./src/push-notifications/index.ts"
+			"require": "./dist/cjs/push-notifications/index.js"
 		},
 		"./in-app-messaging/pinpoint": {
+			"react-native": "./src/in-app-messaging/pinpoint/index.ts",
 			"types": "./dist/esm/in-app-messaging/pinpoint/index.d.ts",
 			"import": "./dist/esm/in-app-messaging/pinpoint/index.mjs",
-			"require": "./dist/cjs/in-app-messaging/pinpoint/index.js",
-			"react-native": "./src/in-app-messaging/pinpoint/index.ts"
+			"require": "./dist/cjs/in-app-messaging/pinpoint/index.js"
 		},
 		"./push-notifications/pinpoint": {
+			"react-native": "./src/push-notifications/pinpoint/index.ts",
 			"types": "./dist/esm/push-notifications/pinpoint/index.d.ts",
 			"import": "./dist/esm/push-notifications/pinpoint/index.mjs",
-			"require": "./dist/cjs/push-notifications/pinpoint/index.js",
-			"react-native": "./src/push-notifications/pinpoint/index.ts"
+			"require": "./dist/cjs/push-notifications/pinpoint/index.js"
 		},
 		"./adapter-core": {
 			"types": "./dist/esm/adapter-core/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -111,10 +111,10 @@
 	],
 	"exports": {
 		".": {
+			"react-native": "./src/index.ts",
 			"types": "./dist/esm/index.d.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./server": {
 			"types": "./dist/esm/server.d.ts",
@@ -127,40 +127,40 @@
 			"require": "./dist/cjs/adapterCore/index.js"
 		},
 		"./internals/aws-client-utils": {
+			"react-native": "./src/clients/index.ts",
 			"types": "./dist/esm/clients/index.d.ts",
 			"import": "./dist/esm/clients/index.mjs",
-			"require": "./dist/cjs/clients/index.js",
-			"react-native": "./src/clients/index.ts"
+			"require": "./dist/cjs/clients/index.js"
 		},
 		"./internals/aws-client-utils/composers": {
+			"react-native": "./src/clients/internal/index.ts",
 			"types": "./dist/esm/clients/internal/index.d.ts",
 			"import": "./dist/esm/clients/internal/index.mjs",
-			"require": "./dist/cjs/clients/internal/index.js",
-			"react-native": "./src/clients/internal/index.ts"
+			"require": "./dist/cjs/clients/internal/index.js"
 		},
 		"./internals/aws-clients/cognitoIdentity": {
+			"react-native": "./src/awsClients/cognitoIdentity/index.ts",
 			"types": "./dist/esm/awsClients/cognitoIdentity/index.d.ts",
 			"import": "./dist/esm/awsClients/cognitoIdentity/index.mjs",
-			"require": "./dist/cjs/awsClients/cognitoIdentity/index.js",
-			"react-native": "./src/awsClients/cognitoIdentity/index.ts"
+			"require": "./dist/cjs/awsClients/cognitoIdentity/index.js"
 		},
 		"./internals/aws-clients/pinpoint": {
+			"react-native": "./src/awsClients/pinpoint/index.ts",
 			"types": "./dist/esm/awsClients/pinpoint/index.d.ts",
 			"import": "./dist/esm/awsClients/pinpoint/index.mjs",
-			"require": "./dist/cjs/awsClients/pinpoint/index.js",
-			"react-native": "./src/awsClients/pinpoint/index.ts"
+			"require": "./dist/cjs/awsClients/pinpoint/index.js"
 		},
 		"./internals/providers/pinpoint": {
+			"react-native": "./src/providers/pinpoint/index.ts",
 			"types": "./dist/esm/providers/pinpoint/index.d.ts",
 			"import": "./dist/esm/providers/pinpoint/index.mjs",
-			"require": "./dist/cjs/providers/pinpoint/index.js",
-			"react-native": "./src/providers/pinpoint/index.ts"
+			"require": "./dist/cjs/providers/pinpoint/index.js"
 		},
 		"./internals/utils": {
+			"react-native": "./src/libraryUtils.ts",
 			"types": "./dist/esm/libraryUtils.d.ts",
 			"import": "./dist/esm/libraryUtils.mjs",
-			"require": "./dist/cjs/libraryUtils.js",
-			"react-native": "./src/libraryUtils.ts"
+			"require": "./dist/cjs/libraryUtils.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -30,16 +30,16 @@
 	},
 	"exports": {
 		".": {
+			"react-native": "./src/index.ts",
 			"types": "./dist/esm/index.d.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./location-service": {
+			"react-native": "./src/providers/location-service/AmazonLocationServiceProvider.ts",
 			"types": "./dist/esm/providers/location-service/AmazonLocationServiceProvider.d.ts",
 			"import": "./dist/esm/providers/location-service/AmazonLocationServiceProvider.mjs",
-			"require": "./dist/cjs/providers/location-service/AmazonLocationServiceProvider.js",
-			"react-native": "./src/providers/location-service/AmazonLocationServiceProvider.ts"
+			"require": "./dist/cjs/providers/location-service/AmazonLocationServiceProvider.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -42,16 +42,16 @@
 			"require": "./dist/cjs/index.js"
 		},
 		"./lex-v1": {
+			"react-native": "./src/lex-v1/index.ts",
 			"types": "./dist/esm/lex-v1/index.d.ts",
 			"import": "./dist/esm/lex-v1/index.mjs",
-			"require": "./dist/cjs/lex-v1/index.js",
-			"react-native": "./src/lex-v1/index.ts"
+			"require": "./dist/cjs/lex-v1/index.js"
 		},
 		"./lex-v2": {
+			"react-native": "./src/lex-v2/index.ts",
 			"types": "./dist/esm/lex-v2/index.d.ts",
 			"import": "./dist/esm/lex-v2/index.mjs",
-			"require": "./dist/cjs/lex-v2/index.js",
-			"react-native": "./src/lex-v2/index.ts"
+			"require": "./dist/cjs/lex-v2/index.js"
 		}
 	},
 	"repository": {

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -43,33 +43,33 @@
 	},
 	"exports": {
 		".": {
+			"react-native": "./src/index.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./in-app-messaging": {
+			"react-native": "./src/inAppMessaging/index.ts",
 			"types": "./dist/esm/inAppMessaging/index.d.ts",
 			"import": "./dist/esm/inAppMessaging/index.mjs",
-			"require": "./dist/cjs/inAppMessaging/index.js",
-			"react-native": "./src/inAppMessaging/index.ts"
+			"require": "./dist/cjs/inAppMessaging/index.js"
 		},
 		"./push-notifications": {
+			"react-native": "./src/pushNotifications/index.ts",
 			"types": "./dist/esm/pushNotifications/index.d.ts",
 			"import": "./dist/esm/pushNotifications/index.mjs",
-			"require": "./dist/cjs/pushNotifications/index.js",
-			"react-native": "./src/pushNotifications/index.ts"
+			"require": "./dist/cjs/pushNotifications/index.js"
 		},
 		"./in-app-messaging/pinpoint": {
+			"react-native": "./src/inAppMessaging/providers/pinpoint/index.ts",
 			"types": "./dist/esm/inAppMessaging/providers/pinpoint/index.d.ts",
 			"import": "./dist/esm/inAppMessaging/providers/pinpoint/index.mjs",
-			"require": "./dist/cjs/inAppMessaging/providers/pinpoint/index.js",
-			"react-native": "./src/inAppMessaging/providers/pinpoint/index.ts"
+			"require": "./dist/cjs/inAppMessaging/providers/pinpoint/index.js"
 		},
 		"./push-notifications/pinpoint": {
+			"react-native": "./src/pushNotifications/providers/pinpoint/index.ts",
 			"types": "./dist/esm/pushNotifications/providers/pinpoint/index.d.ts",
 			"import": "./dist/esm/pushNotifications/providers/pinpoint/index.mjs",
-			"require": "./dist/cjs/pushNotifications/providers/pinpoint/index.js",
-			"react-native": "./src/pushNotifications/providers/pinpoint/index.ts"
+			"require": "./dist/cjs/pushNotifications/providers/pinpoint/index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -37,22 +37,22 @@
 	},
 	"exports": {
 		".": {
+			"react-native": "./src/index.ts",
 			"types": "./dist/esm/index.d.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./iot": {
+			"react-native": "./src/clients/iot.ts",
 			"types": "./dist/esm/clients/iot.d.ts",
 			"import": "./dist/esm/clients/iot.mjs",
-			"require": "./dist/cjs/clients/iot.js",
-			"react-native": "./src/clients/iot.ts"
+			"require": "./dist/cjs/clients/iot.js"
 		},
 		"./mqtt": {
+			"react-native": "./src/clients/mqtt.ts",
 			"types": "./dist/esm/clients/mqtt.d.ts",
 			"import": "./dist/esm/clients/mqtt.mjs",
-			"require": "./dist/cjs/clients/mqtt.js",
-			"react-native": "./src/clients/mqtt.ts"
+			"require": "./dist/cjs/clients/mqtt.js"
 		}
 	},
 	"repository": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -79,10 +79,10 @@
 	},
 	"exports": {
 		".": {
+			"react-native": "./src/index.ts",
 			"types": "./dist/esm/index.d.ts",
 			"import": "./dist/esm/index.mjs",
-			"require": "./dist/cjs/index.js",
-			"react-native": "./src/index.ts"
+			"require": "./dist/cjs/index.js"
 		},
 		"./internals": {
 			"types": "./dist/esm/internals/index.d.ts",
@@ -95,10 +95,10 @@
 			"require": "./dist/cjs/server.js"
 		},
 		"./s3": {
+			"react-native": "./src/providers/s3/index.ts",
 			"types": "./dist/esm/providers/s3/index.d.ts",
 			"import": "./dist/esm/providers/s3/index.mjs",
-			"require": "./dist/cjs/providers/s3/index.js",
-			"react-native": "./src/providers/s3/index.ts"
+			"require": "./dist/cjs/providers/s3/index.js"
 		},
 		"./s3/server": {
 			"types": "./dist/esm/providers/s3/server.d.ts",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

React native 0.79 now resolves module by looking up the `exports` define in the `package.json` by default. Amplify packages that required subpath aliases have set up the `exports` fields with adding `react-native` condition. However, it appears to that the `react-native` condition has to be placed on before `import` so that metro bundler can resolve modules from correct paths.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-js/issues/14352


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
