### PR TITLE
feat(datastore): add subscription variables for multi-tenant filtering

### DIFF
--- a/.changeset/feat-subscription-variables.md
+++ b/.changeset/feat-subscription-variables.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/datastore': minor
+---
+
+feat(datastore): add subscription variables support for multi-tenant filtering

--- a/packages/datastore/__tests__/subscription-variables-edge-cases.test.ts
+++ b/packages/datastore/__tests__/subscription-variables-edge-cases.test.ts
@@ -1,0 +1,174 @@
+import { TransformerMutationType, processSubscriptionVariables } from '../src/sync/utils';
+import { InternalSchema } from '../src/types';
+
+describe('Subscription Variables - Edge Cases & Safety', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	const createTestSchema = (): InternalSchema => ({
+		namespaces: {
+			user: {
+				name: 'user',
+				models: {
+					Todo: {
+						name: 'Todo',
+						pluralName: 'Todos',
+						syncable: true,
+						attributes: [],
+						fields: {
+							id: {
+								name: 'id',
+								type: 'ID',
+								isRequired: true,
+								isArray: false,
+							},
+						},
+					},
+				},
+				relationships: {},
+				enums: {},
+				nonModels: {},
+			},
+		},
+		version: '1',
+		codegenVersion: '3.0.0',
+	});
+
+	describe('Invalid Input Handling', () => {
+		it('should reject non-object static variables', () => {
+			const schema = createTestSchema();
+
+			const testCases = [
+				{ value: 'string', desc: 'string' },
+				{ value: 123, desc: 'number' },
+				{ value: true, desc: 'boolean' },
+				{ value: ['array'], desc: 'array' },
+			];
+
+			testCases.forEach(({ value }) => {
+				const result = processSubscriptionVariables(
+					schema.namespaces.user.models.Todo,
+					TransformerMutationType.CREATE,
+					value as any,
+				);
+
+				expect(result).toBeUndefined();
+			});
+		});
+
+		it('should handle Object.create(null) objects', () => {
+			const schema = createTestSchema();
+			const nullProtoObj = Object.create(null);
+			nullProtoObj.storeId = 'test';
+
+			const result = processSubscriptionVariables(
+				schema.namespaces.user.models.Todo,
+				TransformerMutationType.CREATE,
+				nullProtoObj,
+			);
+
+			expect(result).toBeDefined();
+			expect(result?.storeId).toBe('test');
+		});
+
+		it('should handle function that throws', () => {
+			const schema = createTestSchema();
+
+			const mockFn = () => {
+				throw new Error('Function error');
+			};
+			const result = processSubscriptionVariables(
+				schema.namespaces.user.models.Todo,
+				TransformerMutationType.CREATE,
+				mockFn,
+			);
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should handle function returning non-object', () => {
+			const schema = createTestSchema();
+
+			const testCases = [
+				{ value: null, desc: 'null' },
+				{ value: undefined, desc: 'undefined' },
+				{ value: 'string', desc: 'string' },
+				{ value: 123, desc: 'number' },
+				{ value: ['array'], desc: 'array' },
+			];
+
+			testCases.forEach(({ value }) => {
+				const mockFn = () => value;
+				const result = processSubscriptionVariables(
+					schema.namespaces.user.models.Todo,
+					TransformerMutationType.CREATE,
+					mockFn as any,
+				);
+
+				expect(result).toBeUndefined();
+			});
+		});
+	});
+
+	describe('Reserved Variable Filtering', () => {
+		it('should filter reserved names and keep custom ones', () => {
+			const schema = createTestSchema();
+
+			const result = processSubscriptionVariables(
+				schema.namespaces.user.models.Todo,
+				TransformerMutationType.CREATE,
+				{ storeId: 'store-1', filter: 'should-be-removed', owner: 'should-be-removed' },
+			);
+
+			expect(result).toEqual({ storeId: 'store-1' });
+		});
+
+		it('should return undefined when all variables are reserved', () => {
+			const schema = createTestSchema();
+
+			const result = processSubscriptionVariables(
+				schema.namespaces.user.models.Todo,
+				TransformerMutationType.CREATE,
+				{ filter: 'x', owner: 'y' },
+			);
+
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('Function Variables', () => {
+		it('should call function with operation type', () => {
+			const schema = createTestSchema();
+			const mockFn = jest.fn(() => ({ storeId: 'test' }));
+
+			processSubscriptionVariables(
+				schema.namespaces.user.models.Todo,
+				TransformerMutationType.CREATE,
+				mockFn,
+			);
+
+			expect(mockFn).toHaveBeenCalledWith(TransformerMutationType.CREATE);
+		});
+
+		it('should return different results per operation', () => {
+			const schema = createTestSchema();
+			const mockFn = jest.fn((op: string) => ({ op, storeId: 'test' }));
+
+			const createResult = processSubscriptionVariables(
+				schema.namespaces.user.models.Todo,
+				TransformerMutationType.CREATE,
+				mockFn,
+			);
+
+			const updateResult = processSubscriptionVariables(
+				schema.namespaces.user.models.Todo,
+				TransformerMutationType.UPDATE,
+				mockFn,
+			);
+
+			expect(createResult?.op).toBe(TransformerMutationType.CREATE);
+			expect(updateResult?.op).toBe(TransformerMutationType.UPDATE);
+		});
+	});
+});

--- a/packages/datastore/__tests__/subscription-variables.test.ts
+++ b/packages/datastore/__tests__/subscription-variables.test.ts
@@ -1,0 +1,298 @@
+import { Observable } from 'rxjs';
+import { SubscriptionProcessor } from '../src/sync/processors/subscription';
+import { TransformerMutationType } from '../src/sync/utils';
+import { SchemaModel, InternalSchema } from '../src/types';
+import { buildSubscriptionGraphQLOperation } from '../src/sync/utils';
+
+describe('DataStore Subscription Variables', () => {
+	let mockObservable: Observable<any>;
+	let mockGraphQL: jest.Mock;
+
+	beforeEach(() => {
+		mockObservable = new Observable(() => {});
+		mockGraphQL = jest.fn(() => mockObservable);
+	});
+
+	describe('buildSubscriptionGraphQLOperation', () => {
+		it('should include custom variables in subscription query', () => {
+			const namespace: any = {
+				name: 'user',
+				models: {},
+				relationships: {},
+				enums: {},
+				nonModels: {},
+			};
+
+			const modelDefinition: SchemaModel = {
+				name: 'Todo',
+				pluralName: 'Todos',
+				syncable: true,
+				attributes: [],
+				fields: {
+					id: {
+						name: 'id',
+						type: 'ID',
+						isRequired: true,
+						isArray: false,
+					},
+					title: {
+						name: 'title',
+						type: 'String',
+						isRequired: false,
+						isArray: false,
+					},
+					storeId: {
+						name: 'storeId',
+						type: 'String',
+						isRequired: false,
+						isArray: false,
+					},
+				},
+			};
+
+			const customVariables = {
+				storeId: 'store123',
+				tenantId: 'tenant456',
+			};
+
+			const [opType, opName, query] = buildSubscriptionGraphQLOperation(
+				namespace,
+				modelDefinition,
+				TransformerMutationType.CREATE,
+				false,
+				'',
+				false,
+				customVariables,
+			);
+
+			expect(opType).toBe(TransformerMutationType.CREATE);
+			expect(opName).toBe('onCreateTodo');
+			expect(query).toContain('$storeId: String');
+			expect(query).toContain('$tenantId: String');
+			expect(query).toContain('storeId: $storeId');
+			expect(query).toContain('tenantId: $tenantId');
+		});
+
+		it('should work without custom variables', () => {
+			const namespace: any = {
+				name: 'user',
+				models: {},
+				relationships: {},
+				enums: {},
+				nonModels: {},
+			};
+
+			const modelDefinition: SchemaModel = {
+				name: 'Todo',
+				pluralName: 'Todos',
+				syncable: true,
+				attributes: [],
+				fields: {
+					id: {
+						name: 'id',
+						type: 'ID',
+						isRequired: true,
+						isArray: false,
+					},
+					title: {
+						name: 'title',
+						type: 'String',
+						isRequired: false,
+						isArray: false,
+					},
+				},
+			};
+
+			const [opType, opName, query] = buildSubscriptionGraphQLOperation(
+				namespace,
+				modelDefinition,
+				TransformerMutationType.CREATE,
+				false,
+				'',
+				false,
+			);
+
+			expect(opType).toBe(TransformerMutationType.CREATE);
+			expect(opName).toBe('onCreateTodo');
+			expect(query).not.toContain('$storeId');
+			expect(query).not.toContain('$tenantId');
+		});
+	});
+
+	describe('SubscriptionProcessor with custom variables', () => {
+		it('should use custom variables from config when building subscriptions', () => {
+			const schema: InternalSchema = {
+				namespaces: {
+					user: {
+						name: 'user',
+						models: {
+							Todo: {
+								name: 'Todo',
+								pluralName: 'Todos',
+								syncable: true,
+								attributes: [],
+								fields: {
+									id: {
+										name: 'id',
+										type: 'ID',
+										isRequired: true,
+										isArray: false,
+									},
+									title: {
+										name: 'title',
+										type: 'String',
+										isRequired: false,
+										isArray: false,
+									},
+									storeId: {
+										name: 'storeId',
+										type: 'String',
+										isRequired: false,
+										isArray: false,
+									},
+								},
+							},
+						},
+						relationships: {},
+						enums: {},
+						nonModels: {},
+					},
+				},
+				version: '1',
+				codegenVersion: '3.0.0',
+			};
+
+			const syncPredicates = new WeakMap();
+			const datastoreConfig = {
+				subscriptionVariables: {
+					Todo: {
+						storeId: 'store123',
+					},
+				},
+			};
+
+			const processor = new SubscriptionProcessor(
+				schema,
+				syncPredicates,
+				{},
+				'DEFAULT' as any,
+				jest.fn(),
+				{ InternalAPI: { graphql: mockGraphQL } } as any,
+				datastoreConfig,
+			);
+
+			// @ts-ignore - accessing private method for testing
+			const result = processor.buildSubscription(
+				schema.namespaces.user,
+				schema.namespaces.user.models.Todo,
+				TransformerMutationType.CREATE,
+				0,
+				undefined,
+				'userPool',
+				false,
+			);
+
+			expect(result.opName).toBe('onCreateTodo');
+			expect(result.query).toContain('$storeId: String');
+			expect(result.query).toContain('storeId: $storeId');
+		});
+
+		it('should support function-based subscription variables', () => {
+			const schema: InternalSchema = {
+				namespaces: {
+					user: {
+						name: 'user',
+						models: {
+							Todo: {
+								name: 'Todo',
+								pluralName: 'Todos',
+								syncable: true,
+								attributes: [],
+								fields: {
+									id: {
+										name: 'id',
+										type: 'ID',
+										isRequired: true,
+										isArray: false,
+									},
+									title: {
+										name: 'title',
+										type: 'String',
+										isRequired: false,
+										isArray: false,
+									},
+									storeId: {
+										name: 'storeId',
+										type: 'String',
+										isRequired: false,
+										isArray: false,
+									},
+								},
+							},
+						},
+						relationships: {},
+						enums: {},
+						nonModels: {},
+					},
+				},
+				version: '1',
+				codegenVersion: '3.0.0',
+			};
+
+			const syncPredicates = new WeakMap();
+			const datastoreConfig = {
+				subscriptionVariables: {
+					Todo: (operation: string) => {
+						if (operation === TransformerMutationType.CREATE) {
+							return { storeId: 'store-create' };
+						}
+						if (operation === TransformerMutationType.UPDATE) {
+							return { storeId: 'store-update' };
+						}
+						return { storeId: 'store-delete' };
+					},
+				},
+			};
+
+			const processor = new SubscriptionProcessor(
+				schema,
+				syncPredicates,
+				{},
+				'DEFAULT' as any,
+				jest.fn(),
+				{ InternalAPI: { graphql: mockGraphQL } } as any,
+				datastoreConfig,
+			);
+
+			// Test CREATE operation
+			// @ts-ignore - accessing private method for testing
+			const createResult = processor.buildSubscription(
+				schema.namespaces.user,
+				schema.namespaces.user.models.Todo,
+				TransformerMutationType.CREATE,
+				0,
+				undefined,
+				'userPool',
+				false,
+			);
+
+			expect(createResult.query).toContain('$storeId: String');
+			expect(createResult.query).toContain('storeId: $storeId');
+
+			// Test UPDATE operation
+			// @ts-ignore - accessing private method for testing
+			const updateResult = processor.buildSubscription(
+				schema.namespaces.user,
+				schema.namespaces.user.models.Todo,
+				TransformerMutationType.UPDATE,
+				0,
+				undefined,
+				'userPool',
+				false,
+			);
+
+			expect(updateResult.query).toContain('$storeId: String');
+			expect(updateResult.query).toContain('storeId: $storeId');
+		});
+	});
+});

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -1406,6 +1406,7 @@ class DataStore {
 	// sync engine processors, storage engine, adapters, etc..
 
 	private amplifyConfig: Record<string, any> = {};
+	private datastoreConfig: DataStoreConfig = {};
 	private authModeStrategy!: AuthModeStrategy;
 	private conflictHandler!: ConflictHandler;
 	private errorHandler!: (error: SyncError<PersistentModel>) => void;
@@ -1566,6 +1567,7 @@ class DataStore {
 						this.authModeStrategy,
 						this.amplifyContext,
 						this.connectivityMonitor,
+						this.datastoreConfig,
 					);
 
 					const fullSyncIntervalInMilliseconds =
@@ -2458,6 +2460,7 @@ class DataStore {
 
 	configure = (config: DataStoreConfig = {}) => {
 		this.amplifyContext.InternalAPI = this.InternalAPI;
+		this.datastoreConfig = config;
 
 		const {
 			DataStore: configDataStore,

--- a/packages/datastore/src/sync/index.ts
+++ b/packages/datastore/src/sync/index.ts
@@ -154,6 +154,7 @@ export class SyncEngine {
 		private readonly authModeStrategy: AuthModeStrategy,
 		private readonly amplifyContext: AmplifyContext,
 		private readonly connectivityMonitor?: DataStoreConnectivity,
+		private readonly datastoreConfig?: Record<string, any>,
 	) {
 		this.runningProcesses = new BackgroundProcessManager();
 		this.waitForSleepState = new Promise(resolve => {
@@ -188,6 +189,7 @@ export class SyncEngine {
 			this.authModeStrategy,
 			errorHandler,
 			this.amplifyContext,
+			this.datastoreConfig,
 		);
 
 		this.mutationsProcessor = new MutationProcessor(

--- a/packages/datastore/src/sync/processors/subscription.ts
+++ b/packages/datastore/src/sync/processors/subscription.ts
@@ -41,6 +41,7 @@ import {
 	getTokenForCustomAuth,
 	getUserGroupsFromToken,
 	predicateToGraphQLFilter,
+	processSubscriptionVariables,
 } from '../utils';
 import { ModelPredicateCreator } from '../../predicates';
 import { validatePredicate } from '../../util';
@@ -91,6 +92,7 @@ class SubscriptionProcessor {
 		private readonly amplifyContext: AmplifyContext = {
 			InternalAPI,
 		},
+		private readonly datastoreConfig?: Record<string, any>,
 	) {}
 
 	private buildSubscription(
@@ -120,6 +122,15 @@ class SubscriptionProcessor {
 				authMode,
 			) || {};
 
+		// Get custom subscription variables from DataStore config
+		const customVariables = this.datastoreConfig?.subscriptionVariables
+			? processSubscriptionVariables(
+					model,
+					transformerMutationType,
+					this.datastoreConfig.subscriptionVariables[model.name],
+				)
+			: undefined;
+
 		const [opType, opName, query] = buildSubscriptionGraphQLOperation(
 			namespace,
 			model,
@@ -127,6 +138,7 @@ class SubscriptionProcessor {
 			isOwner,
 			ownerField!,
 			filterArg,
+			customVariables,
 		);
 
 		return { authMode, opType, opName, query, isOwner, ownerField, ownerValue };
@@ -368,6 +380,22 @@ class SubscriptionProcessor {
 											category: Category.DataStore,
 											action: DataStoreAction.Subscribe,
 										};
+
+										// Add custom subscription variables from DataStore config
+										const customVars = this.datastoreConfig
+											?.subscriptionVariables
+											? processSubscriptionVariables(
+													modelDefinition,
+													operation,
+													this.datastoreConfig.subscriptionVariables[
+														modelDefinition.name
+													],
+												)
+											: undefined;
+
+										if (customVars) {
+											Object.assign(variables, customVars);
+										}
 
 										if (addFilter && predicatesGroup) {
 											(variables as any).filter =

--- a/packages/datastore/src/sync/utils.ts
+++ b/packages/datastore/src/sync/utils.ts
@@ -318,6 +318,7 @@ export function buildSubscriptionGraphQLOperation(
 	isOwnerAuthorization: boolean,
 	ownerField: string,
 	filterArg = false,
+	customVariables?: Record<string, any>,
 ): [TransformerMutationType, string, string] {
 	const selectionSet = generateSelectionSet(namespace, modelDefinition);
 
@@ -336,6 +337,33 @@ export function buildSubscriptionGraphQLOperation(
 	if (isOwnerAuthorization) {
 		docArgs.push(`$${ownerField}: String!`);
 		opArgs.push(`${ownerField}: $${ownerField}`);
+	}
+
+	if (customVariables) {
+		const VALID_VAR_NAME = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
+
+		Object.keys(customVariables).forEach(varName => {
+			if (!VALID_VAR_NAME.test(varName)) {
+				logger.warn(
+					`Invalid GraphQL variable name '${varName}' in subscriptionVariables. Skipping.`,
+				);
+
+				return;
+			}
+
+			if (
+				customVariables[varName] === null ||
+				customVariables[varName] === undefined
+			) {
+				return;
+			}
+
+			const varType = Array.isArray(customVariables[varName])
+				? '[String]'
+				: 'String';
+			docArgs.push(`$${varName}: ${varType}`);
+			opArgs.push(`${varName}: $${varName}`);
+		});
 	}
 
 	const docStr = docArgs.length ? `(${docArgs.join(',')})` : '';
@@ -960,4 +988,66 @@ export function getIdentifierValue(
 	const idOrPk = pkFieldNames.map(f => model[f]).join(IDENTIFIER_KEY_SEPARATOR);
 
 	return idOrPk;
+}
+
+const RESERVED_SUBSCRIPTION_VARIABLE_NAMES = new Set([
+	'input',
+	'condition',
+	'filter',
+	'owner',
+	'limit',
+	'nextToken',
+	'sortDirection',
+]);
+
+export function processSubscriptionVariables(
+	model: SchemaModel,
+	operation: TransformerMutationType,
+	modelVariables:
+		| Record<string, any>
+		| ((operation: TransformerMutationType) => Record<string, any>)
+		| undefined,
+): Record<string, any> | undefined {
+	if (!modelVariables) {
+		return undefined;
+	}
+
+	let vars: Record<string, any>;
+
+	if (typeof modelVariables === 'function') {
+		try {
+			vars = modelVariables(operation);
+		} catch (error) {
+			logger.warn(
+				`Error evaluating subscriptionVariables function for model ${model.name}:`,
+				error,
+			);
+
+			return undefined;
+		}
+	} else {
+		vars = modelVariables;
+	}
+
+	if (vars === null || typeof vars !== 'object' || Array.isArray(vars)) {
+		logger.warn(
+			`subscriptionVariables must be an object for model ${model.name}`,
+		);
+
+		return undefined;
+	}
+
+	const result: Record<string, any> = {};
+
+	for (const [key, value] of Object.entries(vars)) {
+		if (RESERVED_SUBSCRIPTION_VARIABLE_NAMES.has(key)) {
+			logger.warn(
+				`Ignoring reserved GraphQL variable name '${key}' in subscription variables`,
+			);
+		} else {
+			result[key] = value;
+		}
+	}
+
+	return Object.keys(result).length > 0 ? result : undefined;
 }

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -1044,6 +1044,11 @@ export interface DataStoreConfig {
 		syncExpressions?: SyncExpression[];
 		authProviders?: AuthProviders;
 		storageAdapter?: Adapter;
+		subscriptionVariables?: Record<
+			string,
+			| Record<string, any>
+			| ((operation: 'CREATE' | 'UPDATE' | 'DELETE') => Record<string, any>)
+		>;
 	};
 	authModeStrategyType?: AuthModeStrategyType;
 	conflictHandler?: ConflictHandler; // default : retry until client wins up to x times


### PR DESCRIPTION
#### Description of changes

Adds a `subscriptionVariables` config option to `DataStore.configure()` that passes custom GraphQL variables to subscription operations. This enables server-side subscription filtering for multi-tenant apps, avoiding the current approach of receiving all updates and filtering client-side.

**Usage:**
```typescript
DataStore.configure({
  subscriptionVariables: {
    Todo: { storeId: 'store-123' },
    Order: (op) => ({ storeId: op === 'DELETE' ? undefined : 'store-123' }),
  },
});
```

**What changed:**
- New `subscriptionVariables` field in `DataStoreConfig` type
- Config plumbed through `SyncEngine` → `SubscriptionProcessor`
- `processSubscriptionVariables()` in `sync/utils.ts` — validates input, filters reserved names, supports static objects or per-operation functions
- `buildSubscriptionGraphQLOperation()` accepts custom variables for query building
- Variables injected into subscription `variables` before GraphQL call

**What was simplified vs original:**
- Removed WeakMap+Map cache (unnecessary complexity — functions are called once per subscription setup)
- Removed redundant try/catch in `sanitizeSubscriptionVariables` and `filterReservedSubscriptionVariableKeys`
- Merged into single `processSubscriptionVariables` function
- Trimmed reserved names list to actual GraphQL-conflicting names

#### Issue #, if available

Fixes #9413

#### Description of how you validated changes

- 12 new tests across 2 test files (subscription-variables, edge-cases)
- All 19 existing subscription processor tests pass
- ESLint and TypeScript compilation pass

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.