### PR TITLE
ci(detox): fix runner image breakage and harden e2e setup steps

### DIFF
--- a/.github/workflows/callable-e2e-test-detox.yml
+++ b/.github/workflows/callable-e2e-test-detox.yml
@@ -96,8 +96,7 @@ jobs:
         run: |
           for i in 1 2 3; do
             echo "pod install attempt $i"
-            cd ios && pod install && break || true
-            cd ..
+            (cd ios && pod install) && break
             if [ "$i" -eq 3 ]; then
               echo "::error::pod install failed after 3 attempts"
               exit 1

--- a/.github/workflows/callable-e2e-test-detox.yml
+++ b/.github/workflows/callable-e2e-test-detox.yml
@@ -21,7 +21,9 @@ on:
 jobs:
   e2e-test:
     name: E2E-Detox ${{ inputs.test_name }}
-    runs-on: macos-latest-large
+    # Pin to macos-15-large: macos-latest rolled to macOS-26 (2026-07-15) which
+    # removed all Xcode 16.x versions. macos-15 image ships Xcode 16.0–16.4.
+    runs-on: macos-15-large
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
     steps:
@@ -32,8 +34,44 @@ jobs:
       - name: Setup node and build the repository
         uses: ./amplify-js/.github/actions/node-and-build
       - name: Set Xcode version
+        # Prefer Xcode 16.4; fall back to newest 16.x if the exact version is
+        # missing (e.g. runner image update removed it). Fails loudly if no
+        # Xcode 16.x is available at all.
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.4.app
+          XCODE_PATH="/Applications/Xcode_16.4.app"
+          if [ ! -d "$XCODE_PATH" ]; then
+            echo "::warning::Xcode_16.4.app not found. Available Xcode installations:"
+            ls -d /Applications/Xcode_*.app 2>/dev/null || echo "  (none found)"
+            # Fall back to the newest Xcode 16.x
+            XCODE_PATH=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -n1)
+            if [ -z "$XCODE_PATH" ]; then
+              echo "::error::No Xcode 16.x found in /Applications. Cannot proceed."
+              exit 1
+            fi
+            echo "Falling back to: $XCODE_PATH"
+          fi
+          sudo xcode-select -s "$XCODE_PATH"
+          echo "Active Xcode: $(xcode-select -p)"
+      - name: Ensure iPhone 15 simulator exists
+        # The 'iPhone 15' device name is required by detox config in the samples
+        # repo. If the runner image doesn't ship one, create it with the newest
+        # available iOS runtime. Passkeys tests handle their own sim (iOS 17.4).
+        if: ${{ !contains(inputs.test_name, 'integ_rn_ios_passkeys') }}
+        run: |
+          if xcrun simctl list devices available | grep -q '"iPhone 15"'; then
+            echo "iPhone 15 simulator already available."
+          else
+            echo "iPhone 15 simulator not found — creating one."
+            # Pick the newest iOS runtime available on this image
+            RUNTIME=$(xcrun simctl list runtimes iOS | grep -oE 'com\.apple\.CoreSimulator\.SimRuntime\.iOS-[0-9]+-[0-9]+' | sort -V | tail -n1)
+            if [ -z "$RUNTIME" ]; then
+              echo "::error::No iOS runtime found. Cannot create simulator."
+              exit 1
+            fi
+            echo "Using runtime: $RUNTIME"
+            xcrun simctl create "iPhone 15" "com.apple.CoreSimulator.SimDeviceType.iPhone-15" "$RUNTIME"
+            echo "iPhone 15 simulator created successfully."
+          fi
       - name: Download iOS platform and create simulator
         if: ${{ contains(inputs.test_name, 'integ_rn_ios_passkeys') }}
         run: |
@@ -54,8 +92,19 @@ jobs:
           $GITHUB_WORKSPACE/amplify-js/scripts/retry-yarn-script.sh -s 'install --frozen-lockfile --non-interactive' -n 3
         shell: bash
       - name: Install CocoaPods
+        # Retry to guard against transient network failures (CDN/specs fetch)
         run: |
-          cd ios && pod install
+          for i in 1 2 3; do
+            echo "pod install attempt $i"
+            cd ios && pod install && break || true
+            cd ..
+            if [ "$i" -eq 3 ]; then
+              echo "::error::pod install failed after 3 attempts"
+              exit 1
+            fi
+            echo "Attempt $i failed, retrying in 5s..."
+            sleep 5
+          done
         working-directory: ${{ inputs.working_directory }}
         shell: bash
       - name: Start iOS simulator (background)
@@ -68,12 +117,33 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash
       - name: Configure Detox
+        # Retry brew/npm installs to guard against transient network failures
         env:
           HOMEBREW_NO_AUTO_UPDATE: '1'
         run: |
+          # Install applesimutils with retries
           brew tap wix/brew
-          brew install applesimutils
-          yarn global add detox-cli
+          for i in 1 2 3; do
+            echo "brew install applesimutils attempt $i"
+            brew install applesimutils && break || true
+            if [ "$i" -eq 3 ]; then
+              echo "::error::brew install applesimutils failed after 3 attempts"
+              exit 1
+            fi
+            echo "Attempt $i failed, retrying in 5s..."
+            sleep 5
+          done
+          # Install detox-cli with retries
+          for i in 1 2 3; do
+            echo "yarn global add detox-cli attempt $i"
+            yarn global add detox-cli && break || true
+            if [ "$i" -eq 3 ]; then
+              echo "::error::yarn global add detox-cli failed after 3 attempts"
+              exit 1
+            fi
+            echo "Attempt $i failed, retrying in 5s..."
+            sleep 5
+          done
         working-directory: ${{ inputs.working_directory }}
         shell: bash
       - name: Detox Build

--- a/.github/workflows/callable-e2e-test-detox.yml
+++ b/.github/workflows/callable-e2e-test-detox.yml
@@ -122,6 +122,8 @@ jobs:
         run: |
           # Install applesimutils with retries
           brew tap wix/brew
+          # Newer Homebrew (macos-15 image ≥2026-06) requires explicit tap trust
+          brew trust wix/brew || true
           for i in 1 2 3; do
             echo "brew install applesimutils attempt $i"
             brew install applesimutils && break || true


### PR DESCRIPTION
# Description of changes

The detox iOS e2e suite has had a ~50% failure rate over its last 15 executing runs, and since 2026-07-15 all 8 detox jobs fail instantly. Root cause of the hard failure: `macos-latest-large` rolled over to the macOS-26 runner image ([actions/runner-images#14167](https://github.com/actions/runner-images/issues/14167)), which ships **no Xcode 16.x** and **no iPhone 15 simulators** — the workflow hardcodes `xcode-select -s /Applications/Xcode_16.4.app`.

This PR hardens `callable-e2e-test-detox.yml`:

1. **Pin `runs-on: macos-15-large`** — the macOS-15 image still ships Xcode 16.0–16.4 (16.4 default) and iOS 18.x simulator runtimes. This unblocks all 8 detox jobs immediately.
2. **Resilient Xcode selection** — prefer Xcode 16.4; if missing, fall back to the newest installed `Xcode_16*.app`; otherwise fail loudly listing the available Xcode installations (so the next image rollover is diagnosable at a glance instead of a cryptic `xcode-select` error).
3. **Ensure the "iPhone 15" simulator exists** — if the image no longer ships one, create it via `xcrun simctl create` with the newest available iOS runtime (skipped for the passkeys test, which provisions its own iOS 17.4 simulator).
4. **Retries for network-dependent setup steps** — 3 attempts with 5s backoff (matching the repo's existing inline retry pattern) for `pod install` (subshell-isolated so cwd is never mutated), `brew install applesimutils`, and `yarn global add detox-cli`. `yarn install` and `detox test` already retry via `scripts/retry-yarn-script.sh`.

Failure history analysis (last ~25 runs / 16 with detox jobs): 1× runner image breakage (current blocker), 3× dependency/install breakage, 2× flaky tests (`device_tracking`, `multipart_progress` — tracked separately in samples-staging), 1× genuine assertion failure.

## Testing

- YAML validated (`yaml.safe_load`)
- Runner image inventory verified against [macos-15-Readme](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md) / [macos-26-Readme](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md): Xcode 16.4 present on macos-15, absent on macos-26
- End-to-end verification requires the detox suite to run on this PR (`run-tests` label)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
