### PR TITLE
chore: update node version in node and build workflow

### DIFF
--- a/.github/actions/node-and-build/action.yml
+++ b/.github/actions/node-and-build/action.yml
@@ -7,10 +7,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Setup Node.js 20
-      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+    - name: Setup Node.js 22
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: 20
+        node-version: 22
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
     - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0


### PR DESCRIPTION
#### Description of changes

This PR updates Node to version 22 for our workflows. Currently, the build is failing due to metro-config requiring node 22.

#### Issue #, if available

#### Description of how you validated changes

* Run [E2E tests](https://github.com/aws-amplify/amplify-js/actions/runs/16366007132)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
