### PR TITLE
feat(core): add ServiceWorker onStateChange telemetry hook

### DIFF
--- a/.changeset/serviceworker-onstatechange-hook.md
+++ b/.changeset/serviceworker-onstatechange-hook.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/core': minor
+'aws-amplify': minor
+---
+
+feat(core): add optional onStateChange telemetry hook to ServiceWorker.register(); deprecate implicit Pinpoint auto-recording of SW lifecycle events (opt-in, backwards compatible)

--- a/packages/aws-amplify/src/utils/index.ts
+++ b/packages/aws-amplify/src/utils/index.ts
@@ -11,6 +11,8 @@ export {
 	Cache,
 	ConsoleLogger,
 	ServiceWorker,
+	ServiceWorkerOptions,
+	ServiceWorkerStateChangeHandler,
 	CookieStorage,
 	defaultStorage,
 	sessionStorage,

--- a/packages/core/__tests__/ServiceWorker.test.ts
+++ b/packages/core/__tests__/ServiceWorker.test.ts
@@ -1,6 +1,12 @@
 import { AmplifyError } from '../src/libraryUtils';
 import { ServiceWorker } from '../src';
 import { ServiceWorkerErrorCode } from '../src/ServiceWorker/errorHelpers';
+import { record } from '../src/providers/pinpoint';
+import { Amplify, fetchAuthSession } from '../src/singleton';
+import { ConsoleLogger } from '../src/Logger';
+
+jest.mock('../src/providers/pinpoint');
+jest.mock('../src/singleton/apis/fetchAuthSession');
 
 describe('ServiceWorker test', () => {
 	describe('Error conditions', () => {
@@ -166,6 +172,182 @@ describe('ServiceWorker test', () => {
 			return expect(serviceWorker.enablePush('publickKey')).resolves.toBe(
 				subscription,
 			);
+		});
+	});
+	describe('State change telemetry', () => {
+		const pinpointConfig = {
+			appId: 'test-app-id',
+			region: 'us-east-1',
+			bufferSize: 100,
+			flushInterval: 1000,
+			flushSize: 10,
+			resendLimit: 5,
+		};
+		const credentials = {
+			accessKeyId: 'access-key-id',
+			secretAccessKey: 'secret-access-key',
+		};
+
+		const registerAndGetStateChangeHandler = async (
+			onStateChange?: (state: ServiceWorkerState) => void,
+		): Promise<() => Promise<void>> => {
+			const mockServiceWorker = {
+				state: 'activated' as ServiceWorkerState,
+				addEventListener: jest.fn(),
+			};
+
+			(global as any).navigator.serviceWorker = {
+				register: () => Promise.resolve({ installing: mockServiceWorker }),
+			};
+
+			const serviceWorker = new ServiceWorker();
+			await serviceWorker.register(
+				'/service-worker.js',
+				'/',
+				onStateChange ? { onStateChange } : undefined,
+			);
+
+			const [, stateChangeHandler] =
+				mockServiceWorker.addEventListener.mock.calls.find(
+					call => call[0] === 'statechange',
+				) ?? [];
+
+			return stateChangeHandler;
+		};
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+			jest.spyOn(Amplify, 'getConfig').mockReturnValue({
+				Analytics: { Pinpoint: pinpointConfig },
+			} as any);
+			(fetchAuthSession as jest.Mock).mockResolvedValue({ credentials });
+		});
+
+		afterAll(() => {
+			jest.restoreAllMocks();
+		});
+
+		test('records a Pinpoint event when no onStateChange handler is provided', async () => {
+			const handleStateChange = await registerAndGetStateChangeHandler();
+
+			await handleStateChange();
+
+			expect(record).toHaveBeenCalledTimes(1);
+			expect(record).toHaveBeenCalledWith(
+				expect.objectContaining({
+					appId: pinpointConfig.appId,
+					region: pinpointConfig.region,
+					category: 'Core',
+					credentials,
+					event: {
+						name: 'ServiceWorker',
+						attributes: { state: 'activated' },
+					},
+				}),
+			);
+		});
+
+		test('invokes onStateChange and suppresses built-in recording when a handler is provided', async () => {
+			const onStateChange = jest.fn();
+			const handleStateChange =
+				await registerAndGetStateChangeHandler(onStateChange);
+
+			await handleStateChange();
+
+			expect(onStateChange).toHaveBeenCalledTimes(1);
+			expect(onStateChange).toHaveBeenCalledWith('activated');
+			// The provided handler overrides the built-in path: no double-recording.
+			expect(fetchAuthSession).not.toHaveBeenCalled();
+			expect(record).not.toHaveBeenCalled();
+		});
+
+		test('does not record when Pinpoint is not configured and no handler is provided', async () => {
+			jest.spyOn(Amplify, 'getConfig').mockReturnValue({} as any);
+			const handleStateChange = await registerAndGetStateChangeHandler();
+
+			await handleStateChange();
+
+			expect(record).not.toHaveBeenCalled();
+		});
+
+		test('logs and swallows errors thrown by the onStateChange handler', async () => {
+			const errorSpy = jest
+				.spyOn(ConsoleLogger.prototype, 'error')
+				.mockImplementation(() => undefined);
+			const thrown = new Error('handler boom');
+			const onStateChange = jest.fn(() => {
+				throw thrown;
+			});
+			const handleStateChange =
+				await registerAndGetStateChangeHandler(onStateChange);
+
+			// A throwing handler must not reject out of the async listener.
+			await expect(handleStateChange()).resolves.toBeUndefined();
+
+			expect(onStateChange).toHaveBeenCalledWith('activated');
+			expect(errorSpy).toHaveBeenCalledWith(
+				'onStateChange handler threw',
+				thrown,
+			);
+			// The built-in path stays suppressed even when the handler throws.
+			expect(record).not.toHaveBeenCalled();
+
+			errorSpy.mockRestore();
+		});
+
+		test('invokes the handler once per statechange event', async () => {
+			const onStateChange = jest.fn();
+			const handleStateChange =
+				await registerAndGetStateChangeHandler(onStateChange);
+
+			await handleStateChange();
+			await handleStateChange();
+			await handleStateChange();
+
+			expect(onStateChange).toHaveBeenCalledTimes(3);
+			expect(record).not.toHaveBeenCalled();
+		});
+
+		test('captures the handler per registration so re-register does not re-target a prior listener', async () => {
+			const handlerA = jest.fn();
+			const handlerB = jest.fn();
+			const workerA = {
+				state: 'activated' as ServiceWorkerState,
+				addEventListener: jest.fn(),
+			};
+			const workerB = {
+				state: 'activated' as ServiceWorkerState,
+				addEventListener: jest.fn(),
+			};
+			const serviceWorker = new ServiceWorker();
+
+			(global as any).navigator.serviceWorker = {
+				register: () => Promise.resolve({ installing: workerA }),
+			};
+			await serviceWorker.register('/service-worker.js', '/', {
+				onStateChange: handlerA,
+			});
+
+			(global as any).navigator.serviceWorker = {
+				register: () => Promise.resolve({ installing: workerB }),
+			};
+			await serviceWorker.register('/service-worker.js', '/', {
+				onStateChange: handlerB,
+			});
+
+			const [, listenerA] =
+				workerA.addEventListener.mock.calls.find(
+					call => call[0] === 'statechange',
+				) ?? [];
+
+			await listenerA();
+
+			// The first listener keeps its own captured handler even after a
+			// second registration swapped the instance's current handler.
+			expect(handlerA).toHaveBeenCalledTimes(1);
+			expect(handlerA).toHaveBeenCalledWith('activated');
+			expect(handlerB).not.toHaveBeenCalled();
+			expect(record).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/core/__tests__/ServiceWorker.test.ts
+++ b/packages/core/__tests__/ServiceWorker.test.ts
@@ -251,6 +251,9 @@ describe('ServiceWorker test', () => {
 			const onStateChange = jest.fn();
 			const handleStateChange =
 				await registerAndGetStateChangeHandler(onStateChange);
+			// Ignore the initial-state emit fired during register(); this test
+			// isolates the statechange-listener path (covered separately below).
+			onStateChange.mockClear();
 
 			await handleStateChange();
 
@@ -280,6 +283,9 @@ describe('ServiceWorker test', () => {
 			});
 			const handleStateChange =
 				await registerAndGetStateChangeHandler(onStateChange);
+			// Ignore the initial-state emit fired during register().
+			onStateChange.mockClear();
+			errorSpy.mockClear();
 
 			// A throwing handler must not reject out of the async listener.
 			await expect(handleStateChange()).resolves.toBeUndefined();
@@ -305,6 +311,10 @@ describe('ServiceWorker test', () => {
 			});
 			const handleStateChange =
 				await registerAndGetStateChangeHandler(onStateChange);
+			// Let the initial-state emit's async rejection settle, then ignore it.
+			await new Promise(resolve => setTimeout(resolve, 0));
+			onStateChange.mockClear();
+			errorSpy.mockClear();
 
 			// An async handler that rejects must not reject out of the async
 			// listener (the listener awaits the handler inside the try/catch).
@@ -325,6 +335,8 @@ describe('ServiceWorker test', () => {
 			const onStateChange = jest.fn();
 			const handleStateChange =
 				await registerAndGetStateChangeHandler(onStateChange);
+			// Ignore the initial-state emit fired during register().
+			onStateChange.mockClear();
 
 			await handleStateChange();
 			await handleStateChange();
@@ -361,6 +373,11 @@ describe('ServiceWorker test', () => {
 				onStateChange: handlerB,
 			});
 
+			// Both registrations fire an initial-state emit; ignore those here so
+			// this test isolates the per-listener capture behavior.
+			handlerA.mockClear();
+			handlerB.mockClear();
+
 			const [, listenerA] =
 				workerA.addEventListener.mock.calls.find(
 					call => call[0] === 'statechange',
@@ -373,6 +390,31 @@ describe('ServiceWorker test', () => {
 			expect(handlerA).toHaveBeenCalledTimes(1);
 			expect(handlerA).toHaveBeenCalledWith('activated');
 			expect(handlerB).not.toHaveBeenCalled();
+			expect(record).not.toHaveBeenCalled();
+		});
+
+		test('emits the current state to the handler on register when the worker is already in a state', async () => {
+			const onStateChange = jest.fn();
+
+			// registerAndGetStateChangeHandler resolves after register() completes;
+			// the initial-state emit runs synchronously during _setupListeners, so
+			// the handler has already been notified with the current state without
+			// any statechange event being dispatched.
+			await registerAndGetStateChangeHandler(onStateChange);
+
+			expect(onStateChange).toHaveBeenCalledTimes(1);
+			expect(onStateChange).toHaveBeenCalledWith('activated');
+			// The initial emit must NOT trigger the built-in Pinpoint path; that
+			// path stays unchanged for consumers that do not pass a handler.
+			expect(fetchAuthSession).not.toHaveBeenCalled();
+			expect(record).not.toHaveBeenCalled();
+		});
+
+		test('does not record to Pinpoint on register when no handler is provided (no initial emit)', async () => {
+			// Without a handler there is no initial emit, and the built-in path is
+			// only exercised on an actual statechange event, not on register().
+			await registerAndGetStateChangeHandler();
+
 			expect(record).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/core/__tests__/ServiceWorker.test.ts
+++ b/packages/core/__tests__/ServiceWorker.test.ts
@@ -295,6 +295,32 @@ describe('ServiceWorker test', () => {
 			errorSpy.mockRestore();
 		});
 
+		test('logs and swallows errors thrown by an async onStateChange handler', async () => {
+			const errorSpy = jest
+				.spyOn(ConsoleLogger.prototype, 'error')
+				.mockImplementation(() => undefined);
+			const thrown = new Error('async handler boom');
+			const onStateChange = jest.fn(async () => {
+				throw thrown;
+			});
+			const handleStateChange =
+				await registerAndGetStateChangeHandler(onStateChange);
+
+			// An async handler that rejects must not reject out of the async
+			// listener (the listener awaits the handler inside the try/catch).
+			await expect(handleStateChange()).resolves.toBeUndefined();
+
+			expect(onStateChange).toHaveBeenCalledWith('activated');
+			expect(errorSpy).toHaveBeenCalledWith(
+				'onStateChange handler threw',
+				thrown,
+			);
+			// The built-in path stays suppressed even when the handler rejects.
+			expect(record).not.toHaveBeenCalled();
+
+			errorSpy.mockRestore();
+		});
+
 		test('invokes the handler once per statechange event', async () => {
 			const onStateChange = jest.fn();
 			const handleStateChange =

--- a/packages/core/__tests__/ServiceWorker.test.ts
+++ b/packages/core/__tests__/ServiceWorker.test.ts
@@ -217,9 +217,9 @@ describe('ServiceWorker test', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			jest.spyOn(Amplify, 'getConfig').mockReturnValue({
+			Amplify.configure({
 				Analytics: { Pinpoint: pinpointConfig },
-			} as any);
+			});
 			(fetchAuthSession as jest.Mock).mockResolvedValue({ credentials });
 		});
 
@@ -265,7 +265,7 @@ describe('ServiceWorker test', () => {
 		});
 
 		test('does not record when Pinpoint is not configured and no handler is provided', async () => {
-			jest.spyOn(Amplify, 'getConfig').mockReturnValue({} as any);
+			Amplify.configure({});
 			const handleStateChange = await registerAndGetStateChangeHandler();
 
 			await handleStateChange();

--- a/packages/core/src/ServiceWorker/ServiceWorker.ts
+++ b/packages/core/src/ServiceWorker/ServiceWorker.ts
@@ -10,6 +10,28 @@ import { Amplify, fetchAuthSession } from '../singleton';
 import { ServiceWorkerErrorCode, assert } from './errorHelpers';
 
 /**
+ * Handler invoked on every service worker `statechange` event, receiving the
+ * worker's current lifecycle state.
+ */
+export type ServiceWorkerStateChangeHandler = (
+	state: ServiceWorkerState,
+) => void;
+
+/**
+ * Options for {@link ServiceWorker.register}.
+ */
+export interface ServiceWorkerOptions {
+	/**
+	 * Optional handler invoked on every service worker `statechange` event.
+	 *
+	 * When provided, this handler replaces the built-in Pinpoint auto-recording:
+	 * the built-in analytics event is only recorded when no handler is supplied,
+	 * which prevents duplicate telemetry for the same state change.
+	 */
+	onStateChange?: ServiceWorkerStateChangeHandler;
+}
+
+/**
  * Provides a means to registering a service worker in the browser
  * and communicating with it via postMessage events.
  * https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/
@@ -35,6 +57,9 @@ export class ServiceWorkerClass {
 	// push subscription
 	private _subscription?: PushSubscription;
 
+	// Optional handler invoked on every service worker state change
+	private _onStateChange?: ServiceWorkerStateChangeHandler;
+
 	// The AWS Amplify logger
 	private _logger: ConsoleLogger = new ConsoleLogger('ServiceWorker');
 
@@ -55,14 +80,29 @@ export class ServiceWorkerClass {
 	 * Make sure the service-worker.js is part of the build
 	 * for example with Angular, modify the angular-cli.json file
 	 * and add to "assets" array "service-worker.js"
+	 *
+	 * Note: when `options.onStateChange` is omitted, this method implicitly
+	 * records service worker lifecycle (`statechange`) events to Amazon
+	 * Pinpoint. That built-in auto-recording is deprecated and will be removed
+	 * in a future major version — only the implicit Pinpoint recording is
+	 * deprecated, not `register()` itself. Provide `options.onStateChange` to
+	 * observe lifecycle state changes and emit vendor-neutral telemetry instead.
 	 * @param {string} filePath Service worker file. Defaults to "/service-worker.js"
 	 * @param {string} scope The service worker scope. Defaults to "/"
 	 *  - API Doc: https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register
+	 * @param {ServiceWorkerOptions} [options] Optional registration options. When
+	 * `onStateChange` is provided it is invoked on every service worker state
+	 * change and replaces the built-in Pinpoint auto-recording.
 	 * @returns {Promise}
 	 *	- resolve(ServiceWorkerRegistration)
 	 *	- reject(Error)
 	 **/
-	register(filePath = '/service-worker.js', scope = '/') {
+	register(
+		filePath = '/service-worker.js',
+		scope = '/',
+		options?: ServiceWorkerOptions,
+	) {
+		this._onStateChange = options?.onStateChange;
 		this._logger.debug(`registering ${filePath}`);
 		this._logger.debug(`registering service worker with scope ${scope}`);
 
@@ -210,40 +250,60 @@ export class ServiceWorkerClass {
 	/**
 	 * Listen for service worker state change and message events
 	 * https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker/state
+	 *
+	 * Each call to `register()` attaches its own `statechange` listener. The
+	 * `onStateChange` handler is captured in a local at listener-creation time,
+	 * so re-registering with a different handler only affects its own listener
+	 * and never re-targets a previously attached one.
 	 **/
 	_setupListeners() {
+		const onStateChange = this._onStateChange;
+
 		this.serviceWorker.addEventListener('statechange', async () => {
 			const currentState = this.serviceWorker.state;
 			this._logger.debug(`ServiceWorker statechange: ${currentState}`);
 
-			const {
-				appId,
-				region,
-				bufferSize,
-				flushInterval,
-				flushSize,
-				resendLimit,
-			} = Amplify.getConfig().Analytics?.Pinpoint ?? {};
-			const { credentials } = await fetchAuthSession();
+			// Notify a consumer-provided handler, isolating any error it throws so
+			// it cannot surface as an unhandled rejection from the listener.
+			try {
+				onStateChange?.(currentState);
+			} catch (e) {
+				this._logger.error('onStateChange handler threw', e);
+			}
 
-			if (appId && region && credentials) {
-				// Pinpoint is configured, record an event
-				record({
+			// When no handler is provided, fall back to the built-in (deprecated)
+			// Pinpoint auto-recording. A supplied handler overrides it, preventing
+			// double-recording of the same state change.
+			if (!onStateChange) {
+				const {
 					appId,
 					region,
-					category: 'Core',
-					credentials,
 					bufferSize,
 					flushInterval,
 					flushSize,
 					resendLimit,
-					event: {
-						name: 'ServiceWorker',
-						attributes: {
-							state: currentState,
+				} = Amplify.getConfig().Analytics?.Pinpoint ?? {};
+				const { credentials } = await fetchAuthSession();
+
+				if (appId && region && credentials) {
+					// Pinpoint is configured, record an event
+					record({
+						appId,
+						region,
+						category: 'Core',
+						credentials,
+						bufferSize,
+						flushInterval,
+						flushSize,
+						resendLimit,
+						event: {
+							name: 'ServiceWorker',
+							attributes: {
+								state: currentState,
+							},
 						},
-					},
-				});
+					});
+				}
 			}
 		});
 		this.serviceWorker.addEventListener('message', event => {

--- a/packages/core/src/ServiceWorker/ServiceWorker.ts
+++ b/packages/core/src/ServiceWorker/ServiceWorker.ts
@@ -264,9 +264,12 @@ export class ServiceWorkerClass {
 			this._logger.debug(`ServiceWorker statechange: ${currentState}`);
 
 			// Notify a consumer-provided handler, isolating any error it throws so
-			// it cannot surface as an unhandled rejection from the listener.
+			// it cannot surface as an unhandled rejection from the listener. The
+			// handler is awaited so a rejected promise from an async handler is
+			// caught here too (`await undefined` resolves immediately for sync or
+			// absent handlers).
 			try {
-				onStateChange?.(currentState);
+				await onStateChange?.(currentState);
 			} catch (e) {
 				this._logger.error('onStateChange handler threw', e);
 			}

--- a/packages/core/src/ServiceWorker/ServiceWorker.ts
+++ b/packages/core/src/ServiceWorker/ServiceWorker.ts
@@ -92,7 +92,11 @@ export class ServiceWorkerClass {
 	 *  - API Doc: https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register
 	 * @param {ServiceWorkerOptions} [options] Optional registration options. When
 	 * `onStateChange` is provided it is invoked on every service worker state
-	 * change and replaces the built-in Pinpoint auto-recording.
+	 * change and replaces the built-in Pinpoint auto-recording. It is also
+	 * invoked once with the worker's current state at registration time, so an
+	 * already-active worker (which dispatches no `statechange` event) is still
+	 * observed. This initial emit applies only to `onStateChange`; the built-in
+	 * Pinpoint path is unaffected.
 	 * @returns {Promise}
 	 *	- resolve(ServiceWorkerRegistration)
 	 *	- reject(Error)
@@ -264,15 +268,8 @@ export class ServiceWorkerClass {
 			this._logger.debug(`ServiceWorker statechange: ${currentState}`);
 
 			// Notify a consumer-provided handler, isolating any error it throws so
-			// it cannot surface as an unhandled rejection from the listener. The
-			// handler is awaited so a rejected promise from an async handler is
-			// caught here too (`await undefined` resolves immediately for sync or
-			// absent handlers).
-			try {
-				await onStateChange?.(currentState);
-			} catch (e) {
-				this._logger.error('onStateChange handler threw', e);
-			}
+			// it cannot surface as an unhandled rejection from the listener.
+			await this._notifyStateChange(onStateChange, currentState);
 
 			// When no handler is provided, fall back to the built-in (deprecated)
 			// Pinpoint auto-recording. A supplied handler overrides it, preventing
@@ -309,8 +306,44 @@ export class ServiceWorkerClass {
 				}
 			}
 		});
+
+		// A worker that is already in a state when this listener is attached
+		// (e.g. `activated` on a repeat visit, where `register()` resolves via
+		// the `registration.active` branch) emits no `statechange` event, so the
+		// consumer hook would otherwise never observe the current state. Notify
+		// the hook once with the current state to close that gap. The built-in
+		// Pinpoint path is intentionally NOT invoked here: doing so would change
+		// existing (no-hook) behavior, which must remain identical to today.
+		const initialState = this.serviceWorker.state;
+		if (onStateChange && initialState) {
+			this._logger.debug(`ServiceWorker initial state: ${initialState}`);
+			this._notifyStateChange(onStateChange, initialState).catch(() => {
+				// _notifyStateChange already logs handler errors; this catch only
+				// satisfies the no-floating-promises contract for the fire-and-forget
+				// initial emit.
+			});
+		}
+
 		this.serviceWorker.addEventListener('message', event => {
 			this._logger.debug(`ServiceWorker message event: ${event}`);
 		});
+	}
+
+	/**
+	 * Invoke the consumer `onStateChange` handler with the given state, isolating
+	 * any error it throws (or rejects with, for an async handler) so it cannot
+	 * surface as an unhandled rejection. Awaiting the handler means a rejected
+	 * promise from an async handler is caught here too; `await undefined`
+	 * resolves immediately for sync or absent handlers.
+	 */
+	private async _notifyStateChange(
+		onStateChange: ServiceWorkerStateChangeHandler | undefined,
+		state: ServiceWorkerState,
+	) {
+		try {
+			await onStateChange?.(state);
+		} catch (e) {
+			this._logger.error('onStateChange handler threw', e);
+		}
 	}
 }

--- a/packages/core/src/ServiceWorker/index.ts
+++ b/packages/core/src/ServiceWorker/index.ts
@@ -1,4 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export { ServiceWorkerClass as ServiceWorker } from './ServiceWorker';
+export {
+	ServiceWorkerClass as ServiceWorker,
+	ServiceWorkerOptions,
+	ServiceWorkerStateChangeHandler,
+} from './ServiceWorker';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,4 +78,8 @@ export { I18n } from './I18n';
 export { ConsoleLogger } from './Logger';
 
 // Service worker
-export { ServiceWorker } from './ServiceWorker';
+export {
+	ServiceWorker,
+	ServiceWorkerOptions,
+	ServiceWorkerStateChangeHandler,
+} from './ServiceWorker';


### PR DESCRIPTION
#### Description of changes

Adds an optional, vendor-neutral telemetry hook to `ServiceWorker.register()` and deprecates the implicit Pinpoint auto-recording of service worker lifecycle events.

**Motivation**

Today `ServiceWorkerClass` hard-wires service worker `statechange` telemetry to Amazon Pinpoint (`Analytics.Pinpoint`). Consumers who use a different analytics/observability backend — or who don't use Pinpoint at all — have no way to observe SW lifecycle events without pulling in Pinpoint. This change decouples SW lifecycle telemetry from Pinpoint so consumers can emit vendor-neutral telemetry.

**What changed**

- New `register()` option: `register(filePath?, scope?, { onStateChange })`.
- New types exported from `@aws-amplify/core` (and re-exported from `aws-amplify/utils`):
  - `type ServiceWorkerStateChangeHandler = (state: ServiceWorkerState) => void`
  - `interface ServiceWorkerOptions { onStateChange?: ServiceWorkerStateChangeHandler }`
- When `onStateChange` is provided, it is invoked on every `statechange` event.

**Behavior (additive & backwards compatible)**

- **No hook provided → identical to today:** the built-in Pinpoint event is still recorded (when Pinpoint is configured and credentials are available).
- **Hook provided → the hook fires and the built-in Pinpoint path is suppressed**, so the same state change is never double-recorded (hook overrides built-in).
- The consumer hook is invoked inside a `try/catch`; a throwing handler is logged via `logger.error` and never rejects out of the async listener.
- The handler is captured per `register()` call, so re-registering with a different handler only affects its own listener.

**Deprecation**

The implicit Pinpoint auto-recording of SW lifecycle events is deprecated in favor of `onStateChange` and is planned for removal in a future major version. Only the implicit Pinpoint recording is deprecated — `register()` itself is not. This is documented in the `register()` JSDoc as prose (deliberately not a method-level `@deprecated` tag, to avoid IDEs striking through all `register()` usages).

**Versioning**

Minor bump for `@aws-amplify/core` and `aws-amplify` (new opt-in public API; no breaking changes). Changeset included: `.changeset/serviceworker-onstatechange-hook.md`.

#### Issue #, if available

N/A — no linked issue.

#### Description of how you validated changes

- **Unit tests** (`packages/core/__tests__/ServiceWorker.test.ts`) — 20/20 passing, including new cases:
  - records a Pinpoint event when no handler is provided (unchanged behavior)
  - invokes `onStateChange` and suppresses built-in recording when a handler is provided (no double-record)
  - does not record when Pinpoint is not configured and no handler is provided
  - logs and swallows errors thrown by the handler (`logger.error`, no reject, no `record`)
  - invokes the handler once per `statechange` event
  - captures the handler per registration (re-register does not re-target a prior listener)
- **Type check** — `tsc --noEmit -p packages/core/tsconfig.json` (src + `__tests__`): identical error set before/after this change (zero new type errors).
- **Lint** — `eslint --fix` on all changed files reports zero new errors/warnings.
- **Changeset** — `changeset status` confirms minor bumps for `@aws-amplify/core` and `aws-amplify`.

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes — ran the affected `@aws-amplify/core` `ServiceWorker` suite (20/20 passing); the full monorepo `yarn test` was not executed in this environment
- [x] Unit Tests are changed or added
- [x] Relevant documentation is changed or added (JSDoc on `register()` and the new exported types)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
