### PR TITLE
fix(auth): dispatch customOAuthState before signInWithRedirect_failure on OAuth error redirects

### DIFF
--- a/.changeset/late-rings-melt.md
+++ b/.changeset/late-rings-melt.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/auth": patch
+---
+
+fix(auth): dispatch customOAuthState before signInWithRedirect_failure on OAuth error redirects

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Hub, decodeJWT } from '@aws-amplify/core';
+import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
 
 import { handleFailure } from '../../../../../src/providers/cognito/utils/oauth/handleFailure';
 import { validateState } from '../../../../../src/providers/cognito/utils/oauth/validateState';
@@ -82,6 +83,7 @@ describe('completeOAuthFlow', () => {
 		(oAuthStore.clearOAuthInflightData as jest.Mock).mockClear();
 		(oAuthStore.clearOAuthData as jest.Mock).mockClear();
 		(oAuthStore.storeOAuthSignIn as jest.Mock).mockClear();
+		(oAuthStore.loadOAuthState as jest.Mock).mockReset();
 	});
 
 	it('handles error presented in the redirect url', async () => {
@@ -97,6 +99,72 @@ describe('completeOAuthFlow', () => {
 				domain: 'localhost:3000',
 			}),
 		).rejects.toThrow(expectedErrorMessage);
+	});
+
+	it('dispatches customOAuthState from the persisted state before throwing on error', async () => {
+		const expectedErrorMessage = 'some error message';
+		(oAuthStore.loadOAuthState as jest.Mock).mockResolvedValueOnce(
+			'someState-2f696e766974652f616263',
+		);
+
+		await expect(
+			completeOAuthFlow({
+				currentUrl: `http://localhost:3000?error=true&error_description=${expectedErrorMessage}`,
+				userAgentValue: 'UserAgent',
+				clientId: 'clientId',
+				redirectUri: 'http://localhost:3000/',
+				responseType: 'code',
+				domain: 'localhost:3000',
+			}),
+		).rejects.toThrow(expectedErrorMessage);
+
+		expect(mockHubDispatch).toHaveBeenCalledWith(
+			'auth',
+			{
+				event: 'customOAuthState',
+				data: '/invite/abc',
+			},
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+
+	it('does not dispatch customOAuthState on error when the persisted state has no custom state', async () => {
+		const expectedErrorMessage = 'some error message';
+		(oAuthStore.loadOAuthState as jest.Mock).mockResolvedValueOnce(
+			'someStateWithoutCustom',
+		);
+
+		await expect(
+			completeOAuthFlow({
+				currentUrl: `http://localhost:3000?error=true&error_description=${expectedErrorMessage}`,
+				userAgentValue: 'UserAgent',
+				clientId: 'clientId',
+				redirectUri: 'http://localhost:3000/',
+				responseType: 'code',
+				domain: 'localhost:3000',
+			}),
+		).rejects.toThrow(expectedErrorMessage);
+
+		expect(mockHubDispatch).not.toHaveBeenCalled();
+	});
+
+	it('does not dispatch customOAuthState on error when there is no persisted state', async () => {
+		const expectedErrorMessage = 'some error message';
+		(oAuthStore.loadOAuthState as jest.Mock).mockResolvedValueOnce(null);
+
+		await expect(
+			completeOAuthFlow({
+				currentUrl: `http://localhost:3000?error=true&error_description=${expectedErrorMessage}`,
+				userAgentValue: 'UserAgent',
+				clientId: 'clientId',
+				redirectUri: 'http://localhost:3000/',
+				responseType: 'code',
+				domain: 'localhost:3000',
+			}),
+		).rejects.toThrow(expectedErrorMessage);
+
+		expect(mockHubDispatch).not.toHaveBeenCalled();
 	});
 
 	describe('handleCodeFlow', () => {

--- a/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
@@ -40,6 +40,18 @@ export const completeOAuthFlow = async ({
 	const errorMessage = urlParams.searchParams.get('error_description');
 
 	if (error) {
+		const storedState = await oAuthStore.loadOAuthState();
+		if (storedState && isCustomState(storedState)) {
+			Hub.dispatch(
+				'auth',
+				{
+					event: 'customOAuthState',
+					data: urlSafeDecode(getCustomState(storedState)),
+				},
+				'Auth',
+				AMPLIFY_SYMBOL,
+			);
+		}
 		throw createOAuthError(errorMessage ?? error);
 	}
 


### PR DESCRIPTION
#### Description of changes

When `signInWithRedirect` fails during the OAuth callback (e.g. Cognito redirects back with `?error=...&error_description=...&state=...`, such as when a PreSignUp Lambda trigger throws to block sign-in), `completeOAuthFlow` threw before reaching the point where `customOAuthState` is dispatched. As a result, any `customState` passed to `signInWithRedirect({ customState })` was lost on failure — only `signInWithRedirect_failure` fired, with no way to recover the custom state via the Hub event system.

This change dispatches `customOAuthState` from the `error` branch of `completeOAuthFlow` before throwing, so `signInWithRedirect_failure` listeners can still read the custom state that was passed to `signInWithRedirect`.

Per the maintainer's guidance on the issue, the custom state is recovered from the state Amplify itself persisted when `signInWithRedirect({ customState })` was called (`oAuthStore.loadOAuthState()`), rather than from the unvalidated `state` query param. This avoids dispatching attacker-influenceable data into `customOAuthState`, which commonly drives a redirect target. The existing `isCustomState` / `getCustomState` / `urlSafeDecode` helpers are reused, matching the success path in `completeFlow`.

#### Issue #, if available

#14853

#### Description of how you validated changes

Added unit tests in `completeOAuthFlow.test.ts` covering the error redirect path:
- dispatches `customOAuthState` (recovered from the persisted state) before throwing when the persisted state contains a custom state
- does not dispatch `customOAuthState` when the persisted state has no custom state
- does not dispatch `customOAuthState` when there is no persisted state

`yarn test --scope @aws-amplify/auth` passes for the affected suites.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
