### PR TITLE
Auth/refactor reset auto signin wrapper

### DIFF
--- a/packages/auth/__tests__/providers/cognito/autoSignIn.test.ts
+++ b/packages/auth/__tests__/providers/cognito/autoSignIn.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../src/providers/cognito';
 import {
 	autoSignIn,
-	resetAutoSignIn,
+	resetAutoSignInCompletely,
 } from '../../../src/providers/cognito/apis/autoSignIn';
 import * as initiateAuthHelpers from '../../../src/providers/cognito/utils/signInHelpers';
 import {
@@ -84,7 +84,7 @@ describe('autoSignIn()', () => {
 			mockCreateSignUpClient.mockClear();
 			handleUserSRPAuthFlowSpy.mockClear();
 
-			resetAutoSignIn();
+			resetAutoSignInCompletely();
 		});
 
 		afterAll(() => {
@@ -163,7 +163,7 @@ describe('autoSignIn()', () => {
 			mockHandleUserAuthFlow.mockClear();
 			mockCreateConfirmSignUpClient.mockClear();
 
-			resetAutoSignIn();
+			resetAutoSignInCompletely();
 		});
 
 		afterAll(() => {

--- a/packages/auth/src/providers/cognito/apis/autoSignIn.ts
+++ b/packages/auth/src/providers/cognito/apis/autoSignIn.ts
@@ -121,3 +121,17 @@ export function resetAutoSignIn(resetCallback = true) {
 	}
 	autoSignInStore.dispatch({ type: 'RESET' });
 }
+
+/**
+ * Clears auto sign-in state and triggers reset callback.
+ */
+export function resetAutoSignInCompletely() {
+	return resetAutoSignIn(true);
+}
+
+/**
+ * Clears auto sign-in state without triggering reset callback
+ */
+export function resetAutoSignInStoreOnly() {
+	return resetAutoSignIn(false);
+}

--- a/packages/auth/src/providers/cognito/apis/autoSignIn.ts
+++ b/packages/auth/src/providers/cognito/apis/autoSignIn.ts
@@ -126,12 +126,12 @@ export function resetAutoSignIn(resetCallback = true) {
  * Clears auto sign-in state and triggers reset callback.
  */
 export function resetAutoSignInCompletely() {
-	return resetAutoSignIn(true);
+	resetAutoSignIn(true);
 }
 
 /**
  * Clears auto sign-in state without triggering reset callback
  */
 export function resetAutoSignInStoreOnly() {
-	return resetAutoSignIn(false);
+	resetAutoSignIn(false);
 }

--- a/packages/auth/src/providers/cognito/apis/confirmSignUp.ts
+++ b/packages/auth/src/providers/cognito/apis/confirmSignUp.ts
@@ -20,7 +20,7 @@ import { createConfirmSignUpClient } from '../../../foundation/factories/service
 import { createCognitoUserPoolEndpointResolver } from '../factories';
 import { autoSignInStore } from '../../../client/utils/store';
 
-import { resetAutoSignIn } from './autoSignIn';
+import { resetAutoSignInCompletely } from './autoSignIn';
 
 /**
  * Confirms a new user account.
@@ -93,7 +93,7 @@ export async function confirmSignUp(
 				autoSignInStoreState.username !== username
 			) {
 				resolve(signUpOut);
-				resetAutoSignIn();
+				resetAutoSignInCompletely();
 
 				return;
 			}

--- a/packages/auth/src/providers/cognito/apis/signIn.ts
+++ b/packages/auth/src/providers/cognito/apis/signIn.ts
@@ -14,7 +14,7 @@ import { signInWithCustomSRPAuth } from './signInWithCustomSRPAuth';
 import { signInWithSRP } from './signInWithSRP';
 import { signInWithUserPassword } from './signInWithUserPassword';
 import { signInWithUserAuth } from './signInWithUserAuth';
-import { resetAutoSignIn } from './autoSignIn';
+import { resetAutoSignInStoreOnly } from './autoSignIn';
 
 /**
  * Signs a user in
@@ -32,7 +32,7 @@ export async function signIn(input: SignInInput): Promise<SignInOutput> {
 	// The callback is reset when the underlying promise resolves or rejects.
 	// With the advent of session based sign in, this guarantees that the signIn API initiates a new auth flow,
 	// regardless of whether it is called for a user currently engaged in an active auto sign in session.
-	resetAutoSignIn(false);
+	resetAutoSignInStoreOnly();
 
 	const authFlowType = input.options?.authFlowType;
 	await assertUserNotAuthenticated();

--- a/packages/auth/src/providers/cognito/apis/signInWithSRP.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithSRP.ts
@@ -35,7 +35,7 @@ import { tokenOrchestrator } from '../tokenProvider';
 import { dispatchSignedInHubEvent } from '../utils/dispatchSignedInHubEvent';
 import { getNewDeviceMetadata } from '../utils/getNewDeviceMetadata';
 
-import { resetAutoSignIn } from './autoSignIn';
+import { resetAutoSignInCompletely } from './autoSignIn';
 
 /**
  * Signs a user in
@@ -106,7 +106,7 @@ export async function signInWithSRP(
 
 			await dispatchSignedInHubEvent();
 
-			resetAutoSignIn();
+			resetAutoSignInCompletely();
 
 			return {
 				isSignedIn: true,
@@ -120,7 +120,7 @@ export async function signInWithSRP(
 		});
 	} catch (error) {
 		resetActiveSignInState();
-		resetAutoSignIn();
+		resetAutoSignInCompletely();
 		assertServiceError(error);
 		const result = getSignInResultFromError(error.name);
 		if (result) return result;

--- a/packages/auth/src/providers/cognito/apis/signInWithUserAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithUserAuth.ts
@@ -39,7 +39,7 @@ import {
 } from '../../../client/flows/userAuth/handleUserAuthFlow';
 import { getNewDeviceMetadata } from '../utils/getNewDeviceMetadata';
 
-import { resetAutoSignIn } from './autoSignIn';
+import { resetAutoSignInCompletely } from './autoSignIn';
 
 /**
  * Signs a user in through a registered email or phone number without a password by by receiving and entering an OTP.
@@ -115,7 +115,7 @@ export async function signInWithUserAuth(
 
 			await dispatchSignedInHubEvent();
 
-			resetAutoSignIn();
+			resetAutoSignInCompletely();
 
 			return {
 				isSignedIn: true,
@@ -133,7 +133,7 @@ export async function signInWithUserAuth(
 		});
 	} catch (error) {
 		resetActiveSignInState();
-		resetAutoSignIn();
+		resetAutoSignInCompletely();
 		assertServiceError(error);
 		const result = getSignInResultFromError(error.name);
 		if (result) return result;

--- a/packages/auth/src/providers/cognito/apis/signInWithUserPassword.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithUserPassword.ts
@@ -33,7 +33,7 @@ import { dispatchSignedInHubEvent } from '../utils/dispatchSignedInHubEvent';
 import { retryOnResourceNotFoundException } from '../utils/retryOnResourceNotFoundException';
 import { getNewDeviceMetadata } from '../utils/getNewDeviceMetadata';
 
-import { resetAutoSignIn } from './autoSignIn';
+import { resetAutoSignInCompletely } from './autoSignIn';
 
 /**
  * Signs a user in using USER_PASSWORD_AUTH AuthFlowType
@@ -101,7 +101,7 @@ export async function signInWithUserPassword(
 
 			await dispatchSignedInHubEvent();
 
-			resetAutoSignIn();
+			resetAutoSignInCompletely();
 
 			return {
 				isSignedIn: true,
@@ -115,7 +115,7 @@ export async function signInWithUserPassword(
 		});
 	} catch (error) {
 		resetActiveSignInState();
-		resetAutoSignIn();
+		resetAutoSignInCompletely();
 		assertServiceError(error);
 		const result = getSignInResultFromError(error.name);
 		if (result) return result;

--- a/packages/auth/src/providers/cognito/utils/signUpHelpers.ts
+++ b/packages/auth/src/providers/cognito/utils/signUpHelpers.ts
@@ -8,7 +8,7 @@ import { SignInInput, SignInOutput } from '../types';
 import { AutoSignInEventData } from '../types/models';
 import { AutoSignInCallback } from '../../../types/models';
 import { AuthError } from '../../../errors/AuthError';
-import { resetAutoSignIn, setAutoSignIn } from '../apis/autoSignIn';
+import { resetAutoSignInCompletely, setAutoSignIn } from '../apis/autoSignIn';
 import { AUTO_SIGN_IN_EXCEPTION } from '../../../errors/constants';
 import { signInWithUserAuth } from '../apis/signInWithUserAuth';
 
@@ -37,7 +37,7 @@ export function handleCodeAutoSignIn(signInInput: SignInInput) {
 	const timeOutId = setTimeout(() => {
 		stopHubListener();
 		clearTimeout(timeOutId);
-		resetAutoSignIn();
+		resetAutoSignInCompletely();
 	}, MAX_AUTOSIGNIN_POLLING_MS);
 }
 
@@ -81,19 +81,19 @@ function handleAutoSignInWithLink(
 						'Try to verify your account by clicking the link sent your email or phone and then login manually.',
 				}),
 			);
-			resetAutoSignIn();
+			resetAutoSignInCompletely();
 		} else {
 			try {
 				const signInOutput = await signIn(signInInput);
 				if (signInOutput.nextStep.signInStep !== 'CONFIRM_SIGN_UP') {
 					resolve(signInOutput);
 					clearInterval(autoSignInPollingIntervalId);
-					resetAutoSignIn();
+					resetAutoSignInCompletely();
 				}
 			} catch (error) {
 				clearInterval(autoSignInPollingIntervalId);
 				reject(error);
-				resetAutoSignIn();
+				resetAutoSignInCompletely();
 			}
 		}
 	}, 5000);
@@ -125,10 +125,10 @@ async function handleAutoSignInWithCodeOrUserConfirmed(
 				: await signIn(signInInput);
 
 		resolve(output);
-		resetAutoSignIn();
+		resetAutoSignInCompletely();
 	} catch (error) {
 		reject(error);
-		resetAutoSignIn();
+		resetAutoSignInCompletely();
 	}
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Refactored the resetAutoSignIn() function in autoSignIn.ts by introducing two named wrapper functions:

resetAutoSignInCompletely() — triggers the reset and reset callback

resetAutoSignInStoreOnly() — resets the store only without invoking the callback

This change improves readability and intent clarity when resetting auto sign-in state throughout the authentication flow.

Also fixed lint errors by removing void return values and formatting code to satisfy Prettier.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
<!-- For external contributions, provide the github issue the PR is addressing. If no github issue exists for the related changes, open a new issue in https://github.com/aws-amplify/amplify-js/issues. -->
#14405


#### Description of how you validated changes
Ran yarn lint --fix to resolve formatting issues

Confirmed all tests pass via:
yarn test 
and
yarn test --scope @aws-amplify/auth

Confirmed all license and compliance checks pass


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are not changed (behavior unchanged, internal refactor)
- [x] No documentation changes required



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
