### PR TITLE
fix: next request check for serverless environments

### DIFF
--- a/packages/adapter-nextjs/__tests__/auth/utils/predicates.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/utils/predicates.test.ts
@@ -39,4 +39,124 @@ describe('isNextRequest', () => {
 
 		expect(isNextRequest(request)).toBe(true);
 	});
+
+	it('returns true when the request is like a next request', () => {
+		const mockNextRequest = {
+			nextUrl: {
+				pathname: '/api/auth',
+				search: '?param=value',
+				searchParams: new URLSearchParams('param=value'),
+				href: 'https://example.com/api/auth?param=value',
+			},
+			cookies: {
+				get: jest.fn(),
+				set: jest.fn(),
+				delete: jest.fn(),
+			},
+			url: 'https://example.com/api/auth?param=value',
+			headers: new Headers({
+				'content-type': 'application/json',
+				'user-agent': 'test-agent',
+			}),
+			method: 'POST',
+			body: null,
+			bodyUsed: false,
+		};
+
+		expect(isNextRequest(mockNextRequest)).toBe(true);
+	});
+
+	it('returns false for regular Request objects without NextRequest properties', () => {
+		const regularRequest = {
+			headers: new Headers(),
+			method: 'GET',
+			url: 'https://example.com',
+		};
+
+		expect(isNextRequest(regularRequest)).toBe(false);
+	});
+
+	it('returns false for objects with nextUrl but missing other required properties', () => {
+		const incompleteObject = {
+			nextUrl: {
+				pathname: '/test',
+				search: '',
+			},
+		};
+
+		expect(isNextRequest(incompleteObject)).toBe(false);
+	});
+
+	it('returns false for objects with malformed nextUrl', () => {
+		const malformedNextUrl = {
+			nextUrl: 'not-an-object',
+			cookies: {},
+			headers: new Headers(),
+			method: 'GET',
+			url: 'https://example.com',
+		};
+
+		expect(isNextRequest(malformedNextUrl)).toBe(false);
+	});
+
+	it('returns false for objects with null nextUrl', () => {
+		const nullNextUrl = {
+			nextUrl: null,
+			cookies: {},
+			headers: new Headers(),
+			method: 'GET',
+			url: 'https://example.com',
+		};
+
+		expect(isNextRequest(nullNextUrl)).toBe(false);
+	});
+
+	it('returns false for objects missing cookies property', () => {
+		const missingCookies = {
+			nextUrl: {
+				pathname: '/test',
+				search: '',
+			},
+			headers: new Headers(),
+			method: 'GET',
+			url: 'https://example.com',
+		};
+
+		expect(isNextRequest(missingCookies)).toBe(false);
+	});
+
+	it('returns false for objects with non-string method', () => {
+		const invalidMethod = {
+			nextUrl: {
+				pathname: '/test',
+				search: '',
+			},
+			cookies: {},
+			headers: new Headers(),
+			method: 123,
+			url: 'https://example.com',
+		};
+
+		expect(isNextRequest(invalidMethod)).toBe(false);
+	});
+
+	it('returns false for objects with non-string url', () => {
+		const invalidUrl = {
+			nextUrl: {
+				pathname: '/test',
+				search: '',
+			},
+			cookies: {},
+			headers: new Headers(),
+			method: 'GET',
+			url: 123,
+		};
+
+		expect(isNextRequest(invalidUrl)).toBe(false);
+	});
+
+	it('returns false for null or undefined inputs', () => {
+		expect(isNextRequest(null as any)).toBe(false);
+		expect(isNextRequest(undefined as any)).toBe(false);
+	});
 });

--- a/packages/adapter-nextjs/src/auth/utils/predicates.ts
+++ b/packages/adapter-nextjs/src/auth/utils/predicates.ts
@@ -10,7 +10,25 @@ import { AuthRoutesHandlerContext } from '../types';
 export function isNextRequest(request: object): request is NextRequest {
 	// NextRequest extends the Web Request API with additional convenience methods.
 	// Details: https://nextjs.org/docs/app/api-reference/functions/next-request#nexturl
-	return request instanceof Request && 'nextUrl' in request;
+	//
+	// Use duck typing instead of instanceof to handle Lambda/serverless environments
+	// where Request constructor references may differ between invocations
+
+	return (
+		typeof request === 'object' &&
+		request !== null &&
+		// NextRequest-specific properties
+		'nextUrl' in request &&
+		typeof (request as any).nextUrl === 'object' &&
+		(request as any).nextUrl !== null &&
+		'cookies' in request &&
+		// Basic Request API properties
+		'url' in request &&
+		typeof (request as any).url === 'string' &&
+		'headers' in request &&
+		'method' in request &&
+		typeof (request as any).method === 'string'
+	);
 }
 
 // AuthRoutesHandlersContext is the 2nd parameter type for the API route handlers in the App Router

--- a/packages/adapter-nextjs/src/auth/utils/predicates.ts
+++ b/packages/adapter-nextjs/src/auth/utils/predicates.ts
@@ -19,15 +19,15 @@ export function isNextRequest(request: object): request is NextRequest {
 		request !== null &&
 		// NextRequest-specific properties
 		'nextUrl' in request &&
-		typeof (request as any).nextUrl === 'object' &&
-		(request as any).nextUrl !== null &&
+		typeof request.nextUrl === 'object' &&
+		request.nextUrl !== null &&
 		'cookies' in request &&
 		// Basic Request API properties
 		'url' in request &&
-		typeof (request as any).url === 'string' &&
+		typeof request.url === 'string' &&
 		'headers' in request &&
 		'method' in request &&
-		typeof (request as any).method === 'string'
+		typeof request.method === 'string'
 	);
 }
 


### PR DESCRIPTION
#### Description of changes

The instanceof Request type guard check fails in AWS Lambda environments (specifically with OpenNext/SST 
deployments). The problem causes authentication API routes to work on cold Lambda starts but fail on subsequent warm invocations with a 500 error: "Invalid request and context/response 
combination. The request cannot be handled." This PR changes the check to use duck typing to prevent possible constructor references to differ between invocations.


#### Issue #, if available
[14455](https://github.com/aws-amplify/amplify-js/issues/14455)


#### Description of how you validated changes
* Units tests
* Deployed sample app and verified manually
* [E2E test](https://github.com/aws-amplify/amplify-js/actions/runs/16265824550) run successfull
**  Failing tests unrelated


#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

#### Checklist for repo maintainers

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
