### PR TITLE
fix(deps): resolve uuid to ^11.1.1 to address CVE-2026-41907 in v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,8 +116,7 @@
 		"qs": "^6.15.2",
 		"**/form-data": "4.0.4",
 		"lodash": "^4.18.1",
-		"js-cookie": "^3.0.7",
-		"uuid": "^11.1.1"
+		"js-cookie": "^3.0.7"
 	},
 	"jest": {
 		"resetMocks": true,

--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
 		"qs": "^6.15.2",
 		"**/form-data": "4.0.4",
 		"lodash": "^4.18.1",
-		"js-cookie": "^3.0.7"
+		"js-cookie": "^3.0.7",
+		"uuid": "^11.1.1"
 	},
 	"jest": {
 		"resetMocks": true,

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -56,7 +56,7 @@
 		"@aws-sdk/util-utf8-browser": "3.6.1",
 		"lodash": "^4.18.1",
 		"tslib": "^1.8.0",
-		"uuid": "^3.2.1"
+		"uuid": "^11.1.1"
 	},
 	"devDependencies": {
 		"@aws-sdk/types": "3.6.1"

--- a/packages/api-graphql/package.json
+++ b/packages/api-graphql/package.json
@@ -58,7 +58,7 @@
     "@aws-amplify/pubsub": "5.6.6",
     "graphql": "15.8.0",
     "tslib": "^1.8.0",
-    "uuid": "^3.2.1",
+    "uuid": "^11.1.1",
     "zen-observable-ts": "0.8.19"
   },
   "size-limit": [

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -42,7 +42,7 @@
 	"homepage": "https://aws-amplify.github.io/",
 	"devDependencies": {
 		"@react-native-community/netinfo": "4.7.0",
-		"@types/uuid": "3.4.6",
+		"@types/uuid": "^9.0.0",
 		"@types/uuid-validate": "^0.0.1",
 		"dexie": "3.2.2",
 		"dexie-export-import": "1.0.3",
@@ -64,7 +64,7 @@
 		"idb": "5.0.6",
 		"immer": "9.0.6",
 		"ulid": "2.3.0",
-		"uuid": "3.4.0",
+		"uuid": "^11.1.1",
 		"zen-observable-ts": "0.8.19",
 		"zen-push": "0.2.1"
 	},

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -53,7 +53,7 @@
 		"@aws-amplify/core": "5.8.16",
 		"@aws-amplify/rtn-push-notification": "1.1.15",
 		"lodash": "^4.18.1",
-		"uuid": "^3.2.1"
+		"uuid": "^11.1.1"
 	},
 	"devDependencies": {
 		"@babel/plugin-proposal-class-properties": "^7.0.0",

--- a/packages/predictions/package.json
+++ b/packages/predictions/package.json
@@ -56,7 +56,7 @@
 		"@aws-sdk/util-utf8-node": "3.6.1",
 		"buffer": "4.9.2",
 		"tslib": "^1.8.0",
-		"uuid": "^3.2.1"
+		"uuid": "^11.1.1"
 	},
 	"size-limit": [
 		{

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -57,7 +57,7 @@
     "graphql": "15.8.0",
     "tslib": "^1.8.0",
     "url": "0.11.0",
-    "uuid": "^3.2.1",
+    "uuid": "^11.1.1",
     "zen-observable-ts": "0.8.19"
   },
   "size-limit": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5535,12 +5535,10 @@
   resolved "https://registry.yarnpkg.com/@types/uuid-validate/-/uuid-validate-0.0.1.tgz#b4eedecbd9db25851490d65a58f13feaa89dd509"
   integrity sha512-RbX9q0U00SLoV+l7loYX0Wrtv4QTClBC0QcdNts6x2b5G1HJN8NI9YlS1HNA6THrI9EH3OXSgya6eMQIlDjKFA==
 
-"@types/uuid@3.4.6":
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.6.tgz#d2c4c48eb85a757bf2927f75f939942d521e3016"
-  integrity sha512-cCdlC/1kGEZdEglzOieLDYBxHsvEOIg7kp/2FYyVR9Pxakq+Qf/inL3RKQ+PA8gOlI/NnL+fXmQH12nwcGzsHw==
-  dependencies:
-    "@types/node" "*"
+"@types/uuid@^9.0.0":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
+  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
 
 "@types/webpack@^5.0.0":
   version "5.28.5"
@@ -17342,10 +17340,25 @@ uuid-validate@^0.0.3:
   resolved "https://registry.yarnpkg.com/uuid-validate/-/uuid-validate-0.0.3.tgz#e30617f75dc742a0e4f95012a11540faf9d39ab4"
   integrity sha512-Fykw5U4eZESbq739BeLvEBFRuJODfrlmjx5eJux7W817LjRaq4b7/i4t2zxQmhcX+fAj4nMfRdTzO4tmwLKn0w==
 
-uuid@3.4.0, uuid@8.3.2, uuid@^11.1.1, uuid@^3.0.0, uuid@^3.2.1, uuid@^3.3.2, uuid@^3.4.0, uuid@^7.0.3, uuid@^8.0.0:
+uuid@8.3.2, uuid@^8.0.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
   integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
+
+uuid@^3.0.0, uuid@^3.3.2, uuid@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 v8-compile-cache@2.3.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6548,7 +6548,7 @@ axe-core@^4.10.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.0.tgz#d9e56ab0147278272739a000880196cdfe113b59"
   integrity sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==
 
-axios@1.16.1, axios@^1.0.0, axios@^1.16.1:
+axios@^1.0.0, axios@^1.16.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.1.tgz#517e29291d19d6e8cf919ff264f4fe157261ba12"
   integrity sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==
@@ -9231,7 +9231,7 @@ fast-xml-builder@^1.2.0:
     path-expression-matcher "^1.5.0"
     xml-naming "^0.1.0"
 
-fast-xml-parser@5.4.1, fast-xml-parser@5.8.0, fast-xml-parser@^5.8.0:
+fast-xml-parser@5.4.1, fast-xml-parser@^5.8.0:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz#64d71f0f8d4bf23621dffd762aef7e98c1884fc1"
   integrity sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==
@@ -17342,20 +17342,10 @@ uuid-validate@^0.0.3:
   resolved "https://registry.yarnpkg.com/uuid-validate/-/uuid-validate-0.0.3.tgz#e30617f75dc742a0e4f95012a11540faf9d39ab4"
   integrity sha512-Fykw5U4eZESbq739BeLvEBFRuJODfrlmjx5eJux7W817LjRaq4b7/i4t2zxQmhcX+fAj4nMfRdTzO4tmwLKn0w==
 
-uuid@3.4.0, uuid@^3.0.0, uuid@^3.2.1, uuid@^3.3.2, uuid@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@8.3.2, uuid@^8.0.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+uuid@3.4.0, uuid@8.3.2, uuid@^11.1.1, uuid@^3.0.0, uuid@^3.2.1, uuid@^3.3.2, uuid@^3.4.0, uuid@^7.0.3, uuid@^8.0.0:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-compile-cache@2.3.0:
   version "2.3.0"


### PR DESCRIPTION
## Issue

Closes part of #14827.

A fresh install of `aws-amplify@^5` still pulls a vulnerable `uuid@3.4.0` transitively:

```
% npm why uuid | grep uuid
uuid@3.4.0
  uuid@"^3.2.1" from @aws-amplify/analytics
  uuid@"^3.2.1" from @aws-amplify/api-graphql
  uuid@"3.4.0"  from @aws-amplify/datastore
  uuid@"^3.2.1" from @aws-amplify/notifications
  uuid@"^3.2.1" from @aws-amplify/predictions
  uuid@"^3.2.1" from @aws-amplify/pubsub
  uuid@"^3.0.0" from @aws-sdk/client-comprehend / client-translate / middleware-retry
```

`uuid < 11.1.1` is affected by **[GHSA-w5hq-g745-h8pq](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq) (CVE-2026-41907)** — the `v3()`/`v5()`/`v6()` methods skip bounds validation on caller-provided output buffers, allowing silent partial writes that can produce truncated/malformed identifiers.

The other items from #14827 — **axios, js-cookie, fast-xml-parser, qs** — were already addressed in #14832. **uuid** was the remaining gap.

## Change

Add a root `resolutions` entry forcing `uuid@^11.1.1`, mirroring the v6 fix in **#14828** (already released):

```diff
   "lodash": "^4.18.1",
-  "js-cookie": "^3.0.7"
+  "js-cookie": "^3.0.7",
+  "uuid": "^11.1.1"
```

After this, all `uuid` ranges collapse to a single resolved `11.1.1` in `yarn.lock` (the vulnerable 3.4.0 / 7.0.3 / 8.3.2 entries are removed).

## Compatibility

uuid changed its import surface in v7 (named exports only), so I verified every import site in v5 source:

```
packages/*/src: import { v1 as uuid } from 'uuid';
                import { v4 as uuid } from 'uuid';
                import { v4 as uuid4 } from 'uuid';
```

**All** usages are named imports of `v1`/`v4` — API-compatible from uuid v3 through v11. There are **no** default imports (`import uuid from 'uuid'`) or `uuid.v4()` member-access patterns that v7+ removed, so no source changes are required. Confirmed `require('uuid')` in the installed 11.1.1 exposes `v1`/`v3`/`v4`/`v5` as functions.

## Notes

- Scope is intentionally minimal: only `package.json` + `yarn.lock`, only `uuid` entries change.
- Following the convention of the prior v5 security PR (#14832), no changeset file is added (v5-stable does not use `.changeset/`).
- Pre-existing `pubsub`/`api-graphql` TypeScript build errors (`symbol` index types) on v5-stable are unrelated to this change — they reproduce on a pristine `v5-stable` checkout (introduced by the Node 24 toolchain bump in #14784) and are unaffected by this resolution.