### PR TITLE
chore(actions): run test suite against PRs and on label

### DIFF
--- a/.github/actions/set-status/action.yml
+++ b/.github/actions/set-status/action.yml
@@ -1,0 +1,68 @@
+name: 'Set Status'
+description: 'Set status on a specified head-sha'
+inputs:
+  context:
+    description: 'Name of the status'
+    required: true
+  description:
+    description: 'Short description of the status'
+    required: false
+  state:
+    description: >-
+      State of the status with possible values of 'error', 'failure', 'pending', 'success'
+    required: true
+  sha:
+    description: 'The commit ID to add the status to'
+    required: true
+  target-url:
+    description: >-
+      Target URL to associate with this status.
+      This URL will be linked from the GitHub UI to allow users to easily see the source of the status.'
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - name: Set a commit status
+      id: set-status
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1 https://github.com/actions/github-script/commit/60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      env:
+        status_context: ${{ inputs.context }}
+        description: ${{ inputs.description }}
+        state: ${{ inputs.state }}
+        sha: ${{ inputs.sha }}
+        target_url: ${{ inputs.target-url }}
+        owner: ${{ github.event.repository.owner.login }}
+        repo: ${{ github.event.repository.name }}
+      with:
+        result-encoding: string
+        script: |
+          const { status_context, description, state, sha, target_url, owner, repo } = process.env;
+          const inputValidationErrors = [];
+          if (state.length === 0) {
+            inputValidationErrors.push('"state" input cannot be empty.');
+          }
+          if (!["error", "failure", "pending", "success"].includes(state)) {
+            inputValidationErrors.push('"state" must be a string input with possible value of "error", "failure", "pending", "success".');
+          }
+          if (context.length === 0) {
+            inputValidationErrors.push('"context" input cannot be empty.');
+          }
+          if (sha.length === 0) {
+            inputValidationErrors.push('"sha" input cannot be empty.');
+          }
+          if (!sha.match(/^[0-9a-z]+$/)) {
+            inputValidationErrors.push('"sha" must be an alphanumeric string.');
+          }
+          if (inputValidationErrors.length > 0) {
+            inputValidationErrors.forEach(core.error);
+            process.exit(1);
+          }
+          github.rest.repos.createCommitStatus({
+            owner,
+            repo,
+            sha,
+            state,
+            context: status_context,
+            description: description.length > 0 ? description : undefined,
+            target_url: target_url.length > 0 ? target_url : undefined,
+          });

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,0 +1,90 @@
+# Description: This workflow runs test suite against PRs that are not from forks.
+#
+# Triggers:
+# - When a PR is opened, updated, or labeled against specific branches
+# - Only runs when the PR has the 'run-tests' label
+# - Only runs for internal PRs (not from forks)
+
+name: Test / Internal PRs
+
+concurrency:
+  group: push-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches: [main, release]
+    types: [opened, synchronize, labeled]
+
+jobs:
+  setup:
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'run-tests')
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write # This is required for running set-status actions
+    steps:
+      - uses: actions/checkout@b80ff79f1755d06ba70441c368a6fe801f5f3a62 # v4.1.3 https://github.com/actions/checkout/commit/cd7d8d697e10461458bc61a30d094dc601a8b017
+      - name: Update status to pending prior to starting tests
+        uses: ./.github/actions/set-status
+        with:
+          sha: ${{ github.event.pull_request.head.sha }}
+          state: 'pending'
+          context: 'Run PR e2e checks'
+          description: 'PR e2e checks are now running'
+          # URL below is a link to the current workflow run to allow users to see the status of the workflow.
+          target-url: https://github.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }}
+
+  prebuild:
+    needs: setup
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+    uses: ./.github/workflows/callable-prebuild-amplify-js.yml
+    with:
+      runs_on: ${{ matrix.platform }}
+
+  prebuild-samples-staging:
+    needs: setup
+    secrets: inherit
+    uses: ./.github/workflows/callable-prebuild-samples-staging.yml
+
+  e2e:
+    needs: [setup, prebuild, prebuild-samples-staging]
+    secrets: inherit
+    uses: ./.github/workflows/callable-e2e-tests.yml
+
+  update-success-status:
+    if: ${{ success() }}
+    needs: [setup, prebuild, prebuild-samples-staging, e2e]
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write # This is required for running set-status actions
+    steps:
+      - uses: actions/checkout@b80ff79f1755d06ba70441c368a6fe801f5f3a62 # v4.1.3 https://github.com/actions/checkout/commit/cd7d8d697e10461458bc61a30d094dc601a8b017
+      - name: Update status when tests are successful
+        uses: ./.github/actions/set-status
+        with:
+          sha: ${{ github.event.pull_request.head.sha }}
+          state: 'success'
+          context: 'Run PR e2e checks'
+          description: 'PR e2e checks have finished running'
+          target-url: https://github.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }}
+
+  update-failure-status:
+    if: ${{ failure() }}
+    needs: [setup, prebuild, prebuild-samples-staging, e2e]
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write # This is required for running set-status actions
+    steps:
+      - uses: actions/checkout@b80ff79f1755d06ba70441c368a6fe801f5f3a62 # v4.1.3 https://github.com/actions/checkout/commit/cd7d8d697e10461458bc61a30d094dc601a8b017
+      - name: Update status when tests are not successful
+        uses: ./.github/actions/set-status
+        with:
+          sha: ${{ github.event.pull_request.head.sha }}
+          state: 'failure'
+          context: 'Run e2e PR checks'
+          description: 'PR e2e checks have failed'
+          target-url: https://github.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
#### Description of changes
Currently, to run e2e tests before merging a PR we need to manually push the changes to another branch on upstream and update the `push-integ-test` workflow by updating the trigger branch name. With this change you can directly add the `run-tests` label and it should start running the E2E tests.

[Implementation reference](https://github.com/aws-amplify/amplify-ui/blob/main/.github/workflows/test-internal-prs.yml) taken from UI

(Note: currently only configured for main/release. Can be updated to all branches if required)

**Conditions**
1. PR shouldn't be raised from fork
2. PR should contain the  `run-tests` label
3. PR should raised to main/release (added, can remove) 

#### Description of how you validated changes
Tested the following flows

**Flow 1**
1. Raise a PR from upstream to main/release without the 'run-tests' tag. [Not Trigger]
2. Add 'run-tests' tag [Triggered]
3. Push new commit [New Trigger]

**Flow 2**
1. Raise a PR from upstream to main/release with the 'run-tests' tag. [Triggered]
2. Push new commit [New Trigger]
3. Remove 'run-tests' tag, push new commit [Not Triggered]

Failure case ([CI run](https://github.com/aws-amplify/amplify-js/actions/runs/14765258814?pr=14371))
![Screenshot 2025-04-30 at 3 52 32 PM](https://github.com/user-attachments/assets/6a897ea8-1935-4ad1-85f6-870166c7cc0b)

Success case ([CI run](https://github.com/aws-amplify/amplify-js/actions/runs/14764930195?pr=14371))
![Screenshot 2025-04-30 at 3 52 55 PM](https://github.com/user-attachments/assets/41e48899-7003-49d7-8805-dc3d8f124e59)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
