### PR TITLE
fix(release): decouple amazon-cognito-identity-js latest dist-tag from postpublish hook

### DIFF
--- a/.github/workflows/callable-npm-publish-lts-release.yml
+++ b/.github/workflows/callable-npm-publish-lts-release.yml
@@ -31,6 +31,23 @@ jobs:
           github_user: ${{ vars.GH_USER}}
           github_email: ${{ vars.GH_EMAIL}}
 
+      - name: Promote amazon-cognito-identity-js to the "latest" dist-tag
+        working-directory: ./amplify-js
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # amazon-cognito-identity-js is the only unscoped package whose "latest"
+          # dist-tag must track the v5 line; the rest of the fleet rides "stable-5".
+          # This previously lived in the package's "postpublish" hook, where lerna
+          # ran it mid-parallel-publish, swallowed its output, and a single failure
+          # aborted the entire release. Running it here as an explicit, sequential
+          # step makes the result visible and retryable without re-publishing.
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+          PKG=amazon-cognito-identity-js
+          VERSION=$(node -p "require('./packages/${PKG}/package.json').version")
+          echo "Setting ${PKG}@${VERSION} as latest"
+          npm dist-tag add "${PKG}@${VERSION}" latest
+
       - name: Set github commit user
         env:
           GITHUB_EMAIL: ${{ vars.GH_EMAIL }}
@@ -51,4 +68,5 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target }}
         run: |
-          git push origin $TARGET_BRANCH
+          git pull --rebase origin "$TARGET_BRANCH"
+          git push origin "$TARGET_BRANCH"

--- a/packages/amazon-cognito-identity-js/package.json
+++ b/packages/amazon-cognito-identity-js/package.json
@@ -46,8 +46,7 @@
     "generate-version": "genversion src/Platform/version.ts --es6 --semi",
     "test": "jest --config ./jest.config.js",
     "format": "echo \"Not implemented\"",
-    "ts-coverage": "typescript-coverage-report -p ./tsconfig.build.json",
-    "postpublish": "npm dist-tag add $npm_package_name@$npm_package_version latest"
+    "ts-coverage": "typescript-coverage-report -p ./tsconfig.build.json"
   },
   "main": "lib/index.js",
   "react-native": {


### PR DESCRIPTION
## Summary

The v5 LTS release was failing on the `amazon-cognito-identity-js` `postpublish` hook, which ran `npm dist-tag add … latest` *inside* lerna's parallel publish. lerna swallowed the hook's stderr and a single failure **aborted the entire fleet release** — leaving the v5 line partially published (the umbrella `aws-amplify` and several `@aws-amplify/*` packages never reached npm even though their versions were bumped, committed, and tagged).

This moves the `latest` dist-tag promotion out of the package lifecycle and into an explicit, sequential release step.

## Changes

- **`packages/amazon-cognito-identity-js/package.json`** — remove the `postpublish` hook (`npm dist-tag add $npm_package_name@$npm_package_version latest`).
- **`.github/workflows/callable-npm-publish-lts-release.yml`**
  - Add an explicit *"Promote amazon-cognito-identity-js to the latest dist-tag"* step that runs **after** the fleet publish, reads the just-published version, and fails **loudly** (no swallowed stderr) without aborting the publish.
  - Add `git pull --rebase` before the post-release `git push` to fix the separate non-fast-forward push failure seen on 06-12.

`amazon-cognito-identity-js` is the only package with a `postpublish` and the only unscoped package whose `latest` must track the v5 line while the rest of the fleet rides `stable-5`; everything else is unaffected.

## Why

- Lifecycle hooks running mid-parallel-publish hide their errors and make one package's tag-move fatal to the whole release.
- An explicit post-publish step is observable, retryable, and cannot abort already-published packages.

## Testing

- `yarn && yarn bootstrap && yarn build` green on the branch (Node 22).
- YAML + JSON validated.
- The partial-publish backlog this bug created was separately reconciled out-of-band via `lerna publish from-package` (10 packages republished to `stable-5`; `aws-amplify@5.3.35` now resolves all pinned deps).

## Notes

- Does not change the publish auth path.