### PR TITLE
fix(rtn-web-browser): Don't use custom tabs on default and fallback to normal tabs

### DIFF
--- a/packages/rtn-web-browser/src/apis/openAuthSessionAsync.ts
+++ b/packages/rtn-web-browser/src/apis/openAuthSessionAsync.ts
@@ -37,14 +37,16 @@ export const openAuthSessionAsync = async (
 	if (Platform.OS === 'android') {
 		try {
 			const isChromebookRes = await isChromebook();
-			if (isChromebookRes) {
-				return openAuthSessionChromeOs(httpsUrl, redirectUrls);
+			if (!isChromebookRes) {
+				// If it is not a Chromebook, it probably supports custom tabs
+				return await openAuthSessionAndroid(httpsUrl, redirectUrls);
 			}
 		} catch {
 			// ignore and fallback to android
 		}
 
-		return openAuthSessionAndroid(httpsUrl, redirectUrls);
+		// The ChromeOS way without custom tabs works everywhere
+		return openAuthSessionChromeOs(httpsUrl, redirectUrls);
 	}
 };
 


### PR DESCRIPTION
This is a follow-up of https://github.com/aws-amplify/amplify-js/pull/14523 to change the fallback order. The ChromeOS way works everywhere, the Android not. And the Android tab opening needs to be awaited so that we can catch it. It should also fix https://github.com/aws-amplify/amplify-js/issues/14459

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
https://github.com/aws-amplify/amplify-js/pull/14523
https://github.com/aws-amplify/amplify-js/issues/14459


#### Description of how you validated changes
I used a Chromebook and the Android emulator. Both do the expected.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
