### PR TITLE
feat: add rest auth mode

### DIFF
--- a/packages/api-rest/src/apis/common/publicApis.ts
+++ b/packages/api-rest/src/apis/common/publicApis.ts
@@ -71,6 +71,7 @@ const publicHandler = (
 				method,
 				headers,
 				abortSignal,
+				authMode: apiOptions.authMode,
 			},
 			isIamAuthApplicableForRest,
 			signingServiceInfo,

--- a/packages/api-rest/src/types/index.ts
+++ b/packages/api-rest/src/types/index.ts
@@ -16,6 +16,9 @@ export type PatchOperation = Operation<RestApiResponse>;
 export type DeleteOperation = Operation<RestApiResponse>;
 export type HeadOperation = Operation<Omit<RestApiResponse, 'body'>>;
 
+// Add this type definition
+export type RestApiAuthMode = 'none' | 'iam';
+
 /**
  * @internal
  */
@@ -41,6 +44,7 @@ export interface RestApiOptionsBase {
 	 * @default ` { strategy: 'jittered-exponential-backoff' } `
 	 */
 	retryStrategy?: RetryStrategy;
+	authMode?: RestApiAuthMode;
 }
 
 type Headers = Record<string, string>;


### PR DESCRIPTION
#### Description of changes

This PR adds authMode parameter to Amplify v6 REST API methods to allow skipping Cognito authentication for public endpoints.

#### Issue #, if available

https://github.com/aws-amplify/amplify-js/issues/14460

#### Description of how you validated changes

Unit tests

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
