### PR TITLE
ci: remove Amazon Lex V1 interactions e2e tests (Lex V1 end of support)

### DIFF
--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -611,22 +611,11 @@ tests:
   #   amplifyjs_dir: true
 
   # INTERACTIONS
-  - test_name: integ_react_interactions_react_interactions
-    desc: 'React Interactions'
-    framework: react
-    category: interactions
-    sample_name: [chatbot-component]
-    spec: chatbot-component
-    browser: *minimal_browser_list
-  # Skipping chatbot_v1 test due to persistent AWS Lex V1 rate limiting issues
-  # TODO: Re-enable after investigating bot configuration
-  # - test_name: integ_react_interactions_chatbot_v1
-  #   desc: 'Chatbot V1'
-  #   framework: react
-  #   category: interactions
-  #   sample_name: [lex-test-component]
-  #   spec: chatbot-v1
-  #   browser: *minimal_browser_list
+  # Amazon Lex V1 reached end of support on 2025-09-15 and its runtime
+  # (runtime.lex.*.amazonaws.com) is no longer reachable. The chatbot-component
+  # samples and the standalone chatbot_v1 test exercised Lex V1, so they have
+  # been removed. Lex V2 coverage is provided by integ_react_interactions_chatbot_v2
+  # below. See https://docs.aws.amazon.com/lexv2/latest/dg/migration.html
   - test_name: integ_react_interactions_chatbot_v2
     desc: 'Chatbot V2'
     framework: react
@@ -634,27 +623,6 @@ tests:
     sample_name: [lex-test-component]
     spec: chatbot-v2
     browser: *minimal_browser_list
-  - test_name: integ_angular_interactions
-    desc: 'Angular Interactions'
-    framework: angular
-    category: interactions
-    sample_name: [chatbot-component]
-    spec: chatbot-component
-    browser: *minimal_browser_list
-  - test_name: integ_vue_interactions_vue_2_interactions
-    desc: 'Vue 2 Interactions'
-    framework: vue
-    category: interactions
-    sample_name: [chatbot-component]
-    spec: chatbot-component
-    browser: [chrome]
-  - test_name: integ_vue_interactionsvue_3_interactions
-    desc: 'Vue 3 Interactions'
-    framework: vue
-    category: interactions
-    sample_name: [chatbot-component-vue3]
-    spec: chatbot-component
-    browser: [chrome]
 
   # PREDICTIONS
   - test_name: integ_react_predictions


### PR DESCRIPTION
## What

Removes the four Amazon Lex **V1** Interactions e2e tests from `.github/integ-config/integ-all.yml`:

- `integ_react_interactions_react_interactions`
- `integ_angular_interactions`
- `integ_vue_interactions_vue_2_interactions`
- `integ_vue_interactionsvue_3_interactions`

…plus the already–commented-out `integ_react_interactions_chatbot_v1` entry. These are **deleted**, not skipped, because Lex V1 is not coming back.

The Lex **V2** test `integ_react_interactions_chatbot_v2` (sample `lex-test-component`) is kept and continues to provide Interactions coverage.

## Why

These four jobs have failed **deterministically on every recent v5-stable commit**. They are not a code regression and not flaky:

| Commit | Date | Lex V1 interactions jobs |
|---|---|---|
| d379910 | 2026-03-09 | ✅ pass |
| 9e0742f | 2026-03-13 | ✅ pass |
| 6b1bf74 | 2026-04-10 | ❌ fail (×4) |
| … every commit since | | ❌ fail (×4) |

All four run the same `chatbot-component` spec, which drives the Lex-V1-only `AmplifyChatbot` UI component against the `BookTrip_dev` **Lex V1** bot. The app compiles and the page-render assertions pass; only the live-backend step fails:

```
type and send with button:
  AssertionError: Timed out retrying after 30000ms:
  Expected to find content: 'What city will you be staying in?' but never did.
```

### Root cause: Amazon Lex V1 end of support

**Amazon Lex V1 reached end of support on 2025-09-15** ([AWS docs](https://docs.aws.amazon.com/lexv2/latest/dg/migration.html)) and AWS has retired the V1 runtime. I verified this directly:

- Calling the V1 runtime (`runtime.lex.us-east-1.amazonaws.com`, `PostText`) for `BookTrip_dev` using the sample's own guest Cognito credentials → **connection times out**.
- Endpoint comparison from the same host: Lex **V1 runtime** → TCP 443 blocked/timeout; while **Lex V1 control plane** (`models.lex`), **Lex V2 runtime** (`runtime-v2-lex`), and **Cognito** all connect normally.
- The corresponding Lex **V2** bot (`BookTripNew`, used by `chatbot_v2`) responds correctly to the same input, confirming V2 is healthy.

This is consistent with the green→red CI timeline above (the V1 runtime was wound down in that window) and supersedes the older "rate limiting" note in the config, which was a guess — a quota increase would not help a retired runtime.

## Why remove instead of migrate

Migrating the four framework samples to Lex V2 was considered and rejected as **redundant**: V2 Interactions is **already covered and green** by `integ_react_interactions_chatbot_v2` on both `v5-stable` and `main`. The four `chatbot-component` samples also rely on the legacy V1-only `AmplifyChatbot` component, so migrating them would be a full rewrite duplicating existing coverage. This change also **aligns `v5-stable` with `main`**, which already does not run the V1 `chatbot-component` tests.

## Scope

CI-config-only change. No product/library source code is modified. The Amplify JS `@aws-amplify/interactions` package continues to ship both the V1 (`AWSLexProvider`) and V2 (`AWSLexV2Provider`) providers.