### PR TITLE
chore: add stale issue bot

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           only-issue-labels: pending-community-response

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,26 @@
+name: Close pending-community-response issues
+
+on:
+  schedule:
+    - cron: '30 2 * * *' # runs daily at 02:30 UTC
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          only-issue-labels: pending-community-response
+          stale-issue-label: ''
+          days-before-issue-close: 14
+          close-issue-message: 'Closing due to inactivity. Please feel free to reopen the issue if you have any further questions.'
+          days-before-pr-stale: -1 # ignore PRs
+          days-before-pr-close: -1 # ignore PRs
+          remove-issue-stale-when-updated: true
+          operations-per-run: 100
+          debug-only: true # TODO: remove this when the dry-run succeeds

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -18,7 +18,7 @@ jobs:
           only-issue-labels: pending-community-response
           stale-issue-label: ''
           days-before-issue-close: 14
-          close-issue-message: 'Closing due to inactivity. Please feel free to reopen the issue if you have any further questions.'
+          close-issue-message: 'This issue is being automatically closed due to lack of recent activity. Please feel free to reopen it if you have any further questions.'
           days-before-pr-stale: -1 # ignore PRs
           days-before-pr-close: -1 # ignore PRs
           remove-issue-stale-when-updated: true

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          only-issue-labels: pending-community-response
+          only-issue-labels: pending-community-response,question
           stale-issue-label: ''
           days-before-issue-close: 14
           close-issue-message: 'This issue is being automatically closed due to lack of recent activity. Please feel free to reopen it if you have any further questions.'


### PR DESCRIPTION
#### Description of changes
- Adding a bot to close stale issues with the `pending-community-response`

#### Description of how you validated changes
- I added a `debug-only` flag to dry-run the workflow first to verify it. I will remove that flag in a follow-up PR once I confirm it runs successfully.

#### Checklist

- [X] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)


#### Checklist for repo maintainers

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
