### PR TITLE
docs: fix occured -> occurred typo in catch-block comments

### DIFF
--- a/packages/analytics/src/providers/kinesis/apis/record.ts
+++ b/packages/analytics/src/providers/kinesis/apis/record.ts
@@ -76,7 +76,7 @@ export const record = ({
 			});
 		})
 		.catch(e => {
-			// An error occured while fetching credentials or persisting the event to the buffer
+			// An error occurred while fetching credentials or persisting the event to the buffer
 			logger.warn('Failed to record event.', e);
 		});
 };

--- a/packages/analytics/src/providers/pinpoint/apis/record.ts
+++ b/packages/analytics/src/providers/pinpoint/apis/record.ts
@@ -86,7 +86,7 @@ export const record = (input: RecordInput): void => {
 			});
 		})
 		.catch(e => {
-			// An error occured while fetching credentials or persisting the event to the buffer
+			// An error occurred while fetching credentials or persisting the event to the buffer
 			logger.warn('Failed to record event.', e);
 		});
 };

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/helpers.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/helpers.ts
@@ -67,7 +67,7 @@ export const recordAnalyticsEvent = (
 			});
 		})
 		.catch(e => {
-			// An error occured while fetching credentials or persisting the event to the buffer
+			// An error occurred while fetching credentials or persisting the event to the buffer
 			logger.warn('Failed to record event.', e);
 		});
 };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

Fixes 'occured' -> 'occurred' typo in three catch-block comments across analytics (Kinesis, Pinpoint) and notifications (in-app messaging Pinpoint helpers). Comment-only change, no functional impact.

#### Issue #, if available

N/A.

#### Description of how you validated changes

Files touched only contain code comments. Existing unit tests pass unchanged.

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

#### Checklist for repo maintainers

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
