### PR TITLE
fix: complete partial v5-stable LTS release (publish remaining packages)

### DIFF
--- a/packages/amazon-cognito-identity-js/src/index.js
+++ b/packages/amazon-cognito-identity-js/src/index.js
@@ -16,3 +16,5 @@ export { default as CookieStorage } from './CookieStorage';
 export { default as DateHelper } from './DateHelper';
 export { appendToCognitoUserAgent } from './UserAgent';
 export { default as WordArray } from './utils/WordArray';
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -9,3 +9,5 @@ export {
 	AWSKinesisFirehoseProvider,
 	AmazonPersonalizeProvider,
 } from './Providers';
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/api-graphql/src/index.ts
+++ b/packages/api-graphql/src/index.ts
@@ -6,3 +6,5 @@ export { GraphQLResult, GraphQLAuthError, GRAPHQL_AUTH_MODE } from './types';
 export { GraphQLAPI, GraphQLAPIClass, graphqlOperation } from './GraphQLAPI';
 export * from './types';
 export default GraphQLAPI;
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/api-rest/src/index.ts
+++ b/packages/api-rest/src/index.ts
@@ -3,3 +3,5 @@
 
 export { RestAPI, RestAPIClass } from './RestAPI';
 export { RestClient } from './RestClient';
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -10,3 +10,5 @@ export {
 } from '@aws-amplify/api-graphql';
 
 export type { GraphQLResult } from '@aws-amplify/api-graphql';
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -28,3 +28,5 @@ export {
 	AuthErrorStrings,
 	GRAPHQL_AUTH_MODE,
 };
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/aws-amplify-react-native/src/index.ts
+++ b/packages/aws-amplify-react-native/src/index.ts
@@ -61,3 +61,5 @@ const Amplify = {
 export default Amplify;
 
 I18n.putVocabularies(dict);
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/aws-amplify/src/index.ts
+++ b/packages/aws-amplify/src/index.ts
@@ -36,3 +36,5 @@ export {
 } from '@aws-amplify/core';
 export { withSSRContext } from './withSSRContext';
 export { Geo } from '@aws-amplify/geo';
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -9,3 +9,5 @@ export { BrowserStorageCache, InMemoryCache, CacheConfig };
 
 // Standard `Cache` export to maintain interoperability with React Native
 export { BrowserStorageCache as Cache };
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,3 +92,5 @@ export {
  * @deprecated use named import
  */
 export default Amplify;
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/datastore-storage-adapter/src/index.ts
+++ b/packages/datastore-storage-adapter/src/index.ts
@@ -2,3 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 import SQLiteAdapter from './SQLiteAdapter/SQLiteAdapter';
 export { SQLiteAdapter };
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/datastore/src/index.ts
+++ b/packages/datastore/src/index.ts
@@ -35,3 +35,5 @@ export const utils = {
 };
 
 export * from './types';
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/geo/src/index.ts
+++ b/packages/geo/src/index.ts
@@ -2,3 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 export { Geo } from './Geo';
 export * from './types';
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/interactions/src/index.ts
+++ b/packages/interactions/src/index.ts
@@ -6,3 +6,5 @@ export * from './types';
 export { AbstractInteractionsProvider } from './Providers/InteractionsProvider';
 export { AWSLexProvider } from './Providers/AWSLexProvider';
 export { AWSLexV2Provider } from './Providers/AWSLexV2Provider';
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -24,3 +24,5 @@ export {
 	PushNotificationPermissionStatus,
 } from './PushNotification/types';
 export { NotificationsConfig, UserInfo } from './types';
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/predictions/src/index.ts
+++ b/packages/predictions/src/index.ts
@@ -18,3 +18,5 @@ export {
 	AmazonAIPredictionsProvider,
 	AmazonAIInterpretPredictionsProvider,
 };
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/pubsub/src/index.ts
+++ b/packages/pubsub/src/index.ts
@@ -15,3 +15,5 @@ export {
 	ObserverQuery,
 	mqttTopicMatch,
 } from './Providers';
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/pushnotification/src/index.ts
+++ b/packages/pushnotification/src/index.ts
@@ -6,3 +6,5 @@ import NotificationClass from './PushNotification';
 const _instance = new NotificationClass(null);
 export const PushNotification = _instance;
 Amplify.register(PushNotification);
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/rtn-push-notification/src/index.ts
+++ b/packages/rtn-push-notification/src/index.ts
@@ -8,3 +8,5 @@ export const {
 	AmplifyRTNPushNotification,
 }: { AmplifyRTNPushNotification?: PushNotificationNativeModule } =
 	NativeModules;
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -6,3 +6,5 @@ import { Storage, StorageInstance } from './Storage';
 export { Storage as StorageClass, StorageInstance as Storage };
 export { AWSS3Provider } from './providers';
 export * from './types';
+
+// chore: trigger v5-stable LTS release to complete partial publish (uuid-v11 RN fix, datastore). No functional change.


### PR DESCRIPTION
## What

Triggers a full **v5-stable LTS release** to complete the previous **partial** publish. Adds a one-line no-op comment to the entry file of **every publishable package** so `lerna publish --conventional-commits` detects all of them as changed and republishes the entire v5 suite to the `stable-5` dist-tag at a fresh, consistent version. **No functional code change.**

## Why this is needed

The prior release run published only part of the suite. `lerna publish --dist-tag=stable-5` aborted partway when the `postpublish` dist-tag hook on `amazon-cognito-identity-js` failed (transient npm error), leaving npm split:

- **Published:** `amazon-cognito-identity-js@6.3.17`, `@aws-amplify/analytics@6.5.18`, `@aws-amplify/api-rest@3.5.19`, `@aws-amplify/notifications@1.6.19`, `@aws-amplify/storage@5.9.21`.
- **NOT published:** `aws-amplify@5.3.34`, `@aws-amplify/datastore@4.7.23` (the RN uuid-v11 fix, #14842), `@aws-amplify/datastore-storage-adapter@2.0.66`, `@aws-amplify/api@5.4.22`, `@aws-amplify/auth@5.6.20`, `@aws-amplify/predictions@5.5.23`, `@aws-amplify/pubsub@5.6.7`.

Because the git tags `5.3.34`/`4.7.23` were already pushed, a plain re-run of the publish job finds "no changed packages" and publishes nothing. A `fix:`-typed commit touching every package is the way to make `--conventional-commits` re-release the full suite through the existing merge-to-release pipeline.

## Effect on merge

- `fix:` type → lerna bumps **all** packages a patch level and publishes them to `stable-5`.
- The 7 missing packages reach npm; the ~6 already-published ones are re-published at the new patch version. End state: the whole v5 suite is consistent on `stable-5` with the uuid-v11 RN fix included.

## ⚠️ Reviewer / release-owner notes

- Each change is a pure `+2/-0` comment append (blank line + comment) on `src/index.ts` (or `src/index.js` for cognito). 20 packages touched; no code logic altered.
- This intentionally re-publishes already-live packages at a new patch version (e.g. `storage@5.9.22`, `cognito@6.3.18`) to keep the suite version-aligned; versions `5.3.34`/`4.7.23` remain tagged-but-unpublished.
- Merging pushes to `v5-stable` and **publishes to production npm `stable-5` — irreversible (72h unpublish window).** Please confirm before merging.


## Failed release job (context)

The partial publish that this PR completes occurred in the **`release / Publish to Amplify Package`** job of the LTS release run:

- Failed job: https://github.com/aws-amplify/amplify-js/actions/runs/27424967279/job/81077875199

In that job, `lerna publish --dist-tag=stable-5` began publishing and then aborted when the `postpublish` lifecycle hook on `amazon-cognito-identity-js` (`npm dist-tag add …`) errored:

```
lerna success published @aws-amplify/notifications 1.6.19
lerna success published @aws-amplify/analytics 6.5.18
lerna success published @aws-amplify/api-rest 3.5.19
...
lerna info lifecycle amazon-cognito-identity-js@6.3.17~postpublish: amazon-cognito-identity-js@6.3.17
> npm dist-tag add $npm_package_name@$npm_package_version latest
lerna ERR! lifecycle "postpublish" errored in "amazon-cognito-identity-js", exiting 1
```

Because lerna treats a failed lifecycle hook as fatal, the remaining packages were left unpublished — and since the version-bump commit and git tags (`5.3.34` / `4.7.23`) were already pushed, simply **re-running that job publishes nothing** (`--conventional-commits` sees no changed packages since the existing tags). Hence this fresh `fix:` commit to re-trigger a full release.
