### PR TITLE
refactor(api-rest): allow for body in delete request

### DIFF
--- a/packages/api-rest/src/types/index.ts
+++ b/packages/api-rest/src/types/index.ts
@@ -6,14 +6,14 @@ export type GetInput = ApiInput<RestApiOptionsBase>;
 export type PostInput = ApiInput<RestApiOptionsBase>;
 export type PutInput = ApiInput<RestApiOptionsBase>;
 export type PatchInput = ApiInput<RestApiOptionsBase>;
-export type DeleteInput = ApiInput<Omit<RestApiOptionsBase, 'body'>>;
+export type DeleteInput = ApiInput<RestApiOptionsBase>;
 export type HeadInput = ApiInput<Omit<RestApiOptionsBase, 'body'>>;
 
 export type GetOperation = Operation<RestApiResponse>;
 export type PostOperation = Operation<RestApiResponse>;
 export type PutOperation = Operation<RestApiResponse>;
 export type PatchOperation = Operation<RestApiResponse>;
-export type DeleteOperation = Operation<Omit<RestApiResponse, 'body'>>;
+export type DeleteOperation = Operation<RestApiResponse>;
 export type HeadOperation = Operation<Omit<RestApiResponse, 'body'>>;
 
 /**


### PR DESCRIPTION
#### Description of changes
In the api-rest/index.ts file i change the type of the delete operation to not omit the 'body' attribute. With this change the type of delete allows for an body.
I am not really sure if this is the only changed needed to use body on delete request for rest-api. Maybe some of the amplify team will check on this and provide some guidance if any other changes are necessary.


#### Issue #, if available
12844

#### Description of how you validated changes

- add body in type as for the other types of http methods like put and post.
- run the yarn test suite


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
