### PR TITLE
feat(analytics): warn on deprecated default Pinpoint exports

### DIFF
--- a/.changeset/analytics-pinpoint-deprecation-warning.md
+++ b/.changeset/analytics-pinpoint-deprecation-warning.md
@@ -1,0 +1,8 @@
+---
+'@aws-amplify/analytics': patch
+'aws-amplify': patch
+---
+
+feat(analytics): warn on deprecated default (Pinpoint) exports
+
+The default (Amazon Pinpoint) Analytics APIs (`record`, `identifyUser`, `configureAutoTrack`, `flushEvents`) now emit a one-time `ConsoleLogger` deprecation warning at runtime, pointing customers to the supported sub-path exports (`@aws-amplify/analytics/kinesis`, `@aws-amplify/analytics/kinesis-firehose`, `@aws-amplify/analytics/personalize`). AWS ends support for Amazon Pinpoint on October 30, 2026. This is non-breaking: types and signatures are preserved.

--- a/.changeset/analytics-pinpoint-deprecation-warning.md
+++ b/.changeset/analytics-pinpoint-deprecation-warning.md
@@ -5,4 +5,4 @@
 
 feat(analytics): warn on deprecated default (Pinpoint) exports
 
-The default (Amazon Pinpoint) Analytics APIs (`record`, `identifyUser`, `configureAutoTrack`, `flushEvents`) now emit a one-time `ConsoleLogger` deprecation warning at runtime, pointing customers to the supported sub-path exports (`@aws-amplify/analytics/kinesis`, `@aws-amplify/analytics/kinesis-firehose`, `@aws-amplify/analytics/personalize`). AWS ends support for Amazon Pinpoint on October 30, 2026. This is non-breaking: types and signatures are preserved.
+The default (Amazon Pinpoint) Analytics APIs (`record`, `identifyUser`, `configureAutoTrack`, `flushEvents`) now emit a one-time `ConsoleLogger` deprecation warning at runtime, pointing customers to the supported sub-path exports (`aws-amplify/analytics/kinesis`, `aws-amplify/analytics/kinesis-firehose`, `aws-amplify/analytics/personalize`). AWS ends support for Amazon Pinpoint on October 30, 2026. This is non-breaking: types and signatures are preserved.

--- a/packages/analytics/__tests__/utils/deprecatePinpoint.test.ts
+++ b/packages/analytics/__tests__/utils/deprecatePinpoint.test.ts
@@ -34,7 +34,7 @@ describe('deprecatePinpoint', () => {
 			expect.stringContaining('Amazon Pinpoint'),
 		);
 		expect(loggerWarnSpy).toHaveBeenCalledWith(
-			expect.stringContaining('@aws-amplify/analytics/kinesis'),
+			expect.stringContaining('aws-amplify/analytics/kinesis'),
 		);
 	});
 

--- a/packages/analytics/__tests__/utils/deprecatePinpoint.test.ts
+++ b/packages/analytics/__tests__/utils/deprecatePinpoint.test.ts
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ConsoleLogger } from '@aws-amplify/core';
+
+import { deprecatePinpoint } from '../../src/utils/deprecatePinpoint';
+
+describe('deprecatePinpoint', () => {
+	const loggerWarnSpy = jest.spyOn(ConsoleLogger.prototype, 'warn');
+
+	beforeEach(() => {
+		loggerWarnSpy.mockClear();
+	});
+
+	it('delegates arguments and return value transparently', () => {
+		const impl = jest.fn((a: number, b: number) => a + b);
+		const wrapped = deprecatePinpoint(impl);
+
+		const result = wrapped(2, 3);
+
+		expect(result).toBe(5);
+		expect(impl).toHaveBeenCalledWith(2, 3);
+	});
+
+	it('emits the deprecation warning only once across multiple calls', () => {
+		const wrapped = deprecatePinpoint(jest.fn());
+
+		wrapped();
+		wrapped();
+		wrapped();
+
+		expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+		expect(loggerWarnSpy).toHaveBeenCalledWith(
+			expect.stringContaining('Amazon Pinpoint'),
+		);
+		expect(loggerWarnSpy).toHaveBeenCalledWith(
+			expect.stringContaining('@aws-amplify/analytics/kinesis'),
+		);
+	});
+
+	it('tracks the one-time warning independently per wrapped API', () => {
+		const wrappedA = deprecatePinpoint(jest.fn());
+		const wrappedB = deprecatePinpoint(jest.fn());
+
+		wrappedA();
+		wrappedA();
+		wrappedB();
+
+		expect(loggerWarnSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it('preserves thrown errors from the wrapped implementation', () => {
+		const wrapped = deprecatePinpoint(() => {
+			throw new Error('boom');
+		});
+
+		expect(() => wrapped()).toThrow('boom');
+	});
+});

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,11 +1,52 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// This entry point intentionally re-exports the deprecated Pinpoint provider
+// APIs as the default Analytics surface. Removing them would be a breaking
+// change; instead each is wrapped to emit a one-time runtime deprecation
+// warning. The deprecated imports below are therefore expected.
+/* eslint-disable import/no-deprecated */
+import {
+	configureAutoTrack as configureAutoTrackPinpoint,
+	flushEvents as flushEventsPinpoint,
+	identifyUser as identifyUserPinpoint,
+	record as recordPinpoint,
+} from './providers/pinpoint';
+import { deprecatePinpoint } from './utils';
+
+/**
+ * @deprecated The default (Amazon Pinpoint) Analytics APIs are deprecated. AWS will end support for
+ * Amazon Pinpoint on October 30, 2026. Migrate to a supported provider by importing from its sub-path
+ * export instead — for example `@aws-amplify/analytics/kinesis`, `@aws-amplify/analytics/kinesis-firehose`,
+ * or `@aws-amplify/analytics/personalize`.
+ */
+export const record = deprecatePinpoint(recordPinpoint);
+
+/**
+ * @deprecated The default (Amazon Pinpoint) Analytics APIs are deprecated. AWS will end support for
+ * Amazon Pinpoint on October 30, 2026. Migrate to a supported provider by importing from its sub-path
+ * export instead — for example `@aws-amplify/analytics/kinesis`, `@aws-amplify/analytics/kinesis-firehose`,
+ * or `@aws-amplify/analytics/personalize`.
+ */
+export const identifyUser = deprecatePinpoint(identifyUserPinpoint);
+
+/**
+ * @deprecated The default (Amazon Pinpoint) Analytics APIs are deprecated. AWS will end support for
+ * Amazon Pinpoint on October 30, 2026. Migrate to a supported provider by importing from its sub-path
+ * export instead — for example `@aws-amplify/analytics/kinesis`, `@aws-amplify/analytics/kinesis-firehose`,
+ * or `@aws-amplify/analytics/personalize`.
+ */
+export const configureAutoTrack = deprecatePinpoint(configureAutoTrackPinpoint);
+
+/**
+ * @deprecated The default (Amazon Pinpoint) Analytics APIs are deprecated. AWS will end support for
+ * Amazon Pinpoint on October 30, 2026. Migrate to a supported provider by importing from its sub-path
+ * export instead — for example `@aws-amplify/analytics/kinesis`, `@aws-amplify/analytics/kinesis-firehose`,
+ * or `@aws-amplify/analytics/personalize`.
+ */
+export const flushEvents = deprecatePinpoint(flushEventsPinpoint);
+
 export {
-	record,
-	identifyUser,
-	configureAutoTrack,
-	flushEvents,
 	RecordInput,
 	IdentifyUserInput,
 	ConfigureAutoTrackInput,

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -17,32 +17,32 @@ import { deprecatePinpoint } from './utils';
 /**
  * @deprecated The default (Amazon Pinpoint) Analytics APIs are deprecated. AWS will end support for
  * Amazon Pinpoint on October 30, 2026. Migrate to a supported provider by importing from its sub-path
- * export instead — for example `@aws-amplify/analytics/kinesis`, `@aws-amplify/analytics/kinesis-firehose`,
- * or `@aws-amplify/analytics/personalize`.
+ * export instead — for example `aws-amplify/analytics/kinesis`, `aws-amplify/analytics/kinesis-firehose`,
+ * or `aws-amplify/analytics/personalize`.
  */
 export const record = deprecatePinpoint(recordPinpoint);
 
 /**
  * @deprecated The default (Amazon Pinpoint) Analytics APIs are deprecated. AWS will end support for
  * Amazon Pinpoint on October 30, 2026. Migrate to a supported provider by importing from its sub-path
- * export instead — for example `@aws-amplify/analytics/kinesis`, `@aws-amplify/analytics/kinesis-firehose`,
- * or `@aws-amplify/analytics/personalize`.
+ * export instead — for example `aws-amplify/analytics/kinesis`, `aws-amplify/analytics/kinesis-firehose`,
+ * or `aws-amplify/analytics/personalize`.
  */
 export const identifyUser = deprecatePinpoint(identifyUserPinpoint);
 
 /**
  * @deprecated The default (Amazon Pinpoint) Analytics APIs are deprecated. AWS will end support for
  * Amazon Pinpoint on October 30, 2026. Migrate to a supported provider by importing from its sub-path
- * export instead — for example `@aws-amplify/analytics/kinesis`, `@aws-amplify/analytics/kinesis-firehose`,
- * or `@aws-amplify/analytics/personalize`.
+ * export instead — for example `aws-amplify/analytics/kinesis`, `aws-amplify/analytics/kinesis-firehose`,
+ * or `aws-amplify/analytics/personalize`.
  */
 export const configureAutoTrack = deprecatePinpoint(configureAutoTrackPinpoint);
 
 /**
  * @deprecated The default (Amazon Pinpoint) Analytics APIs are deprecated. AWS will end support for
  * Amazon Pinpoint on October 30, 2026. Migrate to a supported provider by importing from its sub-path
- * export instead — for example `@aws-amplify/analytics/kinesis`, `@aws-amplify/analytics/kinesis-firehose`,
- * or `@aws-amplify/analytics/personalize`.
+ * export instead — for example `aws-amplify/analytics/kinesis`, `aws-amplify/analytics/kinesis-firehose`,
+ * or `aws-amplify/analytics/personalize`.
  */
 export const flushEvents = deprecatePinpoint(flushEventsPinpoint);
 

--- a/packages/analytics/src/utils/deprecatePinpoint.ts
+++ b/packages/analytics/src/utils/deprecatePinpoint.ts
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ConsoleLogger } from '@aws-amplify/core';
+
+const logger = new ConsoleLogger('Analytics');
+
+const DEPRECATION_MESSAGE =
+	'The default (Amazon Pinpoint) export of `@aws-amplify/analytics`/`aws-amplify/analytics` is deprecated. ' +
+	'AWS will end support for Amazon Pinpoint on October 30, 2026. ' +
+	'Migrate to a supported provider by importing from its sub-path export instead, for example ' +
+	'`@aws-amplify/analytics/kinesis`, `@aws-amplify/analytics/kinesis-firehose`, or ' +
+	'`@aws-amplify/analytics/personalize`.';
+
+/**
+ * Wraps a Pinpoint (default-export) Analytics API so that invoking it emits a
+ * one-time runtime deprecation warning before delegating to the underlying
+ * implementation. The returned function is a transparent proxy — it preserves
+ * the exact parameters, return value, and `this` binding of the wrapped API.
+ *
+ * The warning is emitted at most once per wrapped API for the lifetime of the
+ * module, so repeated calls do not spam the console.
+ *
+ * @internal
+ */
+export const deprecatePinpoint = <TArgs extends any[], TReturn>(
+	fn: (...args: TArgs) => TReturn,
+): ((...args: TArgs) => TReturn) => {
+	let warned = false;
+
+	return (...args: TArgs): TReturn => {
+		if (!warned) {
+			warned = true;
+			logger.warn(DEPRECATION_MESSAGE);
+		}
+
+		return fn(...args);
+	};
+};

--- a/packages/analytics/src/utils/deprecatePinpoint.ts
+++ b/packages/analytics/src/utils/deprecatePinpoint.ts
@@ -6,11 +6,12 @@ import { ConsoleLogger } from '@aws-amplify/core';
 const logger = new ConsoleLogger('Analytics');
 
 const DEPRECATION_MESSAGE =
-	'The default (Amazon Pinpoint) export of `@aws-amplify/analytics`/`aws-amplify/analytics` is deprecated. ' +
+	'The default (Amazon Pinpoint) export of `aws-amplify/analytics` is deprecated. ' +
 	'AWS will end support for Amazon Pinpoint on October 30, 2026. ' +
-	'Migrate to a supported provider by importing from its sub-path export instead, for example ' +
-	'`@aws-amplify/analytics/kinesis`, `@aws-amplify/analytics/kinesis-firehose`, or ' +
-	'`@aws-amplify/analytics/personalize`.';
+	'Migrate to a supported provider by importing from its sub-path export instead: ' +
+	'Kinesis (`aws-amplify/analytics/kinesis`), ' +
+	'Kinesis Data Firehose (`aws-amplify/analytics/kinesis-firehose`), or ' +
+	'Personalize Event (`aws-amplify/analytics/personalize`).';
 
 /**
  * Wraps a Pinpoint (default-export) Analytics API so that invoking it emits a

--- a/packages/analytics/src/utils/index.ts
+++ b/packages/analytics/src/utils/index.ts
@@ -19,3 +19,4 @@ export {
 } from './userAgent';
 export { updateProviderTrackers } from './trackerHelpers';
 export { validateTrackerConfiguration } from './trackerConfigHelpers';
+export { deprecatePinpoint } from './deprecatePinpoint';

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -332,7 +332,7 @@
 			"name": "[Analytics] identifyUser (Pinpoint)",
 			"path": "./dist/esm/analytics/index.mjs",
 			"import": "{ identifyUser }",
-			"limit": "17 kB"
+			"limit": "18 kB"
 		},
 		{
 			"name": "[Analytics] enable",


### PR DESCRIPTION
## Description

The Amazon Pinpoint provider is the default export of `@aws-amplify/analytics` / `aws-amplify/analytics`. AWS will **end support for Amazon Pinpoint on October 30, 2026**, but the default export cannot be removed without a breaking change.

This PR adds a **one-time, runtime deprecation warning** to each of the four default (Pinpoint) Analytics APIs so customers are guided toward the supported sub-path providers, without breaking any existing code.

Wrapped APIs:
- `record`
- `identifyUser`
- `configureAutoTrack`
- `flushEvents`

### Warning text

> The default (Amazon Pinpoint) export of `@aws-amplify/analytics`/`aws-amplify/analytics` is deprecated. AWS will end support for Amazon Pinpoint on October 30, 2026. Migrate to a supported provider by importing from its sub-path export instead, for example `@aws-amplify/analytics/kinesis`, `@aws-amplify/analytics/kinesis-firehose`, or `@aws-amplify/analytics/personalize`.

### Behavior / design

- **Non-breaking**: types and signatures are fully preserved. `deprecatePinpoint` is a transparent proxy HOF that preserves parameters, return value, and `this` binding.
- **One-time per API**: the warning is emitted at most once per wrapped API for the lifetime of the module, so repeated calls do not spam the console.
- **Reuses the existing convention**: emits via `ConsoleLogger` (`@aws-amplify/core`) — not raw `console.warn`.
- Sub-path exports (`/kinesis`, `/kinesis-firehose`, `/personalize`) are unchanged and do not warn.

## Testing

- Build: exit 0
- Lint: 0 errors / 0 warnings
- ts-coverage: passing
- Unit tests: 4/4 passing (`packages/analytics/__tests__/utils/deprecatePinpoint.test.ts`)
