### PR TITLE
feat(auth): add prompt parameter to signInWithRedirect

### DIFF
--- a/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
@@ -24,7 +24,10 @@ import { createOAuthError } from '../../../src/providers/cognito/utils/oauth/cre
 import { signInWithRedirect } from '../../../src/providers/cognito/apis/signInWithRedirect';
 import type { OAuthStore } from '../../../src/providers/cognito/utils/types';
 import { mockAuthConfigWithOAuth } from '../../mockData';
-import { AuthPrompt } from '../../../src/types/inputs';
+import {
+	type AuthPrompt,
+	mapAuthPromptForCognito,
+} from '../../../src/types/inputs';
 
 jest.mock('@aws-amplify/core/internals/utils', () => ({
 	...jest.requireActual('@aws-amplify/core/internals/utils'),
@@ -109,10 +112,10 @@ describe('signInWithRedirect', () => {
 	const mockToCodeChallenge = jest.fn(() => mockCodeChallenge);
 
 	const promptTypes = [
-		'none',
-		'login',
-		'consent',
-		'select_account',
+		'NONE',
+		'LOGIN',
+		'CONSENT',
+		'SELECT_ACCOUNT',
 	] as const satisfies readonly AuthPrompt[];
 
 	beforeAll(() => {
@@ -205,8 +208,9 @@ describe('signInWithRedirect', () => {
 				options: { prompt },
 			});
 			const [oauthUrl] = mockOpenAuthSession.mock.calls[0];
+			const cognitoPrompt = mapAuthPromptForCognito(prompt);
 			expect(oauthUrl).toStrictEqual(
-				`https://oauth.domain.com/oauth2/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F&response_type=code&client_id=userPoolClientId&identity_provider=${expectedCustomProvider}&scope=phone%20email%20openid%20profile%20aws.cognito.signin.user.admin&prompt=${prompt}&state=oauth_state&code_challenge=code_challenge&code_challenge_method=S256`,
+				`https://oauth.domain.com/oauth2/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F&response_type=code&client_id=userPoolClientId&identity_provider=${expectedCustomProvider}&scope=phone%20email%20openid%20profile%20aws.cognito.signin.user.admin&prompt=${cognitoPrompt}&state=oauth_state&code_challenge=code_challenge&code_challenge_method=S256`,
 			);
 			mockOpenAuthSession.mockClear();
 		}

--- a/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithRedirect.test.ts
@@ -24,10 +24,7 @@ import { createOAuthError } from '../../../src/providers/cognito/utils/oauth/cre
 import { signInWithRedirect } from '../../../src/providers/cognito/apis/signInWithRedirect';
 import type { OAuthStore } from '../../../src/providers/cognito/utils/types';
 import { mockAuthConfigWithOAuth } from '../../mockData';
-import {
-	type AuthPrompt,
-	mapAuthPromptForCognito,
-} from '../../../src/types/inputs';
+import { type AuthPrompt } from '../../../src/types/inputs';
 
 jest.mock('@aws-amplify/core/internals/utils', () => ({
 	...jest.requireActual('@aws-amplify/core/internals/utils'),
@@ -208,7 +205,7 @@ describe('signInWithRedirect', () => {
 				options: { prompt },
 			});
 			const [oauthUrl] = mockOpenAuthSession.mock.calls[0];
-			const cognitoPrompt = mapAuthPromptForCognito(prompt);
+			const cognitoPrompt = prompt.toLowerCase();
 			expect(oauthUrl).toStrictEqual(
 				`https://oauth.domain.com/oauth2/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F&response_type=code&client_id=userPoolClientId&identity_provider=${expectedCustomProvider}&scope=phone%20email%20openid%20profile%20aws.cognito.signin.user.admin&prompt=${cognitoPrompt}&state=oauth_state&code_challenge=code_challenge&code_challenge_method=S256`,
 			);

--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -15,6 +15,7 @@ import { cognitoHostedUIIdentityProviderMap } from '../types/models';
 import { getAuthUserAgentValue, openAuthSession } from '../../../utils';
 import { assertUserNotAuthenticated } from '../utils/signInHelpers';
 import { SignInWithRedirectInput } from '../types';
+import { mapAuthPromptForCognito } from '../../../types/inputs';
 import {
 	completeOAuthFlow,
 	generateCodeVerifier,
@@ -115,7 +116,7 @@ const oauthSignIn = async ({
 		...(loginHint && { login_hint: loginHint }),
 		...(lang && { lang }),
 		...(nonce && { nonce }),
-		...(prompt && { prompt }),
+		...(prompt && { prompt: mapAuthPromptForCognito(prompt) }),
 		state,
 		...(responseType === 'code' && {
 			code_challenge: toCodeChallenge(),

--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -41,7 +41,10 @@ export async function signInWithRedirect(
 	assertTokenProviderConfig(authConfig);
 	assertOAuthConfig(authConfig);
 	oAuthStore.setAuthConfig(authConfig);
-	await assertUserNotAuthenticated();
+
+	if (!input?.options?.prompt) {
+		await assertUserNotAuthenticated();
+	}
 
 	let provider = 'COGNITO'; // Default
 
@@ -61,6 +64,7 @@ export async function signInWithRedirect(
 			loginHint: input?.options?.loginHint,
 			lang: input?.options?.lang,
 			nonce: input?.options?.nonce,
+			prompt: input?.options?.prompt,
 		},
 	});
 }
@@ -81,7 +85,7 @@ const oauthSignIn = async ({
 	options?: SignInWithRedirectInput['options'];
 }) => {
 	const { domain, redirectSignIn, responseType, scopes } = oauthConfig;
-	const { loginHint, lang, nonce } = options ?? {};
+	const { loginHint, lang, nonce, prompt } = options ?? {};
 	const randomState = generateState();
 
 	/* encodeURIComponent is not URL safe, use urlSafeEncode instead. Cognito
@@ -111,6 +115,7 @@ const oauthSignIn = async ({
 		...(loginHint && { login_hint: loginHint }),
 		...(lang && { lang }),
 		...(nonce && { nonce }),
+		...(prompt && { prompt }),
 		state,
 		...(responseType === 'code' && {
 			code_challenge: toCodeChallenge(),

--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -15,7 +15,6 @@ import { cognitoHostedUIIdentityProviderMap } from '../types/models';
 import { getAuthUserAgentValue, openAuthSession } from '../../../utils';
 import { assertUserNotAuthenticated } from '../utils/signInHelpers';
 import { SignInWithRedirectInput } from '../types';
-import { mapAuthPromptForCognito } from '../../../types/inputs';
 import {
 	completeOAuthFlow,
 	generateCodeVerifier,
@@ -116,7 +115,7 @@ const oauthSignIn = async ({
 		...(loginHint && { login_hint: loginHint }),
 		...(lang && { lang }),
 		...(nonce && { nonce }),
-		...(prompt && { prompt: mapAuthPromptForCognito(prompt) }),
+		...(prompt && { prompt: prompt.toLowerCase() }), // Cognito expects lowercase prompt values
 		state,
 		...(responseType === 'code' && {
 			code_challenge: toCodeChallenge(),

--- a/packages/auth/src/types/inputs.ts
+++ b/packages/auth/src/types/inputs.ts
@@ -67,7 +67,7 @@ export type AuthProvider = 'Amazon' | 'Apple' | 'Facebook' | 'Google';
 export type AuthPrompt = 'NONE' | 'LOGIN' | 'CONSENT' | 'SELECT_ACCOUNT';
 
 /**
- * Maps internal AuthPromptType enum values to the values expected by Cognito
+ * Maps internal AuthPrompt enum values to the values expected by Cognito
  * @internal
  */
 export function mapAuthPromptForCognito(prompt: AuthPrompt): string {

--- a/packages/auth/src/types/inputs.ts
+++ b/packages/auth/src/types/inputs.ts
@@ -64,7 +64,22 @@ export type AuthProvider = 'Amazon' | 'Apple' | 'Facebook' | 'Google';
  *
  * @see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
  */
-export type AuthPrompt = 'none' | 'login' | 'consent' | 'select_account';
+export type AuthPrompt = 'NONE' | 'LOGIN' | 'CONSENT' | 'SELECT_ACCOUNT';
+
+/**
+ * Maps internal AuthPromptType enum values to the values expected by Cognito
+ * @internal
+ */
+export function mapAuthPromptForCognito(prompt: AuthPrompt): string {
+	const map: Record<AuthPrompt, string> = {
+		NONE: 'none',
+		LOGIN: 'login',
+		CONSENT: 'consent',
+		SELECT_ACCOUNT: 'select_account',
+	};
+
+	return map[prompt];
+}
 
 export interface AuthSignInWithRedirectInput {
 	provider?: AuthProvider | { custom: string };

--- a/packages/auth/src/types/inputs.ts
+++ b/packages/auth/src/types/inputs.ts
@@ -54,6 +54,18 @@ export interface AuthSignOutInput {
 
 export type AuthProvider = 'Amazon' | 'Apple' | 'Facebook' | 'Google';
 
+/**
+ * OIDC prompt parameter that specifies whether the Authorization Server prompts the End-User for reauthentication and consent.
+ *
+ * - `'none'` - No authentication or consent UI will be displayed
+ * - `'login'` - Force user to re-authenticate even if they have a valid session
+ * - `'consent'` - Force user to consent to sharing information with the client
+ * - `'select_account'` - Prompt user to select among multiple authenticated accounts
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+ */
+export type AuthPrompt = 'none' | 'login' | 'consent' | 'select_account';
+
 export interface AuthSignInWithRedirectInput {
 	provider?: AuthProvider | { custom: string };
 	customState?: string;
@@ -95,6 +107,12 @@ export interface AuthSignInWithRedirectInput {
 		 * @see https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html
 		 */
 		nonce?: string;
+
+		/**
+		 * An OIDC parameter that controls authentication behavior for existing sessions. It can be used by the Client to make sure that the End-User is still present for the current session or to bring attention to the request. Available in the managed login branding version only, not in the classic hosted UI.
+		 * @see https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html
+		 */
+		prompt?: AuthPrompt;
 	};
 }
 

--- a/packages/auth/src/types/inputs.ts
+++ b/packages/auth/src/types/inputs.ts
@@ -57,10 +57,10 @@ export type AuthProvider = 'Amazon' | 'Apple' | 'Facebook' | 'Google';
 /**
  * OIDC prompt parameter that specifies whether the Authorization Server prompts the End-User for reauthentication and consent.
  *
- * - `'none'` - No authentication or consent UI will be displayed
- * - `'login'` - Force user to re-authenticate even if they have a valid session
- * - `'consent'` - Force user to consent to sharing information with the client
- * - `'select_account'` - Prompt user to select among multiple authenticated accounts
+ * - `'NONE'` - No authentication or consent UI will be displayed
+ * - `'LOGIN'` - Force user to re-authenticate even if they have a valid session
+ * - `'CONSENT'` - Force user to consent to sharing information with the client
+ * - `'SELECT_ACCOUNT'` - Prompt user to select among multiple authenticated accounts
  *
  * @see https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
  */

--- a/packages/auth/src/types/inputs.ts
+++ b/packages/auth/src/types/inputs.ts
@@ -66,21 +66,6 @@ export type AuthProvider = 'Amazon' | 'Apple' | 'Facebook' | 'Google';
  */
 export type AuthPrompt = 'NONE' | 'LOGIN' | 'CONSENT' | 'SELECT_ACCOUNT';
 
-/**
- * Maps internal AuthPrompt enum values to the values expected by Cognito
- * @internal
- */
-export function mapAuthPromptForCognito(prompt: AuthPrompt): string {
-	const map: Record<AuthPrompt, string> = {
-		NONE: 'none',
-		LOGIN: 'login',
-		CONSENT: 'consent',
-		SELECT_ACCOUNT: 'select_account',
-	};
-
-	return map[prompt];
-}
-
 export interface AuthSignInWithRedirectInput {
 	provider?: AuthProvider | { custom: string };
 	customState?: string;


### PR DESCRIPTION
#### Description of changes

This PR adds support for the optional  prompt parameter ([authorization-endpoint.html](https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html)) to signInWithRedirect. 

The prompt parameter is a part of the OpenID Connect (OIDC) specification and allows clients to request specific authentication flows from the authorization server. It requires that the managed branding (and not hosted ui classic) to be set in the user pool.

We already had a PR that was adding the `login` prompt but decided to support all prompt values.

The signInWithRedirect works by generating an URL that is invoked. We can add the prompt parameter to that URL by appending it to the dictionary. 

Also, as we currently block requests to signInWithRedirect if the user is already logged in, we need to allow invocations of signInWithRedirect for logged-in users. This is because all of the flows are supposed to change the behavior for an already signed in user. 

#### Usage Example

```
    await signInWithRedirect({ provider: selected_provider });

    await signInWithRedirect({ provider: selected_provider, options: {prompt: 'NONE'}});

    await signInWithRedirect({ provider: selected_provider, options: {prompt: 'LOGIN'}});

    await signInWithRedirect({ provider: selected_provider, options: {prompt: 'CONSENT'}});

    await signInWithRedirect({ provider: selected_provider,options: {prompt: 'SELECT_ACCOUNT'}});
```

#### Issue #, if available

#4044 

This PR replaces https://github.com/aws-amplify/amplify-js/pull/14413

#### Description of how you validated changes

I setup an example project with different providers and validated that the different flows are triggered succesfully. 

Run E2E tests: https://github.com/aws-amplify/amplify-js/actions/runs/16370175117

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
