### PR TITLE
fix(datastore): load react-native-get-random-values for uuid v11 on React Native

### DIFF
--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -68,6 +68,14 @@
 		"zen-observable-ts": "0.8.19",
 		"zen-push": "0.2.1"
 	},
+	"peerDependencies": {
+		"react-native-get-random-values": ">=1.7.0"
+	},
+	"peerDependenciesMeta": {
+		"react-native-get-random-values": {
+			"optional": true
+		}
+	},
 	"size-limit": [
 		{
 			"name": "DataStore (top-level class)",

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -110,6 +110,12 @@ import {
 } from '../predicates/next';
 import { getIdentifierValue } from '../sync/utils';
 import DataStoreConnectivity from '../sync/datastoreConnectivity';
+import { loadGetRandomValues } from './loadGetRandomValues';
+
+// `uuid` v4 (used below to mint model ids) requires `crypto.getRandomValues`,
+// which is not available in React Native. On RN this loads the
+// `react-native-get-random-values` polyfill; on web/Node it is a no-op.
+loadGetRandomValues();
 
 setAutoFreeze(true);
 enablePatches();

--- a/packages/datastore/src/datastore/loadGetRandomValues.native.ts
+++ b/packages/datastore/src/datastore/loadGetRandomValues.native.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// `uuid` v4 relies on `crypto.getRandomValues`, which is not available in the
+// React Native runtime. `react-native-get-random-values` polyfills it as a
+// side effect and must be loaded before `uuid` is used to mint model ids in
+// `DataStore.save()`. See:
+// https://github.com/uuidjs/uuid#getrandomvalues-not-supported
+export const loadGetRandomValues = () => {
+	try {
+		// metro bundler requires a static string for loading the module.
+		// See: https://facebook.github.io/metro/docs/configuration/#dynamicdepsinpackages
+		require('react-native-get-random-values');
+	} catch (e) {
+		// Surface an actionable message instructing consumers to install the
+		// peer dependency. The error message is rewritten because metro reports
+		// the missing module as `undefined`.
+		const message = (e as Error).message.replace(
+			/undefined/g,
+			'react-native-get-random-values',
+		);
+		throw new Error(message);
+	}
+};

--- a/packages/datastore/src/datastore/loadGetRandomValues.ts
+++ b/packages/datastore/src/datastore/loadGetRandomValues.ts
@@ -1,0 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// No-op on web/Node, where `crypto.getRandomValues` is provided by the
+// platform. The React Native implementation lives in
+// `loadGetRandomValues.native.ts` and is selected automatically by Metro.
+export const loadGetRandomValues = () => {};


### PR DESCRIPTION
## Problem

After #14839 bumped `uuid` to `^11.1.1` (to address CVE-2026-41907), the React Native DataStore E2E suite (`integ_rn_ios_datastore_sqlite_adapter`) started failing at runtime: every `DataStore.save()` of a syncable model fails, so the in-app "Successfully created new user!" notification never appears and the SQLiteAdapter Detox suite cascades to all-red.

### Root cause

- DataStore mints the primary key for syncable models via `uuid4()` — `packages/datastore/src/datastore/datastore.ts` (`import { v4 as uuid4 } from 'uuid'`, used at the `save()` draft producer).
- **uuid v3** `v4()` fell back to `Math.random()` when `crypto.getRandomValues` was unavailable.
- **uuid v11** `v4()` instead **throws** `crypto.getRandomValues() not supported` when it's missing.
- On React Native, `crypto.getRandomValues` does not exist unless the `react-native-get-random-values` polyfill has been loaded. So on RN, uuid v11 throws on every model create.

This is isolated to DataStore — the Storage/Geo RN Detox suites (which don't mint model ids via uuid) pass on the same release runs. CI timeline confirms the job was green on the release immediately before #14839 and red on #14839 and every run since.

## Fix

Load the polyfill from within `@aws-amplify/datastore` via a platform-resolved side-effect module, so **consumers don't have to import it themselves**:

- `loadGetRandomValues.ts` — no-op (web/Node).
- `loadGetRandomValues.native.ts` — `require('react-native-get-random-values')`, selected automatically by Metro's `.native` resolution (same precedent as `InMemoryStore.native.ts`).
- Invoked once at `datastore.ts` module load, before any `uuid4()` call.
- `react-native-get-random-values` declared as an **optional `peerDependency`** so package managers surface the install/pod requirement without affecting web/Node.

This mirrors the `loadGetRandomValues` mechanism already shipped on v6/`main` (`packages/react-native` + `@aws-amplify/core`'s `amplifyUuid/index.native.ts`), adapted to v5 which has no `@aws-amplify/react-native` package.

## Why no samples change

The `SQLiteAdapter` sample already lists `react-native-get-random-values` in its `package.json` (and `Podfile.lock`) — it simply never imported it. This PR makes the library load it, so the fix is verifiable **without modifying the sample**: merge this, re-run the failed `integ_rn_ios_datastore_sqlite_adapter` job, and it should pass on the unchanged sample.

## Test plan

- [ ] Re-run `E2E-Detox integ_rn_ios_datastore_sqlite_adapter` against this branch — expect green with no sample changes.
- [ ] Confirm web/Node DataStore builds/tests unaffected (the default `loadGetRandomValues` is a no-op; no new bundled dependency on the native module).

## Notes

- Does not revert the uuid security bump (#14839); the CVE fix stays.
- Forward-looking: any v5 RN DataStore consumer upgrading into the uuid-bumped release hits the same latent issue; this fix resolves it for all of them (provided the native module is installed/pod-linked, which is inherent to any RN native polyfill — same residual requirement as v6).
