### PR TITLE
test: point integ tests to sample app fix branch

### DIFF
--- a/.github/workflows/push-integ-test.yml
+++ b/.github/workflows/push-integ-test.yml
@@ -8,7 +8,7 @@ concurrency:
 on:
   push:
     branches:
-      - feat/example-integ-test-branch/main
+      - fix/remove-babel-preset-resolution
 
 jobs:
   e2e:


### PR DESCRIPTION
## Purpose

This PR triggers the E2E integration tests against the sample app fix branch `fix/remove-babel-preset-resolution` in `amplify-js-samples-staging`.

### What this does

Updates `.github/workflows/push-integ-test.yml` to trigger on the `fix/remove-babel-preset-resolution` branch. The [`setup-samples-staging` action](.github/actions/setup-samples-staging/action.yml) automatically checks out the matching branch name in `amplify-js-samples-staging`, so the E2E tests will run against the sample apps with the stale `babel-preset-react-app@10.0.0` resolution removed.

### Related PR

- aws-amplify/amplify-js-samples-staging#1118 — removes the `babel-preset-react-app` resolution from 10 sample apps that was breaking webpack 5 builds with ESM packages (e.g., axios).

### Expected outcome

The E2E tests should pass now that the sample apps use `babel-preset-react-app@10.1.0` (the default for react-scripts 5.0.1), which correctly generates fully-specified imports compatible with webpack 5's ESM handling.
