### PR TITLE
feat(notifications): migrate notifications APIs to AmplifyContext

### DIFF
--- a/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/clearMessages.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/clearMessages.test.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { defaultStorage } from '@aws-amplify/core';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import {
 	clearMessages,
@@ -12,16 +16,28 @@ import {
 	STORAGE_KEY_SUFFIX,
 } from '../../../../../src/inAppMessaging/providers/pinpoint/utils';
 import { InAppMessagingError } from '../../../../../src/inAppMessaging/errors';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
-jest.mock('@aws-amplify/core/internals/aws-clients/pinpoint');
 jest.mock('@aws-amplify/core');
-jest.mock('@aws-amplify/core/internals/utils');
+jest.mock('@aws-amplify/core/internals/aws-clients/pinpoint');
+jest.mock('@aws-amplify/core/internals/utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/utils'),
+	sessionListener: { addStateChangeListener: jest.fn() },
+}));
 jest.mock('@aws-amplify/core/internals/providers/pinpoint');
 jest.mock('../../../../../src/inAppMessaging/providers/pinpoint/utils');
 
 const mockDefaultStorage = defaultStorage as jest.Mocked<typeof defaultStorage>;
 
 describe('clearMessages', () => {
+	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
+
 	afterEach(() => {
 		mockDefaultStorage.removeItem.mockClear();
 	});

--- a/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/dispatchEvent.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/dispatchEvent.test.ts
@@ -1,8 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 import { defaultStorage } from '@aws-amplify/core';
 
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 import {
 	dispatchEvent,
 	initializeInAppMessaging,
@@ -31,11 +36,16 @@ const mockProcessInAppMessages = processInAppMessages as jest.Mock;
 
 describe('dispatchEvent', () => {
 	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
 		initializeInAppMessaging();
 	});
 	beforeEach(() => {
 		mockGetConflictHandler.mockReturnValue(() => inAppMessages[0]);
 	});
+	afterAll(() => {
+		clearGlobalContext();
+	});
+
 	afterEach(() => {
 		mockGetConflictHandler.mockReset();
 		mockDefaultStorage.setItem.mockClear();

--- a/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/identifyUser.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/identifyUser.test.ts
@@ -131,6 +131,8 @@ describe('InAppMessaging Pinpoint Provider API: identifyUser', () => {
 			},
 		};
 		await identifyUser(ctx, input);
+		expect(mockResolveConfig).toHaveBeenCalledWith(ctx);
+		expect(mockResolveCredentials).toHaveBeenCalledWith(ctx);
 		expect(mockUpdateEndpoint).toHaveBeenCalledWith({
 			...input,
 			...credentials,

--- a/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/identifyUser.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/identifyUser.test.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { updateEndpoint } from '@aws-amplify/core/internals/providers/pinpoint';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import {
 	identifyUser,
@@ -15,6 +19,7 @@ import {
 	resolveCredentials,
 } from '../../../../../src/inAppMessaging/providers/pinpoint/utils';
 import { IdentifyUserInput } from '../../../../../src/inAppMessaging/providers/pinpoint/types';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 jest.mock('@aws-amplify/core/internals/providers/pinpoint');
 jest.mock('../../../../../src/inAppMessaging/providers/pinpoint/utils');
@@ -37,10 +42,15 @@ describe('InAppMessaging Pinpoint Provider API: identifyUser', () => {
 	const mockResolveCredentials = resolveCredentials as jest.Mock;
 
 	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
 		initializeInAppMessaging();
 		mockgetInAppMessagingUserAgentString.mockReturnValue(userAgentValue);
 		mockResolveConfig.mockReturnValue(config);
 		mockResolveCredentials.mockResolvedValue(credentials);
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
 	});
 
 	beforeEach(() => {
@@ -101,5 +111,33 @@ describe('InAppMessaging Pinpoint Provider API: identifyUser', () => {
 			userProfile: {},
 		};
 		await expect(identifyUser(input)).rejects.toBeDefined();
+	});
+
+	it('passes through parameters when called with explicit context', async () => {
+		const ctx = createMockAmplifyContext({
+			Notifications: {
+				InAppMessaging: { Pinpoint: { appId: 'app-id', region: 'region' } },
+			},
+		});
+		const input: IdentifyUserInput = {
+			userId: 'user-id',
+			userProfile: {
+				customProperties: {
+					hobbies: ['biking', 'climbing'],
+				},
+				email: 'email',
+				name: 'name',
+				plan: 'plan',
+			},
+		};
+		await identifyUser(ctx, input);
+		expect(mockUpdateEndpoint).toHaveBeenCalledWith({
+			...input,
+			...credentials,
+			...config,
+			channelType: CHANNEL_TYPE,
+			category: CATEGORY,
+			userAgentValue,
+		});
 	});
 });

--- a/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.reconfigure.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.reconfigure.test.ts
@@ -1,0 +1,121 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
+
+import { addEventListener } from '../../../../../src/eventListeners';
+import { recordAnalyticsEvent } from '../../../../../src/inAppMessaging/providers/pinpoint/utils/helpers';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
+import { isInitialized } from '../../../../../src/inAppMessaging/utils';
+
+jest.mock('@aws-amplify/core', () => ({
+	...jest.requireActual('@aws-amplify/core'),
+	Hub: { listen: jest.fn() },
+}));
+jest.mock('../../../../../src/eventListeners');
+jest.mock('../../../../../src/inAppMessaging/providers/pinpoint/utils/helpers');
+jest.mock('../../../../../src/inAppMessaging/utils', () => ({
+	...jest.requireActual('../../../../../src/inAppMessaging/utils'),
+	isInitialized: jest.fn(),
+}));
+jest.mock('@aws-amplify/core/internals/utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/utils'),
+	sessionListener: { addStateChangeListener: jest.fn() },
+}));
+
+const mockAddEventListener = addEventListener as jest.Mock;
+const mockRecordAnalyticsEvent = recordAnalyticsEvent as jest.Mock;
+const mockIsInitialized = isInitialized as jest.Mock;
+
+describe('initializeInAppMessaging — reconfigure support', () => {
+	// Must import after mocks are set up
+	let initializeInAppMessaging: (...args: any[]) => void;
+
+	const configA = { appId: 'app-A', region: 'us-west-2' };
+	const configB = { appId: 'app-B', region: 'us-east-1' };
+	const ctxA = createMockAmplifyContext({
+		Notifications: { InAppMessaging: { Pinpoint: configA } },
+	});
+	const ctxB = createMockAmplifyContext({
+		Notifications: { InAppMessaging: { Pinpoint: configB } },
+	});
+
+	beforeAll(() => {
+		({
+			initializeInAppMessaging,
+		} = require('../../../../../src/inAppMessaging/providers/pinpoint/apis'));
+	});
+
+	beforeEach(() => {
+		mockIsInitialized.mockReturnValue(false);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+		clearGlobalContext();
+	});
+
+	it('event listeners use updated global context after reconfigure', () => {
+		setGlobalContext(ctxA);
+
+		// Capture the event handlers registered by initializeInAppMessaging
+		const handlers: Record<string, (message: any) => void> = {};
+		mockAddEventListener.mockImplementation((event: string, handler: any) => {
+			handlers[event] = handler;
+		});
+
+		initializeInAppMessaging();
+
+		// Fire messageDisplayed event — should use ctxA
+		const testMessage = { id: 'msg-1', layout: 'TOP_BANNER', content: [] };
+		handlers.messageDisplayed(testMessage);
+		expect(mockRecordAnalyticsEvent).toHaveBeenCalledWith(
+			ctxA,
+			expect.anything(),
+			testMessage,
+		);
+
+		// Reconfigure — swap global context to ctxB
+		setGlobalContext(ctxB);
+		mockRecordAnalyticsEvent.mockClear();
+
+		// Fire messageDismissed event — should now use ctxB
+		handlers.messageDismissed(testMessage);
+		expect(mockRecordAnalyticsEvent).toHaveBeenCalledWith(
+			ctxB,
+			expect.anything(),
+			testMessage,
+		);
+	});
+
+	it('explicit ctx remains pinned even after global context changes', () => {
+		const explicitCtx = createMockAmplifyContext({
+			Notifications: { InAppMessaging: { Pinpoint: configA } },
+		});
+
+		setGlobalContext(ctxB);
+
+		const handlers: Record<string, (message: any) => void> = {};
+		mockAddEventListener.mockImplementation((event: string, handler: any) => {
+			handlers[event] = handler;
+		});
+
+		// Initialize with explicit context
+		initializeInAppMessaging(explicitCtx);
+
+		// Change global context
+		setGlobalContext(ctxA);
+
+		// Fire event — should still use explicitCtx
+		const testMessage = { id: 'msg-2', layout: 'BOTTOM_BANNER', content: [] };
+		handlers.messageActionTaken(testMessage);
+		expect(mockRecordAnalyticsEvent).toHaveBeenCalledWith(
+			explicitCtx,
+			expect.anything(),
+			testMessage,
+		);
+	});
+});

--- a/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.test.ts
@@ -2,22 +2,41 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Hub } from '@aws-amplify/core';
-import { sessionListener } from '@aws-amplify/core/internals/utils';
+import {
+	clearGlobalContext,
+	sessionListener,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import {
 	addEventListener,
 	notifyEventListeners,
 } from '../../../../../src/eventListeners';
 import { initializeInAppMessaging } from '../../../../../src/inAppMessaging/providers/pinpoint/apis';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
-jest.mock('@aws-amplify/core');
+jest.mock('@aws-amplify/core', () => ({
+	...jest.requireActual('@aws-amplify/core'),
+	Hub: { listen: jest.fn() },
+}));
 jest.mock('../../../../../src/eventListeners');
-jest.mock('@aws-amplify/core/internals/utils');
+jest.mock('@aws-amplify/core/internals/utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/utils'),
+	sessionListener: { addStateChangeListener: jest.fn() },
+}));
 
 const mockNotifyEventListeners = notifyEventListeners as jest.Mock;
 const mockAddEventListener = addEventListener as jest.Mock;
 
 describe('initializeInAppMessaging', () => {
+	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
+
 	beforeEach(() => {
 		mockNotifyEventListeners.mockClear();
 	});

--- a/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/interactionEvents.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/interactionEvents.test.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { setGlobalContext } from '@aws-amplify/core/internals/utils';
+
 import { inAppMessages } from '../../../../testUtils/data';
 import {
 	addEventListener,
@@ -14,6 +16,7 @@ import {
 	onMessageDisplayed,
 	onMessageReceived,
 } from '../../../../../src/inAppMessaging/providers/pinpoint/apis';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 jest.mock('../../../../../src/eventListeners');
 
@@ -23,6 +26,7 @@ const mockAddEventListener = addEventListener as jest.Mock;
 describe('Interaction events', () => {
 	const handler = jest.fn();
 	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
 		initializeInAppMessaging();
 	});
 	it('can be listened to by onMessageReceived', () => {

--- a/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/interactionEvents.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/interactionEvents.test.ts
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { setGlobalContext } from '@aws-amplify/core/internals/utils';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import { inAppMessages } from '../../../../testUtils/data';
 import {
@@ -28,6 +31,10 @@ describe('Interaction events', () => {
 	beforeAll(() => {
 		setGlobalContext(createMockAmplifyContext());
 		initializeInAppMessaging();
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
 	});
 	it('can be listened to by onMessageReceived', () => {
 		onMessageReceived(handler);

--- a/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/setConflictHandler.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/setConflictHandler.test.ts
@@ -2,13 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
+
+import {
 	initializeInAppMessaging,
 	setConflictHandler,
 } from '../../../../../src/inAppMessaging/providers/pinpoint/apis';
 import { setConflictHandler as setConflictHandlerInteral } from '../../../../../src/inAppMessaging/providers/pinpoint/utils';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
-jest.mock('@aws-amplify/core');
-jest.mock('@aws-amplify/core/internals/utils');
+jest.mock('@aws-amplify/core/internals/utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/utils'),
+	sessionListener: { addStateChangeListener: jest.fn() },
+}));
 jest.mock('../../../../../src/inAppMessaging/providers/pinpoint/utils');
 jest.mock('../../../../../src/eventListeners');
 
@@ -16,7 +24,12 @@ const mockSetConflictHandlerInteral = setConflictHandlerInteral as jest.Mock;
 
 describe('setConflictHandler', () => {
 	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
 		initializeInAppMessaging();
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
 	});
 
 	afterEach(() => {

--- a/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/syncMessages.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/syncMessages.test.ts
@@ -134,6 +134,8 @@ describe('syncMessages', () => {
 		});
 		await syncMessages(ctx);
 
+		expect(mockResolveConfig).toHaveBeenCalledWith(ctx);
+		expect(mockResolveCredentials).toHaveBeenCalledWith(ctx);
 		expect(mockDefaultStorage.setItem).toHaveBeenCalledWith(
 			expect.stringContaining(STORAGE_KEY_SUFFIX),
 			JSON.stringify(simpleInAppMessages),

--- a/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/syncMessages.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/apis/syncMessages.test.ts
@@ -7,6 +7,10 @@ import {
 	updateEndpoint,
 } from '@aws-amplify/core/internals/providers/pinpoint';
 import { getInAppMessages } from '@aws-amplify/core/internals/aws-clients/pinpoint';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import {
 	initializeInAppMessaging,
@@ -20,9 +24,10 @@ import {
 } from '../../../../../src/inAppMessaging/providers/pinpoint/utils';
 import { simpleInAppMessages } from '../../../../testUtils/data';
 import { InAppMessagingError } from '../../../../../src/inAppMessaging/errors';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
-jest.mock('@aws-amplify/core/internals/aws-clients/pinpoint');
 jest.mock('@aws-amplify/core');
+jest.mock('@aws-amplify/core/internals/aws-clients/pinpoint');
 jest.mock('@aws-amplify/core/internals/providers/pinpoint');
 jest.mock('../../../../../src/inAppMessaging/providers/pinpoint/utils');
 
@@ -56,6 +61,7 @@ const mockedEmptyMessages = {
 
 describe('syncMessages', () => {
 	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
 		initializeInAppMessaging();
 		mockGetInAppMessagingUserAgentString.mockReturnValue(userAgentValue);
 		mockResolveConfig.mockReturnValue(config);
@@ -65,6 +71,10 @@ describe('syncMessages', () => {
 
 	beforeEach(() => {
 		mockResolveEndpointId.mockResolvedValue('endpoint-id');
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
 	});
 
 	afterEach(() => {
@@ -113,6 +123,20 @@ describe('syncMessages', () => {
 		mockDefaultStorage.setItem.mockRejectedValueOnce(Error);
 		await expect(syncMessages()).rejects.toStrictEqual(
 			expect.any(InAppMessagingError),
+		);
+	});
+
+	it('Gets in-app messages and stores them when called with explicit context', async () => {
+		const ctx = createMockAmplifyContext({
+			Notifications: {
+				InAppMessaging: { Pinpoint: { appId: 'app-id', region: 'region' } },
+			},
+		});
+		await syncMessages(ctx);
+
+		expect(mockDefaultStorage.setItem).toHaveBeenCalledWith(
+			expect.stringContaining(STORAGE_KEY_SUFFIX),
+			JSON.stringify(simpleInAppMessages),
 		);
 	});
 });

--- a/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/utils/resolveConfig.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/utils/resolveConfig.test.ts
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
-
 import { resolveConfig } from '../../../../../src/inAppMessaging/providers/pinpoint/utils';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 describe('resolveConfig', () => {
 	const validConfig = {
@@ -14,8 +13,8 @@ describe('resolveConfig', () => {
 		},
 	};
 	it('should return the configured appId and region', () => {
-		Amplify.configure(validConfig);
-		expect(resolveConfig()).toStrictEqual(
+		const ctx = createMockAmplifyContext(validConfig);
+		expect(resolveConfig(ctx)).toStrictEqual(
 			validConfig.Notifications!.InAppMessaging!.Pinpoint,
 		);
 	});

--- a/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/utils/resolveCredentials.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/providers/pinpoint/utils/resolveCredentials.test.ts
@@ -1,12 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fetchAuthSession } from '@aws-amplify/core';
-
 import { resolveCredentials } from '../../../../../src/inAppMessaging/providers/pinpoint/utils';
-
-jest.mock('@aws-amplify/core');
-const mockFetchAuthSession = fetchAuthSession as jest.Mock;
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 describe('resolveCredentials', () => {
 	const credentials = {
@@ -18,7 +14,8 @@ describe('resolveCredentials', () => {
 	};
 
 	it('should return the credentials and identityId', async () => {
-		mockFetchAuthSession.mockReturnValue(credentials);
-		expect(await resolveCredentials()).toStrictEqual(credentials);
+		const ctx = createMockAmplifyContext();
+		(ctx.fetchAuthSession as jest.Mock).mockResolvedValue(credentials);
+		expect(await resolveCredentials(ctx)).toStrictEqual(credentials);
 	});
 });

--- a/packages/notifications/__tests__/inAppMessaging/utils/processInAppMessages.test.ts
+++ b/packages/notifications/__tests__/inAppMessaging/utils/processInAppMessages.test.ts
@@ -1,8 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 import { cloneDeep } from 'lodash';
 
+import { createMockAmplifyContext } from '../../testUtils/createMockAmplifyContext';
 import {
 	pinpointInAppMessage,
 	simpleInAppMessagingEvent,
@@ -19,8 +24,10 @@ import {
 } from '../../../src/inAppMessaging/providers/pinpoint/utils/helpers';
 import { initializeInAppMessaging } from '../../../src/inAppMessaging/providers/pinpoint/apis';
 
-jest.mock('@aws-amplify/core');
-jest.mock('@aws-amplify/core/internals/utils');
+jest.mock('@aws-amplify/core/internals/utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/utils'),
+	sessionListener: { addStateChangeListener: jest.fn() },
+}));
 jest.mock('../../../src/inAppMessaging/providers/pinpoint/utils/helpers');
 
 const mockIsBeforeEndDate = isBeforeEndDate as jest.Mock;
@@ -46,8 +53,13 @@ describe('processInAppMessages', () => {
 		},
 	];
 	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
 		initializeInAppMessaging();
 	});
+	afterAll(() => {
+		clearGlobalContext();
+	});
+
 	beforeEach(() => {
 		mockMatchesEventType.mockReturnValue(true);
 		mockMatchesAttributes.mockReturnValue(true);

--- a/packages/notifications/__tests__/pushNotifications/index.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/index.test.ts
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ConsoleLogger } from '@aws-amplify/core';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import * as defaultExports from '../../src/pushNotifications';
 import * as customerProfilesExports from '../../src/pushNotifications/providers/customer-profiles';
+import { createMockAmplifyContext } from '../testUtils/createMockAmplifyContext';
 
 const DEPRECATED_RUNTIME_APIS = [
 	'getBadgeCount',
@@ -22,6 +27,14 @@ const DEPRECATED_RUNTIME_APIS = [
 
 describe('push-notifications default (Pinpoint) entry point', () => {
 	const loggerWarnSpy = jest.spyOn(ConsoleLogger.prototype, 'warn');
+
+	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
 
 	beforeEach(() => {
 		loggerWarnSpy.mockClear();

--- a/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/identifyUser.native.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/identifyUser.native.test.ts
@@ -1,9 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
+
 import { identifyUser } from '../../../../../src/pushNotifications/providers/customer-profiles/apis/identifyUser.native';
 import { identifyUserInternal } from '../../../../../src/pushNotifications/providers/customer-profiles/utils/identifyUserInternal';
 import { IdentifyUserInput } from '../../../../../src/pushNotifications/providers/customer-profiles/types';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 jest.mock(
 	'../../../../../src/pushNotifications/providers/customer-profiles/utils/identifyUserInternal',
@@ -11,6 +17,14 @@ jest.mock(
 
 describe('identifyUser (customer-profiles, native)', () => {
 	const mockIdentifyUserInternal = identifyUserInternal as jest.Mock;
+
+	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
 
 	beforeEach(() => {
 		mockIdentifyUserInternal.mockResolvedValue(undefined);
@@ -31,10 +45,10 @@ describe('identifyUser (customer-profiles, native)', () => {
 		await identifyUser(input);
 
 		expect(mockIdentifyUserInternal).toHaveBeenCalledTimes(1);
-		expect(mockIdentifyUserInternal).toHaveBeenCalledWith({
+		expect(mockIdentifyUserInternal).toHaveBeenCalledWith(expect.anything(), {
 			userProfile: input.userProfile,
 		});
-		const call = mockIdentifyUserInternal.mock.calls[0][0];
+		const call = mockIdentifyUserInternal.mock.calls[0][1];
 		// native identify no longer registers a device or sends a userId
 		expect(call).not.toHaveProperty('userId');
 		expect(call).not.toHaveProperty('deviceToken');
@@ -45,7 +59,9 @@ describe('identifyUser (customer-profiles, native)', () => {
 	it('forwards a minimal input (empty userProfile)', async () => {
 		await identifyUser({ userProfile: {} });
 
-		expect(mockIdentifyUserInternal).toHaveBeenCalledWith({ userProfile: {} });
+		expect(mockIdentifyUserInternal).toHaveBeenCalledWith(expect.anything(), {
+			userProfile: {},
+		});
 	});
 
 	it('rejects if the identify request rejects', async () => {

--- a/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/identifyUser.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/identifyUser.test.ts
@@ -1,9 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
+
 import { identifyUser } from '../../../../../src/pushNotifications/providers/customer-profiles/apis/identifyUser';
 import { identifyUserInternal } from '../../../../../src/pushNotifications/providers/customer-profiles/utils/identifyUserInternal';
 import { IdentifyUserInput } from '../../../../../src/pushNotifications/providers/customer-profiles/types';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 jest.mock(
 	'../../../../../src/pushNotifications/providers/customer-profiles/utils/identifyUserInternal',
@@ -11,6 +17,14 @@ jest.mock(
 
 describe('identifyUser (customer-profiles, web)', () => {
 	const mockIdentifyUserInternal = identifyUserInternal as jest.Mock;
+
+	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
 
 	beforeEach(() => {
 		mockIdentifyUserInternal.mockResolvedValue(undefined);
@@ -32,10 +46,10 @@ describe('identifyUser (customer-profiles, web)', () => {
 		await identifyUser(input);
 
 		expect(mockIdentifyUserInternal).toHaveBeenCalledTimes(1);
-		expect(mockIdentifyUserInternal).toHaveBeenCalledWith({
+		expect(mockIdentifyUserInternal).toHaveBeenCalledWith(expect.anything(), {
 			userProfile: input.userProfile,
 		});
-		const call = mockIdentifyUserInternal.mock.calls[0][0];
+		const call = mockIdentifyUserInternal.mock.calls[0][1];
 		expect(call).not.toHaveProperty('userId');
 		expect(call).not.toHaveProperty('deviceToken');
 		expect(call).not.toHaveProperty('channelType');
@@ -45,7 +59,9 @@ describe('identifyUser (customer-profiles, web)', () => {
 	it('forwards a minimal input (empty userProfile)', async () => {
 		await identifyUser({ userProfile: {} });
 
-		expect(mockIdentifyUserInternal).toHaveBeenCalledWith({ userProfile: {} });
+		expect(mockIdentifyUserInternal).toHaveBeenCalledWith(expect.anything(), {
+			userProfile: {},
+		});
 	});
 
 	it('rejects when the underlying identify request rejects', async () => {

--- a/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.native.reconfigure.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.native.reconfigure.test.ts
@@ -1,0 +1,181 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
+import { Hub } from '@aws-amplify/core';
+
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
+import {
+	getToken,
+	isInitialized,
+} from '../../../../../src/pushNotifications/utils';
+import { registerDevice } from '../../../../../src/pushNotifications/providers/customer-profiles/apis/registerDevice';
+import { pushModuleConstants, pushToken } from '../../../../testUtils/data';
+
+jest.mock('@aws-amplify/core', () => ({
+	...jest.requireActual('@aws-amplify/core'),
+	ConsoleLogger: jest.fn(() => ({
+		info: jest.fn(),
+		error: jest.fn(),
+	})),
+	Hub: { listen: jest.fn() },
+}));
+jest.mock('@aws-amplify/react-native', () => ({
+	getOperatingSystem: jest.fn(),
+	loadAmplifyPushNotification: jest.fn(() => ({
+		addMessageEventListener: mockAddMessageEventListener,
+		addTokenEventListener: mockAddTokenEventListener,
+		completeNotification: jest.fn(),
+		getConstants: mockGetConstants,
+		registerHeadlessTask: jest.fn(),
+	})),
+}));
+jest.mock('../../../../../src/eventListeners');
+jest.mock(
+	'../../../../../src/pushNotifications/providers/customer-profiles/utils',
+);
+jest.mock(
+	'../../../../../src/pushNotifications/providers/customer-profiles/apis/registerDevice',
+);
+jest.mock('../../../../../src/pushNotifications/utils');
+
+const mockAddMessageEventListener = jest.fn();
+const mockAddTokenEventListener = jest.fn();
+const mockGetConstants = jest.fn();
+
+const mockRegisterDevice = registerDevice as jest.Mock;
+const mockHubListen = Hub.listen as jest.Mock;
+const mockGetToken = getToken as jest.Mock;
+const mockIsInitialized = isInitialized as jest.Mock;
+
+describe('initializePushNotifications (customer-profiles, native) — reconfigure support', () => {
+	let initializePushNotifications: (...args: any[]) => void;
+
+	const ctxA = createMockAmplifyContext({
+		Notifications: {
+			PushNotification: {
+				CustomerProfiles: {
+					endpoint: 'https://a.example.com',
+					region: 'us-west-2',
+				},
+			},
+		},
+	});
+	const ctxB = createMockAmplifyContext({
+		Notifications: {
+			PushNotification: {
+				CustomerProfiles: {
+					endpoint: 'https://b.example.com',
+					region: 'us-east-1',
+				},
+			},
+		},
+	});
+
+	beforeAll(() => {
+		({
+			initializePushNotifications,
+		} = require('../../../../../src/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.native'));
+	});
+
+	beforeEach(() => {
+		mockGetConstants.mockReturnValue(pushModuleConstants);
+		mockIsInitialized.mockReturnValue(false);
+		mockRegisterDevice.mockResolvedValue(undefined);
+		mockAddMessageEventListener.mockReturnValue({ remove: jest.fn() });
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
+
+	it('token listener uses updated global context after reconfigure', async () => {
+		setGlobalContext(ctxA);
+		mockGetToken.mockReturnValue(undefined);
+
+		let tokenHandler: (token: string) => Promise<void>;
+		mockAddTokenEventListener.mockImplementation((_event, handler) => {
+			tokenHandler = handler;
+		});
+
+		initializePushNotifications();
+
+		// First token — ctx should be ctxA
+		await tokenHandler!('token-1');
+		expect(mockRegisterDevice).toHaveBeenCalledWith(ctxA, { token: 'token-1' });
+
+		// Reconfigure
+		setGlobalContext(ctxB);
+		mockGetToken.mockReturnValue('token-1');
+		mockRegisterDevice.mockClear();
+
+		// Second token — ctx should be ctxB
+		await tokenHandler!('token-2');
+		expect(mockRegisterDevice).toHaveBeenCalledWith(ctxB, { token: 'token-2' });
+	});
+
+	it('auth listener uses updated global context after reconfigure', async () => {
+		setGlobalContext(ctxA);
+		mockGetToken.mockReturnValue(pushToken);
+
+		initializePushNotifications();
+
+		const authHandler = mockHubListen.mock.calls.find(
+			call => call[0] === 'auth',
+		)![1];
+
+		// Fire auth event with ctxA
+		authHandler({ payload: { event: 'signedIn' } });
+		await Promise.resolve();
+		expect(mockRegisterDevice).toHaveBeenCalledWith(ctxA, { token: pushToken });
+
+		// Reconfigure
+		setGlobalContext(ctxB);
+		mockRegisterDevice.mockClear();
+
+		// Fire auth event again — should now use ctxB
+		authHandler({ payload: { event: 'signedIn' } });
+		await Promise.resolve();
+		expect(mockRegisterDevice).toHaveBeenCalledWith(ctxB, { token: pushToken });
+	});
+
+	it('explicit ctx remains pinned even after global context changes', async () => {
+		const explicitCtx = createMockAmplifyContext({
+			Notifications: {
+				PushNotification: {
+					CustomerProfiles: {
+						endpoint: 'https://explicit.example.com',
+						region: 'eu-west-1',
+					},
+				},
+			},
+		});
+
+		setGlobalContext(ctxA);
+		mockGetToken.mockReturnValue(undefined);
+
+		let tokenHandler: (token: string) => Promise<void>;
+		mockAddTokenEventListener.mockImplementation((_event, handler) => {
+			tokenHandler = handler;
+		});
+
+		// Initialize with explicit context
+		initializePushNotifications(explicitCtx);
+
+		// Change global context
+		setGlobalContext(ctxB);
+
+		// Token event should still use explicitCtx
+		await tokenHandler!('token-pinned');
+		expect(mockRegisterDevice).toHaveBeenCalledWith(explicitCtx, {
+			token: 'token-pinned',
+		});
+	});
+});

--- a/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.native.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.native.test.ts
@@ -32,6 +32,7 @@ import {
 } from '../../../../testUtils/data';
 
 jest.mock('@aws-amplify/core', () => ({
+	...jest.requireActual('@aws-amplify/core'),
 	ConsoleLogger: jest.fn(() => ({
 		info: jest.fn(),
 		error: jest.fn(),

--- a/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.native.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.native.test.ts
@@ -1,8 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 import { Hub } from '@aws-amplify/core';
 
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 import {
 	notifyEventListeners,
 	notifyEventListenersAndAwaitHandlers,
@@ -107,6 +112,7 @@ describe('initializePushNotifications (customer-profiles, native)', () => {
 	};
 
 	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
 		({
 			initializePushNotifications,
 		} = require('../../../../../src/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.native'));
@@ -118,6 +124,10 @@ describe('initializePushNotifications (customer-profiles, native)', () => {
 	beforeEach(() => {
 		mockGetConstants.mockReturnValue(pushModuleConstants);
 		mockIsInitialized.mockReturnValue(false);
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
 	});
 
 	afterEach(() => {
@@ -279,7 +289,7 @@ describe('initializePushNotifications (customer-profiles, native)', () => {
 							'tokenReceived',
 							pushToken,
 						);
-						expect(mockRegisterDevice).toHaveBeenCalledWith({
+						expect(mockRegisterDevice).toHaveBeenCalledWith(expect.anything(), {
 							token: pushToken,
 						});
 						expect(mockResolveInflightDeviceRegistration).toHaveBeenCalled();
@@ -357,7 +367,9 @@ describe('initializePushNotifications (customer-profiles, native)', () => {
 			await Promise.resolve();
 
 			expect(mockRegisterDevice).toHaveBeenCalledTimes(1);
-			expect(mockRegisterDevice).toHaveBeenCalledWith({ token: pushToken });
+			expect(mockRegisterDevice).toHaveBeenCalledWith(expect.anything(), {
+				token: pushToken,
+			});
 		});
 
 		it('does NOT re-register when no token has been received yet', () => {

--- a/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/registerDevice.native.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/registerDevice.native.test.ts
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getClientInfo } from '@aws-amplify/core/internals/utils';
+import {
+	clearGlobalContext,
+	getClientInfo,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import { assertIsInitialized } from '../../../../../src/pushNotifications/errors/errorHelpers';
 import {
@@ -16,8 +20,12 @@ import {
 	registerDeviceInternal,
 } from '../../../../../src/pushNotifications/providers/customer-profiles/utils';
 import { channelType, pushToken } from '../../../../testUtils/data';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
-jest.mock('@aws-amplify/core/internals/utils');
+jest.mock('@aws-amplify/core/internals/utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/utils'),
+	getClientInfo: jest.fn(),
+}));
 jest.mock('@aws-amplify/react-native', () => ({
 	getOperatingSystem: jest.fn(),
 	loadAsyncStorage: jest.fn(),
@@ -42,6 +50,14 @@ describe('registerDevice (customer-profiles, native)', () => {
 	const mockGetDeviceId = getDeviceId as jest.Mock;
 	const mockGetToken = getToken as jest.Mock;
 	const mockRegisterDeviceInternal = registerDeviceInternal as jest.Mock;
+
+	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
 
 	beforeEach(() => {
 		mockGetClientInfo.mockReturnValue({ platform: 'ios' });
@@ -73,7 +89,7 @@ describe('registerDevice (customer-profiles, native)', () => {
 
 		expect(mockGetDeviceId).toHaveBeenCalledTimes(1);
 		expect(mockRegisterDeviceInternal).toHaveBeenCalledTimes(1);
-		expect(mockRegisterDeviceInternal).toHaveBeenCalledWith({
+		expect(mockRegisterDeviceInternal).toHaveBeenCalledWith(expect.anything(), {
 			token: pushToken,
 			deviceId: DEVICE_ID,
 			platform: 'ios',

--- a/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/registerDevice.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/registerDevice.test.ts
@@ -1,14 +1,26 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import { registerDevice } from '../../../../../src/pushNotifications/providers/customer-profiles/apis/registerDevice';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 describe('registerDevice (customer-profiles, web stub)', () => {
-	it('throws PlatformNotSupportedError', () => {
-		expect(() => registerDevice({ token: 'token' })).toThrow(
-			new PlatformNotSupportedError(),
+	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
+
+	it('throws PlatformNotSupportedError', async () => {
+		await expect(registerDevice({ token: 'token' })).rejects.toThrow(
+			'Function not supported on current platform',
 		);
 	});
 });

--- a/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/removeDevice.native.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/apis/removeDevice.native.test.ts
@@ -1,12 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
+
 import { assertIsInitialized } from '../../../../../src/pushNotifications/errors/errorHelpers';
 import { removeDevice } from '../../../../../src/pushNotifications/providers/customer-profiles/apis/removeDevice.native';
 import {
 	getDeviceId,
 	removeDeviceInternal,
 } from '../../../../../src/pushNotifications/providers/customer-profiles/utils';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 jest.mock('@aws-amplify/react-native', () => ({
 	getOperatingSystem: jest.fn(),
@@ -23,6 +29,14 @@ describe('removeDevice (customer-profiles, native)', () => {
 	const mockAssertIsInitialized = assertIsInitialized as jest.Mock;
 	const mockGetDeviceId = getDeviceId as jest.Mock;
 	const mockRemoveDeviceInternal = removeDeviceInternal as jest.Mock;
+
+	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
 
 	beforeEach(() => {
 		mockGetDeviceId.mockResolvedValue(DEVICE_ID);
@@ -48,7 +62,10 @@ describe('removeDevice (customer-profiles, native)', () => {
 
 		expect(mockGetDeviceId).toHaveBeenCalledTimes(1);
 		expect(mockRemoveDeviceInternal).toHaveBeenCalledTimes(1);
-		expect(mockRemoveDeviceInternal).toHaveBeenCalledWith(DEVICE_ID);
+		expect(mockRemoveDeviceInternal).toHaveBeenCalledWith(
+			expect.anything(),
+			DEVICE_ID,
+		);
 	});
 
 	it('rejects if the remove-device request rejects', async () => {

--- a/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/authStateTransitions.native.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/authStateTransitions.native.test.ts
@@ -1,8 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify, Hub, fetchAuthSession } from '@aws-amplify/core';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
+import { Hub, fetchAuthSession } from '@aws-amplify/core';
 
+import { createMockAmplifyContext } from '../../../testUtils/createMockAmplifyContext';
 import { customerProfilesConfig, pushToken } from '../../../testUtils/data';
 
 jest.mock('@aws-amplify/core', () => ({
@@ -70,10 +75,10 @@ describe('customer-profiles push device auth-state transitions (native)', () => 
 	const mockFetch = jest.fn();
 
 	interface LoadedProvider {
-		initializePushNotifications(): void;
+		initializePushNotifications(ctx: any): void;
 		setToken(token: string): void;
-		registerDevice(input: { token: string }): Promise<void>;
-		removeDevice(): Promise<void>;
+		registerDevice(ctx: any, input: { token: string }): Promise<void>;
+		removeDevice(ctx: any): Promise<void>;
 	}
 
 	// The initializer, token manager, initialization manager and deviceId resolver
@@ -123,18 +128,31 @@ describe('customer-profiles push device auth-state transitions (native)', () => 
 		}));
 
 	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
 		(global as any).fetch = mockFetch;
 	});
 
-	beforeEach(() => {
-		jest.spyOn(Amplify, 'getConfig').mockReturnValue({
+	const makeTestCtx = () => {
+		const ctx = createMockAmplifyContext({
 			Notifications: {
 				PushNotification: { CustomerProfiles: customerProfilesConfig } as any,
 			},
 		});
+		// Wire the ctx's fetchAuthSession to the test's mock so credential
+		// assertions reflect the configured identity.
+		(ctx as any).fetchAuthSession = mockFetchAuthSession;
+
+		return ctx;
+	};
+
+	beforeEach(() => {
 		jest.spyOn(Hub, 'listen');
 		mockFetch.mockResolvedValue({ ok: true, status: 200 });
 		signInAs(AUTH_IDENTITY_ID);
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
 	});
 
 	afterEach(() => {
@@ -146,7 +164,7 @@ describe('customer-profiles push device auth-state transitions (native)', () => 
 	describe('sign-in re-registration (Hub listener)', () => {
 		it('re-registers the device, signing with the now-authenticated identity', async () => {
 			const { initializePushNotifications, setToken } = loadProvider();
-			initializePushNotifications();
+			initializePushNotifications(makeTestCtx());
 			setToken(pushToken);
 
 			// A returning user signs in: the push token is unchanged so the native
@@ -182,7 +200,7 @@ describe('customer-profiles push device auth-state transitions (native)', () => 
 
 		it('does NOT reach the network when no token has been received yet', async () => {
 			const { initializePushNotifications } = loadProvider();
-			initializePushNotifications();
+			initializePushNotifications(makeTestCtx());
 
 			getAuthListener()({ payload: { event: 'signedIn' } });
 			await flushMicrotasks();
@@ -193,7 +211,7 @@ describe('customer-profiles push device auth-state transitions (native)', () => 
 
 		it('does NOT attempt a removal on signedOut (removal after sign-out cannot work)', async () => {
 			const { initializePushNotifications, setToken } = loadProvider();
-			initializePushNotifications();
+			initializePushNotifications(makeTestCtx());
 			setToken(pushToken);
 
 			// After `signOut` the session is a brand-new guest identity — a removal
@@ -210,7 +228,7 @@ describe('customer-profiles push device auth-state transitions (native)', () => 
 	describe('credential path: the identity that signs each call', () => {
 		const initializeProvider = (): LoadedProvider => {
 			const provider = loadProvider();
-			provider.initializePushNotifications();
+			provider.initializePushNotifications(makeTestCtx());
 			provider.setToken(pushToken);
 
 			return provider;
@@ -220,7 +238,7 @@ describe('customer-profiles push device auth-state transitions (native)', () => 
 			const { registerDevice } = initializeProvider();
 			signInAs(AUTH_IDENTITY_ID);
 
-			await registerDevice({ token: pushToken });
+			await registerDevice(makeTestCtx(), { token: pushToken });
 
 			const [request] = signedRequests();
 			expect(request.url).toBe(
@@ -234,6 +252,7 @@ describe('customer-profiles push device auth-state transitions (native)', () => 
 			);
 			// The client never sends an identity — the backend derives principalId
 			// from the signer.
+
 			expect(JSON.stringify(request.body)).not.toContain(AUTH_IDENTITY_ID);
 		});
 
@@ -241,11 +260,11 @@ describe('customer-profiles push device auth-state transitions (native)', () => 
 			const { registerDevice, removeDevice } = initializeProvider();
 
 			signInAs(AUTH_IDENTITY_ID);
-			await registerDevice({ token: pushToken });
+			await registerDevice(makeTestCtx(), { token: pushToken });
 
 			// Sign-out replaces the session with a fresh guest identity.
 			signInAs(GUEST_IDENTITY_ID);
-			await removeDevice();
+			await removeDevice(makeTestCtx());
 
 			const [registerRequest, removeRequest] = signedRequests();
 			expect(registerRequest.authorization).toContain(
@@ -268,8 +287,8 @@ describe('customer-profiles push device auth-state transitions (native)', () => 
 			const { registerDevice, removeDevice } = initializeProvider();
 			signInAs(AUTH_IDENTITY_ID);
 
-			await registerDevice({ token: pushToken });
-			await removeDevice();
+			await registerDevice(makeTestCtx(), { token: pushToken });
+			await removeDevice(makeTestCtx());
 
 			const [registerRequest, removeRequest] = signedRequests();
 			expect(registerRequest.body.device.deviceId).toBe(DEVICE_ID);
@@ -288,9 +307,9 @@ describe('customer-profiles push device auth-state transitions (native)', () => 
 				credentials: undefined,
 			});
 
-			await expect(registerDevice({ token: pushToken })).rejects.toThrow(
-				'Credentials should not be empty.',
-			);
+			await expect(
+				registerDevice(makeTestCtx(), { token: pushToken }),
+			).rejects.toThrow('Credentials should not be empty.');
 			expect(mockFetch).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/utils/identifyUserInternal.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/utils/identifyUserInternal.test.ts
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PushNotificationAction } from '@aws-amplify/core/internals/utils';
+import {
+	PushNotificationAction,
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import {
 	DeviceRegistration,
@@ -17,6 +21,7 @@ import {
 } from '../../../../../src/pushNotifications/providers/customer-profiles/utils/resolveConfig';
 import { channelType } from '../../../../testUtils/data';
 import { PushNotificationValidationErrorCode } from '../../../../../src/pushNotifications/errors';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 jest.mock(
 	'../../../../../src/pushNotifications/providers/customer-profiles/utils/signedFetch',
@@ -24,6 +29,15 @@ jest.mock(
 
 describe('customer-profiles transport callers', () => {
 	const mockSignedFetch = signedFetch as jest.Mock;
+	const mockCtx = createMockAmplifyContext();
+
+	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
 
 	beforeEach(() => {
 		mockSignedFetch.mockResolvedValue(undefined);
@@ -36,21 +50,23 @@ describe('customer-profiles transport callers', () => {
 	describe('identifyUserInternal', () => {
 		it('POSTs the userProfile to the identify-user route (no userId)', async () => {
 			const userProfile = { email: 'user@example.com', name: 'Jane' };
-			await identifyUserInternal({ userProfile });
+			await identifyUserInternal(mockCtx, { userProfile });
 
 			expect(mockSignedFetch).toHaveBeenCalledTimes(1);
 			expect(mockSignedFetch).toHaveBeenCalledWith(
+				mockCtx,
 				IDENTIFY_USER_PATH,
 				{ userProfile },
 				PushNotificationAction.IdentifyUser,
 			);
-			const [, body] = mockSignedFetch.mock.calls[0];
+			const [, , body] = mockSignedFetch.mock.calls[0];
 			expect(body).not.toHaveProperty('userId');
 		});
 
 		it('defaults userProfile to an empty object when omitted', async () => {
-			await identifyUserInternal({});
+			await identifyUserInternal(mockCtx, {});
 			expect(mockSignedFetch).toHaveBeenCalledWith(
+				mockCtx,
 				IDENTIFY_USER_PATH,
 				{ userProfile: {} },
 				PushNotificationAction.IdentifyUser,
@@ -59,7 +75,7 @@ describe('customer-profiles transport callers', () => {
 
 		it('validates the userProfile before calling signedFetch (invalid profile short-circuits the request)', async () => {
 			await expect(
-				identifyUserInternal({
+				identifyUserInternal(mockCtx, {
 					userProfile: { customAttributes: { principalId: 'x' } },
 				}),
 			).rejects.toMatchObject({
@@ -78,10 +94,11 @@ describe('customer-profiles transport callers', () => {
 				appVersion: '',
 				channelType,
 			};
-			await registerDeviceInternal(device);
+			await registerDeviceInternal(mockCtx, device);
 
 			expect(mockSignedFetch).toHaveBeenCalledTimes(1);
 			expect(mockSignedFetch).toHaveBeenCalledWith(
+				mockCtx,
 				REGISTER_DEVICE_PATH,
 				{ device },
 				PushNotificationAction.RegisterDevice,
@@ -91,10 +108,11 @@ describe('customer-profiles transport callers', () => {
 
 	describe('removeDeviceInternal', () => {
 		it('POSTs the deviceId to the remove-device route', async () => {
-			await removeDeviceInternal('device-id');
+			await removeDeviceInternal(mockCtx, 'device-id');
 
 			expect(mockSignedFetch).toHaveBeenCalledTimes(1);
 			expect(mockSignedFetch).toHaveBeenCalledWith(
+				mockCtx,
 				REMOVE_DEVICE_PATH,
 				{ deviceId: 'device-id' },
 				PushNotificationAction.RemoveDevice,

--- a/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/utils/resolveConfig.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/utils/resolveConfig.test.ts
@@ -1,30 +1,29 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
-
 import { resolveConfig } from '../../../../../src/pushNotifications/providers/customer-profiles/utils/resolveConfig';
 import {
 	PushNotificationError,
 	PushNotificationValidationErrorCode,
 } from '../../../../../src/pushNotifications/errors';
 import { customerProfilesConfig } from '../../../../testUtils/data';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 describe('resolveConfig (customer-profiles)', () => {
-	const getConfigSpy = jest.spyOn(Amplify, 'getConfig');
-
-	const mockCustomerProfilesConfig = (config: unknown) => {
-		getConfigSpy.mockReturnValue({
+	const makeCtx = (config: unknown) =>
+		createMockAmplifyContext({
 			Notifications: {
 				PushNotification: { CustomerProfiles: config as any },
 			},
 		});
-	};
 
-	const expectToThrowWithCode = (code: PushNotificationValidationErrorCode) => {
+	const expectToThrowWithCode = (
+		config: unknown,
+		code: PushNotificationValidationErrorCode,
+	) => {
 		let error: unknown;
 		try {
-			resolveConfig();
+			resolveConfig(makeCtx(config));
 		} catch (caught) {
 			error = caught;
 		}
@@ -32,75 +31,78 @@ describe('resolveConfig (customer-profiles)', () => {
 		expect((error as PushNotificationError).name).toBe(code);
 	};
 
-	afterEach(() => {
-		getConfigSpy.mockReset();
-	});
-
 	it('returns the Customer Profiles endpoint and region for an https endpoint', () => {
-		mockCustomerProfilesConfig(customerProfilesConfig);
-		expect(resolveConfig()).toStrictEqual(customerProfilesConfig);
-	});
-
-	it('throws NoEndpoint if endpoint is missing', () => {
-		mockCustomerProfilesConfig({
-			...customerProfilesConfig,
-			endpoint: undefined,
-		});
-		expectToThrowWithCode(PushNotificationValidationErrorCode.NoEndpoint);
-	});
-
-	it('throws NoRegion if region is missing', () => {
-		mockCustomerProfilesConfig({
-			...customerProfilesConfig,
-			region: undefined,
-		});
-		expectToThrowWithCode(PushNotificationValidationErrorCode.NoRegion);
-	});
-
-	it('throws NoEndpoint if the Customer Profiles config is absent', () => {
-		getConfigSpy.mockReturnValue({
-			Notifications: { PushNotification: {} as any },
-		});
-		expectToThrowWithCode(PushNotificationValidationErrorCode.NoEndpoint);
-	});
-
-	it('throws InvalidEndpoint for an http:// (non-https) endpoint', () => {
-		mockCustomerProfilesConfig({
-			...customerProfilesConfig,
-			endpoint: 'http://abcd1234.execute-api.us-east-1.amazonaws.com/prod',
-		});
-		expectToThrowWithCode(PushNotificationValidationErrorCode.InvalidEndpoint);
-	});
-
-	it('throws InvalidEndpoint for a non-https scheme (ftp://)', () => {
-		mockCustomerProfilesConfig({
-			...customerProfilesConfig,
-			endpoint: 'ftp://x',
-		});
-		expectToThrowWithCode(PushNotificationValidationErrorCode.InvalidEndpoint);
-	});
-
-	it('throws InvalidEndpoint for a malformed (non-URL) endpoint', () => {
-		mockCustomerProfilesConfig({
-			...customerProfilesConfig,
-			endpoint: 'not a url',
-		});
-		expectToThrowWithCode(PushNotificationValidationErrorCode.InvalidEndpoint);
-	});
-
-	it('accepts an execute-api host without a stage path', () => {
-		mockCustomerProfilesConfig({
-			...customerProfilesConfig,
-			endpoint: 'https://abcd1234.execute-api.us-east-1.amazonaws.com',
-		});
-		expect(resolveConfig().endpoint).toBe(
-			'https://abcd1234.execute-api.us-east-1.amazonaws.com',
+		expect(resolveConfig(makeCtx(customerProfilesConfig))).toStrictEqual(
+			customerProfilesConfig,
 		);
 	});
 
+	it('throws NoEndpoint if endpoint is missing', () => {
+		expectToThrowWithCode(
+			{ ...customerProfilesConfig, endpoint: undefined },
+			PushNotificationValidationErrorCode.NoEndpoint,
+		);
+	});
+
+	it('throws NoRegion if region is missing', () => {
+		expectToThrowWithCode(
+			{ ...customerProfilesConfig, region: undefined },
+			PushNotificationValidationErrorCode.NoRegion,
+		);
+	});
+
+	it('throws NoEndpoint if the Customer Profiles config is absent', () => {
+		const ctx = createMockAmplifyContext({
+			Notifications: { PushNotification: {} as any },
+		});
+		let error: unknown;
+		try {
+			resolveConfig(ctx);
+		} catch (caught) {
+			error = caught;
+		}
+		expect(error).toBeInstanceOf(PushNotificationError);
+		expect((error as PushNotificationError).name).toBe(
+			PushNotificationValidationErrorCode.NoEndpoint,
+		);
+	});
+
+	it('throws InvalidEndpoint for an http:// (non-https) endpoint', () => {
+		expectToThrowWithCode(
+			{
+				...customerProfilesConfig,
+				endpoint: 'http://abcd1234.execute-api.us-east-1.amazonaws.com/prod',
+			},
+			PushNotificationValidationErrorCode.InvalidEndpoint,
+		);
+	});
+
+	it('throws InvalidEndpoint for a non-https scheme (ftp://)', () => {
+		expectToThrowWithCode(
+			{ ...customerProfilesConfig, endpoint: 'ftp://x' },
+			PushNotificationValidationErrorCode.InvalidEndpoint,
+		);
+	});
+
+	it('throws InvalidEndpoint for a malformed (non-URL) endpoint', () => {
+		expectToThrowWithCode(
+			{ ...customerProfilesConfig, endpoint: 'not a url' },
+			PushNotificationValidationErrorCode.InvalidEndpoint,
+		);
+	});
+
+	it('accepts an execute-api host without a stage path', () => {
+		expect(
+			resolveConfig(
+				makeCtx({
+					...customerProfilesConfig,
+					endpoint: 'https://abcd1234.execute-api.us-east-1.amazonaws.com',
+				}),
+			).endpoint,
+		).toBe('https://abcd1234.execute-api.us-east-1.amazonaws.com');
+	});
+
 	describe('endpoint host allowlist', () => {
-		// SigV4 execute-api credentials travel with every request to this
-		// endpoint, so a non-API-Gateway host MUST be rejected outright.
 		it.each([
 			['an unrelated host', 'https://evil.com'],
 			['an unrelated host with a plausible path', 'https://evil.com/prod'],
@@ -125,18 +127,18 @@ describe('resolveConfig (customer-profiles)', () => {
 				'https://abcd1234.execute-api.us-east-1.amazonaws.com@evil.com',
 			],
 		])('throws InvalidEndpoint for %s', (_, endpoint) => {
-			mockCustomerProfilesConfig({ ...customerProfilesConfig, endpoint });
 			expectToThrowWithCode(
+				{ ...customerProfilesConfig, endpoint },
 				PushNotificationValidationErrorCode.InvalidEndpoint,
 			);
 		});
 
 		it('accepts the execute-api host of the configured region', () => {
-			mockCustomerProfilesConfig({
+			const ctx = makeCtx({
 				endpoint: 'https://xyz789.execute-api.eu-west-2.amazonaws.com/prod',
 				region: 'eu-west-2',
 			});
-			expect(resolveConfig()).toStrictEqual({
+			expect(resolveConfig(ctx)).toStrictEqual({
 				endpoint: 'https://xyz789.execute-api.eu-west-2.amazonaws.com/prod',
 				region: 'eu-west-2',
 			});
@@ -145,42 +147,47 @@ describe('resolveConfig (customer-profiles)', () => {
 
 	describe('trailing slash normalization', () => {
 		it('strips a trailing slash from a host-only endpoint', () => {
-			mockCustomerProfilesConfig({
-				...customerProfilesConfig,
-				endpoint: 'https://abcd1234.execute-api.us-east-1.amazonaws.com/',
-			});
-			expect(resolveConfig().endpoint).toBe(
-				'https://abcd1234.execute-api.us-east-1.amazonaws.com',
-			);
+			expect(
+				resolveConfig(
+					makeCtx({
+						...customerProfilesConfig,
+						endpoint: 'https://abcd1234.execute-api.us-east-1.amazonaws.com/',
+					}),
+				).endpoint,
+			).toBe('https://abcd1234.execute-api.us-east-1.amazonaws.com');
 		});
 
 		it('strips trailing slashes while PRESERVING a stage path', () => {
-			mockCustomerProfilesConfig({
-				...customerProfilesConfig,
-				endpoint: 'https://abcd1234.execute-api.us-east-1.amazonaws.com/prod/',
-			});
-			expect(resolveConfig().endpoint).toBe(
-				'https://abcd1234.execute-api.us-east-1.amazonaws.com/prod',
-			);
+			expect(
+				resolveConfig(
+					makeCtx({
+						...customerProfilesConfig,
+						endpoint:
+							'https://abcd1234.execute-api.us-east-1.amazonaws.com/prod/',
+					}),
+				).endpoint,
+			).toBe('https://abcd1234.execute-api.us-east-1.amazonaws.com/prod');
 		});
 
 		it('strips repeated trailing slashes', () => {
-			mockCustomerProfilesConfig({
-				...customerProfilesConfig,
-				endpoint:
-					'https://abcd1234.execute-api.us-east-1.amazonaws.com/prod///',
-			});
-			expect(resolveConfig().endpoint).toBe(
-				'https://abcd1234.execute-api.us-east-1.amazonaws.com/prod',
-			);
+			expect(
+				resolveConfig(
+					makeCtx({
+						...customerProfilesConfig,
+						endpoint:
+							'https://abcd1234.execute-api.us-east-1.amazonaws.com/prod///',
+					}),
+				).endpoint,
+			).toBe('https://abcd1234.execute-api.us-east-1.amazonaws.com/prod');
 		});
 
 		it('produces an endpoint that composes with a route path without a double slash', () => {
-			mockCustomerProfilesConfig({
-				...customerProfilesConfig,
-				endpoint: 'https://abcd1234.execute-api.us-east-1.amazonaws.com/',
-			});
-			const { endpoint } = resolveConfig();
+			const { endpoint } = resolveConfig(
+				makeCtx({
+					...customerProfilesConfig,
+					endpoint: 'https://abcd1234.execute-api.us-east-1.amazonaws.com/',
+				}),
+			);
 			expect(new URL(`${endpoint}/identify-user`).toString()).toBe(
 				'https://abcd1234.execute-api.us-east-1.amazonaws.com/identify-user',
 			);

--- a/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/utils/resolveCredentials.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/utils/resolveCredentials.test.ts
@@ -1,12 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fetchAuthSession } from '@aws-amplify/core';
-
 import { PushNotificationError } from '../../../../../src/pushNotifications/errors';
 import { resolveCredentials } from '../../../../../src/pushNotifications/providers/customer-profiles/utils/resolveCredentials';
-
-jest.mock('@aws-amplify/core');
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 describe('Push Notifications Customer Profiles Provider Util: resolveCredentials', () => {
 	const credentials = {
@@ -14,36 +11,34 @@ describe('Push Notifications Customer Profiles Provider Util: resolveCredentials
 		secretAccessKey: 'secret-access-key',
 		sessionToken: 'session-token',
 	};
-	const mockFetchAuthSession = fetchAuthSession as jest.Mock;
-
-	beforeEach(() => {
-		mockFetchAuthSession.mockReset();
-	});
 
 	it('resolves Identity Pool credentials for an authenticated session', async () => {
-		mockFetchAuthSession.mockResolvedValue({
+		const ctx = createMockAmplifyContext();
+		(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
 			tokens: { accessToken: { toString: () => 'ignored' } },
 			credentials,
 			identityId: 'us-east-1:auth-identity-id',
 		});
-		expect(await resolveCredentials()).toStrictEqual({ credentials });
+		expect(await resolveCredentials(ctx)).toStrictEqual({ credentials });
 	});
 
 	it('resolves Identity Pool credentials for a guest session', async () => {
-		mockFetchAuthSession.mockResolvedValue({
+		const ctx = createMockAmplifyContext();
+		(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
 			tokens: undefined,
 			credentials,
 			identityId: 'us-east-1:guest-identity-id',
 		});
-		expect(await resolveCredentials()).toStrictEqual({ credentials });
+		expect(await resolveCredentials(ctx)).toStrictEqual({ credentials });
 	});
 
 	it('throws if no credentials can be resolved', async () => {
-		mockFetchAuthSession.mockResolvedValue({
+		const ctx = createMockAmplifyContext();
+		(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
 			tokens: undefined,
 			credentials: undefined,
 		});
-		await expect(resolveCredentials()).rejects.toBeInstanceOf(
+		await expect(resolveCredentials(ctx)).rejects.toBeInstanceOf(
 			PushNotificationError,
 		);
 	});

--- a/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/utils/signedFetch.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/customer-profiles/utils/signedFetch.test.ts
@@ -2,13 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { signRequest } from '@aws-amplify/core/internals/aws-client-utils';
-import { PushNotificationAction } from '@aws-amplify/core/internals/utils';
+import {
+	PushNotificationAction,
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import { PushNotificationError } from '../../../../../src/pushNotifications/errors';
 import { signedFetch } from '../../../../../src/pushNotifications/providers/customer-profiles/utils/signedFetch';
 import { resolveConfig } from '../../../../../src/pushNotifications/providers/customer-profiles/utils/resolveConfig';
 import { resolveCredentials } from '../../../../../src/pushNotifications/providers/customer-profiles/utils/resolveCredentials';
 import { customerProfilesConfig } from '../../../../testUtils/data';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 jest.mock('@aws-amplify/core/internals/aws-client-utils');
 jest.mock(
@@ -31,12 +36,14 @@ describe('signedFetch (customer-profiles transport)', () => {
 		host: 'abcd1234.execute-api.us-east-1.amazonaws.com',
 		'content-type': 'application/json',
 	};
+	const mockCtx = createMockAmplifyContext();
 	const mockSignRequest = signRequest as jest.Mock;
 	const mockResolveConfig = resolveConfig as jest.Mock;
 	const mockResolveCredentials = resolveCredentials as jest.Mock;
 	const mockFetch = jest.fn();
 
 	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
 		(global as any).fetch = mockFetch;
 	});
 
@@ -51,6 +58,10 @@ describe('signedFetch (customer-profiles transport)', () => {
 		mockFetch.mockResolvedValue({ ok: true, status: 200 });
 	});
 
+	afterAll(() => {
+		clearGlobalContext();
+	});
+
 	afterEach(() => {
 		mockSignRequest.mockReset();
 		mockResolveConfig.mockReset();
@@ -61,6 +72,7 @@ describe('signedFetch (customer-profiles transport)', () => {
 	it('SigV4-signs an execute-api POST and sends the signed request', async () => {
 		const body = { userProfile: { email: 'a@b.com' } };
 		await signedFetch(
+			mockCtx,
 			'/identify-user',
 			body,
 			PushNotificationAction.IdentifyUser,
@@ -96,6 +108,7 @@ describe('signedFetch (customer-profiles transport)', () => {
 
 	it('does NOT send a Bearer/JWT Authorization into signing; fetch uses exactly the signer-returned headers', async () => {
 		await signedFetch(
+			mockCtx,
 			'/register-device',
 			{ device: {} },
 			PushNotificationAction.RegisterDevice,
@@ -121,7 +134,7 @@ describe('signedFetch (customer-profiles transport)', () => {
 		];
 		for (const [path, action] of cases) {
 			mockSignRequest.mockClear();
-			await signedFetch(path, {}, action);
+			await signedFetch(mockCtx, path, {}, action);
 			const ua = mockSignRequest.mock.calls[0][0].headers['x-amz-user-agent'];
 			expect(ua).toContain('aws-amplify/');
 			// category/action pair renders as `pushnotification/<action>`.
@@ -141,6 +154,7 @@ describe('signedFetch (customer-profiles transport)', () => {
 		});
 
 		await signedFetch(
+			mockCtx,
 			'/identify-user',
 			{},
 			PushNotificationAction.IdentifyUser,
@@ -156,14 +170,24 @@ describe('signedFetch (customer-profiles transport)', () => {
 	it('throws a network error when fetch rejects', async () => {
 		mockFetch.mockRejectedValue(new Error('offline'));
 		await expect(
-			signedFetch('/identify-user', {}, PushNotificationAction.IdentifyUser),
+			signedFetch(
+				mockCtx,
+				'/identify-user',
+				{},
+				PushNotificationAction.IdentifyUser,
+			),
 		).rejects.toBeInstanceOf(PushNotificationError);
 	});
 
 	it('throws when the endpoint responds with a non-2xx status', async () => {
 		mockFetch.mockResolvedValue({ ok: false, status: 403 });
 		await expect(
-			signedFetch('/remove-device', {}, PushNotificationAction.RemoveDevice),
+			signedFetch(
+				mockCtx,
+				'/remove-device',
+				{},
+				PushNotificationAction.RemoveDevice,
+			),
 		).rejects.toBeInstanceOf(PushNotificationError);
 	});
 });

--- a/packages/notifications/__tests__/pushNotifications/providers/pinpoint/apis/identifyUser.native.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/pinpoint/apis/identifyUser.native.test.ts
@@ -5,6 +5,10 @@ import {
 	getEndpointId,
 	updateEndpoint,
 } from '@aws-amplify/core/internals/providers/pinpoint';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import { assertIsInitialized } from '../../../../../src/pushNotifications/errors/errorHelpers';
 import { identifyUser } from '../../../../../src/pushNotifications/providers/pinpoint/apis/identifyUser.native';
@@ -24,6 +28,7 @@ import {
 	pinpointConfig,
 	userAgentValue,
 } from '../../../../testUtils/data';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 jest.mock('@aws-amplify/core/internals/providers/pinpoint');
 jest.mock('@aws-amplify/react-native', () => ({
@@ -47,10 +52,15 @@ describe('identifyUser (native)', () => {
 	const mockUpdateEndpoint = updateEndpoint as jest.Mock;
 
 	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
 		mockGetChannelType.mockReturnValue(channelType);
 		mockGetPushNotificationUserAgentString.mockReturnValue(userAgentValue);
 		mockResolveConfig.mockReturnValue(pinpointConfig);
 		mockResolveCredentials.mockResolvedValue(credentials);
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
 	});
 
 	afterEach(() => {

--- a/packages/notifications/__tests__/pushNotifications/providers/pinpoint/apis/identifyUser.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/pinpoint/apis/identifyUser.test.ts
@@ -1,10 +1,24 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
+
 import { identifyUser } from '../../../../../src/pushNotifications/providers/pinpoint/apis/identifyUser';
 import { expectNotSupportedAsync } from '../../../../testUtils/expectNotSupported';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 describe('identifyUser', () => {
+	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
+
 	it('is only supported on React Native', async () => {
 		await expectNotSupportedAsync(
 			identifyUser({ userId: 'user-id', userProfile: {} }),

--- a/packages/notifications/__tests__/pushNotifications/providers/pinpoint/apis/initializePushNotifications.native.reconfigure.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/pinpoint/apis/initializePushNotifications.native.reconfigure.test.ts
@@ -1,0 +1,138 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { updateEndpoint } from '@aws-amplify/core/internals/providers/pinpoint';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
+
+import {
+	getToken,
+	isInitialized,
+	resolveCredentials,
+} from '../../../../../src/pushNotifications/utils';
+import { resolveConfig } from '../../../../../src/pushNotifications/providers/pinpoint/utils';
+import { credentials, pushModuleConstants } from '../../../../testUtils/data';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
+
+jest.mock('@aws-amplify/core/internals/providers/pinpoint');
+jest.mock('@aws-amplify/react-native', () => ({
+	getOperatingSystem: jest.fn(),
+	loadAmplifyPushNotification: jest.fn(() => ({
+		addMessageEventListener: mockAddMessageEventListener,
+		addTokenEventListener: mockAddTokenEventListener,
+		completeNotification: jest.fn(),
+		getConstants: mockGetConstants,
+		registerHeadlessTask: jest.fn(),
+	})),
+}));
+jest.mock('../../../../../src/eventListeners');
+jest.mock('../../../../../src/pushNotifications/providers/pinpoint/utils');
+jest.mock('../../../../../src/pushNotifications/utils');
+
+const mockAddMessageEventListener = jest.fn();
+const mockAddTokenEventListener = jest.fn();
+const mockGetConstants = jest.fn();
+
+const mockUpdateEndpoint = updateEndpoint as jest.Mock;
+const mockGetToken = getToken as jest.Mock;
+const mockIsInitialized = isInitialized as jest.Mock;
+const mockResolveCredentials = resolveCredentials as jest.Mock;
+const mockResolveConfig = resolveConfig as jest.Mock;
+
+describe('initializePushNotifications (native) — reconfigure support', () => {
+	let initializePushNotifications: (...args: any[]) => void;
+
+	const configA = { appId: 'app-A', region: 'us-west-2' };
+	const configB = { appId: 'app-B', region: 'us-east-1' };
+	const ctxA = createMockAmplifyContext({
+		Notifications: { PushNotification: { Pinpoint: configA } },
+	});
+	const ctxB = createMockAmplifyContext({
+		Notifications: { PushNotification: { Pinpoint: configB } },
+	});
+
+	beforeAll(() => {
+		({
+			initializePushNotifications,
+		} = require('../../../../../src/pushNotifications/providers/pinpoint/apis/initializePushNotifications.native'));
+	});
+
+	beforeEach(() => {
+		mockGetConstants.mockReturnValue(pushModuleConstants);
+		mockIsInitialized.mockReturnValue(false);
+		mockResolveCredentials.mockResolvedValue(credentials);
+		mockAddMessageEventListener.mockReturnValue({ remove: jest.fn() });
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
+	});
+
+	it('token listener uses updated global context after Amplify.configure() is called again', async () => {
+		// Set initial global context
+		setGlobalContext(ctxA);
+		mockResolveConfig.mockReturnValue(configA);
+		mockGetToken.mockReturnValue(undefined);
+
+		// Capture the token handler
+		let tokenHandler: (token: string) => Promise<void>;
+		mockAddTokenEventListener.mockImplementation((_event, handler) => {
+			tokenHandler = handler;
+		});
+
+		initializePushNotifications();
+
+		// First token event — should use configA
+		mockResolveConfig.mockReturnValue(configA);
+		await tokenHandler!('token-1');
+		expect(mockUpdateEndpoint).toHaveBeenCalledWith(
+			expect.objectContaining({ appId: configA.appId, region: configA.region }),
+		);
+
+		// Simulate Amplify.configure() swapping global context to ctxB
+		setGlobalContext(ctxB);
+		mockResolveConfig.mockReturnValue(configB);
+		mockGetToken.mockReturnValue('token-1'); // different token needed
+		mockUpdateEndpoint.mockClear();
+
+		// Second token event — should resolve configB from the new global context
+		await tokenHandler!('token-2');
+		expect(mockResolveConfig).toHaveBeenCalledWith(ctxB);
+		expect(mockResolveCredentials).toHaveBeenCalledWith(ctxB);
+		expect(mockUpdateEndpoint).toHaveBeenCalledWith(
+			expect.objectContaining({ appId: configB.appId, region: configB.region }),
+		);
+	});
+
+	it('explicit ctx remains pinned even after global context changes', async () => {
+		const explicitCtx = createMockAmplifyContext({
+			Notifications: { PushNotification: { Pinpoint: configA } },
+		});
+
+		setGlobalContext(ctxB);
+		mockResolveConfig.mockReturnValue(configA);
+		mockGetToken.mockReturnValue(undefined);
+
+		let tokenHandler: (token: string) => Promise<void>;
+		mockAddTokenEventListener.mockImplementation((_event, handler) => {
+			tokenHandler = handler;
+		});
+
+		// Initialize with explicit context
+		initializePushNotifications(explicitCtx);
+
+		// Change global context
+		setGlobalContext(ctxB);
+		mockUpdateEndpoint.mockClear();
+
+		// Token event should still use configA (explicit ctx pinned)
+		await tokenHandler!('token-explicit');
+		expect(mockResolveConfig).toHaveBeenCalledWith(explicitCtx);
+	});
+});

--- a/packages/notifications/__tests__/pushNotifications/providers/pinpoint/apis/initializePushNotifications.native.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/pinpoint/apis/initializePushNotifications.native.test.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { updateEndpoint } from '@aws-amplify/core/internals/providers/pinpoint';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import {
 	notifyEventListeners,
@@ -27,8 +31,8 @@ import {
 	pushToken,
 	simplePushMessage,
 } from '../../../../testUtils/data';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
-jest.mock('@aws-amplify/core');
 jest.mock('@aws-amplify/core/internals/providers/pinpoint');
 jest.mock('@aws-amplify/react-native', () => ({
 	getOperatingSystem: jest.fn(),
@@ -96,6 +100,7 @@ describe('initializePushNotifications (native)', () => {
 	};
 
 	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
 		({
 			initializePushNotifications,
 		} = require('../../../../../src/pushNotifications/providers/pinpoint/apis/initializePushNotifications.native'));
@@ -107,6 +112,10 @@ describe('initializePushNotifications (native)', () => {
 	beforeEach(() => {
 		mockGetConstants.mockReturnValue(pushModuleConstants);
 		mockIsInitialized.mockReturnValue(false);
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
 	});
 
 	afterEach(() => {

--- a/packages/notifications/__tests__/pushNotifications/providers/pinpoint/utils/createMessageEventRecorder.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/pinpoint/utils/createMessageEventRecorder.test.ts
@@ -96,4 +96,41 @@ describe('createMessageEventRecorder', () => {
 			recorder(simplePushMessage);
 		});
 	});
+
+	describe('getter re-resolution', () => {
+		it('resolves context per invocation when a getter is provided', done => {
+			const ctxA = createMockAmplifyContext();
+			const ctxB = createMockAmplifyContext();
+			let callCount = 0;
+			const ctxGetter = () => {
+				callCount += 1;
+
+				return callCount === 1 ? ctxA : ctxB;
+			};
+
+			const recorder = createMessageEventRecorder(
+				ctxGetter,
+				'received_background',
+			);
+
+			let recordCallCount = 0;
+			mockRecord.mockImplementation(() => {
+				recordCallCount += 1;
+				if (recordCallCount === 1) {
+					expect(mockResolveCredentials).toHaveBeenCalledWith(ctxA);
+					expect(mockResolveConfig).toHaveBeenCalledWith(ctxA);
+					mockResolveCredentials.mockClear();
+					mockResolveConfig.mockClear();
+					// Invoke recorder a second time
+					recorder(simplePushMessage);
+				} else {
+					expect(mockResolveCredentials).toHaveBeenCalledWith(ctxB);
+					expect(mockResolveConfig).toHaveBeenCalledWith(ctxB);
+					done();
+				}
+			});
+
+			recorder(simplePushMessage);
+		});
+	});
 });

--- a/packages/notifications/__tests__/pushNotifications/providers/pinpoint/utils/createMessageEventRecorder.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/providers/pinpoint/utils/createMessageEventRecorder.test.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { record } from '@aws-amplify/core/internals/providers/pinpoint';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 
 import { resolveCredentials } from '../../../../../src/pushNotifications/utils';
 import { getAnalyticsEvent } from '../../../../../src/pushNotifications/providers/pinpoint/utils/getAnalyticsEvent';
@@ -15,6 +19,7 @@ import {
 	pinpointConfig,
 	simplePushMessage,
 } from '../../../../testUtils/data';
+import { createMockAmplifyContext } from '../../../../testUtils/createMockAmplifyContext';
 
 jest.mock('@aws-amplify/core/internals/providers/pinpoint');
 jest.mock('@aws-amplify/react-native', () => ({
@@ -33,6 +38,7 @@ jest.mock('../../../../../src/pushNotifications/utils');
 
 describe('createMessageEventRecorder', () => {
 	// assert mocks
+	const mockCtx = createMockAmplifyContext();
 	const mockRecord = record as jest.Mock;
 	const mockGetAnalyticsEvent = getAnalyticsEvent as jest.Mock;
 	const mockGetChannelType = getChannelType as jest.Mock;
@@ -40,10 +46,15 @@ describe('createMessageEventRecorder', () => {
 	const mockResolveConfig = resolveConfig as jest.Mock;
 
 	beforeAll(() => {
+		setGlobalContext(createMockAmplifyContext());
 		mockGetAnalyticsEvent.mockReturnValue(analyticsEvent);
 		mockGetChannelType.mockReturnValue(channelType);
 		mockResolveCredentials.mockResolvedValue(credentials);
 		mockResolveConfig.mockReturnValue(pinpointConfig);
+	});
+
+	afterAll(() => {
+		clearGlobalContext();
 	});
 
 	afterEach(() => {
@@ -51,9 +62,9 @@ describe('createMessageEventRecorder', () => {
 	});
 
 	it('returns message event recorder', () => {
-		expect(createMessageEventRecorder('received_background')).toStrictEqual(
-			expect.any(Function),
-		);
+		expect(
+			createMessageEventRecorder(mockCtx, 'received_background'),
+		).toStrictEqual(expect.any(Function));
 	});
 
 	it('accepts and invokes a callback', done => {
@@ -63,6 +74,7 @@ describe('createMessageEventRecorder', () => {
 			done();
 		});
 		const recorder = createMessageEventRecorder(
+			mockCtx,
 			'received_background',
 			callback,
 		);
@@ -77,7 +89,10 @@ describe('createMessageEventRecorder', () => {
 				);
 				done();
 			});
-			const recorder = createMessageEventRecorder('received_background');
+			const recorder = createMessageEventRecorder(
+				mockCtx,
+				'received_background',
+			);
 			recorder(simplePushMessage);
 		});
 	});

--- a/packages/notifications/__tests__/pushNotifications/utils/resolveConfig.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/utils/resolveConfig.test.ts
@@ -1,47 +1,39 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
-
 import { resolveConfig } from '../../../src/pushNotifications/providers/pinpoint/utils/resolveConfig';
+import { createMockAmplifyContext } from '../../testUtils/createMockAmplifyContext';
 import { pinpointConfig } from '../../testUtils/data';
 
 describe('resolveConfig', () => {
-	// create spies
-	const getConfigSpy = jest.spyOn(Amplify, 'getConfig');
-
-	afterEach(() => {
-		getConfigSpy.mockReset();
-	});
-
 	it('returns required config', () => {
-		getConfigSpy.mockReturnValue({
+		const ctx = createMockAmplifyContext({
 			Notifications: {
 				PushNotification: { Pinpoint: pinpointConfig },
 			},
 		});
-		expect(resolveConfig()).toStrictEqual(pinpointConfig);
+		expect(resolveConfig(ctx)).toStrictEqual(pinpointConfig);
 	});
 
 	it('throws if appId is missing', () => {
-		getConfigSpy.mockReturnValue({
+		const ctx = createMockAmplifyContext({
 			Notifications: {
 				PushNotification: {
 					Pinpoint: { ...pinpointConfig, appId: undefined } as any,
 				},
 			},
 		});
-		expect(resolveConfig).toThrow();
+		expect(() => resolveConfig(ctx)).toThrow();
 	});
 
 	it('throws if region is missing', () => {
-		getConfigSpy.mockReturnValue({
+		const ctx = createMockAmplifyContext({
 			Notifications: {
 				PushNotification: {
 					Pinpoint: { ...pinpointConfig, region: undefined } as any,
 				},
 			},
 		});
-		expect(resolveConfig).toThrow();
+		expect(() => resolveConfig(ctx)).toThrow();
 	});
 });

--- a/packages/notifications/__tests__/pushNotifications/utils/resolveCredentials.test.ts
+++ b/packages/notifications/__tests__/pushNotifications/utils/resolveCredentials.test.ts
@@ -1,31 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fetchAuthSession } from '@aws-amplify/core';
-
-import { resolveCredentials } from '../../../src/pushNotifications/utils';
-import { credentials } from '../../testUtils/data';
-
-jest.mock('@aws-amplify/core');
+import { resolveCredentials } from '../../../src/pushNotifications/utils/resolveCredentials';
+import { createMockAmplifyContext } from '../../testUtils/createMockAmplifyContext';
 
 describe('resolveCredentials', () => {
-	// assert mocks
-	const mockFetchAuthSession = fetchAuthSession as jest.Mock;
+	const credentials = {
+		credentials: {
+			accessKeyId: 'access-key-id',
+			secretAccessKey: 'secret-access-key',
+		},
+		identityId: 'identity-id',
+	};
 
-	beforeEach(() => {
-		mockFetchAuthSession.mockReset();
+	it('should return the credentials and identityId', async () => {
+		const ctx = createMockAmplifyContext();
+		(ctx.fetchAuthSession as jest.Mock).mockResolvedValue(credentials);
+		expect(await resolveCredentials(ctx)).toStrictEqual(credentials);
 	});
 
-	it('resolves required credentials', async () => {
-		mockFetchAuthSession.mockResolvedValue(credentials);
-		expect(await resolveCredentials()).toStrictEqual(credentials);
-	});
-
-	it('throws if credentials are missing', async () => {
-		mockFetchAuthSession.mockReturnValue({
-			...credentials,
-			credentials: undefined,
-		});
-		await expect(resolveCredentials()).rejects.toThrow();
+	it('should throw if credentials are missing', async () => {
+		const ctx = createMockAmplifyContext();
+		(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({});
+		await expect(resolveCredentials(ctx)).rejects.toBeDefined();
 	});
 });

--- a/packages/notifications/__tests__/testUtils/createMockAmplifyContext.ts
+++ b/packages/notifications/__tests__/testUtils/createMockAmplifyContext.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AMPLIFY_CONTEXT_BRAND,
+	AmplifyContext,
+	ResourcesConfig,
+} from '@aws-amplify/core';
+
+/**
+ * Creates a mock AmplifyContext for testing.
+ */
+export function createMockAmplifyContext(
+	resourcesConfig: ResourcesConfig = {},
+): AmplifyContext {
+	const ctx: AmplifyContext = {
+		resourcesConfig,
+		libraryOptions: {},
+		fetchAuthSession: jest.fn().mockResolvedValue({}),
+		clearCredentials: jest.fn().mockResolvedValue(undefined),
+		getTokens: jest.fn().mockResolvedValue(undefined),
+	};
+
+	Object.defineProperty(ctx, AMPLIFY_CONTEXT_BRAND, {
+		value: true,
+		enumerable: false,
+	});
+
+	return ctx;
+}

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/identifyUser.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/identifyUser.ts
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { InAppMessagingAction } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext } from '@aws-amplify/core';
+import {
+	InAppMessagingAction,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
 import {
 	UpdateEndpointException,
 	updateEndpoint,
@@ -69,11 +73,20 @@ import { assertIsInitialized } from '../../../utils';
  *     },
  * });
  */
-export const identifyUser = async (input: IdentifyUserInput): Promise<void> => {
+export async function identifyUser(input: IdentifyUserInput): Promise<void>;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export async function identifyUser(
+	ctx: AmplifyContext,
+	input: IdentifyUserInput,
+): Promise<void>;
+export async function identifyUser(...args: any[]): Promise<void> {
+	const [ctx, input] = resolveCtxArgs<[IdentifyUserInput]>(args);
 	const { userId, userProfile, options } = input;
 	assertIsInitialized();
-	const { credentials, identityId } = await resolveCredentials();
-	const { appId, region } = resolveConfig();
+	const { credentials, identityId } = await resolveCredentials(ctx);
+	const { appId, region } = resolveConfig(ctx);
 	const { address, optOut, userAttributes } = options ?? {};
 	await updateEndpoint({
 		address,
@@ -91,4 +104,4 @@ export const identifyUser = async (input: IdentifyUserInput): Promise<void> => {
 			InAppMessagingAction.IdentifyUser,
 		),
 	});
-};
+}

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.ts
@@ -1,8 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { sessionListener } from '@aws-amplify/core/internals/utils';
-import { Hub, HubCapsule } from '@aws-amplify/core';
+import { AmplifyContext, Hub, HubCapsule } from '@aws-amplify/core';
+import {
+	resolveCtxArgs,
+	sessionListener,
+} from '@aws-amplify/core/internals/utils';
 
 import { InAppMessage, InAppMessagingEvent } from '../../../types';
 import { addEventListener } from '../../../../eventListeners';
@@ -26,7 +29,14 @@ import { dispatchEvent } from './dispatchEvent';
  * initializeInAppMessaging();
  * ```
  */
-export function initializeInAppMessaging(): void {
+export function initializeInAppMessaging(): void;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export function initializeInAppMessaging(ctx: AmplifyContext): void;
+export function initializeInAppMessaging(...args: any[]): void {
+	const [ctx] = resolveCtxArgs<[]>(args);
+
 	if (isInitialized()) {
 		return;
 	}
@@ -35,14 +45,18 @@ export function initializeInAppMessaging(): void {
 
 	// wire up default Pinpoint message event handling
 	addEventListener('messageDisplayed', (message: InAppMessage) => {
-		recordAnalyticsEvent(PinpointMessageEvent.MESSAGE_DISPLAYED, message);
+		recordAnalyticsEvent(ctx, PinpointMessageEvent.MESSAGE_DISPLAYED, message);
 		incrementMessageCounts(message.id);
 	});
 	addEventListener('messageDismissed', (message: InAppMessage) => {
-		recordAnalyticsEvent(PinpointMessageEvent.MESSAGE_DISMISSED, message);
+		recordAnalyticsEvent(ctx, PinpointMessageEvent.MESSAGE_DISMISSED, message);
 	});
 	addEventListener('messageActionTaken', (message: InAppMessage) => {
-		recordAnalyticsEvent(PinpointMessageEvent.MESSAGE_ACTION_TAKEN, message);
+		recordAnalyticsEvent(
+			ctx,
+			PinpointMessageEvent.MESSAGE_ACTION_TAKEN,
+			message,
+		);
 	});
 
 	// listen to analytics hub events

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.ts
@@ -29,6 +29,8 @@ import { dispatchEvent } from './dispatchEvent';
  *
  * @remarks
  * Make sure to call this early in your app at the root entry point after configuring Amplify.
+ * Initialization runs once per session; subsequent calls are no-ops, so a context
+ * passed on a later call will not replace the one captured at first initialization.
  * @example
  * ```ts
  * Amplify.configure(config);

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/initializeInAppMessaging.ts
@@ -1,7 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyContext, Hub, HubCapsule } from '@aws-amplify/core';
+import {
+	AmplifyContext,
+	Hub,
+	HubCapsule,
+	getGlobalContext,
+	isAmplifyContext,
+} from '@aws-amplify/core';
 import {
 	resolveCtxArgs,
 	sessionListener,
@@ -35,7 +41,17 @@ export function initializeInAppMessaging(): void;
  */
 export function initializeInAppMessaging(ctx: AmplifyContext): void;
 export function initializeInAppMessaging(...args: any[]): void {
-	const [ctx] = resolveCtxArgs<[]>(args);
+	// Validate that config is available (throws if not configured yet)
+	resolveCtxArgs<[]>(args);
+
+	// Reconfigure support: the global context is a frozen snapshot swapped on
+	// each Amplify.configure() call. If the caller passed an explicit ctx we pin
+	// it for the lifetime of the listeners; otherwise we resolve the CURRENT
+	// global context at each event so listeners pick up reconfigured values.
+	const explicitCtx = isAmplifyContext(args[0])
+		? (args[0] as AmplifyContext)
+		: undefined;
+	const resolveCtx = (): AmplifyContext => explicitCtx ?? getGlobalContext();
 
 	if (isInitialized()) {
 		return;
@@ -45,15 +61,23 @@ export function initializeInAppMessaging(...args: any[]): void {
 
 	// wire up default Pinpoint message event handling
 	addEventListener('messageDisplayed', (message: InAppMessage) => {
-		recordAnalyticsEvent(ctx, PinpointMessageEvent.MESSAGE_DISPLAYED, message);
+		recordAnalyticsEvent(
+			resolveCtx(),
+			PinpointMessageEvent.MESSAGE_DISPLAYED,
+			message,
+		);
 		incrementMessageCounts(message.id);
 	});
 	addEventListener('messageDismissed', (message: InAppMessage) => {
-		recordAnalyticsEvent(ctx, PinpointMessageEvent.MESSAGE_DISMISSED, message);
+		recordAnalyticsEvent(
+			resolveCtx(),
+			PinpointMessageEvent.MESSAGE_DISMISSED,
+			message,
+		);
 	});
 	addEventListener('messageActionTaken', (message: InAppMessage) => {
 		recordAnalyticsEvent(
-			ctx,
+			resolveCtx(),
 			PinpointMessageEvent.MESSAGE_ACTION_TAKEN,
 			message,
 		);

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/syncMessages.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/apis/syncMessages.ts
@@ -1,9 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { InAppMessagingAction } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext, defaultStorage } from '@aws-amplify/core';
+import {
+	InAppMessagingAction,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
 import { resolveEndpointId } from '@aws-amplify/core/internals/providers/pinpoint';
-import { defaultStorage } from '@aws-amplify/core';
 import {
 	GetInAppMessagesInput,
 	GetInAppMessagesOutput,
@@ -42,9 +45,15 @@ import { assertIsInitialized } from '../../../utils';
  *
  * ```
  */
-export async function syncMessages(): Promise<void> {
+export async function syncMessages(): Promise<void>;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export async function syncMessages(ctx: AmplifyContext): Promise<void>;
+export async function syncMessages(...args: any[]): Promise<void> {
+	const [ctx] = resolveCtxArgs<[]>(args);
 	assertIsInitialized();
-	const messages = await fetchInAppMessages();
+	const messages = await fetchInAppMessages(ctx);
 	if (!messages || messages.length === 0) {
 		return;
 	}
@@ -57,10 +66,10 @@ export async function syncMessages(): Promise<void> {
 	}
 }
 
-async function fetchInAppMessages() {
+async function fetchInAppMessages(ctx: AmplifyContext) {
 	try {
-		const { credentials, identityId } = await resolveCredentials();
-		const { appId, region } = resolveConfig();
+		const { credentials, identityId } = await resolveCredentials(ctx);
+		const { appId, region } = resolveConfig(ctx);
 		const endpointId = await resolveEndpointId({
 			appId,
 			category: CATEGORY,

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/helpers.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/helpers.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ConsoleLogger } from '@aws-amplify/core';
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
 import {
 	InAppMessagingAction,
 	getClientInfo,
@@ -38,13 +38,14 @@ let eventMetricsMemo: Record<string, boolean> = {};
 export const logger = new ConsoleLogger('InAppMessaging.Pinpoint.Utils');
 
 export const recordAnalyticsEvent = (
+	ctx: AmplifyContext,
 	event: PinpointMessageEvent,
 	message: InAppMessage,
 ) => {
-	const { appId, region } = resolveConfig();
+	const { appId, region } = resolveConfig(ctx);
 
 	const { id, metadata } = message;
-	resolveCredentials()
+	resolveCredentials(ctx)
 		.then(({ credentials, identityId }) => {
 			recordCore({
 				appId,

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/resolveConfig.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/resolveConfig.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import {
 	InAppMessagingValidationErrorCode,
@@ -11,9 +11,9 @@ import {
 /**
  * @internal
  */
-export const resolveConfig = () => {
+export const resolveConfig = (ctx: AmplifyContext) => {
 	const { appId, region } =
-		Amplify.getConfig().Notifications?.InAppMessaging?.Pinpoint ?? {};
+		ctx.resourcesConfig.Notifications?.InAppMessaging?.Pinpoint ?? {};
 	assertValidationError(!!appId, InAppMessagingValidationErrorCode.NoAppId);
 	assertValidationError(!!region, InAppMessagingValidationErrorCode.NoRegion);
 

--- a/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/resolveCredentials.ts
+++ b/packages/notifications/src/inAppMessaging/providers/pinpoint/utils/resolveCredentials.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fetchAuthSession } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import {
 	InAppMessagingValidationErrorCode,
@@ -11,8 +11,8 @@ import {
 /**
  * @internal
  */
-export const resolveCredentials = async () => {
-	const { credentials, identityId } = await fetchAuthSession();
+export const resolveCredentials = async (ctx: AmplifyContext) => {
+	const { credentials, identityId } = await ctx.fetchAuthSession();
 	assertValidationError(
 		!!credentials,
 		InAppMessagingValidationErrorCode.NoCredentials,

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/identifyUser.native.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/identifyUser.native.ts
@@ -1,8 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
+
 import { identifyUserInternal } from '../utils/identifyUserInternal';
-import { IdentifyUser } from '../types';
+import { IdentifyUserInput } from '../types';
 
 /**
  * Sends profile information about a user to Amazon Connect Customer Profiles.
@@ -27,6 +30,15 @@ import { IdentifyUser } from '../types';
  *  configuration is incorrect.
  * @returns A promise that will resolve when the operation is complete.
  */
-export const identifyUser: IdentifyUser = async ({ userProfile }) => {
-	await identifyUserInternal({ userProfile });
-};
+export async function identifyUser(input: IdentifyUserInput): Promise<void>;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export async function identifyUser(
+	ctx: AmplifyContext,
+	input: IdentifyUserInput,
+): Promise<void>;
+export async function identifyUser(...args: any[]): Promise<void> {
+	const [ctx, input] = resolveCtxArgs<[IdentifyUserInput]>(args);
+	await identifyUserInternal(ctx, { userProfile: input.userProfile });
+}

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/identifyUser.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/identifyUser.ts
@@ -1,8 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
+
 import { identifyUserInternal } from '../utils/identifyUserInternal';
-import { IdentifyUser } from '../types';
+import { IdentifyUserInput } from '../types';
 
 /**
  * Sends profile information about a user to Amazon Connect Customer Profiles.
@@ -32,6 +35,15 @@ import { IdentifyUser } from '../types';
  * });
  * ```
  */
-export const identifyUser: IdentifyUser = async ({ userProfile }) => {
-	await identifyUserInternal({ userProfile });
-};
+export async function identifyUser(input: IdentifyUserInput): Promise<void>;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export async function identifyUser(
+	ctx: AmplifyContext,
+	input: IdentifyUserInput,
+): Promise<void>;
+export async function identifyUser(...args: any[]): Promise<void> {
+	const [ctx, input] = resolveCtxArgs<[IdentifyUserInput]>(args);
+	await identifyUserInternal(ctx, { userProfile: input.userProfile });
+}

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.native.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.native.ts
@@ -1,7 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyContext, ConsoleLogger, Hub } from '@aws-amplify/core';
+import {
+	AmplifyContext,
+	ConsoleLogger,
+	Hub,
+	getGlobalContext,
+	isAmplifyContext,
+} from '@aws-amplify/core';
 import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
 import { loadAmplifyPushNotification } from '@aws-amplify/react-native';
 
@@ -48,19 +54,29 @@ export function initializePushNotifications(): void;
  */
 export function initializePushNotifications(ctx: AmplifyContext): void;
 export function initializePushNotifications(...args: any[]): void {
-	const [ctx] = resolveCtxArgs<[]>(args);
+	// Validate that config is available (throws if not configured yet)
+	resolveCtxArgs<[]>(args);
+
+	// Reconfigure support: the global context is a frozen snapshot swapped on
+	// each Amplify.configure() call. If the caller passed an explicit ctx we pin
+	// it for the lifetime of the listeners; otherwise we resolve the CURRENT
+	// global context at each event so listeners pick up reconfigured values.
+	const explicitCtx = isAmplifyContext(args[0])
+		? (args[0] as AmplifyContext)
+		: undefined;
+	const resolveCtx = (): AmplifyContext => explicitCtx ?? getGlobalContext();
 
 	if (isInitialized()) {
 		logger.info('Push notifications have already been enabled');
 
 		return;
 	}
-	addNativeListeners(ctx);
-	addAuthListener(ctx);
+	addNativeListeners(resolveCtx);
+	addAuthListener(resolveCtx);
 	initialize();
 }
 
-const addNativeListeners = (ctx: AmplifyContext): void => {
+const addNativeListeners = (resolveCtx: () => AmplifyContext): void => {
 	let launchNotificationOpenedListener:
 		| ReturnType<typeof addMessageEventListener>
 		| undefined;
@@ -166,7 +182,7 @@ const addNativeListeners = (ctx: AmplifyContext): void => {
 			setToken(token);
 			notifyEventListeners('tokenReceived', token);
 			try {
-				await registerReceivedDevice(ctx, token);
+				await registerReceivedDevice(resolveCtx(), token);
 			} catch (err) {
 				logger.error('Failed to register device for push notifications', err);
 				throw err;
@@ -175,7 +191,7 @@ const addNativeListeners = (ctx: AmplifyContext): void => {
 	);
 };
 
-const addAuthListener = (ctx: AmplifyContext): void => {
+const addAuthListener = (resolveCtx: () => AmplifyContext): void => {
 	// Re-register the device at sign-in so it is re-homed from the guest
 	// principal to the now-authenticated one. The push token is unchanged across
 	// a sign-in, so the native token listener short-circuits and would never
@@ -190,7 +206,7 @@ const addAuthListener = (ctx: AmplifyContext): void => {
 				// no token yet — the TOKEN_RECEIVED path performs first registration
 				return;
 			}
-			registerDevice(ctx, { token }).catch(err => {
+			registerDevice(resolveCtx(), { token }).catch(err => {
 				logger.error(
 					'Failed to re-register device for push notifications on sign-in',
 					err,

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.native.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.native.ts
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ConsoleLogger, Hub } from '@aws-amplify/core';
+import { AmplifyContext, ConsoleLogger, Hub } from '@aws-amplify/core';
+import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
 import { loadAmplifyPushNotification } from '@aws-amplify/react-native';
 
 import {
@@ -28,18 +29,38 @@ const logger = new ConsoleLogger('Notifications.PushNotification');
 
 const BACKGROUND_TASK_TIMEOUT = 25; // seconds
 
-export const initializePushNotifications = (): void => {
+/**
+ * Initialize and set up the push notification category. The category must be first initialized before all other
+ * functionalities become available.
+ *
+ * @remarks
+ * It is recommended that this be called as early in your app as possible at the root of your application to allow
+ * background processing of notifications.
+ * @example
+ * ```ts
+ * Amplify.configure(config);
+ * initializePushNotifications();
+ * ```
+ */
+export function initializePushNotifications(): void;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export function initializePushNotifications(ctx: AmplifyContext): void;
+export function initializePushNotifications(...args: any[]): void {
+	const [ctx] = resolveCtxArgs<[]>(args);
+
 	if (isInitialized()) {
 		logger.info('Push notifications have already been enabled');
 
 		return;
 	}
-	addNativeListeners();
-	addAuthListener();
+	addNativeListeners(ctx);
+	addAuthListener(ctx);
 	initialize();
-};
+}
 
-const addNativeListeners = (): void => {
+const addNativeListeners = (ctx: AmplifyContext): void => {
 	let launchNotificationOpenedListener:
 		| ReturnType<typeof addMessageEventListener>
 		| undefined;
@@ -145,7 +166,7 @@ const addNativeListeners = (): void => {
 			setToken(token);
 			notifyEventListeners('tokenReceived', token);
 			try {
-				await registerReceivedDevice(token);
+				await registerReceivedDevice(ctx, token);
 			} catch (err) {
 				logger.error('Failed to register device for push notifications', err);
 				throw err;
@@ -154,7 +175,7 @@ const addNativeListeners = (): void => {
 	);
 };
 
-const addAuthListener = (): void => {
+const addAuthListener = (ctx: AmplifyContext): void => {
 	// Re-register the device at sign-in so it is re-homed from the guest
 	// principal to the now-authenticated one. The push token is unchanged across
 	// a sign-in, so the native token listener short-circuits and would never
@@ -169,7 +190,7 @@ const addAuthListener = (): void => {
 				// no token yet — the TOKEN_RECEIVED path performs first registration
 				return;
 			}
-			registerDevice({ token }).catch(err => {
+			registerDevice(ctx, { token }).catch(err => {
 				logger.error(
 					'Failed to re-register device for push notifications on sign-in',
 					err,
@@ -179,9 +200,12 @@ const addAuthListener = (): void => {
 	});
 };
 
-const registerReceivedDevice = async (token: string): Promise<void> => {
+const registerReceivedDevice = async (
+	ctx: AmplifyContext,
+	token: string,
+): Promise<void> => {
 	try {
-		await registerDevice({ token });
+		await registerDevice(ctx, { token });
 		// always resolve inflight device registration promise here even though the promise is only awaited on by
 		// consumers when device registration is still in flight
 		resolveInflightDeviceRegistration();

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/initializePushNotifications.ts
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
 import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
-
-import { InitializePushNotifications } from '../types';
 
 /**
  * Initialize and set up the push notification category. The category must be first initialized before all other
@@ -21,6 +20,11 @@ import { InitializePushNotifications } from '../types';
  * initializePushNotifications();
  * ```
  */
-export const initializePushNotifications: InitializePushNotifications = () => {
+export function initializePushNotifications(): void;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export function initializePushNotifications(ctx: AmplifyContext): void;
+export function initializePushNotifications(..._args: any[]): void {
 	throw new PlatformNotSupportedError();
-};
+}

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/registerDevice.native.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/registerDevice.native.ts
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getClientInfo } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext } from '@aws-amplify/core';
+import {
+	getClientInfo,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
 
 import { PushNotificationError } from '../../../errors';
 import {
@@ -15,7 +19,7 @@ import {
 	getDeviceId,
 	registerDeviceInternal,
 } from '../utils';
-import { RegisterDevice } from '../types';
+import { RegisterDeviceInput } from '../types';
 
 /**
  * Builds the device-registration wire object. The stable per-install `deviceId`
@@ -62,7 +66,16 @@ export const buildDeviceRegistration = async (
  * @throws validation - Thrown when the library configuration is incorrect.
  * @returns A promise that will resolve when the operation is complete.
  */
-export const registerDevice: RegisterDevice = async ({ token }) => {
+export async function registerDevice(input: RegisterDeviceInput): Promise<void>;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export async function registerDevice(
+	ctx: AmplifyContext,
+	input: RegisterDeviceInput,
+): Promise<void>;
+export async function registerDevice(...args: any[]): Promise<void> {
+	const [ctx, input] = resolveCtxArgs<[RegisterDeviceInput]>(args);
 	assertIsInitialized();
-	await registerDeviceInternal(await buildDeviceRegistration(token));
-};
+	await registerDeviceInternal(ctx, await buildDeviceRegistration(input.token));
+}

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/registerDevice.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/registerDevice.ts
@@ -1,9 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext } from '@aws-amplify/core';
+import {
+	PlatformNotSupportedError,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
 
-import { RegisterDevice } from '../types';
+import { RegisterDeviceInput } from '../types';
 
 /**
  * Registers a push device with Amazon Connect Customer Profiles.
@@ -12,6 +16,15 @@ import { RegisterDevice } from '../types';
  *  an unsupported platform. Currently, only React Native is supported by this
  *  API.
  */
-export const registerDevice: RegisterDevice = () => {
+export async function registerDevice(input: RegisterDeviceInput): Promise<void>;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export async function registerDevice(
+	ctx: AmplifyContext,
+	input: RegisterDeviceInput,
+): Promise<void>;
+export async function registerDevice(...args: any[]): Promise<void> {
+	resolveCtxArgs<[RegisterDeviceInput]>(args);
 	throw new PlatformNotSupportedError();
-};
+}

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/removeDevice.native.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/removeDevice.native.ts
@@ -1,9 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+import { resolveCtxArgs } from '@aws-amplify/core/internals/utils';
+
 import { assertIsInitialized } from '../../../errors/errorHelpers';
 import { getDeviceId, removeDeviceInternal } from '../utils';
-import { RemoveDevice } from '../types';
 
 /**
  * De-registers the current push device from Amazon Connect Customer Profiles.
@@ -31,7 +33,13 @@ import { RemoveDevice } from '../types';
  * await signOut();
  * ```
  */
-export const removeDevice: RemoveDevice = async () => {
+export async function removeDevice(): Promise<void>;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export async function removeDevice(ctx: AmplifyContext): Promise<void>;
+export async function removeDevice(...args: any[]): Promise<void> {
+	const [ctx] = resolveCtxArgs<[]>(args);
 	assertIsInitialized();
-	await removeDeviceInternal(await getDeviceId());
-};
+	await removeDeviceInternal(ctx, await getDeviceId());
+}

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/removeDevice.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/apis/removeDevice.ts
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
 import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
-
-import { RemoveDevice } from '../types';
 
 /**
  * De-registers the current push device from Amazon Connect Customer Profiles.
@@ -18,6 +17,11 @@ import { RemoveDevice } from '../types';
  *  an unsupported platform. Currently, only React Native is supported by this
  *  API.
  */
-export const removeDevice: RemoveDevice = () => {
+export function removeDevice(): Promise<void>;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export function removeDevice(ctx: AmplifyContext): Promise<void>;
+export function removeDevice(..._args: any[]): Promise<void> {
 	throw new PlatformNotSupportedError();
-};
+}

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/types/apis.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/types/apis.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+
 import { IdentifyUserInput, RegisterDeviceInput } from './inputs';
 
 export {
@@ -16,8 +18,17 @@ export {
 	SetBadgeCount,
 } from '../../shared/types';
 
-export type IdentifyUser = (input: IdentifyUserInput) => Promise<void>;
+export interface IdentifyUser {
+	(input: IdentifyUserInput): Promise<void>;
+	(ctx: AmplifyContext, input: IdentifyUserInput): Promise<void>;
+}
 
-export type RegisterDevice = (input: RegisterDeviceInput) => Promise<void>;
+export interface RegisterDevice {
+	(input: RegisterDeviceInput): Promise<void>;
+	(ctx: AmplifyContext, input: RegisterDeviceInput): Promise<void>;
+}
 
-export type RemoveDevice = () => Promise<void>;
+export interface RemoveDevice {
+	(): Promise<void>;
+	(ctx: AmplifyContext): Promise<void>;
+}

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/utils/identifyUserInternal.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/utils/identifyUserInternal.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
 import { PushNotificationAction } from '@aws-amplify/core/internals/utils';
 
 import { ChannelType, UserProfile } from '../types';
@@ -35,13 +36,17 @@ export interface DeviceRegistration {
  *
  * @internal
  */
-export const identifyUserInternal = async ({
-	userProfile,
-}: {
-	userProfile?: UserProfile;
-}): Promise<void> => {
+export const identifyUserInternal = async (
+	ctx: AmplifyContext,
+	{
+		userProfile,
+	}: {
+		userProfile?: UserProfile;
+	},
+): Promise<void> => {
 	validateUserProfile(userProfile);
 	await signedFetch(
+		ctx,
 		IDENTIFY_USER_PATH,
 		{ userProfile: userProfile ?? {} },
 		PushNotificationAction.IdentifyUser,
@@ -55,9 +60,11 @@ export const identifyUserInternal = async ({
  * @internal
  */
 export const registerDeviceInternal = async (
+	ctx: AmplifyContext,
 	device: DeviceRegistration,
 ): Promise<void> => {
 	await signedFetch(
+		ctx,
 		REGISTER_DEVICE_PATH,
 		{ device },
 		PushNotificationAction.RegisterDevice,
@@ -70,8 +77,12 @@ export const registerDeviceInternal = async (
  *
  * @internal
  */
-export const removeDeviceInternal = async (deviceId: string): Promise<void> => {
+export const removeDeviceInternal = async (
+	ctx: AmplifyContext,
+	deviceId: string,
+): Promise<void> => {
 	await signedFetch(
+		ctx,
 		REMOVE_DEVICE_PATH,
 		{ deviceId },
 		PushNotificationAction.RemoveDevice,

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/utils/resolveConfig.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/utils/resolveConfig.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import {
 	PushNotificationError,
@@ -51,9 +51,9 @@ const buildAllowedHostRegExp = (region: string) =>
 /**
  * @internal
  */
-export const resolveConfig = () => {
+export const resolveConfig = (ctx: AmplifyContext) => {
 	const { endpoint, region } =
-		Amplify.getConfig().Notifications?.PushNotification?.CustomerProfiles ?? {};
+		ctx.resourcesConfig.Notifications?.PushNotification?.CustomerProfiles ?? {};
 	assert(!!endpoint, PushNotificationValidationErrorCode.NoEndpoint);
 	assert(!!region, PushNotificationValidationErrorCode.NoRegion);
 

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/utils/resolveCredentials.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/utils/resolveCredentials.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fetchAuthSession } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import { PushNotificationError } from '../../../errors';
 import { PushNotificationValidationErrorCode } from '../../../errors/errorHelpers';
@@ -18,8 +18,8 @@ import { PushNotificationValidationErrorCode } from '../../../errors/errorHelper
  *
  * @internal
  */
-export const resolveCredentials = async () => {
-	const { credentials } = await fetchAuthSession();
+export const resolveCredentials = async (ctx: AmplifyContext) => {
+	const { credentials } = await ctx.fetchAuthSession();
 
 	// Explicit throw (not assert) so TypeScript narrows `credentials` to
 	// non-undefined for the returned value.

--- a/packages/notifications/src/pushNotifications/providers/customer-profiles/utils/signedFetch.ts
+++ b/packages/notifications/src/pushNotifications/providers/customer-profiles/utils/signedFetch.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
 import { signRequest } from '@aws-amplify/core/internals/aws-client-utils';
 import {
 	Category,
@@ -30,12 +31,13 @@ const USER_AGENT_HEADER = 'x-amz-user-agent';
  * @internal
  */
 export const signedFetch = async (
+	ctx: AmplifyContext,
 	path: string,
 	body: unknown,
 	action: PushNotificationAction,
 ): Promise<void> => {
-	const { endpoint, region } = resolveConfig();
-	const { credentials } = await resolveCredentials();
+	const { endpoint, region } = resolveConfig(ctx);
+	const { credentials } = await resolveCredentials(ctx);
 
 	const serializedBody = JSON.stringify(body);
 	const url = new URL(`${endpoint}${path}`);

--- a/packages/notifications/src/pushNotifications/providers/pinpoint/apis/identifyUser.native.ts
+++ b/packages/notifications/src/pushNotifications/providers/pinpoint/apis/identifyUser.native.ts
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PushNotificationAction } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext } from '@aws-amplify/core';
+import {
+	PushNotificationAction,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
 import {
 	getEndpointId,
 	updateEndpoint,
@@ -17,16 +21,32 @@ import {
 	getInflightDeviceRegistration,
 	resolveConfig,
 } from '../utils';
-import { IdentifyUser } from '../types';
+import { IdentifyUserInput } from '../types';
 
-export const identifyUser: IdentifyUser = async ({
-	userId,
-	userProfile,
-	options,
-}) => {
+/**
+ * Sends information about a user to Pinpoint. Sending user information allows you to associate a user to their user
+ * profile and activities or actions in your application. Activity can be tracked across devices & platforms by using
+ * the same `userId`.
+ *
+ * @deprecated AWS will end support for Amazon Pinpoint on October 30, 2026.
+ *
+ * @param input The input object used to construct requests sent to Pinpoint's UpdateEndpoint API.
+ * @returns A promise that will resolve when the operation is complete.
+ */
+export async function identifyUser(input: IdentifyUserInput): Promise<void>;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export async function identifyUser(
+	ctx: AmplifyContext,
+	input: IdentifyUserInput,
+): Promise<void>;
+export async function identifyUser(...args: any[]): Promise<void> {
+	const [ctx, input] = resolveCtxArgs<[IdentifyUserInput]>(args);
+	const { userId, userProfile, options } = input;
 	assertIsInitialized();
-	const { credentials, identityId } = await resolveCredentials();
-	const { appId, region } = resolveConfig();
+	const { credentials, identityId } = await resolveCredentials(ctx);
+	const { appId, region } = resolveConfig(ctx);
 	const { address, optOut, userAttributes } = options ?? {};
 	if (!(await getEndpointId(appId, 'PushNotification'))) {
 		// if there is no cached endpoint id, wait for successful endpoint creation before continuing
@@ -48,4 +68,4 @@ export const identifyUser: IdentifyUser = async ({
 			PushNotificationAction.IdentifyUser,
 		),
 	});
-};
+}

--- a/packages/notifications/src/pushNotifications/providers/pinpoint/apis/identifyUser.ts
+++ b/packages/notifications/src/pushNotifications/providers/pinpoint/apis/identifyUser.ts
@@ -1,11 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+import {
+	PlatformNotSupportedError,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
 import { UpdateEndpointException } from '@aws-amplify/core/internals/providers/pinpoint';
-import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
 
 import { PushNotificationValidationErrorCode } from '../../../errors';
-import { IdentifyUser, IdentifyUserInput } from '../types';
+import { IdentifyUserInput } from '../types';
 
 /**
  * Sends information about a user to Pinpoint. Sending user information allows you to associate a user to their user
@@ -60,6 +64,15 @@ import { IdentifyUser, IdentifyUserInput } from '../types';
  *     },
  * });
  */
-export const identifyUser: IdentifyUser = async () => {
+export async function identifyUser(input: IdentifyUserInput): Promise<void>;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export async function identifyUser(
+	ctx: AmplifyContext,
+	input: IdentifyUserInput,
+): Promise<void>;
+export async function identifyUser(...args: any[]): Promise<void> {
+	resolveCtxArgs<[IdentifyUserInput]>(args);
 	throw new PlatformNotSupportedError();
-};
+}

--- a/packages/notifications/src/pushNotifications/providers/pinpoint/apis/initializePushNotifications.native.ts
+++ b/packages/notifications/src/pushNotifications/providers/pinpoint/apis/initializePushNotifications.native.ts
@@ -1,7 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
+import {
+	AmplifyContext,
+	ConsoleLogger,
+	getGlobalContext,
+	isAmplifyContext,
+} from '@aws-amplify/core';
 import {
 	PushNotificationAction,
 	resolveCtxArgs,
@@ -64,19 +69,29 @@ export function initializePushNotifications(): void;
  */
 export function initializePushNotifications(ctx: AmplifyContext): void;
 export function initializePushNotifications(...args: any[]): void {
-	const [ctx] = resolveCtxArgs<[]>(args);
+	// Validate that config is available (throws if not configured yet)
+	resolveCtxArgs<[]>(args);
+
+	// Reconfigure support: the global context is a frozen snapshot swapped on
+	// each Amplify.configure() call. If the caller passed an explicit ctx we pin
+	// it for the lifetime of the listeners; otherwise we resolve the CURRENT
+	// global context at each event so listeners pick up reconfigured values.
+	const explicitCtx = isAmplifyContext(args[0])
+		? (args[0] as AmplifyContext)
+		: undefined;
+	const resolveCtx = (): AmplifyContext => explicitCtx ?? getGlobalContext();
 
 	if (isInitialized()) {
 		logger.info('Push notifications have already been enabled');
 
 		return;
 	}
-	addNativeListeners(ctx);
-	addAnalyticsListeners(ctx);
+	addNativeListeners(resolveCtx);
+	addAnalyticsListeners(resolveCtx);
 	initialize();
 }
 
-const addNativeListeners = (ctx: AmplifyContext): void => {
+const addNativeListeners = (resolveCtx: () => AmplifyContext): void => {
 	let launchNotificationOpenedListener:
 		| ReturnType<typeof addMessageEventListener>
 		| undefined;
@@ -182,7 +197,7 @@ const addNativeListeners = (ctx: AmplifyContext): void => {
 			setToken(token);
 			notifyEventListeners('tokenReceived', token);
 			try {
-				await registerDevice(ctx, token);
+				await registerDevice(resolveCtx(), token);
 			} catch (err) {
 				logger.error('Failed to register device for push notifications', err);
 				throw err;
@@ -191,22 +206,22 @@ const addNativeListeners = (ctx: AmplifyContext): void => {
 	);
 };
 
-const addAnalyticsListeners = (ctx: AmplifyContext): void => {
+const addAnalyticsListeners = (resolveCtx: () => AmplifyContext): void => {
 	let launchNotificationOpenedListenerRemover: EventListenerRemover | undefined;
 
 	// wire up default Pinpoint message event handling
 	addEventListener(
 		'backgroundMessageReceived',
-		createMessageEventRecorder(ctx, 'received_background'),
+		createMessageEventRecorder(resolveCtx, 'received_background'),
 	);
 	addEventListener(
 		'foregroundMessageReceived',
-		createMessageEventRecorder(ctx, 'received_foreground'),
+		createMessageEventRecorder(resolveCtx, 'received_foreground'),
 	);
 	launchNotificationOpenedListenerRemover = addEventListener(
 		'launchNotificationOpened',
 		createMessageEventRecorder(
-			ctx,
+			resolveCtx,
 			'opened_notification',
 			// once we are done with it we can remove the listener
 			() => {
@@ -218,7 +233,7 @@ const addAnalyticsListeners = (ctx: AmplifyContext): void => {
 	addEventListener(
 		'notificationOpened',
 		createMessageEventRecorder(
-			ctx,
+			resolveCtx,
 			'opened_notification',
 			// if we are in this state, we no longer need the listener as the app was launched via some other means
 			() => {

--- a/packages/notifications/src/pushNotifications/providers/pinpoint/apis/initializePushNotifications.native.ts
+++ b/packages/notifications/src/pushNotifications/providers/pinpoint/apis/initializePushNotifications.native.ts
@@ -1,8 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ConsoleLogger } from '@aws-amplify/core';
-import { PushNotificationAction } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
+import {
+	PushNotificationAction,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
 import { updateEndpoint } from '@aws-amplify/core/internals/providers/pinpoint';
 import { loadAmplifyPushNotification } from '@aws-amplify/react-native';
 
@@ -40,18 +43,40 @@ const logger = new ConsoleLogger('Notifications.PushNotification');
 
 const BACKGROUND_TASK_TIMEOUT = 25; // seconds
 
-export const initializePushNotifications = (): void => {
+/**
+ * Initialize and set up the push notification category. The category must be first initialized before all other
+ * functionalities become available.
+ *
+ * @deprecated AWS will end support for Amazon Pinpoint on October 30, 2026.
+ *
+ * @remarks
+ * It is recommended that this be called as early in your app as possible at the root of your application to allow
+ * background processing of notifications.
+ * @example
+ * ```ts
+ * Amplify.configure(config);
+ * initializePushNotifications();
+ * ```
+ */
+export function initializePushNotifications(): void;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export function initializePushNotifications(ctx: AmplifyContext): void;
+export function initializePushNotifications(...args: any[]): void {
+	const [ctx] = resolveCtxArgs<[]>(args);
+
 	if (isInitialized()) {
 		logger.info('Push notifications have already been enabled');
 
 		return;
 	}
-	addNativeListeners();
-	addAnalyticsListeners();
+	addNativeListeners(ctx);
+	addAnalyticsListeners(ctx);
 	initialize();
-};
+}
 
-const addNativeListeners = (): void => {
+const addNativeListeners = (ctx: AmplifyContext): void => {
 	let launchNotificationOpenedListener:
 		| ReturnType<typeof addMessageEventListener>
 		| undefined;
@@ -157,7 +182,7 @@ const addNativeListeners = (): void => {
 			setToken(token);
 			notifyEventListeners('tokenReceived', token);
 			try {
-				await registerDevice(token);
+				await registerDevice(ctx, token);
 			} catch (err) {
 				logger.error('Failed to register device for push notifications', err);
 				throw err;
@@ -166,21 +191,22 @@ const addNativeListeners = (): void => {
 	);
 };
 
-const addAnalyticsListeners = (): void => {
+const addAnalyticsListeners = (ctx: AmplifyContext): void => {
 	let launchNotificationOpenedListenerRemover: EventListenerRemover | undefined;
 
 	// wire up default Pinpoint message event handling
 	addEventListener(
 		'backgroundMessageReceived',
-		createMessageEventRecorder('received_background'),
+		createMessageEventRecorder(ctx, 'received_background'),
 	);
 	addEventListener(
 		'foregroundMessageReceived',
-		createMessageEventRecorder('received_foreground'),
+		createMessageEventRecorder(ctx, 'received_foreground'),
 	);
 	launchNotificationOpenedListenerRemover = addEventListener(
 		'launchNotificationOpened',
 		createMessageEventRecorder(
+			ctx,
 			'opened_notification',
 			// once we are done with it we can remove the listener
 			() => {
@@ -192,6 +218,7 @@ const addAnalyticsListeners = (): void => {
 	addEventListener(
 		'notificationOpened',
 		createMessageEventRecorder(
+			ctx,
 			'opened_notification',
 			// if we are in this state, we no longer need the listener as the app was launched via some other means
 			() => {
@@ -202,9 +229,12 @@ const addAnalyticsListeners = (): void => {
 	);
 };
 
-const registerDevice = async (address: string): Promise<void> => {
-	const { credentials, identityId } = await resolveCredentials();
-	const { appId, region } = resolveConfig();
+const registerDevice = async (
+	ctx: AmplifyContext,
+	address: string,
+): Promise<void> => {
+	const { credentials, identityId } = await resolveCredentials(ctx);
+	const { appId, region } = resolveConfig(ctx);
 	try {
 		await updateEndpoint({
 			address,

--- a/packages/notifications/src/pushNotifications/providers/pinpoint/apis/initializePushNotifications.ts
+++ b/packages/notifications/src/pushNotifications/providers/pinpoint/apis/initializePushNotifications.ts
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
 import { PlatformNotSupportedError } from '@aws-amplify/core/internals/utils';
-
-import { InitializePushNotifications } from '../types';
 
 /**
  * Initialize and set up the push notification category. The category must be first initialized before all other
@@ -22,6 +21,11 @@ import { InitializePushNotifications } from '../types';
  * initializePushNotifications();
  * ```
  */
-export const initializePushNotifications: InitializePushNotifications = () => {
+export function initializePushNotifications(): void;
+/**
+ * @param ctx - The {@link AmplifyContext} to use for config and credentials.
+ */
+export function initializePushNotifications(ctx: AmplifyContext): void;
+export function initializePushNotifications(..._args: any[]): void {
 	throw new PlatformNotSupportedError();
-};
+}

--- a/packages/notifications/src/pushNotifications/providers/pinpoint/types/apis.ts
+++ b/packages/notifications/src/pushNotifications/providers/pinpoint/types/apis.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+
 import { IdentifyUserInput } from './inputs';
 
 export {
@@ -16,4 +18,7 @@ export {
 	SetBadgeCount,
 } from '../../shared/types';
 
-export type IdentifyUser = (input: IdentifyUserInput) => Promise<void>;
+export interface IdentifyUser {
+	(input: IdentifyUserInput): Promise<void>;
+	(ctx: AmplifyContext, input: IdentifyUserInput): Promise<void>;
+}

--- a/packages/notifications/src/pushNotifications/providers/pinpoint/utils/createMessageEventRecorder.ts
+++ b/packages/notifications/src/pushNotifications/providers/pinpoint/utils/createMessageEventRecorder.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
 import { record } from '@aws-amplify/core/internals/providers/pinpoint';
-import { ConsoleLogger } from '@aws-amplify/core';
 import { AWSCredentials } from '@aws-amplify/core/internals/utils';
 
 import { PinpointMessageEvent } from '../types';
@@ -23,12 +23,13 @@ const logger = new ConsoleLogger('PushNotification.recordMessageEvent');
  */
 export const createMessageEventRecorder =
 	(
+		ctx: AmplifyContext,
 		event: PinpointMessageEvent,
 		callback?: () => void,
 	): OnPushNotificationMessageHandler =>
 	async message => {
-		const { credentials } = await resolveCredentials();
-		const { appId, region } = resolveConfig();
+		const { credentials } = await resolveCredentials(ctx);
+		const { appId, region } = resolveConfig(ctx);
 		await recordMessageEvent({
 			appId,
 			credentials,

--- a/packages/notifications/src/pushNotifications/providers/pinpoint/utils/createMessageEventRecorder.ts
+++ b/packages/notifications/src/pushNotifications/providers/pinpoint/utils/createMessageEventRecorder.ts
@@ -20,14 +20,20 @@ const logger = new ConsoleLogger('PushNotification.recordMessageEvent');
 
 /**
  * @internal
+ *
+ * Accepts either a resolved {@link AmplifyContext} or a getter that returns one.
+ * When a getter is provided the context is resolved at each event invocation,
+ * supporting reconfigure — the global context is a frozen snapshot swapped on
+ * every Amplify.configure() call.
  */
 export const createMessageEventRecorder =
 	(
-		ctx: AmplifyContext,
+		ctxOrGetter: AmplifyContext | (() => AmplifyContext),
 		event: PinpointMessageEvent,
 		callback?: () => void,
 	): OnPushNotificationMessageHandler =>
 	async message => {
+		const ctx = typeof ctxOrGetter === 'function' ? ctxOrGetter() : ctxOrGetter;
 		const { credentials } = await resolveCredentials(ctx);
 		const { appId, region } = resolveConfig(ctx);
 		await recordMessageEvent({

--- a/packages/notifications/src/pushNotifications/providers/pinpoint/utils/resolveConfig.ts
+++ b/packages/notifications/src/pushNotifications/providers/pinpoint/utils/resolveConfig.ts
@@ -1,16 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Amplify } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import { PushNotificationValidationErrorCode, assert } from '../../../errors';
 
 /**
  * @internal
  */
-export const resolveConfig = () => {
+export const resolveConfig = (ctx: AmplifyContext) => {
 	const { appId, region } =
-		Amplify.getConfig().Notifications?.PushNotification?.Pinpoint ?? {};
+		ctx.resourcesConfig.Notifications?.PushNotification?.Pinpoint ?? {};
 	assert(!!appId, PushNotificationValidationErrorCode.NoAppId);
 	assert(!!region, PushNotificationValidationErrorCode.NoRegion);
 

--- a/packages/notifications/src/pushNotifications/providers/shared/types/apis.ts
+++ b/packages/notifications/src/pushNotifications/providers/shared/types/apis.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext } from '@aws-amplify/core';
+
 import {
 	OnNotificationOpenedInput,
 	OnNotificationReceivedInBackgroundInput,
@@ -26,7 +28,10 @@ export type GetLaunchNotification = () => Promise<GetLaunchNotificationOutput>;
 
 export type GetPermissionStatus = () => Promise<GetPermissionStatusOutput>;
 
-export type InitializePushNotifications = () => void;
+export interface InitializePushNotifications {
+	(): void;
+	(ctx: AmplifyContext): void;
+}
 
 export type RequestPermissions = (
 	input?: RequestPermissionsInput,

--- a/packages/notifications/src/pushNotifications/utils/deprecatePinpoint.ts
+++ b/packages/notifications/src/pushNotifications/utils/deprecatePinpoint.ts
@@ -29,12 +29,12 @@ const DEPRECATION_MESSAGE =
  *
  * @internal
  */
-export const deprecatePinpoint = <TArgs extends any[], TReturn>(
-	fn: (...args: TArgs) => TReturn,
-): ((...args: TArgs) => TReturn) => {
+export const deprecatePinpoint = <T extends (...args: any[]) => any>(
+	fn: T,
+): T => {
 	let warned = false;
 
-	return (...args: TArgs): TReturn => {
+	const wrapper = (...args: any[]): any => {
 		if (!warned) {
 			warned = true;
 			logger.warn(DEPRECATION_MESSAGE);
@@ -42,4 +42,6 @@ export const deprecatePinpoint = <TArgs extends any[], TReturn>(
 
 		return fn(...args);
 	};
+
+	return wrapper as unknown as T;
 };

--- a/packages/notifications/src/pushNotifications/utils/resolveCredentials.ts
+++ b/packages/notifications/src/pushNotifications/utils/resolveCredentials.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { fetchAuthSession } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import {
 	PushNotificationValidationErrorCode,
@@ -11,8 +11,8 @@ import {
 /**
  * @internal
  */
-export const resolveCredentials = async () => {
-	const { credentials, identityId } = await fetchAuthSession();
+export const resolveCredentials = async (ctx: AmplifyContext) => {
+	const { credentials, identityId } = await ctx.fetchAuthSession();
 	assert(!!credentials, PushNotificationValidationErrorCode.NoCredentials);
 
 	return { credentials, identityId };


### PR DESCRIPTION
#### Description of changes

B-notifications split of the v6 context migration (Task 6 of the migration plan): migrates `@aws-amplify/notifications` from the `Amplify.getConfig()` / singleton `fetchAuthSession` pattern to explicit `AmplifyContext`, with backward-compatible overloads.

- **In-app messaging (Pinpoint)**: `identifyUser`, `syncMessages`, `initializeInAppMessaging` gain `fn(input)` / `fn(ctx, input)` overloads (Pattern 1/2, variadic impl via `resolveCtxArgs`). Event-listener-only APIs (`onMessage*`, `dispatchEvent`, `clearMessages`, `setConflictHandler`) are deliberately not overloaded — they have no config/credential dependency.
- **Push notifications (Pinpoint + Amazon Connect Customer Profiles, incl. #14866 scope)**: `identifyUser`, `initializePushNotifications`, `registerDevice`, `removeDevice` and all `.native` variants gain overloads; web not-supported stubs use the canonical variadic signature.
- **Utils (Pattern 4)**: all six singleton read sites (`resolveConfig`/`resolveCredentials` across the three providers) now read `ctx.resourcesConfig` and call `ctx.fetchAuthSession()`; `helpers.ts`, `createMessageEventRecorder.ts`, `signedFetch.ts`, `identifyUserInternal.ts` take `ctx` as first param. Zero direct singleton reads remain in `src/`.
- **Types**: `types/apis.ts` in pinpoint, customer-profiles, and shared expose both call signatures; the `deprecatePinpoint` wrapper is typed generically so overloads survive wrapping.
- **Tests**: new `__tests__/testUtils/createMockAmplifyContext.ts` (branded factory matching `packages/auth`); ~28 test files migrated off `@aws-amplify/core` getConfig/fetchAuthSession mocking to `setGlobalContext`/`clearGlobalContext` with cleanup; explicit `(ctx, ...)` overload coverage added.

No server wrappers (client-only package). No changeset (feature-branch target).

#### Issue #, if available

Part of the v6 context migration (base: Split A #14805, reference: B-auth #14836).

#### Description of how you validated changes

- `yarn turbo run build --filter=@aws-amplify/notifications` — exit 0
- `npx eslint '**/*.{ts,tsx}'` in `packages/notifications` — 0 errors
- `yarn turbo run test --filter=@aws-amplify/notifications` — 61/61 suites, 263/263 tests passing (includes new context-overload tests)

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
