### PR TITLE
fix: remove unused uuid dependency from api-graphql, predictions, and interactions

### DIFF
--- a/.changeset/remove-uuid-dependency.md
+++ b/.changeset/remove-uuid-dependency.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/api-graphql': patch
+'@aws-amplify/interactions': patch
+'@aws-amplify/predictions': patch
+---
+
+Remove unused uuid dependency from @aws-amplify/api-graphql, @aws-amplify/interactions, and @aws-amplify/predictions packages. All UUID generation is now consolidated through @aws-amplify/core's amplifyUuid wrapper, addressing security advisory GHSA-w5hq-g745-h8pq.

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -85,8 +85,7 @@
 		"@aws-sdk/types": "^3.973.6",
 		"graphql": "15.8.0",
 		"rxjs": "^7.8.1",
-		"tslib": "^2.5.0",
-		"uuid": "^11.0.0"
+		"tslib": "^2.5.0"
 	},
 	"size-limit": [
 		{

--- a/packages/interactions/__tests__/lex-v1/apis/onComplete.test.ts
+++ b/packages/interactions/__tests__/lex-v1/apis/onComplete.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { v4 as uuid } from 'uuid';
+import { amplifyUuid } from '@aws-amplify/core/internals/utils';
 import { lexProvider } from '../../../src/lex-v1/AWSLexProvider';
 import { onComplete } from '../../../src/lex-v1/apis';
 import { generateRandomLexV1Config } from '../../testUtils/randomConfigGeneration';
@@ -27,7 +27,7 @@ describe('Interactions LexV1 API: onComplete', () => {
 	});
 
 	it('invokes provider onComplete API', () => {
-		const message = uuid();
+		const message = amplifyUuid();
 		const mockCallback = jest.fn();
 		onComplete({ botName: v1BotConfig.name, callback: mockCallback });
 		expect(mockLexProvider).toHaveBeenCalledTimes(1);

--- a/packages/interactions/__tests__/lex-v1/apis/send.test.ts
+++ b/packages/interactions/__tests__/lex-v1/apis/send.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { v4 as uuid } from 'uuid';
+import { amplifyUuid } from '@aws-amplify/core/internals/utils';
 import { lexProvider } from '../../../src/lex-v1/AWSLexProvider';
 import { send } from '../../../src/lex-v1/apis';
 import { generateRandomLexV1Config } from '../../testUtils/randomConfigGeneration';
@@ -27,7 +27,7 @@ describe('Interactions LexV1 API: send', () => {
 	});
 
 	it('invokes provider sendMessage API', async () => {
-		const message = uuid();
+		const message = amplifyUuid();
 		await send({ botName: v1BotConfig.name, message });
 		expect(mockLexProvider).toHaveBeenCalledTimes(1);
 		expect(mockLexProvider).toHaveBeenCalledWith(v1BotConfig, message);
@@ -36,7 +36,7 @@ describe('Interactions LexV1 API: send', () => {
 	it('rejects when bot config does not exist', async () => {
 		mockResolveBotConfig.mockReturnValue(undefined);
 		await expect(
-			send({ botName: v1BotConfig.name, message: uuid() }),
+			send({ botName: v1BotConfig.name, message: amplifyUuid() }),
 		).rejects.toBeInstanceOf(InteractionsError);
 	});
 });

--- a/packages/interactions/__tests__/lex-v2/AWSLexV2Provider.test.ts
+++ b/packages/interactions/__tests__/lex-v2/AWSLexV2Provider.test.ts
@@ -10,8 +10,8 @@ import {
 } from '@aws-sdk/client-lex-runtime-v2';
 import { gzip, strToU8 } from 'fflate';
 import { encode } from 'base-64';
-import { v4 as uuid } from 'uuid';
 import { lexProvider } from '../../src/lex-v2/AWSLexV2Provider';
+import { amplifyUuid } from '@aws-amplify/core/internals/utils';
 
 jest.mock('@aws-amplify/core');
 
@@ -467,7 +467,7 @@ describe('Interactions', () => {
 		describe('onComplete callback from `Interactions.onComplete`', () => {
 			test(`In progress, callback shouldn't be called`, async () => {
 				// callback is only called once conversation is completed
-				let config = { ...botConfig.BookTrip, name: uuid() };
+				let config = { ...botConfig.BookTrip, name: amplifyUuid() };
 				const inProgressCallback = mockCallbackProvider(
 					ACTION_TYPE.IN_PROGRESS,
 				);
@@ -484,7 +484,7 @@ describe('Interactions', () => {
 			});
 
 			test(`task complete; callback with success resp`, async () => {
-				let config = { ...botConfig.BookTrip, name: uuid() };
+				let config = { ...botConfig.BookTrip, name: amplifyUuid() };
 				const completeSuccessCallback = mockCallbackProvider(
 					ACTION_TYPE.COMPLETE,
 				);
@@ -502,7 +502,7 @@ describe('Interactions', () => {
 			});
 
 			test(`task complete; callback with error resp`, async () => {
-				let config = { ...botConfig.BookTrip, name: uuid() };
+				let config = { ...botConfig.BookTrip, name: amplifyUuid() };
 				const completeFailCallback = mockCallbackProvider(ACTION_TYPE.ERROR);
 				provider.onComplete(config, completeFailCallback);
 

--- a/packages/interactions/__tests__/lex-v2/apis/onComplete.test.ts
+++ b/packages/interactions/__tests__/lex-v2/apis/onComplete.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { v4 as uuid } from 'uuid';
+import { amplifyUuid } from '@aws-amplify/core/internals/utils';
 import { lexProvider } from '../../../src/lex-v2/AWSLexV2Provider';
 import { onComplete } from '../../../src/lex-v2/apis';
 import { generateRandomLexV2Config } from '../../testUtils/randomConfigGeneration';
@@ -27,7 +27,7 @@ describe('Interactions LexV2 API: onComplete', () => {
 	});
 
 	it('invokes provider onComplete API', () => {
-		const message = uuid();
+		const message = amplifyUuid();
 		const mockCallback = jest.fn();
 		onComplete({ botName: v2BotConfig.name, callback: mockCallback });
 		expect(mockLexProvider).toHaveBeenCalledTimes(1);

--- a/packages/interactions/__tests__/lex-v2/apis/send.test.ts
+++ b/packages/interactions/__tests__/lex-v2/apis/send.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { v4 as uuid } from 'uuid';
+import { amplifyUuid } from '@aws-amplify/core/internals/utils';
 import { lexProvider } from '../../../src/lex-v2/AWSLexV2Provider';
 import { send } from '../../../src/lex-v2/apis';
 import { generateRandomLexV2Config } from '../../testUtils/randomConfigGeneration';
@@ -27,7 +27,7 @@ describe('Interactions LexV2 API: send', () => {
 	});
 
 	it('invokes provider sendMessage API', async () => {
-		const message = uuid();
+		const message = amplifyUuid();
 		await send({ botName: v2BotConfig.name, message });
 		expect(mockLexProvider).toHaveBeenCalledTimes(1);
 		expect(mockLexProvider).toHaveBeenCalledWith(v2BotConfig, message);
@@ -36,7 +36,7 @@ describe('Interactions LexV2 API: send', () => {
 	it('rejects when bot config does not exist', async () => {
 		mockResolveBotConfig.mockReturnValue(undefined);
 		await expect(
-			send({ botName: v2BotConfig.name, message: uuid() }),
+			send({ botName: v2BotConfig.name, message: amplifyUuid() }),
 		).rejects.toBeInstanceOf(InteractionsError);
 	});
 });

--- a/packages/interactions/__tests__/testUtils/randomConfigGeneration.ts
+++ b/packages/interactions/__tests__/testUtils/randomConfigGeneration.ts
@@ -1,19 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { v4 as uuid } from 'uuid';
+import { amplifyUuid } from '@aws-amplify/core/internals/utils';
 import { AWSLexProviderOption } from '../../src/lex-v1/types';
 import { AWSLexV2ProviderOption } from '../../src/lex-v2/types';
 
 export const generateRandomLexV1Config = (): AWSLexProviderOption => ({
-	name: uuid(),
-	alias: uuid(),
-	region: uuid(),
+	name: amplifyUuid(),
+	alias: amplifyUuid(),
+	region: amplifyUuid(),
 });
 
 export const generateRandomLexV2Config = (): AWSLexV2ProviderOption => ({
-	name: uuid(),
-	aliasId: uuid(),
-	botId: uuid(),
-	region: uuid(),
-	localeId: uuid(),
+	name: amplifyUuid(),
+	aliasId: amplifyUuid(),
+	botId: amplifyUuid(),
+	region: amplifyUuid(),
+	localeId: amplifyUuid(),
 });

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -77,8 +77,7 @@
 		"base-64": "1.0.0",
 		"fflate": "0.7.3",
 		"pako": "2.0.4",
-		"tslib": "^2.5.0",
-		"uuid": "^11.0.0"
+		"tslib": "^2.5.0"
 	},
 	"devDependencies": {
 		"@aws-amplify/core": "6.16.2"

--- a/packages/interactions/src/lex-v2/AWSLexV2Provider.ts
+++ b/packages/interactions/src/lex-v2/AWSLexV2Provider.ts
@@ -10,9 +10,11 @@ import {
 	RecognizeUtteranceCommandInput,
 	RecognizeUtteranceCommandOutput,
 } from '@aws-sdk/client-lex-runtime-v2';
-import { getAmplifyUserAgentObject } from '@aws-amplify/core/internals/utils';
+import {
+	amplifyUuid,
+	getAmplifyUserAgentObject,
+} from '@aws-amplify/core/internals/utils';
 import { ConsoleLogger, fetchAuthSession } from '@aws-amplify/core';
-import { v4 as uuid } from 'uuid';
 
 import { convert, unGzipBase64AsJson } from '../utils';
 import {
@@ -58,7 +60,7 @@ class AWSLexV2Provider {
 		InteractionsOnCompleteCallback
 	> = {};
 
-	private defaultSessionId: string = uuid();
+	private defaultSessionId: string = amplifyUuid();
 
 	/**
 	 * Send a message to a bot

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -52,8 +52,7 @@
 		"@smithy/eventstream-codec": "2.0.9",
 		"@smithy/util-utf8": "2.0.0",
 		"buffer": "4.9.2",
-		"tslib": "^2.5.0",
-		"uuid": "^11.0.0"
+		"tslib": "^2.5.0"
 	},
 	"peerDependencies": {
 		"@aws-amplify/core": "^6.16.2"


### PR DESCRIPTION
## Summary

Removes the direct `uuid` dependency from packages that don't need it, consolidating all UUID generation through `@aws-amplify/core`'s `amplifyUuid` wrapper. This addresses the security advisory [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq).

## Motivation

Dependabot flagged `uuid` for an out-of-bounds write vulnerability in `v3()`, `v5()`, and `v6()` when a caller-supplied buffer has an invalid offset. While this project only uses `v4()` (which is **not affected**), the cleanest resolution is to remove the unnecessary direct dependency from packages that never use it, and consolidate through core.

## Changes

| Package | Change |
|---|---|
| `@aws-amplify/api-graphql` | Removed `uuid` from dependencies — was never imported directly (uses `amplifyUuid` from core) |
| `@aws-amplify/predictions` | Removed `uuid` from dependencies — was never imported anywhere in the package |
| `@aws-amplify/interactions` | Replaced direct `import { v4 as uuid } from 'uuid'` with `amplifyUuid` from `@aws-amplify/core/internals/utils`, then removed `uuid` from dependencies |

After these changes, `uuid` exists only as a dependency in `@aws-amplify/core` (`^11.0.0`), which is the single package that wraps `uuid.v4()` via `amplifyUuid`.

## Why not upgrade to uuid@14?

uuid@12+ dropped CommonJS support. Since amplify-js builds both CJS and ESM outputs with `uuid` kept as an external (not bundled), upgrading would break the CJS build at runtime. Staying on v11 is safe because only `v4()` is used, which is unaffected by the vulnerability.

## Testing

- No behavioral change — `amplifyUuid()` is already a direct re-export of `uuid.v4()`
- The interactions package already imports from `@aws-amplify/core/internals/utils` for `getAmplifyUserAgentObject`, so this follows the existing pattern