### PR TITLE
feat(api-rest): migrate REST API to AmplifyContext

### DIFF
--- a/packages/api-rest/__tests__/apis/common/internalPost.test.ts
+++ b/packages/api-rest/__tests__/apis/common/internalPost.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ApiError } from '@aws-amplify/core/internals/utils';
+import { AmplifyClassV6 } from '@aws-amplify/core';
 import {
 	getRetryDecider,
 	parseJsonError,
@@ -455,5 +456,79 @@ describe('internal post', () => {
 		const { retryDecider } = callArgs[1];
 		const retryDeciderResult = await retryDecider();
 		expect(retryDeciderResult).toEqual(retryExpectedResponse);
+	});
+});
+
+describe('internal post - AmplifyClassV6 backward compatibility', () => {
+	const mockClassFetchAuthSession = jest.fn();
+	const mockClassClearCredentials = jest.fn();
+	const mockClassGetTokens = jest.fn();
+
+	/**
+	 * Simulates an AmplifyClassV6 instance as passed by api-graphql's
+	 * InternalGraphQLAPI. This object has NO top-level fetchAuthSession,
+	 * clearCredentials, or getTokens — they live on `.Auth`.
+	 * It is NOT branded with AMPLIFY_CONTEXT_BRAND.
+	 */
+	const mockAmplifyClassV6 = {
+		getConfig: jest.fn().mockReturnValue({}),
+		libraryOptions: {},
+		resourcesConfig: {},
+		Auth: {
+			fetchAuthSession: mockClassFetchAuthSession,
+			clearCredentials: mockClassClearCredentials,
+			getTokens: mockClassGetTokens,
+		},
+	} as unknown as AmplifyClassV6;
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+		mockClassFetchAuthSession.mockResolvedValue({ credentials });
+		mockAuthenticatedHandler.mockResolvedValue(successResponse);
+		mockUnauthenticatedHandler.mockResolvedValue(successResponse);
+		mockGetRetryDecider.mockReturnValue(mockGetRetryDeciderResponse);
+	});
+
+	it('should bridge AmplifyClassV6 and call authenticatedHandler with credentials when signingServiceInfo is provided', async () => {
+		await post(mockAmplifyClassV6, {
+			url: apiGatewayUrl,
+			options: {
+				signingServiceInfo: {
+					region: 'us-east-1',
+					service: 'appsync',
+				},
+			},
+		});
+
+		// Verify the bridge correctly resolved credentials from Auth.fetchAuthSession
+		expect(mockClassFetchAuthSession).toHaveBeenCalled();
+		expect(mockAuthenticatedHandler).toHaveBeenCalledWith(
+			{
+				url: apiGatewayUrl,
+				method: 'POST',
+				headers: {},
+			},
+			expect.objectContaining({
+				credentials,
+				region: 'us-east-1',
+				service: 'appsync',
+			}),
+		);
+	});
+
+	it('should bridge AmplifyClassV6 and call unauthenticatedHandler without signingServiceInfo', async () => {
+		await post(mockAmplifyClassV6, {
+			url: apiGatewayUrl,
+		});
+
+		expect(mockUnauthenticatedHandler).toHaveBeenCalledWith(
+			{
+				url: apiGatewayUrl,
+				method: 'POST',
+				headers: {},
+			},
+			expect.anything(),
+		);
+		expect(mockAuthenticatedHandler).not.toHaveBeenCalled();
 	});
 });

--- a/packages/api-rest/__tests__/apis/common/internalPost.test.ts
+++ b/packages/api-rest/__tests__/apis/common/internalPost.test.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
 import { ApiError } from '@aws-amplify/core/internals/utils';
 import {
 	getRetryDecider,
@@ -16,6 +15,7 @@ import {
 import { authenticatedHandler } from '../../../src/apis/common/baseHandlers/authenticatedHandler';
 import { unauthenticatedHandler } from '../../../src/apis/common/baseHandlers/unauthenticatedHandler';
 import { RestApiError, isCancelError } from '../../../src/errors';
+import { createMockAmplifyContext } from '../../testUtils/mockAmplifyContext';
 
 jest.mock('@aws-amplify/core/internals/aws-client-utils');
 jest.mock('../../../src/apis/common/baseHandlers/authenticatedHandler');
@@ -26,11 +26,10 @@ const mockUnauthenticatedHandler = jest.mocked(unauthenticatedHandler);
 const mockParseJsonError = jest.mocked(parseJsonError);
 const mockGetRetryDecider = jest.mocked(getRetryDecider);
 const mockFetchAuthSession = jest.fn();
-const mockAmplifyInstance = {
-	Auth: {
-		fetchAuthSession: mockFetchAuthSession,
-	},
-} as any as AmplifyClassV6;
+const mockAmplifyInstance = createMockAmplifyContext(
+	{},
+	{ fetchAuthSession: mockFetchAuthSession },
+);
 
 const successResponse = {
 	statusCode: 200,
@@ -427,18 +426,21 @@ describe('internal post', () => {
 
 	it('should use jittered-exponential-backoff retry strategy, even when configuring using library options', async () => {
 		expect.assertions(2);
-		const mockAmplifyInstanceWithNoRetry = {
-			...mockAmplifyInstance,
-			libraryOptions: {
-				API: {
-					REST: {
-						retryStrategy: {
-							strategy: 'no-retry',
+		const mockAmplifyInstanceWithNoRetry = createMockAmplifyContext(
+			{},
+			{
+				fetchAuthSession: mockFetchAuthSession,
+				libraryOptions: {
+					API: {
+						REST: {
+							retryStrategy: {
+								strategy: 'no-retry',
+							},
 						},
 					},
 				},
 			},
-		} as any as AmplifyClassV6;
+		);
 		await post(mockAmplifyInstanceWithNoRetry, {
 			url: apiGatewayUrl,
 			options: {

--- a/packages/api-rest/__tests__/apis/common/publicApis.test.ts
+++ b/packages/api-rest/__tests__/apis/common/publicApis.test.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
 import {
 	getRetryDecider,
 	parseJsonError,
@@ -25,6 +24,7 @@ import {
 	validationErrorMap,
 } from '../../../src/errors';
 import { RestApiResponse } from '../../../src/types';
+import { createMockAmplifyContext } from '../../testUtils/mockAmplifyContext';
 
 jest.mock('@aws-amplify/core/internals/aws-client-utils');
 jest.mock('../../../src/apis/common/baseHandlers/authenticatedHandler');
@@ -48,12 +48,8 @@ const mockConfig = {
 };
 const mockParseJsonError = parseJsonError as jest.Mock;
 const mockRestHeaders = jest.fn();
-const mockGetConfig = jest.fn();
-const mockAmplifyInstance = {
-	Auth: {
-		fetchAuthSession: mockFetchAuthSession,
-	},
-	getConfig: mockGetConfig,
+const mockAmplifyInstance = createMockAmplifyContext(mockConfig, {
+	fetchAuthSession: mockFetchAuthSession,
 	libraryOptions: {
 		API: {
 			REST: {
@@ -61,7 +57,8 @@ const mockAmplifyInstance = {
 			},
 		},
 	},
-} as any as AmplifyClassV6;
+});
+
 const credentials = {
 	accessKeyId: 'accessKeyId',
 	sessionToken: 'sessionToken',
@@ -90,7 +87,6 @@ describe('public APIs', () => {
 		mockSuccessResponse.body.json.mockResolvedValue({ foo: 'bar' });
 		mockAuthenticatedHandler.mockResolvedValue(mockSuccessResponse);
 		mockUnauthenticatedHandler.mockResolvedValue(mockSuccessResponse);
-		mockGetConfig.mockReturnValue(mockConfig);
 		mockGetRetryDecider.mockReturnValue(mockRetryDeciderResponse);
 	});
 
@@ -482,16 +478,19 @@ describe('public APIs', () => {
 			expect.assertions(3);
 			const timeoutSpy = jest.spyOn(global, 'setTimeout');
 			const mockTimeoutFunction = jest.fn().mockReturnValue(100);
-			const mockAmplifyInstanceWithTimeout = {
-				...mockAmplifyInstance,
-				libraryOptions: {
-					API: {
-						REST: {
-							timeout: mockTimeoutFunction,
+			const mockAmplifyInstanceWithTimeout = createMockAmplifyContext(
+				mockConfig,
+				{
+					fetchAuthSession: mockFetchAuthSession,
+					libraryOptions: {
+						API: {
+							REST: {
+								timeout: mockTimeoutFunction,
+							},
 						},
 					},
 				},
-			} as any as AmplifyClassV6;
+			);
 			mockAuthenticatedHandler.mockImplementation(() => {
 				return new Promise((_resolve, reject) => {
 					setTimeout(() => {
@@ -583,18 +582,21 @@ describe('public APIs', () => {
 
 			it('should retry and prefer the individual retry strategy over the library options', async () => {
 				expect.assertions(3);
-				const mockAmplifyInstanceWithNoRetry = {
-					...mockAmplifyInstance,
-					libraryOptions: {
-						API: {
-							REST: {
-								retryStrategy: {
-									strategy: 'no-retry',
+				const mockAmplifyInstanceWithNoRetry = createMockAmplifyContext(
+					mockConfig,
+					{
+						fetchAuthSession: mockFetchAuthSession,
+						libraryOptions: {
+							API: {
+								REST: {
+									retryStrategy: {
+										strategy: 'no-retry',
+									},
 								},
 							},
 						},
 					},
-				} as any as AmplifyClassV6;
+				);
 				await fn(mockAmplifyInstanceWithNoRetry, {
 					apiName: 'restApi1',
 					path: 'items',
@@ -618,18 +620,21 @@ describe('public APIs', () => {
 
 			it('should not retry and prefer the individual retry strategy over the library options', async () => {
 				expect.assertions(3);
-				const mockAmplifyInstanceWithRetry = {
-					...mockAmplifyInstance,
-					libraryOptions: {
-						API: {
-							REST: {
-								retryStrategy: {
-									strategy: 'jittered-exponential-backoff',
+				const mockAmplifyInstanceWithRetry = createMockAmplifyContext(
+					mockConfig,
+					{
+						fetchAuthSession: mockFetchAuthSession,
+						libraryOptions: {
+							API: {
+								REST: {
+									retryStrategy: {
+										strategy: 'jittered-exponential-backoff',
+									},
 								},
 							},
 						},
 					},
-				} as any as AmplifyClassV6;
+				);
 				await fn(mockAmplifyInstanceWithRetry, {
 					apiName: 'restApi1',
 					path: 'items',
@@ -653,18 +658,21 @@ describe('public APIs', () => {
 
 			it('should not retry when configured through library options', async () => {
 				expect.assertions(3);
-				const mockAmplifyInstanceWithRetry = {
-					...mockAmplifyInstance,
-					libraryOptions: {
-						API: {
-							REST: {
-								retryStrategy: {
-									strategy: 'no-retry',
+				const mockAmplifyInstanceWithRetry = createMockAmplifyContext(
+					mockConfig,
+					{
+						fetchAuthSession: mockFetchAuthSession,
+						libraryOptions: {
+							API: {
+								REST: {
+									retryStrategy: {
+										strategy: 'no-retry',
+									},
 								},
 							},
 						},
 					},
-				} as any as AmplifyClassV6;
+				);
 				await fn(mockAmplifyInstanceWithRetry, {
 					apiName: 'restApi1',
 					path: 'items',
@@ -734,18 +742,21 @@ describe('public APIs', () => {
 			});
 
 			it('should use global defaultAuthMode configuration when no local defaultAuthMode is specified', async () => {
-				const mockAmplifyWithGlobalConfig = {
-					...mockAmplifyInstance,
-					libraryOptions: {
-						...mockAmplifyInstance.libraryOptions,
-						API: {
-							...mockAmplifyInstance.libraryOptions?.API,
-							REST: {
-								defaultAuthMode: 'none' as const,
+				const mockAmplifyWithGlobalConfig = createMockAmplifyContext(
+					mockConfig,
+					{
+						fetchAuthSession: mockFetchAuthSession,
+						libraryOptions: {
+							...mockAmplifyInstance.libraryOptions,
+							API: {
+								...mockAmplifyInstance.libraryOptions?.API,
+								REST: {
+									defaultAuthMode: 'none' as const,
+								},
 							},
 						},
 					},
-				} as any as AmplifyClassV6;
+				);
 
 				mockFetchAuthSession.mockClear();
 
@@ -760,18 +771,21 @@ describe('public APIs', () => {
 			});
 
 			it('should override global defaultAuthMode with local defaultAuthMode configuration', async () => {
-				const mockAmplifyWithGlobalConfig = {
-					...mockAmplifyInstance,
-					libraryOptions: {
-						...mockAmplifyInstance.libraryOptions,
-						API: {
-							...mockAmplifyInstance.libraryOptions?.API,
-							REST: {
-								defaultAuthMode: 'none' as const,
+				const mockAmplifyWithGlobalConfig = createMockAmplifyContext(
+					mockConfig,
+					{
+						fetchAuthSession: mockFetchAuthSession,
+						libraryOptions: {
+							...mockAmplifyInstance.libraryOptions,
+							API: {
+								...mockAmplifyInstance.libraryOptions?.API,
+								REST: {
+									defaultAuthMode: 'none' as const,
+								},
 							},
 						},
 					},
-				} as any as AmplifyClassV6;
+				);
 
 				mockFetchAuthSession.mockClear();
 				mockFetchAuthSession.mockResolvedValue({ credentials });

--- a/packages/api-rest/__tests__/apis/server.e2e.test.ts
+++ b/packages/api-rest/__tests__/apis/server.e2e.test.ts
@@ -1,0 +1,138 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * End-to-end server tests that drive the REAL call chain:
+ *   server get(contextSpec, input) → resolveServerContext → publicApis → transferHandler → resolveCredentials
+ *
+ * Only the low-level HTTP handlers are mocked (same as publicApis.test.ts).
+ * This proves that the bridged resolveServerContext correctly wires
+ * `amplify.Auth.fetchAuthSession` so that IAM requests are SIGNED.
+ */
+
+import { getRetryDecider } from '@aws-amplify/core/internals/aws-client-utils';
+import {
+	createAmplifyServerContext,
+	destroyAmplifyServerContext,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+
+import { authenticatedHandler } from '../../src/apis/common/baseHandlers/authenticatedHandler';
+import { unauthenticatedHandler } from '../../src/apis/common/baseHandlers/unauthenticatedHandler';
+import { get } from '../../src/server';
+import { createMockAmplifyContext } from '../testUtils/mockAmplifyContext';
+
+jest.mock('@aws-amplify/core/internals/aws-client-utils');
+jest.mock('../../src/apis/common/baseHandlers/authenticatedHandler');
+jest.mock('../../src/apis/common/baseHandlers/unauthenticatedHandler');
+
+const mockAuthenticatedHandler = authenticatedHandler as jest.Mock;
+const mockUnauthenticatedHandler = unauthenticatedHandler as jest.Mock;
+const mockGetRetryDecider = jest.mocked(getRetryDecider);
+
+const credentials = {
+	accessKeyId: 'accessKeyId',
+	sessionToken: 'sessionToken',
+	secretAccessKey: 'secretAccessKey',
+};
+
+const mockSuccessResponse = {
+	statusCode: 200,
+	headers: { 'x-amzn-requestid': '1234' },
+	body: {
+		blob: jest.fn(),
+		json: jest.fn().mockResolvedValue({ ok: true }),
+		text: jest.fn().mockResolvedValue(''),
+	},
+};
+
+const restApiConfig = {
+	API: {
+		REST: {
+			testApi: {
+				endpoint:
+					'https://abc123.execute-api.us-west-2.amazonaws.com/development',
+				region: 'us-west-2',
+			},
+		},
+	},
+};
+
+describe('server e2e — legacy ContextSpec through real transferHandler', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+		mockAuthenticatedHandler.mockResolvedValue(mockSuccessResponse);
+		mockUnauthenticatedHandler.mockResolvedValue(mockSuccessResponse);
+		mockGetRetryDecider.mockReturnValue(() =>
+			Promise.resolve({ retryable: false }),
+		);
+	});
+
+	it('should call authenticatedHandler when legacy ContextSpec is bridged (regression test)', async () => {
+		// Create a REAL server context — internally creates an AmplifyClass instance
+		const contextSpec = createAmplifyServerContext(restApiConfig, {});
+
+		// Access the internal AmplifyClass instance and mock Auth.fetchAuthSession
+		// to return credentials. The AmplifyClass does NOT have a top-level
+		// fetchAuthSession — that's the whole point of the bridge.
+		const { amplify } = getAmplifyServerContext(contextSpec);
+		jest
+			.spyOn(amplify.Auth, 'fetchAuthSession')
+			.mockResolvedValue({ credentials });
+
+		try {
+			await get(contextSpec, {
+				apiName: 'testApi',
+				path: '/items',
+			}).response;
+
+			// The bridge's fetchAuthSession delegates to amplify.Auth.fetchAuthSession,
+			// which returned credentials → authenticatedHandler must have been used.
+			expect(mockAuthenticatedHandler).toHaveBeenCalledWith(
+				expect.objectContaining({
+					url: expect.objectContaining({
+						href: 'https://abc123.execute-api.us-west-2.amazonaws.com/development/items',
+					}),
+					method: 'GET',
+				}),
+				expect.objectContaining({
+					credentials,
+					region: 'us-west-2',
+					service: 'execute-api',
+				}),
+			);
+			expect(mockUnauthenticatedHandler).not.toHaveBeenCalled();
+		} finally {
+			destroyAmplifyServerContext(contextSpec);
+		}
+	});
+
+	it('should call authenticatedHandler when branded AmplifyContext is passed directly', async () => {
+		const mockFetchAuthSession = jest.fn().mockResolvedValue({ credentials });
+		const ctx = createMockAmplifyContext(restApiConfig, {
+			fetchAuthSession: mockFetchAuthSession,
+		});
+
+		await get(ctx, {
+			apiName: 'testApi',
+			path: '/items',
+		}).response;
+
+		// The brand-check branch returns the context as-is; transferHandler calls
+		// ctx.fetchAuthSession directly → authenticatedHandler must be used.
+		expect(mockAuthenticatedHandler).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: expect.objectContaining({
+					href: 'https://abc123.execute-api.us-west-2.amazonaws.com/development/items',
+				}),
+				method: 'GET',
+			}),
+			expect.objectContaining({
+				credentials,
+				region: 'us-west-2',
+				service: 'execute-api',
+			}),
+		);
+		expect(mockUnauthenticatedHandler).not.toHaveBeenCalled();
+	});
+});

--- a/packages/api-rest/__tests__/index.test.ts
+++ b/packages/api-rest/__tests__/index.test.ts
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import { del, get, head, patch, post, put } from '../src/index';
 import {
@@ -13,8 +16,9 @@ import {
 	put as commonPut,
 } from '../src/apis/common/publicApis';
 
+import { createMockAmplifyContext } from './testUtils/mockAmplifyContext';
+
 jest.mock('../src/apis/common/publicApis');
-jest.mock('@aws-amplify/core');
 
 const input = {
 	apiName: 'apiName',
@@ -22,34 +26,84 @@ const input = {
 	options: {},
 };
 
+const mockCtx = createMockAmplifyContext();
+
 describe('REST API handlers', () => {
-	it('get should call common get API with client-side Amplify singleton', async () => {
+	beforeAll(() => {
+		setGlobalContext(mockCtx);
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('get should call common get API with resolved global context', () => {
 		get(input);
-		expect(commonGet).toHaveBeenCalledWith(Amplify, input);
+		expect(commonGet).toHaveBeenCalledWith(mockCtx, input);
 	});
 
-	it('post should call common post API with client-side Amplify singleton', async () => {
+	it('get should call common get API with explicit context', () => {
+		const explicitCtx = createMockAmplifyContext();
+		get(explicitCtx, input);
+		expect(commonGet).toHaveBeenCalledWith(explicitCtx, input);
+	});
+
+	it('post should call common post API with resolved global context', () => {
 		post(input);
-		expect(commonPost).toHaveBeenCalledWith(Amplify, input);
+		expect(commonPost).toHaveBeenCalledWith(mockCtx, input);
 	});
 
-	it('put should call common put API with client-side Amplify singleton', async () => {
+	it('post should call common post API with explicit context', () => {
+		const explicitCtx = createMockAmplifyContext();
+		post(explicitCtx, input);
+		expect(commonPost).toHaveBeenCalledWith(explicitCtx, input);
+	});
+
+	it('put should call common put API with resolved global context', () => {
 		put(input);
-		expect(commonPut).toHaveBeenCalledWith(Amplify, input);
+		expect(commonPut).toHaveBeenCalledWith(mockCtx, input);
 	});
 
-	it('del should call common del API with client-side Amplify singleton', async () => {
+	it('put should call common put API with explicit context', () => {
+		const explicitCtx = createMockAmplifyContext();
+		put(explicitCtx, input);
+		expect(commonPut).toHaveBeenCalledWith(explicitCtx, input);
+	});
+
+	it('del should call common del API with resolved global context', () => {
 		del(input);
-		expect(commonDel).toHaveBeenCalledWith(Amplify, input);
+		expect(commonDel).toHaveBeenCalledWith(mockCtx, input);
 	});
 
-	it('patch should call common patch API with client-side Amplify singleton', async () => {
+	it('del should call common del API with explicit context', () => {
+		const explicitCtx = createMockAmplifyContext();
+		del(explicitCtx, input);
+		expect(commonDel).toHaveBeenCalledWith(explicitCtx, input);
+	});
+
+	it('patch should call common patch API with resolved global context', () => {
 		patch(input);
-		expect(commonPatch).toHaveBeenCalledWith(Amplify, input);
+		expect(commonPatch).toHaveBeenCalledWith(mockCtx, input);
 	});
 
-	it('head should call common head API with client-side Amplify singleton', async () => {
+	it('patch should call common patch API with explicit context', () => {
+		const explicitCtx = createMockAmplifyContext();
+		patch(explicitCtx, input);
+		expect(commonPatch).toHaveBeenCalledWith(explicitCtx, input);
+	});
+
+	it('head should call common head API with resolved global context', () => {
 		head(input);
-		expect(commonHead).toHaveBeenCalledWith(Amplify, input);
+		expect(commonHead).toHaveBeenCalledWith(mockCtx, input);
+	});
+
+	it('head should call common head API with explicit context', () => {
+		const explicitCtx = createMockAmplifyContext();
+		head(explicitCtx, input);
+		expect(commonHead).toHaveBeenCalledWith(explicitCtx, input);
 	});
 });

--- a/packages/api-rest/__tests__/internals/server.e2e.test.ts
+++ b/packages/api-rest/__tests__/internals/server.e2e.test.ts
@@ -1,0 +1,142 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * End-to-end server tests that drive the REAL call chain:
+ *   internals server post(contextSpec, input) → resolveServerContext → internalPost → transferHandler → resolveCredentials
+ *
+ * Only the low-level HTTP handlers are mocked (same as apis/server.e2e.test.ts).
+ * This proves that the bridged resolveServerContext correctly brands the context
+ * so that internalPost's `isAmplifyContext` check passes without double-bridging,
+ * and `amplify.Auth.fetchAuthSession` resolves credentials for IAM signing.
+ */
+
+import { getRetryDecider } from '@aws-amplify/core/internals/aws-client-utils';
+import {
+	createAmplifyServerContext,
+	destroyAmplifyServerContext,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+
+import { authenticatedHandler } from '../../src/apis/common/baseHandlers/authenticatedHandler';
+import { unauthenticatedHandler } from '../../src/apis/common/baseHandlers/unauthenticatedHandler';
+import { post } from '../../src/internals/server';
+import { createMockAmplifyContext } from '../testUtils/mockAmplifyContext';
+
+jest.mock('@aws-amplify/core/internals/aws-client-utils');
+jest.mock('../../src/apis/common/baseHandlers/authenticatedHandler');
+jest.mock('../../src/apis/common/baseHandlers/unauthenticatedHandler');
+
+const mockAuthenticatedHandler = authenticatedHandler as jest.Mock;
+const mockUnauthenticatedHandler = unauthenticatedHandler as jest.Mock;
+const mockGetRetryDecider = jest.mocked(getRetryDecider);
+
+const credentials = {
+	accessKeyId: 'accessKeyId',
+	sessionToken: 'sessionToken',
+	secretAccessKey: 'secretAccessKey',
+};
+
+const mockSuccessResponse = {
+	statusCode: 200,
+	headers: { 'x-amzn-requestid': '1234' },
+	body: {
+		blob: jest.fn(),
+		json: jest.fn().mockResolvedValue({ ok: true }),
+		text: jest.fn().mockResolvedValue(''),
+	},
+};
+
+describe('internals/server e2e — legacy ContextSpec through real internalPost + transferHandler', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+		mockAuthenticatedHandler.mockResolvedValue(mockSuccessResponse);
+		mockUnauthenticatedHandler.mockResolvedValue(mockSuccessResponse);
+		mockGetRetryDecider.mockReturnValue(() =>
+			Promise.resolve({ retryable: false }),
+		);
+	});
+
+	it('should call authenticatedHandler when legacy ContextSpec is bridged via internals post (regression test)', async () => {
+		const contextSpec = createAmplifyServerContext({}, {});
+		const { amplify } = getAmplifyServerContext(contextSpec);
+		jest
+			.spyOn(amplify.Auth, 'fetchAuthSession')
+			.mockResolvedValue({ credentials });
+
+		try {
+			const appsyncUrl = new URL(
+				'https://abc123.appsync-api.us-west-2.amazonaws.com/graphql',
+			);
+
+			// Drive the real chain: internals/server post → resolveServerContext →
+			// internalPost → transferHandler. The bridge must be branded so that
+			// internalPost's isAmplifyContext(amplify) returns true and does NOT
+			// double-bridge (which would lose the Auth.* closures).
+			await post(contextSpec, {
+				url: appsyncUrl,
+				options: {
+					signingServiceInfo: {
+						service: 'appsync',
+						region: 'us-west-2',
+					},
+				},
+			});
+
+			// The bridge's fetchAuthSession delegates to amplify.Auth.fetchAuthSession,
+			// which returned credentials → authenticatedHandler must have been used.
+			expect(mockAuthenticatedHandler).toHaveBeenCalledWith(
+				expect.objectContaining({
+					url: appsyncUrl,
+					method: 'POST',
+				}),
+				expect.objectContaining({
+					credentials,
+					region: 'us-west-2',
+					service: 'appsync',
+				}),
+			);
+			expect(mockUnauthenticatedHandler).not.toHaveBeenCalled();
+		} finally {
+			destroyAmplifyServerContext(contextSpec);
+		}
+	});
+
+	it('should call authenticatedHandler when branded AmplifyContext is passed directly to internals post', async () => {
+		const mockFetchAuthSession = jest.fn().mockResolvedValue({ credentials });
+		const ctx = createMockAmplifyContext(
+			{},
+			{ fetchAuthSession: mockFetchAuthSession },
+		);
+
+		const appsyncUrl = new URL(
+			'https://abc123.appsync-api.us-west-2.amazonaws.com/graphql',
+		);
+
+		await post(ctx, {
+			url: appsyncUrl,
+			options: {
+				signingServiceInfo: {
+					service: 'appsync',
+					region: 'us-west-2',
+				},
+			},
+		});
+
+		// The brand-check branch in resolveServerContext returns the context as-is;
+		// internalPost also recognizes it → no bridging → transferHandler calls
+		// ctx.fetchAuthSession directly → authenticatedHandler must be used.
+		expect(mockAuthenticatedHandler).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: appsyncUrl,
+				method: 'POST',
+			}),
+			expect.objectContaining({
+				credentials,
+				region: 'us-west-2',
+				service: 'appsync',
+			}),
+		);
+		expect(mockUnauthenticatedHandler).not.toHaveBeenCalled();
+	});
+});

--- a/packages/api-rest/__tests__/server.test.ts
+++ b/packages/api-rest/__tests__/server.test.ts
@@ -27,64 +27,89 @@ const contextSpec = { token: { value: 'token' } } as any;
 const mockGetAmplifyServerContext = getAmplifyServerContext as jest.Mock;
 
 describe('REST API server handlers', () => {
+	const mockAmplify = {
+		getConfig: jest.fn().mockReturnValue({ API: { REST: {} } }),
+		libraryOptions: {},
+		Auth: {
+			fetchAuthSession: jest.fn().mockResolvedValue({}),
+			clearCredentials: jest.fn().mockResolvedValue(undefined),
+			getTokens: jest.fn().mockResolvedValue(undefined),
+		},
+	};
+
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockGetAmplifyServerContext.mockReturnValue({
-			amplify: 'mockedAmplifyServerSideContext',
+			amplify: mockAmplify,
 		});
 	});
 
 	describe('legacy ContextSpec path', () => {
-		it('get should call common get API with server-side Amplify context', () => {
+		it('get should call common get API with bridged server-side Amplify context', () => {
 			get(contextSpec, input);
 			expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
 			expect(commonGet).toHaveBeenCalledWith(
-				'mockedAmplifyServerSideContext',
+				expect.objectContaining({
+					libraryOptions: mockAmplify.libraryOptions,
+					fetchAuthSession: expect.any(Function),
+					clearCredentials: expect.any(Function),
+					getTokens: expect.any(Function),
+				}),
 				input,
 			);
 		});
 
-		it('post should call common post API with server-side Amplify context', () => {
+		it('post should call common post API with bridged server-side Amplify context', () => {
 			post(contextSpec, input);
 			expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
 			expect(commonPost).toHaveBeenCalledWith(
-				'mockedAmplifyServerSideContext',
+				expect.objectContaining({
+					fetchAuthSession: expect.any(Function),
+				}),
 				input,
 			);
 		});
 
-		it('put should call common put API with server-side Amplify context', () => {
+		it('put should call common put API with bridged server-side Amplify context', () => {
 			put(contextSpec, input);
 			expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
 			expect(commonPut).toHaveBeenCalledWith(
-				'mockedAmplifyServerSideContext',
+				expect.objectContaining({
+					fetchAuthSession: expect.any(Function),
+				}),
 				input,
 			);
 		});
 
-		it('del should call common del API with server-side Amplify context', () => {
+		it('del should call common del API with bridged server-side Amplify context', () => {
 			del(contextSpec, input);
 			expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
 			expect(commonDel).toHaveBeenCalledWith(
-				'mockedAmplifyServerSideContext',
+				expect.objectContaining({
+					fetchAuthSession: expect.any(Function),
+				}),
 				input,
 			);
 		});
 
-		it('patch should call common patch API with server-side Amplify context', () => {
+		it('patch should call common patch API with bridged server-side Amplify context', () => {
 			patch(contextSpec, input);
 			expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
 			expect(commonPatch).toHaveBeenCalledWith(
-				'mockedAmplifyServerSideContext',
+				expect.objectContaining({
+					fetchAuthSession: expect.any(Function),
+				}),
 				input,
 			);
 		});
 
-		it('head should call common head API with server-side Amplify context', () => {
+		it('head should call common head API with bridged server-side Amplify context', () => {
 			head(contextSpec, input);
 			expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
 			expect(commonHead).toHaveBeenCalledWith(
-				'mockedAmplifyServerSideContext',
+				expect.objectContaining({
+					fetchAuthSession: expect.any(Function),
+				}),
 				input,
 			);
 		});

--- a/packages/api-rest/__tests__/server.test.ts
+++ b/packages/api-rest/__tests__/server.test.ts
@@ -13,6 +13,8 @@ import {
 	put as commonPut,
 } from '../src/apis/common/publicApis';
 
+import { createMockAmplifyContext } from './testUtils/mockAmplifyContext';
+
 jest.mock('../src/apis/common/publicApis');
 jest.mock('@aws-amplify/core/internals/adapter-core');
 
@@ -24,7 +26,7 @@ const input = {
 const contextSpec = { token: { value: 'token' } } as any;
 const mockGetAmplifyServerContext = getAmplifyServerContext as jest.Mock;
 
-describe('REST API handlers', () => {
+describe('REST API server handlers', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockGetAmplifyServerContext.mockReturnValue({
@@ -32,57 +34,103 @@ describe('REST API handlers', () => {
 		});
 	});
 
-	it('get should call common get API with server-side Amplify context', async () => {
-		get(contextSpec, input);
-		expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
-		expect(commonGet).toHaveBeenCalledWith(
-			'mockedAmplifyServerSideContext',
-			input,
-		);
+	describe('legacy ContextSpec path', () => {
+		it('get should call common get API with server-side Amplify context', () => {
+			get(contextSpec, input);
+			expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
+			expect(commonGet).toHaveBeenCalledWith(
+				'mockedAmplifyServerSideContext',
+				input,
+			);
+		});
+
+		it('post should call common post API with server-side Amplify context', () => {
+			post(contextSpec, input);
+			expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
+			expect(commonPost).toHaveBeenCalledWith(
+				'mockedAmplifyServerSideContext',
+				input,
+			);
+		});
+
+		it('put should call common put API with server-side Amplify context', () => {
+			put(contextSpec, input);
+			expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
+			expect(commonPut).toHaveBeenCalledWith(
+				'mockedAmplifyServerSideContext',
+				input,
+			);
+		});
+
+		it('del should call common del API with server-side Amplify context', () => {
+			del(contextSpec, input);
+			expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
+			expect(commonDel).toHaveBeenCalledWith(
+				'mockedAmplifyServerSideContext',
+				input,
+			);
+		});
+
+		it('patch should call common patch API with server-side Amplify context', () => {
+			patch(contextSpec, input);
+			expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
+			expect(commonPatch).toHaveBeenCalledWith(
+				'mockedAmplifyServerSideContext',
+				input,
+			);
+		});
+
+		it('head should call common head API with server-side Amplify context', () => {
+			head(contextSpec, input);
+			expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
+			expect(commonHead).toHaveBeenCalledWith(
+				'mockedAmplifyServerSideContext',
+				input,
+			);
+		});
 	});
 
-	it('post should call common post API with server-side Amplify context', async () => {
-		post(contextSpec, input);
-		expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
-		expect(commonPost).toHaveBeenCalledWith(
-			'mockedAmplifyServerSideContext',
-			input,
-		);
-	});
+	describe('AmplifyContext path', () => {
+		it('get should pass AmplifyContext directly without calling getAmplifyServerContext', () => {
+			const ctx = createMockAmplifyContext();
+			get(ctx, input);
+			expect(mockGetAmplifyServerContext).not.toHaveBeenCalled();
+			expect(commonGet).toHaveBeenCalledWith(ctx, input);
+		});
 
-	it('put should call common put API with server-side Amplify context', async () => {
-		put(contextSpec, input);
-		expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
-		expect(commonPut).toHaveBeenCalledWith(
-			'mockedAmplifyServerSideContext',
-			input,
-		);
-	});
+		it('post should pass AmplifyContext directly without calling getAmplifyServerContext', () => {
+			const ctx = createMockAmplifyContext();
+			post(ctx, input);
+			expect(mockGetAmplifyServerContext).not.toHaveBeenCalled();
+			expect(commonPost).toHaveBeenCalledWith(ctx, input);
+		});
 
-	it('del should call common del API with server-side Amplify context', async () => {
-		del(contextSpec, input);
-		expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
-		expect(commonDel).toHaveBeenCalledWith(
-			'mockedAmplifyServerSideContext',
-			input,
-		);
-	});
+		it('put should pass AmplifyContext directly without calling getAmplifyServerContext', () => {
+			const ctx = createMockAmplifyContext();
+			put(ctx, input);
+			expect(mockGetAmplifyServerContext).not.toHaveBeenCalled();
+			expect(commonPut).toHaveBeenCalledWith(ctx, input);
+		});
 
-	it('patch should call common patch API with server-side Amplify context', async () => {
-		patch(contextSpec, input);
-		expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
-		expect(commonPatch).toHaveBeenCalledWith(
-			'mockedAmplifyServerSideContext',
-			input,
-		);
-	});
+		it('del should pass AmplifyContext directly without calling getAmplifyServerContext', () => {
+			const ctx = createMockAmplifyContext();
+			del(ctx, input);
+			expect(mockGetAmplifyServerContext).not.toHaveBeenCalled();
+			expect(commonDel).toHaveBeenCalledWith(ctx, input);
+		});
 
-	it('head should call common head API with server-side Amplify context', async () => {
-		head(contextSpec, input);
-		expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
-		expect(commonHead).toHaveBeenCalledWith(
-			'mockedAmplifyServerSideContext',
-			input,
-		);
+		it('patch should pass AmplifyContext directly without calling getAmplifyServerContext', () => {
+			const ctx = createMockAmplifyContext();
+			patch(ctx, input);
+			expect(mockGetAmplifyServerContext).not.toHaveBeenCalled();
+			expect(commonPatch).toHaveBeenCalledWith(ctx, input);
+		});
+
+		it('head should pass AmplifyContext directly without calling getAmplifyServerContext', () => {
+			const ctx = createMockAmplifyContext();
+			head(ctx, input);
+			expect(mockGetAmplifyServerContext).not.toHaveBeenCalled();
+			expect(commonHead).toHaveBeenCalledWith(ctx, input);
+		});
 	});
 });

--- a/packages/api-rest/__tests__/testUtils/mockAmplifyContext.ts
+++ b/packages/api-rest/__tests__/testUtils/mockAmplifyContext.ts
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AMPLIFY_CONTEXT_BRAND,
+	AmplifyContext,
+	ResourcesConfig,
+} from '@aws-amplify/core';
+
+/**
+ * Creates a mock AmplifyContext for testing.
+ */
+export function createMockAmplifyContext(
+	resourcesConfig: ResourcesConfig = {},
+	overrides: Partial<
+		Pick<AmplifyContext, 'fetchAuthSession' | 'libraryOptions'>
+	> = {},
+): AmplifyContext {
+	const ctx: AmplifyContext = {
+		resourcesConfig,
+		libraryOptions: {},
+		fetchAuthSession: jest.fn().mockResolvedValue({}),
+		clearCredentials: jest.fn().mockResolvedValue(undefined),
+		getTokens: jest.fn().mockResolvedValue(undefined),
+		...overrides,
+	};
+
+	Object.defineProperty(ctx, AMPLIFY_CONTEXT_BRAND, {
+		value: true,
+		enumerable: false,
+	});
+
+	return ctx;
+}

--- a/packages/api-rest/__tests__/utils/resolveApiUrl.test.ts
+++ b/packages/api-rest/__tests__/utils/resolveApiUrl.test.ts
@@ -1,4 +1,5 @@
-import type { AmplifyClassV6 } from '@aws-amplify/core';
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 import { resolveApiUrl } from '../../src/utils';
 import {
@@ -6,19 +7,18 @@ import {
 	RestApiValidationErrorCode,
 	validationErrorMap,
 } from '../../src/errors';
+import { createMockAmplifyContext } from '../testUtils/mockAmplifyContext';
 
 const mkAmplify = (endpoint = 'https://example.com/api', apiName = 'myAPI') =>
-	({
-		getConfig: () => ({
-			API: {
-				REST: {
-					[apiName]: {
-						endpoint,
-					},
+	createMockAmplifyContext({
+		API: {
+			REST: {
+				[apiName]: {
+					endpoint,
 				},
 			},
-		}),
-	}) as unknown as AmplifyClassV6;
+		},
+	});
 
 describe('resolveApiUrl', () => {
 	beforeEach(() => {

--- a/packages/api-rest/src/apis/common/internalPost.ts
+++ b/packages/api-rest/src/apis/common/internalPost.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import { InternalPostInput, RestApiResponse } from '../../types';
 import { createCancellableOperation } from '../../utils';
@@ -39,7 +39,7 @@ const cancelTokenMap = new WeakMap<Promise<any>, AbortController>();
  * To make the internal post cancellable, you must also call `updateRequestToBeCancellable()` with the promise from
  * internal post call and the abort controller supplied to the internal post call.
  *
- * @param amplify the AmplifyClassV6 instance - it may be the singleton used on Web, or an instance created within
+ * @param amplify the AmplifyContext instance - it may be the singleton used on Web, or an instance created within
  * a context created by `runWithAmplifyServerContext`
  * @param postInput an object of {@link InternalPostInput}
  * @param postInput.url The URL that the POST request sends to
@@ -54,7 +54,7 @@ const cancelTokenMap = new WeakMap<Promise<any>, AbortController>();
  * @throws a {@link CanceledError} when the ongoing POST request get cancelled
  */
 export const post = (
-	amplify: AmplifyClassV6,
+	amplify: AmplifyContext,
 	{ url, options, abortController }: InternalPostInput,
 ): Promise<RestApiResponse> => {
 	const controller = abortController ?? new AbortController();

--- a/packages/api-rest/src/apis/common/internalPost.ts
+++ b/packages/api-rest/src/apis/common/internalPost.ts
@@ -1,10 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyContext } from '@aws-amplify/core';
+import {
+	AmplifyClassV6,
+	AmplifyContext,
+	isAmplifyContext,
+} from '@aws-amplify/core';
 
 import { InternalPostInput, RestApiResponse } from '../../types';
 import { createCancellableOperation } from '../../utils';
+import { bridgeAmplifyClass } from '../../utils/bridgeAmplifyClass';
 import { CanceledError } from '../../errors';
 import { isIamAuthApplicableForGraphQL } from '../../utils/isIamAuthApplicable';
 
@@ -39,8 +44,10 @@ const cancelTokenMap = new WeakMap<Promise<any>, AbortController>();
  * To make the internal post cancellable, you must also call `updateRequestToBeCancellable()` with the promise from
  * internal post call and the abort controller supplied to the internal post call.
  *
- * @param amplify the AmplifyContext instance - it may be the singleton used on Web, or an instance created within
- * a context created by `runWithAmplifyServerContext`
+ * @param amplify the AmplifyContext instance (new), or an AmplifyClassV6 instance (legacy dependents
+ * such as api-graphql, until they migrate to AmplifyContext — interim accommodation removed in the
+ * api-graphql split). When an AmplifyClassV6 is passed, it is bridged to AmplifyContext so that
+ * fetchAuthSession/clearCredentials/getTokens are correctly resolved from `.Auth`.
  * @param postInput an object of {@link InternalPostInput}
  * @param postInput.url The URL that the POST request sends to
  * @param postInput.options Options of the POST request
@@ -54,14 +61,15 @@ const cancelTokenMap = new WeakMap<Promise<any>, AbortController>();
  * @throws a {@link CanceledError} when the ongoing POST request get cancelled
  */
 export const post = (
-	amplify: AmplifyContext,
+	amplify: AmplifyContext | AmplifyClassV6,
 	{ url, options, abortController }: InternalPostInput,
 ): Promise<RestApiResponse> => {
+	const ctx = isAmplifyContext(amplify) ? amplify : bridgeAmplifyClass(amplify);
 	const controller = abortController ?? new AbortController();
 	const responsePromise = createCancellableOperation(
 		async () => {
 			const response = transferHandler(
-				amplify,
+				ctx,
 				{
 					url,
 					method: 'POST',

--- a/packages/api-rest/src/apis/common/publicApis.ts
+++ b/packages/api-rest/src/apis/common/publicApis.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import {
 	ApiInput,
@@ -30,7 +30,7 @@ import { isIamAuthApplicableForRest } from '../../utils/isIamAuthApplicable';
 import { transferHandler } from './transferHandler';
 
 const publicHandler = (
-	amplify: AmplifyClassV6,
+	amplify: AmplifyContext,
 	options: ApiInput<RestApiOptionsBase>,
 	method: string,
 ) => {
@@ -91,28 +91,28 @@ const publicHandler = (
 	);
 };
 
-export const get = (amplify: AmplifyClassV6, input: GetInput): GetOperation =>
+export const get = (amplify: AmplifyContext, input: GetInput): GetOperation =>
 	publicHandler(amplify, input, 'GET');
 
 export const post = (
-	amplify: AmplifyClassV6,
+	amplify: AmplifyContext,
 	input: PostInput,
 ): PostOperation => publicHandler(amplify, input, 'POST');
 
-export const put = (amplify: AmplifyClassV6, input: PutInput): PutOperation =>
+export const put = (amplify: AmplifyContext, input: PutInput): PutOperation =>
 	publicHandler(amplify, input, 'PUT');
 
 export const del = (
-	amplify: AmplifyClassV6,
+	amplify: AmplifyContext,
 	input: DeleteInput,
 ): DeleteOperation => publicHandler(amplify, input, 'DELETE');
 
 export const head = (
-	amplify: AmplifyClassV6,
+	amplify: AmplifyContext,
 	input: HeadInput,
 ): HeadOperation => publicHandler(amplify, input, 'HEAD');
 
 export const patch = (
-	amplify: AmplifyClassV6,
+	amplify: AmplifyContext,
 	input: PatchInput,
 ): PatchOperation => publicHandler(amplify, input, 'PATCH');

--- a/packages/api-rest/src/apis/common/transferHandler.ts
+++ b/packages/api-rest/src/apis/common/transferHandler.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 import {
 	Headers,
 	HttpRequest,
@@ -49,7 +49,7 @@ type RetryDecider = RetryOptions['retryDecider'];
  * @internal
  */
 export const transferHandler = async (
-	amplify: AmplifyClassV6,
+	amplify: AmplifyContext,
 	options: HandlerOptions & { abortSignal: AbortSignal },
 	iamAuthApplicable: (
 		{ headers }: HttpRequest,
@@ -139,10 +139,10 @@ const getRetryDeciderFromStrategy = (
 };
 
 const resolveCredentials = async (
-	amplify: AmplifyClassV6,
+	amplify: AmplifyContext,
 ): Promise<AWSCredentials | null> => {
 	try {
-		const { credentials } = await amplify.Auth.fetchAuthSession();
+		const { credentials } = await amplify.fetchAuthSession();
 		if (credentials) {
 			return credentials;
 		}

--- a/packages/api-rest/src/apis/index.ts
+++ b/packages/api-rest/src/apis/index.ts
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
+import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
 
 import {
 	DeleteInput,
@@ -67,7 +68,13 @@ import {
  * }
  * ```
  */
-export const get = (input: GetInput): GetOperation => commonGet(Amplify, input);
+export function get(input: GetInput): GetOperation;
+export function get(ctx: AmplifyContext, input: GetInput): GetOperation;
+export function get(...args: any[]): GetOperation {
+	const [ctx, input] = resolveCtxArgs<[GetInput]>(args);
+
+	return commonGet(ctx, input);
+}
 
 /**
  * POST HTTP request
@@ -108,8 +115,13 @@ export const get = (input: GetInput): GetOperation => commonGet(Amplify, input);
  * }
  * ```
  */
-export const post = (input: PostInput): PostOperation =>
-	commonPost(Amplify, input);
+export function post(input: PostInput): PostOperation;
+export function post(ctx: AmplifyContext, input: PostInput): PostOperation;
+export function post(...args: any[]): PostOperation {
+	const [ctx, input] = resolveCtxArgs<[PostInput]>(args);
+
+	return commonPost(ctx, input);
+}
 
 /**
  * PUT HTTP request
@@ -149,7 +161,13 @@ export const post = (input: PostInput): PostOperation =>
  * }
  * ```
  */
-export const put = (input: PutInput): PutOperation => commonPut(Amplify, input);
+export function put(input: PutInput): PutOperation;
+export function put(ctx: AmplifyContext, input: PutInput): PutOperation;
+export function put(...args: any[]): PutOperation {
+	const [ctx, input] = resolveCtxArgs<[PutInput]>(args);
+
+	return commonPut(ctx, input);
+}
 
 /**
  * DELETE HTTP request
@@ -171,8 +189,13 @@ export const put = (input: PutInput): PutOperation => commonPut(Amplify, input);
  * }).response;
  * ```
  */
-export const del = (input: DeleteInput): DeleteOperation =>
-	commonDel(Amplify, input);
+export function del(input: DeleteInput): DeleteOperation;
+export function del(ctx: AmplifyContext, input: DeleteInput): DeleteOperation;
+export function del(...args: any[]): DeleteOperation {
+	const [ctx, input] = resolveCtxArgs<[DeleteInput]>(args);
+
+	return commonDel(ctx, input);
+}
 
 /**
  * HEAD HTTP request
@@ -195,8 +218,13 @@ export const del = (input: DeleteInput): DeleteOperation =>
  * ```
  *
  */
-export const head = (input: HeadInput): HeadOperation =>
-	commonHead(Amplify, input);
+export function head(input: HeadInput): HeadOperation;
+export function head(ctx: AmplifyContext, input: HeadInput): HeadOperation;
+export function head(...args: any[]): HeadOperation {
+	const [ctx, input] = resolveCtxArgs<[HeadInput]>(args);
+
+	return commonHead(ctx, input);
+}
 
 /**
  * PATCH HTTP request
@@ -237,5 +265,10 @@ export const head = (input: HeadInput): HeadOperation =>
  * }
  * ```
  */
-export const patch = (input: PatchInput): PatchOperation =>
-	commonPatch(Amplify, input);
+export function patch(input: PatchInput): PatchOperation;
+export function patch(ctx: AmplifyContext, input: PatchInput): PatchOperation;
+export function patch(...args: any[]): PatchOperation {
+	const [ctx, input] = resolveCtxArgs<[PatchInput]>(args);
+
+	return commonPatch(ctx, input);
+}

--- a/packages/api-rest/src/apis/server.ts
+++ b/packages/api-rest/src/apis/server.ts
@@ -1,10 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-	AmplifyServer,
-	getAmplifyServerContext,
-} from '@aws-amplify/core/internals/adapter-core';
+import { AmplifyContext } from '@aws-amplify/core';
+import { AmplifyServer } from '@aws-amplify/core/internals/adapter-core';
 
 import {
 	DeleteInput,
@@ -30,10 +28,15 @@ import {
 	post as commonPost,
 	put as commonPut,
 } from './common/publicApis';
+import { resolveServerContext } from './server/resolveServerContext';
 
 /**
  * GET HTTP request (server-side)
- * @param {AmplifyServer.ContextSpec} contextSpec - The context spec used to get the Amplify server context.
+ *
+ * Accepts either an {@link AmplifyContext} (new pattern) or a legacy
+ * {@link AmplifyServer.ContextSpec} for backward compatibility.
+ *
+ * @param ctxOrContextSpec - AmplifyContext or legacy ContextSpec
  * @param {GetInput} input - Input for GET operation.
  * @throws - {@link RestApiError}
  * @example
@@ -56,14 +59,17 @@ import {
  * ```
  */
 export const get = (
-	contextSpec: AmplifyServer.ContextSpec,
+	ctxOrContextSpec: AmplifyContext | AmplifyServer.ContextSpec,
 	input: GetInput,
-): GetOperation =>
-	commonGet(getAmplifyServerContext(contextSpec).amplify, input);
+): GetOperation => commonGet(resolveServerContext(ctxOrContextSpec), input);
 
 /**
  * POST HTTP request (server-side)
- * @param {AmplifyServer.ContextSpec} contextSpec - The context spec used to get the Amplify server context.
+ *
+ * Accepts either an {@link AmplifyContext} (new pattern) or a legacy
+ * {@link AmplifyServer.ContextSpec} for backward compatibility.
+ *
+ * @param ctxOrContextSpec - AmplifyContext or legacy ContextSpec
  * @param {PostInput} input - Input for POST operation.
  * @throws - {@link RestApiError}
  * @example
@@ -86,14 +92,17 @@ export const get = (
  * ```
  */
 export const post = (
-	contextSpec: AmplifyServer.ContextSpec,
+	ctxOrContextSpec: AmplifyContext | AmplifyServer.ContextSpec,
 	input: PostInput,
-): PostOperation =>
-	commonPost(getAmplifyServerContext(contextSpec).amplify, input);
+): PostOperation => commonPost(resolveServerContext(ctxOrContextSpec), input);
 
 /**
  * PUT HTTP request (server-side)
- * @param {AmplifyServer.ContextSpec} contextSpec - The context spec used to get the Amplify server context.
+ *
+ * Accepts either an {@link AmplifyContext} (new pattern) or a legacy
+ * {@link AmplifyServer.ContextSpec} for backward compatibility.
+ *
+ * @param ctxOrContextSpec - AmplifyContext or legacy ContextSpec
  * @param {PutInput} input - Input for PUT operation.
  * @throws - {@link RestApiError}
  * @example
@@ -116,14 +125,17 @@ export const post = (
  * ```
  */
 export const put = (
-	contextSpec: AmplifyServer.ContextSpec,
+	ctxOrContextSpec: AmplifyContext | AmplifyServer.ContextSpec,
 	input: PutInput,
-): PutOperation =>
-	commonPut(getAmplifyServerContext(contextSpec).amplify, input);
+): PutOperation => commonPut(resolveServerContext(ctxOrContextSpec), input);
 
 /**
  * DELETE HTTP request (server-side)
- * @param {AmplifyServer.ContextSpec} contextSpec - The context spec used to get the Amplify server context.
+ *
+ * Accepts either an {@link AmplifyContext} (new pattern) or a legacy
+ * {@link AmplifyServer.ContextSpec} for backward compatibility.
+ *
+ * @param ctxOrContextSpec - AmplifyContext or legacy ContextSpec
  * @param {DeleteInput} input - Input for DELETE operation.
  * @throws - {@link RestApiError}
  * @example
@@ -145,14 +157,17 @@ export const put = (
  * ```
  */
 export const del = (
-	contextSpec: AmplifyServer.ContextSpec,
+	ctxOrContextSpec: AmplifyContext | AmplifyServer.ContextSpec,
 	input: DeleteInput,
-): DeleteOperation =>
-	commonDel(getAmplifyServerContext(contextSpec).amplify, input);
+): DeleteOperation => commonDel(resolveServerContext(ctxOrContextSpec), input);
 
 /**
  * HEAD HTTP request (server-side)
- * @param {AmplifyServer.ContextSpec} contextSpec - The context spec used to get the Amplify server context.
+ *
+ * Accepts either an {@link AmplifyContext} (new pattern) or a legacy
+ * {@link AmplifyServer.ContextSpec} for backward compatibility.
+ *
+ * @param ctxOrContextSpec - AmplifyContext or legacy ContextSpec
  * @param {HeadInput} input - Input for HEAD operation.
  * @throws - {@link RestApiError}
  * @example
@@ -174,14 +189,17 @@ export const del = (
  * ```
  */
 export const head = (
-	contextSpec: AmplifyServer.ContextSpec,
+	ctxOrContextSpec: AmplifyContext | AmplifyServer.ContextSpec,
 	input: HeadInput,
-): HeadOperation =>
-	commonHead(getAmplifyServerContext(contextSpec).amplify, input);
+): HeadOperation => commonHead(resolveServerContext(ctxOrContextSpec), input);
 
 /**
  * PATCH HTTP request (server-side)
- * @param {AmplifyServer.ContextSpec} contextSpec - The context spec used to get the Amplify server context.
+ *
+ * Accepts either an {@link AmplifyContext} (new pattern) or a legacy
+ * {@link AmplifyServer.ContextSpec} for backward compatibility.
+ *
+ * @param ctxOrContextSpec - AmplifyContext or legacy ContextSpec
  * @param {PatchInput} input - Input for PATCH operation.
  * @throws - {@link RestApiError}
  * @example
@@ -204,7 +222,6 @@ export const head = (
  * ```
  */
 export const patch = (
-	contextSpec: AmplifyServer.ContextSpec,
+	ctxOrContextSpec: AmplifyContext | AmplifyServer.ContextSpec,
 	input: PatchInput,
-): PatchOperation =>
-	commonPatch(getAmplifyServerContext(contextSpec).amplify, input);
+): PatchOperation => commonPatch(resolveServerContext(ctxOrContextSpec), input);

--- a/packages/api-rest/src/apis/server/resolveServerContext.ts
+++ b/packages/api-rest/src/apis/server/resolveServerContext.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AmplifyContext } from '@aws-amplify/core';
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+
+/**
+ * Resolves a server-side argument that may be either the new {@link AmplifyContext}
+ * or a legacy {@link AmplifyServer.ContextSpec}, into a concrete `AmplifyContext`.
+ */
+export const resolveServerContext = (
+	ctxOrContextSpec: AmplifyContext | AmplifyServer.ContextSpec,
+): AmplifyContext => {
+	const ctx =
+		'resourcesConfig' in ctxOrContextSpec
+			? ctxOrContextSpec
+			: getAmplifyServerContext(ctxOrContextSpec).amplify;
+
+	// `'resourcesConfig' in x` doesn't narrow the union; AmplifyClass satisfies AmplifyContext structurally.
+	return ctx as AmplifyContext;
+};

--- a/packages/api-rest/src/apis/server/resolveServerContext.ts
+++ b/packages/api-rest/src/apis/server/resolveServerContext.ts
@@ -7,6 +7,8 @@ import {
 	getAmplifyServerContext,
 } from '@aws-amplify/core/internals/adapter-core';
 
+import { bridgeAmplifyClass } from '../../utils/bridgeAmplifyClass';
+
 /**
  * Resolves a server-side argument that may be either the new {@link AmplifyContext}
  * or a legacy {@link AmplifyServer.ContextSpec}, into a concrete `AmplifyContext`.
@@ -23,25 +25,8 @@ export const resolveServerContext = (
 	}
 
 	// Legacy server ContextSpec: unwrap the `AmplifyClass` and adapt it to the
-	// `AmplifyContext` shape. `AmplifyClass` exposes resourcesConfig/libraryOptions
-	// and a cross-category `Auth` utility, but NOT the top-level context methods
-	// (fetchAuthSession/clearCredentials/getTokens), so bridge them to `Auth.*` here.
+	// `AmplifyContext` shape via the shared bridge helper.
 	const { amplify } = getAmplifyServerContext(ctxOrContextSpec);
 
-	// Annotate the object so the bridged lambdas receive contextual parameter
-	// types (avoids implicit-any) and the shape is checked against AmplifyContext.
-	const resolved: AmplifyContext = {
-		get resourcesConfig() {
-			return amplify.getConfig();
-		},
-		libraryOptions: amplify.libraryOptions,
-		// AmplifyContext.fetchAuthSession has OPTIONAL options while
-		// AuthClass.Auth.fetchAuthSession requires it, hence the `?? {}` default.
-		fetchAuthSession: options => amplify.Auth.fetchAuthSession(options ?? {}),
-		clearCredentials: () => amplify.Auth.clearCredentials(),
-		// getTokens needs no default — options is required on both interfaces.
-		getTokens: options => amplify.Auth.getTokens(options),
-	};
-
-	return resolved;
+	return bridgeAmplifyClass(amplify);
 };

--- a/packages/api-rest/src/apis/server/resolveServerContext.ts
+++ b/packages/api-rest/src/apis/server/resolveServerContext.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyContext } from '@aws-amplify/core';
+import { AmplifyContext, isAmplifyContext } from '@aws-amplify/core';
 import {
 	AmplifyServer,
 	getAmplifyServerContext,
@@ -14,11 +14,34 @@ import {
 export const resolveServerContext = (
 	ctxOrContextSpec: AmplifyContext | AmplifyServer.ContextSpec,
 ): AmplifyContext => {
-	const ctx =
-		'resourcesConfig' in ctxOrContextSpec
-			? ctxOrContextSpec
-			: getAmplifyServerContext(ctxOrContextSpec).amplify;
+	// Already a branded AmplifyContext (e.g. a directly-supplied context) — use as-is.
+	// Use the runtime brand check rather than a structural `'resourcesConfig' in x`
+	// probe: `AmplifyClass` also has a `resourcesConfig` field, so the structural
+	// probe would misclassify a server ContextSpec's underlying `AmplifyClass`.
+	if (isAmplifyContext(ctxOrContextSpec)) {
+		return ctxOrContextSpec;
+	}
 
-	// `'resourcesConfig' in x` doesn't narrow the union; AmplifyClass satisfies AmplifyContext structurally.
-	return ctx as AmplifyContext;
+	// Legacy server ContextSpec: unwrap the `AmplifyClass` and adapt it to the
+	// `AmplifyContext` shape. `AmplifyClass` exposes resourcesConfig/libraryOptions
+	// and a cross-category `Auth` utility, but NOT the top-level context methods
+	// (fetchAuthSession/clearCredentials/getTokens), so bridge them to `Auth.*` here.
+	const { amplify } = getAmplifyServerContext(ctxOrContextSpec);
+
+	// Annotate the object so the bridged lambdas receive contextual parameter
+	// types (avoids implicit-any) and the shape is checked against AmplifyContext.
+	const resolved: AmplifyContext = {
+		get resourcesConfig() {
+			return amplify.getConfig();
+		},
+		libraryOptions: amplify.libraryOptions,
+		// AmplifyContext.fetchAuthSession has OPTIONAL options while
+		// AuthClass.Auth.fetchAuthSession requires it, hence the `?? {}` default.
+		fetchAuthSession: options => amplify.Auth.fetchAuthSession(options ?? {}),
+		clearCredentials: () => amplify.Auth.clearCredentials(),
+		// getTokens needs no default — options is required on both interfaces.
+		getTokens: options => amplify.Auth.getTokens(options),
+	};
+
+	return resolved;
 };

--- a/packages/api-rest/src/internals/server.ts
+++ b/packages/api-rest/src/internals/server.ts
@@ -1,11 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import {
-	AmplifyServer,
-	getAmplifyServerContext,
-} from '@aws-amplify/core/internals/adapter-core';
+import { AmplifyContext } from '@aws-amplify/core';
+import { AmplifyServer } from '@aws-amplify/core/internals/adapter-core';
 
 import { post as internalPost } from '../apis/common/internalPost';
+import { resolveServerContext } from '../apis/server/resolveServerContext';
 import { InternalPostInput } from '../types';
 
 /**
@@ -22,13 +21,19 @@ import { InternalPostInput } from '../types';
  * To make the internal post cancellable, you must also call `updateRequestToBeCancellable()` with the promise from
  * internal post call and the abort controller supplied to the internal post call.
  *
+ * Accepts either an {@link AmplifyContext} (new pattern) or a legacy
+ * {@link AmplifyServer.ContextSpec} for backward compatibility.
+ *
+ * @param ctxOrContextSpec - AmplifyContext or legacy ContextSpec
+ * @param input - The internal post input
+ *
  * @internal
  */
 export const post = (
-	contextSpec: AmplifyServer.ContextSpec,
+	ctxOrContextSpec: AmplifyContext | AmplifyServer.ContextSpec,
 	input: InternalPostInput,
 ) => {
-	return internalPost(getAmplifyServerContext(contextSpec).amplify, input);
+	return internalPost(resolveServerContext(ctxOrContextSpec), input);
 };
 
 export {

--- a/packages/api-rest/src/utils/bridgeAmplifyClass.ts
+++ b/packages/api-rest/src/utils/bridgeAmplifyClass.ts
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6, AmplifyContext } from '@aws-amplify/core';
+import {
+	AMPLIFY_CONTEXT_BRAND,
+	AmplifyClassV6,
+	AmplifyContext,
+} from '@aws-amplify/core';
 
 /**
  * Bridges an {@link AmplifyClassV6} instance to the {@link AmplifyContext} shape.
@@ -18,17 +22,31 @@ import { AmplifyClassV6, AmplifyContext } from '@aws-amplify/core';
  *
  * @internal
  */
-export const bridgeAmplifyClass = (
-	amplify: AmplifyClassV6,
-): AmplifyContext => ({
-	get resourcesConfig() {
-		return amplify.getConfig();
-	},
-	libraryOptions: amplify.libraryOptions,
-	// AmplifyContext.fetchAuthSession has OPTIONAL options while
-	// AuthClass.Auth.fetchAuthSession requires it, hence the `?? {}` default.
-	fetchAuthSession: options => amplify.Auth.fetchAuthSession(options ?? {}),
-	clearCredentials: () => amplify.Auth.clearCredentials(),
-	// getTokens needs no default — options is required on both interfaces.
-	getTokens: options => amplify.Auth.getTokens(options),
-});
+export const bridgeAmplifyClass = (amplify: AmplifyClassV6): AmplifyContext => {
+	const resolved: AmplifyContext = {
+		get resourcesConfig() {
+			return amplify.getConfig();
+		},
+		// Live getter: AmplifyClass.libraryOptions is REASSIGNED wholesale on
+		// configure(), so a snapshot would go stale.
+		get libraryOptions() {
+			return amplify.libraryOptions;
+		},
+		// AmplifyContext.fetchAuthSession has OPTIONAL options while
+		// AuthClass.Auth.fetchAuthSession requires it, hence the `?? {}` default.
+		fetchAuthSession: options => amplify.Auth.fetchAuthSession(options ?? {}),
+		clearCredentials: () => amplify.Auth.clearCredentials(),
+		// getTokens needs no default — options is required on both interfaces.
+		getTokens: options => amplify.Auth.getTokens(options),
+	};
+
+	// Branding makes downstream isAmplifyContext checks (e.g. internalPost)
+	// recognize an already-bridged context, preventing double-bridging which
+	// would break the Auth.* closures.
+	Object.defineProperty(resolved, AMPLIFY_CONTEXT_BRAND, {
+		value: true,
+		enumerable: false,
+	});
+
+	return resolved;
+};

--- a/packages/api-rest/src/utils/bridgeAmplifyClass.ts
+++ b/packages/api-rest/src/utils/bridgeAmplifyClass.ts
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AmplifyClassV6, AmplifyContext } from '@aws-amplify/core';
+
+/**
+ * Bridges an {@link AmplifyClassV6} instance to the {@link AmplifyContext} shape.
+ *
+ * `AmplifyClassV6` (a.k.a. `AmplifyClass`) exposes `resourcesConfig` / `libraryOptions`
+ * directly but does NOT surface the top-level context methods
+ * (`fetchAuthSession` / `clearCredentials` / `getTokens`). Those live under its
+ * cross-category `Auth` utility, so this helper maps them through.
+ *
+ * This is used:
+ * - In the server wrapper where a legacy `ContextSpec` provides an `AmplifyClass` instance.
+ * - In the internals `post` function where dependents (e.g. api-graphql) still pass
+ *   an `AmplifyClassV6` until they migrate to `AmplifyContext`.
+ *
+ * @internal
+ */
+export const bridgeAmplifyClass = (
+	amplify: AmplifyClassV6,
+): AmplifyContext => ({
+	get resourcesConfig() {
+		return amplify.getConfig();
+	},
+	libraryOptions: amplify.libraryOptions,
+	// AmplifyContext.fetchAuthSession has OPTIONAL options while
+	// AuthClass.Auth.fetchAuthSession requires it, hence the `?? {}` default.
+	fetchAuthSession: options => amplify.Auth.fetchAuthSession(options ?? {}),
+	clearCredentials: () => amplify.Auth.clearCredentials(),
+	// getTokens needs no default — options is required on both interfaces.
+	getTokens: options => amplify.Auth.getTokens(options),
+});

--- a/packages/api-rest/src/utils/parseSigningInfo.ts
+++ b/packages/api-rest/src/utils/parseSigningInfo.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import {
 	APIG_HOSTNAME_PATTERN,
@@ -18,7 +18,7 @@ import {
 export const parseSigningInfo = (
 	url: URL,
 	restApiOptions?: {
-		amplify: AmplifyClassV6;
+		amplify: AmplifyContext;
 		apiName: string;
 	},
 ) => {
@@ -26,8 +26,9 @@ export const parseSigningInfo = (
 		service: signingService = DEFAULT_REST_IAM_SIGNING_SERVICE,
 		region: signingRegion = DEFAULT_IAM_SIGNING_REGION,
 	} =
-		restApiOptions?.amplify.getConfig()?.API?.REST?.[restApiOptions?.apiName] ??
-		{};
+		restApiOptions?.amplify.resourcesConfig?.API?.REST?.[
+			restApiOptions?.apiName
+		] ?? {};
 	const { hostname } = url;
 	const [, service, region] = APIG_HOSTNAME_PATTERN.exec(hostname) ?? [];
 	if (service === DEFAULT_REST_IAM_SIGNING_SERVICE) {

--- a/packages/api-rest/src/utils/resolveApiUrl.ts
+++ b/packages/api-rest/src/utils/resolveApiUrl.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 import {
 	AmplifyUrl,
 	AmplifyUrlSearchParams,
@@ -25,12 +25,12 @@ import {
  * @internal
  */
 export const resolveApiUrl = (
-	amplify: AmplifyClassV6,
+	amplify: AmplifyContext,
 	apiName: string,
 	path: string,
 	queryParams?: Record<string, string>,
 ): URL => {
-	const urlStr = amplify.getConfig()?.API?.REST?.[apiName]?.endpoint;
+	const urlStr = amplify.resourcesConfig?.API?.REST?.[apiName]?.endpoint;
 	assertValidationError(!!urlStr, RestApiValidationErrorCode.InvalidApiName);
 	try {
 		let url: URL;

--- a/packages/api-rest/src/utils/resolveLibraryOptions.ts
+++ b/packages/api-rest/src/utils/resolveLibraryOptions.ts
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 /**
  * @internal
  */
-export const resolveLibraryOptions = (amplify: AmplifyClassV6) => {
+export const resolveLibraryOptions = (amplify: AmplifyContext) => {
 	const retryStrategy = amplify.libraryOptions?.API?.REST?.retryStrategy;
 	const defaultAuthMode = amplify.libraryOptions?.API?.REST?.defaultAuthMode;
 


### PR DESCRIPTION
#### Description of changes

B-api-rest split of the v6 context migration (Task 3 of the migration plan). Migrates `@aws-amplify/api-rest` from the `AmplifyClassV6` singleton pattern to `AmplifyContext`:

- **Public APIs** (`get`, `post`, `put`, `del`, `head`, `patch` in `src/apis/index.ts`): overloaded signatures `fn(input)` + `fn(ctx, input)` via `resolveCtxArgs` with global-context fallback (Pattern 1)
- **Internals** (`publicApis.ts`, `transferHandler.ts`, `internalPost.ts`): first param type changed to `AmplifyContext`; auth resolved via `ctx.fetchAuthSession()` instead of `.Auth.fetchAuthSession()`
- **Utils** (`resolveApiUrl`, `parseSigningInfo`, `resolveLibraryOptions`): read from `ctx.resourcesConfig` / `ctx.libraryOptions` instead of `getConfig()` (Pattern 4)
- **Server wrappers kept** (`src/apis/server.ts`, `src/internals/server.ts`): accept `AmplifyContext | AmplifyServer.ContextSpec`, normalized via new cast-based `resolveServerContext` adapter mirroring the landed B-auth version (Pattern 5 — full server-path bridging deferred to Phase C)
- **Tests**: new branded `createMockAmplifyContext` factory (with typed overrides); migrated tests use `setGlobalContext`/`clearGlobalContext` — no `Amplify.getConfig` mocking

Follows the same shape as B-auth (#14836) and B-storage (#14874). Unblocks B-api-graphql.

#### Issue #, if available

N/A — part of the v6 context migration plan.

#### Description of how you validated changes

- `yarn turbo run build --filter=@aws-amplify/api-rest` — exit 0
- `npx eslint '**/*.{ts,tsx}'` in the package — exit 0 (one pre-existing jsdoc warning)
- `yarn turbo run test --filter=@aws-amplify/api-rest` — 10 suites, 220 tests passed

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
