### PR TITLE
fix(push-notifications): add customer-profiles subpath package.json for legacy/Metro resolution

### DIFF
--- a/packages/aws-amplify/push-notifications/customer-profiles/package.json
+++ b/packages/aws-amplify/push-notifications/customer-profiles/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "aws-amplify/push-notifications/customer-profiles",
+	"main": "../../dist/cjs/push-notifications/customer-profiles/index.js",
+	"react-native": "../../dist/cjs/push-notifications/customer-profiles/index.js",
+	"browser": "../../dist/esm/push-notifications/customer-profiles/index.mjs",
+	"module": "../../dist/esm/push-notifications/customer-profiles/index.mjs",
+	"typings": "../../dist/esm/push-notifications/customer-profiles/index.d.ts"
+}


### PR DESCRIPTION
## Description

Adds the missing legacy subpath `package.json` "shim" for the `aws-amplify/push-notifications/customer-profiles` subpath introduced in #14866.

Modern bundlers resolve this subpath via the `"exports"` map in `packages/aws-amplify/package.json`. However, older bundlers — and notably **Metro** (React Native) in its default/legacy resolution mode — ignore the `"exports"` field entirely and instead resolve a subpath by looking for a real directory containing a `package.json` with `main`/`module`/`react-native`/`browser`/`typings` fields.

The sibling pinpoint provider already ships this shim at `packages/aws-amplify/push-notifications/pinpoint/package.json`, but no equivalent existed for customer-profiles. Since the Customer Profiles push provider is **React-Native-only**, this gap directly affects the only supported platform for the feature: consumers on legacy Metro resolution would fail to resolve `aws-amplify/push-notifications/customer-profiles`.

## Changes

- New file: `packages/aws-amplify/push-notifications/customer-profiles/package.json`

It mirrors the pinpoint shim exactly; the only textual difference is the service-name segment (`pinpoint` → `customer-profiles`):

```
sed 's/customer-profiles/pinpoint/g' push-notifications/customer-profiles/package.json \
  | diff - push-notifications/pinpoint/package.json   # no differences
```

The relative dist paths match the pattern already declared in the top-level `"exports"` entry for `./push-notifications/customer-profiles`, and all five referenced files exist in a local build (`dist/cjs/.../index.js`, `dist/esm/.../index.mjs`, `dist/esm/.../index.d.ts`).

## Notes

- No runtime/source code changes. No export strings, API surface, or storage keys were touched.
- Packaging-parity only; no behavior change for existing consumers.

Follow-up to #14866.