### PR TITLE
chore: set xcode version to accommodate latest mocos upgrade

### DIFF
--- a/.github/actions/node-and-build/action.yml
+++ b/.github/actions/node-and-build/action.yml
@@ -33,9 +33,15 @@ runs:
     # TODO We should be able to skip yarn / bootstrap if we cache enough things. Leaving because skipping causes issues.
     - name: Install
       if: inputs.is-prebuild != 'true' || steps.cache-build-artifacts.outputs.cache-hit != 'true'
-      run: yarn
       shell: bash
       working-directory: ./amplify-js
+      run: |
+        for i in {1..3}; do
+          echo "Starting attempt $i."
+          yarn && break
+          echo "Attempt $i failed."
+          sleep 5
+        done
     - name: Bootstrap
       if: inputs.is-prebuild != 'true' || steps.cache-build-artifacts.outputs.cache-hit != 'true'
       run: yarn bootstrap

--- a/.github/workflows/callable-e2e-test-detox.yml
+++ b/.github/workflows/callable-e2e-test-detox.yml
@@ -31,6 +31,9 @@ jobs:
           path: amplify-js
       - name: Setup node and build the repository
         uses: ./amplify-js/.github/actions/node-and-build
+      - name: Set Xcode version
+        run: |
+          sudo xcode-select -s /Applications/Xcode_16.4.app
       - name: Setup samples staging repository
         uses: ./amplify-js/.github/actions/setup-samples-staging
         with:

--- a/.github/workflows/push-integ-test.yml
+++ b/.github/workflows/push-integ-test.yml
@@ -8,7 +8,7 @@ concurrency:
 on:
   push:
     branches:
-      - replace-with-your-branch
+      - fix/detox
 
 jobs:
   e2e:

--- a/.github/workflows/push-integ-test.yml
+++ b/.github/workflows/push-integ-test.yml
@@ -8,7 +8,7 @@ concurrency:
 on:
   push:
     branches:
-      - fix/detox
+      - replace-with-your-branch
 
 jobs:
   e2e:


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
With the latest macos version(15) image we're using for detox tests, the older platform and simulators are no longer supported(see [issue](https://github.com/actions/runner-images/issues/12541) and [macos 15 image](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md)).


Because of the issue mentioned [here](https://github.com/actions/runner-images/issues/12541#issuecomment-3201715033), we need to set the xcode version to 16.4 temporarily, before [this change](https://github.com/actions/runner-images/issues/12751) is populated.

Additionally, add retry for install step as this step fails occasionally with 5xx (see [test run](https://github.com/aws-amplify/amplify-js/actions/runs/17294571810/job/49089842575))


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
<!-- For external contributions, provide the github issue the PR is addressing. If no github issue exists for the related changes, open a new issue in https://github.com/aws-amplify/amplify-js/issues. -->


#### Description of how you validated changes

The change is validated with successful detox tests in github action run: https://github.com/aws-amplify/amplify-js/actions/runs/17294571810



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
