### PR TITLE
fix: use options instead of this.options in PageViewTracker constructor

### DIFF
--- a/packages/analytics/__tests__/trackers/PageViewTracker.test.ts
+++ b/packages/analytics/__tests__/trackers/PageViewTracker.test.ts
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PageViewTracker } from '../../src/trackers/PageViewTracker';
+
+Object.defineProperty(window, 'location', {
+	value: { origin: 'http://localhost:3000', pathname: '/test' },
+});
+Object.defineProperty(window, 'sessionStorage', {
+	value: { getItem: jest.fn(), setItem: jest.fn(), removeItem: jest.fn() },
+});
+
+describe('PageViewTracker', () => {
+	let mockEventRecorder: jest.Mock;
+
+	beforeEach(() => {
+		mockEventRecorder = jest.fn();
+		jest.clearAllMocks();
+	});
+
+	it('should use custom urlProvider when provided', () => {
+		const customUrlProvider = jest.fn(() => 'http://localhost:3000/custom');
+		(window.sessionStorage.getItem as jest.Mock).mockReturnValue(null);
+
+		const tracker = new PageViewTracker(mockEventRecorder, {
+			appType: 'multiPage',
+			urlProvider: customUrlProvider,
+		});
+
+		expect(customUrlProvider).toHaveBeenCalled();
+		expect(mockEventRecorder).toHaveBeenCalledWith('pageView', {
+			url: 'http://localhost:3000/custom',
+		});
+
+		tracker.cleanup();
+	});
+
+	it('should use default urlProvider when none provided', () => {
+		(window.sessionStorage.getItem as jest.Mock).mockReturnValue(null);
+
+		const tracker = new PageViewTracker(mockEventRecorder, {
+			appType: 'multiPage',
+		});
+
+		expect(mockEventRecorder).toHaveBeenCalledWith('pageView', {
+			url: 'http://localhost:3000/test',
+		});
+
+		tracker.cleanup();
+	});
+
+	it('should preserve custom urlProvider after reconfiguration', () => {
+		const customUrlProvider = jest.fn(() => 'http://localhost:3000/custom');
+		(window.sessionStorage.getItem as jest.Mock).mockReturnValue(null);
+
+		const tracker = new PageViewTracker(mockEventRecorder, {
+			urlProvider: customUrlProvider,
+		});
+
+		tracker.configure(mockEventRecorder, {
+			urlProvider: customUrlProvider,
+			appType: 'multiPage',
+		});
+
+		expect(customUrlProvider).toHaveBeenCalled();
+		expect(mockEventRecorder).toHaveBeenCalledWith('pageView', {
+			url: 'http://localhost:3000/custom',
+		});
+
+		tracker.cleanup();
+	});
+});

--- a/packages/analytics/src/trackers/PageViewTracker.ts
+++ b/packages/analytics/src/trackers/PageViewTracker.ts
@@ -57,8 +57,8 @@ export class PageViewTracker implements TrackerInterface {
 		this.options = {
 			appType: options?.appType ?? DEFAULT_APP_TYPE,
 			attributes: options?.attributes ?? undefined,
-			eventName: this.options?.eventName ?? DEFAULT_EVENT_NAME,
-			urlProvider: this.options?.urlProvider ?? DEFAULT_URL_PROVIDER,
+			eventName: options?.eventName ?? DEFAULT_EVENT_NAME,
+			urlProvider: options?.urlProvider ?? DEFAULT_URL_PROVIDER,
 		};
 
 		// Configure SPA or MPA page view tracking


### PR DESCRIPTION
#### Description of changes

Fixed a bug in PageViewTracker constructor where `this.options` was referenced before being initialized, causing `eventName` and `urlProvider` to always use default values instead of user-provided options.

#### Issue

fixes #14548 

#### Description of how you validated changes

- Added unit tests covering the constructor initialization logic
- Tested locally with a Gen 2 project using custom `urlProvider` configuration
- Verified that custom `eventName` and `urlProvider` options are now properly applied

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
