### PR TITLE
chore(ci): fix changelog generation step for latest

### DIFF
--- a/.github/workflows/callable-e2e-test-detox.yml
+++ b/.github/workflows/callable-e2e-test-detox.yml
@@ -45,6 +45,8 @@ jobs:
           GH_TOKEN_STAGING_READ: ${{ secrets.GH_TOKEN_STAGING_READ }}
       - name: Load Verdaccio with AmplifyJs
         uses: ./amplify-js/.github/actions/load-verdaccio-with-amplify-js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Yarn Install
         working-directory: ${{ inputs.working_directory }}
         run: |

--- a/.github/workflows/callable-e2e-test.yml
+++ b/.github/workflows/callable-e2e-test.yml
@@ -76,6 +76,8 @@ jobs:
           GH_TOKEN_STAGING_READ: ${{ secrets.GH_TOKEN_STAGING_READ }}
       - name: Load Verdaccio with AmplifyJs
         uses: ./amplify-js/.github/actions/load-verdaccio-with-amplify-js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run cypress tests for ${{ inputs.test_name }} dev
         shell: bash
         working-directory: amplify-js-samples-staging


### PR DESCRIPTION
#### Description of changes

The `load-verdaccio-with-amplify-js` composite action fails when unconsumed changeset files exist in the repository. The `publish:verdaccio` script runs `changeset version --snapshot` which triggers changelog generation via `@changesets/changelog-github`. This plugin requires `GITHUB_TOKEN` to fetch PR metadata from the GitHub API, but the token was never passed to the verdaccio step in either e2e workflow.

This was a latent bug introduced in the changesets migration (#14695, Feb 11) but only surfaced on March 23 when `03301e80a` merged with an unconsumed changeset file (`fix-websocket-auth-reconnection.md`). Prior to that, all changeset files had been consumed by Version Packages PRs before e2e runs triggered, so `changeset version` never invoked the changelog plugin.

The fix adds `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the "Load Verdaccio with AmplifyJs" step in both `callable-e2e-test.yml` and `callable-e2e-test-detox.yml`. `secrets.GITHUB_TOKEN` is the automatic GitHub-provided token — no new secrets are required.

#### Issue #, if available

N/A — CI pipeline failure on main since March 23.

#### Description of how you validated changes

- Traced the failure to the missing `GITHUB_TOKEN` by reproducing the exact `changeset version` error locally.
- Confirmed the error only occurs when unconsumed changeset `.md` files exist (triggering `@changesets/changelog-github`).
- Verified `secrets.GITHUB_TOKEN` is already used in the same workflow's publish job (`release-latest.yml`), so no new permission scope is introduced.
- Security review confirmed: fork PRs are blocked, the token is short-lived/auto-scoped, and the composite action does not log or exfiltrate environment variables.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

#### Checklist for repo maintainers

- [x] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
