### PR TITLE
chore: Update `registry.directory` for all `package.json`

### DIFF
--- a/packages/adapter-nextjs/api/package.json
+++ b/packages/adapter-nextjs/api/package.json
@@ -3,5 +3,11 @@
 	"main": "../dist/cjs/api/index.js",
 	"browser": "../dist/esm/api/index.mjs",
 	"module": "../dist/esm/api/index.mjs",
-	"typings": "../dist/esm/api/index.d.ts"
+	"typings": "../dist/esm/api/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/adapter-nextjs/api"
+	}
 }

--- a/packages/adapter-nextjs/data/package.json
+++ b/packages/adapter-nextjs/data/package.json
@@ -3,5 +3,11 @@
 	"main": "../dist/cjs/api/index.js",
 	"browser": "../dist/esm/api/index.mjs",
 	"module": "../dist/esm/api/index.mjs",
-	"typings": "../dist/esm/api/index.d.ts"
+	"typings": "../dist/esm/api/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/adapter-nextjs/data"
+	}
 }

--- a/packages/adapter-nextjs/package.json
+++ b/packages/adapter-nextjs/package.json
@@ -67,5 +67,10 @@
 		"lint:fix": "eslint '**/*.{ts,tsx}' --fix",
 		"test": "npm run lint && jest -w 1 --coverage --logHeapUsage",
 		"ts-coverage": "typescript-coverage-report -p ./tsconfig.build.json -t 90.31"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/adapter-nextjs"
 	}
 }

--- a/packages/analytics/kinesis-firehose/package.json
+++ b/packages/analytics/kinesis-firehose/package.json
@@ -4,5 +4,11 @@
 	"browser": "../dist/esm/providers/kinesis-firehose/index.mjs",
 	"module": "../dist/esm/providers/kinesis-firehose/index.mjs",
 	"react-native": "../dist/cjs/providers/kinesis-firehose/index.js",
-	"typings": "../dist/esm/providers/kinesis-firehose/index.d.ts"
+	"typings": "../dist/esm/providers/kinesis-firehose/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/analytics/kinesis-firehose"
+	}
 }

--- a/packages/analytics/kinesis/package.json
+++ b/packages/analytics/kinesis/package.json
@@ -4,5 +4,11 @@
 	"browser": "../dist/esm/providers/kinesis/index.mjs",
 	"module": "../dist/esm/providers/kinesis/index.mjs",
 	"react-native": "../dist/cjs/providers/kinesis/index.js",
-	"typings": "../dist/esm/providers/kinesis/index.d.ts"
+	"typings": "../dist/esm/providers/kinesis/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/analytics/kinesis"
+	}
 }

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -75,7 +75,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/analytics"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/analytics/personalize/package.json
+++ b/packages/analytics/personalize/package.json
@@ -4,5 +4,11 @@
 	"browser": "../dist/esm/providers/personalize/index.mjs",
 	"module": "../dist/esm/providers/personalize/index.mjs",
 	"react-native": "../dist/cjs/providers/personalize/index.js",
-	"typings": "../dist/esm/providers/personalize/index.d.ts"
+	"typings": "../dist/esm/providers/personalize/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/analytics/personalize"
+	}
 }

--- a/packages/analytics/pinpoint/package.json
+++ b/packages/analytics/pinpoint/package.json
@@ -4,5 +4,11 @@
 	"browser": "../dist/esm/providers/pinpoint/index.mjs",
 	"module": "../dist/esm/providers/pinpoint/index.mjs",
 	"react-native": "../dist/cjs/providers/pinpoint/index.js",
-	"typings": "../dist/esm/providers/pinpoint/index.d.ts"
+	"typings": "../dist/esm/providers/pinpoint/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/analytics/pinpoint"
+	}
 }

--- a/packages/api-graphql/internals/package.json
+++ b/packages/api-graphql/internals/package.json
@@ -4,5 +4,11 @@
 	"main": "../dist/cjs/internals/index.js",
 	"module": "../dist/esm/internals/index.mjs",
 	"react-native": "../dist/cjs/internals/index.js",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/api-graphql/internals"
+	}
 }

--- a/packages/api-graphql/internals/server/package.json
+++ b/packages/api-graphql/internals/server/package.json
@@ -4,5 +4,11 @@
 	"main": "../../dist/cjs/internals/server/index.js",
 	"module": "../../dist/esm/internals/server/index.mjs",
 	"react-native": "../../dist/cjs/internals/server/index.js",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/api-graphql/internals/server"
+	}
 }

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -63,7 +63,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/api-graphql"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/api-graphql/server/package.json
+++ b/packages/api-graphql/server/package.json
@@ -3,5 +3,11 @@
 	"types": "../dist/esm/server/index.d.ts",
 	"main": "../dist/cjs/server/index.js",
 	"module": "../dist/esm/server/index.mjs",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/api-graphql/server"
+	}
 }

--- a/packages/api-rest/internals/package.json
+++ b/packages/api-rest/internals/package.json
@@ -4,5 +4,11 @@
 	"main": "../dist/cjs/internals/index.js",
 	"module": "../dist/esm/internals/index.mjs",
 	"react-native": "../dist/cjs/internals/index.js",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/api-rest/internals"
+	}
 }

--- a/packages/api-rest/internals/server/package.json
+++ b/packages/api-rest/internals/server/package.json
@@ -3,5 +3,11 @@
 	"types": "../../dist/esm/internals/server.d.ts",
 	"main": "../../dist/cjs/internals/server.js",
 	"module": "../../dist/esm/internals/server.mjs",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/api-rest/internals/server"
+	}
 }

--- a/packages/api-rest/package.json
+++ b/packages/api-rest/package.json
@@ -65,7 +65,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/api-rest"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/api-rest/server/package.json
+++ b/packages/api-rest/server/package.json
@@ -3,5 +3,11 @@
 	"types": "../dist/esm/server.d.ts",
 	"main": "../dist/cjs/server.js",
 	"module": "../dist/esm/server.mjs",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/api-rest/server"
+	}
 }

--- a/packages/api/internals/package.json
+++ b/packages/api/internals/package.json
@@ -4,5 +4,11 @@
 	"main": "../dist/cjs/internals/index.js",
 	"module": "../dist/esm/internals/index.mjs",
 	"react-native": "../dist/cjs/internals/index.js",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/api/internals"
+	}
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -59,7 +59,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/api"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/api/server/package.json
+++ b/packages/api/server/package.json
@@ -3,5 +3,11 @@
 	"types": "../dist/esm/server.d.ts",
 	"main": "../dist/cjs/server.js",
 	"module": "../dist/esm/server.mjs",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/api/server"
+	}
 }

--- a/packages/auth/cognito/package.json
+++ b/packages/auth/cognito/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../dist/cjs/providers/cognito/index.js",
 	"browser": "../dist/esm/providers/cognito/index.mjs",
 	"module": "../dist/esm/providers/cognito/index.mjs",
-	"typings": "../dist/esm/providers/cognito/index.d.ts"
+	"typings": "../dist/esm/providers/cognito/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/auth/cognito"
+	}
 }

--- a/packages/auth/cognito/server/package.json
+++ b/packages/auth/cognito/server/package.json
@@ -3,5 +3,11 @@
 	"main": "../../dist/cjs/providers/cognito/apis/server/index.js",
 	"browser": "../../dist/esm/providers/cognito/apis/server/index.mjs",
 	"module": "../../dist/esm/providers/cognito/apis/server/index.mjs",
-	"typings": "../../dist/esm/providers/cognito/apis/server/index.d.ts"
+	"typings": "../../dist/esm/providers/cognito/apis/server/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/auth/cognito/server"
+	}
 }

--- a/packages/auth/enable-oauth-listener/package.json
+++ b/packages/auth/enable-oauth-listener/package.json
@@ -3,5 +3,11 @@
 	"types": "../dist/esm/providers/cognito/utils/oauth/enableOAuthListener.d.ts",
 	"main": "../dist/cjs/providers/cognito/utils/oauth/enableOAuthListener.js",
 	"module": "../dist/esm/providers/cognito/utils/oauth/enableOAuthListener.mjs",
-	"sideEffects": true
+	"sideEffects": true,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/auth/enable-oauth-listener"
+	}
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -74,7 +74,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/auth"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/auth/server/package.json
+++ b/packages/auth/server/package.json
@@ -3,5 +3,11 @@
 	"types": "../dist/esm/server.d.ts",
 	"main": "../dist/cjs/server.js",
 	"module": "../dist/esm/server.mjs",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/auth/server"
+	}
 }

--- a/packages/aws-amplify/adapter-core/internals/package.json
+++ b/packages/aws-amplify/adapter-core/internals/package.json
@@ -3,5 +3,11 @@
 	"types": "../../dist/esm/adapter-core/internals.d.ts",
 	"main": "../../dist/cjs/adapter-core/internals.js",
 	"module": "../../dist/esm/adapter-core/internals.mjs",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/adapter-core/internals"
+	}
 }

--- a/packages/aws-amplify/adapter-core/package.json
+++ b/packages/aws-amplify/adapter-core/package.json
@@ -3,5 +3,11 @@
 	"types": "../dist/esm/adapter-core/index.d.ts",
 	"main": "../dist/cjs/adapter-core/index.js",
 	"module": "../dist/esm/adapter-core/index.mjs",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/adapter-core"
+	}
 }

--- a/packages/aws-amplify/analytics/kinesis-firehose/package.json
+++ b/packages/aws-amplify/analytics/kinesis-firehose/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../../dist/cjs/analytics/kinesis-firehose/index.js",
 	"browser": "../../dist/esm/analytics/kinesis-firehose/index.mjs",
 	"module": "../../dist/esm/analytics/kinesis-firehose/index.mjs",
-	"typings": "../../dist/esm/analytics/kinesis-firehose/index.d.ts"
+	"typings": "../../dist/esm/analytics/kinesis-firehose/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/analytics/kinesis-firehose"
+	}
 }

--- a/packages/aws-amplify/analytics/kinesis/package.json
+++ b/packages/aws-amplify/analytics/kinesis/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../../dist/cjs/analytics/kinesis/index.js",
 	"browser": "../../dist/esm/analytics/kinesis/index.mjs",
 	"module": "../../dist/esm/analytics/kinesis/index.mjs",
-	"typings": "../../dist/esm/analytics/kinesis/index.d.ts"
+	"typings": "../../dist/esm/analytics/kinesis/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/analytics/kinesis"
+	}
 }

--- a/packages/aws-amplify/analytics/package.json
+++ b/packages/aws-amplify/analytics/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../dist/cjs/analytics/index.js",
 	"browser": "../dist/esm/analytics/index.mjs",
 	"module": "../dist/esm/analytics/index.mjs",
-	"typings": "../dist/esm/analytics/index.d.ts"
+	"typings": "../dist/esm/analytics/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/analytics"
+	}
 }

--- a/packages/aws-amplify/analytics/personalize/package.json
+++ b/packages/aws-amplify/analytics/personalize/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../../dist/cjs/analytics/personalize/index.js",
 	"browser": "../../dist/esm/analytics/personalize/index.mjs",
 	"module": "../../dist/esm/analytics/personalize/index.mjs",
-	"typings": "../../dist/esm/analytics/personalize/index.d.ts"
+	"typings": "../../dist/esm/analytics/personalize/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/analytics/personalize"
+	}
 }

--- a/packages/aws-amplify/analytics/pinpoint/package.json
+++ b/packages/aws-amplify/analytics/pinpoint/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../../dist/cjs/analytics/pinpoint/index.js",
 	"browser": "../../dist/esm/analytics/pinpoint/index.mjs",
 	"module": "../../dist/esm/analytics/pinpoint/index.mjs",
-	"typings": "../../dist/esm/analytics/pinpoint/index.d.ts"
+	"typings": "../../dist/esm/analytics/pinpoint/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/analytics/pinpoint"
+	}
 }

--- a/packages/aws-amplify/api/internals/package.json
+++ b/packages/aws-amplify/api/internals/package.json
@@ -3,5 +3,11 @@
 	"main": "../../dist/cjs/api/internals.js",
 	"browser": "../../dist/esm/api/internals.mjs",
 	"module": "../../dist/esm/api/internals.mjs",
-	"typings": "../../dist/esm/api/internals.d.ts"
+	"typings": "../../dist/esm/api/internals.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/api/internals"
+	}
 }

--- a/packages/aws-amplify/api/package.json
+++ b/packages/aws-amplify/api/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../dist/cjs/api/index.js",
 	"browser": "../dist/esm/api/index.mjs",
 	"module": "../dist/esm/api/index.mjs",
-	"typings": "../dist/esm/api/index.d.ts"
+	"typings": "../dist/esm/api/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/api"
+	}
 }

--- a/packages/aws-amplify/api/server/package.json
+++ b/packages/aws-amplify/api/server/package.json
@@ -3,5 +3,11 @@
 	"main": "../../dist/cjs/api/server.js",
 	"browser": "../../dist/esm/api/server.mjs",
 	"module": "../../dist/esm/api/server.mjs",
-	"typings": "../../dist/esm/api/server.d.ts"
+	"typings": "../../dist/esm/api/server.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/api/server"
+	}
 }

--- a/packages/aws-amplify/auth/cognito/package.json
+++ b/packages/aws-amplify/auth/cognito/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../../dist/cjs/auth/cognito/index.js",
 	"browser": "../../dist/esm/auth/cognito/index.mjs",
 	"module": "../../dist/esm/auth/cognito/index.mjs",
-	"typings": "../../dist/esm/auth/cognito/index.d.ts"
+	"typings": "../../dist/esm/auth/cognito/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/auth/cognito"
+	}
 }

--- a/packages/aws-amplify/auth/cognito/server/package.json
+++ b/packages/aws-amplify/auth/cognito/server/package.json
@@ -3,5 +3,11 @@
 	"main": "../../../dist/cjs/auth/cognito/server/index.js",
 	"browser": "../../../dist/esm/auth/cognito/server/index.mjs",
 	"module": "../../../dist/esm/auth/cognito/server/index.mjs",
-	"typings": "../../../dist/esm/auth/cognito/server/index.d.ts"
+	"typings": "../../../dist/esm/auth/cognito/server/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/auth/cognito/server"
+	}
 }

--- a/packages/aws-amplify/auth/enable-oauth-listener/package.json
+++ b/packages/aws-amplify/auth/enable-oauth-listener/package.json
@@ -4,5 +4,11 @@
 	"browser": "../../dist/esm/auth/enableOAuthListener.mjs",
 	"module": "../../dist/esm/auth/enableOAuthListener.mjs",
 	"typings": "../../dist/esm/auth/enableOAuthListener.d.ts",
-	"sideEffects": true
+	"sideEffects": true,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/auth/enable-oauth-listener"
+	}
 }

--- a/packages/aws-amplify/auth/package.json
+++ b/packages/aws-amplify/auth/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../dist/cjs/auth/index.js",
 	"browser": "../dist/esm/auth/index.mjs",
 	"module": "../dist/esm/auth/index.mjs",
-	"typings": "../dist/esm/auth/index.d.ts"
+	"typings": "../dist/esm/auth/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/auth"
+	}
 }

--- a/packages/aws-amplify/auth/server/package.json
+++ b/packages/aws-amplify/auth/server/package.json
@@ -3,5 +3,11 @@
 	"main": "../../dist/cjs/auth/server.js",
 	"browser": "../../dist/esm/auth/server.mjs",
 	"module": "../../dist/esm/auth/server.mjs",
-	"typings": "../../dist/esm/auth/server.d.ts"
+	"typings": "../../dist/esm/auth/server.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/auth/server"
+	}
 }

--- a/packages/aws-amplify/data/package.json
+++ b/packages/aws-amplify/data/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../dist/cjs/api/index.js",
 	"browser": "../dist/esm/api/index.mjs",
 	"module": "../dist/esm/api/index.mjs",
-	"typings": "../dist/esm/api/index.d.ts"
+	"typings": "../dist/esm/api/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/data"
+	}
 }

--- a/packages/aws-amplify/data/server/package.json
+++ b/packages/aws-amplify/data/server/package.json
@@ -3,5 +3,11 @@
 	"main": "../../dist/cjs/api/server.js",
 	"browser": "../../dist/esm/api/server.mjs",
 	"module": "../../dist/esm/api/server.mjs",
-	"typings": "../../dist/esm/api/server.d.ts"
+	"typings": "../../dist/esm/api/server.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/data/server"
+	}
 }

--- a/packages/aws-amplify/datastore/package.json
+++ b/packages/aws-amplify/datastore/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../dist/cjs/datastore/index.js",
 	"browser": "../dist/esm/datastore/index.mjs",
 	"module": "../dist/esm/datastore/index.mjs",
-	"typings": "../dist/esm/datastore/index.d.ts"
+	"typings": "../dist/esm/datastore/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/datastore"
+	}
 }

--- a/packages/aws-amplify/in-app-messaging/package.json
+++ b/packages/aws-amplify/in-app-messaging/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../dist/cjs/in-app-messaging/index.js",
 	"browser": "../dist/esm/in-app-messaging/index.mjs",
 	"module": "../dist/esm/in-app-messaging/index.mjs",
-	"typings": "../dist/esm/in-app-messaging/index.d.ts"
+	"typings": "../dist/esm/in-app-messaging/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/in-app-messaging"
+	}
 }

--- a/packages/aws-amplify/in-app-messaging/pinpoint/package.json
+++ b/packages/aws-amplify/in-app-messaging/pinpoint/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../../dist/cjs/in-app-messaging/pinpoint/index.js",
 	"browser": "../../dist/esm/in-app-messaging/pinpoint/index.mjs",
 	"module": "../../dist/esm/in-app-messaging/pinpoint/index.mjs",
-	"typings": "../../dist/esm/in-app-messaging/pinpoint/index.d.ts"
+	"typings": "../../dist/esm/in-app-messaging/pinpoint/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/in-app-messaging/pinpoint"
+	}
 }

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -269,7 +269,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/aws-amplify/push-notifications/package.json
+++ b/packages/aws-amplify/push-notifications/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../dist/cjs/push-notifications/index.js",
 	"browser": "../dist/esm/push-notifications/index.mjs",
 	"module": "../dist/esm/push-notifications/index.mjs",
-	"typings": "../dist/esm/push-notifications/index.d.ts"
+	"typings": "../dist/esm/push-notifications/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/push-notifications"
+	}
 }

--- a/packages/aws-amplify/push-notifications/pinpoint/package.json
+++ b/packages/aws-amplify/push-notifications/pinpoint/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../../dist/cjs/push-notifications/pinpoint/index.js",
 	"browser": "../../dist/esm/push-notifications/pinpoint/index.mjs",
 	"module": "../../dist/esm/push-notifications/pinpoint/index.mjs",
-	"typings": "../../dist/esm/push-notifications/pinpoint/index.d.ts"
+	"typings": "../../dist/esm/push-notifications/pinpoint/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/push-notifications/pinpoint"
+	}
 }

--- a/packages/aws-amplify/storage/package.json
+++ b/packages/aws-amplify/storage/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../dist/cjs/storage/index.js",
 	"browser": "../dist/esm/storage/index.mjs",
 	"module": "../dist/esm/storage/index.mjs",
-	"typings": "../dist/esm/storage/index.d.ts"
+	"typings": "../dist/esm/storage/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/storage"
+	}
 }

--- a/packages/aws-amplify/storage/s3/package.json
+++ b/packages/aws-amplify/storage/s3/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../../dist/cjs/storage/s3/index.js",
 	"browser": "../../dist/esm/storage/s3/index.mjs",
 	"module": "../../dist/esm/storage/s3/index.mjs",
-	"typings": "../../dist/esm/storage/s3/index.d.ts"
+	"typings": "../../dist/esm/storage/s3/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/storage/s3"
+	}
 }

--- a/packages/aws-amplify/storage/s3/server/package.json
+++ b/packages/aws-amplify/storage/s3/server/package.json
@@ -3,5 +3,11 @@
 	"main": "../../../dist/cjs/storage/s3/server.js",
 	"browser": "../../../dist/esm/storage/s3/server.mjs",
 	"module": "../../../dist/esm/storage/s3/server.mjs",
-	"typings": "../../../dist/esm/storage/s3/server.d.ts"
+	"typings": "../../../dist/esm/storage/s3/server.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/storage/s3/server"
+	}
 }

--- a/packages/aws-amplify/storage/server/package.json
+++ b/packages/aws-amplify/storage/server/package.json
@@ -3,5 +3,11 @@
 	"main": "../../dist/cjs/storage/server.js",
 	"browser": "../../dist/esm/storage/server.mjs",
 	"module": "../../dist/esm/storage/server.mjs",
-	"typings": "../../dist/esm/storage/server.d.ts"
+	"typings": "../../dist/esm/storage/server.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/storage/server"
+	}
 }

--- a/packages/aws-amplify/utils/package.json
+++ b/packages/aws-amplify/utils/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../dist/cjs/utils/index.js",
 	"browser": "../dist/esm/utils/index.mjs",
 	"module": "../dist/esm/utils/index.mjs",
-	"typings": "../dist/esm/utils/index.d.ts"
+	"typings": "../dist/esm/utils/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/aws-amplify/utils"
+	}
 }

--- a/packages/core/internals/adapter-core/package.json
+++ b/packages/core/internals/adapter-core/package.json
@@ -3,5 +3,11 @@
 	"types": "../../dist/esm/adapterCore/index.d.ts",
 	"main": "../../dist/cjs/adapterCore/index.js",
 	"module": "../../dist/esm/adapterCore/index.mjs",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/core/internals/adapter-core"
+	}
 }

--- a/packages/core/internals/aws-client-utils/composers/package.json
+++ b/packages/core/internals/aws-client-utils/composers/package.json
@@ -4,5 +4,11 @@
 	"main": "../../../dist/cjs/clients/internal/index.js",
 	"module": "../../../dist/esm/clients/internal/index.mjs",
 	"react-native": "../../../dist/cjs/clients/internal/index.js",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/core/internals/aws-client-utils/composers"
+	}
 }

--- a/packages/core/internals/aws-client-utils/package.json
+++ b/packages/core/internals/aws-client-utils/package.json
@@ -4,5 +4,11 @@
 	"main": "../../dist/cjs/clients/index.js",
 	"module": "../../dist/esm/clients/index.mjs",
 	"react-native": "../../dist/cjs/clients/index.js",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/core/internals/aws-client-utils"
+	}
 }

--- a/packages/core/internals/aws-clients/cognitoIdentity/package.json
+++ b/packages/core/internals/aws-clients/cognitoIdentity/package.json
@@ -4,5 +4,11 @@
 	"main": "../../../dist/cjs/foundation/factories/serviceClients/cognitoIdentity/index.js",
 	"module": "../../../dist/esm/foundation/factories/serviceClients/cognitoIdentity/index.mjs",
 	"react-native": "../../../dist/cjs/foundation/factories/serviceClients/cognitoIdentity/index.js",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/core/internals/aws-clients/cognitoIdentity"
+	}
 }

--- a/packages/core/internals/aws-clients/pinpoint/package.json
+++ b/packages/core/internals/aws-clients/pinpoint/package.json
@@ -4,5 +4,11 @@
 	"main": "../../../dist/cjs/awsClients/pinpoint/index.js",
 	"module": "../../../dist/esm/awsClients/pinpoint/index.mjs",
 	"react-native": "../../../dist/cjs/awsClients/pinpoint/index.js",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/core/internals/aws-clients/pinpoint"
+	}
 }

--- a/packages/core/internals/providers/pinpoint/package.json
+++ b/packages/core/internals/providers/pinpoint/package.json
@@ -4,5 +4,11 @@
 	"main": "../../../dist/cjs/providers/pinpoint/index.js",
 	"module": "../../../dist/esm/providers/pinpoint/index.mjs",
 	"react-native": "../../../dist/cjs/providers/pinpoint/index.js",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/core/internals/providers/pinpoint"
+	}
 }

--- a/packages/core/internals/utils/package.json
+++ b/packages/core/internals/utils/package.json
@@ -3,5 +3,11 @@
 	"types": "../../dist/esm/libraryUtils.d.ts",
 	"main": "../../dist/cjs/libraryUtils.js",
 	"module": "../../dist/esm/libraryUtils.mjs",
-	"react-native": "../../dist/cjs/libraryUtils.js"
+	"react-native": "../../dist/cjs/libraryUtils.js",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/core/internals/utils"
+	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/core"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/core/server/package.json
+++ b/packages/core/server/package.json
@@ -3,5 +3,11 @@
 	"types": "../dist/esm/server.d.ts",
 	"main": "../dist/cjs/server.js",
 	"module": "../dist/esm/server.mjs",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/core/server"
+	}
 }

--- a/packages/datastore-storage-adapter/package.json
+++ b/packages/datastore-storage-adapter/package.json
@@ -24,7 +24,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/datastore-storage-adapter"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -30,7 +30,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/datastore"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/geo/location-service/package.json
+++ b/packages/geo/location-service/package.json
@@ -4,5 +4,11 @@
 	"browser": "../dist/esm/providers/location-service/AmazonLocationServiceProvider.mjs",
 	"module": "../dist/esm/providers/location-service/AmazonLocationServiceProvider.mjs",
 	"react-native": "../dist/cjs/providers/location-service/AmazonLocationServiceProvider.js",
-	"typings": "../dist/esm/providers/location-service/AmazonLocationServiceProvider.d.ts"
+	"typings": "../dist/esm/providers/location-service/AmazonLocationServiceProvider.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/geo/location-service"
+	}
 }

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -52,7 +52,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/geo"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/interactions/lex-v1/package.json
+++ b/packages/interactions/lex-v1/package.json
@@ -4,5 +4,11 @@
 	"browser": "../dist/esm/lex-v1/index.mjs",
 	"module": "../dist/esm/lex-v1/index.mjs",
 	"react-native": "../dist/cjs/lex-v1/index.js",
-	"typings": "../dist/esm/lex-v1/index.d.ts"
+	"typings": "../dist/esm/lex-v1/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/interactions/lex-v1"
+	}
 }

--- a/packages/interactions/lex-v2/package.json
+++ b/packages/interactions/lex-v2/package.json
@@ -4,5 +4,11 @@
 	"browser": "../dist/esm/lex-v2/index.mjs",
 	"module": "../dist/esm/lex-v2/index.mjs",
 	"react-native": "../dist/cjs/lex-v2/index.js",
-	"typings": "../dist/esm/lex-v2/index.d.ts"
+	"typings": "../dist/esm/lex-v2/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/interactions/lex-v2"
+	}
 }

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -56,7 +56,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/interactions"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/notifications/in-app-messaging/package.json
+++ b/packages/notifications/in-app-messaging/package.json
@@ -4,5 +4,11 @@
 	"browser": "../dist/esm/inAppMessaging/index.mjs",
 	"module": "../dist/esm/inAppMessaging/index.mjs",
 	"react-native": "../dist/cjs/inAppMessaging/index.js",
-	"typings": "../dist/esm/inAppMessaging/index.d.ts"
+	"typings": "../dist/esm/inAppMessaging/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/notifications/in-app-messaging"
+	}
 }

--- a/packages/notifications/in-app-messaging/pinpoint/package.json
+++ b/packages/notifications/in-app-messaging/pinpoint/package.json
@@ -4,5 +4,11 @@
 	"browser": "../../dist/esm/inAppMessaging/providers/pinpoint/index.mjs",
 	"module": "../../dist/esm/inAppMessaging/providers/pinpoint/index.mjs",
 	"react-native": "../../dist/cjs/inAppMessaging/providers/pinpoint/index.js",
-	"typings": "../../dist/esm/inAppMessaging/providers/pinpoint/index.d.ts"
+	"typings": "../../dist/esm/inAppMessaging/providers/pinpoint/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/notifications/in-app-messaging/pinpoint"
+	}
 }

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -75,14 +75,15 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/notifications"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",
 	"bugs": {
 		"url": "https://github.com/aws/aws-amplify/issues"
 	},
-	"homepage": "https://docs.amplify.aws/",
+	"homepage": "https://aws-amplify.github.io/",
 	"files": [
 		"dist/cjs",
 		"dist/esm",

--- a/packages/notifications/push-notifications/package.json
+++ b/packages/notifications/push-notifications/package.json
@@ -4,5 +4,11 @@
 	"browser": "../dist/esm/pushNotifications/index.mjs",
 	"module": "../dist/esm/pushNotifications/index.mjs",
 	"react-native": "../dist/cjs/pushNotifications/index.js",
-	"typings": "../dist/esm/pushNotifications/index.d.ts"
+	"typings": "../dist/esm/pushNotifications/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/notifications/push-notifications"
+	}
 }

--- a/packages/notifications/push-notifications/pinpoint/package.json
+++ b/packages/notifications/push-notifications/pinpoint/package.json
@@ -4,5 +4,11 @@
 	"browser": "../../dist/esm/pushNotifications/providers/pinpoint/index.mjs",
 	"module": "../../dist/esm/pushNotifications/providers/pinpoint/index.mjs",
 	"react-native": "../../dist/cjs/pushNotifications/providers/pinpoint/index.js",
-	"typings": "../../dist/esm/pushNotifications/providers/pinpoint/index.d.ts"
+	"typings": "../../dist/esm/pushNotifications/providers/pinpoint/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/notifications/push-notifications/pinpoint"
+	}
 }

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -29,7 +29,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/predictions"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/pubsub/internals/package.json
+++ b/packages/pubsub/internals/package.json
@@ -4,5 +4,11 @@
 	"main": "../dist/cjs/internals/index.js",
 	"module": "../dist/esm/internals/index.mjs",
 	"react-native": "../dist/cjs/internals/index.js",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/pubsub/internals"
+	}
 }

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -57,7 +57,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/pubsub"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/react-native/example/package.json
+++ b/packages/react-native/example/package.json
@@ -33,5 +33,11 @@
 			"**/react-native",
 			"**/react-native/**"
 		]
+	},
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/react-native/example"
 	}
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -53,14 +53,15 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/react-native"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",
 	"bugs": {
 		"url": "https://github.com/aws-amplify/amplify-js/issues"
 	},
-	"homepage": "https://docs.amplify.aws/",
+	"homepage": "https://aws-amplify.github.io/",
 	"files": [
 		"Amplify*.podspec",
 		"android",

--- a/packages/rtn-passkeys/example/package.json
+++ b/packages/rtn-passkeys/example/package.json
@@ -40,5 +40,11 @@
 			"**/@react-native/codegen",
 			"**/@react-native/codegen/**"
 		]
+	},
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/rtn-passkeys/example"
 	}
 }

--- a/packages/rtn-passkeys/package.json
+++ b/packages/rtn-passkeys/package.json
@@ -47,14 +47,15 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/rtn-passkeys"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",
 	"bugs": {
 		"url": "https://github.com/aws/aws-amplify/issues"
 	},
-	"homepage": "https://docs.amplify.aws",
+	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
 		"react-native": "0.79.2",
 		"typescript": "^5.2.2"

--- a/packages/rtn-push-notification/package.json
+++ b/packages/rtn-push-notification/package.json
@@ -37,14 +37,15 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/rtn-push-notification"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",
 	"bugs": {
 		"url": "https://github.com/aws/aws-amplify/issues"
 	},
-	"homepage": "https://docs.amplify.aws/",
+	"homepage": "https://aws-amplify.github.io/",
 	"files": [
 		"Amplify*.podspec",
 		"android",

--- a/packages/rtn-web-browser/package.json
+++ b/packages/rtn-web-browser/package.json
@@ -31,14 +31,15 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/rtn-web-browser"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",
 	"bugs": {
 		"url": "https://github.com/aws/aws-amplify/issues"
 	},
-	"homepage": "https://docs.amplify.aws/",
+	"homepage": "https://aws-amplify.github.io/",
 	"files": [
 		"Amplify*.podspec",
 		"android",

--- a/packages/storage/internals/package.json
+++ b/packages/storage/internals/package.json
@@ -3,5 +3,11 @@
 	"types": "../dist/esm/internals/index.d.ts",
 	"main": "../dist/cjs/internals/index.js",
 	"module": "../dist/esm/internals/index.mjs",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/storage/internals"
+	}
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -53,7 +53,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aws-amplify/amplify-js.git"
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/storage"
 	},
 	"author": "Amazon Web Services",
 	"license": "Apache-2.0",

--- a/packages/storage/s3/package.json
+++ b/packages/storage/s3/package.json
@@ -4,5 +4,11 @@
 	"react-native": "../dist/cjs/providers/s3/index.js",
 	"browser": "../dist/esm/providers/s3/index.mjs",
 	"module": "../dist/esm/providers/s3/index.mjs",
-	"typings": "../dist/esm/providers/s3/index.d.ts"
+	"typings": "../dist/esm/providers/s3/index.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/storage/s3"
+	}
 }

--- a/packages/storage/s3/server/package.json
+++ b/packages/storage/s3/server/package.json
@@ -3,5 +3,11 @@
 	"main": "../../dist/cjs/providers/s3/server.js",
 	"browser": "../../dist/esm/providers/s3/server.mjs",
 	"module": "../../dist/esm/providers/s3/server.mjs",
-	"typings": "../../dist/esm/providers/s3/server.d.ts"
+	"typings": "../../dist/esm/providers/s3/server.d.ts",
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/storage/s3/server"
+	}
 }

--- a/packages/storage/server/package.json
+++ b/packages/storage/server/package.json
@@ -3,5 +3,11 @@
 	"types": "../dist/esm/server.d.ts",
 	"main": "../dist/cjs/server.js",
 	"module": "../dist/esm/server.mjs",
-	"sideEffects": false
+	"sideEffects": false,
+	"homepage": "https://aws-amplify.github.io/",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aws-amplify/amplify-js.git",
+		"directory": "packages/storage/server"
+	}
 }


### PR DESCRIPTION
#### Description of changes

Update `registry.directory` and `homepage` in `package.json` to link packages from npmjs.com and npmx.dev back to the right place in this monorepo.

#### Issue #, if available

#14790

#### Description of how you validated changes

CI

#### Checklist

- [x] PR description included
- [x] `yarn test` passes

#### Checklist for repo maintainers

- [x] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
