### PR TITLE
fix(ci): declare secrets in callable-release-verification workflow

### DIFF
--- a/.github/workflows/callable-release-verification.yml
+++ b/.github/workflows/callable-release-verification.yml
@@ -1,6 +1,16 @@
 name: Release Verification Tests
 
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN_STAGING_READ:
+        required: true
+      CYPRESS_GOOGLE_CLIENTID:
+        required: true
+      CYPRESS_GOOGLE_CLIENT_SECRET:
+        required: true
+      CYPRESS_GOOGLE_REFRESH_TOKEN:
+        required: true
 
 jobs:
   prebuild-ubuntu:


### PR DESCRIPTION
#### Description of changes

Fixes the release workflow startup failure by declaring required secrets in the `callable-release-verification.yml` workflow. When a parent workflow passes secrets explicitly (not using `secrets: inherit`), the reusable workflow must declare those secrets in its `workflow_call` trigger before they can be inherited by child workflows.

#### Issue #, if available

Fixes workflow runs: 
* https://github.com/aws-amplify/amplify-js/actions/runs/21914449080
* https://github.com/aws-amplify/amplify-js/actions/runs/21914448554

#### Description of how you validated changes

- Verified that the workflow syntax is now valid
- Confirmed that the declared secrets match those passed from `release-unstable.yml`
- Validated that child workflows (`callable-prebuild-samples-staging.yml` and `callable-e2e-test.yml`) can receive these secrets via `secrets: inherit`

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

#### Checklist for repo maintainers

- [x] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
