### PR TITLE
fix(storage): correctly pass upload data when calculating crc32

### DIFF
--- a/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
@@ -156,7 +156,7 @@ export const getMultipartUploadHandlers = (
 		}
 
 		const optionsHash = await calculateContentCRC32(
-			serializeUploadOptions(uploadDataOptions),
+			data,
 		);
 
 		if (!inProgressUpload) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->
I didn't read the guidelines.

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
`calculateContentCRC32` expects to receive binary data, which can be of type `string`. For some reason, the output of `serializeUploadOptions(uploadDataOptions)` (which returns a serialized JSON string) was being passed into it. This seems obviously broken. Changed this to pass `data` instead which makes everything work again.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
<!-- For external contributions, provide the github issue the PR is addressing. If no github issue exists for the related changes, open a new issue in https://github.com/aws-amplify/amplify-js/issues. -->
I didn't open an issue.


#### Description of how you validated changes
I tried it out in my local codebase.



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
