### PR TITLE
fix(deps): patch nanoid and js-yaml Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
 		"xml2js": "0.5.0",
 		"**/form-data": "4.0.6",
 		"qs": "^6.14.1",
-		"js-yaml": "^4.3.0",
+		"js-yaml": "^4.3.1",
 		"launch-editor": "^2.14.1",
 		"serialize-javascript": "^7.0.5",
 		"@tootallnate/once": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9544,10 +9544,10 @@ js-cookie@^3.0.7:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^3.6.1, js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+js-yaml@^3.13.1, js-yaml@^3.6.1, js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 
@@ -10396,9 +10396,9 @@ nanoid@^3.3.16:
   integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
 
 nanoid@^5.1.0:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.6.tgz#30363f664797e7d40429f6c16946d6bd7a3f26c9"
-  integrity sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==
+  version "5.1.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.16.tgz#fe345c0a1f9007c32fbb5c139e1208bfd3f41ef7"
+  integrity sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==
 
 nanospinner@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
## Description of changes

Patches the two open Dependabot alerts. Both are transitive, and both fixes are **within-major** bumps — no breaking major upgrades are forced.

| Package | Before | After | Advisory | Resolution used |
|---|---|---|---|---|
| `js-yaml` | 4.3.0 | 4.3.1 | Quadratic CPU consumption in `!!omap` resolution | root `resolutions` bump `^4.3.0` → `^4.3.1` |
| `nanoid` | 5.1.6 | 5.1.16 | Non-secure generators can loop indefinitely with a negative length | `yarn.lock` re-resolve |

Two different mechanisms are needed because the two packages are constrained differently:

- **`js-yaml`** required the `resolutions` bump: the existing pin (`^4.3.0`) was itself *holding* the tree on the vulnerable 4.3.0, so only lifting the pin moves it.
- **`nanoid`** needed no `package.json` change at all — the existing `^5.1.0` range already permitted the patched 5.1.16, the lockfile was simply stale. A targeted re-resolve was sufficient, which avoids adding an unnecessary `resolutions` entry.

`nanoid@^3.3.16` (3.3.17) is intentionally left untouched — the advisory only affects `>=4.0.0`, and forcing the 3.x consumers onto 5.x would be an ESM-only breaking change.

Total diff is 8 changed lines across 2 files.

## Validation

Run with Node 20.20.2 / Yarn 1.22.22:

- `yarn install` — exit 0, lockfile regenerated cleanly
- `yarn build` — **20/20 turbo tasks successful**; `duplicates-yarn.sh`: `No duplicated Amplify dependencies detected.`
- `yarn workspace @aws-amplify/core test` — **94/94 suites, 632/632 tests passed**
- `yarn test:license` — `All files have licenses.`
- `yarn test:github-actions` — exit 0

Pre-existing `Resolution field ... is incompatible with requested version` warnings for `minipass`/`path-scurry`/`@tootallnate/once` are unchanged by this PR. The `js-yaml` resolution continues to collapse `^3.x` requesters onto 4.x, which is existing behavior on `main`.

## Issue #, if available

N/A — sourced from the repository's open Dependabot alerts.

## By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
