### PR TITLE
ci: configure npm auth and pass GITHUB_TOKEN for unstable publish

### DIFF
--- a/.github/workflows/release-unstable.yml
+++ b/.github/workflows/release-unstable.yml
@@ -29,9 +29,13 @@ jobs:
       - name: Setup node and build the repository
         uses: ./amplify-js/.github/actions/node-and-build
 
+      - name: Configure npm authentication
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish to @unstable
         working-directory: ./amplify-js
         run: yarn publish:unstable
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
#### Description of changes

`changeset publish` calls `npm publish` under the hood, and npm requires auth credentials in `~/.npmrc`. Previously, `changesets/action` handled writing the npm token to `~/.npmrc` automatically. When the switch to a direct `run:` step was made, that setup was lost — `NPM_TOKEN` was passed as an env var, but npm doesn't read auth from environment variables.

This PR adds a dedicated step to write the npm auth token to `~/.npmrc` before publishing, matching the pattern used by the existing `npm-publish` composite action in this repo (`.github/actions/npm-publish/action.yml`).

#### Issue #, if available

Fixes the `Release Unstable` workflow `ENEEDAUTH` failure: https://github.com/aws-amplify/amplify-js/actions/runs/24179532870/job/70568727701

#### Description of how you validated changes

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Unit Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

#### Checklist for repo maintainers

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
