### PR TITLE
fix: skip integ_react_interactions_chatbot_v1 test due to Lex V1 rate limiting

### DIFF
--- a/.github/canary-config/canary-all.yml
+++ b/.github/canary-config/canary-all.yml
@@ -153,13 +153,15 @@ tests:
   #   sample_name: [chatbot-component]
   #   spec: chatbot-component
   #   browser: *minimal_browser_list
-  - test_name: integ_react_interactions_chatbot_v1
-    desc: 'Chatbot V1'
-    framework: react
-    category: interactions
-    sample_name: [lex-test-component]
-    spec: chatbot-v1
-    browser: [chrome, firefox]
+  # Skipping chatbot_v1 test due to persistent AWS Lex V1 rate limiting issues
+  # TODO: Re-enable after investigating bot configuration
+  # - test_name: integ_react_interactions_chatbot_v1
+  #   desc: 'Chatbot V1'
+  #   framework: react
+  #   category: interactions
+  #   sample_name: [lex-test-component]
+  #   spec: chatbot-v1
+  #   browser: [chrome, firefox]
   - test_name: integ_react_interactions_chatbot_v2
     desc: 'Chatbot V2'
     framework: react

--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -820,13 +820,15 @@ tests:
   #   amplifyjs_dir: true
 
   # INTERACTIONS
-  - test_name: integ_react_interactions_chatbot_v1
-    desc: 'Chatbot V1'
-    framework: react
-    category: interactions
-    sample_name: [lex-test-component]
-    spec: chatbot-v1
-    browser: *minimal_browser_list
+  # Skipping chatbot_v1 test due to persistent AWS Lex V1 rate limiting issues
+  # TODO: Re-enable after investigating bot configuration
+  # - test_name: integ_react_interactions_chatbot_v1
+  #   desc: 'Chatbot V1'
+  #   framework: react
+  #   category: interactions
+  #   sample_name: [lex-test-component]
+  #   spec: chatbot-v1
+  #   browser: *minimal_browser_list
   - test_name: integ_react_interactions_chatbot_v2
     desc: 'Chatbot V2'
     framework: react


### PR DESCRIPTION
## Description
Skips the  e2e test that is experiencing persistent AWS Lex V1 rate limiting errors.

## Issue
The chatbot_v1 test consistently fails with "You are sending requests at an excessive rate" errors from AWS Lex V1, even with:
- 60 second delays between requests
- Exponential backoff retry logic

This is blocking releases.

## Temporary Solution
- Comment out the test in both  and 
- Add TODO comments to investigate bot configuration

## Testing
- Verified test is skipped in CI
- Other e2e tests continue to run normally