### PR TITLE
ci: pin Detox e2e runner to macos-15-large

### DIFF
--- a/.github/workflows/callable-e2e-test-detox.yml
+++ b/.github/workflows/callable-e2e-test-detox.yml
@@ -17,7 +17,11 @@ on:
 jobs:
   e2e-test:
     name: E2E-Detox ${{ inputs.test_name }}
-    runs-on: macos-latest-large
+    # Pin to macOS 15 instead of macos-latest: `macos-latest` now resolves to
+    # macOS 26, which ships only Xcode 26.x and iOS 26 simulators. These React
+    # Native sample apps and the "iPhone 16" (iOS 18.x) simulator require the
+    # Xcode 16.4 / iOS 18 toolchain that ships on the macOS 15 image.
+    runs-on: macos-15-large
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
     steps:


### PR DESCRIPTION
The iOS Detox jobs run on macos-latest-large, which GitHub rotated from macOS 15 to macOS 26. The macOS 26 image ships only Xcode 26.x and iOS 26 simulators, so "sudo xcode-select -s /Applications/Xcode_16.4.app" fails with "invalid developer directory" and the RN sample apps / the "iPhone 16" (iOS 18.x) simulator the tests boot are no longer available.

Pin the runner to macos-15-large so the Xcode 16.4 / iOS 18 toolchain these tests were validated against stays available and the pipeline is decoupled from macos-latest image rotation.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
<!-- For external contributions, provide the github issue the PR is addressing. If no github issue exists for the related changes, open a new issue in https://github.com/aws-amplify/amplify-js/issues. -->


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
