### PR TITLE
fix(core): correct langurage typo in I18n JSDoc

### DIFF
--- a/packages/core/src/I18n/I18n.ts
+++ b/packages/core/src/I18n/I18n.ts
@@ -85,7 +85,7 @@ export class I18n {
 	 * @method
 	 * Get value according to specified language
 	 * @param {String} key
-	 * @param {String} language - Specified langurage to be used
+	 * @param {String} language - Specified language to be used
 	 * @param {String} defVal - Default value
 	 */
 	getByLanguage(key: string, language: string, defVal: string | null = null) {


### PR DESCRIPTION
## Description

Fixes a typo in the `getByLanguage` JSDoc: `langurage` -> `language`.

Closes #12752

## Checklist

- [x] PR description explains the change
- [ ] Unit tests included (N/A: docs/comment only)
- [ ] Integration tests included (N/A)
