### PR TITLE
fix(auth): update token provider auth config on reconfigure

### DIFF
--- a/.changeset/fix-stale-auth-config-reconfigure.md
+++ b/.changeset/fix-stale-auth-config-reconfigure.md
@@ -1,0 +1,9 @@
+---
+'aws-amplify': patch
+---
+
+fix(auth): update token provider auth config on reconfigure
+
+When `Amplify.configure()` is called multiple times to switch `userPoolClientId`,
+the token provider now receives the updated auth config, ensuring token refresh
+uses the correct client ID.

--- a/packages/aws-amplify/__tests__/initSingleton.test.ts
+++ b/packages/aws-amplify/__tests__/initSingleton.test.ts
@@ -328,7 +328,7 @@ describe('initSingleton (DefaultAmplify)', () => {
 
 					expect(
 						mockCognitoUserPoolsTokenProviderSetAuthConfig,
-					).not.toHaveBeenCalled();
+					).toHaveBeenCalledWith(mockResourceConfig.Auth);
 					expect(MockCookieStorage).toHaveBeenCalledWith({ sameSite: 'lax' });
 					expect(
 						mockCognitoUserPoolsTokenProviderSetKeyValueStorage,
@@ -348,7 +348,7 @@ describe('initSingleton (DefaultAmplify)', () => {
 
 					expect(
 						mockCognitoUserPoolsTokenProviderSetAuthConfig,
-					).not.toHaveBeenCalled();
+					).toHaveBeenCalledWith(mockResourceConfig.Auth);
 					expect(
 						mockCognitoUserPoolsTokenProviderSetKeyValueStorage,
 					).toHaveBeenCalledWith(defaultStorage);
@@ -369,7 +369,7 @@ describe('initSingleton (DefaultAmplify)', () => {
 
 					expect(
 						mockCognitoUserPoolsTokenProviderSetAuthConfig,
-					).not.toHaveBeenCalled();
+					).toHaveBeenCalledWith(mockResourceConfig.Auth);
 					expect(
 						mockCognitoUserPoolsTokenProviderSetKeyValueStorage,
 					).not.toHaveBeenCalled();
@@ -382,12 +382,38 @@ describe('initSingleton (DefaultAmplify)', () => {
 					);
 				});
 
-				it('should just configure without touching libraryOptions', () => {
+				it('should update auth config and configure without touching libraryOptions', () => {
 					Amplify.configure(mockResourceConfig);
 
+					expect(
+						mockCognitoUserPoolsTokenProviderSetAuthConfig,
+					).toHaveBeenCalledWith(mockResourceConfig.Auth);
 					expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
 						mockResourceConfig,
 					);
+				});
+
+				it('should update token provider auth config when userPoolClientId changes on reconfigure', () => {
+					// First configure
+					Amplify.configure(mockResourceConfig);
+
+					mockCognitoUserPoolsTokenProviderSetAuthConfig.mockClear();
+
+					// Reconfigure with different userPoolClientId
+					const newConfig: ResourcesConfig = {
+						...mockResourceConfig,
+						Auth: {
+							Cognito: {
+								userPoolClientId: 'newUserPoolClientId',
+								userPoolId: 'userPoolId',
+							},
+						},
+					};
+					Amplify.configure(newConfig);
+
+					expect(
+						mockCognitoUserPoolsTokenProviderSetAuthConfig,
+					).toHaveBeenCalledWith(newConfig.Auth);
 				});
 			});
 

--- a/packages/aws-amplify/src/initSingleton.ts
+++ b/packages/aws-amplify/src/initSingleton.ts
@@ -97,6 +97,8 @@ export const DefaultAmplify = {
 				authLibraryOptions.credentialsProvider = resolvedCredentialsProvider;
 			}
 
+			cognitoUserPoolsTokenProvider.setAuthConfig(resolvedResourceConfig.Auth);
+
 			Amplify.configure(resolvedResourceConfig, {
 				Auth: authLibraryOptions,
 				...libraryOptions,
@@ -107,6 +109,7 @@ export const DefaultAmplify = {
 
 		// Finally, if there were no libraryOptions given at all, we should simply not touch the currently
 		// configured libraryOptions.
+		cognitoUserPoolsTokenProvider.setAuthConfig(resolvedResourceConfig.Auth);
 		Amplify.configure(resolvedResourceConfig);
 	},
 	/**


### PR DESCRIPTION
#### Description of changes

When `Amplify.configure()` is called multiple times to switch `userPoolClientId` (e.g. for multi-tenant apps), the `cognitoUserPoolsTokenProvider` was not updated with the new auth config on subsequent calls. This caused `fetchAuthSession({ forceRefresh: true })` and internal token refresh to use the stale `userPoolClientId`, failing with `NotAuthorizedException`.

**Root cause:** In `initSingleton.ts`, `cognitoUserPoolsTokenProvider.setAuthConfig()` was only called on the first configure path (when `!Amplify.libraryOptions.Auth`). The two reconfigure paths — with and without `libraryOptions` — skipped it entirely.

**Fix:** Added `cognitoUserPoolsTokenProvider.setAuthConfig(resolvedResourceConfig.Auth)` to both reconfigure code paths. Two lines added, no structural changes.

#### Issue #, if available

Closes #14620

#### Description of how you validated changes

- Updated 3 existing tests that incorrectly asserted `setAuthConfig` was NOT called on reconfigure
- Added 1 new test verifying `setAuthConfig` is called with updated config when `userPoolClientId` changes
- All 13 tests pass

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.