### PR TITLE
fix: recreate event buffer in pinpoint if the credentials has changed

### DIFF
--- a/packages/core/__tests__/providers/pinpoint/utils/EventBuffer.test.ts
+++ b/packages/core/__tests__/providers/pinpoint/utils/EventBuffer.test.ts
@@ -55,4 +55,15 @@ describe('EventBuffer', () => {
 		buffer.push(EVENT_OBJECT);
 		buffer.push(EVENT_OBJECT);
 	});
+
+	test('haveCredentialsChanged returns true if credentials has changed', () => {
+		const config = { ...DEFAULT_CONFIG, bufferSize: 1 };
+		const buffer = new PinpointEventBuffer(config);
+		expect(
+			buffer.haveCredentialsChanged({
+				accessKeyId: 'different-access-key-id',
+				secretAccessKey: 'different-secret-access-key',
+			}),
+		).toBeTruthy();
+	});
 });

--- a/packages/core/__tests__/providers/pinpoint/utils/getEventBuffer.test.ts
+++ b/packages/core/__tests__/providers/pinpoint/utils/getEventBuffer.test.ts
@@ -22,6 +22,7 @@ const mockConfig = {
 describe('Pinpoint Provider Util: bufferManager', () => {
 	const mockPinpointEventBuffer = PinpointEventBuffer as jest.Mock;
 	const mockIdentityHasChanged = jest.fn();
+	const mockHaveCredentialsChanged = jest.fn();
 	const mockFlush = jest.fn();
 
 	beforeEach(() => {
@@ -30,6 +31,7 @@ describe('Pinpoint Provider Util: bufferManager', () => {
 		mockPinpointEventBuffer.mockReset();
 		mockPinpointEventBuffer.mockImplementation(() => ({
 			identityHasChanged: mockIdentityHasChanged,
+			haveCredentialsChanged: mockHaveCredentialsChanged,
 			flush: mockFlush,
 		}));
 	});
@@ -52,6 +54,18 @@ describe('Pinpoint Provider Util: bufferManager', () => {
 		const testBuffer = getEventBuffer(mockConfig);
 
 		mockIdentityHasChanged.mockReturnValue(true);
+
+		const testBuffer2 = getEventBuffer(mockConfig);
+
+		expect(mockFlush).toHaveBeenCalledTimes(1);
+		expect(testBuffer).not.toBe(testBuffer2);
+	});
+
+	it('flushes & creates a new buffer when the credentials changes', () => {
+		const testBuffer = getEventBuffer(mockConfig);
+
+		mockIdentityHasChanged.mockReturnValue(false);
+		mockHaveCredentialsChanged.mockReturnValue(true);
 
 		const testBuffer2 = getEventBuffer(mockConfig);
 

--- a/packages/core/src/providers/pinpoint/utils/PinpointEventBuffer.ts
+++ b/packages/core/src/providers/pinpoint/utils/PinpointEventBuffer.ts
@@ -14,7 +14,8 @@ import {
 	EventBuffer,
 	PinpointEventBufferConfig,
 } from '../types/buffer';
-import { AuthSession } from '../../../singleton/Auth/types';
+import { AWSCredentials, AuthSession } from '../../../singleton/Auth/types';
+import { haveCredentialsChanged } from '../../../utils/haveCredentialsChanged';
 
 import { isAppInForeground } from './isAppInForeground';
 
@@ -64,6 +65,10 @@ export class PinpointEventBuffer {
 
 	public identityHasChanged(identityId: AuthSession['identityId']) {
 		return this._config.identityId !== identityId;
+	}
+
+	public haveCredentialsChanged(credentials: AWSCredentials) {
+		return haveCredentialsChanged(this._config.credentials, credentials);
 	}
 
 	public flushAll() {

--- a/packages/core/src/providers/pinpoint/utils/getEventBuffer.ts
+++ b/packages/core/src/providers/pinpoint/utils/getEventBuffer.ts
@@ -42,6 +42,8 @@ export const getEventBuffer = ({
 		*/
 		if (buffer.identityHasChanged(identityId)) {
 			buffer.flush();
+		} else if (buffer.haveCredentialsChanged(credentials)) {
+			buffer.flush();
 		} else {
 			return buffer;
 		}


### PR DESCRIPTION

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This change makes sure that the `getEventBuffer` function of the pinpoint flushes and recreates a new EventBuffer when the credentials are updated. 

Continuing to use the older credentials were causing to get `403` error when events are emitted by Analytics as described in this issue: https://github.com/aws-amplify/amplify-js/issues/14398

#### Issue #14398 
<!-- Also, please reference any associated PRs for documentation updates. -->
<!-- For external contributions, provide the github issue the PR is addressing. If no github issue exists for the related changes, open a new issue in https://github.com/aws-amplify/amplify-js/issues. -->


#### Description of how you validated changes

I've validated the changed by linking the updated library to a testing repo and following the reproducing steps provided in the issue.  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
