### PR TITLE
feat(auth): multi-session multi-profile support (client + SSR)

### DIFF
--- a/.changeset/multi-session-support.md
+++ b/.changeset/multi-session-support.md
@@ -1,0 +1,7 @@
+---
+'@aws-amplify/auth': minor
+'@aws-amplify/core': minor
+'aws-amplify': minor
+---
+
+feat(auth): add multi-session multi-profile support. Introduces `setCurrentUser` and `listCurrentUsers` (client and server-side), an `AuthUserList` session roster alongside `LastAuthUser`, and boundary Hub events (`userSignedIn`, `switchActiveUser`, `userSignedOut`). Multiple Cognito users can be signed in simultaneously with one active session at a time.

--- a/.changeset/multi-session-support.md
+++ b/.changeset/multi-session-support.md
@@ -5,3 +5,9 @@
 ---
 
 feat(auth): add multi-session multi-profile support. Introduces `setCurrentUser` and `listCurrentUsers` (client and server-side), an `AuthUserList` session roster alongside `LastAuthUser`, and boundary Hub events (`userSignedIn`, `switchActiveUser`, `userSignedOut`). Multiple Cognito users can be signed in simultaneously with one active session at a time.
+
+Behavior changes for existing single-session apps:
+
+- `signIn` no longer throws `UserAlreadyAuthenticatedException` when a user is already signed in. It now adds a second session and switches the active user to it. (OAuth `signInWithRedirect` still requires `options.prompt` to add another user — without it the Hosted UI SSO cookie would silently reuse the existing session.)
+- The `signedIn` Hub event no longer fires on re-authentication of the already-active user. It fires only on active-pointer none→some transitions (first sign-in or reactivating a parked session).
+- OAuth completion now throws instead of persisting the `'username'` sentinel when no username claim can be resolved from the returned tokens.

--- a/.github/actions/setup-samples-staging/action.yml
+++ b/.github/actions/setup-samples-staging/action.yml
@@ -32,7 +32,10 @@ runs:
       shell: bash
       working-directory: ./amplify-js-samples-staging
       env:
-        BRANCH: ${{ github.ref_name }}
+        # On pull_request events, ref_name is the synthetic '<pr>/merge' ref which
+        # never exists on the samples repo — use the PR head branch instead and
+        # fall back to ref_name for push-triggered runs.
+        BRANCH: ${{ github.head_ref || github.ref_name }}
       run: |
         # Retry to guard against transient git/network failures (e.g. exit code 128)
         select_staging_branch() {

--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -493,6 +493,13 @@ tests:
     sample_name: [javascript-auth]
     spec: functional-auth
     browser: *minimal_browser_list
+  - test_name: integ_react_auth_multi_session
+    desc: 'React Multi-session Auth'
+    framework: react
+    category: auth
+    sample_name: [multi-session]
+    spec: multi-session
+    browser: *minimal_browser_list
   - test_name: integ_react_auth_1_guest_to_authenticated_user
     desc: 'Guest to Authenticated User'
     framework: react

--- a/packages/auth/__tests__/providers/cognito/confirmSignInHappyCases.test.ts
+++ b/packages/auth/__tests__/providers/cognito/confirmSignInHappyCases.test.ts
@@ -25,6 +25,7 @@ import { RespondToAuthChallengeCommandOutput } from '../../../src/foundation/fac
 import { authAPITestParams } from './testUtils/authApiTestParams';
 
 jest.mock('../../../src/providers/cognito/apis/getCurrentUser');
+jest.mock('../../../src/providers/cognito/utils/dispatchSignedInHubEvent');
 jest.mock(
 	'../../../src/foundation/factories/serviceClients/cognitoIdentityProvider',
 );
@@ -106,12 +107,6 @@ describe('confirmSignIn API happy path cases', () => {
 
 		const smsCode = '123456';
 
-		mockedGetCurrentUser.mockImplementationOnce(async () => {
-			return {
-				username: 'username',
-				userId: 'userId',
-			};
-		});
 		const confirmSignInResult = await confirmSignIn({
 			challengeResponse: smsCode,
 		});

--- a/packages/auth/__tests__/providers/cognito/createAuthSessionSwitcher.test.ts
+++ b/packages/auth/__tests__/providers/cognito/createAuthSessionSwitcher.test.ts
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createAuthSessionSwitcher } from '../../../src/providers/cognito/tokenProvider/createAuthSessionSwitcher';
+import { USER_NOT_SIGNED_IN_EXCEPTION } from '../../../src/errors/constants';
+
+const mockGetAuthUserList = jest.fn();
+const mockGetStoredIdToken = jest.fn();
+const mockAddActiveSession = jest.fn();
+const mockStore = {
+	getAuthUserList: mockGetAuthUserList,
+	getStoredIdToken: mockGetStoredIdToken,
+	addActiveSession: mockAddActiveSession,
+};
+
+describe('createAuthSessionSwitcher', () => {
+	beforeEach(() => {
+		mockAddActiveSession.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		mockGetAuthUserList.mockReset();
+		mockGetStoredIdToken.mockReset();
+		mockAddActiveSession.mockReset();
+	});
+
+	it('listSessionUsernames delegates to the store roster read', async () => {
+		mockGetAuthUserList.mockResolvedValue(['alice', 'bob']);
+		const switcher = createAuthSessionSwitcher(mockStore);
+
+		await expect(switcher.listSessionUsernames()).resolves.toEqual([
+			'alice',
+			'bob',
+		]);
+	});
+
+	it('getStoredIdToken delegates to the store', async () => {
+		const idToken = { payload: {}, toString: () => 'idToken' };
+		mockGetStoredIdToken.mockResolvedValue(idToken);
+		const switcher = createAuthSessionSwitcher(mockStore);
+
+		await expect(switcher.getStoredIdToken('alice')).resolves.toBe(idToken);
+		expect(mockGetStoredIdToken).toHaveBeenCalledWith('alice');
+	});
+
+	it('setActiveSession throws when the username is absent and does not reorder', async () => {
+		mockGetAuthUserList.mockResolvedValue(['alice']);
+		const switcher = createAuthSessionSwitcher(mockStore);
+
+		await expect(switcher.setActiveSession('bob')).rejects.toMatchObject({
+			name: USER_NOT_SIGNED_IN_EXCEPTION,
+		});
+		// Non-destructive: never adds a non-signed-in user.
+		expect(mockAddActiveSession).not.toHaveBeenCalled();
+	});
+
+	it('setActiveSession reorders (non-destructively) when the username is present', async () => {
+		mockGetAuthUserList.mockResolvedValue(['alice', 'bob']);
+		const switcher = createAuthSessionSwitcher(mockStore);
+
+		await switcher.setActiveSession('bob');
+
+		expect(mockAddActiveSession).toHaveBeenCalledWith('bob');
+		expect(mockAddActiveSession).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/auth/__tests__/providers/cognito/listCurrentUsers.test.ts
+++ b/packages/auth/__tests__/providers/cognito/listCurrentUsers.test.ts
@@ -2,16 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Amplify } from '@aws-amplify/core';
-import { decodeJWT } from '@aws-amplify/core/internals/utils';
 
 import { listCurrentUsers } from '../../../src/providers/cognito/apis/listCurrentUsers';
 import { cognitoUserPoolsTokenProvider } from '../../../src/providers/cognito/tokenProvider';
-import { AUTH_KEY_PREFIX } from '../../../src/providers/cognito/tokenProvider/constants';
-
-jest.mock('@aws-amplify/core/internals/utils', () => ({
-	...jest.requireActual('@aws-amplify/core/internals/utils'),
-	decodeJWT: jest.fn(),
-}));
 
 const userPoolClientId = '111111-aaaaa-42d8-891d-ee81a1549398';
 const authConfig = {
@@ -27,10 +20,6 @@ Amplify.configure({
 });
 
 const { authTokenStore } = cognitoUserPoolsTokenProvider;
-const mockDecodeJWT = decodeJWT as jest.Mock;
-
-const idTokenKey = (username: string) =>
-	`${AUTH_KEY_PREFIX}.${userPoolClientId}.${username}.idToken`;
 
 const mockKeyValueStorage = {
 	getItem: jest.fn(),
@@ -41,6 +30,7 @@ const mockKeyValueStorage = {
 
 describe('listCurrentUsers', () => {
 	let getAuthUserListSpy: jest.SpyInstance;
+	let getStoredIdTokenSpy: jest.SpyInstance;
 	let loadTokensSpy: jest.SpyInstance;
 
 	beforeEach(() => {
@@ -48,38 +38,23 @@ describe('listCurrentUsers', () => {
 			.spyOn(authTokenStore, 'getKeyValueStorage')
 			.mockReturnValue(mockKeyValueStorage);
 		getAuthUserListSpy = jest.spyOn(authTokenStore, 'getAuthUserList');
+		getStoredIdTokenSpy = jest.spyOn(authTokenStore, 'getStoredIdToken');
 		loadTokensSpy = jest.spyOn(authTokenStore, 'loadTokens');
-
-		// each stored idToken string decodes to a payload identifying its user.
-		mockDecodeJWT.mockImplementation((token: string) => {
-			const username = token.replace('-idToken', '');
-
-			return {
-				payload: {
-					'cognito:username': username,
-					sub: `${username}-sub`,
-				},
-				toString: () => token,
-			};
-		});
 	});
 
 	afterEach(() => {
 		jest.restoreAllMocks();
 		mockKeyValueStorage.getItem.mockReset();
-		mockDecodeJWT.mockReset();
 	});
 
 	it('returns AuthUser[] resolved from stored id tokens in roster order', async () => {
 		getAuthUserListSpy.mockResolvedValue(['alice', 'bob']);
-		mockKeyValueStorage.getItem.mockImplementation((key: string) => {
-			const map: Record<string, string> = {
-				[idTokenKey('alice')]: 'alice-idToken',
-				[idTokenKey('bob')]: 'bob-idToken',
-			};
-
-			return Promise.resolve(map[key] ?? null);
-		});
+		getStoredIdTokenSpy.mockImplementation((username: string) =>
+			Promise.resolve({
+				payload: { 'cognito:username': username, sub: `${username}-sub` },
+				toString: () => `${username}-idToken`,
+			}),
+		);
 
 		const result = await listCurrentUsers();
 
@@ -91,14 +66,13 @@ describe('listCurrentUsers', () => {
 
 	it('drops roster entries whose stored tokens cannot be resolved', async () => {
 		getAuthUserListSpy.mockResolvedValue(['alice', 'ghost', 'bob']);
-		mockKeyValueStorage.getItem.mockImplementation((key: string) => {
-			const map: Record<string, string> = {
-				[idTokenKey('alice')]: 'alice-idToken',
-				[idTokenKey('bob')]: 'bob-idToken',
-				// 'ghost' has no stored idToken -> resolves to null -> dropped.
-			};
+		getStoredIdTokenSpy.mockImplementation((username: string) => {
+			if (username === 'ghost') return Promise.resolve(undefined);
 
-			return Promise.resolve(map[key] ?? null);
+			return Promise.resolve({
+				payload: { 'cognito:username': username, sub: `${username}-sub` },
+				toString: () => `${username}-idToken`,
+			});
 		});
 
 		const result = await listCurrentUsers();
@@ -111,26 +85,18 @@ describe('listCurrentUsers', () => {
 
 	it('drops roster entries whose stored id token lacks a `sub` claim', async () => {
 		getAuthUserListSpy.mockResolvedValue(['alice', 'nosub', 'bob']);
-		mockKeyValueStorage.getItem.mockImplementation((key: string) => {
-			const map: Record<string, string> = {
-				[idTokenKey('alice')]: 'alice-idToken',
-				[idTokenKey('nosub')]: 'nosub-idToken',
-				[idTokenKey('bob')]: 'bob-idToken',
-			};
+		getStoredIdTokenSpy.mockImplementation((username: string) => {
+			if (username === 'nosub') {
+				return Promise.resolve({
+					payload: { 'cognito:username': username },
+					toString: () => `${username}-idToken`,
+				});
+			}
 
-			return Promise.resolve(map[key] ?? null);
-		});
-		// 'nosub' decodes to a payload with no `sub` -> unresolvable -> dropped.
-		mockDecodeJWT.mockImplementation((token: string) => {
-			const username = token.replace('-idToken', '');
-
-			return {
-				payload:
-					username === 'nosub'
-						? { 'cognito:username': username }
-						: { 'cognito:username': username, sub: `${username}-sub` },
-				toString: () => token,
-			};
+			return Promise.resolve({
+				payload: { 'cognito:username': username, sub: `${username}-sub` },
+				toString: () => `${username}-idToken`,
+			});
 		});
 
 		const result = await listCurrentUsers();
@@ -143,14 +109,62 @@ describe('listCurrentUsers', () => {
 
 	it('does not trigger a token refresh', async () => {
 		getAuthUserListSpy.mockResolvedValue(['alice']);
-		mockKeyValueStorage.getItem.mockImplementation((key: string) =>
-			Promise.resolve(key === idTokenKey('alice') ? 'alice-idToken' : null),
-		);
+		getStoredIdTokenSpy.mockResolvedValue({
+			payload: { 'cognito:username': 'alice', sub: 'alice-sub' },
+			toString: () => 'alice-idToken',
+		});
 
 		await listCurrentUsers();
 
 		// identities are read directly from stored tokens; loadTokens (which can
 		// drive a refresh) must not be invoked.
 		expect(loadTokensSpy).not.toHaveBeenCalled();
+	});
+
+	it('includes signInDetails when stored signInDetails key is present', async () => {
+		getAuthUserListSpy.mockResolvedValue(['alice']);
+		getStoredIdTokenSpy.mockResolvedValue({
+			payload: { 'cognito:username': 'alice', sub: 'alice-sub' },
+			toString: () => 'alice-idToken',
+		});
+
+		const signInDetails = {
+			loginId: 'alice@example.com',
+			authFlowType: 'USER_SRP_AUTH',
+		};
+		mockKeyValueStorage.getItem.mockImplementation((key: string) => {
+			if (key.endsWith('.signInDetails')) {
+				return Promise.resolve(JSON.stringify(signInDetails));
+			}
+
+			return Promise.resolve(null);
+		});
+
+		const result = await listCurrentUsers();
+
+		expect(result).toEqual([
+			{
+				username: 'alice',
+				userId: 'alice-sub',
+				signInDetails,
+			},
+		]);
+	});
+
+	it('still returns the user when signInDetails read fails', async () => {
+		getAuthUserListSpy.mockResolvedValue(['alice']);
+		getStoredIdTokenSpy.mockResolvedValue({
+			payload: { 'cognito:username': 'alice', sub: 'alice-sub' },
+			toString: () => 'alice-idToken',
+		});
+
+		// signInDetails key returns invalid JSON — parse will throw, but the
+		// implementation currently only reads it conditionally so it may return
+		// null. Either way the user should still be resolvable.
+		mockKeyValueStorage.getItem.mockResolvedValue(null);
+
+		const result = await listCurrentUsers();
+
+		expect(result).toEqual([{ username: 'alice', userId: 'alice-sub' }]);
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/listCurrentUsers.test.ts
+++ b/packages/auth/__tests__/providers/cognito/listCurrentUsers.test.ts
@@ -1,0 +1,156 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+import { decodeJWT } from '@aws-amplify/core/internals/utils';
+
+import { listCurrentUsers } from '../../../src/providers/cognito/apis/listCurrentUsers';
+import { cognitoUserPoolsTokenProvider } from '../../../src/providers/cognito/tokenProvider';
+import { AUTH_KEY_PREFIX } from '../../../src/providers/cognito/tokenProvider/constants';
+
+jest.mock('@aws-amplify/core/internals/utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/utils'),
+	decodeJWT: jest.fn(),
+}));
+
+const userPoolClientId = '111111-aaaaa-42d8-891d-ee81a1549398';
+const authConfig = {
+	Cognito: {
+		userPoolClientId,
+		userPoolId: 'us-west-2_zzzzz',
+	},
+};
+
+cognitoUserPoolsTokenProvider.setAuthConfig(authConfig);
+Amplify.configure({
+	Auth: authConfig,
+});
+
+const { authTokenStore } = cognitoUserPoolsTokenProvider;
+const mockDecodeJWT = decodeJWT as jest.Mock;
+
+const idTokenKey = (username: string) =>
+	`${AUTH_KEY_PREFIX}.${userPoolClientId}.${username}.idToken`;
+
+const mockKeyValueStorage = {
+	getItem: jest.fn(),
+	setItem: jest.fn(),
+	removeItem: jest.fn(),
+	clear: jest.fn(),
+};
+
+describe('listCurrentUsers', () => {
+	let getAuthUserListSpy: jest.SpyInstance;
+	let loadTokensSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		jest
+			.spyOn(authTokenStore, 'getKeyValueStorage')
+			.mockReturnValue(mockKeyValueStorage);
+		getAuthUserListSpy = jest.spyOn(authTokenStore, 'getAuthUserList');
+		loadTokensSpy = jest.spyOn(authTokenStore, 'loadTokens');
+
+		// each stored idToken string decodes to a payload identifying its user.
+		mockDecodeJWT.mockImplementation((token: string) => {
+			const username = token.replace('-idToken', '');
+
+			return {
+				payload: {
+					'cognito:username': username,
+					sub: `${username}-sub`,
+				},
+				toString: () => token,
+			};
+		});
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+		mockKeyValueStorage.getItem.mockReset();
+		mockDecodeJWT.mockReset();
+	});
+
+	it('returns AuthUser[] resolved from stored id tokens in roster order', async () => {
+		getAuthUserListSpy.mockResolvedValue(['alice', 'bob']);
+		mockKeyValueStorage.getItem.mockImplementation((key: string) => {
+			const map: Record<string, string> = {
+				[idTokenKey('alice')]: 'alice-idToken',
+				[idTokenKey('bob')]: 'bob-idToken',
+			};
+
+			return Promise.resolve(map[key] ?? null);
+		});
+
+		const result = await listCurrentUsers();
+
+		expect(result).toEqual([
+			{ username: 'alice', userId: 'alice-sub' },
+			{ username: 'bob', userId: 'bob-sub' },
+		]);
+	});
+
+	it('drops roster entries whose stored tokens cannot be resolved', async () => {
+		getAuthUserListSpy.mockResolvedValue(['alice', 'ghost', 'bob']);
+		mockKeyValueStorage.getItem.mockImplementation((key: string) => {
+			const map: Record<string, string> = {
+				[idTokenKey('alice')]: 'alice-idToken',
+				[idTokenKey('bob')]: 'bob-idToken',
+				// 'ghost' has no stored idToken -> resolves to null -> dropped.
+			};
+
+			return Promise.resolve(map[key] ?? null);
+		});
+
+		const result = await listCurrentUsers();
+
+		expect(result).toEqual([
+			{ username: 'alice', userId: 'alice-sub' },
+			{ username: 'bob', userId: 'bob-sub' },
+		]);
+	});
+
+	it('drops roster entries whose stored id token lacks a `sub` claim', async () => {
+		getAuthUserListSpy.mockResolvedValue(['alice', 'nosub', 'bob']);
+		mockKeyValueStorage.getItem.mockImplementation((key: string) => {
+			const map: Record<string, string> = {
+				[idTokenKey('alice')]: 'alice-idToken',
+				[idTokenKey('nosub')]: 'nosub-idToken',
+				[idTokenKey('bob')]: 'bob-idToken',
+			};
+
+			return Promise.resolve(map[key] ?? null);
+		});
+		// 'nosub' decodes to a payload with no `sub` -> unresolvable -> dropped.
+		mockDecodeJWT.mockImplementation((token: string) => {
+			const username = token.replace('-idToken', '');
+
+			return {
+				payload:
+					username === 'nosub'
+						? { 'cognito:username': username }
+						: { 'cognito:username': username, sub: `${username}-sub` },
+				toString: () => token,
+			};
+		});
+
+		const result = await listCurrentUsers();
+
+		expect(result).toEqual([
+			{ username: 'alice', userId: 'alice-sub' },
+			{ username: 'bob', userId: 'bob-sub' },
+		]);
+	});
+
+	it('does not trigger a token refresh', async () => {
+		getAuthUserListSpy.mockResolvedValue(['alice']);
+		mockKeyValueStorage.getItem.mockImplementation((key: string) =>
+			Promise.resolve(key === idTokenKey('alice') ? 'alice-idToken' : null),
+		);
+
+		await listCurrentUsers();
+
+		// identities are read directly from stored tokens; loadTokens (which can
+		// drive a refresh) must not be invoked.
+		expect(loadTokensSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/auth/__tests__/providers/cognito/server/listCurrentUsers.test.ts
+++ b/packages/auth/__tests__/providers/cognito/server/listCurrentUsers.test.ts
@@ -1,0 +1,90 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getAmplifyServerContext } from '@aws-amplify/core/internals/adapter-core';
+
+import { listCurrentUsers } from '../../../../src/providers/cognito/apis/server/listCurrentUsers';
+
+jest.mock('@aws-amplify/core/internals/adapter-core');
+
+const mockGetAmplifyServerContext = jest.mocked(getAmplifyServerContext);
+const mockListSessionUsernames = jest.fn();
+const mockGetStoredIdToken = jest.fn();
+const mockSwitcher = {
+	listSessionUsernames: mockListSessionUsernames,
+	getStoredIdToken: mockGetStoredIdToken,
+	setActiveSession: jest.fn(),
+};
+const mockGetTokenProvider = jest.fn();
+const mockContextSpec = { token: { value: Symbol('test') } } as any;
+
+const idToken = (username: string) => ({
+	payload: { 'cognito:username': username, sub: `${username}-sub` },
+	toString: () => `${username}-idToken`,
+});
+
+describe('server-side listCurrentUsers', () => {
+	beforeEach(() => {
+		mockGetTokenProvider.mockReturnValue({
+			getTokens: jest.fn(),
+			getSessionSwitcher: () => mockSwitcher,
+		});
+		mockGetAmplifyServerContext.mockReturnValue({
+			amplify: {
+				Auth: { getTokenProvider: mockGetTokenProvider },
+			},
+		} as any);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('returns AuthUser[] resolved from stored id tokens in roster order', async () => {
+		mockListSessionUsernames.mockResolvedValue(['alice', 'bob']);
+		mockGetStoredIdToken.mockImplementation((username: string) =>
+			Promise.resolve(idToken(username)),
+		);
+
+		await expect(listCurrentUsers(mockContextSpec)).resolves.toEqual([
+			{ username: 'alice', userId: 'alice-sub' },
+			{ username: 'bob', userId: 'bob-sub' },
+		]);
+	});
+
+	it('drops roster entries whose stored id token cannot be resolved', async () => {
+		mockListSessionUsernames.mockResolvedValue(['alice', 'ghost', 'bob']);
+		mockGetStoredIdToken.mockImplementation((username: string) =>
+			Promise.resolve(username === 'ghost' ? undefined : idToken(username)),
+		);
+
+		await expect(listCurrentUsers(mockContextSpec)).resolves.toEqual([
+			{ username: 'alice', userId: 'alice-sub' },
+			{ username: 'bob', userId: 'bob-sub' },
+		]);
+	});
+
+	it('drops roster entries whose stored id token lacks a `sub` claim', async () => {
+		mockListSessionUsernames.mockResolvedValue(['alice', 'nosub', 'bob']);
+		mockGetStoredIdToken.mockImplementation((username: string) =>
+			Promise.resolve(
+				username === 'nosub'
+					? { payload: { 'cognito:username': 'nosub' }, toString: () => 'x' }
+					: idToken(username),
+			),
+		);
+
+		await expect(listCurrentUsers(mockContextSpec)).resolves.toEqual([
+			{ username: 'alice', userId: 'alice-sub' },
+			{ username: 'bob', userId: 'bob-sub' },
+		]);
+	});
+
+	it('throws when the context has no session-switching token provider', async () => {
+		mockGetTokenProvider.mockReturnValue(undefined);
+
+		await expect(listCurrentUsers(mockContextSpec)).rejects.toMatchObject({
+			name: 'TokenProviderNotFoundException',
+		});
+	});
+});

--- a/packages/auth/__tests__/providers/cognito/server/listCurrentUsers.test.ts
+++ b/packages/auth/__tests__/providers/cognito/server/listCurrentUsers.test.ts
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { getAmplifyServerContext } from '@aws-amplify/core/internals/adapter-core';
+
+import { listCurrentUsers } from '../../../../src/providers/cognito/apis/server/listCurrentUsers';
+
+jest.mock('@aws-amplify/core/internals/adapter-core');
+
+const mockGetAmplifyServerContext = jest.mocked(getAmplifyServerContext);
+const mockListSessionUsernames = jest.fn();
+const mockGetStoredIdToken = jest.fn();
+const mockSwitcher = {
+	listSessionUsernames: mockListSessionUsernames,
+	getStoredIdToken: mockGetStoredIdToken,
+	setActiveSession: jest.fn(),
+};
+const setTokenProvider = (tokenProvider: any) =>
+	mockGetAmplifyServerContext.mockReturnValue({
+		amplify: { libraryOptions: { Auth: { tokenProvider } } },
+	} as any);
+const mockContextSpec = { token: { value: Symbol('test') } } as any;
+
+const idToken = (username: string) => ({
+	payload: { 'cognito:username': username, sub: `${username}-sub` },
+	toString: () => `${username}-idToken`,
+});
+
+describe('server-side listCurrentUsers', () => {
+	beforeEach(() => {
+		setTokenProvider({
+			getTokens: jest.fn(),
+			getSessionSwitcher: () => mockSwitcher,
+		});
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('returns AuthUser[] resolved from stored id tokens in roster order', async () => {
+		mockListSessionUsernames.mockResolvedValue(['alice', 'bob']);
+		mockGetStoredIdToken.mockImplementation((username: string) =>
+			Promise.resolve(idToken(username)),
+		);
+
+		await expect(listCurrentUsers(mockContextSpec)).resolves.toEqual([
+			{ username: 'alice', userId: 'alice-sub' },
+			{ username: 'bob', userId: 'bob-sub' },
+		]);
+	});
+
+	it('drops roster entries whose stored id token cannot be resolved', async () => {
+		mockListSessionUsernames.mockResolvedValue(['alice', 'ghost', 'bob']);
+		mockGetStoredIdToken.mockImplementation((username: string) =>
+			Promise.resolve(username === 'ghost' ? undefined : idToken(username)),
+		);
+
+		await expect(listCurrentUsers(mockContextSpec)).resolves.toEqual([
+			{ username: 'alice', userId: 'alice-sub' },
+			{ username: 'bob', userId: 'bob-sub' },
+		]);
+	});
+
+	it('drops roster entries whose stored id token lacks a `sub` claim', async () => {
+		mockListSessionUsernames.mockResolvedValue(['alice', 'nosub', 'bob']);
+		mockGetStoredIdToken.mockImplementation((username: string) =>
+			Promise.resolve(
+				username === 'nosub'
+					? { payload: { 'cognito:username': 'nosub' }, toString: () => 'x' }
+					: idToken(username),
+			),
+		);
+
+		await expect(listCurrentUsers(mockContextSpec)).resolves.toEqual([
+			{ username: 'alice', userId: 'alice-sub' },
+			{ username: 'bob', userId: 'bob-sub' },
+		]);
+	});
+
+	it('throws when the context has no session-switching token provider', async () => {
+		setTokenProvider(undefined);
+
+		await expect(listCurrentUsers(mockContextSpec)).rejects.toMatchObject({
+			name: 'TokenProviderNotFoundException',
+		});
+	});
+});

--- a/packages/auth/__tests__/providers/cognito/server/setCurrentUser.test.ts
+++ b/packages/auth/__tests__/providers/cognito/server/setCurrentUser.test.ts
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Hub } from '@aws-amplify/core';
+import { getAmplifyServerContext } from '@aws-amplify/core/internals/adapter-core';
+
+import { setCurrentUser } from '../../../../src/providers/cognito/apis/server/setCurrentUser';
+import { USER_NOT_SIGNED_IN_EXCEPTION } from '../../../../src/errors/constants';
+import { AuthError } from '../../../../src/errors/AuthError';
+
+jest.mock('@aws-amplify/core/internals/adapter-core');
+jest.mock('@aws-amplify/core', () => ({
+	...jest.requireActual('@aws-amplify/core'),
+	Hub: { dispatch: jest.fn() },
+}));
+
+const mockGetAmplifyServerContext = jest.mocked(getAmplifyServerContext);
+const mockDispatch = Hub.dispatch as jest.Mock;
+const mockSetActiveSession = jest.fn();
+const mockClearCredentials = jest.fn();
+const mockSwitcher = {
+	listSessionUsernames: jest.fn(),
+	getStoredIdToken: jest.fn(),
+	setActiveSession: mockSetActiveSession,
+};
+const mockGetTokenProvider = jest.fn();
+const mockContextSpec = { token: { value: Symbol('test') } } as any;
+
+describe('server-side setCurrentUser', () => {
+	beforeEach(() => {
+		mockSetActiveSession.mockResolvedValue(undefined);
+		mockClearCredentials.mockResolvedValue(undefined);
+		mockGetTokenProvider.mockReturnValue({
+			getTokens: jest.fn(),
+			getSessionSwitcher: () => mockSwitcher,
+		});
+		mockGetAmplifyServerContext.mockReturnValue({
+			amplify: {
+				Auth: {
+					getTokenProvider: mockGetTokenProvider,
+					clearCredentials: mockClearCredentials,
+				},
+			},
+		} as any);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('switches the active session and clears context-scoped credentials', async () => {
+		await setCurrentUser(mockContextSpec, 'bob');
+
+		expect(mockSetActiveSession).toHaveBeenCalledWith('bob');
+		expect(mockClearCredentials).toHaveBeenCalledTimes(1);
+	});
+
+	it('does NOT dispatch a Hub event', async () => {
+		await setCurrentUser(mockContextSpec, 'bob');
+
+		expect(mockDispatch).not.toHaveBeenCalled();
+	});
+
+	it('propagates the switcher error and does not clear credentials when absent', async () => {
+		mockSetActiveSession.mockRejectedValue(
+			new AuthError({
+				name: USER_NOT_SIGNED_IN_EXCEPTION,
+				message: 'no session',
+			}),
+		);
+
+		await expect(
+			setCurrentUser(mockContextSpec, 'ghost'),
+		).rejects.toMatchObject({ name: USER_NOT_SIGNED_IN_EXCEPTION });
+		expect(mockClearCredentials).not.toHaveBeenCalled();
+	});
+});

--- a/packages/auth/__tests__/providers/cognito/server/setCurrentUser.test.ts
+++ b/packages/auth/__tests__/providers/cognito/server/setCurrentUser.test.ts
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Hub } from '@aws-amplify/core';
+import { getAmplifyServerContext } from '@aws-amplify/core/internals/adapter-core';
+
+import { setCurrentUser } from '../../../../src/providers/cognito/apis/server/setCurrentUser';
+import { USER_NOT_SIGNED_IN_EXCEPTION } from '../../../../src/errors/constants';
+import { AuthError } from '../../../../src/errors/AuthError';
+
+jest.mock('@aws-amplify/core/internals/adapter-core');
+jest.mock('@aws-amplify/core', () => ({
+	...jest.requireActual('@aws-amplify/core'),
+	Hub: { dispatch: jest.fn() },
+}));
+
+const mockGetAmplifyServerContext = jest.mocked(getAmplifyServerContext);
+const mockDispatch = Hub.dispatch as jest.Mock;
+const mockSetActiveSession = jest.fn();
+const mockClearCredentials = jest.fn();
+const mockSwitcher = {
+	listSessionUsernames: jest.fn(),
+	getStoredIdToken: jest.fn(),
+	setActiveSession: mockSetActiveSession,
+};
+const mockContextSpec = { token: { value: Symbol('test') } } as any;
+
+describe('server-side setCurrentUser', () => {
+	beforeEach(() => {
+		mockSetActiveSession.mockResolvedValue(undefined);
+		mockClearCredentials.mockResolvedValue(undefined);
+		mockGetAmplifyServerContext.mockReturnValue({
+			amplify: {
+				libraryOptions: {
+					Auth: {
+						tokenProvider: {
+							getTokens: jest.fn(),
+							getSessionSwitcher: () => mockSwitcher,
+						},
+					},
+				},
+				clearCredentials: mockClearCredentials,
+			},
+		} as any);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('switches the active session and clears context-scoped credentials', async () => {
+		await setCurrentUser(mockContextSpec, 'bob');
+
+		expect(mockSetActiveSession).toHaveBeenCalledWith('bob');
+		expect(mockClearCredentials).toHaveBeenCalledTimes(1);
+	});
+
+	it('does NOT dispatch a Hub event', async () => {
+		await setCurrentUser(mockContextSpec, 'bob');
+
+		expect(mockDispatch).not.toHaveBeenCalled();
+	});
+
+	it('propagates the switcher error and does not clear credentials when absent', async () => {
+		mockSetActiveSession.mockRejectedValue(
+			new AuthError({
+				name: USER_NOT_SIGNED_IN_EXCEPTION,
+				message: 'no session',
+			}),
+		);
+
+		await expect(
+			setCurrentUser(mockContextSpec, 'ghost'),
+		).rejects.toMatchObject({ name: USER_NOT_SIGNED_IN_EXCEPTION });
+		expect(mockClearCredentials).not.toHaveBeenCalled();
+	});
+});

--- a/packages/auth/__tests__/providers/cognito/setCurrentUser.test.ts
+++ b/packages/auth/__tests__/providers/cognito/setCurrentUser.test.ts
@@ -5,13 +5,11 @@ import { Hub, clearCredentials } from '@aws-amplify/core';
 import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
 
 import { setCurrentUser } from '../../../src/providers/cognito/apis/setCurrentUser';
-import { getCurrentUser } from '../../../src/providers/cognito/apis/internal/getCurrentUser';
 import { tokenOrchestrator } from '../../../src/providers/cognito/tokenProvider';
 import { AuthTokenStore } from '../../../src/providers/cognito/tokenProvider/types';
 import { USER_NOT_SIGNED_IN_EXCEPTION } from '../../../src/errors/constants';
 
 jest.mock('@aws-amplify/core', () => ({
-	Amplify: {},
 	Hub: {
 		dispatch: jest.fn(),
 	},
@@ -21,20 +19,20 @@ jest.mock('@aws-amplify/core/internals/utils', () => ({
 	...jest.requireActual('@aws-amplify/core/internals/utils'),
 	AMPLIFY_SYMBOL: Symbol('AMPLIFY_SYMBOL'),
 }));
-jest.mock('../../../src/providers/cognito/apis/internal/getCurrentUser');
 jest.mock('../../../src/providers/cognito/tokenProvider');
 
 const mockTokenOrchestrator = tokenOrchestrator as jest.Mocked<
 	typeof tokenOrchestrator
 >;
-const mockGetCurrentUser = getCurrentUser as jest.Mock;
 const mockClearCredentials = clearCredentials as jest.Mock;
 const mockDispatch = Hub.dispatch as jest.Mock;
 const mockGetAuthUserList = jest.fn();
 const mockAddActiveSession = jest.fn();
+const mockGetStoredIdToken = jest.fn();
 const mockTokenStore = {
 	getAuthUserList: mockGetAuthUserList,
 	addActiveSession: mockAddActiveSession,
+	getStoredIdToken: mockGetStoredIdToken,
 };
 
 describe('setCurrentUser', () => {
@@ -50,7 +48,7 @@ describe('setCurrentUser', () => {
 		mockGetAuthUserList.mockReset();
 		mockAddActiveSession.mockReset();
 		mockClearCredentials.mockReset();
-		mockGetCurrentUser.mockReset();
+		mockGetStoredIdToken.mockReset();
 		mockDispatch.mockClear();
 		mockTokenOrchestrator.getTokenStore.mockReset();
 	});
@@ -79,9 +77,8 @@ describe('setCurrentUser', () => {
 
 	it('reorders the roster, clears credentials, and dispatches switchActiveUser', async () => {
 		mockGetAuthUserList.mockResolvedValue(['alice', 'bob']);
-		mockGetCurrentUser.mockResolvedValue({
-			username: 'bob',
-			userId: 'bob-id',
+		mockGetStoredIdToken.mockResolvedValue({
+			payload: { sub: 'bob-id' },
 		});
 
 		await setCurrentUser('bob');
@@ -90,6 +87,8 @@ describe('setCurrentUser', () => {
 		expect(mockAddActiveSession).toHaveBeenCalledWith('bob');
 		// busts the previous active user's identity-pool credentials.
 		expect(mockClearCredentials).toHaveBeenCalledTimes(1);
+		// resolves from stored id token, not getCurrentUser.
+		expect(mockGetStoredIdToken).toHaveBeenCalledWith('bob');
 		// switchActiveUser fires when the active pointer moves between users.
 		expect(mockDispatch).toHaveBeenCalledWith(
 			'auth',
@@ -100,5 +99,17 @@ describe('setCurrentUser', () => {
 			'Auth',
 			AMPLIFY_SYMBOL,
 		);
+	});
+
+	it('skips dispatch when the stored id token has no sub claim', async () => {
+		mockGetAuthUserList.mockResolvedValue(['alice', 'bob']);
+		mockGetStoredIdToken.mockResolvedValue(undefined);
+
+		await setCurrentUser('bob');
+
+		expect(mockAddActiveSession).toHaveBeenCalledWith('bob');
+		expect(mockClearCredentials).toHaveBeenCalledTimes(1);
+		// No dispatch when userId can't be resolved.
+		expect(mockDispatch).not.toHaveBeenCalled();
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/setCurrentUser.test.ts
+++ b/packages/auth/__tests__/providers/cognito/setCurrentUser.test.ts
@@ -1,0 +1,104 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Hub, clearCredentials } from '@aws-amplify/core';
+import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
+
+import { setCurrentUser } from '../../../src/providers/cognito/apis/setCurrentUser';
+import { getCurrentUser } from '../../../src/providers/cognito/apis/internal/getCurrentUser';
+import { tokenOrchestrator } from '../../../src/providers/cognito/tokenProvider';
+import { AuthTokenStore } from '../../../src/providers/cognito/tokenProvider/types';
+import { USER_NOT_SIGNED_IN_EXCEPTION } from '../../../src/errors/constants';
+
+jest.mock('@aws-amplify/core', () => ({
+	Amplify: {},
+	Hub: {
+		dispatch: jest.fn(),
+	},
+	clearCredentials: jest.fn(),
+}));
+jest.mock('@aws-amplify/core/internals/utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/utils'),
+	AMPLIFY_SYMBOL: Symbol('AMPLIFY_SYMBOL'),
+}));
+jest.mock('../../../src/providers/cognito/apis/internal/getCurrentUser');
+jest.mock('../../../src/providers/cognito/tokenProvider');
+
+const mockTokenOrchestrator = tokenOrchestrator as jest.Mocked<
+	typeof tokenOrchestrator
+>;
+const mockGetCurrentUser = getCurrentUser as jest.Mock;
+const mockClearCredentials = clearCredentials as jest.Mock;
+const mockDispatch = Hub.dispatch as jest.Mock;
+const mockGetAuthUserList = jest.fn();
+const mockAddActiveSession = jest.fn();
+const mockTokenStore = {
+	getAuthUserList: mockGetAuthUserList,
+	addActiveSession: mockAddActiveSession,
+};
+
+describe('setCurrentUser', () => {
+	beforeEach(() => {
+		mockTokenOrchestrator.getTokenStore.mockReturnValue(
+			mockTokenStore as unknown as AuthTokenStore,
+		);
+		mockAddActiveSession.mockResolvedValue(undefined);
+		mockClearCredentials.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		mockGetAuthUserList.mockReset();
+		mockAddActiveSession.mockReset();
+		mockClearCredentials.mockReset();
+		mockGetCurrentUser.mockReset();
+		mockDispatch.mockClear();
+		mockTokenOrchestrator.getTokenStore.mockReset();
+	});
+
+	it('throws when the target username has no session in the roster', async () => {
+		mockGetAuthUserList.mockResolvedValue(['alice']);
+
+		await expect(setCurrentUser('bob')).rejects.toMatchObject({
+			name: USER_NOT_SIGNED_IN_EXCEPTION,
+		});
+
+		expect(mockAddActiveSession).not.toHaveBeenCalled();
+		expect(mockClearCredentials).not.toHaveBeenCalled();
+		expect(mockDispatch).not.toHaveBeenCalled();
+	});
+
+	it('is a no-op when the target user is already active', async () => {
+		mockGetAuthUserList.mockResolvedValue(['bob', 'alice']);
+
+		await setCurrentUser('bob');
+
+		expect(mockAddActiveSession).not.toHaveBeenCalled();
+		expect(mockClearCredentials).not.toHaveBeenCalled();
+		expect(mockDispatch).not.toHaveBeenCalled();
+	});
+
+	it('reorders the roster, clears credentials, and dispatches switchActiveUser', async () => {
+		mockGetAuthUserList.mockResolvedValue(['alice', 'bob']);
+		mockGetCurrentUser.mockResolvedValue({
+			username: 'bob',
+			userId: 'bob-id',
+		});
+
+		await setCurrentUser('bob');
+
+		// promotes the target to the front of the roster.
+		expect(mockAddActiveSession).toHaveBeenCalledWith('bob');
+		// busts the previous active user's identity-pool credentials.
+		expect(mockClearCredentials).toHaveBeenCalledTimes(1);
+		// switchActiveUser fires when the active pointer moves between users.
+		expect(mockDispatch).toHaveBeenCalledWith(
+			'auth',
+			{
+				event: 'switchActiveUser',
+				data: { username: 'bob', userId: 'bob-id' },
+			},
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+});

--- a/packages/auth/__tests__/providers/cognito/setCurrentUser.test.ts
+++ b/packages/auth/__tests__/providers/cognito/setCurrentUser.test.ts
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Hub, clearCredentials } from '@aws-amplify/core';
+import { Hub } from '@aws-amplify/core';
 import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
+import { createMockAmplifyContext } from '@aws-amplify/core/internals/testing';
 
 import { setCurrentUser } from '../../../src/providers/cognito/apis/setCurrentUser';
 import { tokenOrchestrator } from '../../../src/providers/cognito/tokenProvider';
@@ -13,7 +14,6 @@ jest.mock('@aws-amplify/core', () => ({
 	Hub: {
 		dispatch: jest.fn(),
 	},
-	clearCredentials: jest.fn(),
 }));
 jest.mock('@aws-amplify/core/internals/utils', () => ({
 	...jest.requireActual('@aws-amplify/core/internals/utils'),
@@ -24,30 +24,33 @@ jest.mock('../../../src/providers/cognito/tokenProvider');
 const mockTokenOrchestrator = tokenOrchestrator as jest.Mocked<
 	typeof tokenOrchestrator
 >;
-const mockClearCredentials = clearCredentials as jest.Mock;
 const mockDispatch = Hub.dispatch as jest.Mock;
 const mockGetAuthUserList = jest.fn();
+const mockGetActiveUsername = jest.fn();
 const mockAddActiveSession = jest.fn();
 const mockGetStoredIdToken = jest.fn();
 const mockTokenStore = {
 	getAuthUserList: mockGetAuthUserList,
+	getActiveUsername: mockGetActiveUsername,
 	addActiveSession: mockAddActiveSession,
 	getStoredIdToken: mockGetStoredIdToken,
 };
 
+let mockCtx: ReturnType<typeof createMockAmplifyContext>;
+
 describe('setCurrentUser', () => {
 	beforeEach(() => {
+		mockCtx = createMockAmplifyContext();
 		mockTokenOrchestrator.getTokenStore.mockReturnValue(
 			mockTokenStore as unknown as AuthTokenStore,
 		);
 		mockAddActiveSession.mockResolvedValue(undefined);
-		mockClearCredentials.mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
 		mockGetAuthUserList.mockReset();
+		mockGetActiveUsername.mockReset();
 		mockAddActiveSession.mockReset();
-		mockClearCredentials.mockReset();
 		mockGetStoredIdToken.mockReset();
 		mockDispatch.mockClear();
 		mockTokenOrchestrator.getTokenStore.mockReset();
@@ -56,37 +59,39 @@ describe('setCurrentUser', () => {
 	it('throws when the target username has no session in the roster', async () => {
 		mockGetAuthUserList.mockResolvedValue(['alice']);
 
-		await expect(setCurrentUser('bob')).rejects.toMatchObject({
+		await expect(setCurrentUser(mockCtx, 'bob')).rejects.toMatchObject({
 			name: USER_NOT_SIGNED_IN_EXCEPTION,
 		});
 
 		expect(mockAddActiveSession).not.toHaveBeenCalled();
-		expect(mockClearCredentials).not.toHaveBeenCalled();
+		expect(mockCtx.clearCredentials).not.toHaveBeenCalled();
 		expect(mockDispatch).not.toHaveBeenCalled();
 	});
 
-	it('is a no-op when the target user is already active', async () => {
+	it('is a no-op when the target user is already the active pointer', async () => {
 		mockGetAuthUserList.mockResolvedValue(['bob', 'alice']);
+		mockGetActiveUsername.mockResolvedValue('bob');
 
-		await setCurrentUser('bob');
+		await setCurrentUser(mockCtx, 'bob');
 
 		expect(mockAddActiveSession).not.toHaveBeenCalled();
-		expect(mockClearCredentials).not.toHaveBeenCalled();
+		expect(mockCtx.clearCredentials).not.toHaveBeenCalled();
 		expect(mockDispatch).not.toHaveBeenCalled();
 	});
 
-	it('reorders the roster, clears credentials, and dispatches switchActiveUser', async () => {
+	it('reorders the roster, clears credentials, and dispatches switchActiveUser when another user was active', async () => {
 		mockGetAuthUserList.mockResolvedValue(['alice', 'bob']);
+		mockGetActiveUsername.mockResolvedValue('alice');
 		mockGetStoredIdToken.mockResolvedValue({
 			payload: { sub: 'bob-id' },
 		});
 
-		await setCurrentUser('bob');
+		await setCurrentUser(mockCtx, 'bob');
 
 		// promotes the target to the front of the roster.
 		expect(mockAddActiveSession).toHaveBeenCalledWith('bob');
 		// busts the previous active user's identity-pool credentials.
-		expect(mockClearCredentials).toHaveBeenCalledTimes(1);
+		expect(mockCtx.clearCredentials).toHaveBeenCalledTimes(1);
 		// resolves from stored id token, not getCurrentUser.
 		expect(mockGetStoredIdToken).toHaveBeenCalledWith('bob');
 		// switchActiveUser fires when the active pointer moves between users.
@@ -101,14 +106,44 @@ describe('setCurrentUser', () => {
 		);
 	});
 
-	it('skips dispatch when the stored id token has no sub claim', async () => {
-		mockGetAuthUserList.mockResolvedValue(['alice', 'bob']);
-		mockGetStoredIdToken.mockResolvedValue(undefined);
+	it('dispatches signedIn (not switchActiveUser) when activating a parked session with no active pointer', async () => {
+		// parked roster after a sign-out: nobody active (empty pointer).
+		mockGetAuthUserList.mockResolvedValue(['bob']);
+		mockGetActiveUsername.mockResolvedValue(undefined);
+		mockGetStoredIdToken.mockResolvedValue({
+			payload: { sub: 'bob-id' },
+		});
 
-		await setCurrentUser('bob');
+		await setCurrentUser(mockCtx, 'bob');
 
 		expect(mockAddActiveSession).toHaveBeenCalledWith('bob');
-		expect(mockClearCredentials).toHaveBeenCalledTimes(1);
+		expect(mockCtx.clearCredentials).toHaveBeenCalledTimes(1);
+		expect(mockDispatch).toHaveBeenCalledWith(
+			'auth',
+			{
+				event: 'signedIn',
+				data: { username: 'bob', userId: 'bob-id' },
+			},
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).not.toHaveBeenCalledWith(
+			'auth',
+			expect.objectContaining({ event: 'switchActiveUser' }),
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+
+	it('skips dispatch when the stored id token has no sub claim', async () => {
+		mockGetAuthUserList.mockResolvedValue(['alice', 'bob']);
+		mockGetActiveUsername.mockResolvedValue('alice');
+		mockGetStoredIdToken.mockResolvedValue(undefined);
+
+		await setCurrentUser(mockCtx, 'bob');
+
+		expect(mockAddActiveSession).toHaveBeenCalledWith('bob');
+		expect(mockCtx.clearCredentials).toHaveBeenCalledTimes(1);
 		// No dispatch when userId can't be resolved.
 		expect(mockDispatch).not.toHaveBeenCalled();
 	});

--- a/packages/auth/__tests__/providers/cognito/setCurrentUser.test.ts
+++ b/packages/auth/__tests__/providers/cognito/setCurrentUser.test.ts
@@ -135,16 +135,20 @@ describe('setCurrentUser', () => {
 		);
 	});
 
-	it('skips dispatch when the stored id token has no sub claim', async () => {
+	it('throws UserNotSignedInException BEFORE mutating when the stored id token is unresolvable', async () => {
 		mockGetAuthUserList.mockResolvedValue(['alice', 'bob']);
 		mockGetActiveUsername.mockResolvedValue('alice');
+		// target session cannot be resolved from its stored id token.
 		mockGetStoredIdToken.mockResolvedValue(undefined);
 
-		await setCurrentUser(mockCtx, 'bob');
+		await expect(setCurrentUser(mockCtx, 'bob')).rejects.toMatchObject({
+			name: USER_NOT_SIGNED_IN_EXCEPTION,
+		});
 
-		expect(mockAddActiveSession).toHaveBeenCalledWith('bob');
-		expect(mockCtx.clearCredentials).toHaveBeenCalledTimes(1);
-		// No dispatch when userId can't be resolved.
+		// identity is resolved up front, so NO mutation/side effect occurs.
+		expect(mockGetStoredIdToken).toHaveBeenCalledWith('bob');
+		expect(mockAddActiveSession).not.toHaveBeenCalled();
+		expect(mockCtx.clearCredentials).not.toHaveBeenCalled();
 		expect(mockDispatch).not.toHaveBeenCalled();
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/signInErrorCases.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInErrorCases.test.ts
@@ -8,8 +8,8 @@ import { AuthError } from '../../../src/errors/AuthError';
 import { AuthValidationErrorCode } from '../../../src/errors/types/validation';
 import { getCurrentUser, signIn } from '../../../src/providers/cognito';
 import { InitiateAuthException } from '../../../src/providers/cognito/types/errors';
-import { USER_ALREADY_AUTHENTICATED_EXCEPTION } from '../../../src/errors/constants';
 import { createInitiateAuthClient } from '../../../src/foundation/factories/serviceClients/cognitoIdentityProvider';
+import * as initiateAuthHelpers from '../../../src/providers/cognito/utils/signInHelpers';
 import { AuthErrorCodes } from '../../../src/common/AuthErrorStrings';
 
 import { authAPITestParams } from './testUtils/authApiTestParams';
@@ -63,18 +63,35 @@ describe('signIn API error path cases:', () => {
 		mockInitiateAuth.mockReset();
 	});
 
-	it('should throw an error when a user is already signed-in', async () => {
+	it('does not throw UserAlreadyAuthenticatedException when a user is already signed-in (multi-session)', async () => {
+		// Multi-session (HLD §6.1): a native signIn for a second user must succeed
+		// and be added to the roster head instead of throwing
+		// UserAlreadyAuthenticatedException. The gate has been removed from signIn
+		// (the OAuth prompt-gate on signInWithRedirect is unaffected). Here we let
+		// the SRP flow resolve to a challenge next step so the call resolves without
+		// exercising token caching / Hub dispatch.
 		mockedGetCurrentUser.mockResolvedValue({
 			username: 'username',
 			userId: 'userId',
 		});
+		const handleUserSRPAuthFlowSpy = jest
+			.spyOn(initiateAuthHelpers, 'handleUserSRPAuthFlow')
+			.mockResolvedValue({
+				ChallengeName: 'SMS_MFA',
+				ChallengeParameters: {},
+				AuthenticationResult: undefined,
+				Session: '1234',
+				$metadata: {},
+			});
 
-		try {
-			await signIn(mockCtx, { username: 'username', password: 'password' });
-		} catch (error: any) {
-			expect(error).toBeInstanceOf(AuthError);
-			expect(error.name).toBe(USER_ALREADY_AUTHENTICATED_EXCEPTION);
-		}
+		const result = await signIn(mockCtx, {
+			username: 'username',
+			password: 'password',
+		});
+
+		expect(result.nextStep.signInStep).toBe('CONFIRM_SIGN_IN_WITH_SMS_CODE');
+
+		handleUserSRPAuthFlowSpy.mockRestore();
 		mockedGetCurrentUser.mockClear();
 	});
 

--- a/packages/auth/__tests__/providers/cognito/signInStateManagement.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInStateManagement.test.ts
@@ -12,6 +12,7 @@ import { RespondToAuthChallengeCommandOutput } from '../../../src/foundation/fac
 import { authAPITestParams } from './testUtils/authApiTestParams';
 
 jest.mock('../../../src/providers/cognito/apis/getCurrentUser');
+jest.mock('../../../src/providers/cognito/utils/dispatchSignedInHubEvent');
 
 //  getCurrentUser is mocked so Hub is able to dispatch a mocked AuthUser
 // before returning an `AuthSignInResult`
@@ -86,12 +87,6 @@ describe('local sign-in state management tests', () => {
 		await signIn({
 			username,
 			password,
-		});
-		mockedGetCurrentUser.mockImplementationOnce(async () => {
-			return {
-				username: 'username',
-				userId: 'userId',
-			};
 		});
 
 		const localSignInState = signInStore.getState();

--- a/packages/auth/__tests__/providers/cognito/signInWithSRP.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signInWithSRP.test.ts
@@ -181,6 +181,33 @@ describe('signIn API happy path cases', () => {
 		expect(handleUserSRPAuthflowSpy).toHaveBeenCalledTimes(1);
 	});
 
+	// Multi-session: a native signIn for a second user must succeed and be added
+	// to the roster head, so the UserAlreadyAuthenticatedException gate has been
+	// removed from signIn (assertUserNotAuthenticated is now only used by
+	// signInWithRedirect). This guards against the gate being reintroduced.
+	test('two sequential signIn calls both succeed without the not-authenticated gate', async () => {
+		const assertUserNotAuthenticatedSpy = jest.spyOn(
+			initiateAuthHelpers,
+			'assertUserNotAuthenticated',
+		);
+
+		const firstResult = await signIn({
+			username: authAPITestParams.user1.username,
+			password: authAPITestParams.user1.password,
+		});
+		const secondResult = await signIn({
+			username: 'secondUser',
+			password: 'secondUserPassword',
+		});
+
+		expect(firstResult).toEqual(authAPITestParams.signInResult());
+		expect(secondResult).toEqual(authAPITestParams.signInResult());
+		expect(handleUserSRPAuthflowSpy).toHaveBeenCalledTimes(2);
+		expect(assertUserNotAuthenticatedSpy).not.toHaveBeenCalled();
+
+		assertUserNotAuthenticatedSpy.mockRestore();
+	});
+
 	test('signInWithSRP API should return a SignInResult', async () => {
 		const result = await signInWithSRP(mockCtx, {
 			username: authAPITestParams.user1.username,

--- a/packages/auth/__tests__/providers/cognito/signOut.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signOut.test.ts
@@ -7,9 +7,9 @@ import {
 	Hub,
 	clearCredentials,
 } from '@aws-amplify/core';
-import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
 
 import { signOut } from '../../../src/providers/cognito/apis/signOut';
+import { getCurrentUser } from '../../../src/providers/cognito/apis/getCurrentUser';
 import { tokenOrchestrator } from '../../../src/providers/cognito/tokenProvider';
 import { DefaultOAuthStore } from '../../../src/providers/cognito/utils/signInWithRedirectStore';
 import { handleOAuthSignOut } from '../../../src/providers/cognito/utils/oauth';
@@ -20,11 +20,14 @@ import {
 } from '../../../src/foundation/factories/serviceClients/cognitoIdentityProvider';
 import { getRegionFromUserPoolId } from '../../../src/foundation/parsers';
 import { createCognitoUserPoolEndpointResolver } from '../../../src/providers/cognito/factories';
+import { dispatchSignOutBoundaryEvents } from '../../../src/providers/cognito/utils/dispatchSignOutHubEvents';
 
 jest.mock('@aws-amplify/core');
 jest.mock('../../../src/providers/cognito/tokenProvider');
+jest.mock('../../../src/providers/cognito/apis/getCurrentUser');
 jest.mock('../../../src/providers/cognito/utils/oauth');
 jest.mock('../../../src/providers/cognito/utils/signInWithRedirectStore');
+jest.mock('../../../src/providers/cognito/utils/dispatchSignOutHubEvents');
 jest.mock('../../../src/utils');
 jest.mock(
 	'../../../src/foundation/factories/serviceClients/cognitoIdentityProvider',
@@ -70,31 +73,44 @@ describe('signOut', () => {
 	);
 	// create mocks
 	const mockLoadTokens = jest.fn();
+	const mockClearTokensForUser = jest.fn();
+	const mockRemoveSession = jest.fn();
+	const mockGetLastAuthUser = jest.fn();
+	const mockGetCurrentUser = getCurrentUser as jest.Mock;
+	const mockDispatchSignOutBoundaryEvents =
+		dispatchSignOutBoundaryEvents as jest.Mock;
 	const mockAuthTokenStore = {
 		loadTokens: mockLoadTokens,
+		clearTokensForUser: mockClearTokensForUser,
+		removeSession: mockRemoveSession,
+		getLastAuthUser: mockGetLastAuthUser,
 	} as unknown as AuthTokenStore;
 	const mockDefaultOAuthStoreInstance = {
 		setAuthConfig: jest.fn(),
 	};
 	// create spies
 	const loggerDebugSpy = jest.spyOn(ConsoleLogger.prototype, 'debug');
+	// active user resolved for the default single-user sign out scenario.
+	const activeUser = { username: 'user1', userId: 'user1-id' };
 	// create test helpers
 	const expectSignOut = () => ({
 		toComplete: () => {
-			expect(mockTokenOrchestrator.clearTokens).toHaveBeenCalledTimes(1);
+			// only the active user's namespace is cleared and dropped from the roster.
+			expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
+			expect(mockRemoveSession).toHaveBeenCalledWith(activeUser.username);
 			expect(mockClearCredentials).toHaveBeenCalledTimes(1);
-			expect(mockHub.dispatch).toHaveBeenCalledWith(
-				'auth',
-				{ event: 'signedOut' },
-				'Auth',
-				AMPLIFY_SYMBOL,
+			// all boundary Hub events are delegated to the shared helper, which
+			// receives the resolved active user and the removeSession result.
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
+				mockAuthTokenStore,
+				activeUser,
+				{ newActiveUser: undefined, isEmpty: true },
 			);
 		},
 		not: {
 			toComplete: () => {
-				expect(mockTokenOrchestrator.clearTokens).not.toHaveBeenCalled();
 				expect(mockClearCredentials).not.toHaveBeenCalled();
-				expect(mockHub.dispatch).not.toHaveBeenCalled();
+				expect(mockDispatchSignOutBoundaryEvents).not.toHaveBeenCalled();
 			},
 		},
 	});
@@ -114,6 +130,14 @@ describe('signOut', () => {
 		mockedRevokeTokenClient.mockReturnValueOnce(mockRevokeToken);
 		mockTokenOrchestrator.getTokenStore.mockReturnValue(mockAuthTokenStore);
 		mockLoadTokens.mockResolvedValue(cognitoAuthTokens);
+		// default single-user sign out: active user resolves and roster empties.
+		mockGetCurrentUser.mockResolvedValue(activeUser);
+		mockClearTokensForUser.mockResolvedValue(undefined);
+		mockRemoveSession.mockResolvedValue({
+			newActiveUser: undefined,
+			isEmpty: true,
+		});
+		mockGetLastAuthUser.mockResolvedValue(activeUser.username);
 	});
 
 	afterEach(() => {
@@ -124,8 +148,13 @@ describe('signOut', () => {
 		mockGetRegionFromUserPoolId.mockClear();
 		mockHub.dispatch.mockClear();
 		mockTokenOrchestrator.clearTokens.mockClear();
+		mockGetCurrentUser.mockReset();
+		mockClearTokensForUser.mockReset();
+		mockRemoveSession.mockReset();
+		mockGetLastAuthUser.mockReset();
 		loggerDebugSpy.mockClear();
 		mockCreateCognitoUserPoolEndpointResolver.mockClear();
+		mockDispatchSignOutBoundaryEvents.mockClear();
 	});
 
 	describe('Without OAuth configured', () => {
@@ -239,6 +268,74 @@ describe('signOut', () => {
 			);
 			expect(mockGetRegionFromUserPoolId).toHaveBeenCalledTimes(1);
 			expectSignOut().toComplete();
+		});
+	});
+
+	describe('multi-session boundaries', () => {
+		it('delegates a parked-user promotion to the shared boundary helper (no second getCurrentUser)', async () => {
+			mockGetCurrentUser.mockResolvedValue(activeUser);
+			mockRemoveSession.mockResolvedValue({
+				newActiveUser: 'user2',
+				isEmpty: false,
+			});
+
+			await signOut();
+
+			expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
+			expect(mockClearCredentials).toHaveBeenCalledTimes(1);
+			// the promoted user's identity is resolved inside the helper from stored
+			// tokens, so getCurrentUser must NOT be called a second time.
+			expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
+				mockAuthTokenStore,
+				activeUser,
+				{
+					newActiveUser: 'user2',
+					isEmpty: false,
+				},
+			);
+		});
+
+		it('delegates the last-user sign out to the shared boundary helper', async () => {
+			mockGetCurrentUser.mockResolvedValue(activeUser);
+			mockRemoveSession.mockResolvedValue({
+				newActiveUser: undefined,
+				isEmpty: true,
+			});
+
+			await signOut();
+
+			expect(mockClearCredentials).toHaveBeenCalledTimes(1);
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
+				mockAuthTokenStore,
+				activeUser,
+				{
+					newActiveUser: undefined,
+					isEmpty: true,
+				},
+			);
+		});
+
+		it('passes an undefined signedOutUser when no active user can be resolved', async () => {
+			// getCurrentUser throws (tokens already gone); fall back to getLastAuthUser.
+			mockGetCurrentUser.mockRejectedValue(new Error('no user'));
+			mockGetLastAuthUser.mockResolvedValue(activeUser.username);
+			mockRemoveSession.mockResolvedValue({
+				newActiveUser: undefined,
+				isEmpty: true,
+			});
+
+			await signOut();
+
+			expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
+				mockAuthTokenStore,
+				undefined,
+				{
+					newActiveUser: undefined,
+					isEmpty: true,
+				},
+			);
 		});
 	});
 

--- a/packages/auth/__tests__/providers/cognito/signOut.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signOut.test.ts
@@ -78,6 +78,7 @@ describe('signOut', () => {
 	const mockRemoveSession = jest.fn();
 	const mockClearActiveUser = jest.fn();
 	const mockGetLastAuthUser = jest.fn();
+	const mockGetActiveUsername = jest.fn();
 	const mockGetStoredIdToken = jest.fn();
 	const mockDispatchSignOutBoundaryEvents =
 		dispatchSignOutBoundaryEvents as jest.Mock;
@@ -87,6 +88,7 @@ describe('signOut', () => {
 		removeSession: mockRemoveSession,
 		clearActiveUser: mockClearActiveUser,
 		getLastAuthUser: mockGetLastAuthUser,
+		getActiveUsername: mockGetActiveUsername,
 		getStoredIdToken: mockGetStoredIdToken,
 	} as unknown as AuthTokenStore;
 	const mockDefaultOAuthStoreInstance = {
@@ -135,6 +137,7 @@ describe('signOut', () => {
 		mockLoadTokens.mockResolvedValue(cognitoAuthTokens);
 		// active user resolves from the stored id token (no refresh).
 		mockGetLastAuthUser.mockResolvedValue(activeUser.username);
+		mockGetActiveUsername.mockResolvedValue(activeUser.username);
 		mockGetStoredIdToken.mockResolvedValue({
 			payload: { sub: activeUser.userId },
 		});
@@ -154,6 +157,7 @@ describe('signOut', () => {
 		mockRemoveSession.mockReset();
 		mockClearActiveUser.mockReset();
 		mockGetLastAuthUser.mockReset();
+		mockGetActiveUsername.mockReset();
 		mockGetStoredIdToken.mockReset();
 		loggerDebugSpy.mockClear();
 		mockCreateCognitoUserPoolEndpointResolver.mockClear();
@@ -316,6 +320,34 @@ describe('signOut', () => {
 			expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
 			expect(mockClearActiveUser).toHaveBeenCalledTimes(1);
 			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(undefined);
+		});
+
+		it('is a no-op with NO signedOut event when there is no active user (parked-only roster)', async () => {
+			// empty active pointer: parked sessions may remain but nobody is active,
+			// so sign-out must not mutate anything and must not fire signedOut.
+			mockGetActiveUsername.mockResolvedValue(undefined);
+
+			await signOut(mockCtx);
+
+			expect(mockClearTokensForUser).not.toHaveBeenCalled();
+			expect(mockRemoveSession).not.toHaveBeenCalled();
+			expect(mockClearActiveUser).not.toHaveBeenCalled();
+			expect(mockClearCredentials).not.toHaveBeenCalled();
+			expect(mockDispatchSignOutBoundaryEvents).not.toHaveBeenCalled();
+		});
+
+		it('invokes clearTokensForUser -> removeSession -> clearActiveUser -> dispatch in order', async () => {
+			await signOut(mockCtx);
+
+			// assert the precise sequencing via invocationCallOrder (mirrors the
+			// sign-in ordering test).
+			const order = [
+				mockClearTokensForUser.mock.invocationCallOrder[0],
+				mockRemoveSession.mock.invocationCallOrder[0],
+				mockClearActiveUser.mock.invocationCallOrder[0],
+				mockDispatchSignOutBoundaryEvents.mock.invocationCallOrder[0],
+			];
+			expect(order).toEqual([...order].sort((a, b) => a - b));
 		});
 	});
 

--- a/packages/auth/__tests__/providers/cognito/signOut.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signOut.test.ts
@@ -1,17 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-	Amplify,
-	ConsoleLogger,
-	Hub,
-	clearCredentials,
-} from '@aws-amplify/core';
-import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
+import { ConsoleLogger, Hub } from '@aws-amplify/core';
 import { createMockAmplifyContext } from '@aws-amplify/core/internals/testing';
 
 import { signOut } from '../../../src/providers/cognito/apis/signOut';
-import { getCurrentUser } from '../../../src/providers/cognito/apis/getCurrentUser';
 import { tokenOrchestrator } from '../../../src/providers/cognito/tokenProvider';
 import { DefaultOAuthStore } from '../../../src/providers/cognito/utils/signInWithRedirectStore';
 import { handleOAuthSignOut } from '../../../src/providers/cognito/utils/oauth';
@@ -29,7 +22,6 @@ jest.mock('@aws-amplify/core', () => ({
 	Hub: { dispatch: jest.fn() },
 }));
 jest.mock('../../../src/providers/cognito/tokenProvider');
-jest.mock('../../../src/providers/cognito/apis/getCurrentUser');
 jest.mock('../../../src/providers/cognito/utils/oauth');
 jest.mock('../../../src/providers/cognito/utils/signInWithRedirectStore');
 jest.mock('../../../src/providers/cognito/utils/dispatchSignOutHubEvents');
@@ -65,7 +57,7 @@ describe('signOut', () => {
 	});
 
 	// assert mocks
-	const mockClearCredentials = () => mockCtx.clearCredentials;
+	const mockClearCredentials = mockCtx.clearCredentials;
 	const mockGetRegionFromUserPoolId = jest.mocked(getRegionFromUserPoolId);
 	const mockGlobalSignOut = jest.fn();
 	const mockCreateGlobalSignOutClient = jest.mocked(createGlobalSignOutClient);
@@ -84,22 +76,25 @@ describe('signOut', () => {
 	const mockLoadTokens = jest.fn();
 	const mockClearTokensForUser = jest.fn();
 	const mockRemoveSession = jest.fn();
+	const mockClearActiveUser = jest.fn();
 	const mockGetLastAuthUser = jest.fn();
-	const mockGetCurrentUser = getCurrentUser as jest.Mock;
+	const mockGetStoredIdToken = jest.fn();
 	const mockDispatchSignOutBoundaryEvents =
 		dispatchSignOutBoundaryEvents as jest.Mock;
 	const mockAuthTokenStore = {
 		loadTokens: mockLoadTokens,
 		clearTokensForUser: mockClearTokensForUser,
 		removeSession: mockRemoveSession,
+		clearActiveUser: mockClearActiveUser,
 		getLastAuthUser: mockGetLastAuthUser,
+		getStoredIdToken: mockGetStoredIdToken,
 	} as unknown as AuthTokenStore;
 	const mockDefaultOAuthStoreInstance = {
 		setAuthConfig: jest.fn(),
 	};
 	// create spies
 	const loggerDebugSpy = jest.spyOn(ConsoleLogger.prototype, 'debug');
-	// active user resolved for the default single-user sign out scenario.
+	// active user resolved (from stored id token, no refresh) for sign out.
 	const activeUser = { username: 'user1', userId: 'user1-id' };
 	// create test helpers
 	const expectSignOut = () => ({
@@ -107,13 +102,13 @@ describe('signOut', () => {
 			// only the active user's namespace is cleared and dropped from the roster.
 			expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
 			expect(mockRemoveSession).toHaveBeenCalledWith(activeUser.username);
+			// the active pointer is cleared explicitly (no promotion of parked users).
+			expect(mockClearActiveUser).toHaveBeenCalledTimes(1);
 			expect(mockClearCredentials).toHaveBeenCalledTimes(1);
 			// all boundary Hub events are delegated to the shared helper, which
-			// receives the resolved active user and the removeSession result.
+			// receives ONLY the resolved signed-out user (signedOut fires ALWAYS).
 			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
-				mockAuthTokenStore,
 				activeUser,
-				{ newActiveUser: undefined, isEmpty: true },
 			);
 		},
 		not: {
@@ -138,27 +133,28 @@ describe('signOut', () => {
 		mockedRevokeTokenClient.mockReturnValueOnce(mockRevokeToken);
 		mockTokenOrchestrator.getTokenStore.mockReturnValue(mockAuthTokenStore);
 		mockLoadTokens.mockResolvedValue(cognitoAuthTokens);
-		// default single-user sign out: active user resolves and roster empties.
-		mockGetCurrentUser.mockResolvedValue(activeUser);
-		mockClearTokensForUser.mockResolvedValue(undefined);
-		mockRemoveSession.mockResolvedValue({
-			newActiveUser: undefined,
-			isEmpty: true,
-		});
+		// active user resolves from the stored id token (no refresh).
 		mockGetLastAuthUser.mockResolvedValue(activeUser.username);
+		mockGetStoredIdToken.mockResolvedValue({
+			payload: { sub: activeUser.userId },
+		});
+		mockClearTokensForUser.mockResolvedValue(undefined);
+		mockRemoveSession.mockResolvedValue({ isEmpty: true });
+		mockClearActiveUser.mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
 		mockGlobalSignOut.mockReset();
 		mockRevokeToken.mockReset();
-		mockClearCredentials().mockClear();
+		mockClearCredentials.mockClear();
 		mockGetRegionFromUserPoolId.mockClear();
 		mockHub.dispatch.mockClear();
 		mockTokenOrchestrator.clearTokens.mockClear();
-		mockGetCurrentUser.mockReset();
 		mockClearTokensForUser.mockReset();
 		mockRemoveSession.mockReset();
+		mockClearActiveUser.mockReset();
 		mockGetLastAuthUser.mockReset();
+		mockGetStoredIdToken.mockReset();
 		loggerDebugSpy.mockClear();
 		mockCreateCognitoUserPoolEndpointResolver.mockClear();
 		mockDispatchSignOutBoundaryEvents.mockClear();
@@ -278,71 +274,48 @@ describe('signOut', () => {
 		});
 	});
 
-	describe('multi-session boundaries', () => {
-		it('delegates a parked-user promotion to the shared boundary helper (no second getCurrentUser)', async () => {
-			mockGetCurrentUser.mockResolvedValue(activeUser);
-			mockRemoveSession.mockResolvedValue({
-				newActiveUser: 'user2',
-				isEmpty: false,
-			});
+	describe('multi-session boundaries (no promotion)', () => {
+		it('clears the active pointer and fires signedOut while leaving parked sessions in the roster', async () => {
+			// parked users remain: removeSession reports the roster is NOT empty, but
+			// sign-out never promotes them — it clears the pointer and fires signedOut.
+			mockRemoveSession.mockResolvedValue({ isEmpty: false });
 
-			await signOut();
+			await signOut(mockCtx);
 
 			expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
+			expect(mockRemoveSession).toHaveBeenCalledWith(activeUser.username);
+			expect(mockClearActiveUser).toHaveBeenCalledTimes(1);
 			expect(mockClearCredentials).toHaveBeenCalledTimes(1);
-			// the promoted user's identity is resolved inside the helper from stored
-			// tokens, so getCurrentUser must NOT be called a second time.
-			expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+			// signedOut ALWAYS; the helper receives only the signed-out user (no
+			// promotion result) so it can NEVER emit switchActiveUser.
 			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
-				mockAuthTokenStore,
 				activeUser,
-				{
-					newActiveUser: 'user2',
-					isEmpty: false,
-				},
 			);
 		});
 
 		it('delegates the last-user sign out to the shared boundary helper', async () => {
-			mockGetCurrentUser.mockResolvedValue(activeUser);
-			mockRemoveSession.mockResolvedValue({
-				newActiveUser: undefined,
-				isEmpty: true,
-			});
+			mockRemoveSession.mockResolvedValue({ isEmpty: true });
 
-			await signOut();
+			await signOut(mockCtx);
 
+			expect(mockClearActiveUser).toHaveBeenCalledTimes(1);
 			expect(mockClearCredentials).toHaveBeenCalledTimes(1);
 			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
-				mockAuthTokenStore,
 				activeUser,
-				{
-					newActiveUser: undefined,
-					isEmpty: true,
-				},
 			);
 		});
 
 		it('passes an undefined signedOutUser when no active user can be resolved', async () => {
-			// getCurrentUser throws (tokens already gone); fall back to getLastAuthUser.
-			mockGetCurrentUser.mockRejectedValue(new Error('no user'));
-			mockGetLastAuthUser.mockResolvedValue(activeUser.username);
-			mockRemoveSession.mockResolvedValue({
-				newActiveUser: undefined,
-				isEmpty: true,
-			});
+			// no stored id token -> the signed-out identity is unresolvable, but the
+			// pointer is still cleared and signedOut still fires (with no data).
+			mockGetStoredIdToken.mockResolvedValue(undefined);
+			mockRemoveSession.mockResolvedValue({ isEmpty: true });
 
-			await signOut();
+			await signOut(mockCtx);
 
 			expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
-			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
-				mockAuthTokenStore,
-				undefined,
-				{
-					newActiveUser: undefined,
-					isEmpty: true,
-				},
-			);
+			expect(mockClearActiveUser).toHaveBeenCalledTimes(1);
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(undefined);
 		});
 	});
 

--- a/packages/auth/__tests__/providers/cognito/signOut.test.ts
+++ b/packages/auth/__tests__/providers/cognito/signOut.test.ts
@@ -1,11 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ConsoleLogger, Hub } from '@aws-amplify/core';
+import {
+	Amplify,
+	ConsoleLogger,
+	Hub,
+	clearCredentials,
+} from '@aws-amplify/core';
 import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
 import { createMockAmplifyContext } from '@aws-amplify/core/internals/testing';
 
 import { signOut } from '../../../src/providers/cognito/apis/signOut';
+import { getCurrentUser } from '../../../src/providers/cognito/apis/getCurrentUser';
 import { tokenOrchestrator } from '../../../src/providers/cognito/tokenProvider';
 import { DefaultOAuthStore } from '../../../src/providers/cognito/utils/signInWithRedirectStore';
 import { handleOAuthSignOut } from '../../../src/providers/cognito/utils/oauth';
@@ -16,14 +22,17 @@ import {
 } from '../../../src/foundation/factories/serviceClients/cognitoIdentityProvider';
 import { getRegionFromUserPoolId } from '../../../src/foundation/parsers';
 import { createCognitoUserPoolEndpointResolver } from '../../../src/providers/cognito/factories';
+import { dispatchSignOutBoundaryEvents } from '../../../src/providers/cognito/utils/dispatchSignOutHubEvents';
 
 jest.mock('@aws-amplify/core', () => ({
 	...jest.requireActual('@aws-amplify/core'),
 	Hub: { dispatch: jest.fn() },
 }));
 jest.mock('../../../src/providers/cognito/tokenProvider');
+jest.mock('../../../src/providers/cognito/apis/getCurrentUser');
 jest.mock('../../../src/providers/cognito/utils/oauth');
 jest.mock('../../../src/providers/cognito/utils/signInWithRedirectStore');
+jest.mock('../../../src/providers/cognito/utils/dispatchSignOutHubEvents');
 jest.mock('../../../src/utils');
 jest.mock(
 	'../../../src/foundation/factories/serviceClients/cognitoIdentityProvider',
@@ -73,31 +82,44 @@ describe('signOut', () => {
 	);
 	// create mocks
 	const mockLoadTokens = jest.fn();
+	const mockClearTokensForUser = jest.fn();
+	const mockRemoveSession = jest.fn();
+	const mockGetLastAuthUser = jest.fn();
+	const mockGetCurrentUser = getCurrentUser as jest.Mock;
+	const mockDispatchSignOutBoundaryEvents =
+		dispatchSignOutBoundaryEvents as jest.Mock;
 	const mockAuthTokenStore = {
 		loadTokens: mockLoadTokens,
+		clearTokensForUser: mockClearTokensForUser,
+		removeSession: mockRemoveSession,
+		getLastAuthUser: mockGetLastAuthUser,
 	} as unknown as AuthTokenStore;
 	const mockDefaultOAuthStoreInstance = {
 		setAuthConfig: jest.fn(),
 	};
 	// create spies
 	const loggerDebugSpy = jest.spyOn(ConsoleLogger.prototype, 'debug');
+	// active user resolved for the default single-user sign out scenario.
+	const activeUser = { username: 'user1', userId: 'user1-id' };
 	// create test helpers
 	const expectSignOut = () => ({
 		toComplete: () => {
-			expect(mockTokenOrchestrator.clearTokens).toHaveBeenCalledTimes(1);
-			expect(mockClearCredentials()).toHaveBeenCalledTimes(1);
-			expect(mockHub.dispatch).toHaveBeenCalledWith(
-				'auth',
-				{ event: 'signedOut' },
-				'Auth',
-				AMPLIFY_SYMBOL,
+			// only the active user's namespace is cleared and dropped from the roster.
+			expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
+			expect(mockRemoveSession).toHaveBeenCalledWith(activeUser.username);
+			expect(mockClearCredentials).toHaveBeenCalledTimes(1);
+			// all boundary Hub events are delegated to the shared helper, which
+			// receives the resolved active user and the removeSession result.
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
+				mockAuthTokenStore,
+				activeUser,
+				{ newActiveUser: undefined, isEmpty: true },
 			);
 		},
 		not: {
 			toComplete: () => {
-				expect(mockTokenOrchestrator.clearTokens).not.toHaveBeenCalled();
-				expect(mockClearCredentials()).not.toHaveBeenCalled();
-				expect(mockHub.dispatch).not.toHaveBeenCalled();
+				expect(mockClearCredentials).not.toHaveBeenCalled();
+				expect(mockDispatchSignOutBoundaryEvents).not.toHaveBeenCalled();
 			},
 		},
 	});
@@ -116,6 +138,14 @@ describe('signOut', () => {
 		mockedRevokeTokenClient.mockReturnValueOnce(mockRevokeToken);
 		mockTokenOrchestrator.getTokenStore.mockReturnValue(mockAuthTokenStore);
 		mockLoadTokens.mockResolvedValue(cognitoAuthTokens);
+		// default single-user sign out: active user resolves and roster empties.
+		mockGetCurrentUser.mockResolvedValue(activeUser);
+		mockClearTokensForUser.mockResolvedValue(undefined);
+		mockRemoveSession.mockResolvedValue({
+			newActiveUser: undefined,
+			isEmpty: true,
+		});
+		mockGetLastAuthUser.mockResolvedValue(activeUser.username);
 	});
 
 	afterEach(() => {
@@ -125,8 +155,13 @@ describe('signOut', () => {
 		mockGetRegionFromUserPoolId.mockClear();
 		mockHub.dispatch.mockClear();
 		mockTokenOrchestrator.clearTokens.mockClear();
+		mockGetCurrentUser.mockReset();
+		mockClearTokensForUser.mockReset();
+		mockRemoveSession.mockReset();
+		mockGetLastAuthUser.mockReset();
 		loggerDebugSpy.mockClear();
 		mockCreateCognitoUserPoolEndpointResolver.mockClear();
+		mockDispatchSignOutBoundaryEvents.mockClear();
 	});
 
 	describe('Without OAuth configured', () => {
@@ -240,6 +275,74 @@ describe('signOut', () => {
 			);
 			expect(mockGetRegionFromUserPoolId).toHaveBeenCalledTimes(1);
 			expectSignOut().toComplete();
+		});
+	});
+
+	describe('multi-session boundaries', () => {
+		it('delegates a parked-user promotion to the shared boundary helper (no second getCurrentUser)', async () => {
+			mockGetCurrentUser.mockResolvedValue(activeUser);
+			mockRemoveSession.mockResolvedValue({
+				newActiveUser: 'user2',
+				isEmpty: false,
+			});
+
+			await signOut();
+
+			expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
+			expect(mockClearCredentials).toHaveBeenCalledTimes(1);
+			// the promoted user's identity is resolved inside the helper from stored
+			// tokens, so getCurrentUser must NOT be called a second time.
+			expect(mockGetCurrentUser).toHaveBeenCalledTimes(1);
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
+				mockAuthTokenStore,
+				activeUser,
+				{
+					newActiveUser: 'user2',
+					isEmpty: false,
+				},
+			);
+		});
+
+		it('delegates the last-user sign out to the shared boundary helper', async () => {
+			mockGetCurrentUser.mockResolvedValue(activeUser);
+			mockRemoveSession.mockResolvedValue({
+				newActiveUser: undefined,
+				isEmpty: true,
+			});
+
+			await signOut();
+
+			expect(mockClearCredentials).toHaveBeenCalledTimes(1);
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
+				mockAuthTokenStore,
+				activeUser,
+				{
+					newActiveUser: undefined,
+					isEmpty: true,
+				},
+			);
+		});
+
+		it('passes an undefined signedOutUser when no active user can be resolved', async () => {
+			// getCurrentUser throws (tokens already gone); fall back to getLastAuthUser.
+			mockGetCurrentUser.mockRejectedValue(new Error('no user'));
+			mockGetLastAuthUser.mockResolvedValue(activeUser.username);
+			mockRemoveSession.mockResolvedValue({
+				newActiveUser: undefined,
+				isEmpty: true,
+			});
+
+			await signOut();
+
+			expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
+				mockAuthTokenStore,
+				undefined,
+				{
+					newActiveUser: undefined,
+					isEmpty: true,
+				},
+			);
 		});
 	});
 

--- a/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
@@ -27,6 +27,11 @@ const mockAuthTokenStore = {
 	clearDeviceMetadata: jest.fn(),
 	setOAuthMetadata: jest.fn(),
 	getOAuthMetadata: jest.fn(),
+	getAuthUserList: jest.fn(),
+	addActiveSession: jest.fn(),
+	removeSession: jest.fn(),
+	clearTokensForUser: jest.fn(),
+	getStoredIdToken: jest.fn(),
 };
 const mockTokenRefresher = jest.fn();
 const validAuthConfig: ResourcesConfig = {
@@ -135,7 +140,10 @@ describe('TokenOrchestrator', () => {
 			});
 			expect(Hub.dispatch).toHaveBeenCalledWith(
 				'auth',
-				{ event: 'tokenRefresh' },
+				{
+					event: 'tokenRefresh',
+					data: { username: 'test-username', userId: '1234567890' },
+				},
 				'Auth',
 				AMPLIFY_SYMBOL,
 			);

--- a/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
@@ -34,6 +34,7 @@ const mockAuthTokenStore = {
 	clearActiveUser: jest.fn(),
 	clearTokensForUser: jest.fn(),
 	getStoredIdToken: jest.fn(),
+	reassertActiveUserPointer: jest.fn(),
 };
 const mockTokenRefresher = jest.fn();
 const validAuthConfig: ResourcesConfig = {

--- a/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
@@ -19,6 +19,7 @@ jest.mock('@aws-amplify/core', () => ({
 
 const mockAuthTokenStore = {
 	getLastAuthUser: jest.fn(),
+	getActiveUsername: jest.fn(),
 	loadTokens: jest.fn(),
 	storeTokens: jest.fn(),
 	clearTokens: jest.fn(),
@@ -30,6 +31,7 @@ const mockAuthTokenStore = {
 	getAuthUserList: jest.fn(),
 	addActiveSession: jest.fn(),
 	removeSession: jest.fn(),
+	clearActiveUser: jest.fn(),
 	clearTokensForUser: jest.fn(),
 	getStoredIdToken: jest.fn(),
 };

--- a/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
@@ -34,6 +34,7 @@ const mockAuthTokenStore = {
 	clearActiveUser: jest.fn(),
 	clearTokensForUser: jest.fn(),
 	getStoredIdToken: jest.fn(),
+	getStoredSignInDetails: jest.fn(),
 	reassertActiveUserPointer: jest.fn(),
 };
 const mockTokenRefresher = jest.fn();

--- a/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
@@ -27,6 +27,11 @@ const mockAuthTokenStore = {
 	clearDeviceMetadata: jest.fn(),
 	setOAuthMetadata: jest.fn(),
 	getOAuthMetadata: jest.fn(),
+	getAuthUserList: jest.fn(),
+	addActiveSession: jest.fn(),
+	removeSession: jest.fn(),
+	clearTokensForUser: jest.fn(),
+	getStoredIdToken: jest.fn(),
 };
 const mockTokenRefresher = jest.fn();
 const validAuthConfig: ResourcesConfig = {
@@ -136,7 +141,10 @@ describe('TokenOrchestrator', () => {
 			});
 			expect(Hub.dispatch).toHaveBeenCalledWith(
 				'auth',
-				{ event: 'tokenRefresh' },
+				{
+					event: 'tokenRefresh',
+					data: { username: 'test-username', userId: '1234567890' },
+				},
 				'Auth',
 				AMPLIFY_SYMBOL,
 			);

--- a/packages/auth/__tests__/providers/cognito/tokenProvider.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider.test.ts
@@ -98,6 +98,10 @@ describe('saving tokens', () => {
 			},
 		});
 		const lastAuthUser = 'amplify@user';
+		// storeTokens no longer manages the active-user pointer; establish the
+		// active session first so tokens are namespaced under this user and
+		// LastAuthUser is set (invariant LastAuthUser === AuthUserList[0]).
+		await tokenStore.addActiveSession(lastAuthUser);
 		await tokenStore.storeTokens({
 			accessToken: decodeJWT(
 				'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.AAA',

--- a/packages/auth/__tests__/providers/cognito/tokenProvider.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider.test.ts
@@ -98,10 +98,10 @@ describe('saving tokens', () => {
 			},
 		});
 		const lastAuthUser = 'amplify@user';
-		// storeTokens no longer manages the active-user pointer; establish the
-		// active session first so tokens are namespaced under this user and
-		// LastAuthUser is set (invariant LastAuthUser === AuthUserList[0]).
-		await tokenStore.addActiveSession(lastAuthUser);
+		// Real sign-in flow order: cacheCognitoTokens (storeTokens) runs BEFORE the
+		// active pointer is moved by addActiveSession. storeTokens must namespace
+		// under tokens.username (NOT the stale/unset pointer), so the tokens remain
+		// reachable once the pointer advances to this user.
 		await tokenStore.storeTokens({
 			accessToken: decodeJWT(
 				'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.AAA',
@@ -118,6 +118,7 @@ describe('saving tokens', () => {
 			},
 			username: lastAuthUser,
 		});
+		await tokenStore.addActiveSession(lastAuthUser);
 
 		expect(
 			await memoryStorage.getItem(
@@ -169,6 +170,15 @@ describe('saving tokens', () => {
 				`CognitoIdentityServiceProvider.${userPoolClientId}.${lastAuthUser}.randomPasswordKey`,
 			),
 		).toBe('random-password2');
+
+		// Regression: tokens stored BEFORE the pointer moved must be reachable via
+		// loadTokens (which resolves keys from the now-active pointer). This is the
+		// exact fresh sign-in path that was broken by no-arg getAuthKeys().
+		const loaded = await tokenStore.loadTokens();
+		expect(loaded?.accessToken.toString()).toBe(
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.AAA',
+		);
+		expect(loaded?.refreshToken).toBe('refresh-token');
 	});
 	it('should save tokens from store clear old tokens', async () => {
 		const tokenStore = new DefaultTokenStore();

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+	AMPLIFY_SYMBOL,
 	AmplifyError,
 	AmplifyErrorCode,
 } from '@aws-amplify/core/internals/utils';
+import { Hub } from '@aws-amplify/core';
 
 import { tokenOrchestrator } from '../../../../src/providers/cognito/tokenProvider';
 import { CognitoAuthTokens } from '../../../../src/providers/cognito/tokenProvider/types';
 import { oAuthStore } from '../../../../src/providers/cognito/utils/oauth/oAuthStore';
+import { dispatchSignOutBoundaryEvents } from '../../../../src/providers/cognito/utils/dispatchSignOutHubEvents';
 
 jest.mock('@aws-amplify/core', () => ({
 	...jest.requireActual('@aws-amplify/core'),
@@ -17,6 +20,10 @@ jest.mock('@aws-amplify/core', () => ({
 	},
 }));
 jest.mock('../../../../src/providers/cognito/utils/oauth/oAuthStore');
+jest.mock('../../../../src/providers/cognito/utils/dispatchSignOutHubEvents');
+
+const mockDispatchSignOutBoundaryEvents =
+	dispatchSignOutBoundaryEvents as jest.Mock;
 
 describe('tokenOrchestrator', () => {
 	const mockTokenRefresher = jest.fn();
@@ -30,6 +37,11 @@ describe('tokenOrchestrator', () => {
 		clearDeviceMetadata: jest.fn(),
 		getOAuthMetadata: jest.fn(),
 		setOAuthMetadata: jest.fn(),
+		getAuthUserList: jest.fn(),
+		addActiveSession: jest.fn(),
+		removeSession: jest.fn(),
+		clearTokensForUser: jest.fn(),
+		getStoredIdToken: jest.fn(),
 	};
 
 	beforeAll(() => {
@@ -93,136 +105,211 @@ describe('tokenOrchestrator', () => {
 			expect(newTokens).toEqual(mockTokens);
 			expect(newTokens?.signInDetails).toEqual(testSignInDetails);
 		});
+
+		it('dispatches the `tokenRefresh` Hub event carrying { username, userId }', async () => {
+			const testUsername = 'username';
+			const userSub = 'user-sub-123';
+			// refreshed tokens whose idToken payload provides the userId (sub).
+			const mockTokens: CognitoAuthTokens = {
+				accessToken: {
+					payload: {},
+				},
+				idToken: {
+					payload: { sub: userSub },
+				},
+				clockDrift: 300,
+				username: testUsername,
+			};
+			mockTokenRefresher.mockResolvedValueOnce(mockTokens);
+			mockTokenStore.storeTokens.mockResolvedValue(undefined);
+			(Hub.dispatch as jest.Mock).mockClear();
+
+			// invoke the private refreshTokens without resorting to `as any`.
+			const invokeRefreshTokens = (
+				tokenOrchestrator as unknown as {
+					refreshTokens(input: {
+						tokens: CognitoAuthTokens;
+						username: string;
+					}): Promise<CognitoAuthTokens | null>;
+				}
+			).refreshTokens.bind(tokenOrchestrator);
+
+			await invokeRefreshTokens({
+				tokens: {
+					accessToken: { payload: {} },
+					clockDrift: 400000,
+					username: testUsername,
+				},
+				username: testUsername,
+			});
+
+			expect(Hub.dispatch).toHaveBeenCalledWith(
+				'auth',
+				{
+					event: 'tokenRefresh',
+					data: { username: testUsername, userId: userSub },
+				},
+				'Auth',
+				AMPLIFY_SYMBOL,
+			);
+		});
 	});
 
 	describe('handleErrors method', () => {
+		const testUsername = 'user1';
+		const testUserId = 'user1-sub';
+		// typed invoker so we can exercise the private handleErrors without `as any`.
+		const invokeHandleErrors = (
+			err: unknown,
+			username = testUsername,
+			userId?: string,
+		) =>
+			(
+				tokenOrchestrator as unknown as {
+					handleErrors(
+						err: unknown,
+						username: string,
+						userId?: string,
+					): Promise<CognitoAuthTokens | null>;
+				}
+			).handleErrors(err, username, userId);
+
 		beforeEach(() => {
 			jest.clearAllMocks();
+			// terminal auth errors now scope the clear to a single user + roster.
+			mockTokenStore.clearTokensForUser.mockResolvedValue(undefined);
+			mockTokenStore.removeSession.mockResolvedValue({
+				newActiveUser: undefined,
+				isEmpty: true,
+			});
 		});
 
-		it('does not call clearTokens() if the error is a network error thrown from fetch handler', () => {
-			const clearTokensSpy = jest.spyOn(tokenOrchestrator, 'clearTokens');
+		it('does not clear a user or emit boundary events for a network error', async () => {
 			const error = new AmplifyError({
 				name: AmplifyErrorCode.NetworkError,
 				message: 'Network Error',
 			});
 
-			expect(() => {
-				(tokenOrchestrator as any).handleErrors(error);
-			}).toThrow(error);
+			await expect(invokeHandleErrors(error)).rejects.toThrow(error);
 
-			expect(clearTokensSpy).not.toHaveBeenCalled();
+			expect(mockTokenStore.clearTokensForUser).not.toHaveBeenCalled();
+			expect(mockTokenStore.removeSession).not.toHaveBeenCalled();
+			expect(mockDispatchSignOutBoundaryEvents).not.toHaveBeenCalled();
 		});
 
-		it('calls clearTokens() for NotAuthorizedException', () => {
-			const clearTokensSpy = jest.spyOn(tokenOrchestrator, 'clearTokens');
+		it('scopes the clear to the failing user and emits boundary events for NotAuthorizedException', async () => {
 			const error = new AmplifyError({
 				name: 'NotAuthorizedException',
 				message: 'Not authorized',
 			});
 
-			const result = (tokenOrchestrator as any).handleErrors(error);
+			const result = await invokeHandleErrors(error, testUsername, testUserId);
 
-			expect(clearTokensSpy).toHaveBeenCalled();
+			// only the failing user's namespace + roster entry are removed; the
+			// roster (AuthUserList) is NOT wiped.
+			expect(mockTokenStore.clearTokensForUser).toHaveBeenCalledWith(
+				testUsername,
+			);
+			expect(mockTokenStore.removeSession).toHaveBeenCalledWith(testUsername);
+			expect(mockTokenStore.clearTokens).not.toHaveBeenCalled();
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
+				mockTokenStore,
+				{ username: testUsername, userId: testUserId },
+				{ newActiveUser: undefined, isEmpty: true },
+			);
 			expect(result).toBeNull();
 		});
 
-		it('calls clearTokens() for TokenRevokedException', () => {
-			const clearTokensSpy = jest.spyOn(tokenOrchestrator, 'clearTokens');
+		it('preserves the tokenRefresh_failure dispatch on terminal errors', async () => {
+			const error = new AmplifyError({
+				name: 'NotAuthorizedException',
+				message: 'Not authorized',
+			});
+
+			await invokeHandleErrors(error);
+
+			expect(Hub.dispatch).toHaveBeenCalledWith(
+				'auth',
+				{ event: 'tokenRefresh_failure', data: { error } },
+				'Auth',
+				AMPLIFY_SYMBOL,
+			);
+		});
+
+		it('scopes the clear for TokenRevokedException', async () => {
 			const error = new AmplifyError({
 				name: 'TokenRevokedException',
 				message: 'Token revoked',
 			});
 
-			expect(() => {
-				(tokenOrchestrator as any).handleErrors(error);
-			}).toThrow(error);
+			await expect(invokeHandleErrors(error)).rejects.toThrow(error);
 
-			expect(clearTokensSpy).toHaveBeenCalled();
+			expect(mockTokenStore.clearTokensForUser).toHaveBeenCalledWith(
+				testUsername,
+			);
+			expect(mockTokenStore.removeSession).toHaveBeenCalledWith(testUsername);
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalled();
 		});
 
-		it('calls clearTokens() for RefreshTokenReuseException', () => {
-			const clearTokensSpy = jest.spyOn(tokenOrchestrator, 'clearTokens');
+		it('scopes the clear for RefreshTokenReuseException', async () => {
 			const error = new AmplifyError({
 				name: 'RefreshTokenReuseException',
 				message: 'Refresh token has been invalidated by rotation',
 			});
 
-			expect(() => {
-				(tokenOrchestrator as any).handleErrors(error);
-			}).toThrow(error);
+			await expect(invokeHandleErrors(error)).rejects.toThrow(error);
 
-			expect(clearTokensSpy).toHaveBeenCalled();
+			expect(mockTokenStore.clearTokensForUser).toHaveBeenCalledWith(
+				testUsername,
+			);
+			expect(mockTokenStore.removeSession).toHaveBeenCalledWith(testUsername);
 		});
 
-		it('calls clearTokens() for UserNotFoundException', () => {
-			const clearTokensSpy = jest.spyOn(tokenOrchestrator, 'clearTokens');
+		it('scopes the clear for UserNotFoundException', async () => {
 			const error = new AmplifyError({
 				name: 'UserNotFoundException',
 				message: 'User not found',
 			});
 
-			expect(() => {
-				(tokenOrchestrator as any).handleErrors(error);
-			}).toThrow(error);
+			await expect(invokeHandleErrors(error)).rejects.toThrow(error);
 
-			expect(clearTokensSpy).toHaveBeenCalled();
+			expect(mockTokenStore.clearTokensForUser).toHaveBeenCalledWith(
+				testUsername,
+			);
+			expect(mockTokenStore.removeSession).toHaveBeenCalledWith(testUsername);
 		});
 
-		it('does not call clearTokens() for service errors (500)', () => {
-			const clearTokensSpy = jest.spyOn(tokenOrchestrator, 'clearTokens');
+		it('emits boundary events with an undefined signedOutUser when userId is unavailable', async () => {
 			const error = new AmplifyError({
-				name: 'InternalServerError',
-				message: 'Internal server error',
+				name: 'NotAuthorizedException',
+				message: 'Not authorized',
 			});
 
-			expect(() => {
-				(tokenOrchestrator as any).handleErrors(error);
-			}).toThrow(error);
+			await invokeHandleErrors(error, testUsername, undefined);
 
-			expect(clearTokensSpy).not.toHaveBeenCalled();
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
+				mockTokenStore,
+				undefined,
+				{ newActiveUser: undefined, isEmpty: true },
+			);
 		});
 
-		it('does not call clearTokens() for rate limit errors', () => {
-			const clearTokensSpy = jest.spyOn(tokenOrchestrator, 'clearTokens');
-			const error = new AmplifyError({
-				name: 'TooManyRequestsException',
-				message: 'Too many requests',
-			});
+		it.each([
+			['InternalServerError', 'Internal server error'],
+			['TooManyRequestsException', 'Too many requests'],
+			['ThrottlingException', 'Request throttled'],
+			['ServiceUnavailable', 'Service temporarily unavailable'],
+		])(
+			'does not clear a user or emit boundary events for %s',
+			async (name, message) => {
+				const error = new AmplifyError({ name, message });
 
-			expect(() => {
-				(tokenOrchestrator as any).handleErrors(error);
-			}).toThrow(error);
+				await expect(invokeHandleErrors(error)).rejects.toThrow(error);
 
-			expect(clearTokensSpy).not.toHaveBeenCalled();
-		});
-
-		it('does not call clearTokens() for throttling errors', () => {
-			const clearTokensSpy = jest.spyOn(tokenOrchestrator, 'clearTokens');
-			const error = new AmplifyError({
-				name: 'ThrottlingException',
-				message: 'Request throttled',
-			});
-
-			expect(() => {
-				(tokenOrchestrator as any).handleErrors(error);
-			}).toThrow(error);
-
-			expect(clearTokensSpy).not.toHaveBeenCalled();
-		});
-
-		it('does not call clearTokens() for temporary service issues', () => {
-			const clearTokensSpy = jest.spyOn(tokenOrchestrator, 'clearTokens');
-			const error = new AmplifyError({
-				name: 'ServiceUnavailable',
-				message: 'Service temporarily unavailable',
-			});
-
-			expect(() => {
-				(tokenOrchestrator as any).handleErrors(error);
-			}).toThrow(error);
-
-			expect(clearTokensSpy).not.toHaveBeenCalled();
-		});
+				expect(mockTokenStore.clearTokensForUser).not.toHaveBeenCalled();
+				expect(mockTokenStore.removeSession).not.toHaveBeenCalled();
+				expect(mockDispatchSignOutBoundaryEvents).not.toHaveBeenCalled();
+			},
+		);
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
@@ -44,6 +44,7 @@ describe('tokenOrchestrator', () => {
 		clearActiveUser: jest.fn(),
 		clearTokensForUser: jest.fn(),
 		getStoredIdToken: jest.fn(),
+		reassertActiveUserPointer: jest.fn(),
 	};
 
 	beforeAll(() => {
@@ -102,6 +103,14 @@ describe('tokenOrchestrator', () => {
 			);
 			// async #2
 			expect(mockTokenStore.storeTokens).toHaveBeenCalledWith(mockTokens);
+
+			// storeTokens no longer writes the LastAuthUser pointer, so the refresh
+			// path must re-assert it for the active user; this drives SSR cookie
+			// migration to re-set the pointer cookie at path '/' (regression:
+			// stale path-scoped LastAuthUser cookie survived a server-side refresh).
+			expect(mockTokenStore.reassertActiveUserPointer).toHaveBeenCalledWith(
+				testUsername,
+			);
 
 			// ensure the result is correct
 			expect(newTokens).toEqual(mockTokens);

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
@@ -30,6 +30,7 @@ describe('tokenOrchestrator', () => {
 	const mockTokenStore = {
 		storeTokens: jest.fn(),
 		getLastAuthUser: jest.fn(),
+		getActiveUsername: jest.fn(),
 		loadTokens: jest.fn(),
 		clearTokens: jest.fn(),
 		setKeyValueStorage: jest.fn(),
@@ -40,6 +41,7 @@ describe('tokenOrchestrator', () => {
 		getAuthUserList: jest.fn(),
 		addActiveSession: jest.fn(),
 		removeSession: jest.fn(),
+		clearActiveUser: jest.fn(),
 		clearTokensForUser: jest.fn(),
 		getStoredIdToken: jest.fn(),
 	};
@@ -178,10 +180,8 @@ describe('tokenOrchestrator', () => {
 			jest.clearAllMocks();
 			// terminal auth errors now scope the clear to a single user + roster.
 			mockTokenStore.clearTokensForUser.mockResolvedValue(undefined);
-			mockTokenStore.removeSession.mockResolvedValue({
-				newActiveUser: undefined,
-				isEmpty: true,
-			});
+			mockTokenStore.removeSession.mockResolvedValue({ isEmpty: true });
+			mockTokenStore.clearActiveUser.mockResolvedValue(undefined);
 		});
 
 		it('does not clear a user or emit boundary events for a network error', async () => {
@@ -211,12 +211,12 @@ describe('tokenOrchestrator', () => {
 				testUsername,
 			);
 			expect(mockTokenStore.removeSession).toHaveBeenCalledWith(testUsername);
+			expect(mockTokenStore.clearActiveUser).toHaveBeenCalledTimes(1);
 			expect(mockTokenStore.clearTokens).not.toHaveBeenCalled();
-			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
-				mockTokenStore,
-				{ username: testUsername, userId: testUserId },
-				{ newActiveUser: undefined, isEmpty: true },
-			);
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith({
+				username: testUsername,
+				userId: testUserId,
+			});
 			expect(result).toBeNull();
 		});
 
@@ -287,11 +287,7 @@ describe('tokenOrchestrator', () => {
 
 			await invokeHandleErrors(error, testUsername, undefined);
 
-			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
-				mockTokenStore,
-				undefined,
-				{ newActiveUser: undefined, isEmpty: true },
-			);
+			expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(undefined);
 		});
 
 		it.each([

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenOrchestrator.test.ts
@@ -44,6 +44,7 @@ describe('tokenOrchestrator', () => {
 		clearActiveUser: jest.fn(),
 		clearTokensForUser: jest.fn(),
 		getStoredIdToken: jest.fn(),
+		getStoredSignInDetails: jest.fn(),
 		reassertActiveUserPointer: jest.fn(),
 	};
 

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
@@ -492,6 +492,19 @@ describe('TokenStore', () => {
 				expect(await tokenStore.getAuthUserList()).toEqual([]);
 			});
 
+			it('still returns the migrated list when persistAuthUserList throws (read-only storage)', async () => {
+				store[lastAuthUserKey] = 'legacyUser';
+				// Simulate read-only storage: setItem throws on write.
+				mockKeyValueStorage.setItem.mockRejectedValue(
+					new Error('Storage is read-only'),
+				);
+
+				const result = await tokenStore.getAuthUserList();
+
+				// Migration still returns the derived list even though persist failed.
+				expect(result).toEqual(['legacyUser']);
+			});
+
 			it('returns an empty roster when nothing is stored', async () => {
 				expect(await tokenStore.getAuthUserList()).toEqual([]);
 			});

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
@@ -129,10 +129,42 @@ describe('TokenStore', () => {
 		});
 
 		it('should return string username when no last auth user exists', async () => {
-			mockKeyValueStorage.getItem.mockResolvedValueOnce(null);
+			// getLastAuthUser now resolves via getAuthUserList, which reads both the
+			// AuthUserList key and the legacy LastAuthUser key; both must be empty.
+			mockKeyValueStorage.getItem.mockResolvedValue(null);
 
 			const result = await tokenStore.getLastAuthUser();
 			expect(result).toBe('username');
+		});
+	});
+
+	describe('getStoredIdToken', () => {
+		it('reads and decodes the stored idToken for a specific user', async () => {
+			const result = await tokenStore.getStoredIdToken(userSub);
+
+			expect(mockKeyValueStorage.getItem).toHaveBeenCalledWith(
+				`${authIDP}.${userPoolClientId}.${userSub}.idToken`,
+			);
+			expect(mockedDecodeJWT).toHaveBeenCalledWith(
+				mockAuthToken.idToken.toString(),
+			);
+			expect(result?.payload.sub).toBe(userSub);
+		});
+
+		it('returns undefined when no idToken is stored', async () => {
+			const result = await tokenStore.getStoredIdToken('absentUser');
+
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined (no throw) when decoding fails', async () => {
+			mockedDecodeJWT.mockImplementationOnce(() => {
+				throw new Error('bad token');
+			});
+
+			const result = await tokenStore.getStoredIdToken(userSub);
+
+			expect(result).toBeUndefined();
 		});
 	});
 
@@ -275,8 +307,11 @@ describe('TokenStore', () => {
 			};
 			const getItemSpy = jest.spyOn(keyValStorage, 'getItem');
 			await tokenStore.storeTokens(mockAuthMetadataWithDeviceMetadata);
+			// isolate the getDeviceMetadata reads from storeTokens' internal
+			// getLastAuthUser lookup (which now also consults the roster key).
+			getItemSpy.mockClear();
 			await tokenStore.getDeviceMetadata(userSub);
-			expect(getItemSpy).toHaveBeenCalledTimes(4);
+			expect(getItemSpy).toHaveBeenCalledTimes(3);
 			expect(getItemSpy).toHaveBeenCalledWith(
 				`${authIDP}.${userPoolClientId}.${userSub}.deviceKey`,
 			);
@@ -401,6 +436,187 @@ describe('TokenStore', () => {
 
 			const finalTokens = await tokenStore.loadTokens();
 			expect(finalTokens?.refreshToken).toBe(newMockAuthToken.refreshToken);
+		});
+	});
+
+	describe('session roster (multi-session)', () => {
+		const authUserListKey = `${authIDP}.${userPoolClientId}.AuthUserList`;
+		const lastAuthUserKey = `${authIDP}.${userPoolClientId}.LastAuthUser`;
+		// stateful in-memory storage so roster reads reflect prior writes.
+		let store: Record<string, string>;
+
+		beforeEach(() => {
+			store = {};
+			mockKeyValueStorage.getItem.mockImplementation((key: string) =>
+				Promise.resolve(key in store ? store[key] : null),
+			);
+			mockKeyValueStorage.setItem.mockImplementation(
+				(key: string, value: string) => {
+					store[key] = value;
+
+					return Promise.resolve();
+				},
+			);
+			mockKeyValueStorage.removeItem.mockImplementation((key: string) => {
+				delete store[key];
+
+				return Promise.resolve();
+			});
+		});
+
+		describe('getAuthUserList', () => {
+			it('parses a comma-separated roster preserving order', async () => {
+				store[authUserListKey] = 'alice,bob,carol';
+
+				expect(await tokenStore.getAuthUserList()).toEqual([
+					'alice',
+					'bob',
+					'carol',
+				]);
+			});
+
+			it('migrates a legacy LastAuthUser when AuthUserList is absent', async () => {
+				store[lastAuthUserKey] = 'legacyUser';
+
+				const result = await tokenStore.getAuthUserList();
+
+				expect(result).toEqual(['legacyUser']);
+				// migration should persist the derived roster to both keys.
+				expect(store[authUserListKey]).toBe('legacyUser');
+				expect(store[lastAuthUserKey]).toBe('legacyUser');
+			});
+
+			it('ignores the "username" fallback sentinel and returns an empty roster', async () => {
+				store[lastAuthUserKey] = 'username';
+
+				expect(await tokenStore.getAuthUserList()).toEqual([]);
+			});
+
+			it('returns an empty roster when nothing is stored', async () => {
+				expect(await tokenStore.getAuthUserList()).toEqual([]);
+			});
+		});
+
+		describe('getLastAuthUser', () => {
+			it('returns the roster head (AuthUserList[0])', async () => {
+				store[authUserListKey] = 'active,parked';
+
+				expect(await tokenStore.getLastAuthUser()).toBe('active');
+			});
+		});
+
+		describe('addActiveSession', () => {
+			it('adds a new user to the front of the roster', async () => {
+				store[authUserListKey] = 'bob,carol';
+
+				await tokenStore.addActiveSession('alice');
+
+				expect(store[authUserListKey]).toBe('alice,bob,carol');
+				// invariant: LastAuthUser === AuthUserList[0]
+				expect(store[lastAuthUserKey]).toBe('alice');
+			});
+
+			it('dedupes and moves an existing user to the front', async () => {
+				store[authUserListKey] = 'bob,carol,dave';
+
+				await tokenStore.addActiveSession('dave');
+
+				expect(store[authUserListKey]).toBe('dave,bob,carol');
+				expect(store[lastAuthUserKey]).toBe('dave');
+			});
+		});
+
+		describe('removeSession', () => {
+			it('removes a user and returns the promoted head', async () => {
+				store[authUserListKey] = 'alice,bob,carol';
+				store[lastAuthUserKey] = 'alice';
+
+				const result = await tokenStore.removeSession('alice');
+
+				expect(result).toEqual({ newActiveUser: 'bob', isEmpty: false });
+				expect(store[authUserListKey]).toBe('bob,carol');
+				expect(store[lastAuthUserKey]).toBe('bob');
+			});
+
+			it('clears BOTH keys when the roster becomes empty', async () => {
+				store[authUserListKey] = 'alice';
+				store[lastAuthUserKey] = 'alice';
+
+				const result = await tokenStore.removeSession('alice');
+
+				expect(result).toEqual({ newActiveUser: undefined, isEmpty: true });
+				expect(mockKeyValueStorage.removeItem).toHaveBeenCalledWith(
+					authUserListKey,
+				);
+				expect(mockKeyValueStorage.removeItem).toHaveBeenCalledWith(
+					lastAuthUserKey,
+				);
+				expect(store[authUserListKey]).toBeUndefined();
+				expect(store[lastAuthUserKey]).toBeUndefined();
+			});
+
+			it('removes LastAuthUser BEFORE AuthUserList when the roster empties', async () => {
+				store[authUserListKey] = 'alice';
+				store[lastAuthUserKey] = 'alice';
+
+				await tokenStore.removeSession('alice');
+
+				// ordering guards against a failed AuthUserList delete leaving a
+				// lingering legacy LastAuthUser that would re-migrate a removed user.
+				const removeOrder = mockKeyValueStorage.removeItem.mock.calls
+					.map(([key]) => key)
+					.filter(key => key === lastAuthUserKey || key === authUserListKey);
+				expect(removeOrder).toEqual([lastAuthUserKey, authUserListKey]);
+			});
+		});
+
+		describe('clearTokensForUser', () => {
+			it('removes only the target user namespace and not the roster keys', async () => {
+				const targetUser = 'alice';
+				store[authUserListKey] = 'alice,bob';
+				store[lastAuthUserKey] = 'alice';
+
+				await tokenStore.clearTokensForUser(targetUser);
+
+				const namespacedKeys = [
+					'accessToken',
+					'idToken',
+					'clockDrift',
+					'refreshToken',
+					'signInDetails',
+					'deviceKey',
+					'deviceGroupKey',
+					'randomPasswordKey',
+					'oauthMetadata',
+				];
+				namespacedKeys.forEach(key => {
+					expect(mockKeyValueStorage.removeItem).toHaveBeenCalledWith(
+						`${authIDP}.${userPoolClientId}.${targetUser}.${key}`,
+					);
+				});
+				// roster pointers must remain untouched.
+				expect(mockKeyValueStorage.removeItem).not.toHaveBeenCalledWith(
+					lastAuthUserKey,
+				);
+				expect(mockKeyValueStorage.removeItem).not.toHaveBeenCalledWith(
+					authUserListKey,
+				);
+			});
+		});
+
+		describe('storeTokens', () => {
+			it('does not write the LastAuthUser or AuthUserList roster keys', async () => {
+				await tokenStore.storeTokens(mockAuthToken);
+
+				expect(mockKeyValueStorage.setItem).not.toHaveBeenCalledWith(
+					lastAuthUserKey,
+					expect.anything(),
+				);
+				expect(mockKeyValueStorage.setItem).not.toHaveBeenCalledWith(
+					authUserListKey,
+					expect.anything(),
+				);
+			});
 		});
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
@@ -400,6 +400,23 @@ describe('TokenStore', () => {
 				JSON.stringify(mockMetadata),
 			);
 		});
+
+		it('namespaces metadata under an explicitly passed username, not the active pointer', async () => {
+			const setItemSpy = jest
+				.spyOn(keyValStorage, 'setItem')
+				.mockResolvedValue(undefined);
+			const mockMetadata = { oauthSignIn: true };
+
+			// The OAuth flow persists metadata BEFORE the pointer advances, so it
+			// passes the signed-in username explicitly; the key must use it (not the
+			// stale LastAuthUser) so a cookie-sharing subdomain can read it later.
+			await tokenStore.setOAuthMetadata(mockMetadata, 'oauthUser');
+
+			expect(setItemSpy).toHaveBeenCalledWith(
+				`${authIDP}.${userPoolClientId}.oauthUser.oauthMetadata`,
+				JSON.stringify(mockMetadata),
+			);
+		});
 	});
 
 	describe('getOAuthMetadata', () => {
@@ -1030,6 +1047,49 @@ describe('TokenStore', () => {
 				expect(store[lastAuthUserKey]).toBeUndefined();
 				// parked sessions survive.
 				expect(store[authUserListKey]).toBe('alice,bob');
+			});
+		});
+
+		describe('reassertActiveUserPointer', () => {
+			it('re-writes the pointer key for the active user without touching the roster', async () => {
+				store[authUserListKey] = 'alice,bob';
+				store[lastAuthUserKey] = 'alice';
+				mockKeyValueStorage.setItem.mockClear();
+
+				await tokenStore.reassertActiveUserPointer('alice');
+
+				// pointer re-written (drives SSR cookie migration to path '/')...
+				expect(mockKeyValueStorage.setItem).toHaveBeenCalledWith(
+					lastAuthUserKey,
+					'alice',
+				);
+				expect(store[lastAuthUserKey]).toBe('alice');
+				// ...and the roster is never re-written (no reorder on refresh).
+				expect(mockKeyValueStorage.setItem).not.toHaveBeenCalledWith(
+					authUserListKey,
+					expect.anything(),
+				);
+				expect(store[authUserListKey]).toBe('alice,bob');
+			});
+
+			it('is a no-op for a non-active (parked) user, never promoting it', async () => {
+				store[authUserListKey] = 'alice,bob';
+				store[lastAuthUserKey] = 'alice';
+				mockKeyValueStorage.setItem.mockClear();
+
+				await tokenStore.reassertActiveUserPointer('bob');
+
+				expect(mockKeyValueStorage.setItem).not.toHaveBeenCalled();
+				expect(store[lastAuthUserKey]).toBe('alice');
+			});
+
+			it('is a no-op when there is no active pointer (sentinel)', async () => {
+				store[lastAuthUserKey] = 'username';
+				mockKeyValueStorage.setItem.mockClear();
+
+				await tokenStore.reassertActiveUserPointer('username');
+
+				expect(mockKeyValueStorage.setItem).not.toHaveBeenCalled();
 			});
 		});
 

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
@@ -172,10 +172,42 @@ describe('TokenStore', () => {
 		});
 
 		it('should return string username when no last auth user exists', async () => {
-			mockKeyValueStorage.getItem.mockResolvedValueOnce(null);
+			// getLastAuthUser now resolves via getAuthUserList, which reads both the
+			// AuthUserList key and the legacy LastAuthUser key; both must be empty.
+			mockKeyValueStorage.getItem.mockResolvedValue(null);
 
 			const result = await tokenStore.getLastAuthUser();
 			expect(result).toBe('username');
+		});
+	});
+
+	describe('getStoredIdToken', () => {
+		it('reads and decodes the stored idToken for a specific user', async () => {
+			const result = await tokenStore.getStoredIdToken(userSub);
+
+			expect(mockKeyValueStorage.getItem).toHaveBeenCalledWith(
+				`${authIDP}.${userPoolClientId}.${userSub}.idToken`,
+			);
+			expect(mockedDecodeJWT).toHaveBeenCalledWith(
+				mockAuthToken.idToken.toString(),
+			);
+			expect(result?.payload.sub).toBe(userSub);
+		});
+
+		it('returns undefined when no idToken is stored', async () => {
+			const result = await tokenStore.getStoredIdToken('absentUser');
+
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined (no throw) when decoding fails', async () => {
+			mockedDecodeJWT.mockImplementationOnce(() => {
+				throw new Error('bad token');
+			});
+
+			const result = await tokenStore.getStoredIdToken(userSub);
+
+			expect(result).toBeUndefined();
 		});
 	});
 
@@ -318,8 +350,11 @@ describe('TokenStore', () => {
 			};
 			const getItemSpy = jest.spyOn(keyValStorage, 'getItem');
 			await tokenStore.storeTokens(mockAuthMetadataWithDeviceMetadata);
+			// isolate the getDeviceMetadata reads from storeTokens' internal
+			// getLastAuthUser lookup (which now also consults the roster key).
+			getItemSpy.mockClear();
 			await tokenStore.getDeviceMetadata(userSub);
-			expect(getItemSpy).toHaveBeenCalledTimes(4);
+			expect(getItemSpy).toHaveBeenCalledTimes(3);
 			expect(getItemSpy).toHaveBeenCalledWith(
 				`${authIDP}.${userPoolClientId}.${userSub}.deviceKey`,
 			);
@@ -712,6 +747,187 @@ describe('TokenStore', () => {
 
 			expect(newStorage.addListener).not.toHaveBeenCalled();
 			expect(newStorage.listenerCount()).toBe(0);
+		});
+	});
+
+	describe('session roster (multi-session)', () => {
+		const authUserListKey = `${authIDP}.${userPoolClientId}.AuthUserList`;
+		const lastAuthUserKey = `${authIDP}.${userPoolClientId}.LastAuthUser`;
+		// stateful in-memory storage so roster reads reflect prior writes.
+		let store: Record<string, string>;
+
+		beforeEach(() => {
+			store = {};
+			mockKeyValueStorage.getItem.mockImplementation((key: string) =>
+				Promise.resolve(key in store ? store[key] : null),
+			);
+			mockKeyValueStorage.setItem.mockImplementation(
+				(key: string, value: string) => {
+					store[key] = value;
+
+					return Promise.resolve();
+				},
+			);
+			mockKeyValueStorage.removeItem.mockImplementation((key: string) => {
+				delete store[key];
+
+				return Promise.resolve();
+			});
+		});
+
+		describe('getAuthUserList', () => {
+			it('parses a comma-separated roster preserving order', async () => {
+				store[authUserListKey] = 'alice,bob,carol';
+
+				expect(await tokenStore.getAuthUserList()).toEqual([
+					'alice',
+					'bob',
+					'carol',
+				]);
+			});
+
+			it('migrates a legacy LastAuthUser when AuthUserList is absent', async () => {
+				store[lastAuthUserKey] = 'legacyUser';
+
+				const result = await tokenStore.getAuthUserList();
+
+				expect(result).toEqual(['legacyUser']);
+				// migration should persist the derived roster to both keys.
+				expect(store[authUserListKey]).toBe('legacyUser');
+				expect(store[lastAuthUserKey]).toBe('legacyUser');
+			});
+
+			it('ignores the "username" fallback sentinel and returns an empty roster', async () => {
+				store[lastAuthUserKey] = 'username';
+
+				expect(await tokenStore.getAuthUserList()).toEqual([]);
+			});
+
+			it('returns an empty roster when nothing is stored', async () => {
+				expect(await tokenStore.getAuthUserList()).toEqual([]);
+			});
+		});
+
+		describe('getLastAuthUser', () => {
+			it('returns the roster head (AuthUserList[0])', async () => {
+				store[authUserListKey] = 'active,parked';
+
+				expect(await tokenStore.getLastAuthUser()).toBe('active');
+			});
+		});
+
+		describe('addActiveSession', () => {
+			it('adds a new user to the front of the roster', async () => {
+				store[authUserListKey] = 'bob,carol';
+
+				await tokenStore.addActiveSession('alice');
+
+				expect(store[authUserListKey]).toBe('alice,bob,carol');
+				// invariant: LastAuthUser === AuthUserList[0]
+				expect(store[lastAuthUserKey]).toBe('alice');
+			});
+
+			it('dedupes and moves an existing user to the front', async () => {
+				store[authUserListKey] = 'bob,carol,dave';
+
+				await tokenStore.addActiveSession('dave');
+
+				expect(store[authUserListKey]).toBe('dave,bob,carol');
+				expect(store[lastAuthUserKey]).toBe('dave');
+			});
+		});
+
+		describe('removeSession', () => {
+			it('removes a user and returns the promoted head', async () => {
+				store[authUserListKey] = 'alice,bob,carol';
+				store[lastAuthUserKey] = 'alice';
+
+				const result = await tokenStore.removeSession('alice');
+
+				expect(result).toEqual({ newActiveUser: 'bob', isEmpty: false });
+				expect(store[authUserListKey]).toBe('bob,carol');
+				expect(store[lastAuthUserKey]).toBe('bob');
+			});
+
+			it('clears BOTH keys when the roster becomes empty', async () => {
+				store[authUserListKey] = 'alice';
+				store[lastAuthUserKey] = 'alice';
+
+				const result = await tokenStore.removeSession('alice');
+
+				expect(result).toEqual({ newActiveUser: undefined, isEmpty: true });
+				expect(mockKeyValueStorage.removeItem).toHaveBeenCalledWith(
+					authUserListKey,
+				);
+				expect(mockKeyValueStorage.removeItem).toHaveBeenCalledWith(
+					lastAuthUserKey,
+				);
+				expect(store[authUserListKey]).toBeUndefined();
+				expect(store[lastAuthUserKey]).toBeUndefined();
+			});
+
+			it('removes LastAuthUser BEFORE AuthUserList when the roster empties', async () => {
+				store[authUserListKey] = 'alice';
+				store[lastAuthUserKey] = 'alice';
+
+				await tokenStore.removeSession('alice');
+
+				// ordering guards against a failed AuthUserList delete leaving a
+				// lingering legacy LastAuthUser that would re-migrate a removed user.
+				const removeOrder = mockKeyValueStorage.removeItem.mock.calls
+					.map(([key]) => key)
+					.filter(key => key === lastAuthUserKey || key === authUserListKey);
+				expect(removeOrder).toEqual([lastAuthUserKey, authUserListKey]);
+			});
+		});
+
+		describe('clearTokensForUser', () => {
+			it('removes only the target user namespace and not the roster keys', async () => {
+				const targetUser = 'alice';
+				store[authUserListKey] = 'alice,bob';
+				store[lastAuthUserKey] = 'alice';
+
+				await tokenStore.clearTokensForUser(targetUser);
+
+				const namespacedKeys = [
+					'accessToken',
+					'idToken',
+					'clockDrift',
+					'refreshToken',
+					'signInDetails',
+					'deviceKey',
+					'deviceGroupKey',
+					'randomPasswordKey',
+					'oauthMetadata',
+				];
+				namespacedKeys.forEach(key => {
+					expect(mockKeyValueStorage.removeItem).toHaveBeenCalledWith(
+						`${authIDP}.${userPoolClientId}.${targetUser}.${key}`,
+					);
+				});
+				// roster pointers must remain untouched.
+				expect(mockKeyValueStorage.removeItem).not.toHaveBeenCalledWith(
+					lastAuthUserKey,
+				);
+				expect(mockKeyValueStorage.removeItem).not.toHaveBeenCalledWith(
+					authUserListKey,
+				);
+			});
+		});
+
+		describe('storeTokens', () => {
+			it('does not write the LastAuthUser or AuthUserList roster keys', async () => {
+				await tokenStore.storeTokens(mockAuthToken);
+
+				expect(mockKeyValueStorage.setItem).not.toHaveBeenCalledWith(
+					lastAuthUserKey,
+					expect.anything(),
+				);
+				expect(mockKeyValueStorage.setItem).not.toHaveBeenCalledWith(
+					authUserListKey,
+					expect.anything(),
+				);
+			});
 		});
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
@@ -163,13 +163,13 @@ describe('TokenStore', () => {
 	});
 
 	describe('getLastAuthUser', () => {
-		it('should return the last authenticated user', async () => {
+		it('should return the active pointer (LastAuthUser) read directly', async () => {
 			const mockUser = 'mockUser';
-			// Return the roster for AuthUserList and nothing for LastAuthUser so
-			// no drift reconciliation is triggered.
+			// getLastAuthUser reads the LastAuthUser pointer key DIRECTLY and never
+			// derives from the roster; only the pointer key is populated here.
 			mockKeyValueStorage.getItem.mockImplementation(key =>
 				Promise.resolve(
-					key === `${authIDP}.${userPoolClientId}.AuthUserList`
+					key === `${authIDP}.${userPoolClientId}.LastAuthUser`
 						? mockUser
 						: null,
 				),
@@ -179,9 +179,8 @@ describe('TokenStore', () => {
 			expect(result).toBe(mockUser);
 		});
 
-		it('should return string username when no last auth user exists', async () => {
-			// getLastAuthUser now resolves via getAuthUserList, which reads both the
-			// AuthUserList key and the legacy LastAuthUser key; both must be empty.
+		it('should return string username when no active pointer exists', async () => {
+			// Empty/absent pointer resolves to the legacy 'username' sentinel.
 			mockKeyValueStorage.getItem.mockResolvedValue(null);
 
 			const result = await tokenStore.getLastAuthUser();
@@ -931,19 +930,37 @@ describe('TokenStore', () => {
 				expect(result).toEqual(['carol', 'alice', 'bob']);
 			});
 
-			it('(g) prunes an external LastAuthUser lacking tokens and corrects the stale pointer', async () => {
+			it('(g) clears a stale external LastAuthUser whose user was pruned', async () => {
 				store[authUserListKey] = 'alice,bob';
 				store[lastAuthUserKey] = 'carol';
 				// carol (the external pointer) has NO stored access token; alice/bob
-				// do. promote+prune nets back to [alice,bob], but the stale pointer
-				// must still be corrected from 'carol' to the new head 'alice'.
+				// do. promote+prune nets back to [alice,bob]. Under the pointer model
+				// a pointer must never name a user absent from the roster, so the
+				// stale 'carol' pointer is CLEARED (not repointed at a new head).
 				setResolvable('alice', 'bob');
 
 				const result = await tokenStore.getAuthUserList();
 
 				expect(result).toEqual(['alice', 'bob']);
 				expect(store[authUserListKey]).toBe('alice,bob');
-				expect(store[lastAuthUserKey]).toBe('alice');
+				expect(store[lastAuthUserKey]).toBeUndefined();
+			});
+
+			it('(h) leaves an empty pointer with a non-empty roster untouched (parked sessions)', async () => {
+				// Legitimate post-sign-out state: parked sessions remain but nobody is
+				// active. An empty pointer must NOT trigger promotion/reconciliation.
+				store[authUserListKey] = 'alice,bob';
+				setResolvable('alice', 'bob');
+				mockKeyValueStorage.setItem.mockClear();
+				mockKeyValueStorage.removeItem.mockClear();
+
+				const result = await tokenStore.getAuthUserList();
+
+				expect(result).toEqual(['alice', 'bob']);
+				// no promotion: roster + pointer are left exactly as-is.
+				expect(mockKeyValueStorage.setItem).not.toHaveBeenCalled();
+				expect(mockKeyValueStorage.removeItem).not.toHaveBeenCalled();
+				expect(store[lastAuthUserKey]).toBeUndefined();
 			});
 		});
 
@@ -961,10 +978,58 @@ describe('TokenStore', () => {
 		});
 
 		describe('getLastAuthUser', () => {
-			it('returns the roster head (AuthUserList[0])', async () => {
+			it('reads the active pointer directly (not the roster head)', async () => {
 				store[authUserListKey] = 'active,parked';
+				store[lastAuthUserKey] = 'active';
 
 				expect(await tokenStore.getLastAuthUser()).toBe('active');
+			});
+
+			it('returns the sentinel when the pointer is empty even with a parked roster', async () => {
+				// roster holds parked sessions but nobody is active -> sentinel, never
+				// the roster head.
+				store[authUserListKey] = 'parked,other';
+
+				expect(await tokenStore.getLastAuthUser()).toBe('username');
+			});
+		});
+
+		describe('getActiveUsername', () => {
+			it('returns the raw pointer when set', async () => {
+				store[lastAuthUserKey] = 'active';
+
+				expect(await tokenStore.getActiveUsername()).toBe('active');
+			});
+
+			it('returns undefined for an empty pointer even with a parked roster', async () => {
+				store[authUserListKey] = 'parked';
+
+				expect(await tokenStore.getActiveUsername()).toBeUndefined();
+			});
+
+			it('returns undefined for the legacy "username" sentinel', async () => {
+				store[lastAuthUserKey] = 'username';
+
+				expect(await tokenStore.getActiveUsername()).toBeUndefined();
+			});
+		});
+
+		describe('clearActiveUser', () => {
+			it('removes ONLY the pointer key, leaving the roster intact', async () => {
+				store[authUserListKey] = 'alice,bob';
+				store[lastAuthUserKey] = 'alice';
+
+				await tokenStore.clearActiveUser();
+
+				expect(mockKeyValueStorage.removeItem).toHaveBeenCalledWith(
+					lastAuthUserKey,
+				);
+				expect(mockKeyValueStorage.removeItem).not.toHaveBeenCalledWith(
+					authUserListKey,
+				);
+				expect(store[lastAuthUserKey]).toBeUndefined();
+				// parked sessions survive.
+				expect(store[authUserListKey]).toBe('alice,bob');
 			});
 		});
 
@@ -990,15 +1055,22 @@ describe('TokenStore', () => {
 		});
 
 		describe('removeSession', () => {
-			it('removes a user and returns the promoted head', async () => {
+			it('removes a user, returns { isEmpty:false } and NEVER touches the pointer', async () => {
 				store[authUserListKey] = 'alice,bob,carol';
 				store[lastAuthUserKey] = 'alice';
 
 				const result = await tokenStore.removeSession('alice');
 
-				expect(result).toEqual({ newActiveUser: 'bob', isEmpty: false });
+				// no promotion: only isEmpty is returned.
+				expect(result).toEqual({ isEmpty: false });
 				expect(store[authUserListKey]).toBe('bob,carol');
-				expect(store[lastAuthUserKey]).toBe('bob');
+				// the active pointer is left untouched (clearing/repointing is the
+				// caller's job via clearActiveUser / addActiveSession).
+				expect(store[lastAuthUserKey]).toBe('alice');
+				expect(mockKeyValueStorage.setItem).not.toHaveBeenCalledWith(
+					lastAuthUserKey,
+					expect.anything(),
+				);
 			});
 
 			it('clears BOTH keys when the roster becomes empty', async () => {
@@ -1007,7 +1079,7 @@ describe('TokenStore', () => {
 
 				const result = await tokenStore.removeSession('alice');
 
-				expect(result).toEqual({ newActiveUser: undefined, isEmpty: true });
+				expect(result).toEqual({ isEmpty: true });
 				expect(mockKeyValueStorage.removeItem).toHaveBeenCalledWith(
 					authUserListKey,
 				);

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
@@ -165,7 +165,15 @@ describe('TokenStore', () => {
 	describe('getLastAuthUser', () => {
 		it('should return the last authenticated user', async () => {
 			const mockUser = 'mockUser';
-			mockKeyValueStorage.getItem.mockResolvedValueOnce(mockUser);
+			// Return the roster for AuthUserList and nothing for LastAuthUser so
+			// no drift reconciliation is triggered.
+			mockKeyValueStorage.getItem.mockImplementation(key =>
+				Promise.resolve(
+					key === `${authIDP}.${userPoolClientId}.AuthUserList`
+						? mockUser
+						: null,
+				),
+			);
 
 			const result = await tokenStore.getLastAuthUser();
 			expect(result).toBe(mockUser);
@@ -821,6 +829,137 @@ describe('TokenStore', () => {
 			});
 		});
 
+		describe('getAuthUserList drift reconciliation', () => {
+			const accessTokenKey = (user: string) =>
+				`${authIDP}.${userPoolClientId}.${user}.accessToken`;
+			// Make an entry's session live by giving it a stored ACCESS TOKEN
+			// (the liveness signal used by pruning; idToken is optional).
+			const setResolvable = (...users: string[]) => {
+				users.forEach(user => {
+					store[accessTokenKey(user)] = 'accessToken';
+				});
+			};
+
+			it('(a) promotes an external LastAuthUser absent from the list and re-persists', async () => {
+				store[authUserListKey] = 'alice,bob';
+				store[lastAuthUserKey] = 'carol';
+				setResolvable('carol', 'alice', 'bob');
+
+				const result = await tokenStore.getAuthUserList();
+
+				expect(result).toEqual(['carol', 'alice', 'bob']);
+				expect(store[authUserListKey]).toBe('carol,alice,bob');
+				expect(store[lastAuthUserKey]).toBe('carol');
+			});
+
+			it('(b) promotes an external LastAuthUser present but not at the head', async () => {
+				store[authUserListKey] = 'alice,bob';
+				store[lastAuthUserKey] = 'bob';
+				setResolvable('alice', 'bob');
+
+				const result = await tokenStore.getAuthUserList();
+
+				expect(result).toEqual(['bob', 'alice']);
+				expect(store[authUserListKey]).toBe('bob,alice');
+			});
+
+			it('(c) prunes an entry whose session is unresolvable on the promotion path', async () => {
+				store[authUserListKey] = 'alice,bob';
+				store[lastAuthUserKey] = 'carol';
+				// bob has no stored access token and must be pruned.
+				setResolvable('carol', 'alice');
+
+				const result = await tokenStore.getAuthUserList();
+
+				expect(result).toEqual(['carol', 'alice']);
+				expect(store[authUserListKey]).toBe('carol,alice');
+			});
+
+			it('(c2) keeps an entry with an access token but no idToken (idToken optional)', async () => {
+				store[authUserListKey] = 'alice,bob';
+				store[lastAuthUserKey] = 'carol';
+				// Only access tokens are set (setResolvable never sets idTokens): a
+				// valid access+refresh session with no idToken must survive pruning.
+				setResolvable('carol', 'alice', 'bob');
+
+				const result = await tokenStore.getAuthUserList();
+
+				expect(result).toEqual(['carol', 'alice', 'bob']);
+				expect(store[authUserListKey]).toBe('carol,alice,bob');
+			});
+
+			it('(d) leaves the hot path untouched when LastAuthUser === list[0]', async () => {
+				store[authUserListKey] = 'alice,bob';
+				store[lastAuthUserKey] = 'alice';
+				mockKeyValueStorage.setItem.mockClear();
+				mockKeyValueStorage.getItem.mockClear();
+
+				const result = await tokenStore.getAuthUserList();
+
+				expect(result).toEqual(['alice', 'bob']);
+				// no reconciliation writes and no per-entry token reads: only the two
+				// roster keys are read (AuthUserList then LastAuthUser).
+				expect(mockKeyValueStorage.setItem).not.toHaveBeenCalled();
+				const readKeys = mockKeyValueStorage.getItem.mock.calls.map(
+					([key]) => key,
+				);
+				expect(readKeys).toEqual([authUserListKey, lastAuthUserKey]);
+			});
+
+			it('(e) ignores the "username" sentinel and does not reconcile', async () => {
+				store[authUserListKey] = 'alice,bob';
+				store[lastAuthUserKey] = 'username';
+				mockKeyValueStorage.setItem.mockClear();
+
+				const result = await tokenStore.getAuthUserList();
+
+				expect(result).toEqual(['alice', 'bob']);
+				expect(mockKeyValueStorage.setItem).not.toHaveBeenCalled();
+			});
+
+			it('(f) returns the reconciled list even when re-persist fails', async () => {
+				store[authUserListKey] = 'alice,bob';
+				store[lastAuthUserKey] = 'carol';
+				setResolvable('carol', 'alice', 'bob');
+				// Simulate read-only storage on the re-persist write.
+				mockKeyValueStorage.setItem.mockRejectedValue(
+					new Error('Storage is read-only'),
+				);
+
+				const result = await tokenStore.getAuthUserList();
+
+				expect(result).toEqual(['carol', 'alice', 'bob']);
+			});
+
+			it('(g) prunes an external LastAuthUser lacking tokens and corrects the stale pointer', async () => {
+				store[authUserListKey] = 'alice,bob';
+				store[lastAuthUserKey] = 'carol';
+				// carol (the external pointer) has NO stored access token; alice/bob
+				// do. promote+prune nets back to [alice,bob], but the stale pointer
+				// must still be corrected from 'carol' to the new head 'alice'.
+				setResolvable('alice', 'bob');
+
+				const result = await tokenStore.getAuthUserList();
+
+				expect(result).toEqual(['alice', 'bob']);
+				expect(store[authUserListKey]).toBe('alice,bob');
+				expect(store[lastAuthUserKey]).toBe('alice');
+			});
+		});
+
+		describe('persistAuthUserList write order', () => {
+			it('writes LastAuthUser before AuthUserList on the non-empty branch', async () => {
+				await tokenStore.addActiveSession('alice');
+
+				// ordering lets LastAuthUser carry the newer intent on a partial
+				// failure; drift reconciliation repairs AuthUserList on next read.
+				const setOrder = mockKeyValueStorage.setItem.mock.calls
+					.map(([key]) => key)
+					.filter(key => key === lastAuthUserKey || key === authUserListKey);
+				expect(setOrder).toEqual([lastAuthUserKey, authUserListKey]);
+			});
+		});
+
 		describe('getLastAuthUser', () => {
 			it('returns the roster head (AuthUserList[0])', async () => {
 				store[authUserListKey] = 'active,parked';
@@ -895,26 +1034,36 @@ describe('TokenStore', () => {
 		});
 
 		describe('clearTokensForUser', () => {
-			it('removes only the target user namespace and not the roster keys', async () => {
+			it('removes only the target user token namespace, preserving device keys and roster', async () => {
 				const targetUser = 'alice';
 				store[authUserListKey] = 'alice,bob';
 				store[lastAuthUserKey] = 'alice';
 
 				await tokenStore.clearTokensForUser(targetUser);
 
-				const namespacedKeys = [
+				// The six token keys are removed on sign-out.
+				const removedKeys = [
 					'accessToken',
 					'idToken',
 					'clockDrift',
 					'refreshToken',
 					'signInDetails',
+					'oauthMetadata',
+				];
+				removedKeys.forEach(key => {
+					expect(mockKeyValueStorage.removeItem).toHaveBeenCalledWith(
+						`${authIDP}.${userPoolClientId}.${targetUser}.${key}`,
+					);
+				});
+				// Device-tracking keys are PRESERVED so a remembered device
+				// survives sign-out (next sign-in can skip MFA).
+				const preservedKeys = [
 					'deviceKey',
 					'deviceGroupKey',
 					'randomPasswordKey',
-					'oauthMetadata',
 				];
-				namespacedKeys.forEach(key => {
-					expect(mockKeyValueStorage.removeItem).toHaveBeenCalledWith(
+				preservedKeys.forEach(key => {
+					expect(mockKeyValueStorage.removeItem).not.toHaveBeenCalledWith(
 						`${authIDP}.${userPoolClientId}.${targetUser}.${key}`,
 					);
 				});

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
@@ -803,6 +803,19 @@ describe('TokenStore', () => {
 				expect(await tokenStore.getAuthUserList()).toEqual([]);
 			});
 
+			it('still returns the migrated list when persistAuthUserList throws (read-only storage)', async () => {
+				store[lastAuthUserKey] = 'legacyUser';
+				// Simulate read-only storage: setItem throws on write.
+				mockKeyValueStorage.setItem.mockRejectedValue(
+					new Error('Storage is read-only'),
+				);
+
+				const result = await tokenStore.getAuthUserList();
+
+				// Migration still returns the derived list even though persist failed.
+				expect(result).toEqual(['legacyUser']);
+			});
+
 			it('returns an empty roster when nothing is stored', async () => {
 				expect(await tokenStore.getAuthUserList()).toEqual([]);
 			});

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
@@ -1150,6 +1150,17 @@ describe('TokenStore', () => {
 		});
 
 		describe('storeTokens', () => {
+			// Build a full token set for a given user. decodeJWT is mocked module-wide,
+			// so accessToken/idToken toString values are opaque here — the namespace
+			// under which they are STORED (tokens.username) is what these assert.
+			const buildTokens = (username: string) => ({
+				accessToken: mockAccessToken,
+				idToken: mockIdToken,
+				refreshToken: `refresh-${username}`,
+				clockDrift: 0,
+				username,
+			});
+
 			it('does not write the LastAuthUser or AuthUserList roster keys', async () => {
 				await tokenStore.storeTokens(mockAuthToken);
 
@@ -1161,6 +1172,57 @@ describe('TokenStore', () => {
 					authUserListKey,
 					expect.anything(),
 				);
+			});
+
+			it('namespaces a fresh sign-in under tokens.username with NO active pointer, and loadTokens finds it after addActiveSession', async () => {
+				// Fresh state (store empty from beforeEach): the active pointer is
+				// unset when cacheCognitoTokens runs, exactly as in the real sign-in
+				// flow. Tokens must be namespaced under tokens.username regardless.
+				await tokenStore.storeTokens(buildTokens('alice'));
+
+				// Written under alice's namespace, not the sentinel/unset pointer.
+				expect(
+					store[`${authIDP}.${userPoolClientId}.alice.accessToken`],
+				).toBeDefined();
+				expect(store[`${authIDP}.${userPoolClientId}.alice.refreshToken`]).toBe(
+					'refresh-alice',
+				);
+				// storeTokens never touches the pointer, so it is still unset.
+				expect(store[lastAuthUserKey]).toBeUndefined();
+
+				// Pointer advances to alice (dispatchSignedInHubEvent/addActiveSession).
+				await tokenStore.addActiveSession('alice');
+
+				const loaded = await tokenStore.loadTokens();
+				expect(loaded).toBeTruthy();
+				expect(loaded?.username).toBe('alice');
+				expect(loaded?.refreshToken).toBe('refresh-alice');
+			});
+
+			it('stores a second user under their own namespace without disturbing the first', async () => {
+				// alice is the active session with stored tokens.
+				await tokenStore.storeTokens(buildTokens('alice'));
+				await tokenStore.addActiveSession('alice');
+
+				// bob signs in: tokens are cached BEFORE the pointer moves to bob.
+				await tokenStore.storeTokens(buildTokens('bob'));
+
+				// bob's tokens land under bob's namespace...
+				expect(
+					store[`${authIDP}.${userPoolClientId}.bob.accessToken`],
+				).toBeDefined();
+				expect(store[`${authIDP}.${userPoolClientId}.bob.refreshToken`]).toBe(
+					'refresh-bob',
+				);
+				// ...and alice's tokens remain untouched.
+				expect(
+					store[`${authIDP}.${userPoolClientId}.alice.accessToken`],
+				).toBeDefined();
+				expect(store[`${authIDP}.${userPoolClientId}.alice.refreshToken`]).toBe(
+					'refresh-alice',
+				);
+				// pointer still names alice until addActiveSession('bob') runs.
+				expect(store[lastAuthUserKey]).toBe('alice');
 			});
 		});
 	});

--- a/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider/tokenStore.test.ts
@@ -12,6 +12,7 @@ import {
 	AUTH_KEY_PREFIX,
 	DefaultTokenStore,
 } from '../../../../src/providers/cognito/tokenProvider';
+import { AuthError } from '../../../../src/errors/AuthError';
 
 const userPoolId = 'us-west-1:0000523';
 const userPoolClientId = 'mockCognitoUserPoolsId';
@@ -215,6 +216,41 @@ describe('TokenStore', () => {
 			const result = await tokenStore.getStoredIdToken(userSub);
 
 			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('getStoredSignInDetails', () => {
+		const signInDetailsKey = `${authIDP}.${userPoolClientId}.${userSub}.signInDetails`;
+
+		it('parses stored signInDetails for a user (keyed via getAuthKeys)', async () => {
+			const details = {
+				loginId: 'alice@example.com',
+				authFlowType: 'USER_SRP_AUTH',
+			};
+			mockKeyValueStorage.getItem.mockImplementation(key =>
+				Promise.resolve(
+					key === signInDetailsKey ? JSON.stringify(details) : null,
+				),
+			);
+
+			const result = await tokenStore.getStoredSignInDetails(userSub);
+
+			expect(mockKeyValueStorage.getItem).toHaveBeenCalledWith(
+				signInDetailsKey,
+			);
+			expect(result).toEqual(details);
+		});
+
+		it('returns undefined when no signInDetails are stored', async () => {
+			mockKeyValueStorage.getItem.mockResolvedValue(null);
+
+			expect(await tokenStore.getStoredSignInDetails(userSub)).toBeUndefined();
+		});
+
+		it('returns undefined (no throw) when the stored value is invalid JSON', async () => {
+			mockKeyValueStorage.getItem.mockResolvedValue('not-json');
+
+			expect(await tokenStore.getStoredSignInDetails(userSub)).toBeUndefined();
 		});
 	});
 
@@ -1111,6 +1147,55 @@ describe('TokenStore', () => {
 
 				expect(store[authUserListKey]).toBe('dave,bob,carol');
 				expect(store[lastAuthUserKey]).toBe('dave');
+			});
+
+			it('serializes concurrent calls so no session is dropped (F3)', async () => {
+				// Start from an empty roster. Apply writes to the in-memory store
+				// immediately but resolve setItem asynchronously: unserialized RMW
+				// would let both reads observe the empty roster and the later write
+				// would clobber the earlier, dropping a user. The mutex must make the
+				// second call read the first call's committed write.
+				mockKeyValueStorage.setItem.mockImplementation(
+					(key: string, value: string) => {
+						store[key] = value;
+
+						return new Promise<void>(resolve => {
+							setTimeout(resolve, 10);
+						});
+					},
+				);
+
+				await Promise.all([
+					tokenStore.addActiveSession('alice'),
+					tokenStore.addActiveSession('bob'),
+				]);
+
+				// both users survive regardless of scheduling order.
+				const finalRoster = (store[authUserListKey] ?? '')
+					.split(',')
+					.filter(Boolean)
+					.sort();
+				expect(finalRoster).toEqual(['alice', 'bob']);
+			});
+
+			it('rethrows a storage write failure as a wrapped AuthError, not the raw error (F4)', async () => {
+				store[authUserListKey] = 'bob';
+				// read-only SSR cookie storage: the persisting write rejects with a
+				// plain Error.
+				mockKeyValueStorage.setItem.mockRejectedValue(
+					new Error('Storage is read-only'),
+				);
+
+				// The rejection must be the descriptive SessionPersistenceException
+				// (an AuthError), NOT the raw storage Error. (This suite auto-mocks
+				// core internals utils, so AmplifyError does not populate `.name`;
+				// the AuthError prototype identity is the reliable signal here.)
+				const rejection = await tokenStore.addActiveSession('alice').then(
+					() => undefined,
+					err => err,
+				);
+				expect(rejection).toBeInstanceOf(AuthError);
+				expect(rejection.message).not.toBe('Storage is read-only');
 			});
 		});
 

--- a/packages/auth/__tests__/providers/cognito/utils/dispatchSignOutHubEvents.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/dispatchSignOutHubEvents.test.ts
@@ -116,7 +116,7 @@ describe('dispatchSignOutBoundaryEvents()', () => {
 		);
 	});
 
-	it('falls back to an empty userId (no throw) when the promoted id token is unavailable', async () => {
+	it('skips switchActiveUser dispatch when the promoted id token is unavailable', async () => {
 		mockGetStoredIdToken.mockResolvedValue(undefined);
 
 		await dispatchSignOutBoundaryEvents(mockTokenStore, undefined, {
@@ -124,9 +124,9 @@ describe('dispatchSignOutBoundaryEvents()', () => {
 			isEmpty: false,
 		});
 
-		expect(mockDispatch).toHaveBeenCalledWith(
+		expect(mockDispatch).not.toHaveBeenCalledWith(
 			'auth',
-			{ event: 'switchActiveUser', data: { username: 'bob', userId: '' } },
+			expect.objectContaining({ event: 'switchActiveUser' }),
 			'Auth',
 			AMPLIFY_SYMBOL,
 		);

--- a/packages/auth/__tests__/providers/cognito/utils/dispatchSignOutHubEvents.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/dispatchSignOutHubEvents.test.ts
@@ -1,0 +1,134 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Hub } from '@aws-amplify/core';
+import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
+
+import { dispatchSignOutBoundaryEvents } from '../../../../src/providers/cognito/utils/dispatchSignOutHubEvents';
+import type { AuthTokenStore } from '../../../../src/providers/cognito/tokenProvider/types';
+
+jest.mock('@aws-amplify/core', () => ({
+	Hub: {
+		dispatch: jest.fn(),
+	},
+}));
+jest.mock('@aws-amplify/core/internals/utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/utils'),
+	AMPLIFY_SYMBOL: Symbol('AMPLIFY_SYMBOL'),
+}));
+
+const mockDispatch = Hub.dispatch as jest.Mock;
+const mockGetStoredIdToken = jest.fn();
+
+// The helper now RECEIVES the token store as a parameter (dependency injection)
+// instead of importing the tokenProvider singleton, so tests pass a mock store.
+const mockTokenStore = {
+	getStoredIdToken: mockGetStoredIdToken,
+} as unknown as AuthTokenStore;
+
+const signedOutUser = { username: 'alice', userId: 'alice-sub' };
+
+describe('dispatchSignOutBoundaryEvents()', () => {
+	afterEach(() => {
+		mockDispatch.mockClear();
+		mockGetStoredIdToken.mockReset();
+	});
+
+	it('dispatches only signedOut (with signedOutUser data) when the roster empties', async () => {
+		await dispatchSignOutBoundaryEvents(mockTokenStore, signedOutUser, {
+			newActiveUser: undefined,
+			isEmpty: true,
+		});
+
+		expect(mockDispatch).toHaveBeenNthCalledWith(
+			1,
+			'auth',
+			{ event: 'userSignedOut', data: signedOutUser },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).toHaveBeenNthCalledWith(
+			2,
+			'auth',
+			{ event: 'signedOut', data: signedOutUser },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).not.toHaveBeenCalledWith(
+			'auth',
+			expect.objectContaining({ event: 'switchActiveUser' }),
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+
+	it('omits userSignedOut when no active user was resolved but still emits signedOut', async () => {
+		await dispatchSignOutBoundaryEvents(mockTokenStore, undefined, {
+			newActiveUser: undefined,
+			isEmpty: true,
+		});
+
+		expect(mockDispatch).not.toHaveBeenCalledWith(
+			'auth',
+			expect.objectContaining({ event: 'userSignedOut' }),
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).toHaveBeenCalledWith(
+			'auth',
+			{ event: 'signedOut', data: undefined },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+
+	it('resolves the promoted user from the STORED id token for switchActiveUser', async () => {
+		mockGetStoredIdToken.mockResolvedValue({ payload: { sub: 'bob-sub' } });
+
+		await dispatchSignOutBoundaryEvents(mockTokenStore, signedOutUser, {
+			newActiveUser: 'bob',
+			isEmpty: false,
+		});
+
+		expect(mockGetStoredIdToken).toHaveBeenCalledWith('bob');
+		expect(mockDispatch).toHaveBeenNthCalledWith(
+			1,
+			'auth',
+			{ event: 'userSignedOut', data: signedOutUser },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).toHaveBeenNthCalledWith(
+			2,
+			'auth',
+			{
+				event: 'switchActiveUser',
+				data: { username: 'bob', userId: 'bob-sub' },
+			},
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).not.toHaveBeenCalledWith(
+			'auth',
+			expect.objectContaining({ event: 'signedOut' }),
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+
+	it('falls back to an empty userId (no throw) when the promoted id token is unavailable', async () => {
+		mockGetStoredIdToken.mockResolvedValue(undefined);
+
+		await dispatchSignOutBoundaryEvents(mockTokenStore, undefined, {
+			newActiveUser: 'bob',
+			isEmpty: false,
+		});
+
+		expect(mockDispatch).toHaveBeenCalledWith(
+			'auth',
+			{ event: 'switchActiveUser', data: { username: 'bob', userId: '' } },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+});

--- a/packages/auth/__tests__/providers/cognito/utils/dispatchSignOutHubEvents.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/dispatchSignOutHubEvents.test.ts
@@ -5,7 +5,6 @@ import { Hub } from '@aws-amplify/core';
 import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
 
 import { dispatchSignOutBoundaryEvents } from '../../../../src/providers/cognito/utils/dispatchSignOutHubEvents';
-import type { AuthTokenStore } from '../../../../src/providers/cognito/tokenProvider/types';
 
 jest.mock('@aws-amplify/core', () => ({
 	Hub: {
@@ -18,27 +17,16 @@ jest.mock('@aws-amplify/core/internals/utils', () => ({
 }));
 
 const mockDispatch = Hub.dispatch as jest.Mock;
-const mockGetStoredIdToken = jest.fn();
-
-// The helper now RECEIVES the token store as a parameter (dependency injection)
-// instead of importing the tokenProvider singleton, so tests pass a mock store.
-const mockTokenStore = {
-	getStoredIdToken: mockGetStoredIdToken,
-} as unknown as AuthTokenStore;
 
 const signedOutUser = { username: 'alice', userId: 'alice-sub' };
 
 describe('dispatchSignOutBoundaryEvents()', () => {
 	afterEach(() => {
 		mockDispatch.mockClear();
-		mockGetStoredIdToken.mockReset();
 	});
 
-	it('dispatches only signedOut (with signedOutUser data) when the roster empties', async () => {
-		await dispatchSignOutBoundaryEvents(mockTokenStore, signedOutUser, {
-			newActiveUser: undefined,
-			isEmpty: true,
-		});
+	it('dispatches userSignedOut then signedOut (both with data) for a resolvable user', async () => {
+		await dispatchSignOutBoundaryEvents(signedOutUser);
 
 		expect(mockDispatch).toHaveBeenNthCalledWith(
 			1,
@@ -54,6 +42,11 @@ describe('dispatchSignOutBoundaryEvents()', () => {
 			'Auth',
 			AMPLIFY_SYMBOL,
 		);
+	});
+
+	it('never dispatches switchActiveUser (no-promotion model)', async () => {
+		await dispatchSignOutBoundaryEvents(signedOutUser);
+
 		expect(mockDispatch).not.toHaveBeenCalledWith(
 			'auth',
 			expect.objectContaining({ event: 'switchActiveUser' }),
@@ -63,10 +56,7 @@ describe('dispatchSignOutBoundaryEvents()', () => {
 	});
 
 	it('omits userSignedOut when no active user was resolved but still emits signedOut', async () => {
-		await dispatchSignOutBoundaryEvents(mockTokenStore, undefined, {
-			newActiveUser: undefined,
-			isEmpty: true,
-		});
+		await dispatchSignOutBoundaryEvents(undefined);
 
 		expect(mockDispatch).not.toHaveBeenCalledWith(
 			'auth',
@@ -82,53 +72,17 @@ describe('dispatchSignOutBoundaryEvents()', () => {
 		);
 	});
 
-	it('resolves the promoted user from the STORED id token for switchActiveUser', async () => {
-		mockGetStoredIdToken.mockResolvedValue({ payload: { sub: 'bob-sub' } });
+	it('always emits signedOut even when parked sessions remain (no promotion)', async () => {
+		// The roster may still hold parked users; signOut only clears the pointer,
+		// so signedOut fires unconditionally and switchActiveUser never does.
+		await dispatchSignOutBoundaryEvents(signedOutUser);
 
-		await dispatchSignOutBoundaryEvents(mockTokenStore, signedOutUser, {
-			newActiveUser: 'bob',
-			isEmpty: false,
-		});
-
-		expect(mockGetStoredIdToken).toHaveBeenCalledWith('bob');
-		expect(mockDispatch).toHaveBeenNthCalledWith(
-			1,
+		expect(mockDispatch).toHaveBeenCalledWith(
 			'auth',
-			{ event: 'userSignedOut', data: signedOutUser },
+			{ event: 'signedOut', data: signedOutUser },
 			'Auth',
 			AMPLIFY_SYMBOL,
 		);
-		expect(mockDispatch).toHaveBeenNthCalledWith(
-			2,
-			'auth',
-			{
-				event: 'switchActiveUser',
-				data: { username: 'bob', userId: 'bob-sub' },
-			},
-			'Auth',
-			AMPLIFY_SYMBOL,
-		);
-		expect(mockDispatch).not.toHaveBeenCalledWith(
-			'auth',
-			expect.objectContaining({ event: 'signedOut' }),
-			'Auth',
-			AMPLIFY_SYMBOL,
-		);
-	});
-
-	it('skips switchActiveUser dispatch when the promoted id token is unavailable', async () => {
-		mockGetStoredIdToken.mockResolvedValue(undefined);
-
-		await dispatchSignOutBoundaryEvents(mockTokenStore, undefined, {
-			newActiveUser: 'bob',
-			isEmpty: false,
-		});
-
-		expect(mockDispatch).not.toHaveBeenCalledWith(
-			'auth',
-			expect.objectContaining({ event: 'switchActiveUser' }),
-			'Auth',
-			AMPLIFY_SYMBOL,
-		);
+		expect(mockDispatch).toHaveBeenCalledTimes(2);
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/utils/dispatchSignedInHubEvent.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/dispatchSignedInHubEvent.test.ts
@@ -10,6 +10,12 @@ import {
 } from '../../../../src/providers/cognito/utils/dispatchSignedInHubEvent';
 import { getCurrentUser } from '../../../../src/providers/cognito/apis/getCurrentUser';
 import { assertAuthTokens } from '../../../../src/providers/cognito/utils/types';
+import type { AuthTokenStore } from '../../../../src/providers/cognito/tokenProvider/types';
+
+// mock names are prefixed with `mock` so jest allows referencing them inside
+// the hoisted factory below.
+const mockGetAuthUserList = jest.fn();
+const mockAddActiveSession = jest.fn();
 
 jest.mock('../../../../src/providers/cognito/apis/getCurrentUser', () => ({
 	getCurrentUser: jest.fn(),
@@ -24,25 +30,139 @@ jest.mock('@aws-amplify/core/internals/utils', () => ({
 	AMPLIFY_SYMBOL: Symbol('AMPLIFY_SYMBOL'),
 }));
 
+// The helper now RECEIVES the token store as a parameter (dependency injection)
+// instead of importing the tokenProvider singleton, so tests pass a mock store.
+const mockTokenStore = {
+	getAuthUserList: mockGetAuthUserList,
+	addActiveSession: mockAddActiveSession,
+} as unknown as AuthTokenStore;
+
 const mockGetCurrentUser = getCurrentUser as jest.Mock;
 const mockDispatch = Hub.dispatch as jest.Mock;
 
-describe('dispatchSignedInHubEvent()', () => {
-	it('dispatches Hub event `signedIn` with `getCurrentUser()` returned data', async () => {
-		const mockGetCurrentUserPayload = {
-			username: 'hello',
-			userId: 'userId',
-		};
-		mockGetCurrentUser.mockResolvedValueOnce(mockGetCurrentUserPayload);
+const mockGetCurrentUserPayload = {
+	username: 'hello',
+	userId: 'userId',
+};
 
-		await dispatchSignedInHubEvent();
+describe('dispatchSignedInHubEvent()', () => {
+	beforeEach(() => {
+		// default: roster starts empty and addActiveSession succeeds.
+		mockGetAuthUserList.mockResolvedValue([]);
+		mockAddActiveSession.mockResolvedValue(undefined);
+		mockGetCurrentUser.mockResolvedValue(mockGetCurrentUserPayload);
+	});
+
+	afterEach(() => {
+		mockGetAuthUserList.mockReset();
+		mockAddActiveSession.mockReset();
+		mockGetCurrentUser.mockReset();
+		mockDispatch.mockClear();
+	});
+
+	it('adds the signed-in user to the roster as the active session', async () => {
+		await dispatchSignedInHubEvent(mockTokenStore, 'hello');
+
+		expect(mockAddActiveSession).toHaveBeenCalledWith('hello');
+	});
+
+	it('dispatches `userSignedIn` with `getCurrentUser()` returned data', async () => {
+		await dispatchSignedInHubEvent(mockTokenStore, 'hello');
 
 		expect(mockDispatch).toHaveBeenCalledWith(
 			'auth',
 			{
-				event: 'signedIn',
+				event: 'userSignedIn',
 				data: mockGetCurrentUserPayload,
 			},
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+
+	it('dispatches `signedIn` on first sign-in from an empty roster', async () => {
+		// roster empty before the new session is added.
+		mockGetAuthUserList.mockResolvedValueOnce([]);
+
+		await dispatchSignedInHubEvent(mockTokenStore, 'hello');
+
+		// userSignedIn tracks membership, signedIn marks the empty->non-empty boundary.
+		expect(mockDispatch).toHaveBeenNthCalledWith(
+			1,
+			'auth',
+			{ event: 'userSignedIn', data: mockGetCurrentUserPayload },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).toHaveBeenNthCalledWith(
+			2,
+			'auth',
+			{ event: 'signedIn', data: mockGetCurrentUserPayload },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).not.toHaveBeenCalledWith(
+			'auth',
+			expect.objectContaining({ event: 'switchActiveUser' }),
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+
+	it('dispatches `switchActiveUser` (not `signedIn`) when a user is already active', async () => {
+		// roster already has an active user before the new session is added.
+		mockGetAuthUserList.mockResolvedValueOnce(['existing']);
+
+		await dispatchSignedInHubEvent(mockTokenStore, 'hello');
+
+		expect(mockDispatch).toHaveBeenNthCalledWith(
+			1,
+			'auth',
+			{ event: 'userSignedIn', data: mockGetCurrentUserPayload },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).toHaveBeenNthCalledWith(
+			2,
+			'auth',
+			{ event: 'switchActiveUser', data: mockGetCurrentUserPayload },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).not.toHaveBeenCalledWith(
+			'auth',
+			expect.objectContaining({ event: 'signedIn' }),
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+
+	it('dispatches `userSignedIn` only (no `signedIn`/`switchActiveUser`) when the active user re-authenticates', async () => {
+		// the signing-in user is already the active roster head.
+		mockGetAuthUserList.mockResolvedValueOnce(['hello']);
+		mockGetCurrentUser.mockResolvedValue({
+			username: 'hello',
+			userId: 'userId',
+		});
+
+		await dispatchSignedInHubEvent(mockTokenStore, 'hello');
+
+		expect(mockDispatch).toHaveBeenCalledTimes(1);
+		expect(mockDispatch).toHaveBeenCalledWith(
+			'auth',
+			{ event: 'userSignedIn', data: { username: 'hello', userId: 'userId' } },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).not.toHaveBeenCalledWith(
+			'auth',
+			expect.objectContaining({ event: 'signedIn' }),
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).not.toHaveBeenCalledWith(
+			'auth',
+			expect.objectContaining({ event: 'switchActiveUser' }),
 			'Auth',
 			AMPLIFY_SYMBOL,
 		);
@@ -53,7 +173,9 @@ describe('dispatchSignedInHubEvent()', () => {
 			assertAuthTokens(null);
 		});
 
-		expect(() => dispatchSignedInHubEvent()).rejects.toThrow(ERROR_MESSAGE);
+		expect(() =>
+			dispatchSignedInHubEvent(mockTokenStore, 'hello'),
+		).rejects.toThrow(ERROR_MESSAGE);
 	});
 
 	it('rethrows error if the error is not handled by itself', () => {
@@ -63,6 +185,8 @@ describe('dispatchSignedInHubEvent()', () => {
 			throw mockError;
 		});
 
-		expect(() => dispatchSignedInHubEvent()).rejects.toThrow(mockError);
+		expect(() =>
+			dispatchSignedInHubEvent(mockTokenStore, 'hello'),
+		).rejects.toThrow(mockError);
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/utils/dispatchSignedInHubEvent.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/dispatchSignedInHubEvent.test.ts
@@ -11,6 +11,13 @@ import {
 } from '../../../../src/providers/cognito/utils/dispatchSignedInHubEvent';
 import { getCurrentUser } from '../../../../src/providers/cognito/apis/getCurrentUser';
 import { assertAuthTokens } from '../../../../src/providers/cognito/utils/types';
+import { tokenOrchestrator } from '../../../../src/providers/cognito/tokenProvider';
+import type { AuthTokenStore } from '../../../../src/providers/cognito/tokenProvider/types';
+
+// mock names are prefixed with `mock` so jest allows referencing them inside
+// the hoisted factory below.
+const mockGetAuthUserList = jest.fn();
+const mockAddActiveSession = jest.fn();
 
 jest.mock('../../../../src/providers/cognito/apis/getCurrentUser', () => ({
 	getCurrentUser: jest.fn(),
@@ -24,27 +31,150 @@ jest.mock('@aws-amplify/core/internals/utils', () => ({
 	...jest.requireActual('@aws-amplify/core/internals/utils'),
 	AMPLIFY_SYMBOL: Symbol('AMPLIFY_SYMBOL'),
 }));
+// The helper resolves the roster/pointer through the module-level token store
+// (the client path), mirroring how main's ctx-native sign-in reaches
+// `tokenOrchestrator` directly. It takes the ctx for the getCurrentUser payload.
+jest.mock('../../../../src/providers/cognito/tokenProvider', () => ({
+	tokenOrchestrator: {
+		getTokenStore: jest.fn(),
+	},
+}));
+
+const mockTokenStore = {
+	getAuthUserList: mockGetAuthUserList,
+	addActiveSession: mockAddActiveSession,
+} as unknown as AuthTokenStore;
 
 const mockGetCurrentUser = getCurrentUser as jest.Mock;
 const mockDispatch = Hub.dispatch as jest.Mock;
+const mockGetTokenStore = tokenOrchestrator.getTokenStore as jest.Mock;
 const mockCtx = createMockAmplifyContext();
 
-describe('dispatchSignedInHubEvent(mockCtx)', () => {
-	it('dispatches Hub event `signedIn` with `getCurrentUser()` returned data', async () => {
-		const mockGetCurrentUserPayload = {
-			username: 'hello',
-			userId: 'userId',
-		};
-		mockGetCurrentUser.mockResolvedValueOnce(mockGetCurrentUserPayload);
+const mockGetCurrentUserPayload = {
+	username: 'hello',
+	userId: 'userId',
+};
 
-		await dispatchSignedInHubEvent(mockCtx);
+describe('dispatchSignedInHubEvent()', () => {
+	beforeEach(() => {
+		// default: roster starts empty and addActiveSession succeeds.
+		mockGetTokenStore.mockReturnValue(mockTokenStore);
+		mockGetAuthUserList.mockResolvedValue([]);
+		mockAddActiveSession.mockResolvedValue(undefined);
+		mockGetCurrentUser.mockResolvedValue(mockGetCurrentUserPayload);
+	});
+
+	afterEach(() => {
+		mockGetAuthUserList.mockReset();
+		mockAddActiveSession.mockReset();
+		mockGetCurrentUser.mockReset();
+		mockGetTokenStore.mockReset();
+		mockDispatch.mockClear();
+	});
+
+	it('adds the signed-in user to the roster as the active session', async () => {
+		await dispatchSignedInHubEvent(mockCtx, 'hello');
+
+		expect(mockAddActiveSession).toHaveBeenCalledWith('hello');
+	});
+
+	it('dispatches `userSignedIn` with `getCurrentUser()` returned data', async () => {
+		await dispatchSignedInHubEvent(mockCtx, 'hello');
 
 		expect(mockDispatch).toHaveBeenCalledWith(
 			'auth',
 			{
-				event: 'signedIn',
+				event: 'userSignedIn',
 				data: mockGetCurrentUserPayload,
 			},
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+
+	it('dispatches `signedIn` on first sign-in from an empty roster', async () => {
+		// roster empty before the new session is added.
+		mockGetAuthUserList.mockResolvedValueOnce([]);
+
+		await dispatchSignedInHubEvent(mockCtx, 'hello');
+
+		// userSignedIn tracks membership, signedIn marks the empty->non-empty boundary.
+		expect(mockDispatch).toHaveBeenNthCalledWith(
+			1,
+			'auth',
+			{ event: 'userSignedIn', data: mockGetCurrentUserPayload },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).toHaveBeenNthCalledWith(
+			2,
+			'auth',
+			{ event: 'signedIn', data: mockGetCurrentUserPayload },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).not.toHaveBeenCalledWith(
+			'auth',
+			expect.objectContaining({ event: 'switchActiveUser' }),
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+
+	it('dispatches `switchActiveUser` (not `signedIn`) when a user is already active', async () => {
+		// roster already has an active user before the new session is added.
+		mockGetAuthUserList.mockResolvedValueOnce(['existing']);
+
+		await dispatchSignedInHubEvent(mockCtx, 'hello');
+
+		expect(mockDispatch).toHaveBeenNthCalledWith(
+			1,
+			'auth',
+			{ event: 'userSignedIn', data: mockGetCurrentUserPayload },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).toHaveBeenNthCalledWith(
+			2,
+			'auth',
+			{ event: 'switchActiveUser', data: mockGetCurrentUserPayload },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).not.toHaveBeenCalledWith(
+			'auth',
+			expect.objectContaining({ event: 'signedIn' }),
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+
+	it('dispatches `userSignedIn` only (no `signedIn`/`switchActiveUser`) when the active user re-authenticates', async () => {
+		// the signing-in user is already the active roster head.
+		mockGetAuthUserList.mockResolvedValueOnce(['hello']);
+		mockGetCurrentUser.mockResolvedValue({
+			username: 'hello',
+			userId: 'userId',
+		});
+
+		await dispatchSignedInHubEvent(mockCtx, 'hello');
+
+		expect(mockDispatch).toHaveBeenCalledTimes(1);
+		expect(mockDispatch).toHaveBeenCalledWith(
+			'auth',
+			{ event: 'userSignedIn', data: { username: 'hello', userId: 'userId' } },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).not.toHaveBeenCalledWith(
+			'auth',
+			expect.objectContaining({ event: 'signedIn' }),
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).not.toHaveBeenCalledWith(
+			'auth',
+			expect.objectContaining({ event: 'switchActiveUser' }),
 			'Auth',
 			AMPLIFY_SYMBOL,
 		);
@@ -55,7 +185,7 @@ describe('dispatchSignedInHubEvent(mockCtx)', () => {
 			assertAuthTokens(null);
 		});
 
-		expect(() => dispatchSignedInHubEvent(mockCtx)).rejects.toThrow(
+		expect(() => dispatchSignedInHubEvent(mockCtx, 'hello')).rejects.toThrow(
 			ERROR_MESSAGE,
 		);
 	});
@@ -67,6 +197,8 @@ describe('dispatchSignedInHubEvent(mockCtx)', () => {
 			throw mockError;
 		});
 
-		expect(() => dispatchSignedInHubEvent(mockCtx)).rejects.toThrow(mockError);
+		expect(() => dispatchSignedInHubEvent(mockCtx, 'hello')).rejects.toThrow(
+			mockError,
+		);
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/utils/dispatchSignedInHubEvent.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/dispatchSignedInHubEvent.test.ts
@@ -16,7 +16,7 @@ import type { AuthTokenStore } from '../../../../src/providers/cognito/tokenProv
 
 // mock names are prefixed with `mock` so jest allows referencing them inside
 // the hoisted factory below.
-const mockGetAuthUserList = jest.fn();
+const mockGetActiveUsername = jest.fn();
 const mockAddActiveSession = jest.fn();
 
 jest.mock('../../../../src/providers/cognito/apis/getCurrentUser', () => ({
@@ -40,8 +40,10 @@ jest.mock('../../../../src/providers/cognito/tokenProvider', () => ({
 	},
 }));
 
+// The helper resolves the roster/pointer through the module-level token store
+// (mocked below) and reads the RAW active pointer (getActiveUsername).
 const mockTokenStore = {
-	getAuthUserList: mockGetAuthUserList,
+	getActiveUsername: mockGetActiveUsername,
 	addActiveSession: mockAddActiveSession,
 } as unknown as AuthTokenStore;
 
@@ -57,15 +59,15 @@ const mockGetCurrentUserPayload = {
 
 describe('dispatchSignedInHubEvent()', () => {
 	beforeEach(() => {
-		// default: roster starts empty and addActiveSession succeeds.
+		// default: no active pointer before, and addActiveSession succeeds.
 		mockGetTokenStore.mockReturnValue(mockTokenStore);
-		mockGetAuthUserList.mockResolvedValue([]);
+		mockGetActiveUsername.mockResolvedValue(undefined);
 		mockAddActiveSession.mockResolvedValue(undefined);
 		mockGetCurrentUser.mockResolvedValue(mockGetCurrentUserPayload);
 	});
 
 	afterEach(() => {
-		mockGetAuthUserList.mockReset();
+		mockGetActiveUsername.mockReset();
 		mockAddActiveSession.mockReset();
 		mockGetCurrentUser.mockReset();
 		mockGetTokenStore.mockReset();
@@ -92,13 +94,13 @@ describe('dispatchSignedInHubEvent()', () => {
 		);
 	});
 
-	it('dispatches `signedIn` on first sign-in from an empty roster', async () => {
-		// roster empty before the new session is added.
-		mockGetAuthUserList.mockResolvedValueOnce([]);
+	it('dispatches `signedIn` on first sign-in when no user is active', async () => {
+		// no active pointer before the new session is added.
+		mockGetActiveUsername.mockResolvedValueOnce(undefined);
 
 		await dispatchSignedInHubEvent(mockCtx, 'hello');
 
-		// userSignedIn tracks membership, signedIn marks the empty->non-empty boundary.
+		// userSignedIn tracks the user; signedIn marks the no-active->active boundary.
 		expect(mockDispatch).toHaveBeenNthCalledWith(
 			1,
 			'auth',
@@ -121,9 +123,31 @@ describe('dispatchSignedInHubEvent()', () => {
 		);
 	});
 
-	it('dispatches `switchActiveUser` (not `signedIn`) when a user is already active', async () => {
-		// roster already has an active user before the new session is added.
-		mockGetAuthUserList.mockResolvedValueOnce(['existing']);
+	it('dispatches `signedIn` when activating from a parked-only roster (empty pointer)', async () => {
+		// Roster holds parked sessions but nobody is active (pointer empty) after a
+		// prior sign-out: signing in reads as a signedIn boundary, not a switch.
+		mockGetActiveUsername.mockResolvedValueOnce(undefined);
+
+		await dispatchSignedInHubEvent(mockCtx, 'hello');
+
+		expect(mockDispatch).toHaveBeenNthCalledWith(
+			2,
+			'auth',
+			{ event: 'signedIn', data: mockGetCurrentUserPayload },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+		expect(mockDispatch).not.toHaveBeenCalledWith(
+			'auth',
+			expect.objectContaining({ event: 'switchActiveUser' }),
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	});
+
+	it('dispatches `switchActiveUser` (not `signedIn`) when a different user is already active', async () => {
+		// a different user is the active pointer before the new session is added.
+		mockGetActiveUsername.mockResolvedValueOnce('existing');
 
 		await dispatchSignedInHubEvent(mockCtx, 'hello');
 
@@ -150,8 +174,8 @@ describe('dispatchSignedInHubEvent()', () => {
 	});
 
 	it('dispatches `userSignedIn` only (no `signedIn`/`switchActiveUser`) when the active user re-authenticates', async () => {
-		// the signing-in user is already the active roster head.
-		mockGetAuthUserList.mockResolvedValueOnce(['hello']);
+		// the signing-in user is already the active pointer.
+		mockGetActiveUsername.mockResolvedValueOnce('hello');
 		mockGetCurrentUser.mockResolvedValue({
 			username: 'hello',
 			userId: 'userId',

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
@@ -12,6 +12,8 @@ import { AuthError } from '../../../../../src/errors/AuthError';
 import { AuthErrorTypes } from '../../../../../src/types/Auth';
 import { OAuthStore } from '../../../../../src/providers/cognito/utils/types';
 import { completeOAuthFlow } from '../../../../../src/providers/cognito/utils/oauth/completeOAuthFlow';
+import { tokenOrchestrator } from '../../../../../src/providers/cognito/tokenProvider';
+import { getCurrentUser } from '../../../../../src/providers/cognito/apis/getCurrentUser';
 
 jest.mock('../../../../../src/providers/cognito/tokenProvider');
 jest.mock('@aws-amplify/core', () => ({
@@ -69,6 +71,16 @@ describe('completeOAuthFlow', () => {
 					},
 				}) as any,
 		);
+		// dispatchSignedInHubEvent (invoked at the end of the OAuth flow) reads the
+		// session roster and resolves the signed-in user for its event payload.
+		(tokenOrchestrator.getTokenStore as jest.Mock).mockReturnValue({
+			getAuthUserList: jest.fn().mockResolvedValue([]),
+			addActiveSession: jest.fn().mockResolvedValue(undefined),
+		});
+		(getCurrentUser as jest.Mock).mockResolvedValue({
+			username: 'testuser',
+			userId: 'testsub',
+		});
 	});
 
 	afterEach(() => {
@@ -200,15 +212,42 @@ describe('completeOAuthFlow', () => {
 				testInput.redirectUri,
 			);
 
-			expect(mockHubDispatch).toHaveBeenCalledTimes(3);
+			expect(mockHubDispatch).toHaveBeenCalledTimes(4);
 
-			// Verify we replace browser tab location before dispatching hub events
+			// Verify we replace browser tab location before dispatching hub events.
+			// dispatchSignedInHubEvent now emits both userSignedIn (roster membership)
+			// and signedIn (empty->non-empty boundary), so there are 3 auth Hub events
+			// plus signInWithRedirect.
 			expect(executionOrder).toEqual([
 				'replaceState',
 				'hubDispatch',
 				'hubDispatch',
 				'hubDispatch',
+				'hubDispatch',
 			]);
+		});
+
+		it('throws (and does not cache tokens) when no username claim can be resolved', async () => {
+			mockCacheCognitoTokens.mockClear();
+			mockValidateState.mockReturnValueOnce('myState-valid_state');
+			(oAuthStore.loadPKCE as jest.Mock).mockResolvedValueOnce('pkce23234a');
+			mockFetch.mockResolvedValueOnce({
+				json: jest.fn(() =>
+					Promise.resolve({
+						access_token: 'access_token',
+						id_token: 'id_token',
+						refresh_token: 'refresh_token',
+						token_type: 'token_type',
+						expires_in: 'expires_in',
+					}),
+				),
+			});
+			// neither the access token nor the id token carries a username claim, so
+			// the sentinel 'username' must NOT be persisted as a real roster entry.
+			mockDecodeJWT.mockReturnValue({ payload: {} });
+
+			await expect(completeOAuthFlow(testInput)).rejects.toThrow();
+			expect(mockCacheCognitoTokens).not.toHaveBeenCalled();
 		});
 
 		it('throws when `fetch` call resolves error', async () => {
@@ -299,7 +338,8 @@ describe('completeOAuthFlow', () => {
 			expect(oAuthStore.storeOAuthSignIn).toHaveBeenCalledWith(true, undefined);
 			expect(mockResolveAndClearInflightPromises).toHaveBeenCalledTimes(1);
 
-			expect(mockHubDispatch).toHaveBeenCalledTimes(2);
+			// signInWithRedirect + userSignedIn + signedIn (empty->non-empty boundary).
+			expect(mockHubDispatch).toHaveBeenCalledTimes(3);
 			expect(mockReplaceState).toHaveBeenCalledWith(
 				'http://localhost:3000/?code=aaaa-111-222&state=aaaaa',
 				'',

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
@@ -17,6 +17,8 @@ import { AuthError } from '../../../../../src/errors/AuthError';
 import { AuthErrorTypes } from '../../../../../src/types/Auth';
 import { OAuthStore } from '../../../../../src/providers/cognito/utils/types';
 import { completeOAuthFlow } from '../../../../../src/providers/cognito/utils/oauth/completeOAuthFlow';
+import { tokenOrchestrator } from '../../../../../src/providers/cognito/tokenProvider';
+import { getCurrentUser } from '../../../../../src/providers/cognito/apis/getCurrentUser';
 
 jest.mock('../../../../../src/providers/cognito/tokenProvider');
 jest.mock('@aws-amplify/core', () => ({
@@ -75,6 +77,16 @@ describe('completeOAuthFlow', () => {
 					},
 				}) as any,
 		);
+		// dispatchSignedInHubEvent (invoked at the end of the OAuth flow) reads the
+		// session roster and resolves the signed-in user for its event payload.
+		(tokenOrchestrator.getTokenStore as jest.Mock).mockReturnValue({
+			getAuthUserList: jest.fn().mockResolvedValue([]),
+			addActiveSession: jest.fn().mockResolvedValue(undefined),
+		});
+		(getCurrentUser as jest.Mock).mockResolvedValue({
+			username: 'testuser',
+			userId: 'testsub',
+		});
 	});
 
 	afterAll(() => {
@@ -210,15 +222,42 @@ describe('completeOAuthFlow', () => {
 				testInput.redirectUri,
 			);
 
-			expect(mockHubDispatch).toHaveBeenCalledTimes(3);
+			expect(mockHubDispatch).toHaveBeenCalledTimes(4);
 
-			// Verify we replace browser tab location before dispatching hub events
+			// Verify we replace browser tab location before dispatching hub events.
+			// dispatchSignedInHubEvent now emits both userSignedIn (roster membership)
+			// and signedIn (empty->non-empty boundary), so there are 3 auth Hub events
+			// plus signInWithRedirect.
 			expect(executionOrder).toEqual([
 				'replaceState',
 				'hubDispatch',
 				'hubDispatch',
 				'hubDispatch',
+				'hubDispatch',
 			]);
+		});
+
+		it('throws (and does not cache tokens) when no username claim can be resolved', async () => {
+			mockCacheCognitoTokens.mockClear();
+			mockValidateState.mockReturnValueOnce('myState-valid_state');
+			(oAuthStore.loadPKCE as jest.Mock).mockResolvedValueOnce('pkce23234a');
+			mockFetch.mockResolvedValueOnce({
+				json: jest.fn(() =>
+					Promise.resolve({
+						access_token: 'access_token',
+						id_token: 'id_token',
+						refresh_token: 'refresh_token',
+						token_type: 'token_type',
+						expires_in: 'expires_in',
+					}),
+				),
+			});
+			// neither the access token nor the id token carries a username claim, so
+			// the sentinel 'username' must NOT be persisted as a real roster entry.
+			mockDecodeJWT.mockReturnValue({ payload: {} });
+
+			await expect(completeOAuthFlow(testInput)).rejects.toThrow();
+			expect(mockCacheCognitoTokens).not.toHaveBeenCalled();
 		});
 
 		it('throws when `fetch` call resolves error', async () => {
@@ -309,7 +348,8 @@ describe('completeOAuthFlow', () => {
 			expect(oAuthStore.storeOAuthSignIn).toHaveBeenCalledWith(true, undefined);
 			expect(mockResolveAndClearInflightPromises).toHaveBeenCalledTimes(1);
 
-			expect(mockHubDispatch).toHaveBeenCalledTimes(2);
+			// signInWithRedirect + userSignedIn + signedIn (empty->non-empty boundary).
+			expect(mockHubDispatch).toHaveBeenCalledTimes(3);
 			expect(mockReplaceState).toHaveBeenCalledWith(
 				'http://localhost:3000/?code=aaaa-111-222&state=aaaaa',
 				'',

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
@@ -247,6 +247,44 @@ describe('completeOAuthFlow', () => {
 			]);
 		});
 
+		it('releases inflight fetchAuthSession callers only AFTER the active-user pointer is set', async () => {
+			// Regression (grant-flow e2e failure, PR #14875): the app-side
+			// getCurrentUser that blocks during the code flow's /oauth2/token
+			// exchange must be released only AFTER addActiveSession moves the
+			// LastAuthUser pointer. Released earlier, loadTokens resolves against the
+			// stale 'username' sentinel namespace and throws
+			// UserUnAuthenticatedException. invocationCallOrder is a jest-global
+			// monotonic counter, so it orders calls across different mocks.
+			const addActiveSession = jest.fn().mockResolvedValue(undefined);
+			(tokenOrchestrator.getTokenStore as jest.Mock).mockReturnValueOnce({
+				getAuthUserList: jest.fn().mockResolvedValue([]),
+				getActiveUsername: jest.fn().mockResolvedValue(undefined),
+				addActiveSession,
+			});
+			mockValidateState.mockReturnValueOnce('myState-valid_state');
+			(oAuthStore.loadPKCE as jest.Mock).mockResolvedValueOnce('pkce');
+			mockDecodeJWT.mockReturnValueOnce({ payload: { username: 'testuser' } });
+			mockFetch.mockResolvedValueOnce({
+				json: jest.fn(() =>
+					Promise.resolve({
+						access_token: 'access_token',
+						id_token: 'id_token',
+						refresh_token: 'refresh_token',
+						token_type: 'token_type',
+						expires_in: 'expires_in',
+					}),
+				),
+			});
+
+			await completeOAuthFlow(testInput);
+
+			expect(addActiveSession).toHaveBeenCalledWith('testuser');
+			expect(mockResolveAndClearInflightPromises).toHaveBeenCalledTimes(1);
+			expect(addActiveSession.mock.invocationCallOrder[0]).toBeLessThan(
+				mockResolveAndClearInflightPromises.mock.invocationCallOrder[0],
+			);
+		});
+
 		it('throws (and does not cache tokens) when no username claim can be resolved', async () => {
 			mockCacheCognitoTokens.mockClear();
 			mockValidateState.mockReturnValueOnce('myState-valid_state');

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
@@ -81,6 +81,7 @@ describe('completeOAuthFlow', () => {
 		// session roster and resolves the signed-in user for its event payload.
 		(tokenOrchestrator.getTokenStore as jest.Mock).mockReturnValue({
 			getAuthUserList: jest.fn().mockResolvedValue([]),
+			getActiveUsername: jest.fn().mockResolvedValue(undefined),
 			addActiveSession: jest.fn().mockResolvedValue(undefined),
 		});
 		(getCurrentUser as jest.Mock).mockResolvedValue({

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthFlow.test.ts
@@ -215,6 +215,15 @@ describe('completeOAuthFlow', () => {
 			expect(oAuthStore.clearOAuthData).toHaveBeenCalledTimes(1);
 			expect(oAuthStore.storeOAuthSignIn).toHaveBeenCalledWith(true, undefined);
 
+			// OAuth metadata must be namespaced under the signed-in user (resolved
+			// from the token claims), NOT the still-stale active pointer — otherwise
+			// a second cookie-sharing subdomain cannot detect the OAuth session on
+			// sign-out (regression: hosted-UI logout never called).
+			expect(tokenOrchestrator.setOAuthMetadata).toHaveBeenCalledWith(
+				{ oauthSignIn: true },
+				'testuser',
+			);
+
 			expect(mockResolveAndClearInflightPromises).toHaveBeenCalledTimes(1);
 
 			expect(mockReplaceState).toHaveBeenCalledWith(

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthSignOut.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthSignOut.test.ts
@@ -1,12 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Hub, clearCredentials } from '@aws-amplify/core';
-import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
+import { clearCredentials } from '@aws-amplify/core';
 
 import { tokenOrchestrator } from '../../../../../src/providers/cognito/tokenProvider/tokenProvider';
 import { completeOAuthSignOut } from '../../../../../src/providers/cognito/utils/oauth/completeOAuthSignOut';
+import { dispatchSignOutBoundaryEvents } from '../../../../../src/providers/cognito/utils/dispatchSignOutHubEvents';
 import { DefaultOAuthStore } from '../../../../../src/providers/cognito/utils/signInWithRedirectStore';
+import { AuthTokenStore } from '../../../../../src/providers/cognito/tokenProvider/types';
 
 jest.mock('@aws-amplify/core', () => {
 	return {
@@ -18,38 +19,96 @@ jest.mock('@aws-amplify/core', () => {
 	};
 });
 jest.mock('../../../../../src/providers/cognito/tokenProvider/tokenProvider');
+jest.mock(
+	'../../../../../src/providers/cognito/utils/dispatchSignOutHubEvents',
+);
 
 describe('completeOAuthSignOut', () => {
 	// assert mocks
 	const mockClearCredentials = clearCredentials as jest.Mock;
-	const mockHub = Hub as jest.Mocked<typeof Hub>;
 	const mockTokenOrchestrator = tokenOrchestrator as jest.Mocked<
 		typeof tokenOrchestrator
 	>;
+	const mockDispatchSignOutBoundaryEvents =
+		dispatchSignOutBoundaryEvents as jest.Mock;
 
 	// create mocks
+	const activeUser = { username: 'user1', userId: 'user1-sub' };
+	const mockLoadTokens = jest.fn();
+	const mockGetLastAuthUser = jest.fn();
+	const mockClearTokensForUser = jest.fn();
+	const mockRemoveSession = jest.fn();
+	const mockTokenStore = {
+		loadTokens: mockLoadTokens,
+		getLastAuthUser: mockGetLastAuthUser,
+		clearTokensForUser: mockClearTokensForUser,
+		removeSession: mockRemoveSession,
+	};
 	const mockStore = {
 		clearOAuthData: jest.fn(),
 	} as unknown as jest.Mocked<DefaultOAuthStore>;
 
+	beforeEach(() => {
+		mockTokenOrchestrator.getTokenStore.mockReturnValue(
+			mockTokenStore as unknown as AuthTokenStore,
+		);
+		mockLoadTokens.mockResolvedValue({
+			username: activeUser.username,
+			idToken: { payload: { sub: activeUser.userId } },
+		});
+		mockGetLastAuthUser.mockResolvedValue(activeUser.username);
+		mockClearTokensForUser.mockResolvedValue(undefined);
+		mockRemoveSession.mockResolvedValue({
+			newActiveUser: undefined,
+			isEmpty: true,
+		});
+	});
+
 	afterEach(() => {
 		mockStore.clearOAuthData.mockClear();
 		mockClearCredentials.mockClear();
-		mockHub.dispatch.mockClear();
-		mockTokenOrchestrator.clearTokens.mockClear();
+		mockLoadTokens.mockReset();
+		mockGetLastAuthUser.mockReset();
+		mockClearTokensForUser.mockReset();
+		mockRemoveSession.mockReset();
+		mockDispatchSignOutBoundaryEvents.mockClear();
+		mockTokenOrchestrator.getTokenStore.mockReset();
 	});
 
-	it('should complete OAuth sign out', async () => {
+	it('clears OAuth data and scopes token removal to the active user only', async () => {
 		await completeOAuthSignOut(mockStore);
 
 		expect(mockStore.clearOAuthData).toHaveBeenCalledTimes(1);
-		expect(mockTokenOrchestrator.clearTokens).toHaveBeenCalledTimes(1);
+		// per-user scope: a blanket clearTokens() would orphan parked sessions.
+		expect(mockTokenOrchestrator.clearTokens).not.toHaveBeenCalled();
+		expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
+		expect(mockRemoveSession).toHaveBeenCalledWith(activeUser.username);
 		expect(mockClearCredentials).toHaveBeenCalledTimes(1);
-		expect(mockHub.dispatch).toHaveBeenCalledWith(
-			'auth',
-			{ event: 'signedOut' },
-			'Auth',
-			AMPLIFY_SYMBOL,
+		expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
+			mockTokenStore,
+			activeUser,
+			{
+				newActiveUser: undefined,
+				isEmpty: true,
+			},
+		);
+	});
+
+	it('falls back to getLastAuthUser when stored tokens are unavailable', async () => {
+		mockLoadTokens.mockResolvedValue(null);
+
+		await completeOAuthSignOut(mockStore);
+
+		expect(mockGetLastAuthUser).toHaveBeenCalledTimes(1);
+		expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
+		// no resolvable userId -> signedOutUser is undefined.
+		expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
+			mockTokenStore,
+			undefined,
+			{
+				newActiveUser: undefined,
+				isEmpty: true,
+			},
 		);
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthSignOut.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthSignOut.test.ts
@@ -34,15 +34,17 @@ describe('completeOAuthSignOut', () => {
 
 	// create mocks
 	const activeUser = { username: 'user1', userId: 'user1-sub' };
-	const mockLoadTokens = jest.fn();
 	const mockGetLastAuthUser = jest.fn();
+	const mockGetStoredIdToken = jest.fn();
 	const mockClearTokensForUser = jest.fn();
 	const mockRemoveSession = jest.fn();
+	const mockClearActiveUser = jest.fn();
 	const mockTokenStore = {
-		loadTokens: mockLoadTokens,
 		getLastAuthUser: mockGetLastAuthUser,
+		getStoredIdToken: mockGetStoredIdToken,
 		clearTokensForUser: mockClearTokensForUser,
 		removeSession: mockRemoveSession,
+		clearActiveUser: mockClearActiveUser,
 	};
 	const mockStore = {
 		clearOAuthData: jest.fn(),
@@ -52,30 +54,28 @@ describe('completeOAuthSignOut', () => {
 		mockTokenOrchestrator.getTokenStore.mockReturnValue(
 			mockTokenStore as unknown as AuthTokenStore,
 		);
-		mockLoadTokens.mockResolvedValue({
-			username: activeUser.username,
-			idToken: { payload: { sub: activeUser.userId } },
-		});
 		mockGetLastAuthUser.mockResolvedValue(activeUser.username);
-		mockClearTokensForUser.mockResolvedValue(undefined);
-		mockRemoveSession.mockResolvedValue({
-			newActiveUser: undefined,
-			isEmpty: true,
+		mockGetStoredIdToken.mockResolvedValue({
+			payload: { sub: activeUser.userId },
 		});
+		mockClearTokensForUser.mockResolvedValue(undefined);
+		mockRemoveSession.mockResolvedValue({ isEmpty: true });
+		mockClearActiveUser.mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
 		mockStore.clearOAuthData.mockClear();
 		mockClearCredentials.mockClear();
-		mockLoadTokens.mockReset();
 		mockGetLastAuthUser.mockReset();
+		mockGetStoredIdToken.mockReset();
 		mockClearTokensForUser.mockReset();
 		mockRemoveSession.mockReset();
+		mockClearActiveUser.mockReset();
 		mockDispatchSignOutBoundaryEvents.mockClear();
 		mockTokenOrchestrator.getTokenStore.mockReset();
 	});
 
-	it('clears OAuth data and scopes token removal to the active user only', async () => {
+	it('clears OAuth data, scopes token removal to the active user and clears the pointer', async () => {
 		await completeOAuthSignOut(mockStore);
 
 		expect(mockStore.clearOAuthData).toHaveBeenCalledTimes(1);
@@ -83,32 +83,22 @@ describe('completeOAuthSignOut', () => {
 		expect(mockTokenOrchestrator.clearTokens).not.toHaveBeenCalled();
 		expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
 		expect(mockRemoveSession).toHaveBeenCalledWith(activeUser.username);
+		// no-promotion sign-out clears the active pointer explicitly.
+		expect(mockClearActiveUser).toHaveBeenCalledTimes(1);
 		expect(mockClearCredentials).toHaveBeenCalledTimes(1);
-		expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
-			mockTokenStore,
-			activeUser,
-			{
-				newActiveUser: undefined,
-				isEmpty: true,
-			},
-		);
+		// signedOut ALWAYS with resolvable user data; no promotion arg.
+		expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(activeUser);
 	});
 
-	it('falls back to getLastAuthUser when stored tokens are unavailable', async () => {
-		mockLoadTokens.mockResolvedValue(null);
+	it('dispatches with no user data when the stored id token is unavailable', async () => {
+		mockGetStoredIdToken.mockResolvedValue(undefined);
 
 		await completeOAuthSignOut(mockStore);
 
 		expect(mockGetLastAuthUser).toHaveBeenCalledTimes(1);
 		expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
+		expect(mockClearActiveUser).toHaveBeenCalledTimes(1);
 		// no resolvable userId -> signedOutUser is undefined.
-		expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(
-			mockTokenStore,
-			undefined,
-			{
-				newActiveUser: undefined,
-				isEmpty: true,
-			},
-		);
+		expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(undefined);
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthSignOut.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/completeOAuthSignOut.test.ts
@@ -35,12 +35,14 @@ describe('completeOAuthSignOut', () => {
 	// create mocks
 	const activeUser = { username: 'user1', userId: 'user1-sub' };
 	const mockGetLastAuthUser = jest.fn();
+	const mockGetActiveUsername = jest.fn();
 	const mockGetStoredIdToken = jest.fn();
 	const mockClearTokensForUser = jest.fn();
 	const mockRemoveSession = jest.fn();
 	const mockClearActiveUser = jest.fn();
 	const mockTokenStore = {
 		getLastAuthUser: mockGetLastAuthUser,
+		getActiveUsername: mockGetActiveUsername,
 		getStoredIdToken: mockGetStoredIdToken,
 		clearTokensForUser: mockClearTokensForUser,
 		removeSession: mockRemoveSession,
@@ -55,6 +57,7 @@ describe('completeOAuthSignOut', () => {
 			mockTokenStore as unknown as AuthTokenStore,
 		);
 		mockGetLastAuthUser.mockResolvedValue(activeUser.username);
+		mockGetActiveUsername.mockResolvedValue(activeUser.username);
 		mockGetStoredIdToken.mockResolvedValue({
 			payload: { sub: activeUser.userId },
 		});
@@ -67,6 +70,7 @@ describe('completeOAuthSignOut', () => {
 		mockStore.clearOAuthData.mockClear();
 		mockClearCredentials.mockClear();
 		mockGetLastAuthUser.mockReset();
+		mockGetActiveUsername.mockReset();
 		mockGetStoredIdToken.mockReset();
 		mockClearTokensForUser.mockReset();
 		mockRemoveSession.mockReset();
@@ -95,10 +99,25 @@ describe('completeOAuthSignOut', () => {
 
 		await completeOAuthSignOut(mockStore);
 
-		expect(mockGetLastAuthUser).toHaveBeenCalledTimes(1);
+		expect(mockGetActiveUsername).toHaveBeenCalledTimes(1);
 		expect(mockClearTokensForUser).toHaveBeenCalledWith(activeUser.username);
 		expect(mockClearActiveUser).toHaveBeenCalledTimes(1);
 		// no resolvable userId -> signedOutUser is undefined.
 		expect(mockDispatchSignOutBoundaryEvents).toHaveBeenCalledWith(undefined);
+	});
+
+	it('clears OAuth data but is otherwise a no-op with NO signedOut event when there is no active user', async () => {
+		// parked-only/empty roster: nobody active. OAuth data is still cleared, but
+		// no token/roster mutation happens and signedOut fires for nobody.
+		mockGetActiveUsername.mockResolvedValue(undefined);
+
+		await completeOAuthSignOut(mockStore);
+
+		expect(mockStore.clearOAuthData).toHaveBeenCalledTimes(1);
+		expect(mockClearTokensForUser).not.toHaveBeenCalled();
+		expect(mockRemoveSession).not.toHaveBeenCalled();
+		expect(mockClearActiveUser).not.toHaveBeenCalled();
+		expect(mockClearCredentials).not.toHaveBeenCalled();
+		expect(mockDispatchSignOutBoundaryEvents).not.toHaveBeenCalled();
 	});
 });

--- a/packages/auth/src/client/flows/userAuth/handleWebAuthnSignInResult.ts
+++ b/packages/auth/src/client/flows/userAuth/handleWebAuthnSignInResult.ts
@@ -16,6 +16,7 @@ import {
 import { getRegionFromUserPoolId } from '../../../foundation/parsers';
 import { createCognitoUserPoolEndpointResolver } from '../../../providers/cognito/factories';
 import { cacheCognitoTokens } from '../../../providers/cognito/tokenProvider/cacheTokens';
+import { tokenOrchestrator } from '../../../providers/cognito/tokenProvider';
 import { dispatchSignedInHubEvent } from '../../../providers/cognito/utils/dispatchSignedInHubEvent';
 import { setActiveSignInState, signInStore } from '../../../client/utils/store';
 import { getAuthUserAgentValue } from '../../../utils';
@@ -101,7 +102,7 @@ export async function handleWebAuthnSignInResult(
 			signInDetails,
 		});
 		signInStore.dispatch({ type: 'RESET_STATE' });
-		await dispatchSignedInHubEvent();
+		await dispatchSignedInHubEvent(tokenOrchestrator.getTokenStore(), username);
 
 		return {
 			isSignedIn: true,

--- a/packages/auth/src/client/flows/userAuth/handleWebAuthnSignInResult.ts
+++ b/packages/auth/src/client/flows/userAuth/handleWebAuthnSignInResult.ts
@@ -102,7 +102,7 @@ export async function handleWebAuthnSignInResult(
 			signInDetails,
 		});
 		signInStore.dispatch({ type: 'RESET_STATE' });
-		await dispatchSignedInHubEvent(ctx);
+		await dispatchSignedInHubEvent(ctx, username);
 
 		return {
 			isSignedIn: true,

--- a/packages/auth/src/errors/constants.ts
+++ b/packages/auth/src/errors/constants.ts
@@ -4,6 +4,7 @@
 import { AuthError } from './AuthError';
 
 export const USER_UNAUTHENTICATED_EXCEPTION = 'UserUnAuthenticatedException';
+export const USER_NOT_SIGNED_IN_EXCEPTION = 'UserNotSignedInException';
 export const USER_ALREADY_AUTHENTICATED_EXCEPTION =
 	'UserAlreadyAuthenticatedException';
 export const DEVICE_METADATA_NOT_FOUND_EXCEPTION =

--- a/packages/auth/src/errors/constants.ts
+++ b/packages/auth/src/errors/constants.ts
@@ -5,6 +5,7 @@ import { AuthError } from './AuthError';
 
 export const USER_UNAUTHENTICATED_EXCEPTION = 'UserUnAuthenticatedException';
 export const USER_NOT_SIGNED_IN_EXCEPTION = 'UserNotSignedInException';
+export const SESSION_PERSISTENCE_EXCEPTION = 'SessionPersistenceException';
 export const USER_ALREADY_AUTHENTICATED_EXCEPTION =
 	'UserAlreadyAuthenticatedException';
 export const DEVICE_METADATA_NOT_FOUND_EXCEPTION =

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -18,6 +18,8 @@ export {
 	updateUserAttributes,
 	updateUserAttribute,
 	getCurrentUser,
+	listCurrentUsers,
+	setCurrentUser,
 	confirmUserAttribute,
 	signInWithRedirect,
 	fetchUserAttributes,

--- a/packages/auth/src/providers/cognito/apis/confirmSignIn.ts
+++ b/packages/auth/src/providers/cognito/apis/confirmSignIn.ts
@@ -122,7 +122,10 @@ export async function confirmSignIn(
 			});
 			resetActiveSignInState();
 
-			await dispatchSignedInHubEvent();
+			await dispatchSignedInHubEvent(
+				tokenOrchestrator.getTokenStore(),
+				username,
+			);
 
 			return {
 				isSignedIn: true,

--- a/packages/auth/src/providers/cognito/apis/confirmSignIn.ts
+++ b/packages/auth/src/providers/cognito/apis/confirmSignIn.ts
@@ -134,7 +134,7 @@ export async function confirmSignIn(
 			});
 			resetActiveSignInState();
 
-			await dispatchSignedInHubEvent(ctx);
+			await dispatchSignedInHubEvent(ctx, username);
 
 			return {
 				isSignedIn: true,

--- a/packages/auth/src/providers/cognito/apis/listCurrentUsers.ts
+++ b/packages/auth/src/providers/cognito/apis/listCurrentUsers.ts
@@ -2,14 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Amplify } from '@aws-amplify/core';
-import {
-	assertTokenProviderConfig,
-	decodeJWT,
-} from '@aws-amplify/core/internals/utils';
+import { assertTokenProviderConfig } from '@aws-amplify/core/internals/utils';
 
 import { AuthUser } from '../types/models';
 import { cognitoUserPoolsTokenProvider } from '../tokenProvider';
-import { AUTH_KEY_PREFIX } from '../tokenProvider/constants';
 
 /**
  * Lists all the users currently signed in for the configured user pool, in
@@ -38,42 +34,35 @@ export async function listCurrentUsers(): Promise<AuthUser[]> {
 	// fail to resolve become undefined and are filtered out below (self-healing).
 	const resolvedUsers = await Promise.all(
 		roster.map(async rosterUsername => {
-			try {
-				const idTokenKey = `${AUTH_KEY_PREFIX}.${userPoolClientId}.${rosterUsername}.idToken`;
-				const idTokenString = await keyValueStorage.getItem(idTokenKey);
+			const idToken = await authTokenStore.getStoredIdToken(rosterUsername);
 
-				if (!idTokenString) {
-					return undefined;
-				}
-
-				const idToken = decodeJWT(idTokenString);
-				const { 'cognito:username': cognitoUsername, sub } =
-					idToken?.payload ?? {};
-
-				// Drop users whose stored id token lacks a `sub` claim: without
-				// `sub` the AuthUser userId contract (always a string) cannot be
-				// satisfied, so treat them as unresolvable.
-				if (!sub) {
-					return undefined;
-				}
-
-				const authUser: AuthUser = {
-					username: (cognitoUsername as string) ?? rosterUsername,
-					userId: sub as string,
-				};
-
-				const signInDetailsKey = `${AUTH_KEY_PREFIX}.${userPoolClientId}.${rosterUsername}.signInDetails`;
-				const signInDetailsString =
-					await keyValueStorage.getItem(signInDetailsKey);
-				if (signInDetailsString) {
-					authUser.signInDetails = JSON.parse(signInDetailsString);
-				}
-
-				return authUser;
-			} catch (err) {
-				// Skip any user whose stored tokens cannot be resolved.
+			if (!idToken) {
 				return undefined;
 			}
+
+			const { 'cognito:username': cognitoUsername, sub } =
+				idToken.payload ?? {};
+
+			// Drop users whose stored id token lacks a `sub` claim: without
+			// `sub` the AuthUser userId contract (always a string) cannot be
+			// satisfied, so treat them as unresolvable.
+			if (!sub) {
+				return undefined;
+			}
+
+			const authUser: AuthUser = {
+				username: (cognitoUsername as string) ?? rosterUsername,
+				userId: sub as string,
+			};
+
+			const signInDetailsKey = `CognitoIdentityServiceProvider.${userPoolClientId}.${rosterUsername}.signInDetails`;
+			const signInDetailsString =
+				await keyValueStorage.getItem(signInDetailsKey);
+			if (signInDetailsString) {
+				authUser.signInDetails = JSON.parse(signInDetailsString);
+			}
+
+			return authUser;
 		}),
 	);
 

--- a/packages/auth/src/providers/cognito/apis/listCurrentUsers.ts
+++ b/packages/auth/src/providers/cognito/apis/listCurrentUsers.ts
@@ -1,0 +1,81 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify } from '@aws-amplify/core';
+import {
+	assertTokenProviderConfig,
+	decodeJWT,
+} from '@aws-amplify/core/internals/utils';
+
+import { AuthUser } from '../types/models';
+import { cognitoUserPoolsTokenProvider } from '../tokenProvider';
+import { AUTH_KEY_PREFIX } from '../tokenProvider/constants';
+
+/**
+ * Lists all the users currently signed in for the configured user pool, in
+ * roster order (the active user first).
+ *
+ * Each user's identity is resolved from that user's STORED id token without
+ * triggering a token refresh. Any user whose stored tokens cannot be resolved
+ * is skipped, keeping the returned list self-healing.
+ *
+ * @returns An array of AuthUser objects, one per resolvable session, ordered
+ * with the active user first.
+ * @throws AuthTokenConfigException - Thrown when the token provider config is invalid.
+ */
+export async function listCurrentUsers(): Promise<AuthUser[]> {
+	const authConfig = Amplify.getConfig().Auth?.Cognito;
+	assertTokenProviderConfig(authConfig);
+	const { userPoolClientId } = authConfig;
+
+	const { authTokenStore } = cognitoUserPoolsTokenProvider;
+	const keyValueStorage = authTokenStore.getKeyValueStorage();
+
+	// Roster is ordered with the active user first; preserve that order.
+	const roster = await authTokenStore.getAuthUserList();
+
+	// Resolve each user in parallel while preserving roster order; users that
+	// fail to resolve become undefined and are filtered out below (self-healing).
+	const resolvedUsers = await Promise.all(
+		roster.map(async rosterUsername => {
+			try {
+				const idTokenKey = `${AUTH_KEY_PREFIX}.${userPoolClientId}.${rosterUsername}.idToken`;
+				const idTokenString = await keyValueStorage.getItem(idTokenKey);
+
+				if (!idTokenString) {
+					return undefined;
+				}
+
+				const idToken = decodeJWT(idTokenString);
+				const { 'cognito:username': cognitoUsername, sub } =
+					idToken?.payload ?? {};
+
+				// Drop users whose stored id token lacks a `sub` claim: without
+				// `sub` the AuthUser userId contract (always a string) cannot be
+				// satisfied, so treat them as unresolvable.
+				if (!sub) {
+					return undefined;
+				}
+
+				const authUser: AuthUser = {
+					username: (cognitoUsername as string) ?? rosterUsername,
+					userId: sub as string,
+				};
+
+				const signInDetailsKey = `${AUTH_KEY_PREFIX}.${userPoolClientId}.${rosterUsername}.signInDetails`;
+				const signInDetailsString =
+					await keyValueStorage.getItem(signInDetailsKey);
+				if (signInDetailsString) {
+					authUser.signInDetails = JSON.parse(signInDetailsString);
+				}
+
+				return authUser;
+			} catch (err) {
+				// Skip any user whose stored tokens cannot be resolved.
+				return undefined;
+			}
+		}),
+	);
+
+	return resolvedUsers.filter((user): user is AuthUser => user !== undefined);
+}

--- a/packages/auth/src/providers/cognito/apis/listCurrentUsers.ts
+++ b/packages/auth/src/providers/cognito/apis/listCurrentUsers.ts
@@ -1,15 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 import {
 	assertTokenProviderConfig,
-	decodeJWT,
+	resolveCtxArgs,
 } from '@aws-amplify/core/internals/utils';
 
 import { AuthUser } from '../types/models';
 import { cognitoUserPoolsTokenProvider } from '../tokenProvider';
-import { AUTH_KEY_PREFIX } from '../tokenProvider/constants';
+
+export async function listCurrentUsers(
+	ctx: AmplifyContext,
+): Promise<AuthUser[]>;
 
 /**
  * Lists all the users currently signed in for the configured user pool, in
@@ -23,8 +26,10 @@ import { AUTH_KEY_PREFIX } from '../tokenProvider/constants';
  * with the active user first.
  * @throws AuthTokenConfigException - Thrown when the token provider config is invalid.
  */
-export async function listCurrentUsers(): Promise<AuthUser[]> {
-	const authConfig = Amplify.getConfig().Auth?.Cognito;
+export async function listCurrentUsers(): Promise<AuthUser[]>;
+export async function listCurrentUsers(...args: any[]): Promise<AuthUser[]> {
+	const [ctx] = resolveCtxArgs<[]>(args);
+	const authConfig = ctx.resourcesConfig.Auth?.Cognito;
 	assertTokenProviderConfig(authConfig);
 	const { userPoolClientId } = authConfig;
 
@@ -38,42 +43,35 @@ export async function listCurrentUsers(): Promise<AuthUser[]> {
 	// fail to resolve become undefined and are filtered out below (self-healing).
 	const resolvedUsers = await Promise.all(
 		roster.map(async rosterUsername => {
-			try {
-				const idTokenKey = `${AUTH_KEY_PREFIX}.${userPoolClientId}.${rosterUsername}.idToken`;
-				const idTokenString = await keyValueStorage.getItem(idTokenKey);
+			const idToken = await authTokenStore.getStoredIdToken(rosterUsername);
 
-				if (!idTokenString) {
-					return undefined;
-				}
-
-				const idToken = decodeJWT(idTokenString);
-				const { 'cognito:username': cognitoUsername, sub } =
-					idToken?.payload ?? {};
-
-				// Drop users whose stored id token lacks a `sub` claim: without
-				// `sub` the AuthUser userId contract (always a string) cannot be
-				// satisfied, so treat them as unresolvable.
-				if (!sub) {
-					return undefined;
-				}
-
-				const authUser: AuthUser = {
-					username: (cognitoUsername as string) ?? rosterUsername,
-					userId: sub as string,
-				};
-
-				const signInDetailsKey = `${AUTH_KEY_PREFIX}.${userPoolClientId}.${rosterUsername}.signInDetails`;
-				const signInDetailsString =
-					await keyValueStorage.getItem(signInDetailsKey);
-				if (signInDetailsString) {
-					authUser.signInDetails = JSON.parse(signInDetailsString);
-				}
-
-				return authUser;
-			} catch (err) {
-				// Skip any user whose stored tokens cannot be resolved.
+			if (!idToken) {
 				return undefined;
 			}
+
+			const { 'cognito:username': cognitoUsername, sub } =
+				idToken.payload ?? {};
+
+			// Drop users whose stored id token lacks a `sub` claim: without
+			// `sub` the AuthUser userId contract (always a string) cannot be
+			// satisfied, so treat them as unresolvable.
+			if (!sub) {
+				return undefined;
+			}
+
+			const authUser: AuthUser = {
+				username: (cognitoUsername as string) ?? rosterUsername,
+				userId: sub as string,
+			};
+
+			const signInDetailsKey = `CognitoIdentityServiceProvider.${userPoolClientId}.${rosterUsername}.signInDetails`;
+			const signInDetailsString =
+				await keyValueStorage.getItem(signInDetailsKey);
+			if (signInDetailsString) {
+				authUser.signInDetails = JSON.parse(signInDetailsString);
+			}
+
+			return authUser;
 		}),
 	);
 

--- a/packages/auth/src/providers/cognito/apis/listCurrentUsers.ts
+++ b/packages/auth/src/providers/cognito/apis/listCurrentUsers.ts
@@ -31,10 +31,8 @@ export async function listCurrentUsers(...args: any[]): Promise<AuthUser[]> {
 	const [ctx] = resolveCtxArgs<[]>(args);
 	const authConfig = ctx.resourcesConfig.Auth?.Cognito;
 	assertTokenProviderConfig(authConfig);
-	const { userPoolClientId } = authConfig;
 
 	const { authTokenStore } = cognitoUserPoolsTokenProvider;
-	const keyValueStorage = authTokenStore.getKeyValueStorage();
 
 	// Roster is ordered with the active user first; preserve that order.
 	const roster = await authTokenStore.getAuthUserList();
@@ -64,11 +62,12 @@ export async function listCurrentUsers(...args: any[]): Promise<AuthUser[]> {
 				userId: sub as string,
 			};
 
-			const signInDetailsKey = `CognitoIdentityServiceProvider.${userPoolClientId}.${rosterUsername}.signInDetails`;
-			const signInDetailsString =
-				await keyValueStorage.getItem(signInDetailsKey);
-			if (signInDetailsString) {
-				authUser.signInDetails = JSON.parse(signInDetailsString);
+			// Keyed via the shared store helper (getAuthKeys) rather than a
+			// hand-built key template, avoiding drift with the token namespace.
+			const signInDetails =
+				await authTokenStore.getStoredSignInDetails(rosterUsername);
+			if (signInDetails) {
+				authUser.signInDetails = signInDetails;
 			}
 
 			return authUser;

--- a/packages/auth/src/providers/cognito/apis/server/index.ts
+++ b/packages/auth/src/providers/cognito/apis/server/index.ts
@@ -3,3 +3,5 @@
 
 export { fetchUserAttributes } from './fetchUserAttributes';
 export { getCurrentUser } from './getCurrentUser';
+export { listCurrentUsers } from './listCurrentUsers';
+export { setCurrentUser } from './setCurrentUser';

--- a/packages/auth/src/providers/cognito/apis/server/index.ts
+++ b/packages/auth/src/providers/cognito/apis/server/index.ts
@@ -1,8 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Pattern 6 (Phase C4): bare re-export of the ctx-native main APIs. They accept
-// `(ctx, input)` via overloads, so no server-specific wrapper or
-// `resolveServerContext` is needed — the caller supplies a branded
+// Pattern 6 (Phase C4): fetchUserAttributes/getCurrentUser are bare re-exports
+// of the ctx-native main APIs. They accept `(ctx, input)` via overloads, so no
+// server-specific wrapper is needed — the caller supplies a branded
 // `AmplifyContext` as the first argument.
 export { fetchUserAttributes, getCurrentUser } from '../..';
+
+// Multi-session server APIs keep dedicated wrappers: their server behavior
+// differs from the client variants (they do NOT emit a `switchActiveUser` Hub
+// event), and they reach the non-destructive session switcher through the
+// per-request context (`ctx.libraryOptions.Auth.tokenProvider`) rather than any
+// global singleton. The HLD's server semantics are authoritative here.
+export { listCurrentUsers } from './listCurrentUsers';
+export { setCurrentUser } from './setCurrentUser';

--- a/packages/auth/src/providers/cognito/apis/server/listCurrentUsers.ts
+++ b/packages/auth/src/providers/cognito/apis/server/listCurrentUsers.ts
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+
+import { AuthUser } from '../../types';
+
+import { resolveSessionSwitcher } from './resolveSessionSwitcher';
+
+/**
+ * Lists all the users currently signed in for the configured user pool, in
+ * roster order (the active user first), from a server context.
+ *
+ * Each user's identity is resolved from that user's STORED id token without
+ * triggering a token refresh or emitting any Hub event. Any user whose stored
+ * id token cannot be resolved is skipped, keeping the returned list
+ * self-healing.
+ *
+ * @param contextSpec - The context spec used to get the Amplify server context.
+ * @returns An array of AuthUser objects, one per resolvable session, ordered
+ * with the active user first.
+ * @throws AuthTokenConfigException - Thrown when the token provider config is invalid.
+ * @throws {@link AuthError} - Thrown with name `TokenProviderNotFoundException`
+ * when no token provider is configured on the resolved context.
+ */
+export const listCurrentUsers = async (
+	contextSpec: AmplifyServer.ContextSpec,
+): Promise<AuthUser[]> => {
+	const { amplify } = getAmplifyServerContext(contextSpec);
+	const switcher = resolveSessionSwitcher(amplify);
+
+	// Roster is ordered with the active user first; preserve that order.
+	const roster = await switcher.listSessionUsernames();
+
+	// Resolve each user in parallel while preserving roster order; users that
+	// fail to resolve become undefined and are filtered out below (self-healing).
+	const resolvedUsers = await Promise.all(
+		roster.map(async rosterUsername => {
+			const idToken = await switcher.getStoredIdToken(rosterUsername);
+
+			const { 'cognito:username': cognitoUsername, sub } =
+				idToken?.payload ?? {};
+
+			// Drop users whose stored id token is missing or lacks a `sub`
+			// claim: without `sub` the AuthUser userId contract (always a
+			// string) cannot be satisfied, so treat them as unresolvable.
+			if (!idToken || !sub) {
+				return undefined;
+			}
+
+			const authUser: AuthUser = {
+				username: (cognitoUsername as string) ?? rosterUsername,
+				userId: sub as string,
+			};
+
+			return authUser;
+		}),
+	);
+
+	return resolvedUsers.filter((user): user is AuthUser => user !== undefined);
+};

--- a/packages/auth/src/providers/cognito/apis/server/listCurrentUsers.ts
+++ b/packages/auth/src/providers/cognito/apis/server/listCurrentUsers.ts
@@ -25,6 +25,8 @@ import { resolveSessionSwitcher } from './resolveSessionSwitcher';
  * @throws AuthTokenConfigException - Thrown when the token provider config is invalid.
  * @throws {@link AuthError} - Thrown with name `TokenProviderNotFoundException`
  * when no token provider is configured on the resolved context.
+ * @remarks Unlike the client variant, AuthUser objects returned in the server
+ * context do not include signInDetails.
  */
 export const listCurrentUsers = async (
 	contextSpec: AmplifyServer.ContextSpec,

--- a/packages/auth/src/providers/cognito/apis/server/resolveSessionSwitcher.ts
+++ b/packages/auth/src/providers/cognito/apis/server/resolveSessionSwitcher.ts
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AmplifyClassV6, TokenProvider } from '@aws-amplify/core';
+
+import { AuthError } from '../../../../errors/AuthError';
+import { AuthSessionSwitcher } from '../../tokenProvider';
+
+/**
+ * A token provider that additionally exposes a session switcher. This mirrors
+ * the shape surfaced by the Cognito server token provider without importing it
+ * (keeping `auth` free of a dependency on `aws-amplify`).
+ */
+type SessionSwitcherProvider = TokenProvider & {
+	getSessionSwitcher(): AuthSessionSwitcher;
+};
+
+const hasSessionSwitcher = (
+	provider: TokenProvider,
+): provider is SessionSwitcherProvider =>
+	'getSessionSwitcher' in provider &&
+	typeof (provider as SessionSwitcherProvider).getSessionSwitcher ===
+		'function';
+
+/**
+ * Resolves the non-destructive {@link AuthSessionSwitcher} from the token
+ * provider configured on the given (server) Amplify context.
+ *
+ * @param amplify - The Amplify instance from the server context.
+ * @returns The session switcher surfaced by the per-request token provider.
+ * @throws {@link AuthError} - With name `TokenProviderNotFoundException` when no
+ * session-switching token provider is configured on the context.
+ */
+export const resolveSessionSwitcher = (
+	amplify: AmplifyClassV6,
+): AuthSessionSwitcher => {
+	const tokenProvider = amplify.Auth.getTokenProvider();
+
+	if (!tokenProvider || !hasSessionSwitcher(tokenProvider)) {
+		throw new AuthError({
+			name: 'TokenProviderNotFoundException',
+			message:
+				'The configured token provider does not support multi-session switching.',
+			recoverySuggestion:
+				'Ensure the Amplify server context is created with the Cognito user pools token provider.',
+		});
+	}
+
+	return tokenProvider.getSessionSwitcher();
+};

--- a/packages/auth/src/providers/cognito/apis/server/resolveSessionSwitcher.ts
+++ b/packages/auth/src/providers/cognito/apis/server/resolveSessionSwitcher.ts
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AmplifyContext, TokenProvider } from '@aws-amplify/core';
+
+import { AuthError } from '../../../../errors/AuthError';
+import { AuthSessionSwitcher } from '../../tokenProvider';
+
+/**
+ * A token provider that additionally exposes a session switcher. This mirrors
+ * the shape surfaced by the Cognito server token provider without importing it
+ * (keeping `auth` free of a dependency on `aws-amplify`).
+ */
+type SessionSwitcherProvider = TokenProvider & {
+	getSessionSwitcher(): AuthSessionSwitcher;
+};
+
+const hasSessionSwitcher = (
+	provider: TokenProvider,
+): provider is SessionSwitcherProvider =>
+	'getSessionSwitcher' in provider &&
+	typeof (provider as SessionSwitcherProvider).getSessionSwitcher ===
+		'function';
+
+/**
+ * Resolves the non-destructive {@link AuthSessionSwitcher} from the token
+ * provider configured on the given (server) Amplify context.
+ *
+ * Post Phase-C the server `AmplifyContext` is a narrow, branded object that no
+ * longer exposes a bare `Amplify` class. The per-request Cognito token provider
+ * is instead injected on `libraryOptions.Auth.tokenProvider` (see the
+ * `aws-amplify` server-context bridge / `createAmplifyContext`), which is a
+ * public, per-request-isolated surface. We read the switcher from there.
+ *
+ * @param ctx - The per-request Amplify context from the server context.
+ * @returns The session switcher surfaced by the per-request token provider.
+ * @throws {@link AuthError} - With name `TokenProviderNotFoundException` when no
+ * session-switching token provider is configured on the context.
+ */
+export const resolveSessionSwitcher = (
+	ctx: AmplifyContext,
+): AuthSessionSwitcher => {
+	const tokenProvider = ctx.libraryOptions.Auth?.tokenProvider;
+
+	if (!tokenProvider || !hasSessionSwitcher(tokenProvider)) {
+		throw new AuthError({
+			name: 'TokenProviderNotFoundException',
+			message:
+				'The configured token provider does not support multi-session switching.',
+			recoverySuggestion:
+				'Ensure the Amplify server context is created with the Cognito user pools token provider.',
+		});
+	}
+
+	return tokenProvider.getSessionSwitcher();
+};

--- a/packages/auth/src/providers/cognito/apis/server/setCurrentUser.ts
+++ b/packages/auth/src/providers/cognito/apis/server/setCurrentUser.ts
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+
+import { resolveSessionSwitcher } from './resolveSessionSwitcher';
+
+/**
+ * Switches the active user to a different signed-in user within a server
+ * context, without requiring re-authentication.
+ *
+ * The target user must already be part of the current session roster (i.e. have
+ * signed in previously and not signed out). The active user pointer is moved to
+ * the front of the roster and the previous active user's identity-pool
+ * credentials are cleared (context-scoped) so subsequent credential requests
+ * resolve against the newly active user.
+ *
+ * Unlike the client API, this does NOT emit a `switchActiveUser` Hub event.
+ *
+ * @param contextSpec - The context spec used to get the Amplify server context.
+ * @param username - The username of the signed-in user to switch to.
+ * @returns void
+ * @throws {@link AuthError} - Thrown with name `UserNotSignedInException` when
+ * the given username has no signed-in session in the roster.
+ * @throws AuthTokenConfigException - Thrown when the token provider config is invalid.
+ * @throws {@link AuthError} - Thrown with name `TokenProviderNotFoundException`
+ * when no token provider is configured on the resolved context.
+ */
+export const setCurrentUser = async (
+	contextSpec: AmplifyServer.ContextSpec,
+	username: string,
+): Promise<void> => {
+	const { amplify } = getAmplifyServerContext(contextSpec);
+	const switcher = resolveSessionSwitcher(amplify);
+
+	// Membership-checked reorder; throws (UserNotSignedInException) if absent.
+	// Never adds a non-signed-in user and never deletes tokens.
+	await switcher.setActiveSession(username);
+
+	// Bust the previous active user's identity-pool credentials so subsequent
+	// credential requests resolve against the newly active user. Uses the
+	// context-scoped clearCredentials, NOT the global import.
+	await amplify.Auth.clearCredentials();
+};

--- a/packages/auth/src/providers/cognito/apis/server/setCurrentUser.ts
+++ b/packages/auth/src/providers/cognito/apis/server/setCurrentUser.ts
@@ -20,11 +20,21 @@ import { resolveSessionSwitcher } from './resolveSessionSwitcher';
  *
  * Unlike the client API, this does NOT emit a `switchActiveUser` Hub event.
  *
+ * Requires a WRITABLE server context — a Route Handler, Server Action, or
+ * Middleware — because the switch must persist the active-session pointer to
+ * cookie storage. A read-only Server Component context cannot persist the
+ * switch (its response cookies are already committed/immutable); attempting it
+ * there rejects with an `AuthError` named `SessionPersistenceException` rather
+ * than silently appearing to succeed.
+ *
  * @param contextSpec - The context spec used to get the Amplify server context.
  * @param username - The username of the signed-in user to switch to.
  * @returns void
  * @throws {@link AuthError} - Thrown with name `UserNotSignedInException` when
  * the given username has no signed-in session in the roster.
+ * @throws {@link AuthError} - Thrown with name `SessionPersistenceException`
+ * when the switch cannot be persisted (read-only storage / already-committed
+ * response).
  * @throws AuthTokenConfigException - Thrown when the token provider config is invalid.
  * @throws {@link AuthError} - Thrown with name `TokenProviderNotFoundException`
  * when no token provider is configured on the resolved context.

--- a/packages/auth/src/providers/cognito/apis/server/setCurrentUser.ts
+++ b/packages/auth/src/providers/cognito/apis/server/setCurrentUser.ts
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+
+import { resolveSessionSwitcher } from './resolveSessionSwitcher';
+
+/**
+ * Switches the active user to a different signed-in user within a server
+ * context, without requiring re-authentication.
+ *
+ * The target user must already be part of the current session roster (i.e. have
+ * signed in previously and not signed out). The active user pointer is moved to
+ * the front of the roster and the previous active user's identity-pool
+ * credentials are cleared (context-scoped) so subsequent credential requests
+ * resolve against the newly active user.
+ *
+ * Unlike the client API, this does NOT emit a `switchActiveUser` Hub event.
+ *
+ * @param contextSpec - The context spec used to get the Amplify server context.
+ * @param username - The username of the signed-in user to switch to.
+ * @returns void
+ * @throws {@link AuthError} - Thrown with name `UserNotSignedInException` when
+ * the given username has no signed-in session in the roster.
+ * @throws AuthTokenConfigException - Thrown when the token provider config is invalid.
+ * @throws {@link AuthError} - Thrown with name `TokenProviderNotFoundException`
+ * when no token provider is configured on the resolved context.
+ */
+export const setCurrentUser = async (
+	contextSpec: AmplifyServer.ContextSpec,
+	username: string,
+): Promise<void> => {
+	const { amplify } = getAmplifyServerContext(contextSpec);
+	const switcher = resolveSessionSwitcher(amplify);
+
+	// Membership-checked reorder; throws (UserNotSignedInException) if absent.
+	// Never adds a non-signed-in user and never deletes tokens.
+	await switcher.setActiveSession(username);
+
+	// Bust the previous active user's identity-pool credentials so subsequent
+	// credential requests resolve against the newly active user. Uses the
+	// context-scoped clearCredentials, NOT the global import.
+	await amplify.clearCredentials();
+};

--- a/packages/auth/src/providers/cognito/apis/setCurrentUser.ts
+++ b/packages/auth/src/providers/cognito/apis/setCurrentUser.ts
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Amplify, Hub, clearCredentials } from '@aws-amplify/core';
+import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
+
+import { AuthError } from '../../../errors/AuthError';
+import { USER_NOT_SIGNED_IN_EXCEPTION } from '../../../errors/constants';
+import { tokenOrchestrator } from '../tokenProvider';
+
+import { getCurrentUser } from './internal/getCurrentUser';
+
+/**
+ * Switches the active user to a different signed-in user without requiring
+ * re-authentication.
+ *
+ * The target user must already be part of the current session roster (i.e.
+ * have signed in previously and not signed out). The active user pointer is
+ * moved to the front of the roster and the previous active user's identity-pool
+ * credentials are cleared so subsequent credential requests resolve against the
+ * newly active user.
+ *
+ * @param username - The username of the signed-in user to switch to.
+ * @returns void
+ * @throws {@link AuthError} - Thrown with name `UserNotSignedInException` when
+ * the given username has no signed-in session in the roster.
+ * @throws AuthTokenConfigException - Thrown when the token provider config is invalid.
+ */
+export async function setCurrentUser(username: string): Promise<void> {
+	const tokenStore = tokenOrchestrator.getTokenStore();
+	// Roster is ordered with the active user first.
+	const list = await tokenStore.getAuthUserList();
+
+	if (!list.includes(username)) {
+		throw new AuthError({
+			name: USER_NOT_SIGNED_IN_EXCEPTION,
+			message: `Cannot switch to user "${username}": no signed-in session found.`,
+			recoverySuggestion:
+				'Please make sure the user has signed in before switching to it.',
+		});
+	}
+
+	// Already the active user; nothing to switch and no event to emit.
+	if (list[0] === username) {
+		return;
+	}
+
+	// Promote the target user to the front of the roster (new active user).
+	await tokenStore.addActiveSession(username);
+
+	// Bust the previous active user's identity-pool credentials so subsequent
+	// credential requests resolve against the newly active user.
+	await clearCredentials();
+
+	// Resolve the now-active user for the event payload.
+	const currentUser = await getCurrentUser(Amplify);
+	const data = {
+		username: currentUser.username,
+		userId: currentUser.userId,
+	};
+
+	// switchActiveUser fires when the active pointer moves between users.
+	Hub.dispatch(
+		'auth',
+		{
+			event: 'switchActiveUser',
+			data,
+		},
+		'Auth',
+		AMPLIFY_SYMBOL,
+	);
+}

--- a/packages/auth/src/providers/cognito/apis/setCurrentUser.ts
+++ b/packages/auth/src/providers/cognito/apis/setCurrentUser.ts
@@ -1,14 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify, Hub, clearCredentials } from '@aws-amplify/core';
+import { Hub, clearCredentials } from '@aws-amplify/core';
 import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
 
 import { AuthError } from '../../../errors/AuthError';
 import { USER_NOT_SIGNED_IN_EXCEPTION } from '../../../errors/constants';
 import { tokenOrchestrator } from '../tokenProvider';
-
-import { getCurrentUser } from './internal/getCurrentUser';
 
 /**
  * Switches the active user to a different signed-in user without requiring
@@ -52,19 +50,22 @@ export async function setCurrentUser(username: string): Promise<void> {
 	// credential requests resolve against the newly active user.
 	await clearCredentials();
 
-	// Resolve the now-active user for the event payload.
-	const currentUser = await getCurrentUser(Amplify);
-	const data = {
-		username: currentUser.username,
-		userId: currentUser.userId,
-	};
+	// Resolve the now-active user's identity from their stored id token (no
+	// refresh). Skip the dispatch if the id token is undecodable — emitting an
+	// event with userId:'' would violate the AuthUser contract.
+	const idToken = await tokenStore.getStoredIdToken(username);
+	const userId = (idToken?.payload?.sub as string) ?? '';
+
+	if (!userId) {
+		return;
+	}
 
 	// switchActiveUser fires when the active pointer moves between users.
 	Hub.dispatch(
 		'auth',
 		{
 			event: 'switchActiveUser',
-			data,
+			data: { username, userId },
 		},
 		'Auth',
 		AMPLIFY_SYMBOL,

--- a/packages/auth/src/providers/cognito/apis/setCurrentUser.ts
+++ b/packages/auth/src/providers/cognito/apis/setCurrentUser.ts
@@ -1,12 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Hub, clearCredentials } from '@aws-amplify/core';
-import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext, Hub } from '@aws-amplify/core';
+import {
+	AMPLIFY_SYMBOL,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
 
 import { AuthError } from '../../../errors/AuthError';
 import { USER_NOT_SIGNED_IN_EXCEPTION } from '../../../errors/constants';
 import { tokenOrchestrator } from '../tokenProvider';
+
+export async function setCurrentUser(
+	ctx: AmplifyContext,
+	username: string,
+): Promise<void>;
 
 /**
  * Switches the active user to a different signed-in user without requiring
@@ -24,9 +32,12 @@ import { tokenOrchestrator } from '../tokenProvider';
  * the given username has no signed-in session in the roster.
  * @throws AuthTokenConfigException - Thrown when the token provider config is invalid.
  */
-export async function setCurrentUser(username: string): Promise<void> {
+export async function setCurrentUser(username: string): Promise<void>;
+export async function setCurrentUser(...args: any[]): Promise<void> {
+	const [ctx, username] = resolveCtxArgs<[string]>(args);
 	const tokenStore = tokenOrchestrator.getTokenStore();
-	// Roster is ordered with the active user first.
+	// Roster membership is required; the roster may hold parked sessions while no
+	// user is active (empty pointer).
 	const list = await tokenStore.getAuthUserList();
 
 	if (!list.includes(username)) {
@@ -38,17 +49,22 @@ export async function setCurrentUser(username: string): Promise<void> {
 		});
 	}
 
+	// Read the RAW active pointer BEFORE mutating so we can both no-op when the
+	// target is already active and pick the correct boundary event below.
+	const activePointer = await tokenStore.getActiveUsername();
+
 	// Already the active user; nothing to switch and no event to emit.
-	if (list[0] === username) {
+	if (activePointer === username) {
 		return;
 	}
 
-	// Promote the target user to the front of the roster (new active user).
+	// Promote the target user to the front of the roster and set it active.
 	await tokenStore.addActiveSession(username);
 
 	// Bust the previous active user's identity-pool credentials so subsequent
-	// credential requests resolve against the newly active user.
-	await clearCredentials();
+	// credential requests resolve against the newly active user. Uses the
+	// context-scoped clearCredentials, NOT the global import.
+	await ctx.clearCredentials();
 
 	// Resolve the now-active user's identity from their stored id token (no
 	// refresh). Skip the dispatch if the id token is undecodable — emitting an
@@ -60,14 +76,30 @@ export async function setCurrentUser(username: string): Promise<void> {
 		return;
 	}
 
-	// switchActiveUser fires when the active pointer moves between users.
-	Hub.dispatch(
-		'auth',
-		{
-			event: 'switchActiveUser',
-			data: { username, userId },
-		},
-		'Auth',
-		AMPLIFY_SYMBOL,
-	);
+	const data = { username, userId };
+
+	if (!activePointer) {
+		// No active user before (empty pointer — activating a parked session after
+		// a sign-out): this is a signedIn boundary, not a switch.
+		Hub.dispatch(
+			'auth',
+			{
+				event: 'signedIn',
+				data,
+			},
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	} else {
+		// A different user was active -> the active pointer moved between users.
+		Hub.dispatch(
+			'auth',
+			{
+				event: 'switchActiveUser',
+				data,
+			},
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	}
 }

--- a/packages/auth/src/providers/cognito/apis/setCurrentUser.ts
+++ b/packages/auth/src/providers/cognito/apis/setCurrentUser.ts
@@ -58,6 +58,24 @@ export async function setCurrentUser(...args: any[]): Promise<void> {
 		return;
 	}
 
+	// Resolve the target's identity from their stored id token (no refresh)
+	// BEFORE any mutation. An unresolvable/undecodable session is effectively not
+	// switchable — treat it as a roster-membership failure and throw up front so
+	// we never move the pointer or clear credentials for a switch that could not
+	// produce a valid active user (emitting an event with userId:'' would also
+	// violate the AuthUser contract).
+	const idToken = await tokenStore.getStoredIdToken(username);
+	const userId = (idToken?.payload?.sub as string) ?? '';
+
+	if (!userId) {
+		throw new AuthError({
+			name: USER_NOT_SIGNED_IN_EXCEPTION,
+			message: `Cannot switch to user "${username}": no resolvable signed-in session found.`,
+			recoverySuggestion:
+				'Please make sure the user has signed in before switching to it.',
+		});
+	}
+
 	// Promote the target user to the front of the roster and set it active.
 	await tokenStore.addActiveSession(username);
 
@@ -65,16 +83,6 @@ export async function setCurrentUser(...args: any[]): Promise<void> {
 	// credential requests resolve against the newly active user. Uses the
 	// context-scoped clearCredentials, NOT the global import.
 	await ctx.clearCredentials();
-
-	// Resolve the now-active user's identity from their stored id token (no
-	// refresh). Skip the dispatch if the id token is undecodable — emitting an
-	// event with userId:'' would violate the AuthUser contract.
-	const idToken = await tokenStore.getStoredIdToken(username);
-	const userId = (idToken?.payload?.sub as string) ?? '';
-
-	if (!userId) {
-		return;
-	}
 
 	const data = { username, userId };
 

--- a/packages/auth/src/providers/cognito/apis/signIn.ts
+++ b/packages/auth/src/providers/cognito/apis/signIn.ts
@@ -8,7 +8,6 @@ import {
 	InitiateAuthException,
 	RespondToAuthChallengeException,
 } from '../types/errors';
-import { assertUserNotAuthenticated } from '../utils/signInHelpers';
 import { SignInInput, SignInOutput } from '../types';
 import { AuthValidationErrorCode } from '../../../errors/types/validation';
 
@@ -45,7 +44,6 @@ export async function signIn(...args: any[]): Promise<SignInOutput> {
 	resetAutoSignIn(false);
 
 	const authFlowType = input.options?.authFlowType;
-	await assertUserNotAuthenticated(ctx);
 	switch (authFlowType) {
 		case 'USER_SRP_AUTH':
 			return signInWithSRP(ctx, input);

--- a/packages/auth/src/providers/cognito/apis/signInWithCustomAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithCustomAuth.ts
@@ -97,7 +97,10 @@ export async function signInWithCustomAuth(
 			});
 			resetActiveSignInState();
 
-			await dispatchSignedInHubEvent();
+			await dispatchSignedInHubEvent(
+				tokenOrchestrator.getTokenStore(),
+				activeUsername,
+			);
 
 			return {
 				isSignedIn: true,

--- a/packages/auth/src/providers/cognito/apis/signInWithCustomAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithCustomAuth.ts
@@ -99,7 +99,7 @@ export async function signInWithCustomAuth(
 			});
 			resetActiveSignInState();
 
-			await dispatchSignedInHubEvent(ctx);
+			await dispatchSignedInHubEvent(ctx, activeUsername);
 
 			return {
 				isSignedIn: true,

--- a/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
@@ -102,7 +102,10 @@ export async function signInWithCustomSRPAuth(
 			});
 			resetActiveSignInState();
 
-			await dispatchSignedInHubEvent();
+			await dispatchSignedInHubEvent(
+				tokenOrchestrator.getTokenStore(),
+				activeUsername,
+			);
 
 			return {
 				isSignedIn: true,

--- a/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
@@ -104,7 +104,7 @@ export async function signInWithCustomSRPAuth(
 			});
 			resetActiveSignInState();
 
-			await dispatchSignedInHubEvent(ctx);
+			await dispatchSignedInHubEvent(ctx, activeUsername);
 
 			return {
 				isSignedIn: true,

--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -55,6 +55,13 @@ export async function signInWithRedirect(...args: any[]): Promise<void> {
 	assertOAuthConfig(authConfig);
 	oAuthStore.setAuthConfig(authConfig);
 
+	// OAuth add-a-user asymmetry (deliberate): password flows add another user
+	// UNCONDITIONALLY, but the OAuth redirect requires an explicit
+	// `options.prompt` to add a second user. Without a prompt the Hosted UI
+	// session cookie would silently SSO the browser straight back as the
+	// EXISTING user, so we assert nobody is authenticated instead of starting a
+	// redirect that cannot actually switch/add a user. A caller that genuinely
+	// wants to add another user must pass a prompt (e.g. 'login'/'select_account').
 	if (!input?.options?.prompt) {
 		await assertUserNotAuthenticated(ctx);
 	}

--- a/packages/auth/src/providers/cognito/apis/signInWithSRP.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithSRP.ts
@@ -104,7 +104,10 @@ export async function signInWithSRP(
 			});
 			resetActiveSignInState();
 
-			await dispatchSignedInHubEvent();
+			await dispatchSignedInHubEvent(
+				tokenOrchestrator.getTokenStore(),
+				activeUsername,
+			);
 
 			resetAutoSignIn();
 

--- a/packages/auth/src/providers/cognito/apis/signInWithSRP.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithSRP.ts
@@ -106,7 +106,7 @@ export async function signInWithSRP(
 			});
 			resetActiveSignInState();
 
-			await dispatchSignedInHubEvent(ctx);
+			await dispatchSignedInHubEvent(ctx, activeUsername);
 
 			resetAutoSignIn();
 

--- a/packages/auth/src/providers/cognito/apis/signInWithUserAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithUserAuth.ts
@@ -114,7 +114,10 @@ export async function signInWithUserAuth(
 			});
 			resetActiveSignInState();
 
-			await dispatchSignedInHubEvent();
+			await dispatchSignedInHubEvent(
+				tokenOrchestrator.getTokenStore(),
+				activeUsername,
+			);
 
 			resetAutoSignIn();
 

--- a/packages/auth/src/providers/cognito/apis/signInWithUserAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithUserAuth.ts
@@ -116,7 +116,7 @@ export async function signInWithUserAuth(
 			});
 			resetActiveSignInState();
 
-			await dispatchSignedInHubEvent(ctx);
+			await dispatchSignedInHubEvent(ctx, activeUsername);
 
 			resetAutoSignIn();
 

--- a/packages/auth/src/providers/cognito/apis/signInWithUserPassword.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithUserPassword.ts
@@ -99,7 +99,10 @@ export async function signInWithUserPassword(
 			});
 			resetActiveSignInState();
 
-			await dispatchSignedInHubEvent();
+			await dispatchSignedInHubEvent(
+				tokenOrchestrator.getTokenStore(),
+				activeUsername,
+			);
 
 			resetAutoSignIn();
 

--- a/packages/auth/src/providers/cognito/apis/signInWithUserPassword.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithUserPassword.ts
@@ -101,7 +101,7 @@ export async function signInWithUserPassword(
 			});
 			resetActiveSignInState();
 
-			await dispatchSignedInHubEvent(ctx);
+			await dispatchSignedInHubEvent(ctx, activeUsername);
 
 			resetAutoSignIn();
 

--- a/packages/auth/src/providers/cognito/apis/signOut.ts
+++ b/packages/auth/src/providers/cognito/apis/signOut.ts
@@ -5,12 +5,10 @@ import {
 	Amplify,
 	CognitoUserPoolConfig,
 	ConsoleLogger,
-	Hub,
 	clearCredentials,
 	defaultStorage,
 } from '@aws-amplify/core';
 import {
-	AMPLIFY_SYMBOL,
 	AuthAction,
 	JWT,
 	assertOAuthConfig,
@@ -18,7 +16,7 @@ import {
 } from '@aws-amplify/core/internals/utils';
 
 import { getAuthUserAgentValue } from '../../../utils';
-import { SignOutInput } from '../types';
+import { GetCurrentUserOutput, SignOutInput } from '../types';
 import { tokenOrchestrator } from '../tokenProvider';
 import { getRegionFromUserPoolId } from '../../../foundation/parsers';
 import {
@@ -27,6 +25,7 @@ import {
 } from '../utils/types';
 import { handleOAuthSignOut } from '../utils/oauth';
 import { DefaultOAuthStore } from '../utils/signInWithRedirectStore';
+import { dispatchSignOutBoundaryEvents } from '../utils/dispatchSignOutHubEvents';
 import { AuthError } from '../../../errors/AuthError';
 import { OAUTH_SIGNOUT_EXCEPTION } from '../../../errors/constants';
 import {
@@ -34,6 +33,8 @@ import {
 	createRevokeTokenClient,
 } from '../../../foundation/factories/serviceClients/cognitoIdentityProvider';
 import { createCognitoUserPoolEndpointResolver } from '../factories';
+
+import { getCurrentUser } from './getCurrentUser';
 
 const logger = new ConsoleLogger('Auth');
 
@@ -79,9 +80,31 @@ export async function signOut(input?: SignOutInput): Promise<void> {
 		}
 	} else {
 		// complete sign out
-		tokenOrchestrator.clearTokens();
+		// capture the active user before any local token/roster mutation so we can
+		// emit the correct boundary events after removal.
+		let active: GetCurrentUserOutput | undefined;
+		try {
+			active = await getCurrentUser();
+		} catch {
+			// no resolvable active user (e.g. tokens already gone); fall back below.
+		}
+		const tokenStore = tokenOrchestrator.getTokenStore();
+		const activeUsername =
+			active?.username ?? (await tokenStore.getLastAuthUser());
+
+		// clear only the active user's namespaced tokens and drop them from the roster
+		await tokenStore.clearTokensForUser(activeUsername);
+		const removeResult = await tokenStore.removeSession(activeUsername);
 		await clearCredentials();
-		Hub.dispatch('auth', { event: 'signedOut' }, 'Auth', AMPLIFY_SYMBOL);
+
+		// emit the shared sign-out boundary events (userSignedOut, then either
+		// signedOut or switchActiveUser). The promoted user's identity is resolved
+		// inside the helper from stored tokens rather than via getCurrentUser().
+		await dispatchSignOutBoundaryEvents(
+			tokenStore,
+			active ? { username: active.username, userId: active.userId } : undefined,
+			removeResult,
+		);
 	}
 }
 

--- a/packages/auth/src/providers/cognito/apis/signOut.ts
+++ b/packages/auth/src/providers/cognito/apis/signOut.ts
@@ -16,7 +16,7 @@ import {
 } from '@aws-amplify/core/internals/utils';
 
 import { getAuthUserAgentValue } from '../../../utils';
-import { GetCurrentUserOutput, SignOutInput } from '../types';
+import { SignOutInput } from '../types';
 import { tokenOrchestrator } from '../tokenProvider';
 import { getRegionFromUserPoolId } from '../../../foundation/parsers';
 import {
@@ -33,8 +33,6 @@ import {
 	createRevokeTokenClient,
 } from '../../../foundation/factories/serviceClients/cognitoIdentityProvider';
 import { createCognitoUserPoolEndpointResolver } from '../factories';
-
-import { getCurrentUser } from './getCurrentUser';
 
 const logger = new ConsoleLogger('Auth');
 export async function signOut(
@@ -85,34 +83,29 @@ export async function signOut(...args: any[]): Promise<void> {
 			});
 		}
 	} else {
-		// Multi-session sign-out: remove only the active user's namespaced tokens
-		// and drop them from the roster, then emit the boundary events.
-		// capture the active user before any local token/roster mutation so we can
-		// emit the correct boundary events after removal.
-		let active: GetCurrentUserOutput | undefined;
-		try {
-			active = await getCurrentUser(ctx);
-		} catch {
-			// no resolvable active user (e.g. tokens already gone); fall back below.
-		}
+		// complete sign out
+		// Resolve the signed-out user identity from STORED tokens (no refresh)
+		// before any local mutation, so the boundary events can carry it.
 		const tokenStore = tokenOrchestrator.getTokenStore();
-		const activeUsername =
-			active?.username ?? (await tokenStore.getLastAuthUser());
+		const activeUsername = await tokenStore.getLastAuthUser();
+		const storedIdToken = await tokenStore.getStoredIdToken(activeUsername);
+		const userId = storedIdToken?.payload?.sub as string | undefined;
+		const signedOutUser = userId
+			? { username: activeUsername, userId }
+			: undefined;
 
-		// clear only the active user's namespaced tokens and drop them from the roster
+		// No-promotion sign-out: clear the active user's namespaced tokens, drop
+		// them from the roster (never promoting a parked user), then clear the
+		// active pointer so getCurrentUser/fetchAuthSession read as signed-out.
 		await tokenStore.clearTokensForUser(activeUsername);
-		const removeResult = await tokenStore.removeSession(activeUsername);
-		// Bust the previous active user's identity-pool credentials (ctx-scoped).
+		await tokenStore.removeSession(activeUsername);
+		await tokenStore.clearActiveUser();
+		// Bust identity-pool credentials via the context-scoped clearCredentials.
 		await ctx.clearCredentials();
 
-		// emit the shared sign-out boundary events (userSignedOut, then either
-		// signedOut or switchActiveUser). The promoted user's identity is resolved
-		// inside the helper from stored tokens rather than via getCurrentUser().
-		await dispatchSignOutBoundaryEvents(
-			tokenStore,
-			active ? { username: active.username, userId: active.userId } : undefined,
-			removeResult,
-		);
+		// emit the shared sign-out boundary events (userSignedOut when resolvable,
+		// then signedOut ALWAYS). No switchActiveUser is ever emitted.
+		await dispatchSignOutBoundaryEvents(signedOutUser);
 	}
 }
 

--- a/packages/auth/src/providers/cognito/apis/signOut.ts
+++ b/packages/auth/src/providers/cognito/apis/signOut.ts
@@ -5,11 +5,9 @@ import {
 	AmplifyContext,
 	CognitoUserPoolConfig,
 	ConsoleLogger,
-	Hub,
 	defaultStorage,
 } from '@aws-amplify/core';
 import {
-	AMPLIFY_SYMBOL,
 	AuthAction,
 	JWT,
 	assertOAuthConfig,
@@ -18,7 +16,7 @@ import {
 } from '@aws-amplify/core/internals/utils';
 
 import { getAuthUserAgentValue } from '../../../utils';
-import { SignOutInput } from '../types';
+import { GetCurrentUserOutput, SignOutInput } from '../types';
 import { tokenOrchestrator } from '../tokenProvider';
 import { getRegionFromUserPoolId } from '../../../foundation/parsers';
 import {
@@ -27,6 +25,7 @@ import {
 } from '../utils/types';
 import { handleOAuthSignOut } from '../utils/oauth';
 import { DefaultOAuthStore } from '../utils/signInWithRedirectStore';
+import { dispatchSignOutBoundaryEvents } from '../utils/dispatchSignOutHubEvents';
 import { AuthError } from '../../../errors/AuthError';
 import { OAUTH_SIGNOUT_EXCEPTION } from '../../../errors/constants';
 import {
@@ -34,6 +33,8 @@ import {
 	createRevokeTokenClient,
 } from '../../../foundation/factories/serviceClients/cognitoIdentityProvider';
 import { createCognitoUserPoolEndpointResolver } from '../factories';
+
+import { getCurrentUser } from './getCurrentUser';
 
 const logger = new ConsoleLogger('Auth');
 export async function signOut(
@@ -84,10 +85,34 @@ export async function signOut(...args: any[]): Promise<void> {
 			});
 		}
 	} else {
-		// complete sign out
-		tokenOrchestrator.clearTokens();
+		// Multi-session sign-out: remove only the active user's namespaced tokens
+		// and drop them from the roster, then emit the boundary events.
+		// capture the active user before any local token/roster mutation so we can
+		// emit the correct boundary events after removal.
+		let active: GetCurrentUserOutput | undefined;
+		try {
+			active = await getCurrentUser(ctx);
+		} catch {
+			// no resolvable active user (e.g. tokens already gone); fall back below.
+		}
+		const tokenStore = tokenOrchestrator.getTokenStore();
+		const activeUsername =
+			active?.username ?? (await tokenStore.getLastAuthUser());
+
+		// clear only the active user's namespaced tokens and drop them from the roster
+		await tokenStore.clearTokensForUser(activeUsername);
+		const removeResult = await tokenStore.removeSession(activeUsername);
+		// Bust the previous active user's identity-pool credentials (ctx-scoped).
 		await ctx.clearCredentials();
-		Hub.dispatch('auth', { event: 'signedOut' }, 'Auth', AMPLIFY_SYMBOL);
+
+		// emit the shared sign-out boundary events (userSignedOut, then either
+		// signedOut or switchActiveUser). The promoted user's identity is resolved
+		// inside the helper from stored tokens rather than via getCurrentUser().
+		await dispatchSignOutBoundaryEvents(
+			tokenStore,
+			active ? { username: active.username, userId: active.userId } : undefined,
+			removeResult,
+		);
 	}
 }
 

--- a/packages/auth/src/providers/cognito/apis/signOut.ts
+++ b/packages/auth/src/providers/cognito/apis/signOut.ts
@@ -84,10 +84,19 @@ export async function signOut(...args: any[]): Promise<void> {
 		}
 	} else {
 		// complete sign out
+		const tokenStore = tokenOrchestrator.getTokenStore();
+
+		// Parked-only guard: when there is NO active user (empty/sentinel pointer)
+		// there is nobody to sign out — a parked roster with no active pointer is a
+		// legitimate post-sign-out state. Skip all local mutation and emit NO
+		// signedOut event for nobody.
+		const activeUsername = await tokenStore.getActiveUsername();
+		if (!activeUsername) {
+			return;
+		}
+
 		// Resolve the signed-out user identity from STORED tokens (no refresh)
 		// before any local mutation, so the boundary events can carry it.
-		const tokenStore = tokenOrchestrator.getTokenStore();
-		const activeUsername = await tokenStore.getLastAuthUser();
 		const storedIdToken = await tokenStore.getStoredIdToken(activeUsername);
 		const userId = storedIdToken?.payload?.sub as string | undefined;
 		const signedOutUser = userId

--- a/packages/auth/src/providers/cognito/index.ts
+++ b/packages/auth/src/providers/cognito/index.ts
@@ -16,6 +16,8 @@ export { setUpTOTP } from './apis/setUpTOTP';
 export { updateUserAttributes } from './apis/updateUserAttributes';
 export { updateUserAttribute } from './apis/updateUserAttribute';
 export { getCurrentUser } from './apis/getCurrentUser';
+export { listCurrentUsers } from './apis/listCurrentUsers';
+export { setCurrentUser } from './apis/setCurrentUser';
 export { confirmUserAttribute } from './apis/confirmUserAttribute';
 export { signInWithRedirect } from './apis/signInWithRedirect';
 export { fetchUserAttributes } from './apis/fetchUserAttributes';
@@ -79,6 +81,8 @@ export {
 	CognitoUserPoolTokenProviderType,
 	TokenOrchestrator,
 	DefaultTokenStore,
+	createAuthSessionSwitcher,
+	AuthSessionSwitcher,
 	refreshAuthTokens,
 	refreshAuthTokensWithoutDedupe,
 	createKeysForAuthStorage,

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -19,6 +19,7 @@ import { assertServiceError } from '../../../errors/utils/assertServiceError';
 import { AuthError } from '../../../errors/AuthError';
 import { oAuthStore } from '../utils/oauth/oAuthStore';
 import { addInflightPromise } from '../utils/oauth/inflightPromise';
+import { dispatchSignOutBoundaryEvents } from '../utils/dispatchSignOutHubEvents';
 import { ClientMetadata, CognitoAuthSignInDetails } from '../types';
 
 import {
@@ -172,23 +173,46 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 			});
 			newTokens.signInDetails = signInDetails;
 			await this.setTokens({ tokens: newTokens });
-			Hub.dispatch('auth', { event: 'tokenRefresh' }, 'Auth', AMPLIFY_SYMBOL);
+			const userId = newTokens.idToken?.payload?.sub;
+			Hub.dispatch(
+				'auth',
+				{
+					event: 'tokenRefresh',
+					data: userId ? { username, userId: userId as string } : undefined,
+				},
+				'Auth',
+				AMPLIFY_SYMBOL,
+			);
 
 			return newTokens;
 		} catch (err) {
-			return this.handleErrors(err);
+			// capture the failing user's id (from the pre-clear tokens) so the
+			// boundary events can carry it before the namespace is removed.
+			const userId = tokens.idToken?.payload?.sub as string | undefined;
+
+			return this.handleErrors(err, username, userId);
 		}
 	}
 
-	private handleErrors(err: unknown) {
+	private async handleErrors(
+		err: unknown,
+		username: string,
+		userId?: string,
+	): Promise<CognitoAuthTokens | null> {
 		assertServiceError(err);
 
 		// Only clear tokens for definitive authentication failures
 		// Do NOT clear tokens for transient errors like service issues, rate limits, etc.
 		const shouldClearTokens = this.isAuthenticationError(err);
 
+		let removeResult: { newActiveUser?: string; isEmpty: boolean } | undefined;
 		if (shouldClearTokens) {
-			this.clearTokens();
+			// Scope the clear to ONLY the failing user's namespace and drop them
+			// from the roster. A blanket clearTokens() would remove AuthUserList and
+			// orphan every other parked session (multi-session support).
+			const tokenStore = this.getTokenStore();
+			await tokenStore.clearTokensForUser(username);
+			removeResult = await tokenStore.removeSession(username);
 		}
 
 		Hub.dispatch(
@@ -200,6 +224,17 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 			'Auth',
 			AMPLIFY_SYMBOL,
 		);
+
+		if (removeResult) {
+			// emit the sign-out boundary events for the removed/promoted session.
+			// Resolve everything from stored tokens; do NOT call getCurrentUser()/
+			// getTokens() here as that would recurse back into token refresh.
+			await dispatchSignOutBoundaryEvents(
+				this.getTokenStore(),
+				userId ? { username, userId } : undefined,
+				removeResult,
+			);
+		}
 
 		if (err.name.startsWith('NotAuthorizedException')) {
 			return null;

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -244,14 +244,19 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 		// Do NOT clear tokens for transient errors like service issues, rate limits, etc.
 		const shouldClearTokens = this.isAuthenticationError(err);
 
-		let removeResult: { newActiveUser?: string; isEmpty: boolean } | undefined;
+		let cleared = false;
+		let signedOutUser: { username: string; userId: string } | undefined;
 		if (shouldClearTokens) {
-			// Scope the clear to ONLY the failing user's namespace and drop them
-			// from the roster. A blanket clearTokens() would remove AuthUserList and
-			// orphan every other parked session (multi-session support).
+			// Scope the clear to ONLY the failing user's namespace, drop them from
+			// the roster (no promotion of a parked user) and clear the active
+			// pointer. A blanket clearTokens() would remove AuthUserList and orphan
+			// every other parked session (multi-session support).
 			const tokenStore = this.getTokenStore();
 			await tokenStore.clearTokensForUser(username);
-			removeResult = await tokenStore.removeSession(username);
+			await tokenStore.removeSession(username);
+			await tokenStore.clearActiveUser();
+			cleared = true;
+			signedOutUser = userId ? { username, userId } : undefined;
 		}
 
 		Hub.dispatch(
@@ -264,15 +269,13 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 			AMPLIFY_SYMBOL,
 		);
 
-		if (removeResult) {
-			// emit the sign-out boundary events for the removed/promoted session.
-			// Resolve everything from stored tokens; do NOT call getCurrentUser()/
-			// getTokens() here as that would recurse back into token refresh.
-			await dispatchSignOutBoundaryEvents(
-				this.getTokenStore(),
-				userId ? { username, userId } : undefined,
-				removeResult,
-			);
+		if (cleared) {
+			// emit the sign-out boundary events for the removed session (userSignedOut
+			// when resolvable, then signedOut ALWAYS; never switchActiveUser). Resolve
+			// everything from the pre-clear tokens; do NOT call getCurrentUser()/
+			// getTokens() here as that would recurse back into token refresh. This
+			// path keeps its existing credential handling (no clearCredentials call).
+			await dispatchSignOutBoundaryEvents(signedOutUser);
 		}
 
 		if (err.name.startsWith('NotAuthorizedException')) {

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -22,6 +22,7 @@ import {
 	addInflightPromise,
 	armInflightDeadline,
 } from '../utils/oauth/inflightPromise';
+import { dispatchSignOutBoundaryEvents } from '../utils/dispatchSignOutHubEvents';
 import { ClientMetadata, CognitoAuthSignInDetails } from '../types';
 
 import {
@@ -211,23 +212,46 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 			});
 			newTokens.signInDetails = signInDetails;
 			await this.setTokens({ tokens: newTokens });
-			Hub.dispatch('auth', { event: 'tokenRefresh' }, 'Auth', AMPLIFY_SYMBOL);
+			const userId = newTokens.idToken?.payload?.sub;
+			Hub.dispatch(
+				'auth',
+				{
+					event: 'tokenRefresh',
+					data: userId ? { username, userId: userId as string } : undefined,
+				},
+				'Auth',
+				AMPLIFY_SYMBOL,
+			);
 
 			return newTokens;
 		} catch (err) {
-			return this.handleErrors(err);
+			// capture the failing user's id (from the pre-clear tokens) so the
+			// boundary events can carry it before the namespace is removed.
+			const userId = tokens.idToken?.payload?.sub as string | undefined;
+
+			return this.handleErrors(err, username, userId);
 		}
 	}
 
-	private handleErrors(err: unknown) {
+	private async handleErrors(
+		err: unknown,
+		username: string,
+		userId?: string,
+	): Promise<CognitoAuthTokens | null> {
 		assertServiceError(err);
 
 		// Only clear tokens for definitive authentication failures
 		// Do NOT clear tokens for transient errors like service issues, rate limits, etc.
 		const shouldClearTokens = this.isAuthenticationError(err);
 
+		let removeResult: { newActiveUser?: string; isEmpty: boolean } | undefined;
 		if (shouldClearTokens) {
-			this.clearTokens();
+			// Scope the clear to ONLY the failing user's namespace and drop them
+			// from the roster. A blanket clearTokens() would remove AuthUserList and
+			// orphan every other parked session (multi-session support).
+			const tokenStore = this.getTokenStore();
+			await tokenStore.clearTokensForUser(username);
+			removeResult = await tokenStore.removeSession(username);
 		}
 
 		Hub.dispatch(
@@ -239,6 +263,17 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 			'Auth',
 			AMPLIFY_SYMBOL,
 		);
+
+		if (removeResult) {
+			// emit the sign-out boundary events for the removed/promoted session.
+			// Resolve everything from stored tokens; do NOT call getCurrentUser()/
+			// getTokens() here as that would recurse back into token refresh.
+			await dispatchSignOutBoundaryEvents(
+				this.getTokenStore(),
+				userId ? { username, userId } : undefined,
+				removeResult,
+			);
+		}
 
 		if (err.name.startsWith('NotAuthorizedException')) {
 			return null;

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -212,6 +212,11 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 			});
 			newTokens.signInDetails = signInDetails;
 			await this.setTokens({ tokens: newTokens });
+			// storeTokens no longer writes the active-user pointer (LastAuthUser);
+			// re-assert it for the active user so SSR cookie migration re-sets it at
+			// path '/' along with the refreshed token cookies. Pointer-only: the
+			// roster is never reordered on refresh.
+			await this.getTokenStore().reassertActiveUserPointer(username);
 			const userId = newTokens.idToken?.payload?.sub;
 			Hub.dispatch(
 				'auth',
@@ -317,8 +322,8 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 		return this.getTokenStore().clearDeviceMetadata(username);
 	}
 
-	setOAuthMetadata(metadata: OAuthMetadata): Promise<void> {
-		return this.getTokenStore().setOAuthMetadata(metadata);
+	setOAuthMetadata(metadata: OAuthMetadata, username?: string): Promise<void> {
+		return this.getTokenStore().setOAuthMetadata(metadata, username);
 	}
 
 	getOAuthMetadata(): Promise<OAuthMetadata | null> {

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { AuthConfig, KeyValueStorageInterface } from '@aws-amplify/core';
 import {
+	JWT,
 	assertTokenProviderConfig,
 	decodeJWT,
 } from '@aws-amplify/core/internals/utils';
@@ -96,12 +97,11 @@ export class DefaultTokenStore implements AuthTokenStore {
 
 	async storeTokens(tokens: CognitoAuthTokens): Promise<void> {
 		assert(tokens !== undefined, TokenProviderErrorCode.InvalidAuthTokens);
-		const lastAuthUser = tokens.username;
-		await this.getKeyValueStorage().setItem(
-			this.getLastAuthUserKey(),
-			lastAuthUser,
-		);
 
+		// Note: storeTokens intentionally does NOT manage the active user pointer
+		// (LastAuthUser / AuthUserList). The active pointer is owned exclusively by
+		// the roster methods (persistAuthUserList). This prevents token refresh from
+		// reordering the session roster.
 		const authKeys = await this.getAuthKeys();
 		await this.getKeyValueStorage().setItem(
 			authKeys.accessToken,
@@ -171,8 +171,53 @@ export class DefaultTokenStore implements AuthTokenStore {
 			this.getKeyValueStorage().removeItem(authKeys.refreshToken),
 			this.getKeyValueStorage().removeItem(authKeys.signInDetails),
 			this.getKeyValueStorage().removeItem(this.getLastAuthUserKey()),
+			this.getKeyValueStorage().removeItem(this.getAuthUserListKey()),
 			this.getKeyValueStorage().removeItem(authKeys.oauthMetadata),
 		]);
+	}
+
+	/**
+	 * Clears ONLY the per-user token namespace for the provided username.
+	 *
+	 * Unlike {@link clearTokens}, this does NOT touch the active pointer keys
+	 * (LastAuthUser / AuthUserList); roster management is handled separately by
+	 * {@link removeSession}.
+	 *
+	 * @param username - The username whose namespaced token keys should be removed.
+	 */
+	async clearTokensForUser(username: string): Promise<void> {
+		const authKeys = await this.getAuthKeys(username);
+		// Not calling clear because it can remove data that is not managed by AuthTokenStore
+		await Promise.all([
+			this.getKeyValueStorage().removeItem(authKeys.accessToken),
+			this.getKeyValueStorage().removeItem(authKeys.idToken),
+			this.getKeyValueStorage().removeItem(authKeys.clockDrift),
+			this.getKeyValueStorage().removeItem(authKeys.refreshToken),
+			this.getKeyValueStorage().removeItem(authKeys.signInDetails),
+			this.getKeyValueStorage().removeItem(authKeys.deviceKey),
+			this.getKeyValueStorage().removeItem(authKeys.deviceGroupKey),
+			this.getKeyValueStorage().removeItem(authKeys.randomPasswordKey),
+			this.getKeyValueStorage().removeItem(authKeys.oauthMetadata),
+		]);
+	}
+
+	/**
+	 * Loads and decodes the stored idToken for a specific user without
+	 * triggering a refresh. Returns undefined if absent/undecodable.
+	 *
+	 * @param username - The username whose stored idToken should be read.
+	 */
+	async getStoredIdToken(username: string): Promise<JWT | undefined> {
+		try {
+			const authKeys = await this.getAuthKeys(username);
+			const idTokenString = await this.getKeyValueStorage().getItem(
+				authKeys.idToken,
+			);
+
+			return idTokenString ? decodeJWT(idTokenString) : undefined;
+		} catch (err) {
+			return undefined;
+		}
 	}
 
 	async getDeviceMetadata(username?: string): Promise<DeviceMetadata | null> {
@@ -224,12 +269,109 @@ export class DefaultTokenStore implements AuthTokenStore {
 		return `${AUTH_KEY_PREFIX}.${identifier}.LastAuthUser`;
 	}
 
-	async getLastAuthUser(): Promise<string> {
-		const lastAuthUser =
-			(await this.getKeyValueStorage().getItem(this.getLastAuthUserKey())) ??
-			'username';
+	/**
+	 * Builds the storage key for the clientId-scoped session roster
+	 * (comma-separated ordered list of usernames, active user first).
+	 *
+	 * Mirrors {@link getLastAuthUserKey} but is NOT scoped to a username.
+	 */
+	private getAuthUserListKey() {
+		assertTokenProviderConfig(this.authConfig?.Cognito);
+		const identifier = this.authConfig.Cognito.userPoolClientId;
 
-		return lastAuthUser;
+		return `${AUTH_KEY_PREFIX}.${identifier}.AuthUserList`;
+	}
+
+	/**
+	 * Returns the ordered session roster (active user first).
+	 *
+	 * If the AuthUserList key is present it is parsed directly. If it is absent
+	 * but a legacy LastAuthUser value exists (and is not the literal 'username'
+	 * fallback), that single user is migrated into a roster and persisted.
+	 * Otherwise an empty roster is returned.
+	 */
+	async getAuthUserList(): Promise<string[]> {
+		const authUserListString = await this.getKeyValueStorage().getItem(
+			this.getAuthUserListKey(),
+		);
+
+		if (authUserListString) {
+			return authUserListString.split(',').filter(Boolean);
+		}
+
+		// Migration: fall back to a legacy single LastAuthUser value if present.
+		const legacyLastAuthUser = await this.getKeyValueStorage().getItem(
+			this.getLastAuthUserKey(),
+		);
+		if (legacyLastAuthUser && legacyLastAuthUser !== 'username') {
+			const migratedList = [legacyLastAuthUser];
+			await this.persistAuthUserList(migratedList);
+
+			return migratedList;
+		}
+
+		return [];
+	}
+
+	/**
+	 * Persists the session roster. This is the ONLY writer of the AuthUserList
+	 * and LastAuthUser keys, keeping the invariant LastAuthUser === list[0].
+	 *
+	 * When the roster is empty both keys are removed.
+	 *
+	 * @param list - The ordered roster to persist (active user first).
+	 */
+	private async persistAuthUserList(list: string[]): Promise<void> {
+		if (list.length === 0) {
+			// Remove LastAuthUser FIRST: if the subsequent AuthUserList delete
+			// fails, a lingering AuthUserList is harmless, but a lingering legacy
+			// LastAuthUser would re-migrate a removed user back into the roster.
+			await this.getKeyValueStorage().removeItem(this.getLastAuthUserKey());
+			await this.getKeyValueStorage().removeItem(this.getAuthUserListKey());
+
+			return;
+		}
+
+		await this.getKeyValueStorage().setItem(
+			this.getAuthUserListKey(),
+			list.join(','),
+		);
+		await this.getKeyValueStorage().setItem(this.getLastAuthUserKey(), list[0]);
+	}
+
+	/**
+	 * Adds (or re-activates) a session for the given username, deduping and
+	 * moving it to the front of the roster so it becomes the active user.
+	 *
+	 * @param username - The username to mark as the active session.
+	 */
+	async addActiveSession(username: string): Promise<void> {
+		const list = await this.getAuthUserList();
+		await this.persistAuthUserList([
+			username,
+			...list.filter(user => user !== username),
+		]);
+	}
+
+	/**
+	 * Removes a session for the given username from the roster.
+	 *
+	 * @param username - The username whose session should be removed.
+	 * @returns The new active user (roster head, if any) and whether the roster
+	 * is now empty.
+	 */
+	async removeSession(
+		username: string,
+	): Promise<{ newActiveUser?: string; isEmpty: boolean }> {
+		const list = await this.getAuthUserList();
+		const newList = list.filter(user => user !== username);
+		await this.persistAuthUserList(newList);
+
+		return { newActiveUser: newList[0], isEmpty: newList.length === 0 };
+	}
+
+	async getLastAuthUser(): Promise<string> {
+		return (await this.getAuthUserList())[0] ?? 'username';
 	}
 
 	async setOAuthMetadata(metadata: OAuthMetadata): Promise<void> {

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
@@ -305,7 +305,14 @@ export class DefaultTokenStore implements AuthTokenStore {
 		);
 		if (legacyLastAuthUser && legacyLastAuthUser !== 'username') {
 			const migratedList = [legacyLastAuthUser];
-			await this.persistAuthUserList(migratedList);
+			// Best-effort persist: on read-only/ephemeral SSR storage the write
+			// may fail — that's acceptable because the migrated list is still
+			// returned to the caller; the next mutable-storage call will retry.
+			try {
+				await this.persistAuthUserList(migratedList);
+			} catch {
+				// Storage is read-only (e.g. SSR); degrade gracefully.
+			}
 
 			return migratedList;
 		}
@@ -336,6 +343,10 @@ export class DefaultTokenStore implements AuthTokenStore {
 			this.getAuthUserListKey(),
 			list.join(','),
 		);
+		// Best-effort / compatibility-only: LastAuthUser is kept in sync for
+		// legacy consumers, but AuthUserList is authoritative when present
+		// (getAuthUserList prefers it). A lost LastAuthUser write does not
+		// affect roster correctness.
 		await this.getKeyValueStorage().setItem(this.getLastAuthUserKey(), list[0]);
 	}
 

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
@@ -405,7 +405,14 @@ export class DefaultTokenStore implements AuthTokenStore {
 		);
 		if (legacyLastAuthUser && legacyLastAuthUser !== 'username') {
 			const migratedList = [legacyLastAuthUser];
-			await this.persistAuthUserList(migratedList);
+			// Best-effort persist: on read-only/ephemeral SSR storage the write
+			// may fail — that's acceptable because the migrated list is still
+			// returned to the caller; the next mutable-storage call will retry.
+			try {
+				await this.persistAuthUserList(migratedList);
+			} catch {
+				// Storage is read-only (e.g. SSR); degrade gracefully.
+			}
 
 			return migratedList;
 		}
@@ -436,6 +443,10 @@ export class DefaultTokenStore implements AuthTokenStore {
 			this.getAuthUserListKey(),
 			list.join(','),
 		);
+		// Best-effort / compatibility-only: LastAuthUser is kept in sync for
+		// legacy consumers, but AuthUserList is authoritative when present
+		// (getAuthUserList prefers it). A lost LastAuthUser write does not
+		// affect roster correctness.
 		await this.getKeyValueStorage().setItem(this.getLastAuthUserKey(), list[0]);
 	}
 

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
@@ -633,6 +633,36 @@ export class DefaultTokenStore implements AuthTokenStore {
 		await this.getKeyValueStorage().removeItem(this.getLastAuthUserKey());
 	}
 
+	/**
+	 * Re-writes the active-user pointer (LastAuthUser) cookie to the CURRENT
+	 * active user, leaving the roster (AuthUserList) and its order untouched.
+	 *
+	 * The token-refresh path calls this after persisting refreshed tokens. SSR
+	 * cookie migration re-sets every WRITTEN key at path '/' (deleting stale
+	 * path-scoped duplicates), but storeTokens no longer writes the pointer
+	 * (single-writer discipline moved it to the roster methods). Without this
+	 * re-assert, a server-side forced refresh would migrate every token cookie
+	 * EXCEPT LastAuthUser, leaving a stale path-scoped LastAuthUser duplicate
+	 * (the remove-path-cookies regression). This restores the pre-multi-session
+	 * behavior where storeTokens re-wrote LastAuthUser on every refresh.
+	 *
+	 * The write is value-idempotent (guarded to the already-active user) and
+	 * deliberately does NOT go through persistAuthUserList: a refresh must never
+	 * reorder the roster nor promote a parked (non-active) session, so this is a
+	 * no-op when `username` is not the current active pointer.
+	 *
+	 * @param username - The user whose tokens were just refreshed.
+	 */
+	async reassertActiveUserPointer(username: string): Promise<void> {
+		if ((await this.getActiveUsername()) !== username) {
+			return;
+		}
+		await this.getKeyValueStorage().setItem(
+			this.getLastAuthUserKey(),
+			username,
+		);
+	}
+
 	async getLastAuthUser(): Promise<string> {
 		// Read the pointer DIRECTLY; return the legacy 'username' sentinel when the
 		// pointer is empty/absent EVEN IF the roster still holds parked sessions.
@@ -640,8 +670,20 @@ export class DefaultTokenStore implements AuthTokenStore {
 		return (await this.getActiveUsername()) ?? 'username';
 	}
 
-	async setOAuthMetadata(metadata: OAuthMetadata): Promise<void> {
-		const { oauthMetadata: oauthMetadataKey } = await this.getAuthKeys();
+	async setOAuthMetadata(
+		metadata: OAuthMetadata,
+		username?: string,
+	): Promise<void> {
+		// Namespace under the token owner (`username`), NOT the active pointer.
+		// The OAuth sign-in flow persists metadata BEFORE addActiveSession moves
+		// the pointer, so a no-arg getAuthKeys() would write under the stale/
+		// sentinel pointer namespace; the metadata would then be unreachable via
+		// getOAuthMetadata (which reads under the now-advanced pointer), and a
+		// second subdomain sharing cookie storage — which has no local
+		// isOAuthSignIn flag — could not detect the OAuth session on sign-out.
+		// Mirrors storeTokens' username-scoped keying (per HLD §4.3).
+		const { oauthMetadata: oauthMetadataKey } =
+			await this.getAuthKeys(username);
 		await this.getKeyValueStorage().setItem(
 			oauthMetadataKey,
 			JSON.stringify(metadata),

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
@@ -8,6 +8,7 @@ import {
 } from '@aws-amplify/core';
 import {
 	AMPLIFY_SYMBOL,
+	JWT,
 	assertTokenProviderConfig,
 	decodeJWT,
 } from '@aws-amplify/core/internals/utils';
@@ -196,12 +197,11 @@ export class DefaultTokenStore implements AuthTokenStore {
 
 	async storeTokens(tokens: CognitoAuthTokens): Promise<void> {
 		assert(tokens !== undefined, TokenProviderErrorCode.InvalidAuthTokens);
-		const lastAuthUser = tokens.username;
-		await this.getKeyValueStorage().setItem(
-			this.getLastAuthUserKey(),
-			lastAuthUser,
-		);
 
+		// Note: storeTokens intentionally does NOT manage the active user pointer
+		// (LastAuthUser / AuthUserList). The active pointer is owned exclusively by
+		// the roster methods (persistAuthUserList). This prevents token refresh from
+		// reordering the session roster.
 		const authKeys = await this.getAuthKeys();
 		await this.getKeyValueStorage().setItem(
 			authKeys.accessToken,
@@ -271,8 +271,53 @@ export class DefaultTokenStore implements AuthTokenStore {
 			this.getKeyValueStorage().removeItem(authKeys.refreshToken),
 			this.getKeyValueStorage().removeItem(authKeys.signInDetails),
 			this.getKeyValueStorage().removeItem(this.getLastAuthUserKey()),
+			this.getKeyValueStorage().removeItem(this.getAuthUserListKey()),
 			this.getKeyValueStorage().removeItem(authKeys.oauthMetadata),
 		]);
+	}
+
+	/**
+	 * Clears ONLY the per-user token namespace for the provided username.
+	 *
+	 * Unlike {@link clearTokens}, this does NOT touch the active pointer keys
+	 * (LastAuthUser / AuthUserList); roster management is handled separately by
+	 * {@link removeSession}.
+	 *
+	 * @param username - The username whose namespaced token keys should be removed.
+	 */
+	async clearTokensForUser(username: string): Promise<void> {
+		const authKeys = await this.getAuthKeys(username);
+		// Not calling clear because it can remove data that is not managed by AuthTokenStore
+		await Promise.all([
+			this.getKeyValueStorage().removeItem(authKeys.accessToken),
+			this.getKeyValueStorage().removeItem(authKeys.idToken),
+			this.getKeyValueStorage().removeItem(authKeys.clockDrift),
+			this.getKeyValueStorage().removeItem(authKeys.refreshToken),
+			this.getKeyValueStorage().removeItem(authKeys.signInDetails),
+			this.getKeyValueStorage().removeItem(authKeys.deviceKey),
+			this.getKeyValueStorage().removeItem(authKeys.deviceGroupKey),
+			this.getKeyValueStorage().removeItem(authKeys.randomPasswordKey),
+			this.getKeyValueStorage().removeItem(authKeys.oauthMetadata),
+		]);
+	}
+
+	/**
+	 * Loads and decodes the stored idToken for a specific user without
+	 * triggering a refresh. Returns undefined if absent/undecodable.
+	 *
+	 * @param username - The username whose stored idToken should be read.
+	 */
+	async getStoredIdToken(username: string): Promise<JWT | undefined> {
+		try {
+			const authKeys = await this.getAuthKeys(username);
+			const idTokenString = await this.getKeyValueStorage().getItem(
+				authKeys.idToken,
+			);
+
+			return idTokenString ? decodeJWT(idTokenString) : undefined;
+		} catch (err) {
+			return undefined;
+		}
 	}
 
 	async getDeviceMetadata(username?: string): Promise<DeviceMetadata | null> {
@@ -324,12 +369,109 @@ export class DefaultTokenStore implements AuthTokenStore {
 		return `${AUTH_KEY_PREFIX}.${identifier}.LastAuthUser`;
 	}
 
-	async getLastAuthUser(): Promise<string> {
-		const lastAuthUser =
-			(await this.getKeyValueStorage().getItem(this.getLastAuthUserKey())) ??
-			'username';
+	/**
+	 * Builds the storage key for the clientId-scoped session roster
+	 * (comma-separated ordered list of usernames, active user first).
+	 *
+	 * Mirrors {@link getLastAuthUserKey} but is NOT scoped to a username.
+	 */
+	private getAuthUserListKey() {
+		assertTokenProviderConfig(this.authConfig?.Cognito);
+		const identifier = this.authConfig.Cognito.userPoolClientId;
 
-		return lastAuthUser;
+		return `${AUTH_KEY_PREFIX}.${identifier}.AuthUserList`;
+	}
+
+	/**
+	 * Returns the ordered session roster (active user first).
+	 *
+	 * If the AuthUserList key is present it is parsed directly. If it is absent
+	 * but a legacy LastAuthUser value exists (and is not the literal 'username'
+	 * fallback), that single user is migrated into a roster and persisted.
+	 * Otherwise an empty roster is returned.
+	 */
+	async getAuthUserList(): Promise<string[]> {
+		const authUserListString = await this.getKeyValueStorage().getItem(
+			this.getAuthUserListKey(),
+		);
+
+		if (authUserListString) {
+			return authUserListString.split(',').filter(Boolean);
+		}
+
+		// Migration: fall back to a legacy single LastAuthUser value if present.
+		const legacyLastAuthUser = await this.getKeyValueStorage().getItem(
+			this.getLastAuthUserKey(),
+		);
+		if (legacyLastAuthUser && legacyLastAuthUser !== 'username') {
+			const migratedList = [legacyLastAuthUser];
+			await this.persistAuthUserList(migratedList);
+
+			return migratedList;
+		}
+
+		return [];
+	}
+
+	/**
+	 * Persists the session roster. This is the ONLY writer of the AuthUserList
+	 * and LastAuthUser keys, keeping the invariant LastAuthUser === list[0].
+	 *
+	 * When the roster is empty both keys are removed.
+	 *
+	 * @param list - The ordered roster to persist (active user first).
+	 */
+	private async persistAuthUserList(list: string[]): Promise<void> {
+		if (list.length === 0) {
+			// Remove LastAuthUser FIRST: if the subsequent AuthUserList delete
+			// fails, a lingering AuthUserList is harmless, but a lingering legacy
+			// LastAuthUser would re-migrate a removed user back into the roster.
+			await this.getKeyValueStorage().removeItem(this.getLastAuthUserKey());
+			await this.getKeyValueStorage().removeItem(this.getAuthUserListKey());
+
+			return;
+		}
+
+		await this.getKeyValueStorage().setItem(
+			this.getAuthUserListKey(),
+			list.join(','),
+		);
+		await this.getKeyValueStorage().setItem(this.getLastAuthUserKey(), list[0]);
+	}
+
+	/**
+	 * Adds (or re-activates) a session for the given username, deduping and
+	 * moving it to the front of the roster so it becomes the active user.
+	 *
+	 * @param username - The username to mark as the active session.
+	 */
+	async addActiveSession(username: string): Promise<void> {
+		const list = await this.getAuthUserList();
+		await this.persistAuthUserList([
+			username,
+			...list.filter(user => user !== username),
+		]);
+	}
+
+	/**
+	 * Removes a session for the given username from the roster.
+	 *
+	 * @param username - The username whose session should be removed.
+	 * @returns The new active user (roster head, if any) and whether the roster
+	 * is now empty.
+	 */
+	async removeSession(
+		username: string,
+	): Promise<{ newActiveUser?: string; isEmpty: boolean }> {
+		const list = await this.getAuthUserList();
+		const newList = list.filter(user => user !== username);
+		await this.persistAuthUserList(newList);
+
+		return { newActiveUser: newList[0], isEmpty: newList.length === 0 };
+	}
+
+	async getLastAuthUser(): Promise<string> {
+		return (await this.getAuthUserList())[0] ?? 'username';
 	}
 
 	async setOAuthMetadata(metadata: OAuthMetadata): Promise<void> {

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
@@ -15,6 +15,8 @@ import {
 
 import { AuthError } from '../../../errors/AuthError';
 import { getCurrentUser } from '../apis/getCurrentUser';
+import { SESSION_PERSISTENCE_EXCEPTION } from '../../../errors/constants';
+import { CognitoAuthSignInDetails } from '../types';
 
 import {
 	AuthKeys,
@@ -31,6 +33,29 @@ export class DefaultTokenStore implements AuthTokenStore {
 	private authConfig?: AuthConfig;
 	keyValueStorage?: KeyValueStorageInterface;
 	private stopNotify?: () => void;
+
+	/**
+	 * In-memory serialization point for roster read-modify-write mutations.
+	 *
+	 * addActiveSession/removeSession (and getAuthUserList's reconciliation write)
+	 * each read the roster, transform it, then persist it. Two such operations
+	 * racing on the same instance would both read the same starting roster and
+	 * the later write would clobber the earlier — silently dropping a session.
+	 * serializeRoster chains every mutation onto a single promise so they run one
+	 * at a time; the `.catch` on the stored tail keeps a rejected mutation from
+	 * wedging the chain while still surfacing the rejection to its own caller.
+	 *
+	 * This guards concurrency WITHIN a single process/instance only; it does not
+	 * coordinate across tabs or the shared cookie storage two subdomains see.
+	 */
+	private rosterMutation: Promise<unknown> = Promise.resolve();
+
+	private serializeRoster<T>(fn: () => Promise<T>): Promise<T> {
+		const run = this.rosterMutation.then(fn, fn);
+		this.rosterMutation = run.catch(() => undefined);
+
+		return run;
+	}
 
 	getKeyValueStorage(): KeyValueStorageInterface {
 		if (!this.keyValueStorage) {
@@ -328,6 +353,29 @@ export class DefaultTokenStore implements AuthTokenStore {
 	}
 
 	/**
+	 * Loads and parses the stored signInDetails for a specific user, keyed via
+	 * the shared {@link getAuthKeys} helper (avoids key drift with the rest of
+	 * the token namespace). Returns undefined when the key is absent or its value
+	 * cannot be parsed.
+	 *
+	 * @param username - The username whose stored signInDetails should be read.
+	 */
+	async getStoredSignInDetails(
+		username: string,
+	): Promise<CognitoAuthSignInDetails | undefined> {
+		try {
+			const authKeys = await this.getAuthKeys(username);
+			const signInDetailsString = await this.getKeyValueStorage().getItem(
+				authKeys.signInDetails,
+			);
+
+			return signInDetailsString ? JSON.parse(signInDetailsString) : undefined;
+		} catch (err) {
+			return undefined;
+		}
+	}
+
+	/**
 	 * Returns true when a live session exists for the username, detected by the
 	 * presence of the ACCESS TOKEN key. This is the correct liveness signal for
 	 * pruning: loadTokens only requires an accessToken, and the idToken is
@@ -434,6 +482,47 @@ export class DefaultTokenStore implements AuthTokenStore {
 	 * hot path (pointer already in sync, or empty) does no per-entry reads.
 	 */
 	async getAuthUserList(): Promise<string[]> {
+		// Compute the reconciled roster with reads only (no writes), then persist
+		// under the roster mutex if reconciliation changed anything. Splitting the
+		// read from the write lets addActiveSession/removeSession reuse the pure
+		// reader INSIDE their own serialized slot without re-entering the mutex
+		// (which would deadlock, since serializeRoster runs one fn at a time).
+		const { list, needsPersist, clearStalePointer } =
+			await this.readReconciledRoster();
+
+		if (needsPersist) {
+			// Best-effort AND serialized: read-only/ephemeral SSR storage may reject
+			// the write (the reconciled list is still returned regardless), and the
+			// mutex prevents a concurrent addActiveSession/removeSession from
+			// clobbering — or being clobbered by — this repair.
+			await this.serializeRoster(async () => {
+				try {
+					await this.persistAuthUserList(list);
+					if (clearStalePointer && list.length > 0) {
+						// Non-empty roster keeps the pointer key (persist didn't touch
+						// it), so clear the stale pointer explicitly.
+						await this.clearActiveUser();
+					}
+				} catch {
+					// Storage is read-only (e.g. SSR); degrade gracefully.
+				}
+			});
+		}
+
+		return list;
+	}
+
+	/**
+	 * Pure (read-only) computation of the reconciled roster. Performs NO writes;
+	 * the caller decides whether/how to persist. Returns the reconciled list plus
+	 * whether a persist is warranted and whether a stale non-empty pointer must be
+	 * cleared. See {@link getAuthUserList} for the reconciliation semantics.
+	 */
+	private async readReconciledRoster(): Promise<{
+		list: string[];
+		needsPersist: boolean;
+		clearStalePointer: boolean;
+	}> {
 		const authUserListString = await this.getKeyValueStorage().getItem(
 			this.getAuthUserListKey(),
 		);
@@ -486,43 +575,24 @@ export class DefaultTokenStore implements AuthTokenStore {
 			// roster (the pointer is single-writer — owned by addActiveSession), so
 			// a surviving promoted pointer is left as the external writer set it.
 			// When reconciledList is empty, persistAuthUserList([]) clears both keys.
-			if (
-				reconciledList.join(',') !== parsedList.join(',') ||
-				clearStalePointer
-			) {
-				// Best-effort: read-only/ephemeral SSR storage may reject the write;
-				// the reconciled list is still returned to the caller.
-				try {
-					await this.persistAuthUserList(reconciledList);
-					if (clearStalePointer && reconciledList.length > 0) {
-						// Non-empty roster keeps the pointer key (persist didn't touch
-						// it), so clear the stale pointer explicitly.
-						await this.clearActiveUser();
-					}
-				} catch {
-					// Storage is read-only (e.g. SSR); degrade gracefully.
-				}
-			}
+			const needsPersist =
+				reconciledList.join(',') !== parsedList.join(',') || clearStalePointer;
 
-			return reconciledList;
+			return { list: reconciledList, needsPersist, clearStalePointer };
 		}
 
 		// Migration: fall back to a legacy single LastAuthUser value if present.
+		// The derived roster is returned to the caller; getAuthUserList persists it
+		// best-effort (the next mutable-storage call will retry on SSR).
 		if (lastAuthUser && lastAuthUser !== 'username') {
-			const migratedList = [lastAuthUser];
-			// Best-effort persist: on read-only/ephemeral SSR storage the write
-			// may fail — that's acceptable because the migrated list is still
-			// returned to the caller; the next mutable-storage call will retry.
-			try {
-				await this.persistAuthUserList(migratedList);
-			} catch {
-				// Storage is read-only (e.g. SSR); degrade gracefully.
-			}
-
-			return migratedList;
+			return {
+				list: [lastAuthUser],
+				needsPersist: true,
+				clearStalePointer: false,
+			};
 		}
 
-		return [];
+		return { list: [], needsPersist: false, clearStalePointer: false };
 	}
 
 	/**
@@ -582,11 +652,32 @@ export class DefaultTokenStore implements AuthTokenStore {
 	 * @param username - The username to mark as the active session.
 	 */
 	async addActiveSession(username: string): Promise<void> {
-		const list = await this.getAuthUserList();
-		await this.persistAuthUserList(
-			[username, ...list.filter(user => user !== username)],
-			{ setPointerTo: username },
-		);
+		return this.serializeRoster(async () => {
+			// Read INSIDE the mutex via the pure reader (not getAuthUserList, which
+			// would re-enter serializeRoster and deadlock) so the read-modify-write
+			// is atomic with respect to other roster mutations.
+			const { list } = await this.readReconciledRoster();
+			try {
+				await this.persistAuthUserList(
+					[username, ...list.filter(user => user !== username)],
+					{ setPointerTo: username },
+				);
+			} catch (err) {
+				// Unlike getAuthUserList's best-effort reconciliation, an active-session
+				// switch MUST persist: a switch that silently failed to write would
+				// look successful while the pointer never moved. Rethrow the raw
+				// storage error as a descriptive AuthError so a read-only SSR context
+				// (Server Component / already-committed response) surfaces clearly.
+				throw new AuthError({
+					name: SESSION_PERSISTENCE_EXCEPTION,
+					message:
+						'The active-session switch could not be persisted: storage is read-only or the response has already been committed.',
+					recoverySuggestion:
+						'Perform the session switch from a writable server context (Route Handler, Server Action, or Middleware); a read-only Server Component cannot persist a switch.',
+					underlyingError: err,
+				});
+			}
+		});
 	}
 
 	/**
@@ -599,11 +690,15 @@ export class DefaultTokenStore implements AuthTokenStore {
 	 * @returns Whether the roster is now empty.
 	 */
 	async removeSession(username: string): Promise<{ isEmpty: boolean }> {
-		const list = await this.getAuthUserList();
-		const newList = list.filter(user => user !== username);
-		await this.persistAuthUserList(newList);
+		return this.serializeRoster(async () => {
+			// Pure reader inside the mutex (see addActiveSession) so a concurrent
+			// mutation cannot clobber this filter-and-persist.
+			const { list } = await this.readReconciledRoster();
+			const newList = list.filter(user => user !== username);
+			await this.persistAuthUserList(newList);
 
-		return { isEmpty: newList.length === 0 };
+			return { isEmpty: newList.length === 0 };
+		});
 	}
 
 	/**

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
@@ -402,24 +402,30 @@ export class DefaultTokenStore implements AuthTokenStore {
 	}
 
 	/**
-	 * Returns the ordered session roster (active user first).
+	 * Returns the session roster (AuthUserList). The roster is the set of
+	 * signed-in sessions; it is NOT the active pointer. Under the pointer model
+	 * the roster may be non-empty while nobody is active (parked sessions after a
+	 * sign-out), so this method deliberately does NOT derive or promote an active
+	 * user — {@link getLastAuthUser} reads the LastAuthUser pointer directly.
 	 *
 	 * If the AuthUserList key is present it is parsed directly. If it is absent
 	 * but a legacy LastAuthUser value exists (and is not the literal 'username'
-	 * fallback), that single user is migrated into a roster and persisted.
-	 * Otherwise an empty roster is returned.
+	 * fallback), that single user is migrated into a roster and persisted; the
+	 * pointer is left as-is so that user remains active.
 	 *
-	 * Every read is also a reconciliation point. External writers (older Amplify
-	 * versions and amazon-cognito-identity-js sharing the same storage) mutate
-	 * LastAuthUser directly, drifting it from AuthUserList[0]; and a partial
-	 * persist (LastAuthUser written, AuthUserList not) leaves the same skew. When
-	 * LastAuthUser names a real user that isn't the current head, it is promoted
-	 * to the front and the roster is pruned of entries whose tokens are no longer
-	 * resolvable, then re-persisted (best-effort — SSR storage may be read-only).
-	 * The head LastAuthUser read happens on every call (a single cheap read); the
-	 * "no extra reads" guarantee is per-entry only — the per-entry token reads and
-	 * the re-persist run ONLY on the promotion path, so the hot path (already in
-	 * sync) does no per-entry storage reads / JWT decodes.
+	 * Every read is also a reconciliation point, but reconciliation now respects
+	 * pointer semantics. External writers (older Amplify versions and
+	 * amazon-cognito-identity-js sharing the same storage) mutate LastAuthUser
+	 * directly, and a partial persist can leave skew. Reconciliation runs ONLY
+	 * when the pointer is NON-EMPTY and NON-SENTINEL: if it names a user absent
+	 * from the roster it is added to the front (external sign-in); if present but
+	 * not the head it is moved to the head. An EMPTY pointer alongside a non-empty
+	 * roster is a LEGITIMATE state (parked sessions, nobody active) and is left
+	 * untouched — never promoted. On the (rare) promotion path the roster is
+	 * pruned of entries whose tokens are no longer resolvable, and if the pointer
+	 * user itself was pruned the pointer is CLEARED rather than left naming a
+	 * removed user. All writes are best-effort (SSR storage may be read-only). The
+	 * hot path (pointer already in sync, or empty) does no per-entry reads.
 	 */
 	async getAuthUserList(): Promise<string[]> {
 		const authUserListString = await this.getKeyValueStorage().getItem(
@@ -432,9 +438,14 @@ export class DefaultTokenStore implements AuthTokenStore {
 		if (authUserListString) {
 			const parsedList = authUserListString.split(',').filter(Boolean);
 			let reconciledList = parsedList;
+			// Whether the (non-empty) pointer must be cleared because its own user
+			// was pruned during reconciliation (a pointer must never name a user
+			// absent from the roster).
+			let clearStalePointer = false;
 
-			// Reconcile drift: LastAuthUser may have been advanced by an external
-			// writer or a partial persist. Ignore the 'username' sentinel/empty.
+			// Reconcile drift ONLY for a real active pointer. An empty pointer or the
+			// 'username' sentinel means "nobody active" and is a legitimate state
+			// under the pointer model, so it is never promoted from the roster.
 			const shouldReconcile =
 				!!lastAuthUser &&
 				lastAuthUser !== 'username' &&
@@ -457,24 +468,31 @@ export class DefaultTokenStore implements AuthTokenStore {
 					}
 				}
 				reconciledList = prunedList;
+
+				// If the pointer's own user was pruned, the stored pointer is now
+				// stale: mark it for clearing rather than leaving it pointing at a
+				// user no longer in the roster.
+				clearStalePointer = !reconciledList.includes(lastAuthUser);
 			}
 
-			// Re-persist when reconciliation changed the roster contents, OR when it
-			// ran but the stored LastAuthUser pointer still doesn't match the new
-			// head. The latter covers promotion+prune netting back to the original
-			// list (e.g. external LastAuthUser='C' with no tokens: [A,B]→[C,A,B]→
-			// [A,B]) where LastAuthUser would otherwise stay stale at 'C' and re-run
-			// the full prune on every read. When reconciledList is empty,
-			// persistAuthUserList([]) clears both keys — the intended outcome when
-			// no resolvable session remains.
+			// Re-persist when reconciliation changed the roster contents, or when a
+			// stale pointer must be cleared. persistAuthUserList writes only the
+			// roster (the pointer is single-writer — owned by addActiveSession), so
+			// a surviving promoted pointer is left as the external writer set it.
+			// When reconciledList is empty, persistAuthUserList([]) clears both keys.
 			if (
 				reconciledList.join(',') !== parsedList.join(',') ||
-				(shouldReconcile && reconciledList[0] !== lastAuthUser)
+				clearStalePointer
 			) {
 				// Best-effort: read-only/ephemeral SSR storage may reject the write;
 				// the reconciled list is still returned to the caller.
 				try {
 					await this.persistAuthUserList(reconciledList);
+					if (clearStalePointer && reconciledList.length > 0) {
+						// Non-empty roster keeps the pointer key (persist didn't touch
+						// it), so clear the stale pointer explicitly.
+						await this.clearActiveUser();
+					}
 				} catch {
 					// Storage is read-only (e.g. SSR); degrade gracefully.
 				}
@@ -502,14 +520,26 @@ export class DefaultTokenStore implements AuthTokenStore {
 	}
 
 	/**
-	 * Persists the session roster. This is the ONLY writer of the AuthUserList
-	 * and LastAuthUser keys, keeping the invariant LastAuthUser === list[0].
+	 * Persists the session roster (AuthUserList). This is the ONLY writer of the
+	 * AuthUserList key, and the SINGLE WRITER of the LastAuthUser pointer.
 	 *
-	 * When the roster is empty both keys are removed.
+	 * Pointer discipline: the LastAuthUser pointer is written here ONLY when the
+	 * caller explicitly passes `setPointerTo` (addActiveSession does this so the
+	 * pointer + roster head are written together). removeSession's persist omits
+	 * it, so removing a session NEVER promotes a parked user into the pointer.
 	 *
-	 * @param list - The ordered roster to persist (active user first).
+	 * When the roster is empty both keys are removed (pointer first) regardless of
+	 * `setPointerTo`.
+	 *
+	 * @param list - The roster to persist (by convention the active user, when
+	 * any, is the head).
+	 * @param options - When `setPointerTo` is provided, the LastAuthUser pointer
+	 * is set to it in the same write.
 	 */
-	private async persistAuthUserList(list: string[]): Promise<void> {
+	private async persistAuthUserList(
+		list: string[],
+		options?: { setPointerTo?: string },
+	): Promise<void> {
 		if (list.length === 0) {
 			// Remove LastAuthUser FIRST: if the subsequent AuthUserList delete
 			// fails, a lingering AuthUserList is harmless, but a lingering legacy
@@ -520,13 +550,18 @@ export class DefaultTokenStore implements AuthTokenStore {
 			return;
 		}
 
-		// Write LastAuthUser FIRST, then AuthUserList. On a partial failure the
-		// newer intent survives in LastAuthUser (the pointer legacy/external
-		// consumers read), and getAuthUserList's drift reconciliation repairs
-		// AuthUserList from it on the next read. LastAuthUser is also kept in
-		// sync for legacy consumers, though AuthUserList is authoritative when
-		// both are present.
-		await this.getKeyValueStorage().setItem(this.getLastAuthUserKey(), list[0]);
+		// Write the pointer FIRST (when requested), then AuthUserList. On a partial
+		// failure the newer intent survives in LastAuthUser (the pointer legacy/
+		// external consumers read), and getAuthUserList's drift reconciliation
+		// repairs AuthUserList from it on the next read. The pointer is written
+		// ONLY on this explicit-request path to preserve single-writer discipline;
+		// removeSession's persist leaves the pointer for clearActiveUser to manage.
+		if (options?.setPointerTo !== undefined) {
+			await this.getKeyValueStorage().setItem(
+				this.getLastAuthUserKey(),
+				options.setPointerTo,
+			);
+		}
 		await this.getKeyValueStorage().setItem(
 			this.getAuthUserListKey(),
 			list.join(','),
@@ -535,37 +570,68 @@ export class DefaultTokenStore implements AuthTokenStore {
 
 	/**
 	 * Adds (or re-activates) a session for the given username, deduping and
-	 * moving it to the front of the roster so it becomes the active user.
+	 * moving it to the front of the roster AND setting it as the active pointer
+	 * (LastAuthUser). The pointer and roster head are written together.
 	 *
 	 * @param username - The username to mark as the active session.
 	 */
 	async addActiveSession(username: string): Promise<void> {
 		const list = await this.getAuthUserList();
-		await this.persistAuthUserList([
-			username,
-			...list.filter(user => user !== username),
-		]);
+		await this.persistAuthUserList(
+			[username, ...list.filter(user => user !== username)],
+			{ setPointerTo: username },
+		);
 	}
 
 	/**
-	 * Removes a session for the given username from the roster.
+	 * Removes a session for the given username from the roster. Under the pointer
+	 * model this NEVER chooses or promotes a next active user and NEVER touches
+	 * the LastAuthUser pointer (clearing/repointing the active user is the
+	 * caller's responsibility via {@link clearActiveUser} / addActiveSession).
 	 *
 	 * @param username - The username whose session should be removed.
-	 * @returns The new active user (roster head, if any) and whether the roster
-	 * is now empty.
+	 * @returns Whether the roster is now empty.
 	 */
-	async removeSession(
-		username: string,
-	): Promise<{ newActiveUser?: string; isEmpty: boolean }> {
+	async removeSession(username: string): Promise<{ isEmpty: boolean }> {
 		const list = await this.getAuthUserList();
 		const newList = list.filter(user => user !== username);
 		await this.persistAuthUserList(newList);
 
-		return { newActiveUser: newList[0], isEmpty: newList.length === 0 };
+		return { isEmpty: newList.length === 0 };
+	}
+
+	/**
+	 * Reads the RAW active-user pointer (LastAuthUser) without the sentinel
+	 * fallback, returning `undefined` when the pointer is empty/absent or holds
+	 * the legacy 'username' sentinel. Used to distinguish "nobody active" from an
+	 * actual active user (see dispatchSignedInHubEvent / setCurrentUser); does NOT
+	 * derive from the roster.
+	 */
+	async getActiveUsername(): Promise<string | undefined> {
+		const lastAuthUser = await this.getKeyValueStorage().getItem(
+			this.getLastAuthUserKey(),
+		);
+
+		return lastAuthUser && lastAuthUser !== 'username'
+			? lastAuthUser
+			: undefined;
+	}
+
+	/**
+	 * Clears the active-user pointer (LastAuthUser key) ONLY, leaving the
+	 * AuthUserList roster intact so parked sessions survive. After this,
+	 * getLastAuthUser returns the 'username' sentinel and getCurrentUser/
+	 * fetchAuthSession behave as signed-out until setCurrentUser is called.
+	 */
+	async clearActiveUser(): Promise<void> {
+		await this.getKeyValueStorage().removeItem(this.getLastAuthUserKey());
 	}
 
 	async getLastAuthUser(): Promise<string> {
-		return (await this.getAuthUserList())[0] ?? 'username';
+		// Read the pointer DIRECTLY; return the legacy 'username' sentinel when the
+		// pointer is empty/absent EVEN IF the roster still holds parked sessions.
+		// Never falls back to the roster head.
+		return (await this.getActiveUsername()) ?? 'username';
 	}
 
 	async setOAuthMetadata(metadata: OAuthMetadata): Promise<void> {

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
@@ -202,7 +202,13 @@ export class DefaultTokenStore implements AuthTokenStore {
 		// (LastAuthUser / AuthUserList). The active pointer is owned exclusively by
 		// the roster methods (persistAuthUserList). This prevents token refresh from
 		// reordering the session roster.
-		const authKeys = await this.getAuthKeys();
+		//
+		// Keys are resolved from tokens.username (the user these tokens belong to),
+		// INDEPENDENT of the active pointer. A fresh sign-in caches tokens BEFORE
+		// addActiveSession moves the pointer, so a no-arg getAuthKeys() would namespace
+		// under the stale/sentinel pointer and the tokens would be unreachable once the
+		// pointer advances to the new user's (empty) namespace (per HLD §4.3).
+		const authKeys = await this.getAuthKeys(tokens.username);
 		await this.getKeyValueStorage().setItem(
 			authKeys.accessToken,
 			tokens.accessToken.toString(),

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
@@ -288,15 +288,16 @@ export class DefaultTokenStore implements AuthTokenStore {
 	async clearTokensForUser(username: string): Promise<void> {
 		const authKeys = await this.getAuthKeys(username);
 		// Not calling clear because it can remove data that is not managed by AuthTokenStore
+		// Device-tracking keys (deviceKey/deviceGroupKey/randomPasswordKey) are
+		// deliberately PRESERVED here, mirroring legacy `clearTokens` semantics: a
+		// remembered device must survive sign-out so the next sign-in can skip MFA.
+		// Only forgetDevice/deleteUser clear device metadata (via clearDeviceMetadata).
 		await Promise.all([
 			this.getKeyValueStorage().removeItem(authKeys.accessToken),
 			this.getKeyValueStorage().removeItem(authKeys.idToken),
 			this.getKeyValueStorage().removeItem(authKeys.clockDrift),
 			this.getKeyValueStorage().removeItem(authKeys.refreshToken),
 			this.getKeyValueStorage().removeItem(authKeys.signInDetails),
-			this.getKeyValueStorage().removeItem(authKeys.deviceKey),
-			this.getKeyValueStorage().removeItem(authKeys.deviceGroupKey),
-			this.getKeyValueStorage().removeItem(authKeys.randomPasswordKey),
 			this.getKeyValueStorage().removeItem(authKeys.oauthMetadata),
 		]);
 	}
@@ -318,6 +319,24 @@ export class DefaultTokenStore implements AuthTokenStore {
 		} catch (err) {
 			return undefined;
 		}
+	}
+
+	/**
+	 * Returns true when a live session exists for the username, detected by the
+	 * presence of the ACCESS TOKEN key. This is the correct liveness signal for
+	 * pruning: loadTokens only requires an accessToken, and the idToken is
+	 * OPTIONAL (storeTokens removes the idToken key when a session lacks one), so
+	 * a valid accessToken+refreshToken session may legitimately have no idToken
+	 * and must NOT be evicted. Read-only, no decode.
+	 *
+	 * @param username - The username whose session presence should be checked.
+	 */
+	private async hasStoredSession(username: string): Promise<boolean> {
+		const authKeys = await this.getAuthKeys(username);
+
+		return (
+			(await this.getKeyValueStorage().getItem(authKeys.accessToken)) != null
+		);
 	}
 
 	async getDeviceMetadata(username?: string): Promise<DeviceMetadata | null> {
@@ -389,22 +408,84 @@ export class DefaultTokenStore implements AuthTokenStore {
 	 * but a legacy LastAuthUser value exists (and is not the literal 'username'
 	 * fallback), that single user is migrated into a roster and persisted.
 	 * Otherwise an empty roster is returned.
+	 *
+	 * Every read is also a reconciliation point. External writers (older Amplify
+	 * versions and amazon-cognito-identity-js sharing the same storage) mutate
+	 * LastAuthUser directly, drifting it from AuthUserList[0]; and a partial
+	 * persist (LastAuthUser written, AuthUserList not) leaves the same skew. When
+	 * LastAuthUser names a real user that isn't the current head, it is promoted
+	 * to the front and the roster is pruned of entries whose tokens are no longer
+	 * resolvable, then re-persisted (best-effort — SSR storage may be read-only).
+	 * The head LastAuthUser read happens on every call (a single cheap read); the
+	 * "no extra reads" guarantee is per-entry only — the per-entry token reads and
+	 * the re-persist run ONLY on the promotion path, so the hot path (already in
+	 * sync) does no per-entry storage reads / JWT decodes.
 	 */
 	async getAuthUserList(): Promise<string[]> {
 		const authUserListString = await this.getKeyValueStorage().getItem(
 			this.getAuthUserListKey(),
 		);
+		const lastAuthUser = await this.getKeyValueStorage().getItem(
+			this.getLastAuthUserKey(),
+		);
 
 		if (authUserListString) {
-			return authUserListString.split(',').filter(Boolean);
+			const parsedList = authUserListString.split(',').filter(Boolean);
+			let reconciledList = parsedList;
+
+			// Reconcile drift: LastAuthUser may have been advanced by an external
+			// writer or a partial persist. Ignore the 'username' sentinel/empty.
+			const shouldReconcile =
+				!!lastAuthUser &&
+				lastAuthUser !== 'username' &&
+				lastAuthUser !== parsedList[0];
+
+			if (shouldReconcile) {
+				// Promote to front (move if already present, otherwise prepend).
+				reconciledList = [
+					lastAuthUser,
+					...parsedList.filter(user => user !== lastAuthUser),
+				];
+
+				// Prune entries with no live session — only on the (rare) promotion
+				// path, to keep the hot path free of per-entry reads. Liveness is the
+				// ACCESS TOKEN key (idToken is optional), see hasStoredSession.
+				const prunedList: string[] = [];
+				for (const entry of reconciledList) {
+					if (await this.hasStoredSession(entry)) {
+						prunedList.push(entry);
+					}
+				}
+				reconciledList = prunedList;
+			}
+
+			// Re-persist when reconciliation changed the roster contents, OR when it
+			// ran but the stored LastAuthUser pointer still doesn't match the new
+			// head. The latter covers promotion+prune netting back to the original
+			// list (e.g. external LastAuthUser='C' with no tokens: [A,B]→[C,A,B]→
+			// [A,B]) where LastAuthUser would otherwise stay stale at 'C' and re-run
+			// the full prune on every read. When reconciledList is empty,
+			// persistAuthUserList([]) clears both keys — the intended outcome when
+			// no resolvable session remains.
+			if (
+				reconciledList.join(',') !== parsedList.join(',') ||
+				(shouldReconcile && reconciledList[0] !== lastAuthUser)
+			) {
+				// Best-effort: read-only/ephemeral SSR storage may reject the write;
+				// the reconciled list is still returned to the caller.
+				try {
+					await this.persistAuthUserList(reconciledList);
+				} catch {
+					// Storage is read-only (e.g. SSR); degrade gracefully.
+				}
+			}
+
+			return reconciledList;
 		}
 
 		// Migration: fall back to a legacy single LastAuthUser value if present.
-		const legacyLastAuthUser = await this.getKeyValueStorage().getItem(
-			this.getLastAuthUserKey(),
-		);
-		if (legacyLastAuthUser && legacyLastAuthUser !== 'username') {
-			const migratedList = [legacyLastAuthUser];
+		if (lastAuthUser && lastAuthUser !== 'username') {
+			const migratedList = [lastAuthUser];
 			// Best-effort persist: on read-only/ephemeral SSR storage the write
 			// may fail — that's acceptable because the migrated list is still
 			// returned to the caller; the next mutable-storage call will retry.
@@ -439,15 +520,17 @@ export class DefaultTokenStore implements AuthTokenStore {
 			return;
 		}
 
+		// Write LastAuthUser FIRST, then AuthUserList. On a partial failure the
+		// newer intent survives in LastAuthUser (the pointer legacy/external
+		// consumers read), and getAuthUserList's drift reconciliation repairs
+		// AuthUserList from it on the next read. LastAuthUser is also kept in
+		// sync for legacy consumers, though AuthUserList is authoritative when
+		// both are present.
+		await this.getKeyValueStorage().setItem(this.getLastAuthUserKey(), list[0]);
 		await this.getKeyValueStorage().setItem(
 			this.getAuthUserListKey(),
 			list.join(','),
 		);
-		// Best-effort / compatibility-only: LastAuthUser is kept in sync for
-		// legacy consumers, but AuthUserList is authoritative when present
-		// (getAuthUserList prefers it). A lost LastAuthUser write does not
-		// affect roster correctness.
-		await this.getKeyValueStorage().setItem(this.getLastAuthUserKey(), list[0]);
 	}
 
 	/**

--- a/packages/auth/src/providers/cognito/tokenProvider/createAuthSessionSwitcher.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/createAuthSessionSwitcher.ts
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AuthError } from '../../../errors/AuthError';
+import { USER_NOT_SIGNED_IN_EXCEPTION } from '../../../errors/constants';
+
+import { AuthSessionSwitcher, AuthTokenStore } from './types';
+
+/**
+ * The subset of a token store the switcher is allowed to touch: only reads and
+ * the roster reorder. This narrowing (via `Pick`) guarantees, by construction,
+ * that the switcher cannot reach any destructive store method.
+ */
+type SwitchableTokenStore = Pick<
+	AuthTokenStore,
+	'getAuthUserList' | 'getStoredIdToken' | 'addActiveSession'
+>;
+
+/**
+ * Builds a non-destructive {@link AuthSessionSwitcher} over a token store.
+ *
+ * The returned object can only read the roster / stored id tokens and perform a
+ * membership-checked reorder. It deliberately does not close over — nor expose —
+ * any destructive store method, so it is safe to surface across a server context
+ * boundary.
+ *
+ * @param store - The (read + reorder) slice of the token store to wrap.
+ * @returns A narrow session switcher.
+ */
+export const createAuthSessionSwitcher = (
+	store: SwitchableTokenStore,
+): AuthSessionSwitcher => ({
+	listSessionUsernames: () => store.getAuthUserList(),
+	getStoredIdToken: username => store.getStoredIdToken(username),
+	setActiveSession: async username => {
+		// Roster is ordered with the active user first.
+		const list = await store.getAuthUserList();
+
+		if (!list.includes(username)) {
+			throw new AuthError({
+				name: USER_NOT_SIGNED_IN_EXCEPTION,
+				message: `Cannot switch to user "${username}": no signed-in session found.`,
+				recoverySuggestion:
+					'Please make sure the user has signed in before switching to it.',
+			});
+		}
+
+		// Membership confirmed: promote the target to the front of the roster.
+		// addActiveSession only reorders an existing member here; it never adds a
+		// non-signed-in user (guarded above) and never deletes tokens.
+		await store.addActiveSession(username);
+	},
+});

--- a/packages/auth/src/providers/cognito/tokenProvider/index.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/index.ts
@@ -7,6 +7,8 @@ export {
 } from '../utils/refreshAuthTokens';
 export { DefaultTokenStore, createKeysForAuthStorage } from './TokenStore';
 export { TokenOrchestrator } from './TokenOrchestrator';
+export { createAuthSessionSwitcher } from './createAuthSessionSwitcher';
+export { AuthSessionSwitcher } from './types';
 export { CognitoUserPoolTokenProviderType } from './types';
 export {
 	cognitoUserPoolsTokenProvider,

--- a/packages/auth/src/providers/cognito/tokenProvider/types.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/types.ts
@@ -8,6 +8,7 @@ import {
 	KeyValueStorageInterface,
 	TokenProvider,
 } from '@aws-amplify/core';
+import { JWT } from '@aws-amplify/core/internals/utils';
 
 import { ClientMetadata, CognitoAuthSignInDetails } from '../types';
 
@@ -40,9 +41,16 @@ export const AuthTokenStorageKeys = {
 
 export interface AuthTokenStore {
 	getLastAuthUser(): Promise<string>;
+	getAuthUserList(): Promise<string[]>;
+	getStoredIdToken(username: string): Promise<JWT | undefined>;
+	addActiveSession(username: string): Promise<void>;
+	removeSession(
+		username: string,
+	): Promise<{ newActiveUser?: string; isEmpty: boolean }>;
 	loadTokens(): Promise<CognitoAuthTokens | null>;
 	storeTokens(tokens: CognitoAuthTokens): Promise<void>;
 	clearTokens(): Promise<void>;
+	clearTokensForUser(username: string): Promise<void>;
 	setKeyValueStorage(keyValueStorage: KeyValueStorageInterface): void;
 	getDeviceMetadata(username?: string): Promise<DeviceMetadata | null>;
 	clearDeviceMetadata(username?: string): Promise<void>;
@@ -72,6 +80,44 @@ export interface CognitoUserPoolTokenProviderType extends TokenProvider {
 	setClientMetadataProvider(
 		clientMetadataProvider: ClientMetadataProvider,
 	): void;
+}
+
+/**
+ * A deliberately narrow, Cognito-only capability for reading and switching the
+ * active session within an existing roster.
+ *
+ * It exposes ONLY read access and a membership-checked reorder. It intentionally
+ * omits every destructive token-store operation (storeTokens / clearTokens /
+ * clearTokensForUser / removeSession) so that a server context can switch the
+ * active session without any ability to mint or delete sessions.
+ *
+ * This is NOT part of the generic {@link TokenProvider} contract in `core`; it
+ * is surfaced separately by the Cognito server token provider.
+ */
+export interface AuthSessionSwitcher {
+	/**
+	 * Reads the ordered session roster (active user first) without triggering a
+	 * token refresh.
+	 */
+	listSessionUsernames(): Promise<string[]>;
+	/**
+	 * Reads and decodes a specific user's stored id token without triggering a
+	 * refresh. Resolves to `undefined` when absent/undecodable.
+	 *
+	 * @param username - The username whose stored id token should be read.
+	 */
+	getStoredIdToken(username: string): Promise<JWT | undefined>;
+	/**
+	 * Promotes an ALREADY signed-in user to the active session (roster head).
+	 *
+	 * This is a membership-checked reorder: it throws when `username` is not part
+	 * of the current roster and NEVER adds a non-signed-in user or deletes tokens.
+	 *
+	 * @param username - The signed-in username to make active.
+	 * @throws {@link AuthError} - With name `UserNotSignedInException` when the
+	 * username has no signed-in session in the roster.
+	 */
+	setActiveSession(username: string): Promise<void>;
 }
 
 export type CognitoAuthTokens = AuthTokens & {

--- a/packages/auth/src/providers/cognito/tokenProvider/types.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/types.ts
@@ -47,6 +47,7 @@ export interface AuthTokenStore {
 	addActiveSession(username: string): Promise<void>;
 	removeSession(username: string): Promise<{ isEmpty: boolean }>;
 	clearActiveUser(): Promise<void>;
+	reassertActiveUserPointer(username: string): Promise<void>;
 	loadTokens(): Promise<CognitoAuthTokens | null>;
 	storeTokens(tokens: CognitoAuthTokens): Promise<void>;
 	clearTokens(): Promise<void>;
@@ -54,7 +55,7 @@ export interface AuthTokenStore {
 	setKeyValueStorage(keyValueStorage: KeyValueStorageInterface): void;
 	getDeviceMetadata(username?: string): Promise<DeviceMetadata | null>;
 	clearDeviceMetadata(username?: string): Promise<void>;
-	setOAuthMetadata(metadata: OAuthMetadata): Promise<void>;
+	setOAuthMetadata(metadata: OAuthMetadata, username?: string): Promise<void>;
 	getOAuthMetadata(): Promise<OAuthMetadata | null>;
 }
 
@@ -70,7 +71,7 @@ export interface AuthTokenOrchestrator {
 	clearTokens(): Promise<void>;
 	getDeviceMetadata(username?: string): Promise<DeviceMetadata | null>;
 	clearDeviceMetadata(username?: string): Promise<void>;
-	setOAuthMetadata(metadata: OAuthMetadata): Promise<void>;
+	setOAuthMetadata(metadata: OAuthMetadata, username?: string): Promise<void>;
 	getOAuthMetadata(): Promise<OAuthMetadata | null>;
 }
 

--- a/packages/auth/src/providers/cognito/tokenProvider/types.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/types.ts
@@ -41,12 +41,12 @@ export const AuthTokenStorageKeys = {
 
 export interface AuthTokenStore {
 	getLastAuthUser(): Promise<string>;
+	getActiveUsername(): Promise<string | undefined>;
 	getAuthUserList(): Promise<string[]>;
 	getStoredIdToken(username: string): Promise<JWT | undefined>;
 	addActiveSession(username: string): Promise<void>;
-	removeSession(
-		username: string,
-	): Promise<{ newActiveUser?: string; isEmpty: boolean }>;
+	removeSession(username: string): Promise<{ isEmpty: boolean }>;
+	clearActiveUser(): Promise<void>;
 	loadTokens(): Promise<CognitoAuthTokens | null>;
 	storeTokens(tokens: CognitoAuthTokens): Promise<void>;
 	clearTokens(): Promise<void>;

--- a/packages/auth/src/providers/cognito/tokenProvider/types.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/types.ts
@@ -44,6 +44,9 @@ export interface AuthTokenStore {
 	getActiveUsername(): Promise<string | undefined>;
 	getAuthUserList(): Promise<string[]>;
 	getStoredIdToken(username: string): Promise<JWT | undefined>;
+	getStoredSignInDetails(
+		username: string,
+	): Promise<CognitoAuthSignInDetails | undefined>;
 	addActiveSession(username: string): Promise<void>;
 	removeSession(username: string): Promise<{ isEmpty: boolean }>;
 	clearActiveUser(): Promise<void>;

--- a/packages/auth/src/providers/cognito/utils/dispatchSignOutHubEvents.ts
+++ b/packages/auth/src/providers/cognito/utils/dispatchSignOutHubEvents.ts
@@ -61,6 +61,14 @@ export async function dispatchSignOutBoundaryEvents(
 		tokenStore,
 		removeResult.newActiveUser,
 	);
+
+	// If the promoted user's identity can't be resolved (undecodable/missing
+	// idToken), skip the dispatch — emitting userId:'' would violate the
+	// AuthUser contract.
+	if (!promoted.userId) {
+		return;
+	}
+
 	Hub.dispatch(
 		'auth',
 		{ event: 'switchActiveUser', data: promoted },

--- a/packages/auth/src/providers/cognito/utils/dispatchSignOutHubEvents.ts
+++ b/packages/auth/src/providers/cognito/utils/dispatchSignOutHubEvents.ts
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Hub } from '@aws-amplify/core';
+import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
+
+import type { AuthTokenStore } from '../tokenProvider/types';
+
+/**
+ * Dispatches the sign-out boundary Hub events shared across every sign-out path
+ * (apis/signOut, OAuth sign-out, and terminal token-refresh failure) so they
+ * stay consistent.
+ *
+ * Event contract (all payloads are exactly `{ username, userId }`):
+ * - `userSignedOut` fires whenever a resolvable active user was removed; it
+ *   tracks roster membership.
+ * - `signedOut` fires only when the roster transitioned to empty.
+ * - `switchActiveUser` fires when the active pointer moved to a promoted parked
+ *   user; its identity is resolved from the promoted user's STORED id token
+ *   WITHOUT triggering a token refresh.
+ *
+ * @param tokenStore - The token store used to resolve the promoted user's
+ * identity from their stored id token (injected to avoid a tokenProvider import
+ * cycle).
+ * @param signedOutUser - The user that was signed out, or `undefined` when no
+ * active user could be resolved before removal.
+ * @param removeResult - The result of `removeSession`: the promoted roster head
+ * (if any) and whether the roster is now empty.
+ */
+export async function dispatchSignOutBoundaryEvents(
+	tokenStore: AuthTokenStore,
+	signedOutUser: { username: string; userId: string } | undefined,
+	removeResult: { newActiveUser?: string; isEmpty: boolean },
+): Promise<void> {
+	// userSignedOut tracks roster membership: fires for every sign-out where we
+	// had a resolvable active user.
+	if (signedOutUser) {
+		Hub.dispatch(
+			'auth',
+			{ event: 'userSignedOut', data: signedOutUser },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+	}
+
+	if (removeResult.isEmpty) {
+		// roster went non-empty -> empty: emit the signedOut boundary event.
+		Hub.dispatch(
+			'auth',
+			{ event: 'signedOut', data: signedOutUser },
+			'Auth',
+			AMPLIFY_SYMBOL,
+		);
+
+		return;
+	}
+
+	// active pointer moved to a promoted roster member; resolve the new active
+	// user's identity from their stored id token (no refresh) and announce it.
+	const promoted = await resolvePromotedUser(
+		tokenStore,
+		removeResult.newActiveUser,
+	);
+	Hub.dispatch(
+		'auth',
+		{ event: 'switchActiveUser', data: promoted },
+		'Auth',
+		AMPLIFY_SYMBOL,
+	);
+}
+
+/**
+ * Resolves the promoted user's identity from their STORED id token without
+ * triggering a token refresh. Falls back to an empty userId (rather than
+ * throwing) when the id token cannot be read or decoded.
+ *
+ * @param tokenStore - The token store used to read the promoted user's stored
+ * id token.
+ * @param newActiveUser - The promoted roster head (may be undefined).
+ * @returns The `{ username, userId }` payload for the `switchActiveUser` event.
+ */
+async function resolvePromotedUser(
+	tokenStore: AuthTokenStore,
+	newActiveUser: string | undefined,
+): Promise<{ username: string; userId: string }> {
+	const username = newActiveUser ?? '';
+	try {
+		const idToken = await tokenStore.getStoredIdToken(username);
+
+		if (idToken) {
+			const { sub } = idToken.payload ?? {};
+
+			return { username, userId: (sub as string) ?? '' };
+		}
+	} catch (err) {
+		// Fall through to the empty-userId fallback below rather than throwing.
+	}
+
+	return { username, userId: '' };
+}

--- a/packages/auth/src/providers/cognito/utils/dispatchSignOutHubEvents.ts
+++ b/packages/auth/src/providers/cognito/utils/dispatchSignOutHubEvents.ts
@@ -4,36 +4,31 @@
 import { Hub } from '@aws-amplify/core';
 import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
 
-import type { AuthTokenStore } from '../tokenProvider/types';
-
 /**
  * Dispatches the sign-out boundary Hub events shared across every sign-out path
  * (apis/signOut, OAuth sign-out, and terminal token-refresh failure) so they
  * stay consistent.
  *
- * Event contract (all payloads are exactly `{ username, userId }`):
- * - `userSignedOut` fires whenever a resolvable active user was removed; it
- *   tracks roster membership.
- * - `signedOut` fires only when the roster transitioned to empty.
- * - `switchActiveUser` fires when the active pointer moved to a promoted parked
- *   user; its identity is resolved from the promoted user's STORED id token
- *   WITHOUT triggering a token refresh.
+ * Under the no-promotion sign-out model a sign-out NEVER promotes a parked
+ * session, so no `switchActiveUser` event is ever emitted here (that resolution
+ * logic has been removed). Parked sessions may remain in the roster; sign-out
+ * only clears the ACTIVE pointer.
  *
- * @param tokenStore - The token store used to resolve the promoted user's
- * identity from their stored id token (injected to avoid a tokenProvider import
- * cycle).
+ * Event contract:
+ * - `userSignedOut` (payload `{ username, userId }`) fires whenever a resolvable
+ *   signed-out user was captured; skipped when the identity is unresolvable
+ *   (missing/undecodable id token) to avoid violating the AuthUser contract.
+ * - `signedOut` fires ALWAYS — its data is the signed-out user when resolvable,
+ *   otherwise undefined (no data).
+ *
  * @param signedOutUser - The user that was signed out, or `undefined` when no
  * active user could be resolved before removal.
- * @param removeResult - The result of `removeSession`: the promoted roster head
- * (if any) and whether the roster is now empty.
  */
 export async function dispatchSignOutBoundaryEvents(
-	tokenStore: AuthTokenStore,
 	signedOutUser: { username: string; userId: string } | undefined,
-	removeResult: { newActiveUser?: string; isEmpty: boolean },
 ): Promise<void> {
-	// userSignedOut tracks roster membership: fires for every sign-out where we
-	// had a resolvable active user.
+	// userSignedOut tracks the specific user leaving: fires only when we had a
+	// resolvable signed-out identity.
 	if (signedOutUser) {
 		Hub.dispatch(
 			'auth',
@@ -43,66 +38,12 @@ export async function dispatchSignOutBoundaryEvents(
 		);
 	}
 
-	if (removeResult.isEmpty) {
-		// roster went non-empty -> empty: emit the signedOut boundary event.
-		Hub.dispatch(
-			'auth',
-			{ event: 'signedOut', data: signedOutUser },
-			'Auth',
-			AMPLIFY_SYMBOL,
-		);
-
-		return;
-	}
-
-	// active pointer moved to a promoted roster member; resolve the new active
-	// user's identity from their stored id token (no refresh) and announce it.
-	const promoted = await resolvePromotedUser(
-		tokenStore,
-		removeResult.newActiveUser,
-	);
-
-	// If the promoted user's identity can't be resolved (undecodable/missing
-	// idToken), skip the dispatch — emitting userId:'' would violate the
-	// AuthUser contract.
-	if (!promoted.userId) {
-		return;
-	}
-
+	// signedOut is the sign-out boundary and fires ALWAYS under the no-promotion
+	// model, regardless of any parked sessions remaining in the roster.
 	Hub.dispatch(
 		'auth',
-		{ event: 'switchActiveUser', data: promoted },
+		{ event: 'signedOut', data: signedOutUser },
 		'Auth',
 		AMPLIFY_SYMBOL,
 	);
-}
-
-/**
- * Resolves the promoted user's identity from their STORED id token without
- * triggering a token refresh. Falls back to an empty userId (rather than
- * throwing) when the id token cannot be read or decoded.
- *
- * @param tokenStore - The token store used to read the promoted user's stored
- * id token.
- * @param newActiveUser - The promoted roster head (may be undefined).
- * @returns The `{ username, userId }` payload for the `switchActiveUser` event.
- */
-async function resolvePromotedUser(
-	tokenStore: AuthTokenStore,
-	newActiveUser: string | undefined,
-): Promise<{ username: string; userId: string }> {
-	const username = newActiveUser ?? '';
-	try {
-		const idToken = await tokenStore.getStoredIdToken(username);
-
-		if (idToken) {
-			const { sub } = idToken.payload ?? {};
-
-			return { username, userId: (sub as string) ?? '' };
-		}
-	} catch (err) {
-		// Fall through to the empty-userId fallback below rather than throwing.
-	}
-
-	return { username, userId: '' };
 }

--- a/packages/auth/src/providers/cognito/utils/dispatchSignedInHubEvent.ts
+++ b/packages/auth/src/providers/cognito/utils/dispatchSignedInHubEvent.ts
@@ -10,21 +10,67 @@ import {
 	USER_UNAUTHENTICATED_EXCEPTION,
 } from '../../../errors/constants';
 import { AuthError } from '../../../errors/AuthError';
+import type { AuthTokenStore } from '../tokenProvider/types';
 
 export const ERROR_MESSAGE =
 	'Unable to get user session following successful sign-in.';
 
-export const dispatchSignedInHubEvent = async () => {
+export const dispatchSignedInHubEvent = async (
+	tokenStore: AuthTokenStore,
+	username: string,
+) => {
 	try {
+		// Capture the current roster head BEFORE adding the new active session so
+		// we can distinguish first sign-in (empty roster), a genuine active-user
+		// switch, and the active user simply re-authenticating.
+		const list = await tokenStore.getAuthUserList();
+		const head = list[0];
+		// Add/promote the signed-in user to the front of the roster BEFORE
+		// resolving the payload so getLastAuthUser reflects the new active user.
+		await tokenStore.addActiveSession(username);
+
+		const currentUser = await getCurrentUser();
+		const data = {
+			username: currentUser.username,
+			userId: currentUser.userId,
+		};
+
+		// userSignedIn tracks roster membership and fires on every sign-in.
 		Hub.dispatch(
 			'auth',
 			{
-				event: 'signedIn',
-				data: await getCurrentUser(),
+				event: 'userSignedIn',
+				data,
 			},
 			'Auth',
 			AMPLIFY_SYMBOL,
 		);
+
+		if (!head) {
+			// roster was empty -> non-empty: emit the signedIn boundary event.
+			Hub.dispatch(
+				'auth',
+				{
+					event: 'signedIn',
+					data,
+				},
+				'Auth',
+				AMPLIFY_SYMBOL,
+			);
+		} else if (head !== username) {
+			// a different user was active -> the active pointer moved between users.
+			Hub.dispatch(
+				'auth',
+				{
+					event: 'switchActiveUser',
+					data,
+				},
+				'Auth',
+				AMPLIFY_SYMBOL,
+			);
+		}
+		// else the already-active user re-authenticated: neither signedIn nor
+		// switchActiveUser is a meaningful boundary, so dispatch neither.
 	} catch (error) {
 		if ((error as AuthError).name === USER_UNAUTHENTICATED_EXCEPTION) {
 			throw new AuthError({

--- a/packages/auth/src/providers/cognito/utils/dispatchSignedInHubEvent.ts
+++ b/packages/auth/src/providers/cognito/utils/dispatchSignedInHubEvent.ts
@@ -23,19 +23,23 @@ export const dispatchSignedInHubEvent = async (
 		// The roster/pointer live in the module-level token store (client path);
 		// main's ctx-native sign-in likewise reaches `tokenOrchestrator` directly.
 		const tokenStore = tokenOrchestrator.getTokenStore();
-		// Capture the current roster head BEFORE adding the new active session so
-		// we can distinguish first sign-in (empty roster), a genuine active-user
-		// switch, and the active user simply re-authenticating.
-		const list = await tokenStore.getAuthUserList();
-		const head = list[0];
-		// Add/promote the signed-in user to the front of the roster BEFORE
-		// resolving the payload so getLastAuthUser reflects the new active user.
+		// Capture the RAW active pointer BEFORE adding the new active session so we
+		// can distinguish activating from no-active-user (first sign-in OR a parked
+		// roster after sign-out), a genuine active-user switch, and the active user
+		// simply re-authenticating. A parked-only roster reads as no active pointer.
+		const activePointer = await tokenStore.getActiveUsername();
+		// Add/promote the signed-in user to the front of the roster AND set the
+		// active pointer BEFORE resolving the payload so getLastAuthUser reflects
+		// the new active user.
 		await tokenStore.addActiveSession(username);
 
-		// Resolve the now-active user's identity via the ctx-native getCurrentUser.
-		const data = await getCurrentUser(ctx);
+		const currentUser = await getCurrentUser(ctx);
+		const data = {
+			username: currentUser.username,
+			userId: currentUser.userId,
+		};
 
-		// userSignedIn tracks roster membership and fires on every sign-in.
+		// userSignedIn tracks the specific user signing in and fires on every sign-in.
 		Hub.dispatch(
 			'auth',
 			{
@@ -46,8 +50,9 @@ export const dispatchSignedInHubEvent = async (
 			AMPLIFY_SYMBOL,
 		);
 
-		if (!head) {
-			// roster was empty -> non-empty: emit the signedIn boundary event.
+		if (!activePointer) {
+			// no active user before (empty pointer: first sign-in or activating a
+			// parked session after sign-out) -> emit the signedIn boundary event.
 			Hub.dispatch(
 				'auth',
 				{
@@ -57,7 +62,7 @@ export const dispatchSignedInHubEvent = async (
 				'Auth',
 				AMPLIFY_SYMBOL,
 			);
-		} else if (head !== username) {
+		} else if (activePointer !== username) {
 			// a different user was active -> the active pointer moved between users.
 			Hub.dispatch(
 				'auth',

--- a/packages/auth/src/providers/cognito/utils/dispatchSignedInHubEvent.ts
+++ b/packages/auth/src/providers/cognito/utils/dispatchSignedInHubEvent.ts
@@ -10,21 +10,67 @@ import {
 	USER_UNAUTHENTICATED_EXCEPTION,
 } from '../../../errors/constants';
 import { AuthError } from '../../../errors/AuthError';
+import { tokenOrchestrator } from '../tokenProvider';
 
 export const ERROR_MESSAGE =
 	'Unable to get user session following successful sign-in.';
 
-export const dispatchSignedInHubEvent = async (ctx: AmplifyContext) => {
+export const dispatchSignedInHubEvent = async (
+	ctx: AmplifyContext,
+	username: string,
+) => {
 	try {
+		// The roster/pointer live in the module-level token store (client path);
+		// main's ctx-native sign-in likewise reaches `tokenOrchestrator` directly.
+		const tokenStore = tokenOrchestrator.getTokenStore();
+		// Capture the current roster head BEFORE adding the new active session so
+		// we can distinguish first sign-in (empty roster), a genuine active-user
+		// switch, and the active user simply re-authenticating.
+		const list = await tokenStore.getAuthUserList();
+		const head = list[0];
+		// Add/promote the signed-in user to the front of the roster BEFORE
+		// resolving the payload so getLastAuthUser reflects the new active user.
+		await tokenStore.addActiveSession(username);
+
+		// Resolve the now-active user's identity via the ctx-native getCurrentUser.
+		const data = await getCurrentUser(ctx);
+
+		// userSignedIn tracks roster membership and fires on every sign-in.
 		Hub.dispatch(
 			'auth',
 			{
-				event: 'signedIn',
-				data: await getCurrentUser(ctx),
+				event: 'userSignedIn',
+				data,
 			},
 			'Auth',
 			AMPLIFY_SYMBOL,
 		);
+
+		if (!head) {
+			// roster was empty -> non-empty: emit the signedIn boundary event.
+			Hub.dispatch(
+				'auth',
+				{
+					event: 'signedIn',
+					data,
+				},
+				'Auth',
+				AMPLIFY_SYMBOL,
+			);
+		} else if (head !== username) {
+			// a different user was active -> the active pointer moved between users.
+			Hub.dispatch(
+				'auth',
+				{
+					event: 'switchActiveUser',
+					data,
+				},
+				'Auth',
+				AMPLIFY_SYMBOL,
+			);
+		}
+		// else the already-active user re-authenticated: neither signedIn nor
+		// switchActiveUser is a meaningful boundary, so dispatch neither.
 	} catch (error) {
 		if ((error as AuthError).name === USER_UNAUTHENTICATED_EXCEPTION) {
 			throw new AuthError({

--- a/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
@@ -138,8 +138,10 @@ const handleCodeFlow = async ({
 		throw createOAuthError(errorMessage ?? error);
 	}
 
-	const username =
-		(access_token && decodeJWT(access_token).payload.username) ?? 'username';
+	const username = resolveUsername({
+		accessToken: access_token,
+		idToken: id_token,
+	});
 
 	await cacheCognitoTokens({
 		username,
@@ -153,6 +155,7 @@ const handleCodeFlow = async ({
 	return completeFlow({
 		redirectUri,
 		state: validatedState,
+		username,
 		preferPrivateSession,
 	});
 };
@@ -201,8 +204,10 @@ const handleImplicitFlow = async ({
 	}
 
 	const validatedState = await validateState(state);
-	const username =
-		(access_token && decodeJWT(access_token).payload.username) ?? 'username';
+	const username = resolveUsername({
+		accessToken: access_token,
+		idToken: id_token,
+	});
 
 	await cacheCognitoTokens({
 		username,
@@ -215,6 +220,7 @@ const handleImplicitFlow = async ({
 	return completeFlow({
 		redirectUri,
 		state: validatedState,
+		username,
 		preferPrivateSession,
 	});
 };
@@ -222,11 +228,13 @@ const handleImplicitFlow = async ({
 const completeFlow = async ({
 	redirectUri,
 	state,
+	username,
 	preferPrivateSession,
 }: {
 	preferPrivateSession?: boolean;
 	redirectUri: string;
 	state: string;
+	username: string;
 }) => {
 	await tokenOrchestrator.setOAuthMetadata({
 		oauthSignIn: true,
@@ -254,7 +262,7 @@ const completeFlow = async ({
 		);
 	}
 	Hub.dispatch('auth', { event: 'signInWithRedirect' }, 'Auth', AMPLIFY_SYMBOL);
-	await dispatchSignedInHubEvent();
+	await dispatchSignedInHubEvent(tokenOrchestrator.getTokenStore(), username);
 };
 
 const isCustomState = (state: string): boolean => {
@@ -263,6 +271,40 @@ const isCustomState = (state: string): boolean => {
 
 const getCustomState = (state: string): string => {
 	return state.split('-').splice(1).join('-');
+};
+
+/**
+ * Resolves the signed-in username from the OAuth tokens' claims (the access
+ * token's `username` claim, falling back to the id token's `cognito:username`),
+ * mirroring how other sign-in paths derive the username.
+ *
+ * Throws an OAuth error rather than silently persisting the literal 'username'
+ * sentinel as a real roster entry when no username claim can be resolved.
+ */
+const resolveUsername = ({
+	accessToken,
+	idToken,
+}: {
+	accessToken?: string;
+	idToken?: string;
+}): string => {
+	const usernameFromAccessToken =
+		accessToken &&
+		(decodeJWT(accessToken).payload.username as string | undefined);
+	if (usernameFromAccessToken) {
+		return usernameFromAccessToken;
+	}
+
+	const usernameFromIdToken =
+		idToken &&
+		(decodeJWT(idToken).payload['cognito:username'] as string | undefined);
+	if (usernameFromIdToken) {
+		return usernameFromIdToken;
+	}
+
+	throw createOAuthError(
+		'Unable to resolve the username from the OAuth tokens.',
+	);
 };
 
 const clearHistory = (redirectUri: string) => {

--- a/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
@@ -236,9 +236,17 @@ const completeFlow = async ({
 	state: string;
 	username: string;
 }) => {
-	await tokenOrchestrator.setOAuthMetadata({
-		oauthSignIn: true,
-	});
+	await tokenOrchestrator.setOAuthMetadata(
+		{
+			oauthSignIn: true,
+		},
+		// Namespace the metadata under the signed-in user. dispatchSignedInHubEvent
+		// (below) is what moves the LastAuthUser pointer via addActiveSession, so at
+		// this point the pointer is still the stale/sentinel value; a no-arg call
+		// would strand the metadata under the wrong namespace and break OAuth
+		// sign-out detection on a second cookie-sharing subdomain.
+		username,
+	);
 	await oAuthStore.clearOAuthData();
 	await oAuthStore.storeOAuthSignIn(true, preferPrivateSession);
 

--- a/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
@@ -250,11 +250,6 @@ const completeFlow = async ({
 	await oAuthStore.clearOAuthData();
 	await oAuthStore.storeOAuthSignIn(true, preferPrivateSession);
 
-	// this should be called before any call that involves `fetchAuthSession`
-	// e.g. `getCurrentUser()` below, so it allows every inflight async calls to
-	//  `fetchAuthSession` can be resolved
-	resolveAndClearInflightPromises();
-
 	// clear history before sending out final Hub events
 	clearHistory(redirectUri);
 
@@ -270,7 +265,22 @@ const completeFlow = async ({
 		);
 	}
 	Hub.dispatch('auth', { event: 'signInWithRedirect' }, 'Auth', AMPLIFY_SYMBOL);
-	await dispatchSignedInHubEvent(getGlobalContext(), username);
+	try {
+		// dispatchSignedInHubEvent moves the LastAuthUser pointer to the signed-in
+		// user (via addActiveSession). Inflight `fetchAuthSession`/`getCurrentUser`
+		// callers — e.g. an app that fired getCurrentUser while the code flow was
+		// awaiting the /oauth2/token exchange — MUST only be released AFTER the
+		// pointer is set. loadTokens namespaces by the active pointer, so releasing
+		// them earlier makes them resolve against the stale 'username' sentinel
+		// namespace and throw UserUnAuthenticatedException (the implicit flow has no
+		// token-exchange await, so no caller blocks and the bug does not surface).
+		// clearOAuthData() above already cleared the inflight flag, so the
+		// getCurrentUser inside dispatchSignedInHubEvent does not block here.
+		await dispatchSignedInHubEvent(getGlobalContext(), username);
+	} finally {
+		// Always release blocked callers, even on failure, so the app never hangs.
+		resolveAndClearInflightPromises();
+	}
 };
 
 const isCustomState = (state: string): boolean => {

--- a/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/completeOAuthFlow.ts
@@ -138,8 +138,10 @@ const handleCodeFlow = async ({
 		throw createOAuthError(errorMessage ?? error);
 	}
 
-	const username =
-		(access_token && decodeJWT(access_token).payload.username) ?? 'username';
+	const username = resolveUsername({
+		accessToken: access_token,
+		idToken: id_token,
+	});
 
 	await cacheCognitoTokens({
 		username,
@@ -153,6 +155,7 @@ const handleCodeFlow = async ({
 	return completeFlow({
 		redirectUri,
 		state: validatedState,
+		username,
 		preferPrivateSession,
 	});
 };
@@ -201,8 +204,10 @@ const handleImplicitFlow = async ({
 	}
 
 	const validatedState = await validateState(state);
-	const username =
-		(access_token && decodeJWT(access_token).payload.username) ?? 'username';
+	const username = resolveUsername({
+		accessToken: access_token,
+		idToken: id_token,
+	});
 
 	await cacheCognitoTokens({
 		username,
@@ -215,6 +220,7 @@ const handleImplicitFlow = async ({
 	return completeFlow({
 		redirectUri,
 		state: validatedState,
+		username,
 		preferPrivateSession,
 	});
 };
@@ -222,11 +228,13 @@ const handleImplicitFlow = async ({
 const completeFlow = async ({
 	redirectUri,
 	state,
+	username,
 	preferPrivateSession,
 }: {
 	preferPrivateSession?: boolean;
 	redirectUri: string;
 	state: string;
+	username: string;
 }) => {
 	await tokenOrchestrator.setOAuthMetadata({
 		oauthSignIn: true,
@@ -254,7 +262,7 @@ const completeFlow = async ({
 		);
 	}
 	Hub.dispatch('auth', { event: 'signInWithRedirect' }, 'Auth', AMPLIFY_SYMBOL);
-	await dispatchSignedInHubEvent(getGlobalContext());
+	await dispatchSignedInHubEvent(getGlobalContext(), username);
 };
 
 const isCustomState = (state: string): boolean => {
@@ -263,6 +271,40 @@ const isCustomState = (state: string): boolean => {
 
 const getCustomState = (state: string): string => {
 	return state.split('-').splice(1).join('-');
+};
+
+/**
+ * Resolves the signed-in username from the OAuth tokens' claims (the access
+ * token's `username` claim, falling back to the id token's `cognito:username`),
+ * mirroring how other sign-in paths derive the username.
+ *
+ * Throws an OAuth error rather than silently persisting the literal 'username'
+ * sentinel as a real roster entry when no username claim can be resolved.
+ */
+const resolveUsername = ({
+	accessToken,
+	idToken,
+}: {
+	accessToken?: string;
+	idToken?: string;
+}): string => {
+	const usernameFromAccessToken =
+		accessToken &&
+		(decodeJWT(accessToken).payload.username as string | undefined);
+	if (usernameFromAccessToken) {
+		return usernameFromAccessToken;
+	}
+
+	const usernameFromIdToken =
+		idToken &&
+		(decodeJWT(idToken).payload['cognito:username'] as string | undefined);
+	if (usernameFromIdToken) {
+		return usernameFromIdToken;
+	}
+
+	throw createOAuthError(
+		'Unable to resolve the username from the OAuth tokens.',
+	);
 };
 
 const clearHistory = (redirectUri: string) => {

--- a/packages/auth/src/providers/cognito/utils/oauth/completeOAuthSignOut.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/completeOAuthSignOut.ts
@@ -1,15 +1,33 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Hub, clearCredentials } from '@aws-amplify/core';
-import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
+import { clearCredentials } from '@aws-amplify/core';
 
 import { DefaultOAuthStore } from '../../utils/signInWithRedirectStore';
 import { tokenOrchestrator } from '../../tokenProvider';
+import { dispatchSignOutBoundaryEvents } from '../dispatchSignOutHubEvents';
 
 export const completeOAuthSignOut = async (store: DefaultOAuthStore) => {
 	await store.clearOAuthData();
-	tokenOrchestrator.clearTokens();
+
+	const tokenStore = tokenOrchestrator.getTokenStore();
+	// Resolve the active user from STORED tokens (no refresh), then remove ONLY
+	// that user's namespace + roster entry. A blanket clearTokens() would remove
+	// AuthUserList and orphan every other parked session (multi-session support).
+	const tokens = await tokenStore.loadTokens();
+	const activeUsername =
+		tokens?.username ?? (await tokenStore.getLastAuthUser());
+	const activeUserId = tokens?.idToken?.payload?.sub as string | undefined;
+
+	await tokenStore.clearTokensForUser(activeUsername);
+	const removeResult = await tokenStore.removeSession(activeUsername);
 	await clearCredentials();
-	Hub.dispatch('auth', { event: 'signedOut' }, 'Auth', AMPLIFY_SYMBOL);
+
+	await dispatchSignOutBoundaryEvents(
+		tokenStore,
+		activeUserId
+			? { username: activeUsername, userId: activeUserId }
+			: undefined,
+		removeResult,
+	);
 };

--- a/packages/auth/src/providers/cognito/utils/oauth/completeOAuthSignOut.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/completeOAuthSignOut.ts
@@ -12,22 +12,21 @@ export const completeOAuthSignOut = async (store: DefaultOAuthStore) => {
 
 	const tokenStore = tokenOrchestrator.getTokenStore();
 	// Resolve the active user from STORED tokens (no refresh), then remove ONLY
-	// that user's namespace + roster entry. A blanket clearTokens() would remove
-	// AuthUserList and orphan every other parked session (multi-session support).
-	const tokens = await tokenStore.loadTokens();
-	const activeUsername =
-		tokens?.username ?? (await tokenStore.getLastAuthUser());
-	const activeUserId = tokens?.idToken?.payload?.sub as string | undefined;
+	// that user's namespace + roster entry and clear the active pointer. A
+	// blanket clearTokens() would remove AuthUserList and orphan every other
+	// parked session (multi-session support).
+	const activeUsername = await tokenStore.getLastAuthUser();
+	const storedIdToken = await tokenStore.getStoredIdToken(activeUsername);
+	const activeUserId = storedIdToken?.payload?.sub as string | undefined;
+	const signedOutUser = activeUserId
+		? { username: activeUsername, userId: activeUserId }
+		: undefined;
 
 	await tokenStore.clearTokensForUser(activeUsername);
-	const removeResult = await tokenStore.removeSession(activeUsername);
+	await tokenStore.removeSession(activeUsername);
+	await tokenStore.clearActiveUser();
 	await clearCredentials();
 
-	await dispatchSignOutBoundaryEvents(
-		tokenStore,
-		activeUserId
-			? { username: activeUsername, userId: activeUserId }
-			: undefined,
-		removeResult,
-	);
+	// userSignedOut (when resolvable) then signedOut ALWAYS; never switchActiveUser.
+	await dispatchSignOutBoundaryEvents(signedOutUser);
 };

--- a/packages/auth/src/providers/cognito/utils/oauth/completeOAuthSignOut.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/completeOAuthSignOut.ts
@@ -11,11 +11,18 @@ export const completeOAuthSignOut = async (store: DefaultOAuthStore) => {
 	await store.clearOAuthData();
 
 	const tokenStore = tokenOrchestrator.getTokenStore();
+	// Parked-only guard: when there is NO active user (empty/sentinel pointer),
+	// there is nobody to sign out. OAuth data has already been cleared above; skip
+	// the per-user token/roster mutation and emit NO signedOut event for nobody.
+	const activeUsername = await tokenStore.getActiveUsername();
+	if (!activeUsername) {
+		return;
+	}
+
 	// Resolve the active user from STORED tokens (no refresh), then remove ONLY
 	// that user's namespace + roster entry and clear the active pointer. A
 	// blanket clearTokens() would remove AuthUserList and orphan every other
 	// parked session (multi-session support).
-	const activeUsername = await tokenStore.getLastAuthUser();
 	const storedIdToken = await tokenStore.getStoredIdToken(activeUsername);
 	const activeUserId = storedIdToken?.payload?.sub as string | undefined;
 	const signedOutUser = activeUserId

--- a/packages/aws-amplify/__tests__/adapterCore/authProvidersFactories/cognito/createUserPoolsTokenProvider.test.ts
+++ b/packages/aws-amplify/__tests__/adapterCore/authProvidersFactories/cognito/createUserPoolsTokenProvider.test.ts
@@ -4,6 +4,7 @@
 import {
 	DefaultTokenStore,
 	TokenOrchestrator,
+	createAuthSessionSwitcher,
 	refreshAuthTokensWithoutDedupe,
 } from '@aws-amplify/auth/cognito';
 import { AuthConfig, KeyValueStorageInterface } from '@aws-amplify/core';
@@ -28,10 +29,17 @@ const mockAuthConfig: AuthConfig = {
 const MockDefaultTokenStore = DefaultTokenStore as jest.Mock;
 const MockTokenOrchestrator = TokenOrchestrator as jest.Mock;
 const mockRefreshAuthTokens = refreshAuthTokensWithoutDedupe as jest.Mock;
+const mockCreateAuthSessionSwitcher = createAuthSessionSwitcher as jest.Mock;
+const mockSwitcher = {
+	listSessionUsernames: jest.fn(),
+	getStoredIdToken: jest.fn(),
+	setActiveSession: jest.fn(),
+};
 
 describe('createUserPoolsTokenProvider', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
+		mockCreateAuthSessionSwitcher.mockReturnValue(mockSwitcher);
 	});
 
 	it('should create a token provider with underlying dependencies', () => {
@@ -63,6 +71,30 @@ describe('createUserPoolsTokenProvider', () => {
 		).toHaveBeenCalledWith(mockRefreshAuthTokens);
 
 		expect(tokenProvider).toBeDefined();
+	});
+
+	it('surfaces a non-destructive session switcher and no destructive store methods', () => {
+		const tokenProvider = createUserPoolsTokenProvider(
+			mockAuthConfig,
+			mockKeyValueStorage,
+		);
+		const mockTokenStoreInstance = MockDefaultTokenStore.mock.instances[0];
+
+		// the switcher is built from the closure's DefaultTokenStore.
+		expect(mockCreateAuthSessionSwitcher).toHaveBeenCalledWith(
+			mockTokenStoreInstance,
+		);
+		expect(tokenProvider.getSessionSwitcher()).toBe(mockSwitcher);
+
+		// ONLY read + reorder cross the boundary: no raw store, no destructive op.
+		expect(Object.keys(tokenProvider).sort()).toEqual([
+			'getSessionSwitcher',
+			'getTokens',
+		]);
+		expect('storeTokens' in tokenProvider).toBe(false);
+		expect('clearTokens' in tokenProvider).toBe(false);
+		expect('clearTokensForUser' in tokenProvider).toBe(false);
+		expect('removeSession' in tokenProvider).toBe(false);
 	});
 
 	it('should call TokenOrchestrator.getTokens method with the default forceRefresh value', async () => {

--- a/packages/aws-amplify/__tests__/exports.test.ts
+++ b/packages/aws-amplify/__tests__/exports.test.ts
@@ -183,6 +183,8 @@ describe('aws-amplify Exports', () => {
 					'associateWebAuthnCredential',
 					'listWebAuthnCredentials',
 					'deleteWebAuthnCredential',
+					'listCurrentUsers',
+					'setCurrentUser',
 				].sort(),
 			);
 		});
@@ -230,6 +232,9 @@ describe('aws-amplify Exports', () => {
 					'refreshAuthTokens',
 					'refreshAuthTokensWithoutDedupe',
 					'validateState',
+					'createAuthSessionSwitcher',
+					'listCurrentUsers',
+					'setCurrentUser',
 				].sort(),
 			);
 		});

--- a/packages/aws-amplify/__tests__/exports.test.ts
+++ b/packages/aws-amplify/__tests__/exports.test.ts
@@ -189,6 +189,8 @@ describe('aws-amplify Exports', () => {
 					'associateWebAuthnCredential',
 					'listWebAuthnCredentials',
 					'deleteWebAuthnCredential',
+					'listCurrentUsers',
+					'setCurrentUser',
 				].sort(),
 			);
 		});
@@ -236,6 +238,9 @@ describe('aws-amplify Exports', () => {
 					'refreshAuthTokens',
 					'refreshAuthTokensWithoutDedupe',
 					'validateState',
+					'createAuthSessionSwitcher',
+					'listCurrentUsers',
+					'setCurrentUser',
 				].sort(),
 			);
 		});

--- a/packages/aws-amplify/__tests__/exports.test.ts
+++ b/packages/aws-amplify/__tests__/exports.test.ts
@@ -6,6 +6,7 @@ import * as utilsExports from '../src/utils';
 import * as apiTopLevelExports from '../src/api';
 import * as authTopLevelExports from '../src/auth';
 import * as authCognitoExports from '../src/auth/cognito';
+import * as authServerExports from '../src/auth/server';
 import * as analyticsTopLevelExports from '../src/analytics';
 import * as analyticsPinpointExports from '../src/analytics/pinpoint';
 import * as inAppMessagingTopLevelExports from '../src/in-app-messaging';
@@ -242,6 +243,22 @@ describe('aws-amplify Exports', () => {
 					'listCurrentUsers',
 					'setCurrentUser',
 				].sort(),
+			);
+		});
+	});
+
+	describe('Auth server exports', () => {
+		it('should export the multi-session server APIs', () => {
+			// The server entry re-exports @aws-amplify/core/server symbols too, so
+			// assert the auth server surface CONTAINS the multi-session APIs rather
+			// than pinning the full (core-dependent) set.
+			expect(Object.keys(authServerExports)).toEqual(
+				expect.arrayContaining([
+					'getCurrentUser',
+					'fetchUserAttributes',
+					'listCurrentUsers',
+					'setCurrentUser',
+				]),
 			);
 		});
 	});

--- a/packages/aws-amplify/src/adapter-core/authProvidersFactories/cognito/createUserPoolsTokenProvider.ts
+++ b/packages/aws-amplify/src/adapter-core/authProvidersFactories/cognito/createUserPoolsTokenProvider.ts
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+	AuthSessionSwitcher,
 	DefaultTokenStore,
 	TokenOrchestrator,
+	createAuthSessionSwitcher,
 	refreshAuthTokensWithoutDedupe,
 } from '@aws-amplify/auth/cognito';
 import {
@@ -13,15 +15,30 @@ import {
 } from '@aws-amplify/core';
 
 /**
- * Creates an object that implements {@link TokenProvider}.
+ * A {@link TokenProvider} that additionally exposes a non-destructive Cognito
+ * session switcher for server contexts.
+ *
+ * The switcher only permits reading the roster and a membership-checked reorder;
+ * the underlying token store (and its destructive methods) is never surfaced.
+ */
+export interface UserPoolsTokenProvider extends TokenProvider {
+	/**
+	 * Returns the non-destructive session switcher bound to this provider's
+	 * per-request token store.
+	 */
+	getSessionSwitcher(): AuthSessionSwitcher;
+}
+
+/**
+ * Creates an object that implements {@link UserPoolsTokenProvider}.
  * @param authConfig The Auth config that the credentials provider needs to function.
  * @param keyValueStorage An object that implements the {@link KeyValueStorageInterface}.
- * @returns An object that implements {@link TokenProvider}.
+ * @returns An object that implements {@link UserPoolsTokenProvider}.
  */
 export const createUserPoolsTokenProvider = (
 	authConfig: AuthConfig,
 	keyValueStorage: KeyValueStorageInterface,
-): TokenProvider => {
+): UserPoolsTokenProvider => {
 	const authTokenStore = new DefaultTokenStore();
 	authTokenStore.setAuthConfig(authConfig);
 	authTokenStore.setKeyValueStorage(keyValueStorage);
@@ -30,8 +47,13 @@ export const createUserPoolsTokenProvider = (
 	tokenOrchestrator.setAuthTokenStore(authTokenStore);
 	tokenOrchestrator.setTokenRefresher(refreshAuthTokensWithoutDedupe);
 
+	// Build the switcher over ONLY the read + reorder slice of the store. The
+	// raw store stays closure-trapped; only these narrow capabilities escape.
+	const sessionSwitcher = createAuthSessionSwitcher(authTokenStore);
+
 	return {
 		getTokens: ({ forceRefresh } = { forceRefresh: false }) =>
 			tokenOrchestrator.getTokens({ forceRefresh }),
+		getSessionSwitcher: () => sessionSwitcher,
 	};
 };

--- a/packages/core/src/Hub/types/AuthTypes.ts
+++ b/packages/core/src/Hub/types/AuthTypes.ts
@@ -19,12 +19,18 @@ export type AuthHubEventData =
 			data: { error?: AuthError };
 	  }
 	/** Dispatched when auth tokens are successfully refreshed. */
-	| { event: 'tokenRefresh' }
+	| { event: 'tokenRefresh'; data?: AuthUser }
 	/** Dispatched when there is an error in the refresh of tokens. */
 	| { event: 'tokenRefresh_failure'; data: { error?: AuthError } }
 	/** Dispatched when there is a customState passed in the options of the `signInWithRedirect` API. */
 	| { event: 'customOAuthState'; data: string }
-	/** Dispatched when the user is signed-in. */
+	/** Dispatched when the roster transitions from empty to non-empty. */
 	| { event: 'signedIn'; data: AuthUser }
-	/** Dispatched after the user calls the `signOut` API successfully. */
-	| { event: 'signedOut' };
+	/** Dispatched when the roster transitions from non-empty to empty. */
+	| { event: 'signedOut'; data?: AuthUser }
+	/** Dispatched when a user is added to the roster on sign-in. */
+	| { event: 'userSignedIn'; data: AuthUser }
+	/** Dispatched when the active user pointer moves between users. */
+	| { event: 'switchActiveUser'; data: AuthUser }
+	/** Dispatched when a user is removed from the roster on sign-out. */
+	| { event: 'userSignedOut'; data: AuthUser };

--- a/packages/core/src/Hub/types/AuthTypes.ts
+++ b/packages/core/src/Hub/types/AuthTypes.ts
@@ -24,9 +24,12 @@ export type AuthHubEventData =
 	| { event: 'tokenRefresh_failure'; data: { error?: AuthError } }
 	/** Dispatched when there is a customState passed in the options of the `signInWithRedirect` API. */
 	| { event: 'customOAuthState'; data: string }
-	/** Dispatched when the roster transitions from empty to non-empty. */
+	/** Dispatched when the active user pointer transitions from none to some —
+	 * the first sign-in, or reactivating a parked session after a sign-out. */
 	| { event: 'signedIn'; data: AuthUser }
-	/** Dispatched when the roster transitions from non-empty to empty. */
+	/** Dispatched on every active-user sign-out. This fires EVEN when parked
+	 * sessions remain in the roster; it signals that no user is active, NOT that
+	 * the roster is empty. */
 	| { event: 'signedOut'; data?: AuthUser }
 	/** Dispatched when a user is added to the roster on sign-in. */
 	| { event: 'userSignedIn'; data: AuthUser }

--- a/packages/core/src/singleton/Auth/index.ts
+++ b/packages/core/src/singleton/Auth/index.ts
@@ -9,6 +9,7 @@ import {
 	CredentialsAndIdentityId,
 	FetchAuthSessionOptions,
 	LibraryAuthOptions,
+	TokenProvider,
 } from './types';
 
 const logger = new ConsoleLogger('Auth');
@@ -108,6 +109,25 @@ export class AuthClass {
 		return (
 			(await this.authOptions?.tokenProvider?.getTokens(options)) ?? undefined
 		);
+	}
+
+	/**
+	 * Returns the currently configured token provider, if any.
+	 *
+	 * This is an additive accessor exposing the token provider that was supplied
+	 * via {@link LibraryAuthOptions} at configure time (for a server context, the
+	 * per-request provider built by the adapter). It is intended for provider
+	 * implementations that surface additional, provider-specific capabilities on
+	 * top of the generic {@link TokenProvider} contract (e.g. Cognito session
+	 * switching); callers must narrow to the concrete provider type themselves.
+	 *
+	 * @internal
+	 *
+	 * @returns The configured {@link TokenProvider}, or `undefined` when none has
+	 * been configured.
+	 */
+	getTokenProvider(): TokenProvider | undefined {
+		return this.authOptions?.tokenProvider;
 	}
 }
 


### PR DESCRIPTION
## Description

Adds **multi-session / multi-profile** support to Cognito auth: multiple users can be signed in to the same user pool simultaneously, with **one active session at a time** and the others parked. Works both client-side and in **SSR (HttpOnly cookies)**.

### New public APIs
- `setCurrentUser(username)` — switch the active session to an already-signed-in user (throws if not signed in). Client + server.
- `listCurrentUsers(): Promise<AuthUser[]>` — list all signed-in users, active first. Client + server.

Server variants live under `aws-amplify/auth/server` and accept a `contextSpec`, operating on the per-request cookie-backed token store.

### Storage model
- New `AuthUserList` key holds a comma-separated, ordered roster (active first). `LastAuthUser` remains the single-username active pointer for cross-SDK compatibility and may be EMPTY while parked sessions remain: **sign-out never auto-promotes a parked session** — the app reactivates one explicitly via `setCurrentUser`. Per-user token namespaces are unchanged.

### Hub events (boundary model)
- New: `userSignedIn`, `switchActiveUser`, `userSignedOut` (per-session roster membership / active-pointer moves).
- `signedIn` fires when the active pointer goes none→some (first sign-in, or `setCurrentUser` reactivating a parked session); `signedOut` fires on EVERY active-user sign-out (even with parked sessions remaining). Payloads unchanged (`{ username, userId }`), with an optional user payload added to `signedOut`/`tokenRefresh`. Backward compatible for existing single-session apps.

### Server-side safety
Server exposure is deliberately minimal and **non-destructive**: the per-request token provider surfaces only a narrow `AuthSessionSwitcher` (read + validated reorder). The *switcher* is non-destructive by construction: destructive token-store operations (`storeTokens`, `clearTokens`, `clearTokensForUser`, `removeSession`) are not reachable through it. (`getTokens({ forceRefresh })` remains server-exposed as before; a revoked refresh token triggers the user-scoped, no-promotion clear.) Reachability is via a new additive `AuthClass.getTokenProvider()` accessor; core's generic `TokenProvider` interface is unchanged.

## Commits
1. `feat(core): add multi-session auth Hub events`
2. `feat(auth): add client-side multi-session support`
3. `feat(auth): expose multi-session APIs for server-side rendering`

## Testing
- `yarn build` clean across `@aws-amplify/auth`, `aws-amplify`, `@aws-amplify/adapter-nextjs`.
- `@aws-amplify/auth`: full unit suite green (1193+ tests), incl. new tests for the roster, boundary events, `setCurrentUser`/`listCurrentUsers` (client + server), and the session switcher.
- `aws-amplify`: 51/51 incl. the API-surface `exports` guard (updated for the intended new symbols only).
- `yarn lint` clean.
- Underlying modules mocked (not `Amplify.getConfig`), per repo convention.

## Notes
- `adapter-nextjs` required **no change** — the server APIs are callable through `runWithAmplifyServerContext` like `getCurrentUser`.
- Concurrent active sessions are out of scope (one active user at a time).

## Checklist
- [x] Tests added/updated
- [x] Changeset added
- [x] Build + lint pass locally


