### PR TITLE
feat: allow setting json compatible content types

### DIFF
--- a/packages/api-rest/__tests__/utils/resolveHeaders.test.ts
+++ b/packages/api-rest/__tests__/utils/resolveHeaders.test.ts
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { resolveHeaders } from '../../src/utils/resolveHeaders';
+
+describe('resolveHeaders', () => {
+	describe('content-type handling without body', () => {
+		it('should not set content-type when no body is provided', () => {
+			const headers = { 'x-custom': 'value' };
+			const result = resolveHeaders(headers);
+
+			expect(result).toEqual({ 'x-custom': 'value' });
+			expect(result['content-type']).toBeUndefined();
+		});
+	});
+
+	describe('content-type handling with body', () => {
+		it('should set default content-type when no content-type header exists', () => {
+			const headers = { 'x-custom': 'value' };
+			const body = { data: 'test' };
+
+			const result = resolveHeaders(headers, body);
+
+			expect(result).toEqual({
+				'x-custom': 'value',
+				'content-type': 'application/json; charset=UTF-8',
+			});
+		});
+
+		it('should preserve existing application/json with charset', () => {
+			const headers = { 'Content-Type': 'application/json; charset=utf-8' };
+			const body = { data: 'test' };
+
+			const result = resolveHeaders(headers, body);
+
+			expect(result['content-type']).toBe('application/json; charset=utf-8');
+		});
+
+		it('should preserve +json content-type', () => {
+			const headers = { 'Content-Type': 'application/json-patch+json' };
+			const body = { data: 'test' };
+
+			const result = resolveHeaders(headers, body);
+
+			expect(result['content-type']).toBe('application/json-patch+json');
+		});
+
+		it('should override non-json content-type with default content-type', () => {
+			const headers = { 'Content-Type': 'text/plain' };
+			const body = { data: 'test' };
+
+			const result = resolveHeaders(headers, body);
+
+			expect(result['content-type']).toBe('application/json; charset=UTF-8');
+		});
+
+		it('should remove content-type when body is FormData', () => {
+			const headers = { 'Content-Type': 'application/json' };
+			const formData = new FormData();
+			formData.append('field', 'value');
+
+			const result = resolveHeaders(headers, formData);
+
+			expect(result['content-type']).toBeUndefined();
+		});
+	});
+});

--- a/packages/api-rest/src/utils/resolveHeaders.ts
+++ b/packages/api-rest/src/utils/resolveHeaders.ts
@@ -14,7 +14,8 @@ export const resolveHeaders = (
 		const isJsonCompatible =
 			contentType &&
 			(contentType.startsWith('application/json') ||
-				contentType.includes('+json'));
+				(contentType.startsWith('application/') &&
+					contentType.includes('+json')));
 
 		if (!isJsonCompatible) {
 			normalizedHeaders['content-type'] = 'application/json; charset=UTF-8';

--- a/packages/api-rest/src/utils/resolveHeaders.ts
+++ b/packages/api-rest/src/utils/resolveHeaders.ts
@@ -10,11 +10,11 @@ export const resolveHeaders = (
 		normalizedHeaders[key.toLowerCase()] = headers[key];
 	}
 	if (body) {
-		const existingContentType = normalizedHeaders['content-type'];
+		const contentType = normalizedHeaders['content-type'];
 		const isJsonCompatible =
-			existingContentType &&
-			(existingContentType.startsWith('application/json') ||
-				existingContentType.includes('+json'));
+			contentType &&
+			(contentType.startsWith('application/json') ||
+				contentType.includes('+json'));
 
 		if (!isJsonCompatible) {
 			normalizedHeaders['content-type'] = 'application/json; charset=UTF-8';

--- a/packages/api-rest/src/utils/resolveHeaders.ts
+++ b/packages/api-rest/src/utils/resolveHeaders.ts
@@ -10,7 +10,16 @@ export const resolveHeaders = (
 		normalizedHeaders[key.toLowerCase()] = headers[key];
 	}
 	if (body) {
-		normalizedHeaders['content-type'] = 'application/json; charset=UTF-8';
+		const jsonContentTypeRegex = /^application\/json|.*\+json/i;
+		const existingContentType = normalizedHeaders['content-type'];
+
+		if (
+			!existingContentType ||
+			!jsonContentTypeRegex.test(existingContentType)
+		) {
+			normalizedHeaders['content-type'] = 'application/json; charset=UTF-8';
+		}
+
 		if (body instanceof FormData) {
 			/**
 			 * If body is a FormData we should not allow setting content-type.

--- a/packages/api-rest/src/utils/resolveHeaders.ts
+++ b/packages/api-rest/src/utils/resolveHeaders.ts
@@ -10,13 +10,13 @@ export const resolveHeaders = (
 		normalizedHeaders[key.toLowerCase()] = headers[key];
 	}
 	if (body) {
-		const jsonContentTypeRegex = /^application\/json|.*\+json/i;
 		const existingContentType = normalizedHeaders['content-type'];
+		const isJsonCompatible =
+			existingContentType &&
+			(existingContentType.startsWith('application/json') ||
+				existingContentType.includes('+json'));
 
-		if (
-			!existingContentType ||
-			!jsonContentTypeRegex.test(existingContentType)
-		) {
+		if (!isJsonCompatible) {
 			normalizedHeaders['content-type'] = 'application/json; charset=UTF-8';
 		}
 


### PR DESCRIPTION
#### Description of changes

This PR enables setting json compatible content types.

#### Issue #, if available
#14092 


#### Description of how you validated changes

Unit tests, [E2E tests](https://github.com/aws-amplify/amplify-js/actions/runs/16592882592)

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)


#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
