### PR TITLE
chore: add a warning if amplify configure has not been called

### DIFF
--- a/packages/core/src/singleton/Amplify.ts
+++ b/packages/core/src/singleton/Amplify.ts
@@ -19,6 +19,8 @@ export class AmplifyClass {
 		| ((authConfig: AuthConfig['Cognito']) => void)
 		| undefined = undefined;
 
+	private isConfigured = false;
+
 	resourcesConfig: ResourcesConfig;
 	libraryOptions: LibraryOptions;
 
@@ -76,6 +78,7 @@ export class AmplifyClass {
 		);
 
 		this.notifyOAuthListener();
+		this.isConfigured = true;
 	}
 
 	/**
@@ -84,6 +87,13 @@ export class AmplifyClass {
 	 * @returns Returns the immutable back-end resource configuration.
 	 */
 	getConfig(): Readonly<ResourcesConfig> {
+		if (!this.isConfigured) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				`Amplify has not been configured. Please call Amplify.configure() before using this service.`,
+			);
+		}
+
 		return this.resourcesConfig;
 	}
 


### PR DESCRIPTION
#### Description of changes

The purpose of this PR is to add a warning if Amplify.configure() has not been called. This adds more context to errors resulting from missing configuration.

#### Issue #, if available

#### Description of how you validated changes

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

#### Checklist for repo maintainers

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
