### PR TITLE
ci: run release verification on every commit to main only once

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -32,11 +32,8 @@ jobs:
       #       case of (2), `@changesets/action` will know that packages have already been published and will
       #       skip publish.
 
-  # Job 2: Run release verification tests when Version Packages PR is merged
-  # This ensures all tests pass before publishing
+  # Job 2: Run release verification tests on every commit
   release-verification:
-    needs: setup
-    if: needs.setup.outputs.has-changesets != 'true'
     secrets:
       GH_TOKEN_STAGING_READ: ${{ secrets.GH_TOKEN_STAGING_READ }}
       CYPRESS_GOOGLE_CLIENTID: ${{ secrets.CYPRESS_GOOGLE_CLIENTID }}
@@ -44,11 +41,11 @@ jobs:
       CYPRESS_GOOGLE_REFRESH_TOKEN: ${{ secrets.CYPRESS_GOOGLE_REFRESH_TOKEN }}
     uses: ./.github/workflows/callable-release-verification.yml
 
-  # Job 3: Publish packages after all tests pass
+  # Job 3: Publish packages after all tests pass (only when there are no changesets)
   publish:
     runs-on: ubuntu-latest
-    needs: release-verification
-    if: github.repository_owner == 'aws-amplify'
+    needs: [setup, release-verification]
+    if: github.repository_owner == 'aws-amplify' && needs.setup.outputs.has-changesets != 'true'
     outputs:
       published: ${{ steps.changesets.outputs.published }}
     steps:

--- a/.github/workflows/release-unstable.yml
+++ b/.github/workflows/release-unstable.yml
@@ -16,20 +16,8 @@ on:
       - main
 
 jobs:
-  # Job 1: Run release verification tests before publishing
-  # We skip the release if the commit message contains [skip release] to prevent unnecessary builds, e.g., docs commits
-  release-verification:
-    if: "!contains(github.event.head_commit.message, '[skip release]')"
-    secrets:
-      GH_TOKEN_STAGING_READ: ${{ secrets.GH_TOKEN_STAGING_READ }}
-      CYPRESS_GOOGLE_CLIENTID: ${{ secrets.CYPRESS_GOOGLE_CLIENTID }}
-      CYPRESS_GOOGLE_CLIENT_SECRET: ${{ secrets.CYPRESS_GOOGLE_CLIENT_SECRET }}
-      CYPRESS_GOOGLE_REFRESH_TOKEN: ${{ secrets.CYPRESS_GOOGLE_REFRESH_TOKEN }}
-    uses: ./.github/workflows/callable-release-verification.yml
-
-  # Job 2: Publish unstable packages after tests pass
+  # Job 1: Publish unstable packages
   unstable-release:
-    needs: release-verification
     runs-on: ubuntu-latest
     if: github.repository_owner == 'aws-amplify'
     steps:


### PR DESCRIPTION
#### Description of changes

This PR refactors the release workflows to improve CI efficiency:

- Removed `release-verification` job from `release-unstable` workflow since unstable does not require that all E2E tests pass.
- Modified `release-latest` workflow to run `release-verification` on every commit to main
- Made the `publish` step conditional instead of the `release-verification` step  - only runs when there are no changesets (i.e., after "Version Packages" PR is merged)

This ensures that release verification tests run on all commits through the `release-latest` workflow, while publishing only occurs when appropriate.

#### Issue #, if available

N/A - Internal workflow optimization

#### Description of how you validated changes

- Reviewed workflow YAML syntax
- Verified job dependencies and conditional logic
- Confirmed `setup` and `release-verification` can run in parallel
- Ensured `publish` correctly depends on both jobs and checks changeset status

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes (N/A - workflow changes only)
- [ ] Unit Tests are changed or added (N/A - workflow changes only)
- [ ] Relevant documentation is changed or added (and PR referenced)

#### Checklist for repo maintainers

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
