### PR TITLE
fix(deps): bump uuid to ^11.1.1

### DIFF
--- a/.changeset/fix-uuid-cve-2026-41907.md
+++ b/.changeset/fix-uuid-cve-2026-41907.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/core': patch
+---
+
+fix(deps): bump uuid to ^11.1.1 to fix CVE-2026-41907 (missing buffer bounds check in v3/v5/v6)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,7 @@
 		"js-cookie": "^3.0.7",
 		"rxjs": "^7.8.1",
 		"tslib": "^2.5.0",
-		"uuid": "^11.0.0"
+		"uuid": "^11.1.1"
 	},
 	"devDependencies": {
 		"@aws-amplify/react-native": "1.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12930,7 +12930,7 @@ uuid-validate@^0.0.3:
   resolved "https://registry.yarnpkg.com/uuid-validate/-/uuid-validate-0.0.3.tgz#e30617f75dc742a0e4f95012a11540faf9d39ab4"
   integrity sha512-Fykw5U4eZESbq739BeLvEBFRuJODfrlmjx5eJux7W817LjRaq4b7/i4t2zxQmhcX+fAj4nMfRdTzO4tmwLKn0w==
 
-uuid@^11.0.0:
+uuid@^11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
   integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==


### PR DESCRIPTION
## Summary

Bumps `uuid` from `^11.0.0` to `^11.1.1` in `@aws-amplify/core` to address [CVE-2026-41907](https://nvd.nist.gov/vuln/detail/CVE-2026-41907) ([GHSA-w5hq-g745-h8pq](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq)).

## Vulnerability

**Missing buffer bounds check in uuid v3/v5/v6 when `buf` is provided.**

The `v3()`, `v5()`, and `v6()` API methods accept external output buffers but do not reject out-of-range writes (small `buf` or large `offset`), allowing silent partial writes into caller-provided buffers. Fixed in uuid 11.1.1.

- **Severity**: Medium (CVSS 6.3)
- **CWE**: CWE-787 (Out-of-bounds Write), CWE-1285 (Improper Validation of Specified Index)
- **Fix**: uuid >= 11.1.1

## Changes

- `packages/core/package.json`: Bumped uuid from `^11.0.0` to `^11.1.1`
- `yarn.lock`: Updated to resolve uuid 11.1.1
- `.changeset/fix-uuid-cve-2026-41907.md`: Added patch changeset for `@aws-amplify/core`

Closes https://github.com/aws-amplify/amplify-js/security/dependabot/247