### PR TITLE
Security: Potential open redirect due to unvalidated redirect path fallback logic

### DIFF
--- a/packages/adapter-nextjs/src/auth/utils/getRedirectOrDefault.ts
+++ b/packages/adapter-nextjs/src/auth/utils/getRedirectOrDefault.ts
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const getRedirectOrDefault = (redirect: string | undefined): string =>
-	redirect || '/';
+	redirect?.startsWith('/') && !redirect.startsWith('//') ? redirect : '/';


### PR DESCRIPTION
## Problem

`getRedirectOrDefault` returns the provided `redirect` string directly when present. If this value is user-controlled and later used in a redirect response, it can enable open redirect attacks to external sites.

**Severity**: `medium`
**File**: `packages/adapter-nextjs/src/auth/utils/getRedirectOrDefault.ts`

## Solution

Validate redirect targets before use: allow only relative paths (e.g., starting with `/` and not `//`) or enforce a strict origin allowlist for absolute URLs. Normalize and reject invalid or external destinations.

## Changes

- `packages/adapter-nextjs/src/auth/utils/getRedirectOrDefault.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
