### PR TITLE
fix: await AppSyncEvent WebSocket connection establishment

### DIFF
--- a/packages/api-graphql/__tests__/AWSAppSyncEventProvider.test.ts
+++ b/packages/api-graphql/__tests__/AWSAppSyncEventProvider.test.ts
@@ -60,6 +60,59 @@ jest.mock('@aws-amplify/core', () => {
 });
 
 describe('AppSyncEventProvider', () => {
+	describe('connect', () => {
+		let fakeWebSocketInterface: FakeWebSocketInterface;
+		const loggerSpy: jest.SpyInstance = jest.spyOn(
+			ConsoleLogger.prototype,
+			'_log',
+		);
+		let provider: AWSAppSyncEventProvider;
+		beforeEach(async () => {
+			fakeWebSocketInterface = new FakeWebSocketInterface();
+			provider = new AWSAppSyncEventProvider();
+
+			Object.defineProperty(provider, 'socketStatus', {
+				value: constants.SOCKET_STATUS.CLOSED,
+			});
+			
+			jest.spyOn(provider as any, '_getNewWebSocket').mockImplementation(() => {
+				fakeWebSocketInterface.newWebSocket();
+				return fakeWebSocketInterface.webSocket as WebSocket;
+			});
+		})
+
+		afterEach(async () => {
+			provider?.close();
+			await fakeWebSocketInterface?.closeInterface();
+			fakeWebSocketInterface?.teardown();
+			loggerSpy.mockClear();
+		});
+
+		test('socket status should be READY', async () => {
+
+			// Connect to the provider
+			const connectPromise = provider.connect({
+				appSyncGraphqlEndpoint: 'ws://localhost:8080',
+				authenticationType: 'apiKey',
+				apiKey: 'test-api-key',
+				region: 'us-east-1'
+			});
+
+			// Trigger the websocket open event
+			await fakeWebSocketInterface.readyForUse;
+			await fakeWebSocketInterface.triggerOpen();
+
+			await fakeWebSocketInterface.sendDataMessage({
+				type: MESSAGE_TYPES.GQL_CONNECTION_ACK
+			});
+
+			// Wait for connection to complete
+			await connectPromise;
+
+			// Verify the socket status
+			expect((provider as any).socketStatus).toBe(constants.SOCKET_STATUS.READY);
+		});
+	});
 	describe('subscribe()', () => {
 		describe('returned observer', () => {
 			describe('connection logic with mocked websocket', () => {

--- a/packages/api-graphql/__tests__/AWSAppSyncEventProvider.test.ts
+++ b/packages/api-graphql/__tests__/AWSAppSyncEventProvider.test.ts
@@ -98,10 +98,15 @@ describe('AppSyncEventProvider', () => {
 				region: 'us-east-1'
 			});
 
+			// Verify the socket status to be CONNECTING
+			await new Promise(resolve => setTimeout(resolve, 1));
+			expect((provider as any).socketStatus).toBe(constants.SOCKET_STATUS.CONNECTING);
+
 			// Trigger the websocket open event
 			await fakeWebSocketInterface.readyForUse;
 			await fakeWebSocketInterface.triggerOpen();
 
+			// Initiate handshake			
 			await fakeWebSocketInterface.sendDataMessage({
 				type: MESSAGE_TYPES.GQL_CONNECTION_ACK
 			});

--- a/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
@@ -61,7 +61,7 @@ export class AWSAppSyncEventProvider extends AWSWebSocketProvider {
 	}
 
 	public async connect(options: AWSAppSyncEventProviderOptions) {
-		super.connect(options);
+		return super.connect(options);
 	}
 
 	public subscribe(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

This PR fix the race condition between web socket connection and subsequent publish event while using AppSyncEvents. 

Before this change, the web socket connection Promise is resolve while the connection is still being established. It allows subsequent publish event calls to the web socket connection is ready.

Now the web socket connection Promise will be resolved only when the connection is established completely.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
<!-- For external contributions, provide the github issue the PR is addressing. If no github issue exists for the related changes, open a new issue in https://github.com/aws-amplify/amplify-js/issues. -->


#### Description of how you validated changes

Run [unit, E2E tests](https://github.com/aws-amplify/amplify-js/actions/runs/15758916563) and verified manually that WebSocket connection is established before any event is being published.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
