### PR TITLE
fix(ci): declare secret in callable-docs-update workflow

### DIFF
--- a/.github/workflows/callable-docs-update.yml
+++ b/.github/workflows/callable-docs-update.yml
@@ -1,6 +1,10 @@
 name: Build the API References and open a docs PR
 
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN_AMPLIFY_JS_WRITE:
+        required: true
 
 jobs:
   docs-update-prep:


### PR DESCRIPTION
#### Description of changes

Fixes the `Release Latest` workflow startup failure by declaring the required `GH_TOKEN_AMPLIFY_JS_WRITE` secret in the `callable-docs-update.yml` workflow. When a parent workflow passes secrets explicitly (not using `secrets: inherit`), the reusable workflow must declare those secrets in its `workflow_call` trigger.

#### Issue #, if available

Fixes workflow run: https://github.com/aws-amplify/amplify-js/actions/runs/21940989128

#### Description of how you validated changes

- Verified that the workflow syntax is now valid
- Confirmed that the declared secret matches the one passed from `release-latest.yml`
- Validated that the secret is used in the workflow steps for checking out the docs repository and creating PRs

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

#### Checklist for repo maintainers

- [x] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
