### PR TITLE
fix: account for EVENT_SUBSCRIBE_ERROR in AppSync

### DIFF
--- a/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
@@ -704,7 +704,7 @@ export abstract class AWSWebSocketProvider {
 
 				if (type === MESSAGE_TYPES.EVENT_SUBSCRIBE_ERROR) {
 					const { errors } = JSON.parse(String(message.data));
-					if (errors && Array.isArray(errors) && errors.length > 0) {
+					if (Array.isArray(errors) && errors.length > 0) {
 						const error = errors[0];
 						errorMessage = `${error.errorType}: ${error.message}`;
 					}

--- a/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
@@ -684,7 +684,10 @@ export abstract class AWSWebSocketProvider {
 			return;
 		}
 
-		if (type === MESSAGE_TYPES.GQL_ERROR) {
+		if (
+			type === MESSAGE_TYPES.GQL_ERROR ||
+			type === MESSAGE_TYPES.EVENT_SUBSCRIBE_ERROR
+		) {
 			const subscriptionState = SUBSCRIPTION_STATUS.FAILED;
 			if (observer) {
 				this.subscriptionObserverMap.set(id, {
@@ -697,15 +700,23 @@ export abstract class AWSWebSocketProvider {
 					subscriptionState,
 				});
 
-				this.logger.debug(
-					`${CONTROL_MSG.CONNECTION_FAILED}: ${JSON.stringify(payload ?? data)}`,
-				);
+				let errorMessage = JSON.stringify(payload ?? data);
+
+				if (type === MESSAGE_TYPES.EVENT_SUBSCRIBE_ERROR) {
+					const { errors } = JSON.parse(String(message.data));
+					if (errors && Array.isArray(errors) && errors.length > 0) {
+						const error = errors[0];
+						errorMessage = `${error.errorType}: ${error.message}`;
+					}
+				}
+
+				this.logger.debug(`${CONTROL_MSG.CONNECTION_FAILED}: ${errorMessage}`);
 
 				observer.error({
 					errors: [
 						{
 							...new GraphQLError(
-								`${CONTROL_MSG.CONNECTION_FAILED}: ${JSON.stringify(payload ?? data)}`,
+								`${CONTROL_MSG.CONNECTION_FAILED}: ${errorMessage}`,
 							),
 						},
 					],

--- a/packages/api-graphql/src/Providers/constants.ts
+++ b/packages/api-graphql/src/Providers/constants.ts
@@ -93,6 +93,11 @@ export enum MESSAGE_TYPES {
 	 * This is the ack response from AWS AppSync Events to EVENT_STOP message
 	 */
 	EVENT_COMPLETE = 'unsubscribe_success',
+	/**
+	 * Server -> Client message.
+	 * This message type is for sending error messages from AWS AppSync Events to the client
+	 */
+	EVENT_SUBSCRIBE_ERROR = 'subscribe_error',
 }
 
 export enum SUBSCRIPTION_STATUS {


### PR DESCRIPTION
## Fix: AppSync Events subscribe_error messages not triggering error callbacks

### Problem
AppSync Events subscribe_error messages (like authorization failures) weren't being handled, so error callbacks never fired. Subscriptions failed silently.

### Solution
Added EVENT_SUBSCRIBE_ERROR to the error handling logic so these messages properly trigger the observer's error callback.

Before:
```typescript
const sub = channel.subscribe({
  error: (err) => console.error('error', err), // Never called
})
```


After:
```typescript
const sub = channel.subscribe({
  error: (err) => console.error('error', err), // Now properly called on subscribe errors
})
```

#### Description of how you validated changes

e2e, yarn test

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] PR description included
- [x ] `yarn test` passes
- [ x] Unit Tests are added
- [ ] Relevant documentation is changed or added (and PR referenced)
