### PR TITLE
chore: add engines field to package.json files

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -93,6 +93,9 @@
 		"kinesis-firehose",
 		"personalize"
 	],
+	"engines": {
+		"node": ">=18"
+	},
 	"dependencies": {
 		"@aws-sdk/client-firehose": "^3.1012.0",
 		"@aws-sdk/client-kinesis": "^3.1012.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -67,6 +67,9 @@
 	"bugs": {
 		"url": "https://github.com/aws/aws-amplify/issues"
 	},
+	"engines": {
+		"node": ">=18"
+	},
 	"homepage": "https://docs.amplify.aws/",
 	"devDependencies": {
 		"@aws-amplify/core": "6.16.3",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -91,6 +91,9 @@
 		"server",
 		"enable-oauth-listener"
 	],
+	"engines": {
+		"node": ">=18"
+	},
 	"dependencies": {
 		"@aws-crypto/sha256-js": "5.2.0",
 		"@smithy/types": "^3.3.0",

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -293,6 +293,9 @@
 		"push-notifications",
 		"utils"
 	],
+	"engines": {
+		"node": ">=18"
+	},
 	"dependencies": {
 		"@aws-amplify/analytics": "7.0.94",
 		"@aws-amplify/api": "6.3.26",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,9 @@
 		"internals",
 		"server"
 	],
+	"engines": {
+		"node": ">=18"
+	},
 	"dependencies": {
 		"@aws-crypto/sha256-js": "5.2.0",
 		"@aws-sdk/types": "^3.973.6",

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -72,6 +72,9 @@
 		"lex-v1",
 		"lex-v2"
 	],
+	"engines": {
+		"node": ">=18"
+	},
 	"dependencies": {
 		"@aws-sdk/client-lex-runtime-service": "^3.1012.0",
 		"@aws-sdk/client-lex-runtime-v2": "^3.1012.0",

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -43,6 +43,9 @@
 		"dist/esm",
 		"src"
 	],
+	"engines": {
+		"node": ">=18"
+	},
 	"dependencies": {
 		"@aws-amplify/storage": "6.15.0",
 		"@aws-sdk/client-comprehend": "^3.1012.0",

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -73,6 +73,9 @@
 		"iot",
 		"mqtt"
 	],
+	"engines": {
+		"node": ">=18"
+	},
 	"dependencies": {
 		"@aws-amplify/auth": "6.20.0",
 		"buffer": "4.9.2",


### PR DESCRIPTION
This makes it easier for consumers to know what to expect as far as compatibility goes.

Both human consumers and static analysis tools.