### PR TITLE
fix(deps): bump transitive nanoid to 3.3.18

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10391,9 +10391,9 @@ ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 nanoid@^3.3.16:
-  version "3.3.17"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
-  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 nanoid@^5.1.0:
   version "5.1.16"


### PR DESCRIPTION
## Description of changes

Patches the open Dependabot alert for **nanoid < 3.3.18** — an infinite-loop denial of service in `customAlphabet` / `customRandom` when invoked with size `0`. Patched upstream in `3.3.18`.

| Package | Before | After | Mechanism |
|---|---|---|---|
| `nanoid` (3.x line) | 3.3.17 | 3.3.18 | `yarn.lock` re-resolve — no `package.json` change needed |

### Why a plain lockfile re-resolve is sufficient

The vulnerable copy is a deep transitive dependency:

```
_project_ > @aws-amplify/adapter-nextjs > next > postcss > nanoid@3.3.17
```

`postcss` requests `nanoid@^3.3.16`, and that range **already permits** the patched `3.3.18` — the lockfile was simply pinned to `3.3.17`. So re-resolving that single entry is enough, and **no root `resolutions` entry is required**. That keeps the change to a 3-line lockfile diff and avoids introducing a new global pin that would need maintaining.

This also means the 5.x line is untouched. That matters: Yarn 1 `resolutions` are global by package name, so a `"nanoid": "3.3.18"` entry would have clobbered the separate `nanoid@^5.1.0` (5.1.16) copy used by `@size-limit/webpack` and forced a CJS downgrade on an ESM-only consumer. Re-resolving sidesteps that entirely.

### Verification

`yarn why nanoid` after the change — patched 3.x, 5.x intact:

```
=> Found "nanoid@5.1.16"
   - "_project_#@size-limit#webpack" depends on it
=> Found "postcss#nanoid@3.3.18"
   This module exists because "_project_#@aws-amplify#adapter-nextjs#next#postcss" depends on it.
```

## Validation

Run with Node 20.20.2 / Yarn 1.22.22:

- `yarn install` — exit 0, minimal lockfile delta (3 insertions / 3 deletions, `nanoid` only)
- `yarn build` — **20/20 turbo tasks successful**; `duplicates-yarn.sh`: `No duplicated Amplify dependencies detected.`
- `yarn workspace @aws-amplify/adapter-nextjs test` — **41/41 suites, 300 passed / 1 skipped** (this is the workspace that owns the affected `next` > `postcss` chain)

## Issue #, if available

N/A — sourced from the repository's open Dependabot alerts. Follows on from #14910, which covered the `js-yaml` and `nanoid` 5.x alerts.

## By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
