### PR TITLE
fix(core): add timeout to BackgroundProcessManager.close()

### DIFF
--- a/.changeset/fix-bpm-close-timeout.md
+++ b/.changeset/fix-bpm-close-timeout.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/core': patch
+---
+
+fix(core): add timeout to BackgroundProcessManager.close() to prevent permanent stuck state

--- a/packages/core/__tests__/BackgroundProcessManager.test.ts
+++ b/packages/core/__tests__/BackgroundProcessManager.test.ts
@@ -664,4 +664,31 @@ describe('BackgroundProcessManager', () => {
 		unblock?.();
 		await close;
 	});
+
+	test('close() resolves after timeout even if jobs never complete', async () => {
+		const manager = new BackgroundProcessManager();
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+		manager.add(
+			// eslint-disable-next-line @typescript-eslint/no-empty-function
+			() => new Promise<void>(() => {}),
+			'hanging job',
+		);
+
+		const start = Date.now();
+		await manager.close();
+		const elapsed = Date.now() - start;
+
+		expect(manager.isClosed).toBe(true);
+		expect(manager.length).toBe(0);
+		// should resolve around the 10s internal timeout, not hang forever
+		expect(elapsed).toBeLessThan(15_000);
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining('timed out'),
+			expect.arrayContaining(['hanging job']),
+		);
+
+		warnSpy.mockRestore();
+	}, 20_000);
 });

--- a/packages/core/src/BackgroundProcessManager/BackgroundProcessManager.ts
+++ b/packages/core/src/BackgroundProcessManager/BackgroundProcessManager.ts
@@ -389,7 +389,35 @@ export class BackgroundProcessManager {
 				Array.from(this.jobs).map(j => j.promise),
 			);
 
+			const CLOSE_TIMEOUT_MS = 10_000;
+			let timer: ReturnType<typeof setTimeout>;
+			let didTimeout = false;
+			const timeoutPromise = new Promise<PromiseSettledResult<any>[]>(
+				resolve => {
+					timer = setTimeout(() => {
+						didTimeout = true;
+						resolve([]);
+					}, CLOSE_TIMEOUT_MS);
+				},
+			);
+			this._closingPromise = Promise.race([
+				this._closingPromise,
+				timeoutPromise,
+			]);
 			await this._closingPromise;
+			clearTimeout(timer!);
+
+			if (didTimeout) {
+				const pendingDescriptions = this.pending.filter(Boolean);
+
+				// eslint-disable-next-line no-console
+				console.warn(
+					`BackgroundProcessManager.close() timed out after ${CLOSE_TIMEOUT_MS}ms with ${this.jobs.size} pending job(s):`,
+					pendingDescriptions,
+				);
+				this.jobs.clear();
+			}
+
 			this._state = BackgroundProcessManagerState.Closed;
 		}
 


### PR DESCRIPTION
#### Description of changes

`BackgroundProcessManager.close()` awaits `Promise.allSettled(jobs)` with no timeout. When jobs ignore the `onTerminate` signal (e.g. the subscription processor has a TODO at subscription.ts:411), `close()` hangs forever. This causes DataStore to get permanently stuck in "Stopping" state after network drops — every subsequent save/query/start throws `DataStoreStateError` and only an app restart recovers.

**Fix:** Race `_closingPromise` against a 10s timeout so `close()` always resolves. Key details:
- Reassigns `this._closingPromise` to the race result (required because `async close()` returns it, and callers would otherwise re-block on the original never-settling `allSettled`)
- On timeout, logs a warning with pending job descriptions for debuggability
- Clears `this.jobs` set after timeout to prevent zombie jobs persisting across `close()` → `open()` cycles (used by all DataStore sync processors)

#### Issue #, if available

Related: #13035 #10612 #12359

#### Description of how you validated changes

- All 31 BackgroundProcessManager tests pass (including new timeout test)
- New test verifies: close resolves within 15s, state transitions to Closed, jobs set is cleared, warning is logged with pending job descriptions

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.