### PR TITLE
fix: install auth explicitly into next sample app

### DIFF
--- a/.github/workflows/callable-canary-sampleapp-tests.yml
+++ b/.github/workflows/callable-canary-sampleapp-tests.yml
@@ -125,7 +125,7 @@ jobs:
         run: npm install
         working-directory: amplify-js-samples-staging/samples/next/auth/new-next-app
       - name: Install latest stable amplify version
-        run: npm install aws-amplify@latest @aws-amplify/adapter-nextjs@latest
+        run: npm install aws-amplify@latest @aws-amplify/adapter-nextjs@latest @aws-amplify/auth@latest
         working-directory: amplify-js-samples-staging/samples/next/auth/new-next-app
       - name: Start application and run test
         run: |


### PR DESCRIPTION
#### Description of changes
installs `@aws-amplify/auth` into the next-canaries.

**Reason:**
Since the latest AmplifyJS release, 2 versions of Amplify get installed (one in the root folder, and one in the Next-App)
Generally not a problem, but:
since the next-app tests for SSR, it creates server-contexts.
For it all [ ... auth, ssr ...] to work, you should only have one context, or at least make sure, you use the same.

In our case, the server uses its own Amplify installation to create the context, and then `getCurrentUser` (this is what the next-app calls to validate SSR) uses the root-folder Amplify, because that's where `@aws-amplify/auth` was installed to.

so the fix is, install auth as part of the next-app and make `getCurrentUser` use the same server-context.

**NOTE:**
This is specific to our setup of the e2e tests in AmplifyJS
a normal user, that does not fiddle with such a setup, will not be affected.

#### Issue #, if available
_- none -_


#### Description of how you validated changes
- installed the `auth` package
- ran `next dev`, signed in and visited `/profile`
- also, ran the cypress-spec against the server and it passed.

#### Checklist

- [ ] ~PR description included~ does not apply
- [ ] ~`yarn test` passes~ does not apply
- [ ] ~Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)~ does not apply
- [ ] ~Relevant documentation is changed or added (and PR referenced)~ does not apply



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
