### PR TITLE
feat(storage): add server uploadData storage api

### DIFF
--- a/.changeset/storage-server-upload-data.md
+++ b/.changeset/storage-server-upload-data.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/storage': minor
+'aws-amplify': minor
+---
+
+feat(storage): add server-side `uploadData` storage API.

--- a/packages/storage/__tests__/internals/apis/uploadData.test.ts
+++ b/packages/storage/__tests__/internals/apis/uploadData.test.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Amplify } from '@aws-amplify/core';
+
 import { uploadData as advancedUploadData } from '../../../src/internals';
 import { uploadData as uploadDataInternal } from '../../../src/providers/s3/apis/internal/uploadData';
 
@@ -54,7 +56,7 @@ describe('uploadData (internal)', () => {
 		});
 
 		expect(mockedUploadDataInternal).toHaveBeenCalledTimes(1);
-		expect(mockedUploadDataInternal).toHaveBeenCalledWith({
+		expect(mockedUploadDataInternal).toHaveBeenCalledWith(Amplify, {
 			path: 'input/path/to/mock/object',
 			data: 'data',
 			options: {

--- a/packages/storage/__tests__/providers/s3/apis/internal/uploadData/index.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/internal/uploadData/index.test.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyClassV6 } from '@aws-amplify/core';
+
 import { uploadData } from '../../../../../../src/providers/s3/apis/internal/uploadData';
 import { MAX_OBJECT_SIZE } from '../../../../../../src/providers/s3/utils/constants';
 import { createUploadTask } from '../../../../../../src/providers/s3/utils';
@@ -22,6 +24,8 @@ jest.mock(
 jest.mock(
 	'../../../../../../src/providers/s3/apis/internal/uploadData/multipart',
 );
+
+const mockAmplifyInstance = {} as AmplifyClassV6;
 
 const testPath = 'testPath/object';
 const validBucketOwner = '111122223333';
@@ -48,7 +52,7 @@ describe('uploadData with key', () => {
 				key: 'key',
 				data: { size: MAX_OBJECT_SIZE + 1 } as any,
 			};
-			expect(() => uploadData(mockUploadInput)).toThrow(
+			expect(() => uploadData(mockAmplifyInstance, mockUploadInput)).toThrow(
 				expect.objectContaining(
 					validationErrorMap[StorageValidationErrorCode.ObjectIsTooLarge],
 				),
@@ -57,7 +61,7 @@ describe('uploadData with key', () => {
 
 		it('should throw if data size is unknown', async () => {
 			expect(() =>
-				uploadData({
+				uploadData(mockAmplifyInstance, {
 					key: 'key',
 					data: {} as any,
 				}),
@@ -72,7 +76,7 @@ describe('uploadData with key', () => {
 	describe('use putObject for small uploads', () => {
 		const smallData = { size: 5 * 1024 * 1024 } as any;
 		it('should use putObject if data size is <= 5MB', async () => {
-			uploadData({
+			uploadData(mockAmplifyInstance, {
 				key: 'key',
 				data: smallData,
 			});
@@ -86,9 +90,10 @@ describe('uploadData with key', () => {
 				data: '', // 0 bytes
 			};
 
-			uploadData(testInput);
+			uploadData(mockAmplifyInstance, testInput);
 
 			expect(mockPutObjectJob).toHaveBeenCalledWith(
+				mockAmplifyInstance,
 				expect.objectContaining(testInput),
 				expect.any(AbortSignal),
 				expect.any(Number),
@@ -99,7 +104,7 @@ describe('uploadData with key', () => {
 		it('should use uploadTask', async () => {
 			mockPutObjectJob.mockReturnValueOnce('putObjectJob');
 			mockCreateUploadTask.mockReturnValueOnce('uploadTask');
-			const task = uploadData({
+			const task = uploadData(mockAmplifyInstance, {
 				key: 'key',
 				data: smallData,
 			});
@@ -117,7 +122,7 @@ describe('uploadData with key', () => {
 	describe('use multipartUpload for large uploads', () => {
 		const biggerData = { size: 5 * 1024 * 1024 + 1 } as any;
 		it('should use multipartUpload if data size is > 5MB', async () => {
-			uploadData({
+			uploadData(mockAmplifyInstance, {
 				key: 'key',
 				data: biggerData,
 			});
@@ -127,7 +132,7 @@ describe('uploadData with key', () => {
 
 		it('should use uploadTask', async () => {
 			mockCreateUploadTask.mockReturnValueOnce('uploadTask');
-			const task = uploadData({
+			const task = uploadData(mockAmplifyInstance, {
 				key: 'key',
 				data: biggerData,
 			});
@@ -144,7 +149,7 @@ describe('uploadData with key', () => {
 		});
 
 		it('should call getMultipartUploadHandlers', async () => {
-			uploadData({
+			uploadData(mockAmplifyInstance, {
 				key: 'key',
 				data: biggerData,
 			});
@@ -164,7 +169,7 @@ describe('uploadData with path', () => {
 				path: testPath,
 				data: { size: MAX_OBJECT_SIZE + 1 } as any,
 			};
-			expect(() => uploadData(mockUploadInput)).toThrow(
+			expect(() => uploadData(mockAmplifyInstance, mockUploadInput)).toThrow(
 				expect.objectContaining(
 					validationErrorMap[StorageValidationErrorCode.ObjectIsTooLarge],
 				),
@@ -173,7 +178,7 @@ describe('uploadData with path', () => {
 
 		it('should throw if data size is unknown', async () => {
 			expect(() =>
-				uploadData({
+				uploadData(mockAmplifyInstance, {
 					path: testPath,
 					data: {} as any,
 				}),
@@ -203,9 +208,10 @@ describe('uploadData with path', () => {
 					data: smallData,
 				};
 
-				uploadData(testInput);
+				uploadData(mockAmplifyInstance, testInput);
 
 				expect(mockPutObjectJob).toHaveBeenCalledWith(
+					mockAmplifyInstance,
 					expect.objectContaining(testInput),
 					expect.any(AbortSignal),
 					expect.any(Number),
@@ -220,9 +226,10 @@ describe('uploadData with path', () => {
 				data: '', // 0 bytes
 			};
 
-			uploadData(testInput);
+			uploadData(mockAmplifyInstance, testInput);
 
 			expect(mockPutObjectJob).toHaveBeenCalledWith(
+				mockAmplifyInstance,
 				expect.objectContaining(testInput),
 				expect.any(AbortSignal),
 				expect.any(Number),
@@ -234,7 +241,7 @@ describe('uploadData with path', () => {
 			mockPutObjectJob.mockReturnValueOnce('putObjectJob');
 			mockCreateUploadTask.mockReturnValueOnce('uploadTask');
 
-			const task = uploadData({
+			const task = uploadData(mockAmplifyInstance, {
 				path: testPath,
 				data: smallData,
 			});
@@ -258,10 +265,11 @@ describe('uploadData with path', () => {
 				data: biggerData,
 			};
 
-			uploadData(testInput);
+			uploadData(mockAmplifyInstance, testInput);
 
 			expect(mockPutObjectJob).not.toHaveBeenCalled();
 			expect(mockGetMultipartUploadHandlers).toHaveBeenCalledWith(
+				mockAmplifyInstance,
 				expect.objectContaining(testInput),
 				expect.any(Number),
 			);
@@ -269,7 +277,7 @@ describe('uploadData with path', () => {
 
 		it('should use uploadTask', async () => {
 			mockCreateUploadTask.mockReturnValueOnce('uploadTask');
-			const task = uploadData({
+			const task = uploadData(mockAmplifyInstance, {
 				path: testPath,
 				data: biggerData,
 			});
@@ -290,7 +298,7 @@ describe('uploadData with path', () => {
 		it('should include expectedBucketOwner in headers when provided for singlepartUpload', async () => {
 			mockPutObjectJob.mockReturnValueOnce('putObjectJob');
 			const smallData = 'smallData';
-			uploadData({
+			uploadData(mockAmplifyInstance, {
 				path: testPath,
 				data: smallData,
 				options: {
@@ -298,6 +306,7 @@ describe('uploadData with path', () => {
 				},
 			});
 			expect(mockPutObjectJob).toHaveBeenCalledWith(
+				mockAmplifyInstance,
 				expect.objectContaining({
 					path: 'testPath/object',
 					data: 'smallData',
@@ -320,8 +329,9 @@ describe('uploadData with path', () => {
 					expectedBucketOwner: validBucketOwner,
 				},
 			};
-			uploadData(testInput);
+			uploadData(mockAmplifyInstance, testInput);
 			expect(mockGetMultipartUploadHandlers).toHaveBeenCalledWith(
+				mockAmplifyInstance,
 				{
 					...testInput,
 					options: expect.objectContaining(testInput.options),

--- a/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/internal/uploadData/multipartHandlers.test.ts
@@ -190,6 +190,7 @@ describe('getMultipartUploadHandlers with key', () => {
 
 	it('should return multipart upload handlers', async () => {
 		const multipartUploadHandlers = getMultipartUploadHandlers(
+			Amplify,
 			{
 				key: defaultKey,
 				data: { size: 5 * 1024 * 1024 } as any,
@@ -235,6 +236,7 @@ describe('getMultipartUploadHandlers with key', () => {
 				async (_, twoPartsPayload) => {
 					mockMultipartUploadSuccess();
 					const { multipartUploadJob } = getMultipartUploadHandlers(
+						Amplify,
 						{
 							key: defaultKey,
 							data: twoPartsPayload,
@@ -293,6 +295,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			async (_, twoPartsPayload, expectedCrc32, finalCrc32) => {
 				mockMultipartUploadSuccess();
 				const { multipartUploadJob } = getMultipartUploadHandlers(
+					Amplify,
 					{
 						key: defaultKey,
 						data: twoPartsPayload,
@@ -341,6 +344,7 @@ describe('getMultipartUploadHandlers with key', () => {
 				},
 			};
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new Uint8Array(8 * MB),
@@ -356,6 +360,7 @@ describe('getMultipartUploadHandlers with key', () => {
 		it('should throw if unsupported payload type is provided', async () => {
 			mockMultipartUploadSuccess();
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: 1 as any,
@@ -388,6 +393,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			} as any as File;
 			mockMultipartUploadSuccess();
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: file,
@@ -417,6 +423,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			});
 
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(8 * MB),
@@ -440,6 +447,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockCreateMultipartUpload.mockRejectedValueOnce(new Error('error'));
 
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(8 * MB),
@@ -456,6 +464,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockCompleteMultipartUpload.mockRejectedValueOnce(new Error('error'));
 
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(8 * MB),
@@ -477,6 +486,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockUploadPart.mockRejectedValueOnce(new Error('error'));
 
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(8 * MB),
@@ -495,6 +505,7 @@ describe('getMultipartUploadHandlers with key', () => {
 				const mockRegion = 'region-1';
 				mockMultipartUploadSuccess();
 				const { multipartUploadJob } = getMultipartUploadHandlers(
+					Amplify,
 					{
 						key: 'key',
 						data: mockData,
@@ -524,6 +535,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			it('should override bucket in putObject call when bucket as string', async () => {
 				mockMultipartUploadSuccess();
 				const { multipartUploadJob } = getMultipartUploadHandlers(
+					Amplify,
 					{
 						key: 'key',
 						data: mockData,
@@ -585,6 +597,7 @@ describe('getMultipartUploadHandlers with key', () => {
 
 				const onProgress = jest.fn();
 				const { multipartUploadJob } = getMultipartUploadHandlers(
+					Amplify,
 					{
 						key: defaultKey,
 						data: new ArrayBuffer(8 * MB),
@@ -616,6 +629,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockMultipartUploadSuccess();
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(size),
@@ -645,6 +659,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			};
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(size),
@@ -669,6 +684,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockMultipartUploadSuccess();
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(size),
@@ -700,6 +716,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(size),
@@ -721,6 +738,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new File([new ArrayBuffer(size)], 'someName'),
@@ -759,6 +777,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new File([new ArrayBuffer(size)], 'someName'),
@@ -791,6 +810,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(size),
@@ -812,6 +832,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(size),
@@ -842,6 +863,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(size),
@@ -867,6 +889,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(size),
@@ -891,6 +914,7 @@ describe('getMultipartUploadHandlers with key', () => {
 	describe('cancel()', () => {
 		it('should abort in-flight uploadPart requests and throw if upload is canceled', async () => {
 			const { multipartUploadJob, onCancel } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(8 * MB),
@@ -931,6 +955,7 @@ describe('getMultipartUploadHandlers with key', () => {
 
 			const { multipartUploadJob, onPause, onResume } =
 				getMultipartUploadHandlers(
+					Amplify,
 					{
 						key: defaultKey,
 						data: new ArrayBuffer(8 * MB),
@@ -963,6 +988,7 @@ describe('getMultipartUploadHandlers with key', () => {
 			const onProgress = jest.fn();
 			mockMultipartUploadSuccess();
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(8 * MB),
@@ -1013,6 +1039,7 @@ describe('getMultipartUploadHandlers with key', () => {
 
 			const onProgress = jest.fn();
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					key: defaultKey,
 					data: new ArrayBuffer(8 * MB),
@@ -1059,6 +1086,7 @@ describe('getMultipartUploadHandlers with path', () => {
 
 	it('should return multipart upload handlers', async () => {
 		const multipartUploadHandlers = getMultipartUploadHandlers(
+			Amplify,
 			{
 				path: testPath,
 				data: { size: 5 * 1024 * 1024 } as any,
@@ -1097,6 +1125,7 @@ describe('getMultipartUploadHandlers with path', () => {
 				async (_, twoPartsPayload) => {
 					mockMultipartUploadSuccess();
 					const { multipartUploadJob } = getMultipartUploadHandlers(
+						Amplify,
 						{
 							path: inputPath,
 							data: twoPartsPayload,
@@ -1154,6 +1183,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			async (_, twoPartsPayload, expectedCrc32, finalCrc32) => {
 				mockMultipartUploadSuccess();
 				const { multipartUploadJob } = getMultipartUploadHandlers(
+					Amplify,
 					{
 						path: testPath,
 						data: twoPartsPayload,
@@ -1202,6 +1232,7 @@ describe('getMultipartUploadHandlers with path', () => {
 				},
 			};
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new Uint8Array(8 * MB),
@@ -1217,6 +1248,7 @@ describe('getMultipartUploadHandlers with path', () => {
 		it('should throw if unsupported payload type is provided', async () => {
 			mockMultipartUploadSuccess();
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: 1 as any,
@@ -1249,6 +1281,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			} as any as File;
 			mockMultipartUploadSuccess();
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: file,
@@ -1278,6 +1311,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			});
 
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(8 * MB),
@@ -1301,6 +1335,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockCreateMultipartUpload.mockRejectedValueOnce(new Error('error'));
 
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(8 * MB),
@@ -1317,6 +1352,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockCompleteMultipartUpload.mockRejectedValueOnce(new Error('error'));
 
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(8 * MB),
@@ -1338,6 +1374,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockUploadPart.mockRejectedValueOnce(new Error('error'));
 
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(8 * MB),
@@ -1355,6 +1392,7 @@ describe('getMultipartUploadHandlers with path', () => {
 				mockMultipartUploadSuccess();
 
 				const { multipartUploadJob } = getMultipartUploadHandlers(
+					Amplify,
 					{
 						path: testPath,
 						data: new ArrayBuffer(8 * MB),
@@ -1385,6 +1423,7 @@ describe('getMultipartUploadHandlers with path', () => {
 				const mockRegion = 'region-1';
 				mockMultipartUploadSuccess();
 				const { multipartUploadJob } = getMultipartUploadHandlers(
+					Amplify,
 					{
 						path: 'path/',
 						data: mockData,
@@ -1416,6 +1455,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			it('should override bucket in putObject call when bucket as string', async () => {
 				mockMultipartUploadSuccess();
 				const { multipartUploadJob } = getMultipartUploadHandlers(
+					Amplify,
 					{
 						path: 'path/',
 						data: mockData,
@@ -1480,6 +1520,7 @@ describe('getMultipartUploadHandlers with path', () => {
 
 				const onProgress = jest.fn();
 				const { multipartUploadJob } = getMultipartUploadHandlers(
+					Amplify,
 					{
 						path: testPath,
 						data: new ArrayBuffer(8 * MB),
@@ -1511,6 +1552,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockMultipartUploadSuccess();
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(size),
@@ -1528,6 +1570,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockMultipartUploadSuccess();
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(size),
@@ -1560,6 +1603,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			};
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(size),
@@ -1595,6 +1639,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(size),
@@ -1616,6 +1661,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new File([new ArrayBuffer(size)], 'someName'),
@@ -1655,6 +1701,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new File([new ArrayBuffer(size)], 'someName'),
@@ -1687,6 +1734,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(size),
@@ -1708,6 +1756,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(size),
@@ -1736,6 +1785,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(size),
@@ -1761,6 +1811,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			mockListParts.mockResolvedValueOnce({ Parts: [], $metadata: {} });
 			const size = 8 * MB;
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(size),
@@ -1785,6 +1836,7 @@ describe('getMultipartUploadHandlers with path', () => {
 	describe('cancel()', () => {
 		it('should abort in-flight uploadPart requests and throw if upload is canceled', async () => {
 			const { multipartUploadJob, onCancel } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(8 * MB),
@@ -1824,6 +1876,7 @@ describe('getMultipartUploadHandlers with path', () => {
 
 			const { multipartUploadJob, onPause, onResume } =
 				getMultipartUploadHandlers(
+					Amplify,
 					{
 						path: testPath,
 						data: new ArrayBuffer(8 * MB),
@@ -1857,6 +1910,7 @@ describe('getMultipartUploadHandlers with path', () => {
 			const onProgress = jest.fn();
 			mockMultipartUploadSuccess();
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(8 * MB),
@@ -1908,6 +1962,7 @@ describe('getMultipartUploadHandlers with path', () => {
 
 			const onProgress = jest.fn();
 			const { multipartUploadJob } = getMultipartUploadHandlers(
+				Amplify,
 				{
 					path: testPath,
 					data: new ArrayBuffer(8 * MB),

--- a/packages/storage/__tests__/providers/s3/apis/internal/uploadData/putObjectJob.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/internal/uploadData/putObjectJob.test.ts
@@ -88,6 +88,7 @@ describe('putObjectJob with key', () => {
 			const useAccelerateEndpoint = true;
 
 			const job = putObjectJob(
+				Amplify,
 				{
 					key: inputKey,
 					data,
@@ -155,6 +156,7 @@ describe('putObjectJob with key', () => {
 			},
 		};
 		const job = putObjectJob(
+			Amplify,
 			{
 				key: 'key',
 				data: 'data',
@@ -173,6 +175,7 @@ describe('putObjectJob with key', () => {
 			const mockRegion = 'region-1';
 
 			const job = putObjectJob(
+				Amplify,
 				{
 					key: 'key',
 					data,
@@ -207,6 +210,7 @@ describe('putObjectJob with key', () => {
 		it('should override bucket in putObject call when bucket as string', async () => {
 			const abortController = new AbortController();
 			const job = putObjectJob(
+				Amplify,
 				{
 					key: 'key',
 					data,
@@ -239,6 +243,7 @@ describe('putObjectJob with key', () => {
 	describe('cacheControl passed in option', () => {
 		it('should include CacheControl header', async () => {
 			const job = putObjectJob(
+				Amplify,
 				{
 					path: testPath,
 					data,
@@ -309,6 +314,7 @@ describe('putObjectJob with path', () => {
 			const useAccelerateEndpoint = true;
 
 			const job = putObjectJob(
+				Amplify,
 				{
 					path: inputPath,
 					data,
@@ -376,6 +382,7 @@ describe('putObjectJob with path', () => {
 			},
 		};
 		const job = putObjectJob(
+			Amplify,
 			{
 				path: testPath,
 				data,
@@ -390,6 +397,7 @@ describe('putObjectJob with path', () => {
 	describe('overwrite prevention', () => {
 		it('should include if-none-match header', async () => {
 			const job = putObjectJob(
+				Amplify,
 				{
 					path: testPath,
 					data,
@@ -416,6 +424,7 @@ describe('putObjectJob with path', () => {
 			const mockRegion = 'region-1';
 
 			const job = putObjectJob(
+				Amplify,
 				{
 					path: 'path/',
 					data,
@@ -450,6 +459,7 @@ describe('putObjectJob with path', () => {
 		it('should override bucket in putObject call when bucket as string', async () => {
 			const abortController = new AbortController();
 			const job = putObjectJob(
+				Amplify,
 				{
 					path: 'path/',
 					data,
@@ -482,6 +492,7 @@ describe('putObjectJob with path', () => {
 			const abortController = new AbortController();
 			const testData = 'data';
 			const job = putObjectJob(
+				Amplify,
 				{
 					key: 'image.jpg',
 					data: testData,
@@ -503,6 +514,7 @@ describe('putObjectJob with path', () => {
 			const abortController = new AbortController();
 			const file = new File(['content'], 'test.png', { type: 'image/png' });
 			const job = putObjectJob(
+				Amplify,
 				{
 					key: 'test.jpg', // Different extension to test File.type takes precedence
 					data: file,
@@ -524,6 +536,7 @@ describe('putObjectJob with path', () => {
 			const abortController = new AbortController();
 			const testData = 'data';
 			const job = putObjectJob(
+				Amplify,
 				{
 					key: 'image.jpg',
 					data: testData,
@@ -548,6 +561,7 @@ describe('putObjectJob with path', () => {
 	describe('cacheControl passed in option', () => {
 		it('should include CacheControl header', async () => {
 			const job = putObjectJob(
+				Amplify,
 				{
 					path: testPath,
 					data,
@@ -570,6 +584,7 @@ describe('putObjectJob with path', () => {
 
 		it('should NOT include CacheControl header', async () => {
 			const job = putObjectJob(
+				Amplify,
 				{
 					path: testPath,
 					data,

--- a/packages/storage/__tests__/providers/s3/apis/server/uploadData.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/server/uploadData.test.ts
@@ -1,0 +1,81 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getAmplifyServerContext } from '@aws-amplify/core/internals/adapter-core';
+
+import { UploadDataInput, UploadDataWithPathInput } from '../../../../../src';
+import { uploadData } from '../../../../../src/providers/s3/apis/server';
+import { uploadData as internalUploadDataImpl } from '../../../../../src/providers/s3/apis/internal/uploadData';
+
+jest.mock('../../../../../src/providers/s3/apis/internal/uploadData');
+jest.mock('@aws-amplify/core/internals/adapter-core');
+
+const mockInternalUploadDataImpl = jest.mocked(internalUploadDataImpl);
+const mockGetAmplifyServerContext = jest.mocked(getAmplifyServerContext);
+const mockInternalResult = 'UPLOAD_TASK' as any;
+const mockAmplifyClass = 'AMPLIFY_CLASS' as any;
+const mockAmplifyContextSpec = {
+	token: { value: Symbol('123') },
+};
+
+describe('server-side uploadData', () => {
+	beforeEach(() => {
+		mockGetAmplifyServerContext.mockReturnValue({
+			amplify: mockAmplifyClass,
+		} as any);
+		mockInternalUploadDataImpl.mockReturnValue(mockInternalResult);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should pass through input with path and return output from internal implementation', () => {
+		const input: UploadDataWithPathInput = {
+			path: 'path/to/object',
+			data: 'data',
+			options: {
+				contentType: 'text/plain',
+			},
+		};
+		expect(uploadData(mockAmplifyContextSpec as any, input)).toEqual(
+			mockInternalResult,
+		);
+		expect(mockInternalUploadDataImpl).toBeCalledWith(mockAmplifyClass, input);
+	});
+
+	it('should pass through input with key and return output from internal implementation', () => {
+		const input: UploadDataInput = {
+			key: 'some-key',
+			data: 'data',
+			options: {
+				accessLevel: 'protected' as const,
+			},
+		};
+		expect(uploadData(mockAmplifyContextSpec as any, input)).toEqual(
+			mockInternalResult,
+		);
+		expect(mockInternalUploadDataImpl).toBeCalledWith(mockAmplifyClass, input);
+	});
+
+	it('should NOT inject resumableUploadsCache (server-side does not support pause/resume)', () => {
+		const input: UploadDataWithPathInput = {
+			path: 'path/to/object',
+			data: 'data',
+		};
+		uploadData(mockAmplifyContextSpec as any, input);
+		const passedInput = mockInternalUploadDataImpl.mock.calls[0][1] as any;
+		expect(passedInput.options?.resumableUploadsCache).toBeUndefined();
+	});
+
+	it('should use server context amplify instance, not global Amplify', () => {
+		const input: UploadDataWithPathInput = {
+			path: 'path/to/object',
+			data: 'data',
+		};
+		uploadData(mockAmplifyContextSpec as any, input);
+		expect(mockGetAmplifyServerContext).toBeCalledWith(mockAmplifyContextSpec);
+		// Ensure the amplify passed to internal uploadData is from the server context
+		expect(mockInternalUploadDataImpl.mock.calls[0][0]).toBe(mockAmplifyClass);
+	});
+});

--- a/packages/storage/__tests__/providers/s3/apis/server/uploadData.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/server/uploadData.test.ts
@@ -3,7 +3,12 @@
 
 import { getAmplifyServerContext } from '@aws-amplify/core/internals/adapter-core';
 
-import { UploadDataInput, UploadDataWithPathInput } from '../../../../../src';
+import {
+	UploadDataInput,
+	UploadDataServerOutput,
+	UploadDataServerWithPathOutput,
+	UploadDataWithPathInput,
+} from '../../../../../src';
 import { uploadData } from '../../../../../src/providers/s3/apis/server';
 import { uploadData as internalUploadDataImpl } from '../../../../../src/providers/s3/apis/internal/uploadData';
 
@@ -12,7 +17,13 @@ jest.mock('@aws-amplify/core/internals/adapter-core');
 
 const mockInternalUploadDataImpl = jest.mocked(internalUploadDataImpl);
 const mockGetAmplifyServerContext = jest.mocked(getAmplifyServerContext);
-const mockInternalResult = 'UPLOAD_TASK' as any;
+const mockInternalResult: any = {
+	cancel: jest.fn(),
+	pause: jest.fn(),
+	resume: jest.fn(),
+	state: 'IN_PROGRESS',
+	result: Promise.resolve({ path: 'x' }),
+};
 const mockAmplifyClass = 'AMPLIFY_CLASS' as any;
 const mockAmplifyContextSpec = {
 	token: { value: Symbol('123') },
@@ -77,5 +88,34 @@ describe('server-side uploadData', () => {
 		expect(mockGetAmplifyServerContext).toBeCalledWith(mockAmplifyContextSpec);
 		// Ensure the amplify passed to internal uploadData is from the server context
 		expect(mockInternalUploadDataImpl.mock.calls[0][0]).toBe(mockAmplifyClass);
+	});
+
+	it('should return a task type that does NOT expose pause/resume at the type level', () => {
+		const withPathInput: UploadDataWithPathInput = {
+			path: 'path/to/object',
+			data: 'data',
+		};
+		const withKeyInput: UploadDataInput = { key: 'k', data: 'd' };
+
+		// Compile-time type assertions: the returned types should be the server
+		// (non-pausable) outputs. If uploadData returned UploadDataOutput /
+		// UploadDataWithPathOutput instead, these assignments would still
+		// compile because UploadTask is a supertype — so we also rely on the
+		// commented-out pause/resume lines below, which MUST fail to compile.
+		const pathTask: UploadDataServerWithPathOutput = uploadData(
+			mockAmplifyContextSpec as any,
+			withPathInput,
+		);
+		const keyTask: UploadDataServerOutput = uploadData(
+			mockAmplifyContextSpec as any,
+			withKeyInput,
+		);
+
+		// pause/resume are intentionally absent from the type and would cause a
+		// TS2339 error if uncommented:
+		//   pathTask.pause();
+		//   pathTask.resume();
+		expect(typeof pathTask.cancel).toBe('function');
+		expect(typeof keyTask.cancel).toBe('function');
 	});
 });

--- a/packages/storage/__tests__/providers/s3/apis/uploadData.test.ts
+++ b/packages/storage/__tests__/providers/s3/apis/uploadData.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { defaultStorage } from '@aws-amplify/core';
+import { Amplify, defaultStorage } from '@aws-amplify/core';
 
 import { uploadData } from '../../../../src/providers/s3/apis';
 import { uploadData as internalUploadDataImpl } from '../../../../src/providers/s3/apis/internal/uploadData';
@@ -26,7 +26,7 @@ describe('client-side uploadData', () => {
 			},
 		};
 		expect(uploadData(input)).toEqual(mockInternalResult);
-		expect(mockInternalUploadDataImpl).toBeCalledWith({
+		expect(mockInternalUploadDataImpl).toBeCalledWith(Amplify, {
 			...input,
 			options: {
 				...input.options,
@@ -46,7 +46,7 @@ describe('client-side uploadData', () => {
 			},
 		};
 		expect(uploadData(input)).toEqual(mockInternalResult);
-		expect(mockInternalUploadDataImpl).toBeCalledWith({
+		expect(mockInternalUploadDataImpl).toBeCalledWith(Amplify, {
 			...input,
 			options: {
 				...input.options,

--- a/packages/storage/__tests__/providers/s3/utils/readFile.test.ts
+++ b/packages/storage/__tests__/providers/s3/utils/readFile.test.ts
@@ -87,4 +87,28 @@ describe('readFile', () => {
 		expect(result).toBe(mockArrayBuffer);
 		expect(result.byteLength).toBe(1024 * 1024 * 10);
 	});
+
+	describe('when FileReader is unavailable (server-side)', () => {
+		const originalFileReader = (global as any).FileReader;
+
+		beforeEach(() => {
+			delete (global as any).FileReader;
+		});
+
+		afterEach(() => {
+			(global as any).FileReader = originalFileReader;
+		});
+
+		it('should fall back to Blob.arrayBuffer()', async () => {
+			const mockArrayBuffer = new ArrayBuffer(12);
+			const mockBlob = {
+				arrayBuffer: jest.fn().mockResolvedValue(mockArrayBuffer),
+			} as unknown as Blob;
+
+			const result = await readFile(mockBlob);
+
+			expect(mockBlob.arrayBuffer).toHaveBeenCalled();
+			expect(result).toBe(mockArrayBuffer);
+		});
+	});
 });

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -33,6 +33,8 @@ export {
 export {
 	UploadDataOutput,
 	UploadDataWithPathOutput,
+	UploadDataServerOutput,
+	UploadDataServerWithPathOutput,
 	DownloadDataOutput,
 	DownloadDataWithPathOutput,
 	RemoveOutput,

--- a/packages/storage/src/internals/apis/uploadData.ts
+++ b/packages/storage/src/internals/apis/uploadData.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Amplify } from '@aws-amplify/core';
+
 import { UploadDataInput } from '../types/inputs';
 import { UploadDataOutput } from '../types/outputs';
 import { uploadData as uploadDataInternal } from '../../providers/s3/apis/internal/uploadData';
@@ -11,7 +13,7 @@ import { uploadData as uploadDataInternal } from '../../providers/s3/apis/intern
 export const uploadData = (input: UploadDataInput) => {
 	const { data, path, options } = input;
 
-	return uploadDataInternal({
+	return uploadDataInternal(Amplify, {
 		path,
 		data,
 		options: {

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/index.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/index.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyClassV6 } from '@aws-amplify/core';
+
 import { createUploadTask } from '../../../utils';
 import { assertValidationError } from '../../../../../errors/utils/assertValidationError';
 import { StorageValidationErrorCode } from '../../../../../errors/types/validation';
@@ -14,6 +16,7 @@ import {
 } from './multipart';
 
 export const uploadData = (
+	amplify: AmplifyClassV6,
 	input: SinglePartUploadDataInput | MultipartUploadDataInput,
 ) => {
 	const { data } = input;
@@ -36,7 +39,7 @@ export const uploadData = (
 
 		return createUploadTask({
 			isMultipartUpload: false,
-			job: putObjectJob(input, abortController.signal, dataByteLength),
+			job: putObjectJob(amplify, input, abortController.signal, dataByteLength),
 			onCancel: (message?: string) => {
 				abortController.abort(message);
 			},
@@ -44,7 +47,7 @@ export const uploadData = (
 	} else {
 		// Multipart upload
 		const { multipartUploadJob, onPause, onResume, onCancel } =
-			getMultipartUploadHandlers(input, dataByteLength);
+			getMultipartUploadHandlers(amplify, input, dataByteLength);
 
 		return createUploadTask({
 			isMultipartUpload: true,

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/multipart/uploadHandlers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-	Amplify,
+	AmplifyClassV6,
 	KeyValueStorageInterface,
 	StorageAccessLevel,
 } from '@aws-amplify/core';
@@ -86,6 +86,7 @@ export type MultipartUploadDataInput = WithResumableCacheConfig<
  * @internal
  */
 export const getMultipartUploadHandlers = (
+	amplify: AmplifyClassV6,
 	uploadDataInput: MultipartUploadDataInput,
 	size: number,
 ) => {
@@ -119,7 +120,7 @@ export const getMultipartUploadHandlers = (
 	const startUpload = async (): Promise<ItemWithKey | ItemWithPath> => {
 		const { options: uploadDataOptions, data } = uploadDataInput;
 		const resolvedS3Options = await resolveS3ConfigAndInput(
-			Amplify,
+			amplify,
 			uploadDataInput,
 		);
 
@@ -155,7 +156,7 @@ export const getMultipartUploadHandlers = (
 
 			resolvedKeyPrefix = resolvedS3Options.keyPrefix;
 			finalKey = resolvedKeyPrefix + objectKey;
-			resolvedAccessLevel = resolveAccessLevel(accessLevel);
+			resolvedAccessLevel = resolveAccessLevel(amplify, accessLevel);
 		}
 
 		const optionsHash = await calculateContentCRC32(
@@ -364,9 +365,12 @@ export const getMultipartUploadHandlers = (
 	};
 };
 
-const resolveAccessLevel = (accessLevel?: StorageAccessLevel) =>
+const resolveAccessLevel = (
+	amplify: AmplifyClassV6,
+	accessLevel?: StorageAccessLevel,
+) =>
 	accessLevel ??
-	Amplify.libraryOptions.Storage?.S3?.defaultAccessLevel ??
+	amplify.libraryOptions.Storage?.S3?.defaultAccessLevel ??
 	DEFAULT_ACCESS_LEVEL;
 
 const validateCompletedParts = (completedParts: Part[], size: number) => {

--- a/packages/storage/src/providers/s3/apis/internal/uploadData/putObjectJob.ts
+++ b/packages/storage/src/providers/s3/apis/internal/uploadData/putObjectJob.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
+import { AmplifyClassV6 } from '@aws-amplify/core';
 import { StorageAction } from '@aws-amplify/core/internals/utils';
 
 import { UploadDataInput } from '../../../types';
@@ -42,6 +42,7 @@ export type SinglePartUploadDataInput =
  */
 export const putObjectJob =
 	(
+		amplify: AmplifyClassV6,
 		uploadDataInput: SinglePartUploadDataInput,
 		abortSignal: AbortSignal,
 		totalLength: number,
@@ -49,7 +50,7 @@ export const putObjectJob =
 	async (): Promise<ItemWithKey | ItemWithPath> => {
 		const { options: uploadDataOptions, data } = uploadDataInput;
 		const { bucket, keyPrefix, s3Config, isObjectLockEnabled, identityId } =
-			await resolveS3ConfigAndInput(Amplify, uploadDataInput);
+			await resolveS3ConfigAndInput(amplify, uploadDataInput);
 		const { inputType, objectKey } = validateStorageOperationInput(
 			uploadDataInput,
 			identityId,

--- a/packages/storage/src/providers/s3/apis/server/index.ts
+++ b/packages/storage/src/providers/s3/apis/server/index.ts
@@ -6,3 +6,4 @@ export { getUrl } from './getUrl';
 export { list } from './list';
 export { remove } from './remove';
 export { copy } from './copy';
+export { uploadData } from './uploadData';

--- a/packages/storage/src/providers/s3/apis/server/uploadData.ts
+++ b/packages/storage/src/providers/s3/apis/server/uploadData.ts
@@ -8,31 +8,28 @@ import {
 
 import {
 	UploadDataInput,
-	UploadDataOutput,
+	UploadDataServerOutput,
+	UploadDataServerWithPathOutput,
 	UploadDataWithPathInput,
-	UploadDataWithPathOutput,
 } from '../../types';
 import { uploadData as uploadDataInternal } from '../internal/uploadData';
 
 /**
- * Upload data to the specified S3 object path. By default uses single PUT operation to upload if the payload is less than 5MB.
- * Otherwise, uses multipart upload to upload the payload.
+ * Upload data to the specified S3 object path. By default uses a single PUT
+ * operation to upload when the payload is less than 5MB. Otherwise, uses
+ * multipart upload to upload the payload.
  *
- * Server-side uploadData is intended for use in SSR contexts (e.g. Next.js Route Handlers, Server Actions,
- * Nuxt.js server routes). Unlike the client-side counterpart, it does NOT support pause/resume of
- * multipart uploads (pause/resume relies on client-side persistent storage).
- *
- * Limitations:
- * * Maximum object size is 5TB.
- * * Maximum object size if the size cannot be determined before upload is 50GB.
+ * Server-side `uploadData` is intended for use in SSR contexts such as
+ * Next.js Route Handlers and Server Actions.
  *
  * @param contextSpec - The isolated server context.
  * @param input - A `UploadDataWithPathInput` object.
  *
- * @returns A cancelable task exposing the result promise from the `result` property.
+ * @returns An `UploadDataServerWithPathOutput` task. Await the `result`
+ * 	promise to get the upload result.
  *
- * @throws Service: `S3Exception` thrown when checking for existence of the object.
- * @throws Validation: `StorageValidationErrorCode` thrown when a validation error occurs.
+ * @throws An `S3Exception` when the underlying S3 service returned error.
+ * @throws A `StorageValidationErrorCode` when API call parameters are invalid.
  *
  * @example
  * ```ts
@@ -56,34 +53,43 @@ import { uploadData as uploadDataInternal } from '../internal/uploadData';
 export function uploadData(
 	contextSpec: AmplifyServer.ContextSpec,
 	input: UploadDataWithPathInput,
-): UploadDataWithPathOutput;
+): UploadDataServerWithPathOutput;
 
 /**
  * @deprecated The `key` and `accessLevel` parameters are deprecated and may be removed in the next major version.
  * Please use {@link https://docs.amplify.aws/javascript/build-a-backend/storage/upload/#uploaddata | path} instead.
  *
- * Upload data to the specified S3 object key. By default uses single PUT operation to upload if the payload is less than 5MB.
- * Otherwise, uses multipart upload to upload the payload.
+ * Upload data to the specified S3 object key. By default uses a single PUT
+ * operation to upload when the payload is less than 5MB. Otherwise, uses
+ * multipart upload to upload the payload.
+ *
+ * The returned task does NOT support `pause()` / `resume()` server-side. See
+ * the path-based overload above for details.
  *
  * @param contextSpec - The isolated server context.
  * @param input - A `UploadDataInput` object.
  *
- * @returns A cancelable task exposing the result promise from the `result` property.
+ * @returns An `UploadDataServerOutput` task. Await the `result` promise to
+ * 	get the upload result.
  *
- * @throws Service: `S3Exception` thrown when checking for existence of the object.
- * @throws Validation: `StorageValidationErrorCode` thrown when a validation error occurs.
+ * @throws An `S3Exception` when the underlying S3 service returned error.
+ * @throws A `StorageValidationErrorCode` when API call parameters are invalid.
  */
 export function uploadData(
 	contextSpec: AmplifyServer.ContextSpec,
 	input: UploadDataInput,
-): UploadDataOutput;
+): UploadDataServerOutput;
 
 export function uploadData(
 	contextSpec: AmplifyServer.ContextSpec,
 	input: UploadDataInput | UploadDataWithPathInput,
-) {
+): UploadDataServerOutput | UploadDataServerWithPathOutput {
+	// The internal uploadData returns an UploadTask which has pause/resume. On
+	// the server path we intentionally hide pause/resume from the type because
+	// they are not supported across isolated server requests. The runtime
+	// object still exposes them as no-ops (delegated to createUploadTask).
 	return uploadDataInternal(
 		getAmplifyServerContext(contextSpec).amplify,
 		input,
-	);
+	) as UploadDataServerOutput | UploadDataServerWithPathOutput;
 }

--- a/packages/storage/src/providers/s3/apis/server/uploadData.ts
+++ b/packages/storage/src/providers/s3/apis/server/uploadData.ts
@@ -28,8 +28,8 @@ import { uploadData as uploadDataInternal } from '../internal/uploadData';
  * @returns An `UploadDataServerWithPathOutput` task. Await the `result`
  * 	promise to get the upload result.
  *
- * @throws An `S3Exception` when the underlying S3 service returned error.
- * @throws A `StorageValidationErrorCode` when API call parameters are invalid.
+ * @throws S3Exception when the underlying S3 service returned error.
+ * @throws StorageValidationErrorCode when API call parameters are invalid.
  *
  * @example
  * ```ts
@@ -72,8 +72,8 @@ export function uploadData(
  * @returns An `UploadDataServerOutput` task. Await the `result` promise to
  * 	get the upload result.
  *
- * @throws An `S3Exception` when the underlying S3 service returned error.
- * @throws A `StorageValidationErrorCode` when API call parameters are invalid.
+ * @throws S3Exception when the underlying S3 service returned error.
+ * @throws StorageValidationErrorCode when API call parameters are invalid.
  */
 export function uploadData(
 	contextSpec: AmplifyServer.ContextSpec,

--- a/packages/storage/src/providers/s3/apis/server/uploadData.ts
+++ b/packages/storage/src/providers/s3/apis/server/uploadData.ts
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+
+import {
+	UploadDataInput,
+	UploadDataOutput,
+	UploadDataWithPathInput,
+	UploadDataWithPathOutput,
+} from '../../types';
+import { uploadData as uploadDataInternal } from '../internal/uploadData';
+
+/**
+ * Upload data to the specified S3 object path. By default uses single PUT operation to upload if the payload is less than 5MB.
+ * Otherwise, uses multipart upload to upload the payload.
+ *
+ * Server-side uploadData is intended for use in SSR contexts (e.g. Next.js Route Handlers, Server Actions,
+ * Nuxt.js server routes). Unlike the client-side counterpart, it does NOT support pause/resume of
+ * multipart uploads (pause/resume relies on client-side persistent storage).
+ *
+ * Limitations:
+ * * Maximum object size is 5TB.
+ * * Maximum object size if the size cannot be determined before upload is 50GB.
+ *
+ * @param contextSpec - The isolated server context.
+ * @param input - A `UploadDataWithPathInput` object.
+ *
+ * @returns A cancelable task exposing the result promise from the `result` property.
+ *
+ * @throws Service: `S3Exception` thrown when checking for existence of the object.
+ * @throws Validation: `StorageValidationErrorCode` thrown when a validation error occurs.
+ *
+ * @example
+ * ```ts
+ * // In a Next.js Route Handler
+ * import { runWithAmplifyServerContext } from '@aws-amplify/adapter-nextjs';
+ * import { uploadData } from 'aws-amplify/storage/server';
+ * import { cookies } from 'next/headers';
+ *
+ * export async function POST(request: Request) {
+ *   const formData = await request.formData();
+ *   const file = formData.get('file') as File;
+ *   const result = await runWithAmplifyServerContext({
+ *     nextServerContext: { cookies },
+ *     operation: (contextSpec) =>
+ *       uploadData(contextSpec, { path: `uploads/${file.name}`, data: file }).result,
+ *   });
+ *   return Response.json(result);
+ * }
+ * ```
+ */
+export function uploadData(
+	contextSpec: AmplifyServer.ContextSpec,
+	input: UploadDataWithPathInput,
+): UploadDataWithPathOutput;
+
+/**
+ * @deprecated The `key` and `accessLevel` parameters are deprecated and may be removed in the next major version.
+ * Please use {@link https://docs.amplify.aws/javascript/build-a-backend/storage/upload/#uploaddata | path} instead.
+ *
+ * Upload data to the specified S3 object key. By default uses single PUT operation to upload if the payload is less than 5MB.
+ * Otherwise, uses multipart upload to upload the payload.
+ *
+ * @param contextSpec - The isolated server context.
+ * @param input - A `UploadDataInput` object.
+ *
+ * @returns A cancelable task exposing the result promise from the `result` property.
+ *
+ * @throws Service: `S3Exception` thrown when checking for existence of the object.
+ * @throws Validation: `StorageValidationErrorCode` thrown when a validation error occurs.
+ */
+export function uploadData(
+	contextSpec: AmplifyServer.ContextSpec,
+	input: UploadDataInput,
+): UploadDataOutput;
+
+export function uploadData(
+	contextSpec: AmplifyServer.ContextSpec,
+	input: UploadDataInput | UploadDataWithPathInput,
+) {
+	return uploadDataInternal(
+		getAmplifyServerContext(contextSpec).amplify,
+		input,
+	);
+}

--- a/packages/storage/src/providers/s3/apis/uploadData.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { defaultStorage } from '@aws-amplify/core';
+import { Amplify, defaultStorage } from '@aws-amplify/core';
 
 import {
 	UploadDataInput,
@@ -123,7 +123,7 @@ export function uploadData(
 export function uploadData(input: UploadDataInput): UploadDataOutput;
 
 export function uploadData(input: UploadDataInput | UploadDataWithPathInput) {
-	return uploadDataInternal({
+	return uploadDataInternal(Amplify, {
 		...input,
 		options: {
 			...input?.options,

--- a/packages/storage/src/providers/s3/apis/uploadData.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData.ts
@@ -20,8 +20,8 @@ import { uploadData as uploadDataInternal } from './internal/uploadData';
  * * Maximum object size is 5TB.
  * * Maximum object size if the size cannot be determined before upload is 50GB.
  *
- * @throws Service: `S3Exception` thrown when checking for existence of the object.
- * @throws Validation: `StorageValidationErrorCode` thrown when a validation error occurs.
+ * @throws An `S3Exception` when the underlying S3 service returned error.
+ * @throws A `StorageValidationErrorCode` when API call parameters are invalid.
  *
  * @param input - A `UploadDataWithPathInput` object.
  *
@@ -78,8 +78,8 @@ export function uploadData(
  * @deprecated The `key` and `accessLevel` parameters are deprecated and will be removed in next major version.
  * Please use {@link https://docs.amplify.aws/javascript/build-a-backend/storage/upload/#uploaddata | path} instead.
  *
- * @throws Service: `S3Exception` thrown when checking for existence of the object.
- * @throws Validation: `StorageValidationErrorCode` thrown when a validation error occurs.
+ * @throws An `S3Exception` when the underlying S3 service returned error.
+ * @throws A `StorageValidationErrorCode` when API call parameters are invalid.
  *
  * @param input - A `UploadDataInput` object.
  *

--- a/packages/storage/src/providers/s3/apis/uploadData.ts
+++ b/packages/storage/src/providers/s3/apis/uploadData.ts
@@ -20,8 +20,8 @@ import { uploadData as uploadDataInternal } from './internal/uploadData';
  * * Maximum object size is 5TB.
  * * Maximum object size if the size cannot be determined before upload is 50GB.
  *
- * @throws An `S3Exception` when the underlying S3 service returned error.
- * @throws A `StorageValidationErrorCode` when API call parameters are invalid.
+ * @throws S3Exception when the underlying S3 service returned error.
+ * @throws StorageValidationErrorCode when API call parameters are invalid.
  *
  * @param input - A `UploadDataWithPathInput` object.
  *
@@ -78,8 +78,8 @@ export function uploadData(
  * @deprecated The `key` and `accessLevel` parameters are deprecated and will be removed in next major version.
  * Please use {@link https://docs.amplify.aws/javascript/build-a-backend/storage/upload/#uploaddata | path} instead.
  *
- * @throws An `S3Exception` when the underlying S3 service returned error.
- * @throws A `StorageValidationErrorCode` when API call parameters are invalid.
+ * @throws S3Exception when the underlying S3 service returned error.
+ * @throws StorageValidationErrorCode when API call parameters are invalid.
  *
  * @param input - A `UploadDataInput` object.
  *

--- a/packages/storage/src/providers/s3/index.ts
+++ b/packages/storage/src/providers/s3/index.ts
@@ -33,6 +33,8 @@ export {
 export {
 	UploadDataOutput,
 	UploadDataWithPathOutput,
+	UploadDataServerOutput,
+	UploadDataServerWithPathOutput,
 	DownloadDataOutput,
 	DownloadDataWithPathOutput,
 	RemoveOutput,

--- a/packages/storage/src/providers/s3/types/index.ts
+++ b/packages/storage/src/providers/s3/types/index.ts
@@ -21,6 +21,8 @@ export {
 export {
 	UploadDataOutput,
 	UploadDataWithPathOutput,
+	UploadDataServerOutput,
+	UploadDataServerWithPathOutput,
 	DownloadDataOutput,
 	DownloadDataWithPathOutput,
 	RemoveOutput,

--- a/packages/storage/src/providers/s3/types/outputs.ts
+++ b/packages/storage/src/providers/s3/types/outputs.ts
@@ -3,6 +3,7 @@
 
 import {
 	DownloadTask,
+	NonPausableTransferTask,
 	StorageDownloadDataOutput,
 	StorageGetUrlOutput,
 	StorageItemWithKey,
@@ -79,6 +80,24 @@ export type UploadDataOutput = UploadTask<ItemWithKey>;
  *  Output type with path for S3 uploadData API.
  * */
 export type UploadDataWithPathOutput = UploadTask<ItemWithPath>;
+
+/**
+ * Output type for the server-side S3 uploadData API.
+ *
+ * Non-pausable variant of {@link UploadDataOutput}. See {@link uploadData}
+ * server-side API documentation for details.
+ *
+ * @deprecated Use {@link UploadDataServerWithPathOutput} instead.
+ */
+export type UploadDataServerOutput = NonPausableTransferTask<ItemWithKey>;
+/**
+ * Output type with path for the server-side S3 uploadData API.
+ *
+ * Non-pausable variant of {@link UploadDataWithPathOutput}. See
+ * {@link uploadData} server-side API documentation for details.
+ */
+export type UploadDataServerWithPathOutput =
+	NonPausableTransferTask<ItemWithPath>;
 
 /**
  * Output type for S3 getProperties API.

--- a/packages/storage/src/providers/s3/utils/readFile.ts
+++ b/packages/storage/src/providers/s3/utils/readFile.ts
@@ -1,17 +1,24 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export const readFile = (file: Blob): Promise<ArrayBuffer> =>
-	new Promise((resolve, reject) => {
-		const reader = new FileReader();
-		reader.onload = () => {
-			resolve(reader.result as ArrayBuffer);
-		};
-		reader.onabort = () => {
-			reject(new Error('Read aborted'));
-		};
-		reader.onerror = () => {
-			reject(reader.error);
-		};
-		reader.readAsArrayBuffer(file);
-	});
+export const readFile = (file: Blob): Promise<ArrayBuffer> => {
+	// Browser path: use FileReader when available.
+	if (typeof FileReader !== 'undefined') {
+		return new Promise((resolve, reject) => {
+			const reader = new FileReader();
+			reader.onload = () => {
+				resolve(reader.result as ArrayBuffer);
+			};
+			reader.onabort = () => {
+				reject(new Error('Read aborted'));
+			};
+			reader.onerror = () => {
+				reject(reader.error);
+			};
+			reader.readAsArrayBuffer(file);
+		});
+	}
+
+	// Server (Node.js 18+) path: Blob/File both expose arrayBuffer().
+	return file.arrayBuffer();
+};

--- a/packages/storage/src/types/index.ts
+++ b/packages/storage/src/types/index.ts
@@ -3,6 +3,7 @@
 
 export {
 	DownloadTask,
+	NonPausableTransferTask,
 	TransferProgressEvent,
 	TransferTaskState,
 	UploadTask,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Adds a new server-side `uploadData` API for Storage, consumable in Next.js Server Components, Route Handlers, and Server Actions. Customers can now upload data directly from server contexts using the same Amplify server context pattern already used by `list`, `getProperties`, `getUrl`, `remove`, and `copy`.

This addresses a long-standing customer request to upload files from a Next.js backend (tracked in #13636), which was previously only possible from the client. Enabling server-side upload unblocks common patterns where the file needs to be validated, transformed, or persisted together with database state on the server before being stored in S3.

##### Usage

```ts
import { runWithAmplifyServerContext } from '@aws-amplify/adapter-nextjs';
import { uploadData } from 'aws-amplify/storage/server';

await runWithAmplifyServerContext({
  nextServerContext: { cookies },
  operation: (contextSpec) =>
    uploadData(contextSpec, {
      path: 'uploads/file.jpg',
      data: file,
    }).result,
});
```

##### Implementation approach

Rather than duplicating the upload pipeline, this PR refactors the existing internal `uploadData` implementation to accept an `AmplifyClassV6` instance via dependency injection (first positional argument), eliminating its dependency on the global `Amplify` singleton. The existing client-side API, the advanced `internals/apis/uploadData`, and the new server-side API all pass their respective `Amplify` instance to the same shared internal pipeline. This keeps multipart upload, checksum computation, cancellation, and progress reporting logic in a single place.

##### Key changes

- Refactored `providers/s3/apis/internal/uploadData/*` to accept `amplify: AmplifyClassV6` as first parameter (removes implicit dependency on the global `Amplify` singleton).
- New public API: `providers/s3/apis/server/uploadData.ts` — thin wrapper that injects `getAmplifyServerContext(contextSpec).amplify` into the internal pipeline.
- Updated client-side `providers/s3/apis/uploadData.ts` to explicitly pass `Amplify`.
- Updated advanced `internals/apis/uploadData.ts` to explicitly pass `Amplify`.
- Exported the new `uploadData` from `providers/s3/apis/server/index.ts`; automatically flows through the existing `@aws-amplify/storage/server` → `aws-amplify/storage/server` re-export chain.
- Fixed `providers/s3/utils/readFile.ts` to fall back to `Blob.arrayBuffer()` when `FileReader` is unavailable, so server-side uploads (which depend on this path for CRC32/MD5 checksum calculation on sliced parts) work under Node.js runtimes.

##### Server-side behavior notes

- `resumableUploadsCache` (used for pause/resume on the client) is intentionally NOT injected on the server path, since every server request runs in an isolated context and there is no consistent cross-request storage for upload state. `task.pause()` / `task.resume()` are gracefully handled as no-ops in this case (already supported by `createUploadTask`).
- Multipart uploads work end-to-end on the server for files above the default 5 MiB part size threshold.

#### Issue #, if available

Closes #13636

#### Description of how you validated changes

##### Unit tests

All 796 storage unit tests pass (`yarn test` from `packages/storage`), including:

- Updated: `internal/uploadData/index.test.ts` (18 tests), `internal/uploadData/putObjectJob.test.ts` (19 tests), `internal/uploadData/multipartHandlers.test.ts` (93 tests), `providers/s3/apis/uploadData.test.ts` (client wrapper), `internals/apis/uploadData.test.ts` (advanced API) — all updated to pass an Amplify instance as first argument.
- New: `providers/s3/apis/server/uploadData.test.ts` — 4 tests covering path-based input, key-based input, verification that `resumableUploadsCache` is NOT injected server-side, and verification that the server context's `amplify` (not the global singleton) is used.
- Added: server-side fallback test in `providers/s3/utils/readFile.test.ts`.

##### Build

`yarn build` in `packages/storage` passes with no type errors.

##### Manual E2E validation in a Next.js 16 (App Router, Turbopack) sample app

- Small file upload (<5 MiB) via Route Handler using the new `uploadData` from `@aws-amplify/storage/server` — succeeded, single PutObject path.
- Large file upload (9 MiB and larger) via Route Handler — succeeded, multipart upload path (2+ parts) with CRC32 checksum on each part.
- Same scenarios validated through a Next.js Server Action — succeeded.
- Verified authentication via Amplify server context (HTTP-only cookie) flows through to S3 request signing.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

#### Checklist for repo maintainers

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
