### PR TITLE
feat(interactions): migrate Lex providers to AmplifyContext

### DIFF
--- a/packages/core/__tests__/context/resolveCtxArgs.test.ts
+++ b/packages/core/__tests__/context/resolveCtxArgs.test.ts
@@ -105,6 +105,13 @@ describe('resolveCtxArgs', () => {
 			);
 		});
 
+		it('wins over the undefined-first-arg guard when a context exists later', () => {
+			const ctx = makeBrandedContext();
+			expect(() => resolveCtxArgs([undefined, ctx])).toThrow(
+				'AmplifyContext must be passed as the first argument',
+			);
+		});
+
 		it('does NOT throw for plain object args that are not branded contexts', () => {
 			const globalCtx = makeBrandedContext();
 			setGlobalContext(globalCtx);

--- a/packages/core/__tests__/context/resolveCtxArgs.test.ts
+++ b/packages/core/__tests__/context/resolveCtxArgs.test.ts
@@ -89,6 +89,38 @@ describe('resolveCtxArgs', () => {
 		});
 	});
 
+	describe('mis-ordered context guard', () => {
+		it('throws when a context is passed in a later position (e.g. fn(input, ctx))', () => {
+			setGlobalContext(makeBrandedContext());
+			const ctx = makeBrandedContext();
+			expect(() => resolveCtxArgs([{ username: 'test' }, ctx])).toThrow(
+				'AmplifyContext must be passed as the first argument',
+			);
+		});
+
+		it('throws even when no global context is set', () => {
+			const ctx = makeBrandedContext();
+			expect(() => resolveCtxArgs(['arg1', ctx, 'arg2'])).toThrow(
+				'AmplifyContext must be passed as the first argument',
+			);
+		});
+
+		it('does NOT throw for plain object args that are not branded contexts', () => {
+			const globalCtx = makeBrandedContext();
+			setGlobalContext(globalCtx);
+			const unbranded = {
+				resourcesConfig: {},
+				libraryOptions: {},
+				fetchAuthSession: jest.fn(),
+				clearCredentials: jest.fn(),
+				getTokens: jest.fn(),
+			};
+			const [resolved, opts] = resolveCtxArgs([unbranded]);
+			expect(resolved).toBe(globalCtx);
+			expect(opts).toBe(unbranded);
+		});
+	});
+
 	describe('multi-arg scenarios', () => {
 		it('returns all remaining args when context is first', () => {
 			const ctx = makeBrandedContext();

--- a/packages/core/src/context/resolveCtxArgs.ts
+++ b/packages/core/src/context/resolveCtxArgs.ts
@@ -35,5 +35,15 @@ export function resolveCtxArgs<T extends unknown[]>(
 		return [args[0], ...args.slice(1)] as [AmplifyContext, ...T];
 	}
 
+	// Guard against mis-ordered calls (e.g. `send(input, ctx)` from untyped JS):
+	// a context anywhere but the first position would otherwise be silently
+	// treated as a regular argument while the call falls back to the global context.
+	if (args.some(isAmplifyContext)) {
+		throw new Error(
+			'AmplifyContext must be passed as the first argument. ' +
+				'Found an AmplifyContext in a later position — check the argument order.',
+		);
+	}
+
 	return [getGlobalContext(), ...args] as [AmplifyContext, ...T];
 }

--- a/packages/core/src/context/resolveCtxArgs.ts
+++ b/packages/core/src/context/resolveCtxArgs.ts
@@ -25,12 +25,6 @@ import { getGlobalContext } from './globalContext';
 export function resolveCtxArgs<T extends unknown[]>(
 	args: unknown[],
 ): [AmplifyContext, ...T] {
-	if (args.length > 1 && args[0] === undefined) {
-		throw new Error(
-			'Undefined AmplifyContext passed. Call configure() first or omit the parameter.',
-		);
-	}
-
 	if (isAmplifyContext(args[0])) {
 		return [args[0], ...args.slice(1)] as [AmplifyContext, ...T];
 	}
@@ -38,10 +32,18 @@ export function resolveCtxArgs<T extends unknown[]>(
 	// Guard against mis-ordered calls (e.g. `send(input, ctx)` from untyped JS):
 	// a context anywhere but the first position would otherwise be silently
 	// treated as a regular argument while the call falls back to the global context.
+	// Checked before the undefined-first-arg guard so the more specific message
+	// wins whenever a context actually exists somewhere in `args`.
 	if (args.some(isAmplifyContext)) {
 		throw new Error(
 			'AmplifyContext must be passed as the first argument. ' +
 				'Found an AmplifyContext in a later position — check the argument order.',
+		);
+	}
+
+	if (args.length > 1 && args[0] === undefined) {
+		throw new Error(
+			'Undefined AmplifyContext passed. Call configure() first or omit the parameter.',
 		);
 	}
 

--- a/packages/interactions/__tests__/lex-v1/AWSLexProvider.test.ts
+++ b/packages/interactions/__tests__/lex-v1/AWSLexProvider.test.ts
@@ -7,9 +7,7 @@ import {
 	PostTextCommandOutput,
 } from '@aws-sdk/client-lex-runtime-service';
 import { lexProvider } from '../../src/lex-v1/AWSLexProvider';
-import { fetchAuthSession } from '@aws-amplify/core';
-
-jest.mock('@aws-amplify/core');
+import { createMockAmplifyContext } from '../testUtils/mockAmplifyContext';
 
 (global as any).Response = class Response {
 	arrayBuffer(blob: Blob) {
@@ -45,7 +43,8 @@ const credentials = {
 	identityId: 'identity-id',
 };
 
-const mockFetchAuthSession = fetchAuthSession as jest.Mock;
+const mockCtx = createMockAmplifyContext();
+const mockFetchAuthSession = mockCtx.fetchAuthSession as jest.Mock;
 
 LexRuntimeServiceClient.prototype.send = jest.fn((command, callback) => {
 	if (command instanceof PostTextCommand) {
@@ -158,13 +157,13 @@ describe('Interactions', () => {
 		});
 
 		test('send simple text message to bot and fulfill', async () => {
-			let response = await provider.sendMessage(botConfig.BookTrip, 'hi');
+			let response = await provider.sendMessage(mockCtx, botConfig.BookTrip, 'hi');
 			expect(response).toEqual({
 				dialogState: 'ElicitSlot',
 				message: 'echo:hi',
 			});
 
-			response = await provider.sendMessage(botConfig.BookTrip, 'done');
+			response = await provider.sendMessage(mockCtx, botConfig.BookTrip, 'done');
 			expect(response).toEqual({
 				dialogState: 'ReadyForFulfillment',
 				message: 'echo:done',
@@ -177,7 +176,7 @@ describe('Interactions', () => {
 		});
 
 		test('send obj text message to bot and fulfill', async () => {
-			let response = await provider.sendMessage(botConfig.BookTrip, {
+			let response = await provider.sendMessage(mockCtx, botConfig.BookTrip, {
 				content: 'hi',
 				options: {
 					messageType: 'text',
@@ -189,7 +188,7 @@ describe('Interactions', () => {
 				audioStream: new Uint8Array(),
 			});
 
-			response = await provider.sendMessage(botConfig.BookTrip, {
+			response = await provider.sendMessage(mockCtx, botConfig.BookTrip, {
 				content: 'done',
 				options: {
 					messageType: 'text',
@@ -221,7 +220,7 @@ describe('Interactions', () => {
 				},
 			};
 
-			let response = await provider.sendMessage(botconfig['BookTrip:hi'], {
+			let response = await provider.sendMessage(mockCtx, botconfig['BookTrip:hi'], {
 				content: createBlob(),
 				options: {
 					messageType: 'voice',
@@ -233,7 +232,7 @@ describe('Interactions', () => {
 				audioStream: new Uint8Array(),
 			});
 
-			response = await provider.sendMessage(botconfig['BookTrip:done'], {
+			response = await provider.sendMessage(mockCtx, botconfig['BookTrip:done'], {
 				content: createBlob(),
 				options: {
 					messageType: 'voice',
@@ -255,7 +254,7 @@ describe('Interactions', () => {
 			mockFetchAuthSession.mockReturnValue(Promise.reject(new Error()));
 
 			await expect(
-				provider.sendMessage(botConfig.BookTrip, 'hi'),
+				provider.sendMessage(mockCtx, botConfig.BookTrip, 'hi'),
 			).rejects.toThrow('No credentials');
 			expect.assertions(1);
 		});
@@ -263,7 +262,7 @@ describe('Interactions', () => {
 		test('send obj text and obj voice messages in wrong format', async () => {
 			// obj text in wrong format
 			await expect(
-				provider.sendMessage(botConfig.BookTrip, {
+				provider.sendMessage(mockCtx, botConfig.BookTrip, {
 					content: createBlob(),
 					options: {
 						messageType: 'text',
@@ -273,7 +272,7 @@ describe('Interactions', () => {
 
 			// obj voice in wrong format
 			await expect(
-				provider.sendMessage(botConfig.BookTrip, {
+				provider.sendMessage(mockCtx, botConfig.BookTrip, {
 					content: 'Hi',
 					options: {
 						messageType: 'voice',
@@ -345,16 +344,19 @@ describe('Interactions', () => {
 
 			// mock responses
 			inProgressResp = (await provider.sendMessage(
+				mockCtx,
 				botConfig.BookTrip,
 				'hi',
 			)) as PostTextCommandOutput;
 
 			completeSuccessResp = (await provider.sendMessage(
+				mockCtx,
 				botConfig.BookTrip,
 				'done',
 			)) as PostTextCommandOutput;
 
 			completeFailResp = (await provider.sendMessage(
+				mockCtx,
 				botConfig.BookTrip,
 				'error',
 			)) as PostTextCommandOutput;

--- a/packages/interactions/__tests__/lex-v1/apis/onComplete.test.ts
+++ b/packages/interactions/__tests__/lex-v1/apis/onComplete.test.ts
@@ -1,10 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { amplifyUuid } from '@aws-amplify/core/internals/utils';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 import { lexProvider } from '../../../src/lex-v1/AWSLexProvider';
 import { onComplete } from '../../../src/lex-v1/apis';
 import { generateRandomLexV1Config } from '../../testUtils/randomConfigGeneration';
+import { createMockAmplifyContext } from '../../testUtils/mockAmplifyContext';
 import { resolveBotConfig } from '../../../src/lex-v1/utils';
 import { InteractionsError } from '../../../src/errors/InteractionsError';
 
@@ -13,9 +17,18 @@ jest.mock('../../../src/lex-v1/utils');
 
 describe('Interactions LexV1 API: onComplete', () => {
 	const v1BotConfig = generateRandomLexV1Config();
+	const mockCtx = createMockAmplifyContext();
 
 	const mockLexProvider = lexProvider.onComplete as jest.Mock;
 	const mockResolveBotConfig = resolveBotConfig as jest.Mock;
+
+	beforeAll(() => {
+		setGlobalContext(mockCtx);
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
 
 	beforeEach(() => {
 		mockResolveBotConfig.mockReturnValue(v1BotConfig);
@@ -27,9 +40,27 @@ describe('Interactions LexV1 API: onComplete', () => {
 	});
 
 	it('invokes provider onComplete API', () => {
-		const message = amplifyUuid();
 		const mockCallback = jest.fn();
 		onComplete({ botName: v1BotConfig.name, callback: mockCallback });
+		expect(mockResolveBotConfig).toHaveBeenCalledWith(
+			mockCtx,
+			v1BotConfig.name,
+		);
+		expect(mockLexProvider).toHaveBeenCalledTimes(1);
+		expect(mockLexProvider).toHaveBeenCalledWith(v1BotConfig, mockCallback);
+	});
+
+	it('invokes provider onComplete API with explicit context', () => {
+		const explicitCtx = createMockAmplifyContext();
+		const mockCallback = jest.fn();
+		onComplete(explicitCtx, {
+			botName: v1BotConfig.name,
+			callback: mockCallback,
+		});
+		expect(mockResolveBotConfig).toHaveBeenCalledWith(
+			explicitCtx,
+			v1BotConfig.name,
+		);
 		expect(mockLexProvider).toHaveBeenCalledTimes(1);
 		expect(mockLexProvider).toHaveBeenCalledWith(v1BotConfig, mockCallback);
 	});

--- a/packages/interactions/__tests__/lex-v1/apis/onComplete.test.ts
+++ b/packages/interactions/__tests__/lex-v1/apis/onComplete.test.ts
@@ -71,4 +71,18 @@ describe('Interactions LexV1 API: onComplete', () => {
 			onComplete({ botName: v1BotConfig.name, callback: jest.fn }),
 		).toThrow(InteractionsError);
 	});
+
+	it('throws on mis-ordered args (context not first)', () => {
+		const explicitCtx = createMockAmplifyContext();
+		const onCompleteUntyped = onComplete as unknown as (
+			...args: unknown[]
+		) => void;
+		expect(() =>
+			onCompleteUntyped(
+				{ botName: v1BotConfig.name, callback: jest.fn() },
+				explicitCtx,
+			),
+		).toThrow('AmplifyContext must be passed as the first argument');
+		expect(mockLexProvider).not.toHaveBeenCalled();
+	});
 });

--- a/packages/interactions/__tests__/lex-v1/apis/send.test.ts
+++ b/packages/interactions/__tests__/lex-v1/apis/send.test.ts
@@ -1,10 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { amplifyUuid } from '@aws-amplify/core/internals/utils';
+import {
+	amplifyUuid,
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 import { lexProvider } from '../../../src/lex-v1/AWSLexProvider';
 import { send } from '../../../src/lex-v1/apis';
 import { generateRandomLexV1Config } from '../../testUtils/randomConfigGeneration';
+import { createMockAmplifyContext } from '../../testUtils/mockAmplifyContext';
 import { resolveBotConfig } from '../../../src/lex-v1/utils';
 import { InteractionsError } from '../../../src/errors/InteractionsError';
 
@@ -13,9 +18,18 @@ jest.mock('../../../src/lex-v1/utils');
 
 describe('Interactions LexV1 API: send', () => {
 	const v1BotConfig = generateRandomLexV1Config();
+	const mockCtx = createMockAmplifyContext();
 
 	const mockLexProvider = lexProvider.sendMessage as jest.Mock;
 	const mockResolveBotConfig = resolveBotConfig as jest.Mock;
+
+	beforeAll(() => {
+		setGlobalContext(mockCtx);
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
 
 	beforeEach(() => {
 		mockResolveBotConfig.mockReturnValue(v1BotConfig);
@@ -29,8 +43,28 @@ describe('Interactions LexV1 API: send', () => {
 	it('invokes provider sendMessage API', async () => {
 		const message = amplifyUuid();
 		await send({ botName: v1BotConfig.name, message });
+		expect(mockResolveBotConfig).toHaveBeenCalledWith(
+			mockCtx,
+			v1BotConfig.name,
+		);
 		expect(mockLexProvider).toHaveBeenCalledTimes(1);
-		expect(mockLexProvider).toHaveBeenCalledWith(v1BotConfig, message);
+		expect(mockLexProvider).toHaveBeenCalledWith(mockCtx, v1BotConfig, message);
+	});
+
+	it('invokes provider sendMessage API with explicit context', async () => {
+		const explicitCtx = createMockAmplifyContext();
+		const message = amplifyUuid();
+		await send(explicitCtx, { botName: v1BotConfig.name, message });
+		expect(mockResolveBotConfig).toHaveBeenCalledWith(
+			explicitCtx,
+			v1BotConfig.name,
+		);
+		expect(mockLexProvider).toHaveBeenCalledTimes(1);
+		expect(mockLexProvider).toHaveBeenCalledWith(
+			explicitCtx,
+			v1BotConfig,
+			message,
+		);
 	});
 
 	it('rejects when bot config does not exist', async () => {

--- a/packages/interactions/__tests__/lex-v1/apis/send.test.ts
+++ b/packages/interactions/__tests__/lex-v1/apis/send.test.ts
@@ -73,4 +73,15 @@ describe('Interactions LexV1 API: send', () => {
 			send({ botName: v1BotConfig.name, message: amplifyUuid() }),
 		).rejects.toBeInstanceOf(InteractionsError);
 	});
+
+	it('throws on mis-ordered args (context not first)', async () => {
+		const explicitCtx = createMockAmplifyContext();
+		const sendUntyped = send as unknown as (
+			...args: unknown[]
+		) => Promise<unknown>;
+		await expect(
+			sendUntyped({ botName: v1BotConfig.name, message: 'hi' }, explicitCtx),
+		).rejects.toThrow('AmplifyContext must be passed as the first argument');
+		expect(mockLexProvider).not.toHaveBeenCalled();
+	});
 });

--- a/packages/interactions/__tests__/lex-v1/utils/resolveBotConfig.test.ts
+++ b/packages/interactions/__tests__/lex-v1/utils/resolveBotConfig.test.ts
@@ -1,60 +1,36 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
 import {
 	generateRandomLexV1Config,
 	generateRandomLexV2Config,
 } from '../../testUtils/randomConfigGeneration';
+import { createMockAmplifyContext } from '../../testUtils/mockAmplifyContext';
 import { resolveBotConfig } from '../../../src/lex-v1/utils';
 
 describe('Interactions LexV1 Util: resolveBotConfig', () => {
-	const getConfigSpy = jest.spyOn(Amplify, 'getConfig');
-
-	afterEach(() => {
-		getConfigSpy.mockReset();
+	const v1BotConfigs = [...Array(5)].map(generateRandomLexV1Config);
+	const v2BotConfigs = [...Array(5)].map(generateRandomLexV2Config);
+	const mockCtx = createMockAmplifyContext({
+		Interactions: {
+			LexV1: Object.fromEntries(v1BotConfigs.map(bot => [bot.name, bot])),
+			LexV2: Object.fromEntries(v2BotConfigs.map(bot => [bot.name, bot])),
+		},
 	});
 
 	it('find correct bot config if exist', () => {
-		const v1BotConfigs = [...Array(5)].map(generateRandomLexV1Config);
-		const v2BotConfigs = [...Array(5)].map(generateRandomLexV2Config);
-		getConfigSpy.mockReturnValue({
-			Interactions: {
-				LexV1: Object.fromEntries(v1BotConfigs.map(bot => [bot.name, bot])),
-				LexV2: Object.fromEntries(v2BotConfigs.map(bot => [bot.name, bot])),
-			},
-		});
-
-		const result = resolveBotConfig(v1BotConfigs[3].name);
+		const result = resolveBotConfig(mockCtx, v1BotConfigs[3].name);
 		expect(result).not.toBeUndefined();
 		expect(result).toStrictEqual(v1BotConfigs[3]);
 	});
 
 	it('ignore v2 bot config', () => {
-		const v1BotConfigs = [...Array(5)].map(generateRandomLexV1Config);
-		const v2BotConfigs = [...Array(5)].map(generateRandomLexV2Config);
-		getConfigSpy.mockReturnValue({
-			Interactions: {
-				LexV1: Object.fromEntries(v1BotConfigs.map(bot => [bot.name, bot])),
-				LexV2: Object.fromEntries(v2BotConfigs.map(bot => [bot.name, bot])),
-			},
-		});
-
-		const result = resolveBotConfig(v2BotConfigs[3].name);
+		const result = resolveBotConfig(mockCtx, v2BotConfigs[3].name);
 		expect(result).toBeUndefined();
 	});
 
 	it('return undefined for non-exist bot', () => {
-		const v1BotConfigs = [...Array(5)].map(generateRandomLexV1Config);
-		const v2BotConfigs = [...Array(5)].map(generateRandomLexV2Config);
-		getConfigSpy.mockReturnValue({
-			Interactions: {
-				LexV1: Object.fromEntries(v1BotConfigs.map(bot => [bot.name, bot])),
-				LexV2: Object.fromEntries(v2BotConfigs.map(bot => [bot.name, bot])),
-			},
-		});
-
-		const result = resolveBotConfig('test');
+		const result = resolveBotConfig(mockCtx, 'test');
 		expect(result).toBeUndefined();
 	});
 });

--- a/packages/interactions/__tests__/lex-v2/AWSLexV2Provider.test.ts
+++ b/packages/interactions/__tests__/lex-v2/AWSLexV2Provider.test.ts
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { fetchAuthSession } from '@aws-amplify/core';
 import {
 	IntentState,
 	LexRuntimeV2Client,
@@ -12,8 +11,7 @@ import { gzip, strToU8 } from 'fflate';
 import { encode } from 'base-64';
 import { lexProvider } from '../../src/lex-v2/AWSLexV2Provider';
 import { amplifyUuid } from '@aws-amplify/core/internals/utils';
-
-jest.mock('@aws-amplify/core');
+import { createMockAmplifyContext } from '../testUtils/mockAmplifyContext';
 
 (global as any).Response = class Response {
 	arrayBuffer(blob: Blob) {
@@ -46,7 +44,8 @@ const credentials = {
 	identityId: 'identity-id',
 };
 
-const mockFetchAuthSession = fetchAuthSession as jest.Mock;
+const mockCtx = createMockAmplifyContext();
+const mockFetchAuthSession = mockCtx.fetchAuthSession as jest.Mock;
 
 const arrayBufferToBase64 = (buffer: Uint8Array) => {
 	var binary = '';
@@ -232,7 +231,7 @@ describe('Interactions', () => {
 		afterEach(() => mockFetchAuthSession.mockReset());
 
 		test('send simple text message to bot and fulfill', async () => {
-			let response = await provider.sendMessage(botConfig.BookTrip, 'hi');
+			let response = await provider.sendMessage(mockCtx, botConfig.BookTrip, 'hi');
 			expect(response).toEqual({
 				sessionState: {
 					intent: {
@@ -242,7 +241,7 @@ describe('Interactions', () => {
 				messages: [{ content: 'echo:hi' }],
 			});
 
-			response = await provider.sendMessage(botConfig.BookTrip, 'done');
+			response = await provider.sendMessage(mockCtx, botConfig.BookTrip, 'done');
 			expect(response).toEqual({
 				sessionState: {
 					intent: {
@@ -256,7 +255,7 @@ describe('Interactions', () => {
 		});
 
 		test('send obj text message to bot and fulfill', async () => {
-			let response = await provider.sendMessage(botConfig.BookTrip, {
+			let response = await provider.sendMessage(mockCtx, botConfig.BookTrip, {
 				content: 'hi',
 				options: {
 					messageType: 'text',
@@ -272,7 +271,7 @@ describe('Interactions', () => {
 				audioStream: new Uint8Array(),
 			});
 
-			response = await provider.sendMessage(botConfig.BookTrip, {
+			response = await provider.sendMessage(mockCtx, botConfig.BookTrip, {
 				content: 'done',
 				options: {
 					messageType: 'text',
@@ -302,7 +301,7 @@ describe('Interactions', () => {
 				},
 			};
 
-			let response = await provider.sendMessage(botconfig.BookTrip, {
+			let response = await provider.sendMessage(mockCtx, botconfig.BookTrip, {
 				content: createBlob(),
 				options: {
 					messageType: 'voice',
@@ -319,7 +318,7 @@ describe('Interactions', () => {
 			});
 
 			botconfig.BookTrip.botId = '0DNZS5QI8M:done';
-			response = await provider.sendMessage(botconfig.BookTrip, {
+			response = await provider.sendMessage(mockCtx, botconfig.BookTrip, {
 				content: createBlob(),
 				options: {
 					messageType: 'voice',
@@ -342,7 +341,7 @@ describe('Interactions', () => {
 			mockFetchAuthSession.mockReturnValue(Promise.reject(new Error()));
 
 			await expect(
-				provider.sendMessage(botConfig.BookTrip, 'hi'),
+				provider.sendMessage(mockCtx, botConfig.BookTrip, 'hi'),
 			).rejects.toThrow('No credentials');
 			expect.assertions(1);
 		});
@@ -350,7 +349,7 @@ describe('Interactions', () => {
 		test('send obj text and obj voice messages in wrong format', async () => {
 			// obj text in wrong format
 			await expect(
-				provider.sendMessage(botConfig.BookTrip, {
+				provider.sendMessage(mockCtx, botConfig.BookTrip, {
 					content: createBlob(),
 					options: {
 						messageType: 'text',
@@ -360,7 +359,7 @@ describe('Interactions', () => {
 
 			// obj voice in wrong format
 			await expect(
-				provider.sendMessage(botConfig.BookTrip, {
+				provider.sendMessage(mockCtx, botConfig.BookTrip, {
 					content: 'Hi',
 					options: {
 						messageType: 'voice',
@@ -434,16 +433,19 @@ describe('Interactions', () => {
 			};
 
 			const inProgressResp = (await provider.sendMessage(
+				mockCtx,
 				botConfig.BookTrip,
 				'in progress. callback isnt fired',
 			)) as RecognizeTextCommandOutput;
 
 			const completeSuccessResp = (await provider.sendMessage(
+				mockCtx,
 				botConfig.BookTrip,
 				'done',
 			)) as RecognizeTextCommandOutput;
 
 			const completeFailResp = (await provider.sendMessage(
+				mockCtx,
 				botConfig.BookTrip,
 				'error',
 			)) as RecognizeTextCommandOutput;

--- a/packages/interactions/__tests__/lex-v2/apis/onComplete.test.ts
+++ b/packages/interactions/__tests__/lex-v2/apis/onComplete.test.ts
@@ -1,10 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { amplifyUuid } from '@aws-amplify/core/internals/utils';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 import { lexProvider } from '../../../src/lex-v2/AWSLexV2Provider';
 import { onComplete } from '../../../src/lex-v2/apis';
 import { generateRandomLexV2Config } from '../../testUtils/randomConfigGeneration';
+import { createMockAmplifyContext } from '../../testUtils/mockAmplifyContext';
 import { resolveBotConfig } from '../../../src/lex-v2/utils';
 import { InteractionsError } from '../../../src/errors/InteractionsError';
 
@@ -13,9 +17,18 @@ jest.mock('../../../src/lex-v2/utils');
 
 describe('Interactions LexV2 API: onComplete', () => {
 	const v2BotConfig = generateRandomLexV2Config();
+	const mockCtx = createMockAmplifyContext();
 
 	const mockLexProvider = lexProvider.onComplete as jest.Mock;
 	const mockResolveBotConfig = resolveBotConfig as jest.Mock;
+
+	beforeAll(() => {
+		setGlobalContext(mockCtx);
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
 
 	beforeEach(() => {
 		mockResolveBotConfig.mockReturnValue(v2BotConfig);
@@ -27,9 +40,27 @@ describe('Interactions LexV2 API: onComplete', () => {
 	});
 
 	it('invokes provider onComplete API', () => {
-		const message = amplifyUuid();
 		const mockCallback = jest.fn();
 		onComplete({ botName: v2BotConfig.name, callback: mockCallback });
+		expect(mockResolveBotConfig).toHaveBeenCalledWith(
+			mockCtx,
+			v2BotConfig.name,
+		);
+		expect(mockLexProvider).toHaveBeenCalledTimes(1);
+		expect(mockLexProvider).toHaveBeenCalledWith(v2BotConfig, mockCallback);
+	});
+
+	it('invokes provider onComplete API with explicit context', () => {
+		const explicitCtx = createMockAmplifyContext();
+		const mockCallback = jest.fn();
+		onComplete(explicitCtx, {
+			botName: v2BotConfig.name,
+			callback: mockCallback,
+		});
+		expect(mockResolveBotConfig).toHaveBeenCalledWith(
+			explicitCtx,
+			v2BotConfig.name,
+		);
 		expect(mockLexProvider).toHaveBeenCalledTimes(1);
 		expect(mockLexProvider).toHaveBeenCalledWith(v2BotConfig, mockCallback);
 	});

--- a/packages/interactions/__tests__/lex-v2/apis/onComplete.test.ts
+++ b/packages/interactions/__tests__/lex-v2/apis/onComplete.test.ts
@@ -71,4 +71,18 @@ describe('Interactions LexV2 API: onComplete', () => {
 			onComplete({ botName: v2BotConfig.name, callback: jest.fn }),
 		).toThrow(InteractionsError);
 	});
+
+	it('throws on mis-ordered args (context not first)', () => {
+		const explicitCtx = createMockAmplifyContext();
+		const onCompleteUntyped = onComplete as unknown as (
+			...args: unknown[]
+		) => void;
+		expect(() =>
+			onCompleteUntyped(
+				{ botName: v2BotConfig.name, callback: jest.fn() },
+				explicitCtx,
+			),
+		).toThrow('AmplifyContext must be passed as the first argument');
+		expect(mockLexProvider).not.toHaveBeenCalled();
+	});
 });

--- a/packages/interactions/__tests__/lex-v2/apis/send.test.ts
+++ b/packages/interactions/__tests__/lex-v2/apis/send.test.ts
@@ -73,4 +73,15 @@ describe('Interactions LexV2 API: send', () => {
 			send({ botName: v2BotConfig.name, message: amplifyUuid() }),
 		).rejects.toBeInstanceOf(InteractionsError);
 	});
+
+	it('throws on mis-ordered args (context not first)', async () => {
+		const explicitCtx = createMockAmplifyContext();
+		const sendUntyped = send as unknown as (
+			...args: unknown[]
+		) => Promise<unknown>;
+		await expect(
+			sendUntyped({ botName: v2BotConfig.name, message: 'hi' }, explicitCtx),
+		).rejects.toThrow('AmplifyContext must be passed as the first argument');
+		expect(mockLexProvider).not.toHaveBeenCalled();
+	});
 });

--- a/packages/interactions/__tests__/lex-v2/apis/send.test.ts
+++ b/packages/interactions/__tests__/lex-v2/apis/send.test.ts
@@ -1,10 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { amplifyUuid } from '@aws-amplify/core/internals/utils';
+import {
+	amplifyUuid,
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 import { lexProvider } from '../../../src/lex-v2/AWSLexV2Provider';
 import { send } from '../../../src/lex-v2/apis';
 import { generateRandomLexV2Config } from '../../testUtils/randomConfigGeneration';
+import { createMockAmplifyContext } from '../../testUtils/mockAmplifyContext';
 import { resolveBotConfig } from '../../../src/lex-v2/utils';
 import { InteractionsError } from '../../../src/errors/InteractionsError';
 
@@ -13,9 +18,18 @@ jest.mock('../../../src/lex-v2/utils');
 
 describe('Interactions LexV2 API: send', () => {
 	const v2BotConfig = generateRandomLexV2Config();
+	const mockCtx = createMockAmplifyContext();
 
 	const mockLexProvider = lexProvider.sendMessage as jest.Mock;
 	const mockResolveBotConfig = resolveBotConfig as jest.Mock;
+
+	beforeAll(() => {
+		setGlobalContext(mockCtx);
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
 
 	beforeEach(() => {
 		mockResolveBotConfig.mockReturnValue(v2BotConfig);
@@ -29,8 +43,28 @@ describe('Interactions LexV2 API: send', () => {
 	it('invokes provider sendMessage API', async () => {
 		const message = amplifyUuid();
 		await send({ botName: v2BotConfig.name, message });
+		expect(mockResolveBotConfig).toHaveBeenCalledWith(
+			mockCtx,
+			v2BotConfig.name,
+		);
 		expect(mockLexProvider).toHaveBeenCalledTimes(1);
-		expect(mockLexProvider).toHaveBeenCalledWith(v2BotConfig, message);
+		expect(mockLexProvider).toHaveBeenCalledWith(mockCtx, v2BotConfig, message);
+	});
+
+	it('invokes provider sendMessage API with explicit context', async () => {
+		const explicitCtx = createMockAmplifyContext();
+		const message = amplifyUuid();
+		await send(explicitCtx, { botName: v2BotConfig.name, message });
+		expect(mockResolveBotConfig).toHaveBeenCalledWith(
+			explicitCtx,
+			v2BotConfig.name,
+		);
+		expect(mockLexProvider).toHaveBeenCalledTimes(1);
+		expect(mockLexProvider).toHaveBeenCalledWith(
+			explicitCtx,
+			v2BotConfig,
+			message,
+		);
 	});
 
 	it('rejects when bot config does not exist', async () => {

--- a/packages/interactions/__tests__/lex-v2/utils/resolveBotConfig.test.ts
+++ b/packages/interactions/__tests__/lex-v2/utils/resolveBotConfig.test.ts
@@ -1,60 +1,36 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
 import {
 	generateRandomLexV1Config,
 	generateRandomLexV2Config,
 } from '../../testUtils/randomConfigGeneration';
+import { createMockAmplifyContext } from '../../testUtils/mockAmplifyContext';
 import { resolveBotConfig } from '../../../src/lex-v2/utils';
 
 describe('Interactions LexV2 Util: resolveBotConfig', () => {
-	const getConfigSpy = jest.spyOn(Amplify, 'getConfig');
-
-	afterEach(() => {
-		getConfigSpy.mockReset();
+	const v1BotConfigs = [...Array(5)].map(generateRandomLexV1Config);
+	const v2BotConfigs = [...Array(5)].map(generateRandomLexV2Config);
+	const mockCtx = createMockAmplifyContext({
+		Interactions: {
+			LexV1: Object.fromEntries(v1BotConfigs.map(bot => [bot.name, bot])),
+			LexV2: Object.fromEntries(v2BotConfigs.map(bot => [bot.name, bot])),
+		},
 	});
 
 	it('find correct bot config if exist', () => {
-		const v1BotConfigs = [...Array(5)].map(generateRandomLexV1Config);
-		const v2BotConfigs = [...Array(5)].map(generateRandomLexV2Config);
-		getConfigSpy.mockReturnValue({
-			Interactions: {
-				LexV1: Object.fromEntries(v1BotConfigs.map(bot => [bot.name, bot])),
-				LexV2: Object.fromEntries(v2BotConfigs.map(bot => [bot.name, bot])),
-			},
-		});
-
-		const result = resolveBotConfig(v2BotConfigs[3].name);
+		const result = resolveBotConfig(mockCtx, v2BotConfigs[3].name);
 		expect(result).not.toBeUndefined();
 		expect(result).toStrictEqual(v2BotConfigs[3]);
 	});
 
-	it('ignore v2 bot config', () => {
-		const v1BotConfigs = [...Array(5)].map(generateRandomLexV1Config);
-		const v2BotConfigs = [...Array(5)].map(generateRandomLexV2Config);
-		getConfigSpy.mockReturnValue({
-			Interactions: {
-				LexV1: Object.fromEntries(v1BotConfigs.map(bot => [bot.name, bot])),
-				LexV2: Object.fromEntries(v2BotConfigs.map(bot => [bot.name, bot])),
-			},
-		});
-
-		const result = resolveBotConfig(v1BotConfigs[3].name);
+	it('ignore v1 bot config', () => {
+		const result = resolveBotConfig(mockCtx, v1BotConfigs[3].name);
 		expect(result).toBeUndefined();
 	});
 
 	it('return undefined for non-exist bot', () => {
-		const v1BotConfigs = [...Array(5)].map(generateRandomLexV1Config);
-		const v2BotConfigs = [...Array(5)].map(generateRandomLexV2Config);
-		getConfigSpy.mockReturnValue({
-			Interactions: {
-				LexV1: Object.fromEntries(v1BotConfigs.map(bot => [bot.name, bot])),
-				LexV2: Object.fromEntries(v2BotConfigs.map(bot => [bot.name, bot])),
-			},
-		});
-
-		const result = resolveBotConfig('test');
+		const result = resolveBotConfig(mockCtx, 'test');
 		expect(result).toBeUndefined();
 	});
 });

--- a/packages/interactions/__tests__/testUtils/mockAmplifyContext.ts
+++ b/packages/interactions/__tests__/testUtils/mockAmplifyContext.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AMPLIFY_CONTEXT_BRAND,
+	AmplifyContext,
+	ResourcesConfig,
+} from '@aws-amplify/core';
+
+/**
+ * Creates a mock AmplifyContext for testing.
+ */
+export function createMockAmplifyContext(
+	resourcesConfig: ResourcesConfig = {},
+): AmplifyContext {
+	const ctx: AmplifyContext = {
+		resourcesConfig,
+		libraryOptions: {},
+		fetchAuthSession: jest.fn().mockResolvedValue({}),
+		clearCredentials: jest.fn().mockResolvedValue(undefined),
+		getTokens: jest.fn().mockResolvedValue(undefined),
+	};
+
+	Object.defineProperty(ctx, AMPLIFY_CONTEXT_BRAND, {
+		value: true,
+		enumerable: false,
+	});
+
+	return ctx;
+}

--- a/packages/interactions/src/lex-v1/AWSLexProvider.ts
+++ b/packages/interactions/src/lex-v1/AWSLexProvider.ts
@@ -11,7 +11,7 @@ import {
 	PostTextCommandOutput,
 } from '@aws-sdk/client-lex-runtime-service';
 import { getAmplifyUserAgentObject } from '@aws-amplify/core/internals/utils';
-import { ConsoleLogger, fetchAuthSession } from '@aws-amplify/core';
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
 
 import {
 	InteractionsMessage,
@@ -69,13 +69,14 @@ class AWSLexProvider {
 	}
 
 	async sendMessage(
+		ctx: AmplifyContext,
 		botConfig: AWSLexProviderOption,
 		message: string | InteractionsMessage,
 	): Promise<InteractionsResponse> {
 		// check if credentials are present
 		let session;
 		try {
-			session = await fetchAuthSession();
+			session = await ctx.fetchAuthSession();
 		} catch (error) {
 			return Promise.reject(new Error('No credentials'));
 		}

--- a/packages/interactions/src/lex-v1/apis/onComplete.ts
+++ b/packages/interactions/src/lex-v1/apis/onComplete.ts
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
+
 import { OnCompleteInput } from '../types';
 import { resolveBotConfig } from '../utils';
 import { lexProvider } from '../AWSLexProvider';
@@ -9,13 +12,16 @@ import {
 	assertValidationError,
 } from '../../errors';
 
-export const onComplete = (input: OnCompleteInput): void => {
+export function onComplete(input: OnCompleteInput): void;
+export function onComplete(ctx: AmplifyContext, input: OnCompleteInput): void;
+export function onComplete(...args: any[]): void {
+	const [ctx, input] = resolveCtxArgs<[OnCompleteInput]>(args);
 	const { botName, callback } = input;
-	const botConfig = resolveBotConfig(botName);
+	const botConfig = resolveBotConfig(ctx, botName);
 	assertValidationError(
 		!!botConfig,
 		InteractionsValidationErrorCode.NoBotConfig,
 		`Bot ${botName} does not exist.`,
 	);
 	lexProvider.onComplete(botConfig, callback);
-};
+}

--- a/packages/interactions/src/lex-v1/apis/send.ts
+++ b/packages/interactions/src/lex-v1/apis/send.ts
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
+
 import { SendInput, SendOutput } from '../types';
 import { resolveBotConfig } from '../utils';
 import { lexProvider } from '../AWSLexProvider';
@@ -9,14 +12,20 @@ import {
 	assertValidationError,
 } from '../../errors';
 
-export const send = async (input: SendInput): Promise<SendOutput> => {
+export function send(input: SendInput): Promise<SendOutput>;
+export function send(
+	ctx: AmplifyContext,
+	input: SendInput,
+): Promise<SendOutput>;
+export async function send(...args: any[]): Promise<SendOutput> {
+	const [ctx, input] = resolveCtxArgs<[SendInput]>(args);
 	const { botName, message } = input;
-	const botConfig = resolveBotConfig(botName);
+	const botConfig = resolveBotConfig(ctx, botName);
 	assertValidationError(
 		!!botConfig,
 		InteractionsValidationErrorCode.NoBotConfig,
 		`Bot ${botName} does not exist.`,
 	);
 
-	return lexProvider.sendMessage(botConfig, message);
-};
+	return lexProvider.sendMessage(ctx, botConfig, message);
+}

--- a/packages/interactions/src/lex-v1/types/AWSLexProviderOption.ts
+++ b/packages/interactions/src/lex-v1/types/AWSLexProviderOption.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+
 import { OnCompleteInput, SendInput } from './inputs';
 import { SendOutput } from './outputs';
 
@@ -12,5 +14,7 @@ export interface AWSLexProviderOption {
 
 export interface IInteractions {
 	send(input: SendInput): Promise<SendOutput>;
+	send(ctx: AmplifyContext, input: SendInput): Promise<SendOutput>;
 	onComplete(input: OnCompleteInput): void;
+	onComplete(ctx: AmplifyContext, input: OnCompleteInput): void;
 }

--- a/packages/interactions/src/lex-v1/utils/resolveBotConfig.ts
+++ b/packages/interactions/src/lex-v1/utils/resolveBotConfig.ts
@@ -1,15 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import { AWSLexProviderOption } from '../types';
 
 export const resolveBotConfig = (
+	ctx: AmplifyContext,
 	botName: string,
 ): AWSLexProviderOption | undefined => {
 	const { [botName]: botConfig = undefined } =
-		Amplify.getConfig().Interactions?.LexV1 ?? {};
+		ctx.resourcesConfig.Interactions?.LexV1 ?? {};
 	if (botConfig !== undefined) {
 		return { ...botConfig, name: botName };
 	}

--- a/packages/interactions/src/lex-v2/AWSLexV2Provider.ts
+++ b/packages/interactions/src/lex-v2/AWSLexV2Provider.ts
@@ -14,7 +14,7 @@ import {
 	amplifyUuid,
 	getAmplifyUserAgentObject,
 } from '@aws-amplify/core/internals/utils';
-import { ConsoleLogger, fetchAuthSession } from '@aws-amplify/core';
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
 
 import { convert, unGzipBase64AsJson } from '../utils';
 import {
@@ -65,18 +65,20 @@ class AWSLexV2Provider {
 	/**
 	 * Send a message to a bot
 	 * @async
+	 * @param {AmplifyContext} ctx - Amplify context used to resolve credentials
 	 * @param {AWSLexV2ProviderOption} botConfig - Bot configuration for sending the message
 	 * @param {string | InteractionsMessage} message - message to send to the bot
 	 * @return {Promise<InteractionsResponse>} A promise resolves to the response from the bot
 	 */
 	public async sendMessage(
+		ctx: AmplifyContext,
 		botConfig: AWSLexV2ProviderOption,
 		message: string | InteractionsMessage,
 	): Promise<InteractionsResponse> {
 		// check if credentials are present
 		let session;
 		try {
-			session = await fetchAuthSession();
+			session = await ctx.fetchAuthSession();
 		} catch (error) {
 			return Promise.reject(new Error('No credentials'));
 		}

--- a/packages/interactions/src/lex-v2/apis/onComplete.ts
+++ b/packages/interactions/src/lex-v2/apis/onComplete.ts
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
+
 import { OnCompleteInput } from '../types';
 import { resolveBotConfig } from '../utils';
 import { lexProvider } from '../AWSLexV2Provider';
@@ -9,13 +12,16 @@ import {
 	assertValidationError,
 } from '../../errors';
 
-export const onComplete = (input: OnCompleteInput): void => {
+export function onComplete(input: OnCompleteInput): void;
+export function onComplete(ctx: AmplifyContext, input: OnCompleteInput): void;
+export function onComplete(...args: any[]): void {
+	const [ctx, input] = resolveCtxArgs<[OnCompleteInput]>(args);
 	const { botName, callback } = input;
-	const botConfig = resolveBotConfig(botName);
+	const botConfig = resolveBotConfig(ctx, botName);
 	assertValidationError(
 		!!botConfig,
 		InteractionsValidationErrorCode.NoBotConfig,
 		`Bot ${botName} does not exist.`,
 	);
 	lexProvider.onComplete(botConfig, callback);
-};
+}

--- a/packages/interactions/src/lex-v2/apis/send.ts
+++ b/packages/interactions/src/lex-v2/apis/send.ts
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
+
 import { SendInput, SendOutput } from '../types';
 import { lexProvider } from '../AWSLexV2Provider';
 import { resolveBotConfig } from '../utils';
@@ -9,14 +12,20 @@ import {
 	assertValidationError,
 } from '../../errors';
 
-export const send = async (input: SendInput): Promise<SendOutput> => {
+export function send(input: SendInput): Promise<SendOutput>;
+export function send(
+	ctx: AmplifyContext,
+	input: SendInput,
+): Promise<SendOutput>;
+export async function send(...args: any[]): Promise<SendOutput> {
+	const [ctx, input] = resolveCtxArgs<[SendInput]>(args);
 	const { botName, message } = input;
-	const botConfig = resolveBotConfig(botName);
+	const botConfig = resolveBotConfig(ctx, botName);
 	assertValidationError(
 		!!botConfig,
 		InteractionsValidationErrorCode.NoBotConfig,
 		`Bot ${botName} does not exist.`,
 	);
 
-	return lexProvider.sendMessage(botConfig, message);
-};
+	return lexProvider.sendMessage(ctx, botConfig, message);
+}

--- a/packages/interactions/src/lex-v2/types/AWSLexV2ProviderOption.ts
+++ b/packages/interactions/src/lex-v2/types/AWSLexV2ProviderOption.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+
 import { OnCompleteInput, SendInput } from './inputs';
 import { SendOutput } from './outputs';
 
@@ -14,5 +16,7 @@ export interface AWSLexV2ProviderOption {
 
 export interface IInteractions {
 	send(input: SendInput): Promise<SendOutput>;
+	send(ctx: AmplifyContext, input: SendInput): Promise<SendOutput>;
 	onComplete(input: OnCompleteInput): void;
+	onComplete(ctx: AmplifyContext, input: OnCompleteInput): void;
 }

--- a/packages/interactions/src/lex-v2/utils/resolveBotConfig.ts
+++ b/packages/interactions/src/lex-v2/utils/resolveBotConfig.ts
@@ -1,15 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import { AWSLexV2ProviderOption } from '../types';
 
 export const resolveBotConfig = (
+	ctx: AmplifyContext,
 	botName: string,
 ): AWSLexV2ProviderOption | undefined => {
 	const { [botName]: botConfig = undefined } =
-		Amplify.getConfig().Interactions?.LexV2 ?? {};
+		ctx.resourcesConfig.Interactions?.LexV2 ?? {};
 	if (botConfig !== undefined) {
 		return { ...botConfig, name: botName };
 	}


### PR DESCRIPTION
## Description

B-interactions split (Task 5) of the v6 → v7 AmplifyContext migration. Migrates the `@aws-amplify/interactions` package (both Lex v1 and Lex v2 providers) from the singleton-based `Amplify.getConfig()` pattern to explicit `AmplifyContext` threading.

### Changes

- **Public APIs** `send` / `onComplete` (lex-v1 + lex-v2 subpaths): dual overloads — `fn(input)` (backward compatible) and `fn(ctx, input)` — resolved via `resolveCtxArgs` with global-context fallback
- **`resolveBotConfig`** (both versions): now takes `(ctx, botName)` and reads from `ctx.resourcesConfig.Interactions`
- **Providers**: `sendMessage(ctx, botConfig, message)` — credentials resolved via `ctx.fetchAuthSession()`; no direct singleton imports remain
- **Types**: `IInteractions` gains the dual overload signatures
- **Tests**: all 8 test files migrated to `createMockAmplifyContext()` + `setGlobalContext`/`clearGlobalContext` (no `Amplify.getConfig` mocking); added explicit-ctx test cases

### Design note

The `lexProvider` singleton is kept (ctx threaded per call) rather than adopting v7-poc's `createLexProvider(ctx)` per-call factory — the factory would break the stateful `onComplete` callback registry (`_botsCompleteCallback`), since a callback registered on one instance would never fire from a later `send`.

No server wrappers (interactions is client-only). No changeset (feature-branch target).

## Validation

- `yarn turbo run test --filter=@aws-amplify/interactions` — 8 suites, 34 tests pass (lint runs first in the package test script)
- `yarn turbo run build --filter=@aws-amplify/interactions` — pass
- `npx eslint '**/*.{ts,tsx}'` in package — clean
- `yarn test:size` — within budget (45.87/57 kB default+v2, 39.57/49 kB v1)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
