### PR TITLE
fix(datastore): bump immer to ^11.1.9 to remediate prototype pollution

### DIFF
--- a/.changeset/fix-datastore-immer-prototype-pollution.md
+++ b/.changeset/fix-datastore-immer-prototype-pollution.md
@@ -1,0 +1,7 @@
+---
+"@aws-amplify/datastore": patch
+---
+
+fix(datastore): bump immer to ^11.1.9 to remediate prototype pollution
+
+`@aws-amplify/datastore` depended on `immer@9.0.6`, which is vulnerable to prototype pollution via `draft.constructor.prototype` (affects immer 4.0.0–11.1.8; bypasses the earlier CVE-2021-23436 remediation). Bump immer to `^11.1.9`, the first fixed release. DataStore uses only stable immer core APIs (`produce`, `Draft`, `immerable`, `setAutoFreeze`, `enablePatches`, `Patch`, `applyPatches`), which are preserved across the 9 → 11 major versions.

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -49,7 +49,7 @@
 		"@aws-amplify/api-graphql": "4.8.8",
 		"buffer": "4.9.2",
 		"idb": "5.0.6",
-		"immer": "9.0.6",
+		"immer": "^11.1.9",
 		"rxjs": "^7.8.1",
 		"ulid": "^2.3.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -8606,10 +8606,10 @@ immediate@^3.2.2:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.3.0.tgz#1aef225517836bcdf7f2a2de2600c79ff0269266"
   integrity sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==
 
-immer@9.0.6:
-  version "9.0.6"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
-  integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
+immer@^11.1.9:
+  version "11.1.11"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-11.1.11.tgz#bbf825a333ae1b16fd450d8da5f61d54de6a553d"
+  integrity sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==
 
 import-fresh@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
> **Draft** — v6 (`main`) counterpart to the v5 LTS fix #14868. Opening as draft for review before marking ready.

## Description

`@aws-amplify/datastore@5.1.8` (shipped by `aws-amplify@6.18.0`, the current `latest`) depends on **`immer@9.0.6`**, which is vulnerable to a **prototype pollution** flaw.

- **Type:** Prototype pollution via `draft.constructor.prototype` — bypasses the earlier remediation for CVE-2021-23436.
- **Affected:** immer `4.0.0` through `11.1.8` (the proxy `get` trap returned `constructor` / `__proto__` without safeguards, allowing attacker-supplied input to mutate `Object.prototype`).
- **First fixed:** immer **`11.1.9`**.

This bumps `immer` in the `datastore` package to `^11.1.9` (resolves to `11.1.11`), adds a changeset (patch), and regenerates `yarn.lock`.

## Vulnerable dependency chain (before)

```
aws-amplify@6.18.0 (latest)  ->  @aws-amplify/datastore@5.1.8  ->  immer@9.0.6
```

The v5 LTS line was already fixed in #14868 (`@aws-amplify/datastore@4.7.27`, `aws-amplify@5.3.38`). This PR closes the same gap on the current v6 / `latest` line, which is the default install and majority-consumer path.

## Compatibility / breaking-change assessment

DataStore uses only **stable core immer APIs**, all preserved across the 9 → 10 → 11 major versions:

- `Draft`, `Patch`, `enablePatches`, `immerable`, `produce`, `setAutoFreeze` — `packages/datastore/src/datastore/datastore.ts`
- `produce`, `applyPatches`, `Patch` — `packages/datastore/src/util.ts`
- `Patch` — `packages/datastore/src/storage/storage.ts`

No use of `enableES5()` / `enableAllPlugins()` (removed in immer 10). ⚠️ Consumer-facing note: immer 10+ dropped the ES5 fallback and requires a `Proxy`-capable (ES2015+) runtime. DataStore already targets such environments, but flagging for any downstream consumer on a legacy runtime.

## Testing

- `tsc --noEmit` on the datastore package: **no immer-related type errors** (only pre-existing unbuilt-sibling module resolution errors in a fresh clone).
- `turbo run build --filter=@aws-amplify/datastore`: **9/9 tasks successful**.
- Jest: `util.test.ts` (**48 passed** — directly exercises `mergePatches` / `applyPatches`), `storage.test.ts`, and `mutation.test.ts` (**10 passed**) all green on the upgraded dependency.