### PR TITLE
ci: capture Detox device logs and artifacts on failure

### DIFF
--- a/.github/workflows/callable-e2e-test-detox.yml
+++ b/.github/workflows/callable-e2e-test-detox.yml
@@ -83,6 +83,20 @@ jobs:
         shell: bash
       - name: Detox run
         run: |
-          $GITHUB_WORKSPACE/amplify-js/scripts/retry-yarn-script.sh -s 'detox test -c ios.sim.debug -u' -n 3
+          $GITHUB_WORKSPACE/amplify-js/scripts/retry-yarn-script.sh -s 'detox test -c ios.sim.debug -u --record-logs all --take-screenshots failing --artifacts-location ./artifacts' -n 3
         working-directory: ${{ inputs.working_directory }}
         shell: bash
+      - name: Upload Detox artifacts
+        # Captures per-test device/app logs (RN + Hermes JS errors, crashes) and
+        # screenshots so app-level failures can be diagnosed. Also grabs the
+        # simulator's CoreSimulator logs as a fallback.
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: failure()
+        with:
+          name: detox-artifacts-${{ inputs.test_name }}
+          if-no-files-found: ignore
+          path: |
+            ${{ inputs.working_directory }}/artifacts
+            /Users/runner/Library/Logs/CoreSimulator
+          retention-days: 7
+          overwrite: true


### PR DESCRIPTION
The iOS Detox jobs fail at "Detox run" with the app disconnecting from the Detox server, but the app-side JS/native error is never surfaced in CI logs, so app-level failures can't be diagnosed.

Record device/app logs and failing-test screenshots via Detox (--record-logs all --take-screenshots failing --artifacts-location) and upload them (plus CoreSimulator logs) as a workflow artifact on failure. This exposes the actual React Native / Hermes crash so the current Detox failures can be root-caused.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
<!-- For external contributions, provide the github issue the PR is addressing. If no github issue exists for the related changes, open a new issue in https://github.com/aws-amplify/amplify-js/issues. -->


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
