### PR TITLE
fix(security): bump brace-expansion 5.0.4 -> 5.0.7 (GHSA-3jxr-9vmj-r5cp)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6317,9 +6317,9 @@ brace-expansion@^2.0.1, brace-expansion@^2.0.2:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.2:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.4.tgz#614daaecd0a688f660bbbc909a8748c3d80d4336"
-  integrity sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
+  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
## Security Fix

Remediates **Dependabot alert 268** (severity: **high**): https://github.com/aws-amplify/amplify-js/security/dependabot/268

**Vulnerability:** `brace-expansion` — DoS via exponential-time expansion of consecutive non-expanding `{}` groups ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)). Transitive dev dependency via `minimatch@10.2.4`. Vulnerable range `>= 3.0.0, < 5.0.7`; first patched version `5.0.7`.

## Fix

Lockfile-only change: re-resolved the `brace-expansion@^5.0.2` entry in `yarn.lock` from 5.0.4 to **5.0.7** (satisfies the existing `^5.0.2` range — no `package.json` changes, no resolutions added). The non-vulnerable entries `brace-expansion@1.1.12` and `@2.0.2` are untouched.

`yarn why brace-expansion` confirms all 5.x instances now resolve to 5.0.7; no version in `[3.0.0, 5.0.7)` remains in the lockfile.

## Verification

- `yarn install` — pass
- `yarn build` — pass (full monorepo, no duplicated Amplify dependencies detected)
- `yarn test` — pass (all 33 turbo test tasks)
- `yarn lint` — 6 pre-existing tsconfig parsing errors in `@aws-amplify/rtn-passkeys` only; reproduced identically on the untouched `origin/main` lockfile, unrelated to this change

## Description of how you validated changes

Ran the repo's own CI scripts locally (install/build/test) — all green.

## Checklist

- [x] PR description included
- [ ] `yarn test` passes *(passes — checkbox per template)*
- [x] Security fix, no new tests required (lockfile-only dependency bump)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.