### PR TITLE
chore: bump activesupport gem version

### DIFF
--- a/packages/react-native/example/Gemfile
+++ b/packages/react-native/example/Gemfile
@@ -10,6 +10,6 @@ gem 'mutex_m'
 
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
-gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
+gem 'activesupport', '>= 7.2.3.1'
 gem 'xcodeproj', '< 1.26.0'
 gem 'concurrent-ruby', '<= 1.3.4'

--- a/packages/rtn-passkeys/example/Gemfile
+++ b/packages/rtn-passkeys/example/Gemfile
@@ -5,7 +5,7 @@ ruby ">= 2.6.10"
 
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
-gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
+gem 'activesupport', '>= 7.2.3.1'
 gem 'xcodeproj', '< 1.26.0'
 gem 'concurrent-ruby', '< 1.3.4'
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
bumps vulnerable activesupport gem to fixed version in `react-native` and `rtn-passkeys` workspace.

this fixes CVE-2026-33169, CVE-2026-33176 and CVE-2026-33170


#### Issue #, if available
_- none -_


#### Description of how you validated changes


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
