### PR TITLE
fix: update change set config.

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,9 @@
 {
 	"$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-
+	"changelog": [
+		"@changesets/changelog-github",
+		{ "repo": "aws-amplify/amplify-js" }
+	],
 	"snapshot": {
 		"useCalculatedVersion": true
 	},

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,21 +1,21 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-  "changelog": [
-    "@changesets/changelog-github",
-    { "repo": "aws-amplify/amplify-js" }
-  ],
-  "snapshot": {
-      "useCalculatedVersion": true
-  },
-  "commit": false,
-  "fixed": [],
-  "linked": [],
-  "access": "public",
-  "baseBranch": "main",
-  "updateInternalDependencies": "patch",
-  "ignore": [
-    "@aws-amplify/react-native-example",
-    "@aws-amplify/rtn-passkeys-example",
-    "tsc-compliance-test"
-  ]
+	"$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
+
+	"snapshot": {
+		"useCalculatedVersion": true
+	},
+	"commit": false,
+	"fixed": [],
+	"linked": [],
+	"access": "public",
+	"baseBranch": "main",
+	"updateInternalDependencies": "patch",
+	"ignore": [
+		"@aws-amplify/react-native-example",
+		"@aws-amplify/rtn-passkeys-example",
+		"tsc-compliance-test"
+	],
+	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+		"onlyUpdatePeerDependentsWhenOutOfRange": true
+	}
 }


### PR DESCRIPTION
  #### Description of changes

  Updates `.changeset/config.json` to enable the experimental `onlyUpdatePeerDependentsWhenOutOfRange` option so Changesets only bumps peer-dependent packages when the new version falls outside the declared peer range. This avoids unnecessary version bumps (and downstream churn, e.g. for the Next.js adapter) when peer ranges are already satisfied.

  #### Issue #, if available

  N/A

  #### Description of how you validated changes

  - Validated `.changeset/config.json` is valid JSON and conforms to the Changesets schema.
  - Ran `yarn changeset version` locally against sample changesets to confirm peer-dependent packages are only bumped when out of range.

  #### Checklist

  - [x] PR description included
  - [x] `yarn test` passes
  - [ ] Unit Tests are changed or added — N/A (tooling/config-only change)
  - [ ] Relevant documentation is changed or added (and PR referenced) — N/A

  #### Checklist for repo maintainers

  - [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
  - [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.