### PR TITLE
chore(e2e): add CustomerProfilesPushApp to the detox E2E matrix

### DIFF
--- a/.github/integ-config/detox-integ-all.yml
+++ b/.github/integ-config/detox-integ-all.yml
@@ -23,3 +23,6 @@
 - test_name: 'integ_rn_ios_passkeys'
   working_directory: amplify-js-samples-staging/samples/react-native/auth/Passkeys
   timeout_minutes: 120
+- test_name: 'integ_rn_ios_push_notifications_customer_profiles'
+  working_directory: amplify-js-samples-staging/samples/react-native/push-notifications/CustomerProfilesPushApp
+  timeout_minutes: 120

--- a/.github/workflows/push-integ-test.yml
+++ b/.github/workflows/push-integ-test.yml
@@ -8,7 +8,7 @@ concurrency:
 on:
   push:
     branches:
-      - replace-with-your-branch
+      - chore/push-notifications-tests
 
 jobs:
   e2e:


### PR DESCRIPTION
#### Description of changes

Adds the `CustomerProfilesPushApp` React Native sample from aws-amplify/amplify-js-samples-staging#1127 to the Detox E2E matrix (`.github/integ-config/detox-integ-all.yml`).

This branch is named to match the staging PR branch (`chore/push-notifications-tests`) so `setup-samples-staging` checks out the right sample app, and `push-integ-test.yml` points at this branch so the run shows up here.

#### Issue #, if available

aws-amplify/amplify-js-samples-staging#1127

#### Description of how you validated changes

Verified the sample path against the staging PR and that both changed YAML files parse into the expected matrix entry and branch filter.

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes — not run; CI config only, no library source touched
- [ ] Unit Tests are changed or added — n/a, test logic lives in the samples repo
- [ ] Relevant documentation is changed or added — n/a

#### Checklist for repo maintainers

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows — needs a run from upstream; fork runs can't access `GH_TOKEN_STAGING_READ`
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate — n/a, no new source paths

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
