### PR TITLE
fix(aws-amplify): sync Cognito auth config and merge libraryOptions on reconfigure

### DIFF
--- a/.changeset/fix-init-singleton-auth-reconfigure.md
+++ b/.changeset/fix-init-singleton-auth-reconfigure.md
@@ -2,4 +2,4 @@
 'aws-amplify': patch
 ---
 
-fix(aws-amplify): merge libraryOptions when Auth is overridden and refresh default Cognito auth config on reconfigure.
+fix(aws-amplify): refresh default Cognito auth config on DefaultAmplify reconfigure.

--- a/.changeset/fix-init-singleton-auth-reconfigure.md
+++ b/.changeset/fix-init-singleton-auth-reconfigure.md
@@ -1,0 +1,5 @@
+---
+'aws-amplify': patch
+---
+
+fix(aws-amplify): merge libraryOptions when Auth is overridden and refresh default Cognito auth config on reconfigure.

--- a/packages/aws-amplify/__tests__/initSingleton.integration.test.ts
+++ b/packages/aws-amplify/__tests__/initSingleton.integration.test.ts
@@ -1,0 +1,123 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration-style tests using the real @aws-amplify/core Amplify singleton
+ * (initSingleton.test.ts mocks core).
+ */
+import { Amplify as CoreAmplify, ResourcesConfig } from '@aws-amplify/core';
+
+import { cognitoUserPoolsTokenProvider } from '../src/auth/cognito';
+import { Amplify as DefaultAmplify } from '../src';
+
+const poolAConfig: ResourcesConfig = {
+	Auth: {
+		Cognito: {
+			userPoolClientId: 'client-a',
+			userPoolId: 'pool-a',
+		},
+	},
+};
+
+const poolBConfig: ResourcesConfig = {
+	Auth: {
+		Cognito: {
+			userPoolClientId: 'client-b',
+			userPoolId: 'pool-b',
+		},
+	},
+};
+
+const storageLibraryOptions = {
+	Storage: {
+		S3: {
+			defaultAccessLevel: 'private' as const,
+			isObjectLockEnabled: true,
+		},
+	},
+};
+
+describe('DefaultAmplify.configure integration', () => {
+	let setAuthConfigSpy: jest.SpyInstance;
+	let setKeyValueStorageSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		CoreAmplify.libraryOptions = {};
+		CoreAmplify.resourcesConfig = {};
+		setAuthConfigSpy = jest.spyOn(
+			cognitoUserPoolsTokenProvider,
+			'setAuthConfig',
+		);
+		setKeyValueStorageSpy = jest.spyOn(
+			cognitoUserPoolsTokenProvider,
+			'setKeyValueStorage',
+		);
+	});
+
+	afterEach(() => {
+		setAuthConfigSpy.mockRestore();
+		setKeyValueStorageSpy.mockRestore();
+		CoreAmplify.libraryOptions = {};
+		CoreAmplify.resourcesConfig = {};
+	});
+
+	it('keeps Storage and refreshes Cognito auth config on partial reconfigure', () => {
+		DefaultAmplify.configure(poolAConfig, storageLibraryOptions);
+
+		expect(CoreAmplify.libraryOptions.Storage).toEqual(
+			storageLibraryOptions.Storage,
+		);
+		expect(CoreAmplify.libraryOptions.Auth?.tokenProvider).toBe(
+			cognitoUserPoolsTokenProvider,
+		);
+		expect(setAuthConfigSpy).toHaveBeenCalledWith(poolAConfig.Auth);
+
+		setAuthConfigSpy.mockClear();
+
+		DefaultAmplify.configure(poolBConfig, { ssr: false });
+
+		expect(CoreAmplify.libraryOptions.Storage).toEqual(
+			storageLibraryOptions.Storage,
+		);
+		expect(CoreAmplify.getConfig().Auth?.Cognito?.userPoolClientId).toBe(
+			'client-b',
+		);
+		expect(setAuthConfigSpy).toHaveBeenCalledWith(poolBConfig.Auth);
+	});
+
+	it('merges prior libraryOptions when libraryOptions.Auth overrides default provider', () => {
+		DefaultAmplify.configure(poolAConfig, storageLibraryOptions);
+
+		setAuthConfigSpy.mockClear();
+
+		DefaultAmplify.configure(poolBConfig, {
+			Auth: {
+				tokenProvider: cognitoUserPoolsTokenProvider,
+				credentialsProvider:
+					CoreAmplify.libraryOptions.Auth!.credentialsProvider!,
+			},
+		});
+
+		expect(CoreAmplify.libraryOptions.Storage).toEqual(
+			storageLibraryOptions.Storage,
+		);
+		expect(setAuthConfigSpy).toHaveBeenCalledWith(poolBConfig.Auth);
+		expect(CoreAmplify.getConfig().Auth?.Cognito?.userPoolClientId).toBe(
+			'client-b',
+		);
+	});
+
+	it('syncs default Cognito auth config when only resource config is passed', () => {
+		DefaultAmplify.configure(poolAConfig, storageLibraryOptions);
+
+		setAuthConfigSpy.mockClear();
+
+		DefaultAmplify.configure(poolBConfig);
+
+		expect(CoreAmplify.libraryOptions.Storage).toEqual(
+			storageLibraryOptions.Storage,
+		);
+		expect(setAuthConfigSpy).toHaveBeenCalledWith(poolBConfig.Auth);
+		expect(CoreAmplify.getConfig().Auth?.Cognito?.userPoolId).toBe('pool-b');
+	});
+});

--- a/packages/aws-amplify/__tests__/initSingleton.integration.test.ts
+++ b/packages/aws-amplify/__tests__/initSingleton.integration.test.ts
@@ -28,15 +28,6 @@ const poolBConfig: ResourcesConfig = {
 	},
 };
 
-const storageLibraryOptions = {
-	Storage: {
-		S3: {
-			defaultAccessLevel: 'private' as const,
-			isObjectLockEnabled: true,
-		},
-	},
-};
-
 describe('DefaultAmplify.configure integration', () => {
 	let setAuthConfigSpy: jest.SpyInstance;
 	let setKeyValueStorageSpy: jest.SpyInstance;
@@ -61,32 +52,25 @@ describe('DefaultAmplify.configure integration', () => {
 		CoreAmplify.resourcesConfig = {};
 	});
 
-	it('keeps Storage and refreshes Cognito auth config on partial reconfigure', () => {
-		DefaultAmplify.configure(poolAConfig, storageLibraryOptions);
+	it('refreshes Cognito auth config on reconfigure with partial libraryOptions', () => {
+		DefaultAmplify.configure(poolAConfig);
 
-		expect(CoreAmplify.libraryOptions.Storage).toEqual(
-			storageLibraryOptions.Storage,
-		);
-		expect(CoreAmplify.libraryOptions.Auth?.tokenProvider).toBe(
-			cognitoUserPoolsTokenProvider,
-		);
 		expect(setAuthConfigSpy).toHaveBeenCalledWith(poolAConfig.Auth);
 
 		setAuthConfigSpy.mockClear();
+		setKeyValueStorageSpy.mockClear();
 
 		DefaultAmplify.configure(poolBConfig, { ssr: false });
 
-		expect(CoreAmplify.libraryOptions.Storage).toEqual(
-			storageLibraryOptions.Storage,
-		);
+		expect(setAuthConfigSpy).toHaveBeenCalledWith(poolBConfig.Auth);
+		expect(setKeyValueStorageSpy).toHaveBeenCalled();
 		expect(CoreAmplify.getConfig().Auth?.Cognito?.userPoolClientId).toBe(
 			'client-b',
 		);
-		expect(setAuthConfigSpy).toHaveBeenCalledWith(poolBConfig.Auth);
 	});
 
-	it('merges prior libraryOptions when libraryOptions.Auth overrides default provider', () => {
-		DefaultAmplify.configure(poolAConfig, storageLibraryOptions);
+	it('passes through when libraryOptions.Auth is provided', () => {
+		DefaultAmplify.configure(poolAConfig);
 
 		setAuthConfigSpy.mockClear();
 
@@ -98,26 +82,22 @@ describe('DefaultAmplify.configure integration', () => {
 			},
 		});
 
-		expect(CoreAmplify.libraryOptions.Storage).toEqual(
-			storageLibraryOptions.Storage,
-		);
-		expect(setAuthConfigSpy).toHaveBeenCalledWith(poolBConfig.Auth);
+		expect(setAuthConfigSpy).not.toHaveBeenCalled();
 		expect(CoreAmplify.getConfig().Auth?.Cognito?.userPoolClientId).toBe(
 			'client-b',
 		);
 	});
 
-	it('syncs default Cognito auth config when only resource config is passed', () => {
-		DefaultAmplify.configure(poolAConfig, storageLibraryOptions);
+	it('refreshes Cognito auth config when only resource config is passed', () => {
+		DefaultAmplify.configure(poolAConfig);
 
 		setAuthConfigSpy.mockClear();
+		setKeyValueStorageSpy.mockClear();
 
 		DefaultAmplify.configure(poolBConfig);
 
-		expect(CoreAmplify.libraryOptions.Storage).toEqual(
-			storageLibraryOptions.Storage,
-		);
 		expect(setAuthConfigSpy).toHaveBeenCalledWith(poolBConfig.Auth);
+		expect(setKeyValueStorageSpy).toHaveBeenCalled();
 		expect(CoreAmplify.getConfig().Auth?.Cognito?.userPoolId).toBe('pool-b');
 	});
 });

--- a/packages/aws-amplify/__tests__/initSingleton.test.ts
+++ b/packages/aws-amplify/__tests__/initSingleton.test.ts
@@ -246,16 +246,29 @@ describe('initSingleton (DefaultAmplify)', () => {
 		});
 
 		describe('when ResourcesConfig.Auth is defined', () => {
-			it('should just configure with the provided config and options when libraryOptions.Auth is defined', () => {
+			it('should merge with existing libraryOptions when libraryOptions.Auth is defined', () => {
+				const customTokenProvider = { getTokens: jest.fn() };
+				const storageLibraryOptions = {
+					S3: { defaultAccessLevel: 'private' as const },
+				};
+				AmplifySingleton.libraryOptions = {
+					Storage: storageLibraryOptions,
+				};
 				const libraryOptions = {
-					Auth: { tokenProvider: { getTokens: jest.fn() } },
+					Auth: { tokenProvider: customTokenProvider },
 				};
 				Amplify.configure(mockResourceConfig, libraryOptions);
 
 				expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
 					mockResourceConfig,
-					libraryOptions,
+					{
+						Storage: storageLibraryOptions,
+						Auth: libraryOptions.Auth,
+					},
 				);
+				expect(
+					mockCognitoUserPoolsTokenProviderSetAuthConfig,
+				).not.toHaveBeenCalled();
 			});
 
 			describe('when the singleton libraryOptions have not yet been configured with Auth', () => {
@@ -324,11 +337,12 @@ describe('initSingleton (DefaultAmplify)', () => {
 
 				it('should preserve current auth providers (default or otherwise) and configure provider with a new CookieStorage instance', () => {
 					const libraryOptions = { ssr: true };
+					const authLibraryOptions = AmplifySingleton.libraryOptions.Auth;
 					Amplify.configure(mockResourceConfig, libraryOptions);
 
 					expect(
 						mockCognitoUserPoolsTokenProviderSetAuthConfig,
-					).not.toHaveBeenCalled();
+					).toHaveBeenCalledWith(mockResourceConfig.Auth);
 					expect(MockCookieStorage).toHaveBeenCalledWith({ sameSite: 'lax' });
 					expect(
 						mockCognitoUserPoolsTokenProviderSetKeyValueStorage,
@@ -336,7 +350,7 @@ describe('initSingleton (DefaultAmplify)', () => {
 					expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
 						mockResourceConfig,
 						{
-							Auth: AmplifySingleton.libraryOptions.Auth,
+							Auth: authLibraryOptions,
 							...libraryOptions,
 						},
 					);
@@ -344,18 +358,19 @@ describe('initSingleton (DefaultAmplify)', () => {
 
 				it('should preserve current auth providers (default or otherwise) and configure provider with defaultStorage', () => {
 					const libraryOptions = { ssr: false };
+					const authLibraryOptions = AmplifySingleton.libraryOptions.Auth;
 					Amplify.configure(mockResourceConfig, libraryOptions);
 
 					expect(
 						mockCognitoUserPoolsTokenProviderSetAuthConfig,
-					).not.toHaveBeenCalled();
+					).toHaveBeenCalledWith(mockResourceConfig.Auth);
 					expect(
 						mockCognitoUserPoolsTokenProviderSetKeyValueStorage,
 					).toHaveBeenCalledWith(defaultStorage);
 					expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
 						mockResourceConfig,
 						{
-							Auth: AmplifySingleton.libraryOptions.Auth,
+							Auth: authLibraryOptions,
 							...libraryOptions,
 						},
 					);
@@ -365,29 +380,89 @@ describe('initSingleton (DefaultAmplify)', () => {
 					const libraryOptions = {
 						Storage: { S3: { isObjectLockEnabled: true } },
 					};
+					const authLibraryOptions = AmplifySingleton.libraryOptions.Auth;
 					Amplify.configure(mockResourceConfig, libraryOptions);
 
 					expect(
 						mockCognitoUserPoolsTokenProviderSetAuthConfig,
-					).not.toHaveBeenCalled();
+					).toHaveBeenCalledWith(mockResourceConfig.Auth);
 					expect(
 						mockCognitoUserPoolsTokenProviderSetKeyValueStorage,
 					).not.toHaveBeenCalled();
 					expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
 						mockResourceConfig,
 						{
-							Auth: AmplifySingleton.libraryOptions.Auth,
+							Auth: authLibraryOptions,
 							...libraryOptions,
 						},
 					);
 				});
 
-				it('should just configure without touching libraryOptions', () => {
+				it('should preserve non-Auth library options when reconfiguring with partial libraryOptions', () => {
+					const storageLibraryOptions = {
+						S3: { defaultAccessLevel: 'private' as const },
+					};
+					AmplifySingleton.libraryOptions = {
+						Auth: {
+							tokenProvider: cognitoUserPoolsTokenProvider,
+							credentialsProvider: cognitoCredentialsProvider,
+						},
+						Storage: storageLibraryOptions,
+					};
+					const authLibraryOptions = AmplifySingleton.libraryOptions.Auth;
+
+					Amplify.configure(mockResourceConfig, { ssr: true });
+
+					expect(
+						mockCognitoUserPoolsTokenProviderSetAuthConfig,
+					).toHaveBeenCalledWith(mockResourceConfig.Auth);
+					expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
+						mockResourceConfig,
+						{
+							Auth: authLibraryOptions,
+							Storage: storageLibraryOptions,
+							ssr: true,
+						},
+					);
+				});
+
+				it('should sync default Cognito auth config when reconfiguring with resource config only', () => {
 					Amplify.configure(mockResourceConfig);
 
+					expect(
+						mockCognitoUserPoolsTokenProviderSetAuthConfig,
+					).toHaveBeenCalledWith(mockResourceConfig.Auth);
 					expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
 						mockResourceConfig,
 					);
+				});
+
+				it('should sync default Cognito auth config when libraryOptions.Auth overrides with default provider', () => {
+					const updatedResourceConfig: ResourcesConfig = {
+						Auth: {
+							Cognito: {
+								userPoolClientId: 'newClientId',
+								userPoolId: 'newPoolId',
+							},
+						},
+					};
+					AmplifySingleton.libraryOptions = {
+						Auth: {
+							tokenProvider: cognitoUserPoolsTokenProvider,
+							credentialsProvider: cognitoCredentialsProvider,
+						},
+					};
+
+					Amplify.configure(updatedResourceConfig, {
+						Auth: {
+							tokenProvider: cognitoUserPoolsTokenProvider,
+							credentialsProvider: cognitoCredentialsProvider,
+						},
+					});
+
+					expect(
+						mockCognitoUserPoolsTokenProviderSetAuthConfig,
+					).toHaveBeenCalledWith(updatedResourceConfig.Auth);
 				});
 			});
 

--- a/packages/aws-amplify/__tests__/initSingleton.test.ts
+++ b/packages/aws-amplify/__tests__/initSingleton.test.ts
@@ -246,14 +246,8 @@ describe('initSingleton (DefaultAmplify)', () => {
 		});
 
 		describe('when ResourcesConfig.Auth is defined', () => {
-			it('should merge with existing libraryOptions when libraryOptions.Auth is defined', () => {
+			it('should pass through when libraryOptions.Auth is defined', () => {
 				const customTokenProvider = { getTokens: jest.fn() };
-				const storageLibraryOptions = {
-					S3: { defaultAccessLevel: 'private' as const },
-				};
-				AmplifySingleton.libraryOptions = {
-					Storage: storageLibraryOptions,
-				};
 				const libraryOptions = {
 					Auth: { tokenProvider: customTokenProvider },
 				};
@@ -261,10 +255,7 @@ describe('initSingleton (DefaultAmplify)', () => {
 
 				expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
 					mockResourceConfig,
-					{
-						Storage: storageLibraryOptions,
-						Auth: libraryOptions.Auth,
-					},
+					libraryOptions,
 				);
 				expect(
 					mockCognitoUserPoolsTokenProviderSetAuthConfig,
@@ -335,9 +326,8 @@ describe('initSingleton (DefaultAmplify)', () => {
 					};
 				});
 
-				it('should preserve current auth providers (default or otherwise) and configure provider with a new CookieStorage instance', () => {
+				it('should refresh default Cognito auth config and configure provider with a new CookieStorage instance on reconfigure', () => {
 					const libraryOptions = { ssr: true };
-					const authLibraryOptions = AmplifySingleton.libraryOptions.Auth;
 					Amplify.configure(mockResourceConfig, libraryOptions);
 
 					expect(
@@ -350,15 +340,18 @@ describe('initSingleton (DefaultAmplify)', () => {
 					expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
 						mockResourceConfig,
 						{
-							Auth: authLibraryOptions,
 							...libraryOptions,
+							Auth: {
+								tokenProvider: cognitoUserPoolsTokenProvider,
+								credentialsProvider:
+									mockCognitoAWSCredentialsAndIdentityIdProviderInstance,
+							},
 						},
 					);
 				});
 
-				it('should preserve current auth providers (default or otherwise) and configure provider with defaultStorage', () => {
+				it('should refresh default Cognito auth config and configure provider with defaultStorage on reconfigure', () => {
 					const libraryOptions = { ssr: false };
-					const authLibraryOptions = AmplifySingleton.libraryOptions.Auth;
 					Amplify.configure(mockResourceConfig, libraryOptions);
 
 					expect(
@@ -370,17 +363,19 @@ describe('initSingleton (DefaultAmplify)', () => {
 					expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
 						mockResourceConfig,
 						{
-							Auth: authLibraryOptions,
 							...libraryOptions,
+							Auth: {
+								tokenProvider: cognitoUserPoolsTokenProvider,
+								credentialsProvider: cognitoCredentialsProvider,
+							},
 						},
 					);
 				});
 
-				it('should preserve current auth providers (default or otherwise)', () => {
+				it('should refresh default Cognito auth config when reconfiguring with non-Auth libraryOptions', () => {
 					const libraryOptions = {
 						Storage: { S3: { isObjectLockEnabled: true } },
 					};
-					const authLibraryOptions = AmplifySingleton.libraryOptions.Auth;
 					Amplify.configure(mockResourceConfig, libraryOptions);
 
 					expect(
@@ -388,56 +383,40 @@ describe('initSingleton (DefaultAmplify)', () => {
 					).toHaveBeenCalledWith(mockResourceConfig.Auth);
 					expect(
 						mockCognitoUserPoolsTokenProviderSetKeyValueStorage,
-					).not.toHaveBeenCalled();
+					).toHaveBeenCalledWith(defaultStorage);
 					expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
 						mockResourceConfig,
 						{
-							Auth: authLibraryOptions,
 							...libraryOptions,
+							Auth: {
+								tokenProvider: cognitoUserPoolsTokenProvider,
+								credentialsProvider: cognitoCredentialsProvider,
+							},
 						},
 					);
 				});
 
-				it('should preserve non-Auth library options when reconfiguring with partial libraryOptions', () => {
-					const storageLibraryOptions = {
-						S3: { defaultAccessLevel: 'private' as const },
-					};
-					AmplifySingleton.libraryOptions = {
-						Auth: {
-							tokenProvider: cognitoUserPoolsTokenProvider,
-							credentialsProvider: cognitoCredentialsProvider,
-						},
-						Storage: storageLibraryOptions,
-					};
-					const authLibraryOptions = AmplifySingleton.libraryOptions.Auth;
-
-					Amplify.configure(mockResourceConfig, { ssr: true });
-
-					expect(
-						mockCognitoUserPoolsTokenProviderSetAuthConfig,
-					).toHaveBeenCalledWith(mockResourceConfig.Auth);
-					expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
-						mockResourceConfig,
-						{
-							Auth: authLibraryOptions,
-							Storage: storageLibraryOptions,
-							ssr: true,
-						},
-					);
-				});
-
-				it('should sync default Cognito auth config when reconfiguring with resource config only', () => {
+				it('should refresh default Cognito auth config when reconfiguring with resource config only', () => {
 					Amplify.configure(mockResourceConfig);
 
 					expect(
 						mockCognitoUserPoolsTokenProviderSetAuthConfig,
 					).toHaveBeenCalledWith(mockResourceConfig.Auth);
+					expect(
+						mockCognitoUserPoolsTokenProviderSetKeyValueStorage,
+					).toHaveBeenCalledWith(defaultStorage);
 					expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
 						mockResourceConfig,
+						{
+							Auth: {
+								tokenProvider: cognitoUserPoolsTokenProvider,
+								credentialsProvider: cognitoCredentialsProvider,
+							},
+						},
 					);
 				});
 
-				it('should sync default Cognito auth config when libraryOptions.Auth overrides with default provider', () => {
+				it('should pass through when libraryOptions.Auth is provided on reconfigure', () => {
 					const updatedResourceConfig: ResourcesConfig = {
 						Auth: {
 							Cognito: {
@@ -446,23 +425,22 @@ describe('initSingleton (DefaultAmplify)', () => {
 							},
 						},
 					};
-					AmplifySingleton.libraryOptions = {
+					const libraryOptions = {
 						Auth: {
 							tokenProvider: cognitoUserPoolsTokenProvider,
 							credentialsProvider: cognitoCredentialsProvider,
 						},
 					};
 
-					Amplify.configure(updatedResourceConfig, {
-						Auth: {
-							tokenProvider: cognitoUserPoolsTokenProvider,
-							credentialsProvider: cognitoCredentialsProvider,
-						},
-					});
+					Amplify.configure(updatedResourceConfig, libraryOptions);
 
 					expect(
 						mockCognitoUserPoolsTokenProviderSetAuthConfig,
-					).toHaveBeenCalledWith(updatedResourceConfig.Auth);
+					).not.toHaveBeenCalled();
+					expect(mockAmplifySingletonConfigure).toHaveBeenCalledWith(
+						updatedResourceConfig,
+						libraryOptions,
+					);
 				});
 			});
 

--- a/packages/aws-amplify/src/initSingleton.ts
+++ b/packages/aws-amplify/src/initSingleton.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import {
 	Amplify,
+	AuthConfig,
 	CookieStorage,
 	LibraryOptions,
 	ResourcesConfig,
@@ -19,6 +20,15 @@ import {
 	cognitoCredentialsProvider,
 	cognitoUserPoolsTokenProvider,
 } from './auth/cognito';
+
+const usesDefaultCognitoTokenProvider = (
+	authLibraryOptions?: LibraryOptions['Auth'],
+): boolean =>
+	authLibraryOptions?.tokenProvider === cognitoUserPoolsTokenProvider;
+
+const syncDefaultCognitoAuthConfig = (authConfig: AuthConfig): void => {
+	cognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+};
 
 export const DefaultAmplify = {
 	/**
@@ -56,10 +66,25 @@ export const DefaultAmplify = {
 			return;
 		}
 
-		// If Auth options are provided, always just configure as is.
-		// Otherwise, we can assume no Auth libraryOptions were provided from here on.
+		// If Auth options are provided, merge with existing libraryOptions so other categories are preserved.
 		if (libraryOptions?.Auth) {
-			Amplify.configure(resolvedResourceConfig, libraryOptions);
+			const mergedLibraryOptions: LibraryOptions = {
+				...Amplify.libraryOptions,
+				...libraryOptions,
+			};
+
+			if (usesDefaultCognitoTokenProvider(mergedLibraryOptions.Auth)) {
+				syncDefaultCognitoAuthConfig(resolvedResourceConfig.Auth);
+
+				if (libraryOptions.ssr !== undefined) {
+					cognitoUserPoolsTokenProvider.setKeyValueStorage(
+						// TODO: allow configure with a public interface
+						resolvedKeyValueStorage,
+					);
+				}
+			}
+
+			Amplify.configure(resolvedResourceConfig, mergedLibraryOptions);
 
 			return;
 		}
@@ -97,9 +122,14 @@ export const DefaultAmplify = {
 				authLibraryOptions.credentialsProvider = resolvedCredentialsProvider;
 			}
 
+			if (usesDefaultCognitoTokenProvider(authLibraryOptions)) {
+				syncDefaultCognitoAuthConfig(resolvedResourceConfig.Auth);
+			}
+
 			Amplify.configure(resolvedResourceConfig, {
-				Auth: authLibraryOptions,
+				...Amplify.libraryOptions,
 				...libraryOptions,
+				Auth: authLibraryOptions,
 			});
 
 			return;
@@ -107,6 +137,10 @@ export const DefaultAmplify = {
 
 		// Finally, if there were no libraryOptions given at all, we should simply not touch the currently
 		// configured libraryOptions.
+		if (usesDefaultCognitoTokenProvider(Amplify.libraryOptions.Auth)) {
+			syncDefaultCognitoAuthConfig(resolvedResourceConfig.Auth);
+		}
+
 		Amplify.configure(resolvedResourceConfig);
 	},
 	/**

--- a/packages/aws-amplify/src/initSingleton.ts
+++ b/packages/aws-amplify/src/initSingleton.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import {
 	Amplify,
-	AuthConfig,
 	CookieStorage,
 	LibraryOptions,
 	ResourcesConfig,
@@ -20,15 +19,6 @@ import {
 	cognitoCredentialsProvider,
 	cognitoUserPoolsTokenProvider,
 } from './auth/cognito';
-
-const usesDefaultCognitoTokenProvider = (
-	authLibraryOptions?: LibraryOptions['Auth'],
-): boolean =>
-	authLibraryOptions?.tokenProvider === cognitoUserPoolsTokenProvider;
-
-const syncDefaultCognitoAuthConfig = (authConfig: AuthConfig): void => {
-	cognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
-};
 
 export const DefaultAmplify = {
 	/**
@@ -58,90 +48,25 @@ export const DefaultAmplify = {
 				)
 			: cognitoCredentialsProvider;
 
-		// If no Auth config is provided, no special handling will be required, configure as is.
-		// Otherwise, we can assume an Auth config is provided from here on.
-		if (!resolvedResourceConfig.Auth) {
+		if (!resolvedResourceConfig.Auth || libraryOptions?.Auth) {
 			Amplify.configure(resolvedResourceConfig, libraryOptions);
 
 			return;
 		}
 
-		// If Auth options are provided, merge with existing libraryOptions so other categories are preserved.
-		if (libraryOptions?.Auth) {
-			const mergedLibraryOptions: LibraryOptions = {
-				...Amplify.libraryOptions,
-				...libraryOptions,
-			};
+		cognitoUserPoolsTokenProvider.setAuthConfig(resolvedResourceConfig.Auth);
+		cognitoUserPoolsTokenProvider.setKeyValueStorage(
+			// TODO: allow configure with a public interface
+			resolvedKeyValueStorage,
+		);
 
-			if (usesDefaultCognitoTokenProvider(mergedLibraryOptions.Auth)) {
-				syncDefaultCognitoAuthConfig(resolvedResourceConfig.Auth);
-
-				if (libraryOptions.ssr !== undefined) {
-					cognitoUserPoolsTokenProvider.setKeyValueStorage(
-						// TODO: allow configure with a public interface
-						resolvedKeyValueStorage,
-					);
-				}
-			}
-
-			Amplify.configure(resolvedResourceConfig, mergedLibraryOptions);
-
-			return;
-		}
-
-		// If no Auth libraryOptions were previously configured, then always add default providers.
-		if (!Amplify.libraryOptions.Auth) {
-			cognitoUserPoolsTokenProvider.setAuthConfig(resolvedResourceConfig.Auth);
-			cognitoUserPoolsTokenProvider.setKeyValueStorage(
-				// TODO: allow configure with a public interface
-				resolvedKeyValueStorage,
-			);
-
-			Amplify.configure(resolvedResourceConfig, {
-				...libraryOptions,
-				Auth: {
-					tokenProvider: cognitoUserPoolsTokenProvider,
-					credentialsProvider: resolvedCredentialsProvider,
-				},
-			});
-
-			return;
-		}
-
-		// At this point, Auth libraryOptions would have been previously configured and no overriding
-		// Auth options were given, so we should preserve the currently configured Auth libraryOptions.
-		if (libraryOptions) {
-			const authLibraryOptions = Amplify.libraryOptions.Auth;
-			// If ssr is provided through libraryOptions, we should respect the intentional reconfiguration.
-			if (libraryOptions.ssr !== undefined) {
-				cognitoUserPoolsTokenProvider.setKeyValueStorage(
-					// TODO: allow configure with a public interface
-					resolvedKeyValueStorage,
-				);
-
-				authLibraryOptions.credentialsProvider = resolvedCredentialsProvider;
-			}
-
-			if (usesDefaultCognitoTokenProvider(authLibraryOptions)) {
-				syncDefaultCognitoAuthConfig(resolvedResourceConfig.Auth);
-			}
-
-			Amplify.configure(resolvedResourceConfig, {
-				...Amplify.libraryOptions,
-				...libraryOptions,
-				Auth: authLibraryOptions,
-			});
-
-			return;
-		}
-
-		// Finally, if there were no libraryOptions given at all, we should simply not touch the currently
-		// configured libraryOptions.
-		if (usesDefaultCognitoTokenProvider(Amplify.libraryOptions.Auth)) {
-			syncDefaultCognitoAuthConfig(resolvedResourceConfig.Auth);
-		}
-
-		Amplify.configure(resolvedResourceConfig);
+		Amplify.configure(resolvedResourceConfig, {
+			...libraryOptions,
+			Auth: {
+				tokenProvider: cognitoUserPoolsTokenProvider,
+				credentialsProvider: resolvedCredentialsProvider,
+			},
+		});
 	},
 	/**
 	 * Returns the {@link ResourcesConfig} object passed in as the `resourceConfig` parameter when calling


### PR DESCRIPTION
Solves issue : https://github.com/aws-amplify/amplify-js/issues/14820


#### Description of changes
When DefaultAmplify.configure runs again with a new resourcesConfig.Auth but without libraryOptions.Auth, the default cognitoUserPoolsTokenProvider was not always refreshed. TokenStore storage keys depend on authConfig.Cognito.userPoolClientId, so tokens could read/write under stale keys after reconfigure (related to #13707).

Change (packages/aws-amplify/src/initSingleton.ts):

Pass-through to core when !resolvedResourceConfig.Auth or libraryOptions?.Auth is provided (caller owns Auth wiring).
Singleton-managed path (Auth in config, no libraryOptions.Auth): on every configure/reconfigure:
cognitoUserPoolsTokenProvider.setAuthConfig(resolvedResourceConfig.Auth)
cognitoUserPoolsTokenProvider.setKeyValueStorage(...) (SSR-aware: cookies vs defaultStorage)
Amplify.configure with default token + credentials providers
Out of scope: merging libraryOptions across configure calls (discussed on #14820; tracked separately in #14815 / #14816).

Issue #, if available
Fixes #14820
Related: #13707, #14815, #14816

Description of how you validated changes
cd packages/aws-amplify
..\..\node_modules\.bin\jest.cmd initSingleton -w 1
Updated initSingleton.test.ts and initSingleton.integration.test.ts for pass-through vs refresh behavior.

Checklist

 PR description included

 yarn test passes (full monorepo — rely on CI)

 Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

 Relevant documentation is changed or added
Checklist for repo maintainers

 Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows

 New source file paths included in this PR have been added to CODEOWNERS, if appropriate
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
