### PR TITLE
fix(rtn-push-notification): wrong override signature

### DIFF
--- a/packages/rtn-push-notification/android/src/main/kotlin/com/amazonaws/amplify/rtnpushnotification/PushNotificationHeadlessTaskService.kt
+++ b/packages/rtn-push-notification/android/src/main/kotlin/com/amazonaws/amplify/rtnpushnotification/PushNotificationHeadlessTaskService.kt
@@ -14,7 +14,7 @@ class PushNotificationHeadlessTaskService : HeadlessJsTaskService() {
     private val defaultTimeout: Long = 10000 // 10 seconds
 
     @InternalAmplifyApi
-    override fun getTaskConfig(intent: Intent): HeadlessJsTaskConfig? {
+    override fun getTaskConfig(intent: Intent?): HeadlessJsTaskConfig? {
         return NotificationPayload.fromIntent(intent)?.let {
             HeadlessJsTaskConfig(
                 HEADLESS_TASK_KEY, it.toWritableMap(), defaultTimeout, true


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Updated the override `getTaskConfig` method signature to match the class from React Android. 

> Why it wasn't a problem before?
Earlier version of React Android was written in Java, the Java method argument were not marked as nullable (not a feature in Java).

The newer version of React Android was rewritten in Kotlin, the method argument now is marked as nullable explicitly so we need to match.

This change is backwards compatible. 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
<!-- For external contributions, provide the github issue the PR is addressing. If no github issue exists for the related changes, open a new issue in https://github.com/aws-amplify/amplify-js/issues. -->


#### Description of how you validated changes

- manual `npx react-native run-android` with dev and release modes with the following react-native versions:
    1. 0.70.0 (the minimum version supported by Amplify at this moment)
    2. 0.78.0
    3. 0.79.0


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
