### PR TITLE
fix: device attributes type

### DIFF
--- a/packages/auth/src/providers/cognito/types/models.ts
+++ b/packages/auth/src/providers/cognito/types/models.ts
@@ -10,7 +10,6 @@ import {
 	AWSAuthUser,
 	AuthCodeDeliveryDetails,
 	AuthDevice,
-	AuthUserAttribute,
 } from '../../../types';
 import { AuthProvider } from '../../../types/inputs';
 
@@ -89,11 +88,14 @@ export type AutoSignInEventData =
 	| {
 			event: 'autoSignIn';
 	  };
+
+type DeviceAttributeKey = 'device_status' | 'device_name' | 'last_ip_used';
+
 /**
  * Holds the device specific information along with it's id and name.
  */
 export type AWSAuthDevice = AuthDevice & {
-	attributes: AuthUserAttribute<UserAttributeKey>;
+	attributes: Record<DeviceAttributeKey, string>;
 	createDate?: Date;
 	lastAuthenticatedDate?: Date;
 	lastModifiedDate?: Date;


### PR DESCRIPTION
#### Description of changes

The runtime structure returned by `fetchDevices()` contains device attributes as a plain object with keys like `device_status`, `device_name`, and `last_ip_used`, but the TypeScript definition incorrectly defines attributes as `AuthUserAttribute<UserAttributeKey>` (a single object with `attributeKey` and `value` properties). This PR updates the type for device attributes.

#### Issue #, if available
#14517 


#### Description of how you validated changes
Manually verified that the types are correct.


#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
