### PR TITLE
fix: wrap plain Error from fetch as NetworkError in React Native

### DIFF
--- a/.changeset/clever-singers-start.md
+++ b/.changeset/clever-singers-start.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/core": patch
+---
+
+fix: wrap plain Error from fetch as NetworkError in React Native

--- a/packages/core/__tests__/clients/fetch.test.ts
+++ b/packages/core/__tests__/clients/fetch.test.ts
@@ -1,3 +1,4 @@
+import { AmplifyErrorCode } from '../../src/types';
 import { fetchTransferHandler } from '../../src/clients/handlers/fetch';
 
 describe(fetchTransferHandler.name, () => {
@@ -131,4 +132,45 @@ describe(fetchTransferHandler.name, () => {
 			expect(mockFetch.mock.calls[0][1].body).toBe('Mock Body');
 		},
 	);
+
+	it('should throw NetworkError when fetch rejects with TypeError (browser)', async () => {
+		mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+		await expect(fetchTransferHandler(mockRequest, {})).rejects.toMatchObject({
+			name: AmplifyErrorCode.NetworkError,
+			message: 'A network error has occurred.',
+			underlyingError: expect.any(TypeError),
+		});
+	});
+
+	it('should throw NetworkError when fetch rejects with plain Error (React Native native network failure)', async () => {
+		mockFetch.mockRejectedValue(new Error('Network request failed'));
+
+		await expect(fetchTransferHandler(mockRequest, {})).rejects.toMatchObject({
+			name: AmplifyErrorCode.NetworkError,
+			message: 'A network error has occurred.',
+			underlyingError: expect.any(Error),
+		});
+	});
+
+	it('should rethrow AbortError without wrapping', async () => {
+		const abortError = Object.assign(new Error('The user aborted a request.'), {
+			name: 'AbortError',
+		});
+		mockFetch.mockRejectedValue(abortError);
+
+		await expect(fetchTransferHandler(mockRequest, {})).rejects.toBe(
+			abortError,
+		);
+	});
+
+	it('should include the original error as underlyingError', async () => {
+		const cause = new Error('Network request failed');
+		mockFetch.mockRejectedValue(cause);
+
+		await expect(fetchTransferHandler(mockRequest, {})).rejects.toMatchObject({
+			name: AmplifyErrorCode.NetworkError,
+			underlyingError: cause,
+		});
+	});
 });

--- a/packages/core/src/clients/handlers/fetch.ts
+++ b/packages/core/src/clients/handlers/fetch.ts
@@ -30,14 +30,17 @@ export const fetchTransferHandler: TransferHandler<
 			credentials: withCrossDomainCredentials ? 'include' : 'same-origin',
 		});
 	} catch (e) {
-		if (e instanceof TypeError) {
-			throw new AmplifyError({
-				name: AmplifyErrorCode.NetworkError,
-				message: 'A network error has occurred.',
-				underlyingError: e,
-			});
+		if (e instanceof Error && e.name === 'AbortError') {
+			throw e;
 		}
-		throw e;
+		// Fetch only rejects for aborts and network failures. HTTP error responses resolve
+		// normally. Browsers typically throw TypeError, while React Native throws Error
+		// objects for network failures.
+		throw new AmplifyError({
+			name: AmplifyErrorCode.NetworkError,
+			message: 'A network error has occurred.',
+			underlyingError: e,
+		});
 	}
 
 	const responseHeaders: Record<string, string> = {};


### PR DESCRIPTION
#### Description of changes
`fetchTransferHandler` only caught `TypeError` when `fetch()` rejected, converting it to a named `NetworkError`. This is correct for browsers, where the Fetch spec mandates `TypeError` for network failures.

React Native's native network layer throws plain Error objects instead of `TypeError`. These slipped through the `instanceof TypeError` check, were rethrown as-is, and eventually reached `assertServiceError` in the auth package. Because `assertServiceError` treats any error with `name === 'Error'` as an unknown failure, it wrapped them in `AuthError({ name: 'Unknown' })`, discarding all network error context. Callers had no way to distinguish a network failure from a genuine unexpected error.

The fix catches all non-abort errors from `fetch()` and wraps them as `NetworkError`. Aborts are explicitly re-thrown unchanged. This is safe because `fetch()` only rejects for two reasons: abort signals and network failures. HTTP error responses (4xx, 5xx) resolve normally and never reach the catch block.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

#### Checklist for repo maintainers
- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.