### PR TITLE
fix(storage): upload progress exceeds total in Expo/RN

### DIFF
--- a/packages/storage/src/providers/s3/utils/client/runtime/xhrTransferHandler.ts
+++ b/packages/storage/src/providers/s3/utils/client/runtime/xhrTransferHandler.ts
@@ -190,7 +190,11 @@ export const xhrTransferHandler: TransferHandler<
 const convertToTransferProgressEvent = (
 	event: ProgressEvent,
 ): TransferProgressEvent => ({
-	transferredBytes: event.loaded,
+	// `loaded` can exceed the `total` in some cases due to platform issues/bugs e.g. React Native & Expo Android
+	// clamp `loaded` values down to `total` if possible.
+	transferredBytes: event.lengthComputable
+		? Math.min(event.loaded, event.total)
+		: event.loaded,
 	totalBytes: event.lengthComputable ? event.total : undefined,
 });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR attempts to mitigate an issue caused by a bug in Expo 53 ( https://github.com/expo/expo/issues/37526 ) by clamping the values for `event.loaded` so as to not exceed the total, while we dig deeper to investigate the root cause in Expo for Android.

Note: This can be reproduced [without using Amplify](https://github.com/pranavosu/expo-bug-onprogress-repro).

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
<!-- For external contributions, provide the github issue the PR is addressing. If no github issue exists for the related changes, open a new issue in https://github.com/aws-amplify/amplify-js/issues. -->

https://github.com/aws-amplify/amplify-js/issues/14421

#### Description of how you validated changes

Tested locally using an Android simulator, and added unit tests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
