### PR TITLE
ci: prevent concurrent release workflows

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -5,6 +5,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# Prevent concurrent releases to avoid race conditions
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     branches:


### PR DESCRIPTION
#### Description of changes

Adds concurrency control to the `release-latest` workflow to prevent race conditions when multiple commits are pushed to `main` in quick succession. This ensures only one release workflow runs at a time, with subsequent triggers queued rather than running concurrently.

The change prevents potential conflicts during git tag creation, package publishing to npm, and documentation updates.

#### Issue #, if available

N/A

#### Description of how you validated changes

Workflow syntax is valid YAML. The concurrency configuration follows GitHub Actions best practices for preventing concurrent workflow runs.

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

#### Checklist for repo maintainers

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
