### PR TITLE
feat(analytics): add Amazon Connect Customer Profiles provider for identifyUser

### DIFF
--- a/.changeset/analytics-connect-customer-profiles-identify-user.md
+++ b/.changeset/analytics-connect-customer-profiles-identify-user.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/analytics': minor
+'@aws-amplify/core': minor
+'aws-amplify': minor
+---
+
+feat(analytics): add an Amazon Connect Customer Profiles provider that backs `identifyUser` with a REST endpoint (typically fronted by a Lambda). The provider is exposed via the stable subpath `aws-amplify/analytics/customer-profiles` and configured through the `analytics.amazon_connect_customer_profiles` key in `amplify_outputs` (`Analytics.CustomerProfiles = { endpoint, region }`). Additive and non-breaking — the public `IdentifyUserInput`/`UserProfile` signatures are preserved 1:1 and the existing Pinpoint provider is untouched.

--- a/.changeset/analytics-connect-customer-profiles-identify-user.md
+++ b/.changeset/analytics-connect-customer-profiles-identify-user.md
@@ -4,4 +4,8 @@
 'aws-amplify': minor
 ---
 
-feat(analytics): add an Amazon Connect Customer Profiles provider that backs `identifyUser` with a REST endpoint (typically fronted by a Lambda). The provider is exposed via the stable subpath `aws-amplify/analytics/customer-profiles` and configured through the `analytics.amazon_connect_customer_profiles` key in `amplify_outputs` (`Analytics.CustomerProfiles = { endpoint, region }`). Additive and non-breaking — the public `IdentifyUserInput`/`UserProfile` signatures are preserved 1:1 and the existing Pinpoint provider is untouched.
+feat(analytics): add an Amazon Connect Customer Profiles provider that backs `identifyUser` with a REST endpoint (typically fronted by a Lambda). The provider is exposed via the stable subpath `aws-amplify/analytics/customer-profiles` and configured through the `analytics.amazon_connect_customer_profiles` key in `amplify_outputs` (`Analytics.CustomerProfiles = { endpoint, region }`).
+
+`identifyUser` supports both authenticated and guest (unauthenticated) callers, selected automatically from the resolved auth session: authenticated (Cognito user pool) calls `POST /identify-user` with an `Authorization: Bearer <token>` header, while guest (Cognito Identity Pool) calls are SigV4-signed for `execute-api` and sent to `POST /identify-user-guest` using the guest credentials — enabling pre-sign-in use cases such as registering a device before login. New optional `options` fields (`deviceId`, `platform`, `appVersion`, and `previousGuestIdentityId`) are supported; passing `previousGuestIdentityId` on an authenticated call folds the prior guest profile (and its devices) into the authenticated profile (merge-on-sign-in).
+
+Additive and non-breaking — the public `IdentifyUserInput`/`UserProfile` signatures are preserved 1:1 and the existing Pinpoint provider is untouched.

--- a/packages/analytics/__tests__/providers/customer-profiles/apis/identifyUser.test.ts
+++ b/packages/analytics/__tests__/providers/customer-profiles/apis/identifyUser.test.ts
@@ -1,0 +1,132 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AnalyticsError } from '../../../../src/errors';
+import { identifyUser } from '../../../../src/providers/customer-profiles/apis';
+import { IdentifyUserInput } from '../../../../src/providers/customer-profiles/types';
+import {
+	resolveConfig,
+	resolveCredentials,
+} from '../../../../src/providers/customer-profiles/utils';
+
+jest.mock('../../../../src/providers/customer-profiles/utils');
+
+describe('Analytics Customer Profiles Provider API: identifyUser', () => {
+	const endpoint = 'https://example.com/prod';
+	const token = 'user-pool-access-token';
+	const config = { endpoint, region: 'region' };
+
+	const mockResolveConfig = resolveConfig as jest.Mock;
+	const mockResolveCredentials = resolveCredentials as jest.Mock;
+	const mockFetch = jest.fn();
+
+	beforeAll(() => {
+		(global as any).fetch = mockFetch;
+	});
+
+	beforeEach(() => {
+		mockResolveConfig.mockReturnValue(config);
+		mockResolveCredentials.mockResolvedValue({ token });
+		mockFetch.mockResolvedValue({ ok: true, status: 200 });
+	});
+
+	afterEach(() => {
+		mockResolveConfig.mockReset();
+		mockResolveCredentials.mockReset();
+		mockFetch.mockReset();
+	});
+
+	it('POSTs to the identify-user endpoint with the Bearer token attached', async () => {
+		const input: IdentifyUserInput = {
+			userId: 'user-id',
+			userProfile: {},
+		};
+
+		await identifyUser(input);
+
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+		const [url, request] = mockFetch.mock.calls[0];
+		expect(url).toBe(`${endpoint}/identify-user`);
+		expect(request.method).toBe('POST');
+		expect(request.headers).toMatchObject({
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json',
+		});
+	});
+
+	it('sends the frozen request body shape', async () => {
+		const input: IdentifyUserInput = {
+			userId: 'user-id',
+			userProfile: {
+				email: 'email@example.com',
+				customProperties: {
+					phoneNumber: ['555-555-5555'],
+				},
+			},
+			options: {
+				userAttributes: { hobbies: ['biking', 'climbing'] },
+				address: 'device-token',
+				channelType: 'APNS',
+				optOut: 'NONE',
+			},
+		};
+
+		await identifyUser(input);
+
+		const [, request] = mockFetch.mock.calls[0];
+		expect(JSON.parse(request.body)).toEqual({
+			userId: input.userId,
+			userProfile: input.userProfile,
+			options: input.options,
+		});
+	});
+
+	it('omits undefined userId and options from the request body', async () => {
+		const input: IdentifyUserInput = {
+			userId: undefined as unknown as string,
+			userProfile: { email: 'email@example.com' },
+		};
+
+		await identifyUser(input);
+
+		const [, request] = mockFetch.mock.calls[0];
+		expect(JSON.parse(request.body)).toEqual({
+			userProfile: { email: 'email@example.com' },
+		});
+	});
+
+	it('resolves to void on a 2xx response', async () => {
+		mockFetch.mockResolvedValue({ ok: true, status: 200 });
+
+		await expect(
+			identifyUser({ userId: 'user-id', userProfile: {} }),
+		).resolves.toBeUndefined();
+	});
+
+	it('throws a typed AnalyticsError on a non-2xx response', async () => {
+		mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+		await expect(
+			identifyUser({ userId: 'user-id', userProfile: {} }),
+		).rejects.toBeInstanceOf(AnalyticsError);
+	});
+
+	it('throws a typed AnalyticsError when the network request fails', async () => {
+		mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+		await expect(
+			identifyUser({ userId: 'user-id', userProfile: {} }),
+		).rejects.toBeInstanceOf(AnalyticsError);
+	});
+
+	it('rejects if config resolution fails', async () => {
+		mockResolveConfig.mockImplementation(() => {
+			throw new Error('no config');
+		});
+
+		await expect(
+			identifyUser({ userId: 'user-id', userProfile: {} }),
+		).rejects.toBeDefined();
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+});

--- a/packages/analytics/__tests__/providers/customer-profiles/apis/identifyUser.test.ts
+++ b/packages/analytics/__tests__/providers/customer-profiles/apis/identifyUser.test.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { signRequest } from '@aws-amplify/core/internals/aws-client-utils';
+
 import { AnalyticsError } from '../../../../src/errors';
 import { identifyUser } from '../../../../src/providers/customer-profiles/apis';
 import { IdentifyUserInput } from '../../../../src/providers/customer-profiles/types';
@@ -10,6 +12,7 @@ import {
 } from '../../../../src/providers/customer-profiles/utils';
 
 jest.mock('../../../../src/providers/customer-profiles/utils');
+jest.mock('@aws-amplify/core/internals/aws-client-utils');
 
 describe('Analytics Customer Profiles Provider API: identifyUser', () => {
 	const endpoint = 'https://example.com/prod';
@@ -18,6 +21,7 @@ describe('Analytics Customer Profiles Provider API: identifyUser', () => {
 
 	const mockResolveConfig = resolveConfig as jest.Mock;
 	const mockResolveCredentials = resolveCredentials as jest.Mock;
+	const mockSignRequest = signRequest as jest.Mock;
 	const mockFetch = jest.fn();
 
 	beforeAll(() => {
@@ -33,6 +37,7 @@ describe('Analytics Customer Profiles Provider API: identifyUser', () => {
 	afterEach(() => {
 		mockResolveConfig.mockReset();
 		mockResolveCredentials.mockReset();
+		mockSignRequest.mockReset();
 		mockFetch.mockReset();
 	});
 
@@ -79,6 +84,29 @@ describe('Analytics Customer Profiles Provider API: identifyUser', () => {
 			userProfile: input.userProfile,
 			options: input.options,
 		});
+	});
+
+	it('forwards options.previousGuestIdentityId on an authenticated call (merge-on-sign-in)', async () => {
+		const input: IdentifyUserInput = {
+			userId: 'user-id',
+			userProfile: {},
+			options: {
+				previousGuestIdentityId: 'us-east-1:prior-guest-identity-id',
+			},
+		};
+
+		await identifyUser(input);
+
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+		const [url, request] = mockFetch.mock.calls[0];
+		expect(url).toBe(`${endpoint}/identify-user`);
+		expect(request.headers.Authorization).toBe(`Bearer ${token}`);
+		expect(JSON.parse(request.body).options.previousGuestIdentityId).toBe(
+			'us-east-1:prior-guest-identity-id',
+		);
+		// The merge hint travels on the authenticated route; the guest SigV4 path
+		// is not taken when a user-pool token is present.
+		expect(mockSignRequest).not.toHaveBeenCalled();
 	});
 
 	it('omits undefined userId and options from the request body', async () => {
@@ -128,5 +156,62 @@ describe('Analytics Customer Profiles Provider API: identifyUser', () => {
 			identifyUser({ userId: 'user-id', userProfile: {} }),
 		).rejects.toBeDefined();
 		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
+	describe('guest (Identity Pool) path', () => {
+		const credentials = {
+			accessKeyId: 'access-key-id',
+			secretAccessKey: 'secret-access-key',
+			sessionToken: 'session-token',
+		};
+
+		beforeEach(() => {
+			// No user-pool token -> guest credentials only.
+			mockResolveCredentials.mockResolvedValue({
+				token: undefined,
+				credentials,
+				identityId: 'us-east-1:guest',
+			});
+			mockSignRequest.mockReturnValue({
+				headers: {
+					authorization: 'AWS4-HMAC-SHA256 Credential=...',
+					'x-amz-date': '20260704T000000Z',
+					'x-amz-security-token': credentials.sessionToken,
+					host: 'example.com',
+					'content-type': 'application/json',
+				},
+			});
+		});
+
+		it('SigV4-signs a POST to the guest route with the guest credentials', async () => {
+			await identifyUser({ userId: 'guest-user', userProfile: {} });
+
+			// The signer was invoked for execute-api with the guest credentials.
+			expect(mockSignRequest).toHaveBeenCalledTimes(1);
+			const [request, signOptions] = mockSignRequest.mock.calls[0];
+			expect(request.method).toBe('POST');
+			expect(request.url.toString()).toBe(`${endpoint}/identify-user-guest`);
+			expect(signOptions).toMatchObject({
+				credentials,
+				signingRegion: config.region,
+				signingService: 'execute-api',
+			});
+
+			// The request went to the guest route with the signed headers.
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+			const [url, req] = mockFetch.mock.calls[0];
+			expect(url).toBe(`${endpoint}/identify-user-guest`);
+			expect(req.method).toBe('POST');
+			expect(req.headers.authorization).toContain('AWS4-HMAC-SHA256');
+			expect(req.headers).not.toHaveProperty('Authorization');
+		});
+
+		it('throws a typed AnalyticsError on a non-2xx guest response', async () => {
+			mockFetch.mockResolvedValue({ ok: false, status: 403 });
+
+			await expect(
+				identifyUser({ userId: 'guest-user', userProfile: {} }),
+			).rejects.toBeInstanceOf(AnalyticsError);
+		});
 	});
 });

--- a/packages/analytics/__tests__/providers/customer-profiles/utils/resolveConfig.test.ts
+++ b/packages/analytics/__tests__/providers/customer-profiles/utils/resolveConfig.test.ts
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+
+import { resolveConfig } from '../../../../src/providers/customer-profiles/utils';
+
+describe('Analytics Customer Profiles Provider Util: resolveConfig', () => {
+	const customerProfilesConfig = {
+		endpoint: 'https://example.com/prod',
+		region: 'region',
+	};
+	const getConfigSpy = jest.spyOn(Amplify, 'getConfig');
+
+	beforeEach(() => {
+		getConfigSpy.mockReset();
+	});
+
+	it('returns required config', () => {
+		getConfigSpy.mockReturnValue({
+			Analytics: { CustomerProfiles: customerProfilesConfig },
+		});
+		expect(resolveConfig()).toStrictEqual(customerProfilesConfig);
+	});
+
+	it('throws if endpoint is missing', () => {
+		getConfigSpy.mockReturnValue({
+			Analytics: {
+				CustomerProfiles: {
+					...customerProfilesConfig,
+					endpoint: undefined,
+				} as any,
+			},
+		});
+		expect(resolveConfig).toThrow();
+	});
+
+	it('throws if region is missing', () => {
+		getConfigSpy.mockReturnValue({
+			Analytics: {
+				CustomerProfiles: {
+					...customerProfilesConfig,
+					region: undefined,
+				} as any,
+			},
+		});
+		expect(resolveConfig).toThrow();
+	});
+});

--- a/packages/analytics/__tests__/providers/customer-profiles/utils/resolveCredentials.test.ts
+++ b/packages/analytics/__tests__/providers/customer-profiles/utils/resolveCredentials.test.ts
@@ -10,23 +10,51 @@ jest.mock('@aws-amplify/core');
 
 describe('Analytics Customer Profiles Provider Util: resolveCredentials', () => {
 	const token = 'user-pool-access-token';
+	const credentials = {
+		accessKeyId: 'access-key-id',
+		secretAccessKey: 'secret-access-key',
+		sessionToken: 'session-token',
+	};
+	const identityId = 'us-east-1:guest-identity-id';
 	const mockFetchAuthSession = fetchAuthSession as jest.Mock;
 
 	beforeEach(() => {
 		mockFetchAuthSession.mockReset();
 	});
 
-	it('resolves the Cognito user-pool access token', async () => {
+	it('resolves the Cognito user-pool access token (authenticated)', async () => {
 		mockFetchAuthSession.mockResolvedValue({
 			tokens: {
 				accessToken: { toString: () => token },
 			},
+			credentials,
+			identityId,
 		});
-		expect(await resolveCredentials()).toStrictEqual({ token });
+		expect(await resolveCredentials()).toStrictEqual({
+			token,
+			credentials,
+			identityId,
+		});
 	});
 
-	it('throws if the token is missing', async () => {
-		mockFetchAuthSession.mockResolvedValue({ tokens: undefined });
+	it('resolves guest credentials + identityId when no token is present', async () => {
+		mockFetchAuthSession.mockResolvedValue({
+			tokens: undefined,
+			credentials,
+			identityId,
+		});
+		expect(await resolveCredentials()).toStrictEqual({
+			token: undefined,
+			credentials,
+			identityId,
+		});
+	});
+
+	it('throws if neither a token nor credentials can be resolved', async () => {
+		mockFetchAuthSession.mockResolvedValue({
+			tokens: undefined,
+			credentials: undefined,
+		});
 		await expect(resolveCredentials()).rejects.toBeInstanceOf(AnalyticsError);
 	});
 });

--- a/packages/analytics/__tests__/providers/customer-profiles/utils/resolveCredentials.test.ts
+++ b/packages/analytics/__tests__/providers/customer-profiles/utils/resolveCredentials.test.ts
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { fetchAuthSession } from '@aws-amplify/core';
+
+import { AnalyticsError } from '../../../../src/errors';
+import { resolveCredentials } from '../../../../src/providers/customer-profiles/utils';
+
+jest.mock('@aws-amplify/core');
+
+describe('Analytics Customer Profiles Provider Util: resolveCredentials', () => {
+	const token = 'user-pool-access-token';
+	const mockFetchAuthSession = fetchAuthSession as jest.Mock;
+
+	beforeEach(() => {
+		mockFetchAuthSession.mockReset();
+	});
+
+	it('resolves the Cognito user-pool access token', async () => {
+		mockFetchAuthSession.mockResolvedValue({
+			tokens: {
+				accessToken: { toString: () => token },
+			},
+		});
+		expect(await resolveCredentials()).toStrictEqual({ token });
+	});
+
+	it('throws if the token is missing', async () => {
+		mockFetchAuthSession.mockResolvedValue({ tokens: undefined });
+		await expect(resolveCredentials()).rejects.toBeInstanceOf(AnalyticsError);
+	});
+});

--- a/packages/analytics/customer-profiles/package.json
+++ b/packages/analytics/customer-profiles/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@aws-amplify/analytics/customer-profiles",
+	"main": "../dist/cjs/providers/customer-profiles/index.js",
+	"browser": "../dist/esm/providers/customer-profiles/index.mjs",
+	"module": "../dist/esm/providers/customer-profiles/index.mjs",
+	"react-native": "../dist/cjs/providers/customer-profiles/index.js",
+	"typings": "../dist/esm/providers/customer-profiles/index.d.ts"
+}

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -37,6 +37,9 @@
 			],
 			"personalize": [
 				"./dist/esm/providers/personalize/index.d.ts"
+			],
+			"customer-profiles": [
+				"./dist/esm/providers/customer-profiles/index.d.ts"
 			]
 		}
 	},
@@ -71,6 +74,12 @@
 			"import": "./dist/esm/providers/personalize/index.mjs",
 			"require": "./dist/cjs/providers/personalize/index.js"
 		},
+		"./customer-profiles": {
+			"react-native": "./dist/cjs/providers/customer-profiles/index.js",
+			"types": "./dist/esm/providers/customer-profiles/index.d.ts",
+			"import": "./dist/esm/providers/customer-profiles/index.mjs",
+			"require": "./dist/cjs/providers/customer-profiles/index.js"
+		},
 		"./package.json": "./package.json"
 	},
 	"repository": {
@@ -91,7 +100,8 @@
 		"pinpoint",
 		"kinesis",
 		"kinesis-firehose",
-		"personalize"
+		"personalize",
+		"customer-profiles"
 	],
 	"dependencies": {
 		"@aws-sdk/client-firehose": "^3.1012.0",

--- a/packages/analytics/src/errors/validation.ts
+++ b/packages/analytics/src/errors/validation.ts
@@ -12,6 +12,7 @@ export enum AnalyticsValidationErrorCode {
 	UnsupportedPlatform = 'UnsupportedPlatform',
 	NoTrackingId = 'NoTrackingId',
 	InvalidFlushSize = 'InvalidFlushSize',
+	NoEndpoint = 'NoEndpoint',
 }
 
 export const validationErrorMap: AmplifyErrorMap<AnalyticsValidationErrorCode> =
@@ -39,5 +40,10 @@ export const validationErrorMap: AmplifyErrorMap<AnalyticsValidationErrorCode> =
 		},
 		[AnalyticsValidationErrorCode.NoTrackingId]: {
 			message: 'A trackingId is required to use Amazon Personalize',
+		},
+		[AnalyticsValidationErrorCode.NoEndpoint]: {
+			message: 'Missing endpoint.',
+			recoverySuggestion:
+				'Ensure Analytics.CustomerProfiles.endpoint is configured.',
 		},
 	};

--- a/packages/analytics/src/providers/customer-profiles/apis/identifyUser.ts
+++ b/packages/analytics/src/providers/customer-profiles/apis/identifyUser.ts
@@ -1,9 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { signRequest } from '@aws-amplify/core/internals/aws-client-utils';
+
 import { AnalyticsError } from '../../../errors';
 import { IdentifyUserInput } from '../types';
-import { resolveConfig, resolveCredentials } from '../utils';
+import {
+	GUEST_IDENTIFY_USER_PATH,
+	IDENTIFY_USER_PATH,
+	resolveConfig,
+	resolveCredentials,
+} from '../utils';
+
+const CONTENT_TYPE = 'application/json';
+const SIGNING_SERVICE = 'execute-api';
 
 /**
  * Sends information about a user to the Amazon Connect Customer Profiles
@@ -11,17 +21,27 @@ import { resolveConfig, resolveCredentials } from '../utils';
  * Customer Profile so that activity can be tracked across devices & platforms
  * by using the same `userId`.
  *
- * The request is a plain REST call authenticated with the caller's Cognito
- * user-pool access token:
+ * Two authorization modes are supported, selected automatically from the
+ * resolved auth session:
  *
- * `POST {endpoint}/identify-user` with header `Authorization: Bearer <token>`.
+ *  - Authenticated (Cognito user-pool): `POST {endpoint}/identify-user` with
+ *    header `Authorization: Bearer <accessToken>`. The profile is keyed on the
+ *    caller's `cognitoSub`.
+ *  - Guest (Identity Pool unauthenticated): `POST {endpoint}/identify-user-guest`
+ *    SigV4-signed (`execute-api`) with the guest credentials. The profile is
+ *    keyed on the caller's Identity Pool `identityId` — enabling pre-login use
+ *    cases such as registering a push-notification device token before sign-in.
+ *
+ * On sign-in, pass the prior guest `identityId` via
+ * `options.previousGuestIdentityId` on an authenticated call to fold the guest
+ * profile (and its devices) into the authenticated profile.
  *
  * @param {IdentifyUserInput} params The input object used to construct the
  *  request sent to the Customer Profiles endpoint.
  *
  * @throws validation: {@link AnalyticsError} - Thrown when the provided
- *  parameters or library configuration is incorrect, or when the Cognito
- *  user-pool token cannot be resolved.
+ *  parameters or library configuration is incorrect, or when neither a Cognito
+ *  user-pool token nor guest credentials can be resolved.
  * @throws service: {@link AnalyticsError} - Thrown when the endpoint responds
  *  with a non-2xx status code.
  *
@@ -46,19 +66,46 @@ export const identifyUser = async ({
 	userProfile,
 	options,
 }: IdentifyUserInput): Promise<void> => {
-	const { endpoint } = resolveConfig();
-	const { token } = await resolveCredentials();
+	const { endpoint, region } = resolveConfig();
+	const { token, credentials } = await resolveCredentials();
+
+	const body = JSON.stringify({ userId, userProfile, options });
 
 	let response: Response;
 	try {
-		response = await fetch(`${endpoint}/identify-user`, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				Authorization: `Bearer ${token}`,
-			},
-			body: JSON.stringify({ userId, userProfile, options }),
-		});
+		if (token) {
+			response = await fetch(`${endpoint}${IDENTIFY_USER_PATH}`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': CONTENT_TYPE,
+					Authorization: `Bearer ${token}`,
+				},
+				body,
+			});
+		} else {
+			// Guest (Identity Pool) path: SigV4-sign with the guest credentials
+			// using the shared signer so the request is authorized identically
+			// to any other IAM (`execute-api`) request.
+			const url = new URL(`${endpoint}${GUEST_IDENTIFY_USER_PATH}`);
+			const signed = signRequest(
+				{
+					method: 'POST',
+					url,
+					headers: { 'content-type': CONTENT_TYPE },
+					body,
+				},
+				{
+					credentials: credentials!,
+					signingRegion: region,
+					signingService: SIGNING_SERVICE,
+				},
+			);
+			response = await fetch(url.toString(), {
+				method: 'POST',
+				headers: signed.headers,
+				body,
+			});
+		}
 	} catch (error) {
 		throw new AnalyticsError({
 			name: 'NetworkException',

--- a/packages/analytics/src/providers/customer-profiles/apis/identifyUser.ts
+++ b/packages/analytics/src/providers/customer-profiles/apis/identifyUser.ts
@@ -1,0 +1,81 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AnalyticsError } from '../../../errors';
+import { IdentifyUserInput } from '../types';
+import { resolveConfig, resolveCredentials } from '../utils';
+
+/**
+ * Sends information about a user to the Amazon Connect Customer Profiles
+ * endpoint. Sending user information allows you to associate a user with their
+ * Customer Profile so that activity can be tracked across devices & platforms
+ * by using the same `userId`.
+ *
+ * The request is a plain REST call authenticated with the caller's Cognito
+ * user-pool access token:
+ *
+ * `POST {endpoint}/identify-user` with header `Authorization: Bearer <token>`.
+ *
+ * @param {IdentifyUserInput} params The input object used to construct the
+ *  request sent to the Customer Profiles endpoint.
+ *
+ * @throws validation: {@link AnalyticsError} - Thrown when the provided
+ *  parameters or library configuration is incorrect, or when the Cognito
+ *  user-pool token cannot be resolved.
+ * @throws service: {@link AnalyticsError} - Thrown when the endpoint responds
+ *  with a non-2xx status code.
+ *
+ * @returns A promise that will resolve when the operation is complete.
+ *
+ * @example
+ * ```ts
+ * // Identify a user with Amazon Connect Customer Profiles
+ * await identifyUser({
+ *     userId,
+ *     userProfile: {
+ *         email: 'userEmail@example.com',
+ *         customProperties: {
+ *             phoneNumber: ['555-555-5555'],
+ *         },
+ *     },
+ * });
+ * ```
+ */
+export const identifyUser = async ({
+	userId,
+	userProfile,
+	options,
+}: IdentifyUserInput): Promise<void> => {
+	const { endpoint } = resolveConfig();
+	const { token } = await resolveCredentials();
+
+	let response: Response;
+	try {
+		response = await fetch(`${endpoint}/identify-user`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify({ userId, userProfile, options }),
+		});
+	} catch (error) {
+		throw new AnalyticsError({
+			name: 'NetworkException',
+			message:
+				'The request to the Amazon Connect Customer Profiles endpoint failed to complete.',
+			recoverySuggestion:
+				'Check your network connection and ensure the configured Customer Profiles endpoint is reachable.',
+			underlyingError: error,
+		});
+	}
+
+	if (!response.ok) {
+		throw new AnalyticsError({
+			name: 'IdentifyUserException',
+			message: `Failed to identify user with Amazon Connect Customer Profiles. The endpoint responded with status ${response.status}.`,
+			recoverySuggestion:
+				'Ensure the configured Customer Profiles endpoint is reachable and that the request is authorized.',
+		});
+	}
+};

--- a/packages/analytics/src/providers/customer-profiles/apis/index.ts
+++ b/packages/analytics/src/providers/customer-profiles/apis/index.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { identifyUser } from './identifyUser';

--- a/packages/analytics/src/providers/customer-profiles/index.ts
+++ b/packages/analytics/src/providers/customer-profiles/index.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { identifyUser } from './apis';
+export { IdentifyUserInput, IdentifyUserOptions } from './types';

--- a/packages/analytics/src/providers/customer-profiles/types/index.ts
+++ b/packages/analytics/src/providers/customer-profiles/types/index.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { IdentifyUserInput } from './inputs';
+export { IdentifyUserOptions } from './options';

--- a/packages/analytics/src/providers/customer-profiles/types/inputs.ts
+++ b/packages/analytics/src/providers/customer-profiles/types/inputs.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AnalyticsIdentifyUserInput } from '../../../types';
+
+import { IdentifyUserOptions } from './options';
+
+/**
+ * Input type for the Amazon Connect Customer Profiles `identifyUser` API.
+ *
+ * Reuses the public {@link AnalyticsIdentifyUserInput} shape (and therefore the
+ * shared `UserProfile` type) so the public signature is identical to the other
+ * Analytics providers.
+ */
+export type IdentifyUserInput = AnalyticsIdentifyUserInput<IdentifyUserOptions>;

--- a/packages/analytics/src/providers/customer-profiles/types/options.ts
+++ b/packages/analytics/src/providers/customer-profiles/types/options.ts
@@ -5,6 +5,17 @@ import { PinpointServiceOptions } from '@aws-amplify/core/internals/providers/pi
 
 type CustomerProfilesServiceOptions = PinpointServiceOptions & {
 	channelType?: 'GCM' | 'APNS' | 'APNS_SANDBOX' | 'IN_APP';
+	deviceId?: string;
+	platform?: string;
+	appVersion?: string;
+	/**
+	 * On an authenticated `identifyUser` call, the Identity Pool `identityId`
+	 * the caller used while they were a guest. When present the backend folds
+	 * the prior guest profile (keyed on `cognitoIdentityId`) into the
+	 * authenticated profile (keyed on `cognitoSub`), carrying over any devices
+	 * registered pre-login (merge-on-sign-in).
+	 */
+	previousGuestIdentityId?: string;
 };
 
 /**
@@ -12,8 +23,10 @@ type CustomerProfilesServiceOptions = PinpointServiceOptions & {
  *
  * Reuses the shared {@link PinpointServiceOptions} (`address`, `optOut`,
  * `userAttributes`) so callers migrating between providers use the same shape,
- * with an added optional `channelType`. Matches the frozen REST contract's
- * `options` object.
+ * with added optional `channelType`, `deviceId`, `platform`, and `appVersion`.
+ * `platform` / `appVersion` describe the registering device; when omitted the
+ * backend falls back to `userProfile.demographic.platform` / `.appVersion`.
+ * Matches the frozen REST contract's `options` object.
  *
  * The homomorphic `Pick<T, keyof T>` flattens the intersection into a mapped
  * type so TypeScript can prove it satisfies the `Record<string, unknown>`

--- a/packages/analytics/src/providers/customer-profiles/types/options.ts
+++ b/packages/analytics/src/providers/customer-profiles/types/options.ts
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PinpointServiceOptions } from '@aws-amplify/core/internals/providers/pinpoint';
+
+type CustomerProfilesServiceOptions = PinpointServiceOptions & {
+	channelType?: 'GCM' | 'APNS' | 'APNS_SANDBOX' | 'IN_APP';
+};
+
+/**
+ * Options specific to the Amazon Connect Customer Profiles `identifyUser` API.
+ *
+ * Reuses the shared {@link PinpointServiceOptions} (`address`, `optOut`,
+ * `userAttributes`) so callers migrating between providers use the same shape,
+ * with an added optional `channelType`. Matches the frozen REST contract's
+ * `options` object.
+ *
+ * The homomorphic `Pick<T, keyof T>` flattens the intersection into a mapped
+ * type so TypeScript can prove it satisfies the `Record<string, unknown>`
+ * constraint of `AnalyticsServiceOptions` (a plain intersection with the
+ * `PinpointServiceOptions` interface does not).
+ */
+export type IdentifyUserOptions = Pick<
+	CustomerProfilesServiceOptions,
+	keyof CustomerProfilesServiceOptions
+>;

--- a/packages/analytics/src/providers/customer-profiles/utils/index.ts
+++ b/packages/analytics/src/providers/customer-profiles/utils/index.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { resolveConfig } from './resolveConfig';
+export { resolveCredentials } from './resolveCredentials';

--- a/packages/analytics/src/providers/customer-profiles/utils/index.ts
+++ b/packages/analytics/src/providers/customer-profiles/utils/index.ts
@@ -1,5 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export { resolveConfig } from './resolveConfig';
+export {
+	resolveConfig,
+	IDENTIFY_USER_PATH,
+	GUEST_IDENTIFY_USER_PATH,
+} from './resolveConfig';
 export { resolveCredentials } from './resolveCredentials';

--- a/packages/analytics/src/providers/customer-profiles/utils/resolveConfig.ts
+++ b/packages/analytics/src/providers/customer-profiles/utils/resolveConfig.ts
@@ -9,6 +9,20 @@ import {
 } from '../../../errors';
 
 /**
+ * Path of the authenticated (Cognito user-pool) identify route.
+ *
+ * @internal
+ */
+export const IDENTIFY_USER_PATH = '/identify-user';
+
+/**
+ * Path of the guest (Identity Pool unauthenticated, IAM/SigV4) identify route.
+ *
+ * @internal
+ */
+export const GUEST_IDENTIFY_USER_PATH = '/identify-user-guest';
+
+/**
  * @internal
  */
 export const resolveConfig = () => {

--- a/packages/analytics/src/providers/customer-profiles/utils/resolveConfig.ts
+++ b/packages/analytics/src/providers/customer-profiles/utils/resolveConfig.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+
+import {
+	AnalyticsValidationErrorCode,
+	assertValidationError,
+} from '../../../errors';
+
+/**
+ * @internal
+ */
+export const resolveConfig = () => {
+	const { endpoint, region } =
+		Amplify.getConfig().Analytics?.CustomerProfiles ?? {};
+	assertValidationError(!!endpoint, AnalyticsValidationErrorCode.NoEndpoint);
+	assertValidationError(!!region, AnalyticsValidationErrorCode.NoRegion);
+
+	return { endpoint, region };
+};

--- a/packages/analytics/src/providers/customer-profiles/utils/resolveCredentials.ts
+++ b/packages/analytics/src/providers/customer-profiles/utils/resolveCredentials.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { fetchAuthSession } from '@aws-amplify/core';
+
+import {
+	AnalyticsValidationErrorCode,
+	assertValidationError,
+} from '../../../errors';
+
+/**
+ * Resolves the Cognito user-pool access token used to authenticate requests to
+ * the Customer Profiles endpoint.
+ *
+ * @internal
+ */
+export const resolveCredentials = async () => {
+	const { tokens } = await fetchAuthSession();
+	const token = tokens?.accessToken?.toString();
+	assertValidationError(!!token, AnalyticsValidationErrorCode.NoCredentials);
+
+	return { token };
+};

--- a/packages/analytics/src/providers/customer-profiles/utils/resolveCredentials.ts
+++ b/packages/analytics/src/providers/customer-profiles/utils/resolveCredentials.ts
@@ -9,15 +9,28 @@ import {
 } from '../../../errors';
 
 /**
- * Resolves the Cognito user-pool access token used to authenticate requests to
- * the Customer Profiles endpoint.
+ * Resolves the caller's identity used to authenticate requests to the Customer
+ * Profiles endpoint.
+ *
+ * Two mutually-exclusive shapes are returned:
+ *  - Authenticated (Cognito user-pool): a bearer `token` is present. The authed
+ *    route (`POST /identify-user`) is used with `Authorization: Bearer <token>`.
+ *  - Guest (Identity Pool unauthenticated): no `token`, but `credentials` +
+ *    `identityId` are present. The guest route is used, SigV4-signed with the
+ *    guest credentials (service `execute-api`).
  *
  * @internal
  */
 export const resolveCredentials = async () => {
-	const { tokens } = await fetchAuthSession();
+	const { tokens, credentials, identityId } = await fetchAuthSession();
 	const token = tokens?.accessToken?.toString();
-	assertValidationError(!!token, AnalyticsValidationErrorCode.NoCredentials);
 
-	return { token };
+	// Either an authenticated bearer token, or guest Identity Pool credentials
+	// must be resolvable — otherwise there is no way to authorize the request.
+	assertValidationError(
+		!!token || !!credentials,
+		AnalyticsValidationErrorCode.NoCredentials,
+	);
+
+	return { token, credentials, identityId };
 };

--- a/packages/aws-amplify/__tests__/exports.test.ts
+++ b/packages/aws-amplify/__tests__/exports.test.ts
@@ -13,6 +13,7 @@ import * as inAppMessagingPinpointTopLevelExports from '../src/in-app-messaging/
 import * as analyticsKinesisExports from '../src/analytics/kinesis';
 import * as analyticsKinesisFirehoseExports from '../src/analytics/kinesis-firehose';
 import * as analyticsPersonalizeExports from '../src/analytics/personalize';
+import * as analyticsCustomerProfilesExports from '../src/analytics/customer-profiles';
 import * as storageTopLevelExports from '../src/storage';
 import * as storageS3Exports from '../src/storage/s3';
 
@@ -105,6 +106,12 @@ describe('aws-amplify Exports', () => {
 		it('should only export expected symbols from the Personalize provider', () => {
 			expect(Object.keys(analyticsPersonalizeExports).sort()).toEqual(
 				['record', 'flushEvents'].sort(),
+			);
+		});
+
+		it('should only export expected symbols from the Customer Profiles provider', () => {
+			expect(Object.keys(analyticsCustomerProfilesExports).sort()).toEqual(
+				['identifyUser'].sort(),
 			);
 		});
 	});

--- a/packages/aws-amplify/analytics/customer-profiles/package.json
+++ b/packages/aws-amplify/analytics/customer-profiles/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "aws-amplify/analytics/customer-profiles",
+	"main": "../../dist/cjs/analytics/customer-profiles/index.js",
+	"react-native": "../../dist/cjs/analytics/customer-profiles/index.js",
+	"browser": "../../dist/esm/analytics/customer-profiles/index.mjs",
+	"module": "../../dist/esm/analytics/customer-profiles/index.mjs",
+	"typings": "../../dist/esm/analytics/customer-profiles/index.d.ts"
+}

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -110,6 +110,12 @@
 			"import": "./dist/esm/analytics/personalize/index.mjs",
 			"require": "./dist/cjs/analytics/personalize/index.js"
 		},
+		"./analytics/customer-profiles": {
+			"react-native": "./dist/cjs/analytics/customer-profiles/index.js",
+			"types": "./dist/esm/analytics/customer-profiles/index.d.ts",
+			"import": "./dist/esm/analytics/customer-profiles/index.mjs",
+			"require": "./dist/cjs/analytics/customer-profiles/index.js"
+		},
 		"./storage": {
 			"react-native": "./dist/cjs/storage/index.js",
 			"types": "./dist/esm/storage/index.d.ts",
@@ -214,6 +220,9 @@
 			],
 			"analytics/personalize": [
 				"./dist/esm/analytics/personalize/index.d.ts"
+			],
+			"analytics/customer-profiles": [
+				"./dist/esm/analytics/customer-profiles/index.d.ts"
 			],
 			"storage": [
 				"./dist/esm/storage/index.d.ts"

--- a/packages/aws-amplify/src/analytics/customer-profiles/index.ts
+++ b/packages/aws-amplify/src/analytics/customer-profiles/index.ts
@@ -1,0 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+This file maps exports from `aws-amplify/analytics/customer-profiles`. It provides access to the Amazon Connect Customer Profiles APIs.
+*/
+export * from '@aws-amplify/analytics/customer-profiles';

--- a/packages/core/__tests__/parseAmplifyOutputs.test.ts
+++ b/packages/core/__tests__/parseAmplifyOutputs.test.ts
@@ -454,6 +454,60 @@ describe('parseAmplifyOutputs tests', () => {
 				},
 			});
 		});
+
+		it('should parse Amazon Connect Customer Profiles config', () => {
+			const amplifyOutputs: AmplifyOutputs = {
+				version: '1',
+				analytics: {
+					amazon_connect_customer_profiles: {
+						endpoint: 'https://example.com/prod',
+						aws_region: 'us-east-1',
+					},
+				},
+			};
+
+			const result = parseAmplifyOutputs(amplifyOutputs);
+
+			expect(result).toEqual({
+				Analytics: {
+					CustomerProfiles: {
+						endpoint: 'https://example.com/prod',
+						region: 'us-east-1',
+					},
+				},
+			});
+		});
+
+		it('should parse Pinpoint and Customer Profiles together', () => {
+			const amplifyOutputs: AmplifyOutputs = {
+				version: '1',
+				analytics: {
+					amazon_pinpoint: {
+						app_id: 'xxxxx',
+						aws_region: 'us-east-1',
+					},
+					amazon_connect_customer_profiles: {
+						endpoint: 'https://example.com/prod',
+						aws_region: 'us-west-2',
+					},
+				},
+			};
+
+			const result = parseAmplifyOutputs(amplifyOutputs);
+
+			expect(result).toEqual({
+				Analytics: {
+					Pinpoint: {
+						appId: 'xxxxx',
+						region: 'us-east-1',
+					},
+					CustomerProfiles: {
+						endpoint: 'https://example.com/prod',
+						region: 'us-west-2',
+					},
+				},
+			});
+		});
 	});
 
 	describe('geo tests', () => {

--- a/packages/core/src/parseAmplifyOutputs.ts
+++ b/packages/core/src/parseAmplifyOutputs.ts
@@ -181,18 +181,30 @@ function parseAuth(
 export function parseAnalytics(
 	amplifyOutputsAnalyticsProperties?: AmplifyOutputsAnalyticsProperties,
 ): AnalyticsConfig | undefined {
-	if (!amplifyOutputsAnalyticsProperties?.amazon_pinpoint) {
+	const { amazon_pinpoint, amazon_connect_customer_profiles } =
+		amplifyOutputsAnalyticsProperties ?? {};
+
+	if (!amazon_pinpoint && !amazon_connect_customer_profiles) {
 		return undefined;
 	}
 
-	const { amazon_pinpoint } = amplifyOutputsAnalyticsProperties;
+	const analyticsConfig: Partial<AnalyticsConfig> = {};
 
-	return {
-		Pinpoint: {
+	if (amazon_pinpoint) {
+		analyticsConfig.Pinpoint = {
 			appId: amazon_pinpoint.app_id,
 			region: amazon_pinpoint.aws_region,
-		},
-	};
+		};
+	}
+
+	if (amazon_connect_customer_profiles) {
+		analyticsConfig.CustomerProfiles = {
+			endpoint: amazon_connect_customer_profiles.endpoint,
+			region: amazon_connect_customer_profiles.aws_region,
+		};
+	}
+
+	return analyticsConfig as AnalyticsConfig;
 }
 
 function parseGeo(

--- a/packages/core/src/singleton/AmplifyOutputs/types.ts
+++ b/packages/core/src/singleton/AmplifyOutputs/types.ts
@@ -88,6 +88,10 @@ export interface AmplifyOutputsAnalyticsProperties {
 		aws_region: string;
 		app_id: string;
 	};
+	amazon_connect_customer_profiles?: {
+		aws_region: string;
+		endpoint: string;
+	};
 }
 
 export type AuthType =

--- a/packages/core/src/singleton/Analytics/types.ts
+++ b/packages/core/src/singleton/Analytics/types.ts
@@ -7,9 +7,22 @@ import { KinesisFirehoseProviderConfig } from '../../providers/kinesis-firehose/
 import { PersonalizeProviderConfig } from '../../providers/personalize/types';
 import { AtLeastOne } from '../types';
 
+/**
+ * Configuration for the Amazon Connect Customer Profiles Analytics provider.
+ * The provider backs `identifyUser` with a REST endpoint (typically fronted by
+ * a Lambda) that writes to Amazon Connect Customer Profiles.
+ */
+export interface ConnectCustomerProfilesProviderConfig {
+	CustomerProfiles: {
+		endpoint: string;
+		region: string;
+	};
+}
+
 export type AnalyticsConfig = AtLeastOne<
 	PinpointProviderConfig &
 		KinesisProviderConfig &
 		KinesisFirehoseProviderConfig &
-		PersonalizeProviderConfig
+		PersonalizeProviderConfig &
+		ConnectCustomerProfilesProviderConfig
 >;

--- a/packages/core/src/singleton/types.ts
+++ b/packages/core/src/singleton/types.ts
@@ -6,7 +6,10 @@ import {
 	GraphQLProviderConfig,
 	LibraryAPIOptions,
 } from './API/types';
-import { AnalyticsConfig } from './Analytics/types';
+import {
+	AnalyticsConfig,
+	ConnectCustomerProfilesProviderConfig,
+} from './Analytics/types';
 import {
 	AuthConfig,
 	AuthIdentityPoolConfig,
@@ -80,6 +83,7 @@ export {
 	StorageConfig,
 	BucketInfo,
 	AnalyticsConfig,
+	ConnectCustomerProfilesProviderConfig,
 	CognitoIdentityPoolConfig,
 	GeoConfig,
 };


### PR DESCRIPTION
#### Description of changes

Adds a new, **additive** Analytics provider that backs `identifyUser` with an **Amazon Connect Customer Profiles** REST endpoint (typically fronted by a Lambda). Scoped strictly to the analytics `identifyUser` path. Supports both **authenticated (Cognito user pool)** and **guest / unauthenticated (Cognito Identity Pool)** callers.

**What's included**
- **New provider** `packages/analytics/src/providers/customer-profiles/` mirroring the existing Pinpoint provider structure (`apis/identifyUser`, `utils/resolveConfig`, `utils/resolveCredentials`, `types`). `identifyUser` resolves config + the caller's auth session and `POST`s `{ userId, userProfile, options }` to the endpoint (2xx → `void`; non-2xx / network error → typed `AnalyticsError`). Plain `fetch` for the authenticated path; the shared core signer for the guest path — no new dependencies.
- **Authenticated (Cognito user pool)**: `POST ${endpoint}/identify-user` with an `Authorization: Bearer <accessToken>` header. The profile is keyed on the caller's `cognitoSub`.
- **Guest / unauthenticated (Cognito Identity Pool)**: when no user-pool token is present, `resolveCredentials` returns the guest `credentials` + `identityId`, and the request is **SigV4-signed** (service `execute-api`, via `signRequest` from `@aws-amplify/core/internals/aws-client-utils`) and sent to `POST ${endpoint}/identify-user-guest`. The profile is keyed on the caller's Identity Pool `identityId`, enabling pre-sign-in use cases such as registering a device token before login. The auth mode is selected automatically from the resolved session.
- **Guest options + merge-on-sign-in**: new optional `options` fields `deviceId`, `platform`, `appVersion`, and `previousGuestIdentityId`. Passing `previousGuestIdentityId` on an authenticated call folds the prior guest profile (and its devices) into the authenticated profile. Route paths are centralized as the `IDENTIFY_USER_PATH` / `GUEST_IDENTIFY_USER_PATH` constants.
- **Config**: new `analytics.amazon_connect_customer_profiles` key in `amplify_outputs` (`{ aws_region, endpoint }`) is parsed by `parseAnalytics` into `ResourcesConfig.Analytics.CustomerProfiles { endpoint, region }`. New exported type `ConnectCustomerProfilesProviderConfig`. Pinpoint parsing is untouched.
- **Stable subpath export**: `aws-amplify/analytics/customer-profiles` (and `@aws-amplify/analytics/customer-profiles`), mirroring how the `pinpoint`/`personalize` subpaths are exposed. Kept out of the top-level public barrel.
- **Tests**: unit tests for authenticated token attach + request body shape, config resolution, credential resolution (authenticated + guest), `amplify_outputs` parsing, and the guest flow — guest SigV4 signing/attach to `/identify-user-guest`, `previousGuestIdentityId` merge-on-sign-in, and error mapping.

**Backward compatibility**
- Public signatures are preserved **1:1**: `IdentifyUserInput = AnalyticsIdentifyUserInput<IdentifyUserOptions>`, reusing the shared `UserProfile` from `@aws-amplify/core`. The new `options` fields are all optional.
- Purely additive — the existing Pinpoint provider and all existing config are unchanged. No breaking changes (minor version bump; see the changeset `.changeset/analytics-connect-customer-profiles-identify-user.md`).

#### Issue #, if available

N/A

#### Description of how you validated changes

- `tsc --noEmit` type-checks pass for `@aws-amplify/core`, `@aws-amplify/analytics`, and the `aws-amplify` umbrella (after building analytics so the new subpath `.d.ts` resolves).
- ESLint passes for all changed/added files.
- `changeset status` confirms the intended **minor** bumps for `@aws-amplify/analytics`, `@aws-amplify/core`, and `aws-amplify`.
- The customer-profiles unit suite passes: **16/16 tests green** across the authenticated and guest paths (including guest SigV4 signing, merge-on-sign-in, and error mapping) when run under Jest's `node` test environment.
- Note: Jest's default `jsdom` environment currently fails at test-suite setup with a pre-existing, environmental `ERR_REQUIRE_ESM` (jsdom → `http-proxy-agent` → `@tootallnate/once`) on Node v18.20.2 — a pre-existing Pinpoint test fails identically, confirming it is unrelated to these changes. The DOM-free customer-profiles tests were therefore run with `--testEnvironment=node`; CI is expected to run the full suite normally.

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes (the customer-profiles suite passes 16/16 under `--testEnvironment=node`; the default `jsdom` env is blocked locally by the pre-existing environmental `ERR_REQUIRE_ESM` described above; CI expected to pass)
- [x] Unit Tests are changed or added
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
