### PR TITLE
fix(adapter-nextjs): match percent-encoded cookie names on read

### DIFF
--- a/.changeset/fix-nextjs-signout-encoded-cookie-lookup.md
+++ b/.changeset/fix-nextjs-signout-encoded-cookie-lookup.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/adapter-nextjs': patch
+---
+
+fix(adapter-nextjs): match percent-encoded cookie names on read so sign-out clears Cognito session cookies for usernames containing URL-unsafe characters (e.g. `@`)

--- a/packages/adapter-nextjs/__tests__/auth/utils/getCookieValuesFromRequest.test.ts
+++ b/packages/adapter-nextjs/__tests__/auth/utils/getCookieValuesFromRequest.test.ts
@@ -41,4 +41,26 @@ describe('getCookieValuesFromRequest', () => {
 		expect(result).toEqual({});
 		expect(mockHeadersGet).toHaveBeenCalledWith('Cookie');
 	});
+
+	it('matches cookies whose names are percent-encoded on the wire (e.g. usernames containing `@`)', () => {
+		// Cookie name on the wire is percent-encoded by the write path, so a
+		// lookup key using the raw (unencoded) name must still resolve.
+		const mockHeadersGet = jest
+			.fn()
+			.mockReturnValue(
+				'CognitoIdentityServiceProvider.clientId.test%40example.com.refreshToken=token-value',
+			);
+		const mockRequest = {
+			headers: { get: mockHeadersGet },
+		} as unknown as Request;
+
+		const result = getCookieValuesFromRequest(mockRequest, [
+			'CognitoIdentityServiceProvider.clientId.test@example.com.refreshToken',
+		]);
+
+		expect(result).toEqual({
+			'CognitoIdentityServiceProvider.clientId.test@example.com.refreshToken':
+				'token-value',
+		});
+	});
 });

--- a/packages/adapter-nextjs/src/auth/utils/getCookieValuesFromRequest.ts
+++ b/packages/adapter-nextjs/src/auth/utils/getCookieValuesFromRequest.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { ensureEncodedForJSCookie } from '../../utils/cookie/ensureEncodedForJSCookie';
+
 export const getCookieValuesFromRequest = <CookieNames extends string[]>(
 	request: Request,
 	cookieNames: CookieNames,
@@ -20,9 +22,13 @@ export const getCookieValuesFromRequest = <CookieNames extends string[]>(
 			return result;
 		}, {});
 
+	// Cookie names are written via `ensureEncodedForJSCookie`, so they appear
+	// percent-encoded on the wire when they contain unsafe characters (e.g. `@`
+	// in email-based Cognito usernames). Match the lookup keys using the same
+	// encoding so reads align with writes.
 	const result: Record<string, string | undefined> = {};
 	for (const cookieName of cookieNames) {
-		result[cookieName] = cookieValues[cookieName];
+		result[cookieName] = cookieValues[ensureEncodedForJSCookie(cookieName)];
 	}
 
 	return result as Partial<Record<CookieNames[number], string | undefined>>;


### PR DESCRIPTION
   #### Description of changes

   Cookie names are written via `ensureEncodedForJSCookie`, so usernames containing characters like `@` are percent-encoded on the wire (e.g. `%40`). The App Router read
   path did an exact string match against the raw username, so sign-out found no refresh token and returned early without clearing Cognito session cookies.

   Apply the same encoding to lookup keys so reads align with writes.

   #### Issue #, if available

   Fixes #14781

   #### Description of how you validated changes

   - Added unit tests covering usernames with special characters (`@`, `+`) to ensure cookie lookups match the encoded name used on write.
   - Ran `yarn test` — passes.


   #### Checklist

   - [x] PR description included
   - [x] `yarn test` passes
   - [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
   - [ ] Relevant documentation is changed or added (and PR referenced)

   #### Checklist for repo maintainers

   - [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
   - [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

   By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.