### PR TITLE
fix(deps-v5): bump immer to ^11.1.9 in datastore to fix prototype pollution

### DIFF
--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -62,7 +62,7 @@
 		"amazon-cognito-identity-js": "6.3.20",
 		"buffer": "4.9.2",
 		"idb": "5.0.6",
-		"immer": "9.0.6",
+		"immer": "^11.1.9",
 		"ulid": "2.3.0",
 		"uuid": "^11.1.1",
 		"zen-observable-ts": "0.8.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10545,10 +10545,10 @@ immediate@^3.2.2:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.3.0.tgz#1aef225517836bcdf7f2a2de2600c79ff0269266"
   integrity sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==
 
-immer@9.0.6:
-  version "9.0.6"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
-  integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
+immer@^11.1.9:
+  version "11.1.11"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-11.1.11.tgz#bbf825a333ae1b16fd450d8da5f61d54de6a553d"
+  integrity sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==
 
 import-fresh@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

`@aws-amplify/datastore@4.7.26` (shipped by `aws-amplify@5.3.37`, the current v5 LTS) pins **`immer@9.0.6`**, which is vulnerable to a **prototype pollution** flaw.

- **Type:** Prototype pollution via `draft.constructor.prototype` — bypasses the earlier remediation for CVE-2021-23436.
- **Affected:** immer `4.0.0` through `11.1.8` (the proxy `get` trap returned `constructor` / `__proto__` without safeguards, allowing attacker-supplied input to mutate `Object.prototype`).
- **First fixed:** immer **`11.1.9`**.

This bumps `immer` in the `datastore` package to `^11.1.9` (resolves to `11.1.11`) and regenerates `yarn.lock`.

## Vulnerable dependency chain (before)

```
aws-amplify@5.3.37  ->  @aws-amplify/datastore@4.7.26  ->  immer@9.0.6
```

Prior v5 dependency security fixes: #14857, #14839.

## Compatibility / breaking-change assessment

DataStore uses only **stable core immer APIs**, all of which are preserved across the 9 → 10 → 11 major versions:

- `produce`, `Draft`, `immerable`, `setAutoFreeze`, `enablePatches`, `Patch` — `packages/datastore/src/datastore/datastore.ts`
- `produce`, `applyPatches`, `Patch` — `packages/datastore/src/util.ts`
- `Patch` — `packages/datastore/src/storage/storage.ts`

No use of `enableES5()` / `enableAllPlugins()` (removed in immer 10). ⚠️ One consumer-facing note: immer 10+ dropped the ES5 fallback and requires a `Proxy`-capable (ES2015+) runtime. DataStore already targets such environments, but this is worth calling out for any downstream consumer on a legacy runtime.

## Testing

- `tsc --noEmit` on the datastore package: **no immer-related type errors** (only pre-existing unbuilt-sibling module resolution errors in a fresh clone).
- `DataStore.ts` **Basic operations** suite: **73 passed, 0 failed**, including `Save returns the updated model and patches` (scalar + list fields) which exercise immer `produce` and patch generation.

## Follow-up (not in this PR)

To fully close the reported chain, after this merges and a new `@aws-amplify/datastore` v5 LTS is published, the `@aws-amplify/datastore` pin in the `aws-amplify` package should be bumped and a new `aws-amplify` v5 LTS released.