### PR TITLE
fix: upgrade lodash to ^4.18.1 in v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
 		"axios": "1.13.6",
 		"node-gyp": "^10.0.0",
 		"qs": "^6.14.1",
-		"**/form-data": "4.0.4"
+		"**/form-data": "4.0.4",
+		"lodash": "^4.18.1"
 	},
 	"jest": {
 		"resetMocks": true,

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -54,7 +54,7 @@
 		"@aws-sdk/client-kinesis": "3.6.1",
 		"@aws-sdk/client-personalize-events": "3.6.1",
 		"@aws-sdk/util-utf8-browser": "3.6.1",
-		"lodash": "^4.17.20",
+		"lodash": "^4.18.1",
 		"tslib": "^1.8.0",
 		"uuid": "^3.2.1"
 	},

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -52,7 +52,7 @@
 		"@aws-amplify/cache": "5.1.22",
 		"@aws-amplify/core": "5.8.16",
 		"@aws-amplify/rtn-push-notification": "1.1.15",
-		"lodash": "^4.17.21",
+		"lodash": "^4.18.1",
 		"uuid": "^3.2.1"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12047,10 +12047,10 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.3.0, lodash@^4.7.0:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.18.1, lodash@^4.3.0, lodash@^4.7.0:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Upgrades `lodash` to `^4.18.1` in `packages/analytics` and `packages/notifications` to address the following security vulnerabilities:

- **CVE-2025-13465** — Prototype pollution in `_.unset` and `_.omit` (affects 4.0.0–4.17.22)
- **CVE-2026-2950** — Bypass of the CVE-2025-13465 fix via array-wrapped path segments (affects <= 4.17.23, fixed in 4.18.0)

Also adds a `lodash` entry to the root `resolutions` field to ensure transitive dependencies resolve to `^4.18.1`.

#### Issue #, if available

#### Description of how you validated changes

- Verified `yarn.lock` resolves `lodash@^4.18.1` to `4.18.1`

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

#### Checklist for repo maintainers

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
