### PR TITLE
fix: force @aws-sdk/types to 3.186.0 to avoid @smithy/types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,7 @@
 			"**/@types/react-native",
 			"**/@types/react-native/**",
 			"aws-amplify-react-native/prettier",
-			"aws-amplify-react-native/eslint-plugin-prettier",
-			"**/@aws-sdk/types",
-			"**/@aws-sdk/types/**",
-			"**/@smithy/types",
-			"**/@smithy/types/**"
+			"aws-amplify-react-native/eslint-plugin-prettier"
 		]
 	},
 	"repository": {
@@ -69,7 +65,6 @@
 		"@babel/core": "7.17.2",
 		"@babel/preset-env": "7.17.10",
 		"@babel/preset-react": "^7.0.0",
-		"@smithy/types": "4.0.0",
 		"@size-limit/dual-publish": "^8.1.0",
 		"@size-limit/file": "^8.1.0",
 		"@size-limit/webpack": "^8.1.0",
@@ -118,8 +113,7 @@
 		"path-scurry": "1.10.0",
 		"**/glob/minipass": "6.0.2",
 		"fast-xml-parser": "4.4.1",
-		"@aws-sdk/types": "3.186.0",
-		"@smithy/types": "4.0.0"
+		"**/@aws-sdk/types": "3.186.0"
 	},
 	"jest": {
 		"resetMocks": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4628,13 +4628,6 @@
     nanoid "^3.3.6"
     webpack "^5.88.0"
 
-"@smithy/types@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.0.0.tgz#7458c1c4dde3c6cf23221370acf5acd03215de6e"
-  integrity sha512-aNwIGSOgDOhtTRY/rrn2aeuQeKw/IFrQ998yK5l6Ah853WeWIEmFPs/EO4OpfADEdcK+igWnZytm/oUgkLgUYg==
-  dependencies:
-    tslib "^2.6.2"
-
 "@stardust-ui/react-component-event-listener@~0.38.0":
   version "0.38.0"
   resolved "https://registry.yarnpkg.com/@stardust-ui/react-component-event-listener/-/react-component-event-listener-0.38.0.tgz#1787faded94b40ad41226e6289baf13e701c6e7f"


### PR DESCRIPTION
<!--Please make sure to read the Pull Request Guidelines:https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests-->

#### Description of changes

This PR fixes a CI build failure in the v5-stable branch by adding `@smithy/types` as a devDependency and maintaining a yarn resolution for `@aws-sdk/types`.

The dependency `@aws-crypto/sha256-js@1.2.2` (used by `@aws-amplify/core`) depends on `@aws-sdk/types@^3.1.0`. In CI environments, yarn was creating nested node_modules with a version of `@aws-sdk/types` that requires `@smithy/types` as a peer dependency. However, `@smithy/types` was not being installed, causing TypeScript compilation errors during the build process with errors like:

`error TS2307: Cannot find module '@smithy/types' or its corresponding type declarations.`

1. Added `@smithy/types@4.0.0` as a devDependency to satisfy the peer dependency requirement
2. Added yarn resolution for `@aws-sdk/types@3.186.0` to ensure consistent dependency resolution across all packages

#### Issue #, if available

Fixes workflow failure: https://github.com/aws-amplify/amplify-js/actions/runs/21940491138

#### Description of how you validated changes

1. Ran `yarn install` to update yarn.lock with the new devDependency
2. Verified that `@smithy/types@4.0.0` is now present in the dependency tree
3. Confirmed that `@aws-sdk/types` is consistently resolved to version 3.186.0 across all packages
4. Ran `yarn build` locally - build completed successfully
5. Verified no compilation errors related to missing `@smithy/types` module

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions) - N/A (dependency resolution fix)
- [ ] Relevant documentation is changed or added (and PR referenced) - N/A

#### Checklist for repo maintainers

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate - N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

