### PR TITLE
Add missing `NativeModule` for ChromeOS detection

### DIFF
--- a/packages/rtn-web-browser/android/src/main/kotlin/com/amazonaws/amplify/rtnwebbrowser/ChromeOSModule.kt
+++ b/packages/rtn-web-browser/android/src/main/kotlin/com/amazonaws/amplify/rtnwebbrowser/ChromeOSModule.kt
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazonaws.amplify.rtnwebbrowser
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+class ChromeOSModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+
+    override fun getName() = "ChromeOS"
+
+    @ReactMethod
+    fun isChromeOS(promise: Promise) {
+        try {
+            val isChromeOS = detectChromeOS()
+            promise.resolve(isChromeOS)
+        } catch (e: Exception) {
+            promise.reject("CHROMEOS_DETECTION_ERROR", "Failed to detect ChromeOS", e)
+        }
+    }
+
+    private fun detectChromeOS(): Boolean {
+        return try {
+            // Check for Android Runtime for Chrome (ARC) system feature
+            val packageManager = reactApplicationContext.packageManager
+
+            packageManager.hasSystemFeature("org.chromium.arc.device_management") ||
+                    packageManager.hasSystemFeature("org.chromium.arc")
+        } catch (e: Exception) {
+            // If we can't check system features, return false
+            false
+        }
+    }
+}

--- a/packages/rtn-web-browser/android/src/main/kotlin/com/amazonaws/amplify/rtnwebbrowser/WebBrowserPackage.kt
+++ b/packages/rtn-web-browser/android/src/main/kotlin/com/amazonaws/amplify/rtnwebbrowser/WebBrowserPackage.kt
@@ -18,5 +18,8 @@ class WebBrowserPackage : ReactPackage {
 
     override fun createNativeModules(
         reactContext: ReactApplicationContext
-    ): MutableList<NativeModule> = listOf(WebBrowserModule(reactContext)).toMutableList()
+    ): MutableList<NativeModule> = listOf(
+        WebBrowserModule(reactContext),
+        ChromeOSModule(reactContext)
+    ).toMutableList()
 }


### PR DESCRIPTION
This is a follow-up of https://github.com/aws-amplify/amplify-js/pull/14523 because the `NativeModule` used here:
https://github.com/aws-amplify/amplify-js/blob/e0e0237c78fba6ce07100f87a7f592a2637a6a6a/packages/rtn-web-browser/src/apis/openAuthSessionAsync.ts#L36L37
is missing. It should also fix https://github.com/aws-amplify/amplify-js/issues/14459

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
https://github.com/aws-amplify/amplify-js/pull/14523
https://github.com/aws-amplify/amplify-js/issues/14459


#### Description of how you validated changes
I used a Chromebook and the Android emulator. Both do the expected.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
