### PR TITLE
fix(deps): add uuid resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
 		"qs": "^6.14.1",
 		"js-yaml": "4.1.1",
 		"serialize-javascript": "^7.0.5",
-		"@tootallnate/once": "3.0.1"
+		"@tootallnate/once": "3.0.1",
+		"uuid": "^11.1.1"
 	},
 	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12930,15 +12930,10 @@ uuid-validate@^0.0.3:
   resolved "https://registry.yarnpkg.com/uuid-validate/-/uuid-validate-0.0.3.tgz#e30617f75dc742a0e4f95012a11540faf9d39ab4"
   integrity sha512-Fykw5U4eZESbq739BeLvEBFRuJODfrlmjx5eJux7W817LjRaq4b7/i4t2zxQmhcX+fAj4nMfRdTzO4tmwLKn0w==
 
-uuid@^11.1.1:
+uuid@^11.1.1, uuid@^3.4.0:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
   integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
-
-uuid@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"


### PR DESCRIPTION
## Description

Fixes Dependabot security alert [#247](https://github.com/aws-amplify/amplify-js/security/dependabot/247).

**Vulnerability:** `uuid` < 11.1.1 — Missing buffer bounds check in v3/v5/v6 when `buf` is provided (CVE-2026-41907, Medium severity)

### Root Cause

The direct dependency in `@aws-amplify/core` was already bumped to `^11.1.1` in a prior commit, but the transitive dependency from `expo-file-system` (a devDependency of `@aws-amplify/datastore-storage-adapter`) still pulled `uuid@3.4.0` into `yarn.lock`.

### Fix

Added a `"uuid": "^11.1.1"` entry to the root `resolutions` block in `package.json`, which forces all uuid instances (including transitive deps) to resolve to the patched version.

### Verification

- `yarn why uuid` shows only `uuid@11.1.1` (no 3.4.0 remaining)
- `yarn build` passes (20/20 tasks successful)
- No duplicated Amplify dependencies detected
