### PR TITLE
chore: upgrade expo-file-system to 56.0.7

### DIFF
--- a/.changeset/upgrade-expo-file-system.md
+++ b/.changeset/upgrade-expo-file-system.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/datastore-storage-adapter': patch
+---
+
+chore(deps): upgrade expo-file-system from 15.0.0 to 56.0.7 and migrate import to expo-file-system/legacy subpath

--- a/.changeset/upgrade-expo-file-system.md
+++ b/.changeset/upgrade-expo-file-system.md
@@ -1,5 +1,0 @@
----
-'@aws-amplify/datastore-storage-adapter': patch
----
-
-chore(deps): upgrade expo-file-system from 15.0.0 to 56.0.7 and migrate import to expo-file-system/legacy subpath

--- a/packages/datastore-storage-adapter/package.json
+++ b/packages/datastore-storage-adapter/package.json
@@ -41,7 +41,7 @@
 		"@types/better-sqlite3": "^7.6.13",
 		"@types/react-native-sqlite-storage": "5.0.1",
 		"better-sqlite3": "^12.6.2",
-		"expo-file-system": "15.0.0",
+		"expo-file-system": "56.0.7",
 		"expo-sqlite": "10.1.0",
 		"react-native-sqlite-storage": "5.0.0"
 	}

--- a/packages/datastore-storage-adapter/src/ExpoSQLiteAdapter/ExpoSQLiteDatabase.ts
+++ b/packages/datastore-storage-adapter/src/ExpoSQLiteAdapter/ExpoSQLiteDatabase.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ConsoleLogger } from '@aws-amplify/core';
 import { PersistentModel } from '@aws-amplify/datastore';
-import { deleteAsync, documentDirectory } from 'expo-file-system';
+import { deleteAsync, documentDirectory } from 'expo-file-system/legacy';
 import { WebSQLDatabase, openDatabase } from 'expo-sqlite';
 
 import { DB_NAME } from '../common/constants';

--- a/packages/datastore-storage-adapter/tsconfig.json
+++ b/packages/datastore-storage-adapter/tsconfig.json
@@ -22,7 +22,10 @@
 		"allowSyntheticDefaultImports": true,
 		"esModuleInterop": true,
 		"typeRoots": ["./node_modules/@types", "../../node_modules/@types"],
-		"types": ["jest", "node", "lodash"]
+		"types": ["jest", "node", "lodash"],
+		"paths": {
+			"expo-file-system/legacy": ["../../node_modules/expo-file-system/build/legacy/index.d.ts"]
+		}
 	},
 	"include": ["src/**/*", "ExpoSQLiteAdapter", "SQLiteAdapter", "__tests__"]
 }

--- a/packages/datastore-storage-adapter/webpack.config.js
+++ b/packages/datastore-storage-adapter/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
 		'@aws-amplify/datastore',
 		'@aws-amplify/core',
 		'expo-file-system',
+		'expo-file-system/legacy',
 		'expo-sqlite',
 		'react-native-sqlite-storage',
 	],

--- a/yarn.lock
+++ b/yarn.lock
@@ -7851,12 +7851,10 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
-expo-file-system@15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-15.0.0.tgz#e37b31799b9f033916b12282ad045d298c712589"
-  integrity sha512-zxJRSuhIYFoJQwYnEY0DNj3+Ve4rJfy4WOCZ3g0RP21lc5Upkwf4f191v/jAf8r4bOhkQYqQYYQlulAXK70YuA==
-  dependencies:
-    uuid "^3.4.0"
+expo-file-system@56.0.7:
+  version "56.0.7"
+  resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-56.0.7.tgz#66a69361d839afa1773dc247b160da166e3df0da"
+  integrity sha512-dcKzo8ShPloM7jgfnMcJStgQebhP8owVjCkNI/aX6NMFV1CYB8bxKGMdnzJ3mXk5nfaiW+F/lSKr2UIJ02WAUA==
 
 expo-sqlite@10.1.0:
   version "10.1.0"
@@ -12934,11 +12932,6 @@ uuid@^11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
   integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
-
-uuid@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"


### PR DESCRIPTION
## Summary

Upgrades `expo-file-system` from **15.0.0** to **56.0.7** (latest stable) in the `@aws-amplify/datastore-storage-adapter` package.

## Changes

### Breaking change adaptation

`expo-file-system` v56 introduces a new `File`/`Directory`-based API as the primary export. The legacy API (`deleteAsync`, `documentDirectory`, etc.) has been moved to the `expo-file-system/legacy` subpath but remains fully supported.

### Files modified

- **`packages/datastore-storage-adapter/package.json`** — bumped version from `15.0.0` to `56.0.7`
- **`packages/datastore-storage-adapter/src/ExpoSQLiteAdapter/ExpoSQLiteDatabase.ts`** — updated import path from `'expo-file-system'` to `'expo-file-system/legacy'`
- **`packages/datastore-storage-adapter/tsconfig.json`** — added `paths` mapping so TypeScript resolves `expo-file-system/legacy` to pre-compiled `.d.ts` types (the new package ships raw `.ts` source files that require `expo-modules-core`)
- **`packages/datastore-storage-adapter/webpack.config.js`** — added `'expo-file-system/legacy'` to webpack externals
- **`yarn.lock`** — updated lockfile

## Testing

- `yarn turbo run build --filter=@aws-amplify/datastore-storage-adapter` — ✅ compiles successfully (rollup ESM/CJS + webpack UMD)
- Existing tests have pre-existing jsdom/ESM failures unrelated to this change

## Why

The previous version (15.0.0) corresponds to Expo SDK 49 which is no longer actively maintained. Version 56.0.7 is the current stable release aligned with Expo SDK 56.