### PR TITLE
fix: implemented cancel scenario in oauthSignIn for signInWithRedirect

### DIFF
--- a/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
@@ -296,6 +296,30 @@ describe('signInWithRedirect', () => {
 			expect(mockHandleFailure).toHaveBeenCalledWith(expectedError);
 		});
 
+		it('invokes `handleFailure` with the error thrown from `completeOAuthFlow`', async () => {
+			const expectedError = new Error('OAuth flow was cancelled.');
+			const mockOpenAuthSessionResult = {
+				type: 'canceled',
+				url: 'https://url.com',
+			};
+			mockOpenAuthSession.mockResolvedValueOnce(mockOpenAuthSessionResult);
+			mockCompleteOAuthFlow.mockRejectedValueOnce(expectedError);
+
+			await expect(
+				signInWithRedirect({
+					provider: 'Google',
+					options: { preferPrivateSession: true },
+				}),
+			).rejects.toThrow(expectedError);
+
+			expect(mockCompleteOAuthFlow).toHaveBeenCalledWith(
+				expect.objectContaining({
+					currentUrl: mockOpenAuthSessionResult.url,
+				}),
+			);
+			expect(mockHandleFailure).toHaveBeenCalledWith(expectedError);
+		});
+
 		it('should not set the Oauth flag on non-browser environments', async () => {
 			const mockOpenAuthSessionResult = {
 				type: 'success',

--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -137,6 +137,9 @@ const oauthSignIn = async ({
 		if (type === 'error') {
 			throw createOAuthError(String(error));
 		}
+		if (type === 'canceled') {
+			throw createOAuthError(String(type));
+		}
 		if (type === 'success' && url) {
 			await completeOAuthFlow({
 				currentUrl: url,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR fixes the use case to handle when user cancels the pop up for federated Sign In when calling `signInWithRedirect()`.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
<!-- For external contributions, provide the github issue the PR is addressing. If no github issue exists for the related changes, open a new issue in https://github.com/aws-amplify/amplify-js/issues. -->
#9948

#### Description of how you validated changes
Run [unit, E2E tests]()

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
