### PR TITLE
fix(storage): merge authenticated and group permissions in resolveLocationsForCurrentSession

### DIFF
--- a/.changeset/storage-merge-authenticated-and-group-permissions.md
+++ b/.changeset/storage-merge-authenticated-and-group-permissions.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/storage': patch
+---
+
+fix(storage): merge authenticated and group permissions in `resolveLocationsForCurrentSession` so `allow.authenticated` and `allow.groups(...)` access rules are additive for users in a Cognito group, matching IAM. Fixes StorageBrowser hiding folders and under-reporting permissions when both rule types apply (aws-amplify/amplify-ui#6930).

--- a/packages/storage/__tests__/internals/apis/listPaths/resolveLocationsForCurrentSession.test.ts
+++ b/packages/storage/__tests__/internals/apis/listPaths/resolveLocationsForCurrentSession.test.ts
@@ -66,6 +66,12 @@ describe('resolveLocationsForCurrentSession', () => {
 		expect(result).toEqual([
 			{
 				type: 'PREFIX',
+				permission: ['get', 'list', 'write'],
+				bucket: 'bucket1',
+				prefix: 'path1/*',
+			},
+			{
+				type: 'PREFIX',
 				permission: ['get', 'list', 'write', 'delete'],
 				bucket: 'bucket1',
 				prefix: 'path2/*',
@@ -81,7 +87,43 @@ describe('resolveLocationsForCurrentSession', () => {
 			userGroup: 'editor',
 		});
 
-		expect(result).toEqual([]);
+		expect(result).toEqual([
+			{
+				type: 'PREFIX',
+				permission: ['get', 'list', 'write'],
+				bucket: 'bucket1',
+				prefix: 'path1/*',
+			},
+		]);
+	});
+
+	it('should merge authenticated and group permissions (union, deduped) for paths with both rules', () => {
+		const result = resolveLocationsForCurrentSession({
+			buckets: {
+				bucket1: {
+					bucketName: 'bucket1',
+					region: 'region1',
+					paths: {
+						'foo/*': {
+							authenticated: ['list'],
+							groupsAdmins: ['get', 'list', 'write', 'delete'],
+						},
+					},
+				},
+			},
+			isAuthenticated: true,
+			identityId: '12345',
+			userGroup: 'Admins',
+		});
+
+		expect(result).toEqual([
+			{
+				type: 'PREFIX',
+				permission: ['list', 'get', 'write', 'delete'],
+				bucket: 'bucket1',
+				prefix: 'foo/*',
+			},
+		]);
 	});
 
 	it('should continue to next bucket when paths are not defined', () => {

--- a/packages/storage/src/internals/apis/listPaths/resolveLocationsForCurrentSession.ts
+++ b/packages/storage/src/internals/apis/listPaths/resolveLocationsForCurrentSession.ts
@@ -15,18 +15,30 @@ const resolvePermissions = (
 			permission: accessRule.guest,
 		};
 	}
+	const authenticatedPermission = accessRule.authenticated;
+
 	if (groups) {
 		const selectedKey = Object.keys(accessRule).find(access =>
 			access.includes(groups),
 		);
+		const groupPermission = selectedKey ? accessRule[selectedKey] : undefined;
+
+		if (!authenticatedPermission && !groupPermission) {
+			return { permission: undefined };
+		}
 
 		return {
-			permission: selectedKey ? accessRule[selectedKey] : undefined,
+			permission: [
+				...new Set([
+					...(authenticatedPermission ?? []),
+					...(groupPermission ?? []),
+				]),
+			],
 		};
 	}
 
 	return {
-		permission: accessRule.authenticated,
+		permission: authenticatedPermission,
 	};
 };
 


### PR DESCRIPTION
   ### Description of changes

   Fixes the permission resolution in resolveLocationsForCurrentSession (consumed by StorageBrowser's listPaths) so that allow.authenticated and allow.groups(...) access rules are treated as additive rather than mutually exclusive, matching how IAM evaluates the generated policies.

 Root cause. In packages/storage/src/internals/apis/listPaths/resolveLocationsForCurrentSession.ts, the resolvePermissions helper, when the current user was in a Cognito
   group, returned:
   - only the matched groups<Name> permissions, dropping authenticated entirely, or
   - undefined if the path had no matching groups<Name> rule — which removed the location from the returned list completely.

   This produced two user-visible bugs in StorageBrowser (Amplify Gen 2):

   1. Folders reachable only via allow.authenticated.to(['list']) disappeared as soon as the user belonged to any group — UI showed "No folders or files."
   2. On paths combining allow.authenticated.to(['list']) with allow.groups(['Admins']).to(['read','write','delete']), the permissions column showed "Read" only and the actions menu was disabled, even though IAM (and direct uploadData / remove calls) allowed write/delete.

Fix. Return the deduped union of authenticated and matching groups<Name> permissions when the user is in a group, so the two rule types are additive. The existing group-key lookup (access.includes(groups)) is preserved to minimize behavioral risk.

No public API changes; behavior change is confined to how per-location permissions are derived for authenticated users in a Cognito group.

  ### Issue #, if available

   Fixes aws-amplify/amplify-ui#6930

   Description of how you validated changes

   - Updated the two existing tests in resolveLocationsForCurrentSession.test.ts whose assertions encoded the old (buggy) override behavior:
   - 'should generate locations correctly when tokens are true & userGroup' now also expects path1/* (from authenticated) alongside path2/* (from groupsadmin), proving
   Issue 2's union semantics.
   - 'should return empty locations when tokens are true & bad userGroup' now expects path1/* to remain visible via authenticated, proving Issue 1 is fixed (folders no
   longer vanish when a group is set but no group rule matches).
   - Added one regression test: authenticated + group permissions merge as a deduped union on the same path.
   - Ran the affected suites locally:

    npx jest --rootDir packages/storage \
      __tests__/internals/apis/listPaths/resolveLocationsForCurrentSession.test.ts \
      __tests__/internals/apis/listPaths/listPaths.test.ts
    # Test Suites: 2 passed, 2 total
    # Tests:       10 passed, 10 total

   - listPaths.test.ts mocks resolveLocationsForCurrentSession, so its contract is unaffected — confirmed passing.
   - Pre-commit eslint --fix on both changed files passed with no modifications.

      ### Checklist

   - [x] PR description included
   - [x] yarn test passes (ran Jest for the affected packages/storage suites; 10/10 passing)
   - [x] Unit Tests are changed or added (2 existing assertions corrected + 1 new regression test)
   - [ ] Relevant documentation is changed or added (and PR referenced) — N/A: internal helper behavior fix, no public API or documented behavior change

      ###  Checklist for repo maintainers

   - [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
   - [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate — no new source file paths added

   By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.