### PR TITLE
feat(analytics): migrate analytics APIs to AmplifyContext

### DIFF
--- a/packages/analytics/__tests__/providers/kinesis-firehose/apis/configureAutoTrack.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis-firehose/apis/configureAutoTrack.test.ts
@@ -54,10 +54,6 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			try {
 				configureAutoTrack({
@@ -77,10 +73,6 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			try {
 				configureAutoTrack({
@@ -101,10 +93,6 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			expect(() => {
 				configureAutoTrack({
@@ -120,10 +108,6 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			configureAutoTrack(MOCK_INPUT);
 		});
@@ -144,10 +128,6 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			configureAutoTrack(testInput);
 		});
@@ -168,10 +148,6 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			configureAutoTrack(testInput);
 		});
@@ -188,15 +164,34 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			configureAutoTrack(MOCK_INPUT);
 		});
 
-		// The recorder callback passed to the tracker should emit to the configured stream
+		// The recorder callback passed to the tracker should emit to the configured stream.
+		// No context was supplied, so record must be called WITHOUT a captured context —
+		// it resolves the global context lazily at emit time (live config).
+		const emitTrackingEvent = MockEventTracker.mock.calls[0][0];
+		emitTrackingEvent('my-event', { foo: 'bar' });
+
+		expect(mockRecord).toHaveBeenCalledWith({
+			streamName: MOCK_STREAM_NAME,
+			data: {
+				name: 'my-event',
+				attributes: { foo: 'bar' },
+			},
+		});
+	});
+
+	it('passes an explicitly provided context through to record', () => {
+		jest.isolateModules(() => {
+			const {
+				configureAutoTrack,
+			} = require('../../../../src/providers/kinesis-firehose/apis');
+
+			configureAutoTrack(mockCtx, MOCK_INPUT);
+		});
+
 		const emitTrackingEvent = MockEventTracker.mock.calls[0][0];
 		emitTrackingEvent('my-event', { foo: 'bar' });
 
@@ -209,15 +204,25 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 		});
 	});
 
+	it('can be configured before Amplify.configure (no global context)', () => {
+		jest.isolateModules(() => {
+			const {
+				configureAutoTrack,
+			} = require('../../../../src/providers/kinesis-firehose/apis');
+
+			// The isolated registry has NO global context set — tracker setup must
+			// not resolve the context eagerly, so this must not throw.
+			expect(() => {
+				configureAutoTrack(MOCK_INPUT);
+			}).not.toThrow();
+		});
+	});
+
 	it('reconfigures an existing tracker and updates the stream', () => {
 		jest.isolateModules(() => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			// Enable the tracker
 			configureAutoTrack(MOCK_INPUT);
@@ -248,7 +253,7 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 				.calls[0][0];
 			emitTrackingEvent('reconfigured-event', { a: 'b' });
 
-			expect(mockRecord).toHaveBeenCalledWith(mockCtx, {
+			expect(mockRecord).toHaveBeenCalledWith({
 				streamName: 'stream1',
 				data: {
 					name: 'reconfigured-event',
@@ -268,10 +273,6 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			// Enable the tracker
 			configureAutoTrack(MOCK_INPUT);

--- a/packages/analytics/__tests__/providers/kinesis-firehose/apis/configureAutoTrack.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis-firehose/apis/configureAutoTrack.test.ts
@@ -8,9 +8,12 @@ import {
 	SessionTracker,
 } from '../../../../src/trackers';
 import { record } from '../../../../src/providers/kinesis-firehose/apis/record';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 jest.mock('../../../../src/trackers');
 jest.mock('../../../../src/providers/kinesis-firehose/apis/record');
+
+const mockCtx = createMockAmplifyContext();
 
 const MOCK_STREAM_NAME = 'stream0';
 
@@ -51,6 +54,10 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			try {
 				configureAutoTrack({
@@ -70,6 +77,10 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			try {
 				configureAutoTrack({
@@ -90,6 +101,10 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			expect(() => {
 				configureAutoTrack({
@@ -105,6 +120,10 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			configureAutoTrack(MOCK_INPUT);
 		});
@@ -125,6 +144,10 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			configureAutoTrack(testInput);
 		});
@@ -145,6 +168,10 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			configureAutoTrack(testInput);
 		});
@@ -161,6 +188,10 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			configureAutoTrack(MOCK_INPUT);
 		});
@@ -169,7 +200,7 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 		const emitTrackingEvent = MockEventTracker.mock.calls[0][0];
 		emitTrackingEvent('my-event', { foo: 'bar' });
 
-		expect(mockRecord).toHaveBeenCalledWith({
+		expect(mockRecord).toHaveBeenCalledWith(mockCtx, {
 			streamName: MOCK_STREAM_NAME,
 			data: {
 				name: 'my-event',
@@ -183,6 +214,10 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			// Enable the tracker
 			configureAutoTrack(MOCK_INPUT);
@@ -213,7 +248,7 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 				.calls[0][0];
 			emitTrackingEvent('reconfigured-event', { a: 'b' });
 
-			expect(mockRecord).toHaveBeenCalledWith({
+			expect(mockRecord).toHaveBeenCalledWith(mockCtx, {
 				streamName: 'stream1',
 				data: {
 					name: 'reconfigured-event',
@@ -233,6 +268,10 @@ describe('Kinesis Firehose API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis-firehose/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			// Enable the tracker
 			configureAutoTrack(MOCK_INPUT);

--- a/packages/analytics/__tests__/providers/kinesis-firehose/apis/flushEvents.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis-firehose/apis/flushEvents.test.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import {
 	getEventBuffer,
@@ -13,9 +17,16 @@ import {
 	mockKinesisConfig,
 } from '../../../testUtils/mockConstants';
 import { flushEvents } from '../../../../src/providers/kinesis-firehose/apis';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 jest.mock('../../../../src/utils');
 jest.mock('../../../../src/providers/kinesis-firehose/utils');
+
+setGlobalContext(createMockAmplifyContext());
+
+afterAll(() => {
+	clearGlobalContext();
+});
 
 describe('Analytics Kinesis Firehose API: flushEvents', () => {
 	const mockResolveConfig = resolveConfig as jest.Mock;

--- a/packages/analytics/__tests__/providers/kinesis-firehose/apis/record.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis-firehose/apis/record.test.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import {
 	getEventBuffer,
@@ -14,9 +18,16 @@ import {
 } from '../../../testUtils/mockConstants';
 import { record } from '../../../../src/providers/kinesis-firehose';
 import { RecordInput as KinesisFirehoseRecordInput } from '../../../../src/providers/kinesis-firehose/types';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 jest.mock('../../../../src/utils');
 jest.mock('../../../../src/providers/kinesis-firehose/utils');
+
+setGlobalContext(createMockAmplifyContext());
+
+afterAll(() => {
+	clearGlobalContext();
+});
 
 describe('Analytics KinesisFirehose API: record', () => {
 	const mockRecordInput: KinesisFirehoseRecordInput = {

--- a/packages/analytics/__tests__/providers/kinesis-firehose/utils/resolveConfig.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis-firehose/utils/resolveConfig.test.ts
@@ -1,10 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
-
 import { resolveConfig } from '../../../../src/providers/kinesis-firehose/utils';
 import { DEFAULT_KINESIS_FIREHOSE_CONFIG } from '../../../../src/providers/kinesis-firehose/utils/constants';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 describe('Analytics KinesisFirehose Provider Util: resolveConfig', () => {
 	const providedConfig = {
@@ -15,18 +14,12 @@ describe('Analytics KinesisFirehose Provider Util: resolveConfig', () => {
 		resendLimit: 3,
 	};
 
-	const getConfigSpy = jest.spyOn(Amplify, 'getConfig');
-
-	beforeEach(() => {
-		getConfigSpy.mockReset();
-	});
-
 	it('returns required config', () => {
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: { KinesisFirehose: providedConfig },
 		});
 
-		expect(resolveConfig()).toStrictEqual(providedConfig);
+		expect(resolveConfig(mockCtx)).toStrictEqual(providedConfig);
 	});
 
 	it('use default config for optional fields', () => {
@@ -35,11 +28,11 @@ describe('Analytics KinesisFirehose Provider Util: resolveConfig', () => {
 			bufferSize: undefined,
 			resendLimit: undefined,
 		};
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: { KinesisFirehose: requiredFields },
 		});
 
-		expect(resolveConfig()).toStrictEqual({
+		expect(resolveConfig(mockCtx)).toStrictEqual({
 			...DEFAULT_KINESIS_FIREHOSE_CONFIG,
 			region: requiredFields.region,
 			resendLimit: requiredFields.resendLimit,
@@ -47,17 +40,17 @@ describe('Analytics KinesisFirehose Provider Util: resolveConfig', () => {
 	});
 
 	it('throws if region is missing', () => {
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: {
 				KinesisFirehose: { ...providedConfig, region: undefined as any },
 			},
 		});
 
-		expect(resolveConfig).toThrow();
+		expect(() => resolveConfig(mockCtx)).toThrow();
 	});
 
 	it('throws if flushSize is larger than bufferSize', () => {
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: {
 				KinesisFirehose: {
 					...providedConfig,
@@ -66,6 +59,6 @@ describe('Analytics KinesisFirehose Provider Util: resolveConfig', () => {
 			},
 		});
 
-		expect(resolveConfig).toThrow();
+		expect(() => resolveConfig(mockCtx)).toThrow();
 	});
 });

--- a/packages/analytics/__tests__/providers/kinesis/apis/configureAutoTrack.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis/apis/configureAutoTrack.test.ts
@@ -8,9 +8,12 @@ import {
 	SessionTracker,
 } from '../../../../src/trackers';
 import { record } from '../../../../src/providers/kinesis/apis/record';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 jest.mock('../../../../src/trackers');
 jest.mock('../../../../src/providers/kinesis/apis/record');
+
+const mockCtx = createMockAmplifyContext();
 
 const MOCK_STREAM_NAME = 'stream0';
 const MOCK_PARTITION_KEY = 'partition0';
@@ -53,6 +56,10 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			try {
 				configureAutoTrack({
@@ -72,6 +79,10 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			try {
 				configureAutoTrack({
@@ -96,6 +107,10 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			try {
 				configureAutoTrack({
@@ -118,6 +133,10 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			expect(() => {
 				configureAutoTrack({
@@ -133,6 +152,10 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			configureAutoTrack(MOCK_INPUT);
 		});
@@ -153,6 +176,10 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			configureAutoTrack(testInput);
 		});
@@ -173,6 +200,10 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			configureAutoTrack(testInput);
 		});
@@ -189,6 +220,10 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			configureAutoTrack(MOCK_INPUT);
 		});
@@ -197,7 +232,7 @@ describe('Kinesis API: configureAutoTrack', () => {
 		const emitTrackingEvent = MockEventTracker.mock.calls[0][0];
 		emitTrackingEvent('my-event', { foo: 'bar' });
 
-		expect(mockRecord).toHaveBeenCalledWith({
+		expect(mockRecord).toHaveBeenCalledWith(mockCtx, {
 			streamName: MOCK_STREAM_NAME,
 			partitionKey: MOCK_PARTITION_KEY,
 			data: {
@@ -212,6 +247,10 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			// Enable the tracker
 			configureAutoTrack(MOCK_INPUT);
@@ -243,7 +282,7 @@ describe('Kinesis API: configureAutoTrack', () => {
 				.calls[0][0];
 			emitTrackingEvent('reconfigured-event', { a: 'b' });
 
-			expect(mockRecord).toHaveBeenCalledWith({
+			expect(mockRecord).toHaveBeenCalledWith(mockCtx, {
 				streamName: 'stream1',
 				partitionKey: 'partition1',
 				data: {
@@ -264,6 +303,10 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			// Enable the tracker
 			configureAutoTrack(MOCK_INPUT);

--- a/packages/analytics/__tests__/providers/kinesis/apis/configureAutoTrack.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis/apis/configureAutoTrack.test.ts
@@ -56,10 +56,6 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			try {
 				configureAutoTrack({
@@ -79,10 +75,6 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			try {
 				configureAutoTrack({
@@ -107,10 +99,6 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			try {
 				configureAutoTrack({
@@ -133,10 +121,6 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			expect(() => {
 				configureAutoTrack({
@@ -152,10 +136,6 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			configureAutoTrack(MOCK_INPUT);
 		});
@@ -176,10 +156,6 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			configureAutoTrack(testInput);
 		});
@@ -200,10 +176,6 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			configureAutoTrack(testInput);
 		});
@@ -220,15 +192,35 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			configureAutoTrack(MOCK_INPUT);
 		});
 
-		// The recorder callback passed to the tracker should emit to the configured stream
+		// The recorder callback passed to the tracker should emit to the configured stream.
+		// No context was supplied, so record must be called WITHOUT a captured context —
+		// it resolves the global context lazily at emit time (live config).
+		const emitTrackingEvent = MockEventTracker.mock.calls[0][0];
+		emitTrackingEvent('my-event', { foo: 'bar' });
+
+		expect(mockRecord).toHaveBeenCalledWith({
+			streamName: MOCK_STREAM_NAME,
+			partitionKey: MOCK_PARTITION_KEY,
+			data: {
+				name: 'my-event',
+				attributes: { foo: 'bar' },
+			},
+		});
+	});
+
+	it('passes an explicitly provided context through to record', () => {
+		jest.isolateModules(() => {
+			const {
+				configureAutoTrack,
+			} = require('../../../../src/providers/kinesis/apis');
+
+			configureAutoTrack(mockCtx, MOCK_INPUT);
+		});
+
 		const emitTrackingEvent = MockEventTracker.mock.calls[0][0];
 		emitTrackingEvent('my-event', { foo: 'bar' });
 
@@ -242,15 +234,25 @@ describe('Kinesis API: configureAutoTrack', () => {
 		});
 	});
 
+	it('can be configured before Amplify.configure (no global context)', () => {
+		jest.isolateModules(() => {
+			const {
+				configureAutoTrack,
+			} = require('../../../../src/providers/kinesis/apis');
+
+			// The isolated registry has NO global context set — tracker setup must
+			// not resolve the context eagerly, so this must not throw.
+			expect(() => {
+				configureAutoTrack(MOCK_INPUT);
+			}).not.toThrow();
+		});
+	});
+
 	it('reconfigures an existing tracker and updates the stream coordinates', () => {
 		jest.isolateModules(() => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			// Enable the tracker
 			configureAutoTrack(MOCK_INPUT);
@@ -282,7 +284,7 @@ describe('Kinesis API: configureAutoTrack', () => {
 				.calls[0][0];
 			emitTrackingEvent('reconfigured-event', { a: 'b' });
 
-			expect(mockRecord).toHaveBeenCalledWith(mockCtx, {
+			expect(mockRecord).toHaveBeenCalledWith({
 				streamName: 'stream1',
 				partitionKey: 'partition1',
 				data: {
@@ -303,10 +305,6 @@ describe('Kinesis API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/kinesis/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			// Enable the tracker
 			configureAutoTrack(MOCK_INPUT);

--- a/packages/analytics/__tests__/providers/kinesis/apis/flushEvents.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis/apis/flushEvents.test.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import { resolveConfig } from '../../../../src/providers/kinesis/utils/resolveConfig';
 import { resolveCredentials } from '../../../../src/utils';
@@ -11,10 +15,17 @@ import {
 } from '../../../testUtils/mockConstants';
 import { getEventBuffer } from '../../../../src/providers/kinesis/utils/getEventBuffer';
 import { flushEvents } from '../../../../src/providers/kinesis/apis';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 jest.mock('../../../../src/utils');
 jest.mock('../../../../src/providers/kinesis/utils/getEventBuffer');
 jest.mock('../../../../src/providers/kinesis/utils/resolveConfig');
+
+setGlobalContext(createMockAmplifyContext());
+
+afterAll(() => {
+	clearGlobalContext();
+});
 
 describe('Analytics Kinesis API: flushEvents', () => {
 	const mockResolveConfig = resolveConfig as jest.Mock;

--- a/packages/analytics/__tests__/providers/kinesis/apis/record.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis/apis/record.test.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import { getEventBuffer } from '../../../../src/providers/kinesis/utils/getEventBuffer';
 import { resolveConfig } from '../../../../src/providers/kinesis/utils/resolveConfig';
@@ -12,10 +16,17 @@ import {
 } from '../../../testUtils/mockConstants';
 import { record } from '../../../../src/providers/kinesis';
 import { RecordInput as KinesisRecordInput } from '../../../../src/providers/kinesis/types';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 jest.mock('../../../../src/utils');
 jest.mock('../../../../src/providers/kinesis/utils/resolveConfig');
 jest.mock('../../../../src/providers/kinesis/utils/getEventBuffer');
+
+setGlobalContext(createMockAmplifyContext());
+
+afterAll(() => {
+	clearGlobalContext();
+});
 
 describe('Analytics Kinesis API: record', () => {
 	const mockRecordInput: KinesisRecordInput = {

--- a/packages/analytics/__tests__/providers/kinesis/utils/resolveConfig.test.ts
+++ b/packages/analytics/__tests__/providers/kinesis/utils/resolveConfig.test.ts
@@ -1,10 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
-
 import { resolveConfig } from '../../../../src/providers/kinesis/utils/resolveConfig';
 import { DEFAULT_KINESIS_CONFIG } from '../../../../src/providers/kinesis/utils/constants';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 describe('Analytics Kinesis Provider Util: resolveConfig', () => {
 	const kinesisConfig = {
@@ -15,18 +14,12 @@ describe('Analytics Kinesis Provider Util: resolveConfig', () => {
 		resendLimit: 3,
 	};
 
-	const getConfigSpy = jest.spyOn(Amplify, 'getConfig');
-
-	beforeEach(() => {
-		getConfigSpy.mockReset();
-	});
-
 	it('returns required config', () => {
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: { Kinesis: kinesisConfig },
 		});
 
-		expect(resolveConfig()).toStrictEqual(kinesisConfig);
+		expect(resolveConfig(mockCtx)).toStrictEqual(kinesisConfig);
 	});
 
 	it('use default config for optional fields', () => {
@@ -35,11 +28,11 @@ describe('Analytics Kinesis Provider Util: resolveConfig', () => {
 			bufferSize: undefined,
 			resendLimit: undefined,
 		};
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: { Kinesis: requiredFields },
 		});
 
-		expect(resolveConfig()).toStrictEqual({
+		expect(resolveConfig(mockCtx)).toStrictEqual({
 			...DEFAULT_KINESIS_CONFIG,
 			region: requiredFields.region,
 			resendLimit: requiredFields.resendLimit,
@@ -47,20 +40,20 @@ describe('Analytics Kinesis Provider Util: resolveConfig', () => {
 	});
 
 	it('throws if region is missing', () => {
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: { Kinesis: { ...kinesisConfig, region: undefined as any } },
 		});
 
-		expect(resolveConfig).toThrow();
+		expect(() => resolveConfig(mockCtx)).toThrow();
 	});
 
 	it('throws if flushSize is larger than bufferSize', () => {
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: {
 				Kinesis: { ...kinesisConfig, flushSize: kinesisConfig.bufferSize + 1 },
 			},
 		});
 
-		expect(resolveConfig).toThrow();
+		expect(() => resolveConfig(mockCtx)).toThrow();
 	});
 });

--- a/packages/analytics/__tests__/providers/personalize/apis/flushEvents.test.ts
+++ b/packages/analytics/__tests__/providers/personalize/apis/flushEvents.test.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import {
 	getEventBuffer,
@@ -13,9 +17,16 @@ import {
 	mockPersonalizeConfig,
 } from '../../../testUtils/mockConstants';
 import { flushEvents } from '../../../../src/providers/personalize';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 jest.mock('../../../../src/utils');
 jest.mock('../../../../src/providers/personalize/utils');
+
+setGlobalContext(createMockAmplifyContext());
+
+afterAll(() => {
+	clearGlobalContext();
+});
 
 describe('Analytics Personalize API: flushEvents', () => {
 	const mockResolveConfig = resolveConfig as jest.Mock;

--- a/packages/analytics/__tests__/providers/personalize/apis/record.test.ts
+++ b/packages/analytics/__tests__/providers/personalize/apis/record.test.ts
@@ -1,6 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import {
 	autoTrackMedia,
@@ -20,9 +24,16 @@ import {
 	IDENTIFY_EVENT_TYPE,
 	MEDIA_AUTO_TRACK_EVENT_TYPE,
 } from '../../../../src/providers/personalize/utils/constants';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 jest.mock('../../../../src/utils');
 jest.mock('../../../../src/providers/personalize/utils');
+
+setGlobalContext(createMockAmplifyContext());
+
+afterAll(() => {
+	clearGlobalContext();
+});
 
 describe('Analytics Personalize API: record', () => {
 	const mockRecordInput: PersonalizeRecordInput = {

--- a/packages/analytics/__tests__/providers/personalize/utils/resolveConfig.test.ts
+++ b/packages/analytics/__tests__/providers/personalize/utils/resolveConfig.test.ts
@@ -1,13 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
-
 import {
 	DEFAULT_PERSONALIZE_CONFIG,
 	PERSONALIZE_FLUSH_SIZE_MAX,
 	resolveConfig,
 } from '../../../../src/providers/personalize/utils';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 describe('Analytics Personalize Provider Util: resolveConfig', () => {
 	const providedConfig = {
@@ -17,18 +16,12 @@ describe('Analytics Personalize Provider Util: resolveConfig', () => {
 		flushInterval: 1000,
 	};
 
-	const getConfigSpy = jest.spyOn(Amplify, 'getConfig');
-
-	beforeEach(() => {
-		getConfigSpy.mockReset();
-	});
-
 	it('returns required config', () => {
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: { Personalize: providedConfig },
 		});
 
-		expect(resolveConfig()).toStrictEqual({
+		expect(resolveConfig(mockCtx)).toStrictEqual({
 			...providedConfig,
 			bufferSize: providedConfig.flushSize + 1,
 		});
@@ -39,11 +32,11 @@ describe('Analytics Personalize Provider Util: resolveConfig', () => {
 			region: 'us-east-1',
 			trackingId: 'trackingId1',
 		};
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: { Personalize: requiredFields },
 		});
 
-		expect(resolveConfig()).toStrictEqual({
+		expect(resolveConfig(mockCtx)).toStrictEqual({
 			...DEFAULT_PERSONALIZE_CONFIG,
 			region: requiredFields.region,
 			trackingId: requiredFields.trackingId,
@@ -52,17 +45,17 @@ describe('Analytics Personalize Provider Util: resolveConfig', () => {
 	});
 
 	it('throws if region is missing', () => {
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: {
 				Personalize: { ...providedConfig, region: undefined as any },
 			},
 		});
 
-		expect(resolveConfig).toThrow();
+		expect(() => resolveConfig(mockCtx)).toThrow();
 	});
 
 	it('throws if flushSize is larger than max', () => {
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: {
 				Personalize: {
 					...providedConfig,
@@ -71,6 +64,6 @@ describe('Analytics Personalize Provider Util: resolveConfig', () => {
 			},
 		});
 
-		expect(resolveConfig).toThrow();
+		expect(() => resolveConfig(mockCtx)).toThrow();
 	});
 });

--- a/packages/analytics/__tests__/providers/pinpoint/apis/configureAutoTrack.test.ts
+++ b/packages/analytics/__tests__/providers/pinpoint/apis/configureAutoTrack.test.ts
@@ -47,10 +47,6 @@ describe('Pinpoint API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/pinpoint/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			try {
 				configureAutoTrack({
@@ -68,10 +64,6 @@ describe('Pinpoint API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/pinpoint/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			configureAutoTrack(MOCK_INPUT);
 		});
@@ -92,10 +84,6 @@ describe('Pinpoint API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/pinpoint/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			configureAutoTrack(testInput);
 		});
@@ -116,10 +104,6 @@ describe('Pinpoint API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/pinpoint/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			configureAutoTrack(testInput);
 		});
@@ -130,15 +114,40 @@ describe('Pinpoint API: configureAutoTrack', () => {
 		);
 	});
 
+	it('accepts an explicitly provided context', () => {
+		jest.isolateModules(() => {
+			const {
+				configureAutoTrack,
+			} = require('../../../../src/providers/pinpoint/apis');
+
+			configureAutoTrack(mockCtx, MOCK_INPUT);
+		});
+
+		expect(MockEventTracker).toHaveBeenCalledWith(
+			expect.any(Function),
+			MOCK_INPUT.options,
+		);
+	});
+
+	it('can be configured before Amplify.configure (no global context)', () => {
+		jest.isolateModules(() => {
+			const {
+				configureAutoTrack,
+			} = require('../../../../src/providers/pinpoint/apis');
+
+			// The isolated registry has NO global context set — tracker setup must
+			// not resolve the context eagerly, so this must not throw.
+			expect(() => {
+				configureAutoTrack(MOCK_INPUT);
+			}).not.toThrow();
+		});
+	});
+
 	it('Reconfigures an existing tracker', () => {
 		jest.isolateModules(() => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/pinpoint/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			// Enable the tracker
 			configureAutoTrack(MOCK_INPUT);
@@ -165,10 +174,6 @@ describe('Pinpoint API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/pinpoint/apis');
-			// The isolated registry has its own global context storage; register the
-			// mock context so `resolveCtxArgs` can resolve it.
-			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
-			setGlobalContext(mockCtx);
 
 			// Enable the tracker
 			configureAutoTrack(MOCK_INPUT);

--- a/packages/analytics/__tests__/providers/pinpoint/apis/configureAutoTrack.test.ts
+++ b/packages/analytics/__tests__/providers/pinpoint/apis/configureAutoTrack.test.ts
@@ -7,9 +7,11 @@ import {
 	PageViewTracker,
 	SessionTracker,
 } from '../../../../src/trackers';
+import { record } from '../../../../src/providers/pinpoint/apis/record';
 import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 jest.mock('../../../../src/trackers');
+jest.mock('../../../../src/providers/pinpoint/apis/record');
 
 const mockCtx = createMockAmplifyContext();
 
@@ -24,6 +26,7 @@ const MOCK_INPUT = {
 } as ConfigureAutoTrackInput;
 
 describe('Pinpoint API: configureAutoTrack', () => {
+	const mockRecord = record as jest.Mock;
 	const MockEventTracker = EventTracker as jest.MockedClass<
 		typeof EventTracker
 	>;
@@ -38,6 +41,7 @@ describe('Pinpoint API: configureAutoTrack', () => {
 		MockEventTracker.mockClear();
 		MockPageViewTracker.mockClear();
 		MockSessionTracker.mockClear();
+		mockRecord.mockClear();
 	});
 
 	it('Validates the tracker configuration', () => {
@@ -114,7 +118,7 @@ describe('Pinpoint API: configureAutoTrack', () => {
 		);
 	});
 
-	it('accepts an explicitly provided context', () => {
+	it('accepts an explicitly provided context and threads it through to record', () => {
 		jest.isolateModules(() => {
 			const {
 				configureAutoTrack,
@@ -127,6 +131,16 @@ describe('Pinpoint API: configureAutoTrack', () => {
 			expect.any(Function),
 			MOCK_INPUT.options,
 		);
+
+		// Fire the recorder callback handed to the tracker and confirm the
+		// explicit context actually reaches record().
+		const emitTrackingEvent = MockEventTracker.mock.calls[0][0];
+		emitTrackingEvent('my-event', { foo: 'bar' });
+
+		expect(mockRecord).toHaveBeenCalledWith(mockCtx, {
+			name: 'my-event',
+			attributes: { foo: 'bar' },
+		});
 	});
 
 	it('can be configured before Amplify.configure (no global context)', () => {
@@ -140,6 +154,16 @@ describe('Pinpoint API: configureAutoTrack', () => {
 			expect(() => {
 				configureAutoTrack(MOCK_INPUT);
 			}).not.toThrow();
+		});
+
+		// On the global-fallback path record is called WITHOUT a captured context,
+		// so it resolves the live global context lazily at emit time.
+		const emitTrackingEvent = MockEventTracker.mock.calls[0][0];
+		emitTrackingEvent('my-event', { foo: 'bar' });
+
+		expect(mockRecord).toHaveBeenCalledWith({
+			name: 'my-event',
+			attributes: { foo: 'bar' },
 		});
 	});
 

--- a/packages/analytics/__tests__/providers/pinpoint/apis/configureAutoTrack.test.ts
+++ b/packages/analytics/__tests__/providers/pinpoint/apis/configureAutoTrack.test.ts
@@ -7,8 +7,11 @@ import {
 	PageViewTracker,
 	SessionTracker,
 } from '../../../../src/trackers';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 jest.mock('../../../../src/trackers');
+
+const mockCtx = createMockAmplifyContext();
 
 const MOCK_INPUT = {
 	enable: true,
@@ -44,6 +47,10 @@ describe('Pinpoint API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/pinpoint/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			try {
 				configureAutoTrack({
@@ -61,6 +68,10 @@ describe('Pinpoint API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/pinpoint/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			configureAutoTrack(MOCK_INPUT);
 		});
@@ -81,6 +92,10 @@ describe('Pinpoint API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/pinpoint/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			configureAutoTrack(testInput);
 		});
@@ -101,6 +116,10 @@ describe('Pinpoint API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/pinpoint/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			configureAutoTrack(testInput);
 		});
@@ -116,6 +135,10 @@ describe('Pinpoint API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/pinpoint/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			// Enable the tracker
 			configureAutoTrack(MOCK_INPUT);
@@ -142,6 +165,10 @@ describe('Pinpoint API: configureAutoTrack', () => {
 			const {
 				configureAutoTrack,
 			} = require('../../../../src/providers/pinpoint/apis');
+			// The isolated registry has its own global context storage; register the
+			// mock context so `resolveCtxArgs` can resolve it.
+			const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+			setGlobalContext(mockCtx);
 
 			// Enable the tracker
 			configureAutoTrack(MOCK_INPUT);

--- a/packages/analytics/__tests__/providers/pinpoint/apis/flushEvents.test.ts
+++ b/packages/analytics/__tests__/providers/pinpoint/apis/flushEvents.test.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { flushEvents as pinpointFlushEvents } from '@aws-amplify/core/internals/providers/pinpoint';
-import { AnalyticsAction } from '@aws-amplify/core/internals/utils';
+import {
+	AnalyticsAction,
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 import { ConsoleLogger } from '@aws-amplify/core';
 
 import { flushEvents } from '../../../../src';
@@ -11,11 +15,18 @@ import {
 	resolveCredentials,
 } from '../../../../src/providers/pinpoint/utils';
 import { getAnalyticsUserAgentString } from '../../../../src/utils';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 import { config, credentials, identityId } from './testUtils/data';
 
 jest.mock('../../../../src/providers/pinpoint/utils');
 jest.mock('@aws-amplify/core/internals/providers/pinpoint');
+
+setGlobalContext(createMockAmplifyContext());
+
+afterAll(() => {
+	clearGlobalContext();
+});
 
 describe('Pinpoint API: flushEvents', () => {
 	const mockResolveConfig = resolveConfig as jest.Mock;

--- a/packages/analytics/__tests__/providers/pinpoint/apis/identifyUser.test.ts
+++ b/packages/analytics/__tests__/providers/pinpoint/apis/identifyUser.test.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { updateEndpoint } from '@aws-amplify/core/internals/providers/pinpoint';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import { identifyUser } from '../../../../src/providers/pinpoint/apis';
 import { IdentifyUserInput } from '../../../../src/providers/pinpoint/types';
@@ -10,10 +14,17 @@ import {
 	resolveCredentials,
 } from '../../../../src/providers/pinpoint/utils';
 import { getAnalyticsUserAgentString } from '../../../../src/utils/userAgent';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 jest.mock('@aws-amplify/core/internals/providers/pinpoint');
 jest.mock('../../../../src/providers/pinpoint/utils');
 jest.mock('../../../../src/utils/userAgent');
+
+setGlobalContext(createMockAmplifyContext());
+
+afterAll(() => {
+	clearGlobalContext();
+});
 
 describe('Analytics Pinpoint Provider API: identifyUser', () => {
 	const credentials = {

--- a/packages/analytics/__tests__/providers/pinpoint/apis/record.test.ts
+++ b/packages/analytics/__tests__/providers/pinpoint/apis/record.test.ts
@@ -1,5 +1,9 @@
 import { ConsoleLogger, Hub } from '@aws-amplify/core';
 import { record as pinpointRecord } from '@aws-amplify/core/internals/providers/pinpoint';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import { record } from '../../../../src/providers/pinpoint';
 import {
@@ -12,6 +16,7 @@ import {
 	getAnalyticsUserAgentString,
 	isAnalyticsEnabled,
 } from '../../../../src/utils';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 import {
 	appId,
@@ -22,10 +27,21 @@ import {
 	region,
 } from './testUtils/data';
 
-jest.mock('@aws-amplify/core');
+// Partially mock core so `Hub.dispatch` can be asserted while keeping the real
+// AmplifyContext brand (required by `resolveCtxArgs` to recognize the mock context).
+jest.mock('@aws-amplify/core', () => ({
+	...jest.requireActual('@aws-amplify/core'),
+	Hub: { dispatch: jest.fn() },
+}));
 jest.mock('@aws-amplify/core/internals/providers/pinpoint');
 jest.mock('../../../../src/utils');
 jest.mock('../../../../src/providers/pinpoint/utils');
+
+setGlobalContext(createMockAmplifyContext());
+
+afterAll(() => {
+	clearGlobalContext();
+});
 
 describe('Pinpoint API: record', () => {
 	// create spies

--- a/packages/analytics/__tests__/providers/pinpoint/utils/resolveConfig.test.ts
+++ b/packages/analytics/__tests__/providers/pinpoint/utils/resolveConfig.test.ts
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
-
 import { resolveConfig } from '../../../../src/providers/pinpoint/utils';
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 describe('Analytics Pinpoint Provider Util: resolveConfig', () => {
 	const pinpointConfig = {
@@ -14,35 +13,29 @@ describe('Analytics Pinpoint Provider Util: resolveConfig', () => {
 		flushInterval: 50,
 		resendLimit: 3,
 	};
-	// create spies
-	const getConfigSpy = jest.spyOn(Amplify, 'getConfig');
-
-	beforeEach(() => {
-		getConfigSpy.mockReset();
-	});
 
 	it('returns required config', () => {
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: { Pinpoint: pinpointConfig },
 		});
-		expect(resolveConfig()).toStrictEqual(pinpointConfig);
+		expect(resolveConfig(mockCtx)).toStrictEqual(pinpointConfig);
 	});
 
 	it('throws if appId is missing', () => {
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: {
 				Pinpoint: { ...pinpointConfig, appId: undefined } as any,
 			},
 		});
-		expect(resolveConfig).toThrow();
+		expect(() => resolveConfig(mockCtx)).toThrow();
 	});
 
 	it('throws if region is missing', () => {
-		getConfigSpy.mockReturnValue({
+		const mockCtx = createMockAmplifyContext({
 			Analytics: {
 				Pinpoint: { ...pinpointConfig, region: undefined } as any,
 			},
 		});
-		expect(resolveConfig).toThrow();
+		expect(() => resolveConfig(mockCtx)).toThrow();
 	});
 });

--- a/packages/analytics/__tests__/providers/pinpoint/utils/resolveCredentials.test.ts
+++ b/packages/analytics/__tests__/providers/pinpoint/utils/resolveCredentials.test.ts
@@ -1,12 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fetchAuthSession } from '@aws-amplify/core';
-
 import { AnalyticsError } from '../../../../src/errors';
 import { resolveCredentials } from '../../../../src/providers/pinpoint/utils';
-
-jest.mock('@aws-amplify/core');
+import { createMockAmplifyContext } from '../../../testUtils/mockAmplifyContext';
 
 describe('Analytics Pinpoint Provider Util: resolveCredentials', () => {
 	const credentials = {
@@ -16,8 +13,9 @@ describe('Analytics Pinpoint Provider Util: resolveCredentials', () => {
 		},
 		identityId: 'identity-id',
 	};
+	const mockCtx = createMockAmplifyContext();
 	// assert mocks
-	const mockFetchAuthSession = fetchAuthSession as jest.Mock;
+	const mockFetchAuthSession = mockCtx.fetchAuthSession as jest.Mock;
 
 	beforeEach(() => {
 		mockFetchAuthSession.mockReset();
@@ -25,7 +23,7 @@ describe('Analytics Pinpoint Provider Util: resolveCredentials', () => {
 
 	it('resolves required credentials', async () => {
 		mockFetchAuthSession.mockResolvedValue(credentials);
-		expect(await resolveCredentials()).toStrictEqual(credentials);
+		expect(await resolveCredentials(mockCtx)).toStrictEqual(credentials);
 	});
 
 	it('throws if credentials are missing', async () => {
@@ -33,6 +31,8 @@ describe('Analytics Pinpoint Provider Util: resolveCredentials', () => {
 			...credentials,
 			credentials: undefined,
 		});
-		await expect(resolveCredentials()).rejects.toBeInstanceOf(AnalyticsError);
+		await expect(resolveCredentials(mockCtx)).rejects.toBeInstanceOf(
+			AnalyticsError,
+		);
 	});
 });

--- a/packages/analytics/__tests__/testUtils/mockAmplifyContext.ts
+++ b/packages/analytics/__tests__/testUtils/mockAmplifyContext.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AMPLIFY_CONTEXT_BRAND,
+	AmplifyContext,
+	ResourcesConfig,
+} from '@aws-amplify/core';
+
+/**
+ * Creates a mock AmplifyContext for testing.
+ */
+export function createMockAmplifyContext(
+	resourcesConfig: ResourcesConfig = {},
+): AmplifyContext {
+	const ctx: AmplifyContext = {
+		resourcesConfig,
+		libraryOptions: {},
+		fetchAuthSession: jest.fn().mockResolvedValue({}),
+		clearCredentials: jest.fn().mockResolvedValue(undefined),
+		getTokens: jest.fn().mockResolvedValue(undefined),
+	};
+
+	Object.defineProperty(ctx, AMPLIFY_CONTEXT_BRAND, {
+		value: true,
+		enumerable: false,
+	});
+
+	return ctx;
+}

--- a/packages/analytics/__tests__/utils/deprecatePinpoint.test.ts
+++ b/packages/analytics/__tests__/utils/deprecatePinpoint.test.ts
@@ -1,15 +1,32 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ConsoleLogger } from '@aws-amplify/core';
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
 
 import { deprecatePinpoint } from '../../src/utils/deprecatePinpoint';
+// The deprecated default export is imported on purpose — the test verifies the
+// wrapper's typing on the real wrapped API.
+// eslint-disable-next-line import/no-deprecated
+import { record } from '../../src';
+import { RecordInput } from '../../src/providers/pinpoint';
 
 describe('deprecatePinpoint', () => {
 	const loggerWarnSpy = jest.spyOn(ConsoleLogger.prototype, 'warn');
 
 	beforeEach(() => {
 		loggerWarnSpy.mockClear();
+	});
+
+	it('preserves context overloads on wrapped APIs (compile-time check)', () => {
+		// `record` from the package index is wrapped with deprecatePinpoint. Both
+		// the `fn(input)` and `fn(ctx, input)` call signatures must survive the
+		// wrapper — these assignments fail to compile if either overload is lost.
+		const inputOverload: (input: RecordInput) => void = record;
+		const ctxOverload: (ctx: AmplifyContext, input: RecordInput) => void =
+			record;
+
+		expect(inputOverload).toBe(record);
+		expect(ctxOverload).toBe(record);
 	});
 
 	it('delegates arguments and return value transparently', () => {

--- a/packages/analytics/__tests__/utils/resolveCredentials.test.ts
+++ b/packages/analytics/__tests__/utils/resolveCredentials.test.ts
@@ -1,12 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fetchAuthSession } from '@aws-amplify/core';
-
 import { resolveCredentials } from '../../src/utils';
 import { AnalyticsError } from '../../src';
+import { createMockAmplifyContext } from '../testUtils/mockAmplifyContext';
 
-jest.mock('@aws-amplify/core');
 describe('Analytics Kinesis Provider Util: resolveCredentials', () => {
 	const credentials = {
 		credentials: {
@@ -16,7 +14,8 @@ describe('Analytics Kinesis Provider Util: resolveCredentials', () => {
 		},
 		identityId: 'identity-id',
 	};
-	const mockFetchAuthSession = fetchAuthSession as jest.Mock;
+	const mockCtx = createMockAmplifyContext();
+	const mockFetchAuthSession = mockCtx.fetchAuthSession as jest.Mock;
 
 	beforeEach(() => {
 		mockFetchAuthSession.mockReset();
@@ -24,7 +23,7 @@ describe('Analytics Kinesis Provider Util: resolveCredentials', () => {
 
 	it('resolves required credentials', async () => {
 		mockFetchAuthSession.mockResolvedValue(credentials);
-		expect(await resolveCredentials()).toStrictEqual(credentials);
+		expect(await resolveCredentials(mockCtx)).toStrictEqual(credentials);
 	});
 
 	it('throws if credentials are missing', async () => {
@@ -32,6 +31,8 @@ describe('Analytics Kinesis Provider Util: resolveCredentials', () => {
 			...credentials,
 			credentials: undefined,
 		});
-		await expect(resolveCredentials()).rejects.toBeInstanceOf(AnalyticsError);
+		await expect(resolveCredentials(mockCtx)).rejects.toBeInstanceOf(
+			AnalyticsError,
+		);
 	});
 });

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -4,8 +4,9 @@
 // This entry point intentionally re-exports the deprecated Pinpoint provider
 // APIs as the default Analytics surface. Removing them would be a breaking
 // change; instead each is wrapped to emit a one-time runtime deprecation
-// warning. The deprecated imports below are therefore expected.
-/* eslint-disable import/no-deprecated */
+// warning. The deprecated imports below are therefore expected. (Note: the
+// `import/no-deprecated` rule no longer detects these since the APIs became
+// overloaded function declarations, so no disable directive is needed.)
 import {
 	configureAutoTrack as configureAutoTrackPinpoint,
 	flushEvents as flushEventsPinpoint,

--- a/packages/analytics/src/providers/kinesis-firehose/apis/configureAutoTrack.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/apis/configureAutoTrack.ts
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
+
 import {
 	AnalyticsValidationErrorCode,
 	assertValidationError,
@@ -73,9 +76,16 @@ const configuredTrackers: Partial<Record<TrackerType, TrackerInterface>> = {};
  * });
  * ```
  */
-export const configureAutoTrack = (
+export function configureAutoTrack(
 	input: KinesisFirehoseConfigureAutoTrackInput,
-): void => {
+): void;
+export function configureAutoTrack(
+	ctx: AmplifyContext,
+	input: KinesisFirehoseConfigureAutoTrackInput,
+): void;
+export function configureAutoTrack(...args: any[]): void {
+	const [ctx, input] =
+		resolveCtxArgs<[KinesisFirehoseConfigureAutoTrackInput]>(args);
 	validateTrackerConfiguration(input);
 
 	if (input.enable) {
@@ -90,7 +100,7 @@ export const configureAutoTrack = (
 		eventName: string,
 		attributes: TrackerAttributes,
 	) => {
-		record({
+		record(ctx, {
 			streamName: input.options!.streamName,
 			data: {
 				name: eventName,
@@ -107,4 +117,4 @@ export const configureAutoTrack = (
 		configuredTrackers,
 		'kinesis-firehose',
 	);
-};
+}

--- a/packages/analytics/src/providers/kinesis-firehose/apis/configureAutoTrack.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/apis/configureAutoTrack.ts
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyContext } from '@aws-amplify/core';
-import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext, isAmplifyContext } from '@aws-amplify/core';
 
 import {
 	AnalyticsValidationErrorCode,
@@ -84,8 +83,17 @@ export function configureAutoTrack(
 	input: KinesisFirehoseConfigureAutoTrackInput,
 ): void;
 export function configureAutoTrack(...args: any[]): void {
-	const [ctx, input] =
-		resolveCtxArgs<[KinesisFirehoseConfigureAutoTrackInput]>(args);
+	// Resolve the optional leading context WITHOUT falling back to the global
+	// context. The context is only needed when events are emitted; resolving it
+	// eagerly would (a) throw when trackers are configured before
+	// `Amplify.configure()` and (b) pin auto-tracked events to the configuration
+	// snapshot captured at setup time after a later `configure()` call.
+	const [ctx, input] = isAmplifyContext(args[0])
+		? [
+				args[0] as AmplifyContext,
+				args[1] as KinesisFirehoseConfigureAutoTrackInput,
+			]
+		: [undefined, args[0] as KinesisFirehoseConfigureAutoTrackInput];
 	validateTrackerConfiguration(input);
 
 	if (input.enable) {
@@ -95,18 +103,25 @@ export function configureAutoTrack(...args: any[]): void {
 		);
 	}
 
-	// Callback that will emit an appropriate event to Kinesis Data Firehose when required by the Tracker
+	// Callback that will emit an appropriate event to Kinesis Data Firehose when required by the Tracker.
+	// When no explicit context was supplied, `record` resolves the global context
+	// lazily at emit time so auto-tracked events follow the live configuration.
 	const emitTrackingEvent = (
 		eventName: string,
 		attributes: TrackerAttributes,
 	) => {
-		record(ctx, {
+		const recordInput = {
 			streamName: input.options!.streamName,
 			data: {
 				name: eventName,
 				attributes,
 			},
-		});
+		};
+		if (ctx) {
+			record(ctx, recordInput);
+		} else {
+			record(recordInput);
+		}
 	};
 
 	// Initialize or update this provider's trackers. The 'kinesis-firehose' namespace

--- a/packages/analytics/src/providers/kinesis-firehose/apis/flushEvents.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/apis/flushEvents.ts
@@ -1,8 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AnalyticsAction } from '@aws-amplify/core/internals/utils';
-import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	AnalyticsAction,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
 
 import { getEventBuffer, resolveConfig } from '../utils';
 import {
@@ -19,10 +22,13 @@ const logger = new ConsoleLogger('KinesisFirehose');
  * This API will make a best-effort attempt to flush events from the buffer. Events recorded immediately after invoking
  * this API may not be included in the flush.
  */
-export const flushEvents = () => {
+export function flushEvents(): void;
+export function flushEvents(ctx: AmplifyContext): void;
+export function flushEvents(...args: any[]): void {
+	const [ctx] = resolveCtxArgs<[]>(args);
 	const { region, flushSize, flushInterval, bufferSize, resendLimit } =
-		resolveConfig();
-	resolveCredentials()
+		resolveConfig(ctx);
+	resolveCredentials(ctx)
 		.then(({ credentials, identityId }) =>
 			getEventBuffer({
 				region,
@@ -39,4 +45,4 @@ export const flushEvents = () => {
 		.catch(e => {
 			logger.warn('Failed to flush events.', e);
 		});
-};
+}

--- a/packages/analytics/src/providers/kinesis-firehose/apis/record.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/apis/record.ts
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { fromUtf8 } from '@smithy/util-utf8';
-import { AnalyticsAction } from '@aws-amplify/core/internals/utils';
-import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	AnalyticsAction,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
 
 import { RecordInput } from '../types';
 import { getEventBuffer, resolveConfig } from '../utils';
@@ -33,7 +36,12 @@ const logger = new ConsoleLogger('KinesisFirehose');
  * });
  * ```
  */
-export const record = ({ streamName, data }: RecordInput): void => {
+export function record(input: RecordInput): void;
+export function record(ctx: AmplifyContext, input: RecordInput): void;
+export function record(...args: any[]): void {
+	const [ctx, input] = resolveCtxArgs<[RecordInput]>(args);
+	const { streamName, data } = input;
+
 	if (!isAnalyticsEnabled()) {
 		logger.debug('Analytics is disabled, event will not be recorded.');
 
@@ -42,9 +50,9 @@ export const record = ({ streamName, data }: RecordInput): void => {
 
 	const timestamp = Date.now();
 	const { region, bufferSize, flushSize, flushInterval, resendLimit } =
-		resolveConfig();
+		resolveConfig(ctx);
 
-	resolveCredentials()
+	resolveCredentials(ctx)
 		.then(({ credentials, identityId }) => {
 			const buffer = getEventBuffer({
 				region,
@@ -68,4 +76,4 @@ export const record = ({ streamName, data }: RecordInput): void => {
 		.catch(e => {
 			logger.warn('Failed to record event.', e);
 		});
-};
+}

--- a/packages/analytics/src/providers/kinesis-firehose/utils/resolveConfig.ts
+++ b/packages/analytics/src/providers/kinesis-firehose/utils/resolveConfig.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import {
 	AnalyticsValidationErrorCode,
@@ -10,8 +10,8 @@ import {
 
 import { DEFAULT_KINESIS_FIREHOSE_CONFIG } from './constants';
 
-export const resolveConfig = () => {
-	const config = Amplify.getConfig().Analytics?.KinesisFirehose;
+export const resolveConfig = (ctx: AmplifyContext) => {
+	const config = ctx.resourcesConfig.Analytics?.KinesisFirehose;
 	const {
 		region,
 		bufferSize = DEFAULT_KINESIS_FIREHOSE_CONFIG.bufferSize,

--- a/packages/analytics/src/providers/kinesis/apis/configureAutoTrack.ts
+++ b/packages/analytics/src/providers/kinesis/apis/configureAutoTrack.ts
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
+
 import {
 	AnalyticsValidationErrorCode,
 	assertValidationError,
@@ -76,9 +79,13 @@ const configuredTrackers: Partial<Record<TrackerType, TrackerInterface>> = {};
  * });
  * ```
  */
-export const configureAutoTrack = (
+export function configureAutoTrack(input: KinesisConfigureAutoTrackInput): void;
+export function configureAutoTrack(
+	ctx: AmplifyContext,
 	input: KinesisConfigureAutoTrackInput,
-): void => {
+): void;
+export function configureAutoTrack(...args: any[]): void {
+	const [ctx, input] = resolveCtxArgs<[KinesisConfigureAutoTrackInput]>(args);
 	validateTrackerConfiguration(input);
 
 	if (input.enable) {
@@ -97,7 +104,7 @@ export const configureAutoTrack = (
 		eventName: string,
 		attributes: TrackerAttributes,
 	) => {
-		record({
+		record(ctx, {
 			streamName: input.options!.streamName,
 			partitionKey: input.options!.partitionKey,
 			data: {
@@ -115,4 +122,4 @@ export const configureAutoTrack = (
 		configuredTrackers,
 		'kinesis',
 	);
-};
+}

--- a/packages/analytics/src/providers/kinesis/apis/configureAutoTrack.ts
+++ b/packages/analytics/src/providers/kinesis/apis/configureAutoTrack.ts
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyContext } from '@aws-amplify/core';
-import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext, isAmplifyContext } from '@aws-amplify/core';
 
 import {
 	AnalyticsValidationErrorCode,
@@ -85,7 +84,14 @@ export function configureAutoTrack(
 	input: KinesisConfigureAutoTrackInput,
 ): void;
 export function configureAutoTrack(...args: any[]): void {
-	const [ctx, input] = resolveCtxArgs<[KinesisConfigureAutoTrackInput]>(args);
+	// Resolve the optional leading context WITHOUT falling back to the global
+	// context. The context is only needed when events are emitted; resolving it
+	// eagerly would (a) throw when trackers are configured before
+	// `Amplify.configure()` and (b) pin auto-tracked events to the configuration
+	// snapshot captured at setup time after a later `configure()` call.
+	const [ctx, input] = isAmplifyContext(args[0])
+		? [args[0] as AmplifyContext, args[1] as KinesisConfigureAutoTrackInput]
+		: [undefined, args[0] as KinesisConfigureAutoTrackInput];
 	validateTrackerConfiguration(input);
 
 	if (input.enable) {
@@ -99,19 +105,26 @@ export function configureAutoTrack(...args: any[]): void {
 		);
 	}
 
-	// Callback that will emit an appropriate event to Kinesis when required by the Tracker
+	// Callback that will emit an appropriate event to Kinesis when required by the Tracker.
+	// When no explicit context was supplied, `record` resolves the global context
+	// lazily at emit time so auto-tracked events follow the live configuration.
 	const emitTrackingEvent = (
 		eventName: string,
 		attributes: TrackerAttributes,
 	) => {
-		record(ctx, {
+		const recordInput = {
 			streamName: input.options!.streamName,
 			partitionKey: input.options!.partitionKey,
 			data: {
 				name: eventName,
 				attributes,
 			},
-		});
+		};
+		if (ctx) {
+			record(ctx, recordInput);
+		} else {
+			record(recordInput);
+		}
 	};
 
 	// Initialize or update this provider's trackers. The 'kinesis' namespace keeps

--- a/packages/analytics/src/providers/kinesis/apis/flushEvents.ts
+++ b/packages/analytics/src/providers/kinesis/apis/flushEvents.ts
@@ -1,8 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AnalyticsAction } from '@aws-amplify/core/internals/utils';
-import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	AnalyticsAction,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
 
 import { resolveConfig } from '../utils/resolveConfig';
 import {
@@ -20,10 +23,13 @@ const logger = new ConsoleLogger('Kinesis');
  * This API will make a best-effort attempt to flush events from the buffer. Events recorded immediately after invoking
  * this API may not be included in the flush.
  */
-export const flushEvents = () => {
+export function flushEvents(): void;
+export function flushEvents(ctx: AmplifyContext): void;
+export function flushEvents(...args: any[]): void {
+	const [ctx] = resolveCtxArgs<[]>(args);
 	const { region, flushSize, flushInterval, bufferSize, resendLimit } =
-		resolveConfig();
-	resolveCredentials()
+		resolveConfig(ctx);
+	resolveCredentials(ctx)
 		.then(({ credentials, identityId }) =>
 			getEventBuffer({
 				region,
@@ -40,4 +46,4 @@ export const flushEvents = () => {
 		.catch(e => {
 			logger.warn('Failed to flush events.', e);
 		});
-};
+}

--- a/packages/analytics/src/providers/kinesis/apis/record.ts
+++ b/packages/analytics/src/providers/kinesis/apis/record.ts
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { fromUtf8 } from '@smithy/util-utf8';
-import { AnalyticsAction } from '@aws-amplify/core/internals/utils';
-import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	AnalyticsAction,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
 
 import { RecordInput } from '../types';
 import { getEventBuffer } from '../utils/getEventBuffer';
@@ -38,11 +41,12 @@ const logger = new ConsoleLogger('Kinesis');
  *
  * @returns void
  */
-export const record = ({
-	streamName,
-	partitionKey,
-	data,
-}: RecordInput): void => {
+export function record(input: RecordInput): void;
+export function record(ctx: AmplifyContext, input: RecordInput): void;
+export function record(...args: any[]): void {
+	const [ctx, input] = resolveCtxArgs<[RecordInput]>(args);
+	const { streamName, partitionKey, data } = input;
+
 	if (!isAnalyticsEnabled()) {
 		logger.debug('Analytics is disabled, event will not be recorded.');
 
@@ -51,9 +55,9 @@ export const record = ({
 
 	const timestamp = Date.now();
 	const { region, bufferSize, flushSize, flushInterval, resendLimit } =
-		resolveConfig();
+		resolveConfig(ctx);
 
-	resolveCredentials()
+	resolveCredentials(ctx)
 		.then(({ credentials, identityId }) => {
 			const buffer = getEventBuffer({
 				region,
@@ -79,4 +83,4 @@ export const record = ({
 			// An error occurred while fetching credentials or persisting the event to the buffer
 			logger.warn('Failed to record event.', e);
 		});
-};
+}

--- a/packages/analytics/src/providers/kinesis/utils/resolveConfig.ts
+++ b/packages/analytics/src/providers/kinesis/utils/resolveConfig.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import {
 	AnalyticsValidationErrorCode,
@@ -10,8 +10,8 @@ import {
 
 import { DEFAULT_KINESIS_CONFIG } from './constants';
 
-export const resolveConfig = () => {
-	const config = Amplify.getConfig().Analytics?.Kinesis;
+export const resolveConfig = (ctx: AmplifyContext) => {
+	const config = ctx.resourcesConfig.Analytics?.Kinesis;
 	const {
 		region,
 		bufferSize = DEFAULT_KINESIS_CONFIG.bufferSize,

--- a/packages/analytics/src/providers/personalize/apis/flushEvents.ts
+++ b/packages/analytics/src/providers/personalize/apis/flushEvents.ts
@@ -1,8 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AnalyticsAction } from '@aws-amplify/core/internals/utils';
-import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	AnalyticsAction,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
 
 import { getEventBuffer, resolveConfig } from '../utils';
 import {
@@ -19,9 +22,12 @@ const logger = new ConsoleLogger('Personalize');
  * This API will make a best-effort attempt to flush events from the buffer. Events recorded immediately after invoking
  * this API may not be included in the flush.
  */
-export const flushEvents = () => {
-	const { region, flushSize, bufferSize, flushInterval } = resolveConfig();
-	resolveCredentials()
+export function flushEvents(): void;
+export function flushEvents(ctx: AmplifyContext): void;
+export function flushEvents(...args: any[]): void {
+	const [ctx] = resolveCtxArgs<[]>(args);
+	const { region, flushSize, bufferSize, flushInterval } = resolveConfig(ctx);
+	resolveCredentials(ctx)
 		.then(({ credentials, identityId }) =>
 			getEventBuffer({
 				region,
@@ -37,4 +43,4 @@ export const flushEvents = () => {
 		.catch(e => {
 			logger.warn('Failed to flush events', e);
 		});
-};
+}

--- a/packages/analytics/src/providers/personalize/apis/record.ts
+++ b/packages/analytics/src/providers/personalize/apis/record.ts
@@ -1,8 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AnalyticsAction } from '@aws-amplify/core/internals/utils';
-import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	AnalyticsAction,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
 
 import { RecordInput } from '../types';
 import {
@@ -50,12 +53,12 @@ const logger = new ConsoleLogger('Personalize');
  *
  * @returns void
  */
-export const record = ({
-	userId,
-	eventId,
-	eventType,
-	properties,
-}: RecordInput): void => {
+export function record(input: RecordInput): void;
+export function record(ctx: AmplifyContext, input: RecordInput): void;
+export function record(...args: any[]): void {
+	const [ctx, input] = resolveCtxArgs<[RecordInput]>(args);
+	const { userId, eventId, eventType, properties } = input;
+
 	if (!isAnalyticsEnabled()) {
 		logger.debug('Analytics is disabled, event will not be recorded.');
 
@@ -63,8 +66,8 @@ export const record = ({
 	}
 
 	const { region, trackingId, bufferSize, flushSize, flushInterval } =
-		resolveConfig();
-	resolveCredentials()
+		resolveConfig(ctx);
+	resolveCredentials(ctx)
 		.then(async ({ credentials, identityId }) => {
 			const timestamp = Date.now();
 			const { sessionId: cachedSessionId, userId: cachedUserId } =
@@ -127,4 +130,4 @@ export const record = ({
 		.catch(e => {
 			logger.warn('Failed to record event.', e);
 		});
-};
+}

--- a/packages/analytics/src/providers/personalize/utils/resolveConfig.ts
+++ b/packages/analytics/src/providers/personalize/utils/resolveConfig.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import {
 	AnalyticsValidationErrorCode,
@@ -13,8 +13,8 @@ import {
 	PERSONALIZE_FLUSH_SIZE_MAX,
 } from './constants';
 
-export const resolveConfig = () => {
-	const config = Amplify.getConfig().Analytics?.Personalize;
+export const resolveConfig = (ctx: AmplifyContext) => {
+	const config = ctx.resourcesConfig.Analytics?.Personalize;
 	const {
 		region,
 		trackingId,

--- a/packages/analytics/src/providers/pinpoint/apis/configureAutoTrack.ts
+++ b/packages/analytics/src/providers/pinpoint/apis/configureAutoTrack.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
 import { UpdateEndpointException } from '@aws-amplify/core/internals/providers/pinpoint';
 
 import { AnalyticsValidationErrorCode } from '../../../errors';
@@ -22,10 +24,11 @@ const configuredTrackers: Partial<Record<TrackerType, TrackerInterface>> = {};
 
 // Callback that will emit an appropriate event to Pinpoint when required by the Tracker
 const emitTrackingEvent = (
+	ctx: AmplifyContext,
 	eventName: string,
 	attributes: TrackerAttributes,
 ) => {
-	record({
+	record(ctx, {
 		name: eventName,
 		attributes,
 	});
@@ -46,9 +49,19 @@ const emitTrackingEvent = (
  * @throws validation: {@link AnalyticsValidationErrorCode} - Thrown when the provided parameters or library
  *  configuration is incorrect.
  */
-export const configureAutoTrack = (input: ConfigureAutoTrackInput): void => {
+export function configureAutoTrack(input: ConfigureAutoTrackInput): void;
+export function configureAutoTrack(
+	ctx: AmplifyContext,
+	input: ConfigureAutoTrackInput,
+): void;
+export function configureAutoTrack(...args: any[]): void {
+	const [ctx, input] = resolveCtxArgs<[ConfigureAutoTrackInput]>(args);
 	validateTrackerConfiguration(input);
 
 	// Initialize or update this provider's trackers
-	updateProviderTrackers(input, emitTrackingEvent, configuredTrackers);
-};
+	updateProviderTrackers(
+		input,
+		emitTrackingEvent.bind(null, ctx),
+		configuredTrackers,
+	);
+}

--- a/packages/analytics/src/providers/pinpoint/apis/configureAutoTrack.ts
+++ b/packages/analytics/src/providers/pinpoint/apis/configureAutoTrack.ts
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyContext } from '@aws-amplify/core';
-import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext, isAmplifyContext } from '@aws-amplify/core';
 import { UpdateEndpointException } from '@aws-amplify/core/internals/providers/pinpoint';
 
 import { AnalyticsValidationErrorCode } from '../../../errors';
@@ -22,16 +21,25 @@ import { record } from './record';
 // Configured Tracker instances for Pinpoint
 const configuredTrackers: Partial<Record<TrackerType, TrackerInterface>> = {};
 
-// Callback that will emit an appropriate event to Pinpoint when required by the Tracker
+// Callback that will emit an appropriate event to Pinpoint when required by the Tracker.
+// When no explicit context was supplied to `configureAutoTrack`, the context is
+// deliberately NOT captured here — `record` resolves the global context lazily at
+// emit time, so auto-tracked events follow the live configuration and trackers can
+// be set up before `Amplify.configure()` is called.
 const emitTrackingEvent = (
-	ctx: AmplifyContext,
+	ctx: AmplifyContext | undefined,
 	eventName: string,
 	attributes: TrackerAttributes,
 ) => {
-	record(ctx, {
+	const input = {
 		name: eventName,
 		attributes,
-	});
+	};
+	if (ctx) {
+		record(ctx, input);
+	} else {
+		record(input);
+	}
 };
 
 /**
@@ -55,7 +63,15 @@ export function configureAutoTrack(
 	input: ConfigureAutoTrackInput,
 ): void;
 export function configureAutoTrack(...args: any[]): void {
-	const [ctx, input] = resolveCtxArgs<[ConfigureAutoTrackInput]>(args);
+	// Resolve the optional leading context WITHOUT falling back to the global
+	// context. The context is only needed when events are emitted; resolving it
+	// eagerly would (a) throw when trackers are configured before
+	// `Amplify.configure()` and (b) pin auto-tracked events to the configuration
+	// snapshot captured at setup time after a later `configure()` call.
+	const [ctx, input] = isAmplifyContext(args[0])
+		? [args[0] as AmplifyContext, args[1] as ConfigureAutoTrackInput]
+		: [undefined, args[0] as ConfigureAutoTrackInput];
+
 	validateTrackerConfiguration(input);
 
 	// Initialize or update this provider's trackers

--- a/packages/analytics/src/providers/pinpoint/apis/flushEvents.ts
+++ b/packages/analytics/src/providers/pinpoint/apis/flushEvents.ts
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { flushEvents as flushEventsCore } from '@aws-amplify/core/internals/providers/pinpoint';
-import { AnalyticsAction } from '@aws-amplify/core/internals/utils';
-import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	AnalyticsAction,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
 
 import { resolveConfig, resolveCredentials } from '../utils';
 import { getAnalyticsUserAgentString } from '../../../utils';
@@ -19,10 +22,13 @@ const logger = new ConsoleLogger('Analytics');
  * This API will make a best-effort attempt to flush events from the buffer. Events recorded immediately after invoking
  * this API may not be included in the flush.
  */
-export const flushEvents = () => {
+export function flushEvents(): void;
+export function flushEvents(ctx: AmplifyContext): void;
+export function flushEvents(...args: any[]): void {
+	const [ctx] = resolveCtxArgs<[]>(args);
 	const { appId, region, bufferSize, flushSize, flushInterval, resendLimit } =
-		resolveConfig();
-	resolveCredentials()
+		resolveConfig(ctx);
+	resolveCredentials(ctx)
 		.then(({ credentials, identityId }) => {
 			flushEventsCore({
 				appId,
@@ -39,4 +45,4 @@ export const flushEvents = () => {
 		.catch(e => {
 			logger.warn('Failed to flush events', e);
 		});
-};
+}

--- a/packages/analytics/src/providers/pinpoint/apis/identifyUser.ts
+++ b/packages/analytics/src/providers/pinpoint/apis/identifyUser.ts
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AnalyticsAction } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext } from '@aws-amplify/core';
+import {
+	AnalyticsAction,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
 import {
 	UpdateEndpointException,
 	updateEndpoint,
@@ -59,13 +63,16 @@ import { resolveConfig, resolveCredentials } from '../utils';
  *     }
  * });
  */
-export const identifyUser = async ({
-	userId,
-	userProfile,
-	options,
-}: IdentifyUserInput): Promise<void> => {
-	const { credentials, identityId } = await resolveCredentials();
-	const { appId, region } = resolveConfig();
+export async function identifyUser(input: IdentifyUserInput): Promise<void>;
+export async function identifyUser(
+	ctx: AmplifyContext,
+	input: IdentifyUserInput,
+): Promise<void>;
+export async function identifyUser(...args: any[]): Promise<void> {
+	const [ctx, input] = resolveCtxArgs<[IdentifyUserInput]>(args);
+	const { userId, userProfile, options } = input;
+	const { credentials, identityId } = await resolveCredentials(ctx);
+	const { appId, region } = resolveConfig(ctx);
 	const { userAttributes } = options ?? {};
 	await updateEndpoint({
 		appId,
@@ -78,4 +85,4 @@ export const identifyUser = async ({
 		userProfile,
 		userAgentValue: getAnalyticsUserAgentString(AnalyticsAction.IdentifyUser),
 	});
-};
+}

--- a/packages/analytics/src/providers/pinpoint/apis/record.ts
+++ b/packages/analytics/src/providers/pinpoint/apis/record.ts
@@ -1,10 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ConsoleLogger, Hub } from '@aws-amplify/core';
+import { AmplifyContext, ConsoleLogger, Hub } from '@aws-amplify/core';
 import {
 	AMPLIFY_SYMBOL,
 	AnalyticsAction,
+	resolveCtxArgs,
 } from '@aws-amplify/core/internals/utils';
 import { record as recordCore } from '@aws-amplify/core/internals/providers/pinpoint';
 
@@ -51,9 +52,12 @@ const logger = new ConsoleLogger('Analytics');
  * })
  * ```
  */
-export const record = (input: RecordInput): void => {
+export function record(input: RecordInput): void;
+export function record(ctx: AmplifyContext, input: RecordInput): void;
+export function record(...args: any[]): void {
+	const [ctx, input] = resolveCtxArgs<[RecordInput]>(args);
 	const { appId, region, bufferSize, flushSize, flushInterval, resendLimit } =
-		resolveConfig();
+		resolveConfig(ctx);
 
 	if (!isAnalyticsEnabled()) {
 		logger.debug('Analytics is disabled, event will not be recorded.');
@@ -63,7 +67,7 @@ export const record = (input: RecordInput): void => {
 
 	assertValidationError(!!input.name, AnalyticsValidationErrorCode.NoEventName);
 
-	resolveCredentials()
+	resolveCredentials(ctx)
 		.then(({ credentials, identityId }) => {
 			Hub.dispatch(
 				'analytics',
@@ -89,4 +93,4 @@ export const record = (input: RecordInput): void => {
 			// An error occurred while fetching credentials or persisting the event to the buffer
 			logger.warn('Failed to record event.', e);
 		});
-};
+}

--- a/packages/analytics/src/providers/pinpoint/utils/resolveConfig.ts
+++ b/packages/analytics/src/providers/pinpoint/utils/resolveConfig.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import {
 	AnalyticsValidationErrorCode,
@@ -11,9 +11,9 @@ import {
 /**
  * @internal
  */
-export const resolveConfig = () => {
+export const resolveConfig = (ctx: AmplifyContext) => {
 	const { appId, region, bufferSize, flushSize, flushInterval, resendLimit } =
-		Amplify.getConfig().Analytics?.Pinpoint ?? {};
+		ctx.resourcesConfig.Analytics?.Pinpoint ?? {};
 	assertValidationError(!!appId, AnalyticsValidationErrorCode.NoAppId);
 	assertValidationError(!!region, AnalyticsValidationErrorCode.NoRegion);
 

--- a/packages/analytics/src/providers/pinpoint/utils/resolveCredentials.ts
+++ b/packages/analytics/src/providers/pinpoint/utils/resolveCredentials.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fetchAuthSession } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import {
 	AnalyticsValidationErrorCode,
@@ -11,8 +11,8 @@ import {
 /**
  * @internal
  */
-export const resolveCredentials = async () => {
-	const { credentials, identityId } = await fetchAuthSession();
+export const resolveCredentials = async (ctx: AmplifyContext) => {
+	const { credentials, identityId } = await ctx.fetchAuthSession();
 	assertValidationError(
 		!!credentials,
 		AnalyticsValidationErrorCode.NoCredentials,

--- a/packages/analytics/src/utils/deprecatePinpoint.ts
+++ b/packages/analytics/src/utils/deprecatePinpoint.ts
@@ -19,22 +19,28 @@ const DEPRECATION_MESSAGE =
  * implementation. The returned function is a transparent proxy — it preserves
  * the exact parameters, return value, and `this` binding of the wrapped API.
  *
+ * The wrapper is typed as `TFn` (the full type of the wrapped function) rather
+ * than being reconstructed from parameter/return inference, so that APIs with
+ * multiple call signatures — e.g. the `fn(input)` / `fn(ctx, input)` context
+ * overloads — surface ALL of their overloads on the wrapped export instead of
+ * collapsing to a single signature.
+ *
  * The warning is emitted at most once per wrapped API for the lifetime of the
  * module, so repeated calls do not spam the console.
  *
  * @internal
  */
-export const deprecatePinpoint = <TArgs extends any[], TReturn>(
-	fn: (...args: TArgs) => TReturn,
-): ((...args: TArgs) => TReturn) => {
+export const deprecatePinpoint = <TFn extends (...args: any[]) => any>(
+	fn: TFn,
+): TFn => {
 	let warned = false;
 
-	return (...args: TArgs): TReturn => {
+	return ((...args: Parameters<TFn>): ReturnType<TFn> => {
 		if (!warned) {
 			warned = true;
 			logger.warn(DEPRECATION_MESSAGE);
 		}
 
 		return fn(...args);
-	};
+	}) as TFn;
 };

--- a/packages/analytics/src/utils/resolveCredentials.ts
+++ b/packages/analytics/src/utils/resolveCredentials.ts
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fetchAuthSession } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import { AnalyticsValidationErrorCode, assertValidationError } from '../errors';
 
-export const resolveCredentials = async () => {
-	const { credentials, identityId } = await fetchAuthSession();
+export const resolveCredentials = async (ctx: AmplifyContext) => {
+	const { credentials, identityId } = await ctx.fetchAuthSession();
 	assertValidationError(
 		!!credentials,
 		AnalyticsValidationErrorCode.NoCredentials,


### PR DESCRIPTION
## Description

Migrates the `@aws-amplify/analytics` package from the global `Amplify` singleton to explicit `AmplifyContext` threading, following the same pattern as the landed auth migration (#14836). This is the **B-analytics** step of the v6→v7 context migration, targeting the `feat/bobbor/v6-context` feature branch.

### What changed

- **Public APIs across all four providers** got `(ctx, input)` overloads alongside `(input)`, with a variadic impl using `resolveCtxArgs` (global-context fallback preserved for existing callers):
  - **pinpoint**: `record`, `identifyUser`, `flushEvents`, `configureAutoTrack`
  - **kinesis** / **kinesis-firehose**: `record`, `flushEvents`, `configureAutoTrack` (incl. the auto-track APIs added in #14854)
  - **personalize**: `record`, `flushEvents`
- **`resolveConfig` (per provider)**: now takes `ctx: AmplifyContext` and reads `ctx.resourcesConfig.Analytics?.<Provider>` instead of `Amplify.getConfig()`.
- **`resolveCredentials` (shared + pinpoint)**: uses `ctx.fetchAuthSession()` — no direct singleton imports remain.
- **`deprecatePinpoint` wrapper**: retyped as `<TFn extends (...args: any[]) => any>(fn: TFn): TFn` so the context overloads survive on the wrapped default exports (#14877 had erased overload signatures). A compile-time test asserts both call signatures surface on the wrapped `record` from the package index.
- **No server wrappers** — analytics is a client-only package.

### Tests

- Added `__tests__/testUtils/mockAmplifyContext.ts` (branded factory, same as auth).
- Migrated 19 test files off `Amplify.getConfig` spies to `createMockAmplifyContext` + `setGlobalContext`/`clearGlobalContext` (with `afterAll` cleanup). Notes for reviewers:
  - The `jest.isolateModules`-based `configureAutoTrack` tests register the mock context from inside each isolated registry (the global-context store is per-module-registry).
  - `pinpoint/apis/record.test.ts` switched from a full `@aws-amplify/core` automock to a partial mock (`jest.requireActual` + `Hub.dispatch: jest.fn()`) so the real `AMPLIFY_CONTEXT_BRAND` stays intact for `resolveCtxArgs`.
  - Kinesis/firehose `configureAutoTrack` tests now assert `record` is called with `(ctx, payload)`.

## Testing

- `yarn turbo run build --filter=@aws-amplify/analytics` → passes
- `yarn turbo run test --filter=@aws-amplify/analytics` → **30 suites / 112 tests pass**, lint clean, ts-coverage passes
- No `tsconfig.tsbuildinfo` committed

## Checklist

- [x] Unit tests updated/added; coverage preserved
- [x] No changeset (targets a feature branch, not `main`)
- [x] Scope limited to `packages/analytics/`
- [x] Client-only package — no server wrapper changes needed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
