### PR TITLE
feat(geo): migrate Geo to AmplifyContext

### DIFF
--- a/packages/geo/__tests__/Geo.test.ts
+++ b/packages/geo/__tests__/Geo.test.ts
@@ -669,4 +669,127 @@ describe('Geo', () => {
 			);
 		});
 	});
+
+	describe('lazy context resolution', () => {
+		afterEach(() => {
+			clearGlobalContext();
+		});
+
+		test('reconfigure honored: global context change is picked up by the same GeoClass/provider instance', async () => {
+			// Restore the LocationClient mock for this test
+			const sendMock = jest.fn(async command => {
+				if (command instanceof SearchPlaceIndexForTextCommand) {
+					return {
+						Results: [{ Place: TestPlacePascalCase }],
+					};
+				}
+			});
+			LocationClient.prototype.send = sendMock;
+
+			const ctxA = createMockAmplifyContext(awsConfigGeoV4);
+			(ctxA.fetchAuthSession as jest.Mock).mockResolvedValue({ credentials });
+
+			setGlobalContext(ctxA);
+			const geo = new GeoClass();
+
+			// First operation uses ctxA's config
+			const resultsA = await geo.searchByText('test');
+			expect(resultsA).toEqual([testPlaceCamelCase]);
+			expect(ctxA.fetchAuthSession).toHaveBeenCalled();
+
+			// Reconfigure with a different context (different search index)
+			const altConfig = {
+				...awsConfigGeoV4,
+				Geo: {
+					LocationService: {
+						...awsConfigGeoV4.Geo!.LocationService,
+						searchIndices: {
+							items: ['altSearchIndex'],
+							default: 'altSearchIndex',
+						},
+					},
+				},
+			};
+			const ctxB = createMockAmplifyContext(altConfig);
+			(ctxB.fetchAuthSession as jest.Mock).mockResolvedValue({ credentials });
+
+			setGlobalContext(ctxB);
+
+			// Same geo instance's next operation should use ctxB's config
+			const resultsB = await geo.searchByText('test2');
+			expect(resultsB).toEqual([testPlaceCamelCase]);
+			expect(ctxB.fetchAuthSession).toHaveBeenCalled();
+
+			// Second call (index 1) should use ctxB's search index
+			const { input } = sendMock.mock.calls[1][0];
+			expect(input).toHaveProperty('IndexName', 'altSearchIndex');
+		});
+
+		test('explicit ctx pinned: GeoClass constructed with explicit ctx ignores global context changes', async () => {
+			// Restore the LocationClient mock for this test
+			LocationClient.prototype.send = jest.fn(async command => {
+				if (command instanceof SearchPlaceIndexForTextCommand) {
+					return {
+						Results: [{ Place: TestPlacePascalCase }],
+					};
+				}
+			});
+
+			const explicitCtx = createMockAmplifyContext(awsConfigGeoV4);
+			(explicitCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+			});
+
+			const geo = new GeoClass(explicitCtx);
+
+			// Set a different global context
+			const altConfig = {
+				...awsConfigGeoV4,
+				Geo: {
+					LocationService: {
+						...awsConfigGeoV4.Geo!.LocationService,
+						searchIndices: {
+							items: ['globalSearchIndex'],
+							default: 'globalSearchIndex',
+						},
+					},
+				},
+			};
+			const globalCtx = createMockAmplifyContext(altConfig);
+			(globalCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+			});
+			setGlobalContext(globalCtx);
+
+			// Operation should still use the explicit ctx
+			const results = await geo.searchByText('test');
+			expect(results).toEqual([testPlaceCamelCase]);
+			expect(explicitCtx.fetchAuthSession).toHaveBeenCalled();
+			expect(globalCtx.fetchAuthSession).not.toHaveBeenCalled();
+		});
+
+		test('no eager throw: constructing GeoClass and addPluggable before configure does not throw', () => {
+			clearGlobalContext();
+
+			// These should not throw even though global context is not set
+			expect(() => new GeoClass()).not.toThrow();
+			expect(() => new AmazonLocationServiceProvider()).not.toThrow();
+
+			const geo = new GeoClass();
+			const provider = new AmazonLocationServiceProvider();
+			expect(() => {
+				geo.addPluggable(provider);
+			}).not.toThrow();
+		});
+
+		test('no eager throw: operation throws when global context is not set', async () => {
+			clearGlobalContext();
+
+			const geo = new GeoClass();
+
+			await expect(geo.searchByText('test')).rejects.toThrow(
+				'No AmplifyContext available',
+			);
+		});
+	});
 });

--- a/packages/geo/__tests__/Geo.test.ts
+++ b/packages/geo/__tests__/Geo.test.ts
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Amplify, fetchAuthSession } from '@aws-amplify/core';
 import {
 	GetPlaceCommand,
 	LocationClient,
@@ -8,6 +7,11 @@ import {
 	SearchPlaceIndexForSuggestionsCommand,
 	SearchPlaceIndexForTextCommand,
 } from '@aws-sdk/client-location';
+import { AmplifyContext } from '@aws-amplify/core';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 import camelcaseKeys from 'camelcase-keys';
 
 import { GeoClass } from '../src/Geo';
@@ -36,6 +40,7 @@ import {
 	mockGetGeofenceCommand,
 	mockListGeofencesCommand,
 } from './testUtils';
+import { createMockAmplifyContext } from './testUtils/mockAmplifyContext';
 
 LocationClient.prototype.send = jest.fn(async command => {
 	if (
@@ -70,37 +75,36 @@ LocationClient.prototype.send = jest.fn(async command => {
 	}
 });
 
-jest.mock('@aws-amplify/core', () => {
-	const originalModule = jest.requireActual('@aws-amplify/core');
-
-	return {
-		...originalModule,
-		fetchAuthSession: jest.fn(),
-		Amplify: {
-			getConfig: jest.fn(),
-		},
-	};
-});
-
 describe('Geo', () => {
+	let mockCtx: AmplifyContext;
+
+	beforeEach(() => {
+		mockCtx = createMockAmplifyContext(awsConfigGeoV4);
+		(mockCtx.fetchAuthSession as jest.Mock).mockResolvedValue({ credentials });
+	});
+
 	afterEach(() => {
 		jest.restoreAllMocks();
 		jest.clearAllMocks();
 	});
 
-	describe('getModuleName', () => {
-		(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-		const geo = new GeoClass();
-		const moduleName = geo.getModuleName();
+	afterAll(() => {
+		clearGlobalContext();
+	});
 
-		expect(moduleName).toBe('Geo');
+	describe('getModuleName', () => {
+		test('returns Geo', () => {
+			const geo = new GeoClass(mockCtx);
+			const moduleName = geo.getModuleName();
+
+			expect(moduleName).toBe('Geo');
+		});
 	});
 
 	describe('pluggables', () => {
 		test('getPluggable', () => {
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
-			const provider = new AmazonLocationServiceProvider();
+			const geo = new GeoClass(mockCtx);
+			const provider = new AmazonLocationServiceProvider(undefined, mockCtx);
 			geo.addPluggable(provider);
 
 			expect(geo.getPluggable(provider.getProviderName())).toBeInstanceOf(
@@ -109,9 +113,8 @@ describe('Geo', () => {
 		});
 
 		test('removePluggable', () => {
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
-			const provider = new AmazonLocationServiceProvider();
+			const geo = new GeoClass(mockCtx);
+			const provider = new AmazonLocationServiceProvider(undefined, mockCtx);
 			geo.addPluggable(provider);
 			geo.removePluggable(provider.getProviderName());
 
@@ -123,22 +126,28 @@ describe('Geo', () => {
 
 	describe('AmazonLocationService is used as default provider', () => {
 		test('creates the proper default provider', () => {
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 			expect(geo.getPluggable('AmazonLocationService')).toBeInstanceOf(
 				AmazonLocationServiceProvider,
 			);
 		});
 	});
 
+	describe('global context fallback', () => {
+		test('falls back to global context when no ctx is provided', () => {
+			setGlobalContext(mockCtx);
+			const geo = new GeoClass();
+
+			expect(geo.getPluggable('AmazonLocationService')).toBeInstanceOf(
+				AmazonLocationServiceProvider,
+			);
+			clearGlobalContext();
+		});
+	});
+
 	describe('get map resources', () => {
 		test('should fail if there is no provider', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 			geo.removePluggable('AmazonLocationService');
 
 			expect(() => geo.getAvailableMaps()).toThrow(
@@ -150,10 +159,10 @@ describe('Geo', () => {
 		});
 
 		test('should tell you if there are no available map resources', () => {
-			(Amplify.getConfig as jest.Mock).mockReturnValue({
-				Geo: { LocationService: {} },
+			const emptyCtx = createMockAmplifyContext({
+				Geo: { LocationService: { region: 'us-east-1' } },
 			});
-			const geo = new GeoClass();
+			const geo = new GeoClass(emptyCtx);
 
 			expect(() => geo.getAvailableMaps()).toThrow(
 				"No map resources found in amplify config, run 'amplify add geo' to create one and run `amplify push` after",
@@ -161,8 +170,7 @@ describe('Geo', () => {
 		});
 
 		test('should get all available map resources', () => {
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			const maps: AmazonLocationServiceMapStyle[] = [];
 			const availableMaps = awsConfig.geo.amazon_location_service.maps.items;
@@ -177,8 +185,8 @@ describe('Geo', () => {
 		});
 
 		test('should fail gracefully if no config is found', () => {
-			(Amplify.getConfig as jest.Mock).mockReturnValue({});
-			const geo = new GeoClass();
+			const emptyCtx = createMockAmplifyContext({});
+			const geo = new GeoClass(emptyCtx);
 
 			expect(() => geo.getDefaultMap()).toThrow(
 				"No Geo configuration found in amplify config, run 'amplify add geo' to create one and run `amplify push` after",
@@ -186,10 +194,10 @@ describe('Geo', () => {
 		});
 
 		test('should tell you if there is no map resources when running getDefaultMap', () => {
-			(Amplify.getConfig as jest.Mock).mockReturnValue({
-				Geo: { LocationService: {} },
+			const noMapsCtx = createMockAmplifyContext({
+				Geo: { LocationService: { region: 'us-east-1' } },
 			});
-			const geo = new GeoClass();
+			const geo = new GeoClass(noMapsCtx);
 
 			expect(() => geo.getDefaultMap()).toThrow(
 				"No map resources found in amplify config, run 'amplify add geo' to create one and run `amplify push` after",
@@ -197,14 +205,15 @@ describe('Geo', () => {
 		});
 
 		test('should tell you if there is no default map resources (but there are maps) when running getDefaultMap', () => {
-			(Amplify.getConfig as jest.Mock).mockReturnValue({
+			const noDefaultCtx = createMockAmplifyContext({
 				Geo: {
 					LocationService: {
+						region: 'us-east-1',
 						maps: { items: { testMap: { style: 'teststyle' } } },
 					},
 				},
-			} as any);
-			const geo = new GeoClass();
+			});
+			const geo = new GeoClass(noDefaultCtx);
 
 			expect(() => geo.getDefaultMap()).toThrow(
 				"No default map resource found in amplify config, run 'amplify add geo' to create one and run `amplify push` after",
@@ -212,8 +221,7 @@ describe('Geo', () => {
 		});
 
 		test('should get the default map resource', () => {
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			const mapName = awsConfig.geo.amazon_location_service.maps.default;
 			const { style } =
@@ -230,12 +238,7 @@ describe('Geo', () => {
 		const testString = 'star';
 
 		test('should search with just text input', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			const results = await geo.searchByText(testString);
 			expect(results).toEqual([testPlaceCamelCase]);
@@ -249,12 +252,7 @@ describe('Geo', () => {
 		});
 
 		test('should search using given options with biasPosition', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			const searchOptions: SearchByTextOptions = {
 				biasPosition: [12345, 67890],
@@ -279,12 +277,7 @@ describe('Geo', () => {
 		});
 
 		test('should search using given options with searchAreaConstraints', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			const searchOptions: SearchByTextOptions = {
 				searchAreaConstraints: [123, 456, 789, 321],
@@ -307,12 +300,7 @@ describe('Geo', () => {
 		});
 
 		test('should throw an error if both BiasPosition and SearchAreaConstraints are given in the options', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			const searchOptions: SearchByTextOptions = {
 				countries: ['USA'],
@@ -328,12 +316,7 @@ describe('Geo', () => {
 		});
 
 		test('should fail if there is no provider', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 			geo.removePluggable('AmazonLocationService');
 
 			await expect(geo.searchByText(testString)).rejects.toThrow(
@@ -347,12 +330,7 @@ describe('Geo', () => {
 		const testResults = camelcaseKeys(TestPlacePascalCase, { deep: true });
 
 		test('should search with PlaceId as input', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			const results = await geo.searchByPlaceId(testPlaceId);
 			expect(results).toEqual(testResults);
@@ -366,12 +344,7 @@ describe('Geo', () => {
 		});
 
 		test('should fail if there is no provider', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 			geo.removePluggable('AmazonLocationService');
 
 			await expect(geo.searchByPlaceId(testPlaceId)).rejects.toThrow(
@@ -393,12 +366,7 @@ describe('Geo', () => {
 		];
 
 		test('should search with just text input', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			const results = await geo.searchForSuggestions(testString);
 			expect(results).toEqual(testResults);
@@ -412,12 +380,7 @@ describe('Geo', () => {
 		});
 
 		test('should search using given options with biasPosition', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			const searchOptions: SearchByTextOptions = {
 				biasPosition: [12345, 67890],
@@ -440,12 +403,7 @@ describe('Geo', () => {
 		});
 
 		test('should search using given options with searchAreaConstraints', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			const searchOptions: SearchByTextOptions = {
 				searchAreaConstraints: [123, 456, 789, 321],
@@ -468,12 +426,7 @@ describe('Geo', () => {
 		});
 
 		test('should throw an error if both BiasPosition and SearchAreaConstraints are given in the options', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			const searchOptions: SearchByTextOptions = {
 				countries: ['USA'],
@@ -491,12 +444,7 @@ describe('Geo', () => {
 		});
 
 		test('should fail if there is no provider', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 			geo.removePluggable('AmazonLocationService');
 
 			await expect(geo.searchForSuggestions(testString)).rejects.toThrow(
@@ -509,12 +457,7 @@ describe('Geo', () => {
 		const testCoordinates: Coordinates = [45, 90];
 
 		test('should search with just coordinate input', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			const results = await geo.searchByCoordinates(testCoordinates);
 			expect(results).toEqual(testPlaceCamelCase);
@@ -528,12 +471,7 @@ describe('Geo', () => {
 		});
 
 		test('should search using options when given', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			const searchOptions: SearchByCoordinatesOptions = {
 				maxResults: 40,
@@ -555,12 +493,7 @@ describe('Geo', () => {
 		});
 
 		test('should fail if there is no provider', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 			geo.removePluggable('AmazonLocationService');
 
 			await expect(geo.searchByCoordinates(testCoordinates)).rejects.toThrow(
@@ -571,16 +504,11 @@ describe('Geo', () => {
 
 	describe('saveGeofences', () => {
 		test('saveGeofences with a single geofence', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
 			LocationClient.prototype.send = jest
 				.fn()
 				.mockImplementationOnce(mockBatchPutGeofenceCommand);
 
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			// Check that results are what's expected
 			const results = await geo.saveGeofences(validGeofence1);
@@ -604,16 +532,11 @@ describe('Geo', () => {
 		});
 
 		test('saveGeofences with multiple geofences', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
 			LocationClient.prototype.send = jest
 				.fn()
 				.mockImplementation(mockBatchPutGeofenceCommand);
 
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			// Check that results are what's expected
 			const results = await geo.saveGeofences(validGeofences);
@@ -627,12 +550,7 @@ describe('Geo', () => {
 		});
 
 		test('should fail if there is no provider', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 			geo.removePluggable('AmazonLocationService');
 
 			await expect(geo.saveGeofences(validGeofence1)).rejects.toThrow(
@@ -643,16 +561,11 @@ describe('Geo', () => {
 
 	describe('getGeofence', () => {
 		test('getGeofence returns the right geofence', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
 			LocationClient.prototype.send = jest
 				.fn()
 				.mockImplementationOnce(mockGetGeofenceCommand);
 
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			// Check that results are what's expected
 			const results = await geo.getGeofence('testGeofenceId');
@@ -678,16 +591,11 @@ describe('Geo', () => {
 
 	describe('listGeofences', () => {
 		test('listGeofences gets the first 100 geofences when no arguments are given', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
 			LocationClient.prototype.send = jest
 				.fn()
 				.mockImplementationOnce(mockListGeofencesCommand);
 
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			// Check that results are what's expected
 			const results = await geo.listGeofences();
@@ -695,16 +603,11 @@ describe('Geo', () => {
 		});
 
 		test('listGeofences gets the second 100 geofences when nextToken is passed', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
 			LocationClient.prototype.send = jest
 				.fn()
 				.mockImplementation(mockListGeofencesCommand);
 
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-			const geo = new GeoClass();
+			const geo = new GeoClass(mockCtx);
 
 			// Check that results are what's expected
 
@@ -720,6 +623,49 @@ describe('Geo', () => {
 			);
 			expect(second100Geofences.entries[99].geofenceId).toEqual(
 				'validGeofenceId199',
+			);
+		});
+	});
+
+	describe('deleteGeofences', () => {
+		test('deleteGeofences with a single geofence ID', async () => {
+			LocationClient.prototype.send = jest.fn().mockImplementation(() => {
+				return {
+					Errors: [],
+				};
+			});
+
+			const geo = new GeoClass(mockCtx);
+
+			const results = await geo.deleteGeofences('validGeofenceId1');
+			expect(results.successes).toContain('validGeofenceId1');
+			expect(results.errors).toHaveLength(0);
+		});
+
+		test('deleteGeofences with an array of geofence IDs', async () => {
+			LocationClient.prototype.send = jest.fn().mockImplementation(() => {
+				return {
+					Errors: [],
+				};
+			});
+
+			const geo = new GeoClass(mockCtx);
+
+			const results = await geo.deleteGeofences([
+				'validGeofenceId1',
+				'validGeofenceId2',
+			]);
+			expect(results.successes).toContain('validGeofenceId1');
+			expect(results.successes).toContain('validGeofenceId2');
+			expect(results.errors).toHaveLength(0);
+		});
+
+		test('should fail if there is no provider', async () => {
+			const geo = new GeoClass(mockCtx);
+			geo.removePluggable('AmazonLocationService');
+
+			await expect(geo.deleteGeofences(['validGeofenceId1'])).rejects.toThrow(
+				'No plugin found in Geo for the provider',
 			);
 		});
 	});

--- a/packages/geo/__tests__/Providers/AmazonLocationServiceProvider.test.ts
+++ b/packages/geo/__tests__/Providers/AmazonLocationServiceProvider.test.ts
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Amplify, fetchAuthSession } from '@aws-amplify/core';
 import {
 	GetPlaceCommand,
 	LocationClient,
@@ -8,6 +7,7 @@ import {
 	SearchPlaceIndexForSuggestionsCommand,
 	SearchPlaceIndexForTextCommand,
 } from '@aws-sdk/client-location';
+import { AmplifyContext, GeoConfig } from '@aws-amplify/core';
 import camelcaseKeys from 'camelcase-keys';
 
 import { AmazonLocationServiceProvider } from '../../src/providers/location-service/AmazonLocationServiceProvider';
@@ -29,6 +29,7 @@ import {
 	mockGetGeofenceCommand,
 	mockListGeofencesCommand,
 } from '../testUtils';
+import { createMockAmplifyContext } from '../testUtils/mockAmplifyContext';
 import {
 	AmazonLocationServiceGeofence,
 	Coordinates,
@@ -69,55 +70,49 @@ LocationClient.prototype.send = jest.fn(async command => {
 	}
 });
 
-jest.mock('@aws-amplify/core', () => {
-	const originalModule = jest.requireActual('@aws-amplify/core');
-
-	return {
-		...originalModule,
-		fetchAuthSession: jest.fn(),
-		Amplify: {
-			getConfig: jest.fn(),
-		},
-	};
-});
-
 describe('AmazonLocationServiceProvider', () => {
+	let mockCtx: AmplifyContext;
+
+	beforeEach(() => {
+		mockCtx = createMockAmplifyContext(awsConfigGeoV4);
+		(mockCtx.fetchAuthSession as jest.Mock).mockResolvedValue({ credentials });
+	});
+
 	afterEach(() => {
 		jest.restoreAllMocks();
 		jest.clearAllMocks();
 	});
 
-	beforeEach(() => {
-		(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
-	});
-
 	describe('getCategory', () => {
 		test('should return "Geo" when asked for category', () => {
-			const geo = new AmazonLocationServiceProvider();
+			const geo = new AmazonLocationServiceProvider(undefined, mockCtx);
 			expect(geo.getCategory()).toBe('Geo');
 		});
 	});
 
 	describe('getProviderName', () => {
 		test('should return "AmazonLocationService" when asked for Provider', () => {
-			const geo = new AmazonLocationServiceProvider();
+			const geo = new AmazonLocationServiceProvider(undefined, mockCtx);
 			expect(geo.getProviderName()).toBe('AmazonLocationService');
 		});
 	});
 
 	describe('get map resources', () => {
 		test('should tell you if there are no available map resources', () => {
-			(Amplify.getConfig as jest.Mock).mockReturnValue({
-				Geo: { LocationService: {} },
+			const emptyCtx = createMockAmplifyContext({
+				Geo: { LocationService: { region: 'us-east-1' } },
 			});
-			const provider = new AmazonLocationServiceProvider();
+			const provider = new AmazonLocationServiceProvider(undefined, emptyCtx);
 			expect(() => provider.getAvailableMaps()).toThrow(
 				"No map resources found in amplify config, run 'amplify add geo' to create one and run `amplify push` after",
 			);
 		});
 
 		test('should get all available map resources', () => {
-			const provider = new AmazonLocationServiceProvider(awsConfigGeoV4);
+			const provider = new AmazonLocationServiceProvider(
+				awsConfigGeoV4.Geo,
+				mockCtx,
+			);
 
 			const maps: any[] = [];
 			const availableMaps = awsConfig.geo.amazon_location_service.maps.items;
@@ -131,10 +126,10 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should tell you if there is no map resources available when calling getDefaultMap', () => {
-			(Amplify.getConfig as jest.Mock).mockReturnValue({
-				Geo: { LocationService: {} },
+			const emptyCtx = createMockAmplifyContext({
+				Geo: { LocationService: { region: 'us-east-1' } },
 			});
-			const provider = new AmazonLocationServiceProvider();
+			const provider = new AmazonLocationServiceProvider(undefined, emptyCtx);
 
 			expect(() => provider.getDefaultMap()).toThrow(
 				"No map resources found in amplify config, run 'amplify add geo' to create one and run `amplify push` after",
@@ -145,13 +140,15 @@ describe('AmazonLocationServiceProvider', () => {
 			const noDefaultMapConfig = {
 				Geo: {
 					LocationService: {
+						region: 'us-east-1',
 						maps: { items: [{ testMap: { style: 'teststyle' } }] },
 					},
 				},
 			};
-			(Amplify.getConfig as jest.Mock).mockReturnValue(noDefaultMapConfig);
+			const noDefaultCtx = createMockAmplifyContext(noDefaultMapConfig);
 			const provider = new AmazonLocationServiceProvider(
-				noDefaultMapConfig as any,
+				noDefaultMapConfig.Geo as unknown as GeoConfig,
+				noDefaultCtx,
 			);
 
 			expect(() => provider.getDefaultMap()).toThrow(
@@ -160,7 +157,10 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should get the default map resource', () => {
-			const provider = new AmazonLocationServiceProvider(awsConfigGeoV4);
+			const provider = new AmazonLocationServiceProvider(
+				awsConfigGeoV4.Geo,
+				mockCtx,
+			);
 
 			const mapName = awsConfig.geo.amazon_location_service.maps.default;
 			const { style } =
@@ -178,13 +178,9 @@ describe('AmazonLocationServiceProvider', () => {
 		const testString = 'star';
 
 		test('should search with just text input', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const results = await locationProvider.searchByText(testString);
@@ -199,13 +195,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should use biasPosition when given', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const searchOptions: SearchByTextOptions = {
@@ -234,13 +226,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should use searchAreaConstraints when given', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const searchOptions: SearchByTextOptions = {
@@ -268,13 +256,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should throw an error if both BiasPosition and SearchAreaConstraints are given in the options', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const searchOptions: SearchByTextOptions = {
@@ -293,11 +277,14 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should fail if credentials are invalid', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials: undefined });
+			const noCredCtx = createMockAmplifyContext(awsConfigGeoV4);
+			(noCredCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials: undefined,
 			});
-
-			const locationProvider = new AmazonLocationServiceProvider();
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				noCredCtx,
+			);
 
 			await expect(locationProvider.searchByText(testString)).rejects.toThrow(
 				'No credentials',
@@ -305,9 +292,12 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should fail if _getCredentials fails ', async () => {
-			(fetchAuthSession as jest.Mock).mockRejectedValueOnce('Auth Error');
-
-			const locationProvider = new AmazonLocationServiceProvider();
+			const failCtx = createMockAmplifyContext(awsConfigGeoV4);
+			(failCtx.fetchAuthSession as jest.Mock).mockRejectedValue('Auth Error');
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				failCtx,
+			);
 
 			await expect(locationProvider.searchByText(testString)).rejects.toThrow(
 				'No credentials',
@@ -315,14 +305,16 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should fail if there are no search index resources', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
+			const emptyCtx = createMockAmplifyContext({
+				Geo: { LocationService: { region: 'us-east-1' } },
 			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue({
-				Geo: { LocationService: {} },
+			(emptyCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
 			});
-			const locationProvider = new AmazonLocationServiceProvider();
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				emptyCtx,
+			);
 
 			expect(locationProvider.searchByText(testString)).rejects.toThrow(
 				'No Search Index found in amplify config, please run `amplify add geo` to create one and run `amplify push` after.',
@@ -343,13 +335,9 @@ describe('AmazonLocationServiceProvider', () => {
 		];
 
 		test('should search with just text input', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const results = await locationProvider.searchForSuggestions(testString);
@@ -365,13 +353,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should use biasPosition when given', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const searchOptions: SearchByTextOptions = {
@@ -400,13 +384,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should use searchAreaConstraints when given', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const searchOptions: SearchByTextOptions = {
@@ -432,13 +412,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should throw an error if both BiasPosition and SearchAreaConstraints are given in the options', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const searchOptions: SearchByTextOptions = {
@@ -457,11 +433,14 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should fail if credentials are invalid', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials: undefined });
+			const noCredCtx = createMockAmplifyContext(awsConfigGeoV4);
+			(noCredCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials: undefined,
 			});
-
-			const locationProvider = new AmazonLocationServiceProvider();
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				noCredCtx,
+			);
 
 			await expect(
 				locationProvider.searchForSuggestions(testString),
@@ -469,9 +448,12 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should fail if _getCredentials fails ', async () => {
-			(fetchAuthSession as jest.Mock).mockRejectedValueOnce('Auth Error');
-
-			const locationProvider = new AmazonLocationServiceProvider();
+			const failCtx = createMockAmplifyContext(awsConfigGeoV4);
+			(failCtx.fetchAuthSession as jest.Mock).mockRejectedValue('Auth Error');
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				failCtx,
+			);
 
 			await expect(
 				locationProvider.searchForSuggestions(testString),
@@ -479,14 +461,16 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should fail if there are no search index resources', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
+			const emptyCtx = createMockAmplifyContext({
+				Geo: { LocationService: { region: 'us-east-1' } },
 			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue({
-				Geo: { LocationService: {} },
+			(emptyCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
 			});
-			const locationProvider = new AmazonLocationServiceProvider();
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				emptyCtx,
+			);
 
 			await expect(
 				locationProvider.searchForSuggestions(testString),
@@ -501,13 +485,9 @@ describe('AmazonLocationServiceProvider', () => {
 		const testResults = camelcaseKeys(TestPlacePascalCase, { deep: true });
 
 		test('should search with PlaceId as input', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const results = await locationProvider.searchByPlaceId(testPlaceId);
@@ -523,13 +503,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should fail if PlaceId as input is empty string', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			await expect(locationProvider.searchByPlaceId('')).rejects.toThrow(
@@ -538,11 +514,14 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should fail if credentials are invalid', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials: undefined });
+			const noCredCtx = createMockAmplifyContext(awsConfigGeoV4);
+			(noCredCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials: undefined,
 			});
-
-			const locationProvider = new AmazonLocationServiceProvider();
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				noCredCtx,
+			);
 
 			await expect(
 				locationProvider.searchByPlaceId(testPlaceId),
@@ -550,9 +529,12 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should fail if _getCredentials fails ', async () => {
-			(fetchAuthSession as jest.Mock).mockRejectedValueOnce('Auth Error');
-
-			const locationProvider = new AmazonLocationServiceProvider();
+			const failCtx = createMockAmplifyContext(awsConfigGeoV4);
+			(failCtx.fetchAuthSession as jest.Mock).mockRejectedValue('Auth Error');
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				failCtx,
+			);
 
 			await expect(
 				locationProvider.searchByPlaceId(testPlaceId),
@@ -560,14 +542,16 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should fail if there are no search index resources', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
+			const emptyCtx = createMockAmplifyContext({
+				Geo: { LocationService: { region: 'us-east-1' } },
 			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue({
-				Geo: { LocationService: {} },
+			(emptyCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
 			});
-			const locationProvider = new AmazonLocationServiceProvider();
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				emptyCtx,
+			);
 
 			await expect(
 				locationProvider.searchByPlaceId(testPlaceId),
@@ -581,13 +565,9 @@ describe('AmazonLocationServiceProvider', () => {
 		const testCoordinates: Coordinates = [45, 90];
 
 		test('should search with just text input', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const results =
@@ -603,13 +583,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should use options when given', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const searchOptions: SearchByCoordinatesOptions = {
@@ -632,11 +608,14 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should fail if credentials resolve to invalid', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials: undefined });
+			const noCredCtx = createMockAmplifyContext(awsConfigGeoV4);
+			(noCredCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials: undefined,
 			});
-
-			const locationProvider = new AmazonLocationServiceProvider();
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				noCredCtx,
+			);
 
 			await expect(
 				locationProvider.searchByCoordinates(testCoordinates),
@@ -644,9 +623,12 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should fail if _getCredentials fails ', async () => {
-			(fetchAuthSession as jest.Mock).mockRejectedValueOnce('Auth Error');
-
-			const locationProvider = new AmazonLocationServiceProvider();
+			const failCtx = createMockAmplifyContext(awsConfigGeoV4);
+			(failCtx.fetchAuthSession as jest.Mock).mockRejectedValue('Auth Error');
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				failCtx,
+			);
 
 			await expect(
 				locationProvider.searchByCoordinates(testCoordinates),
@@ -654,14 +636,16 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should fail if there are no search index resources', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
+			const emptyCtx = createMockAmplifyContext({
+				Geo: { LocationService: { region: 'us-east-1' } },
 			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue({
-				Geo: { LocationService: {} },
+			(emptyCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
 			});
-			const locationProvider = new AmazonLocationServiceProvider();
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				emptyCtx,
+			);
 
 			await expect(
 				locationProvider.searchByCoordinates(testCoordinates),
@@ -673,17 +657,13 @@ describe('AmazonLocationServiceProvider', () => {
 
 	describe('saveGeofences', () => {
 		test('saveGeofences with multiple geofences', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
 			LocationClient.prototype.send = jest
 				.fn()
 				.mockImplementation(mockBatchPutGeofenceCommand);
 
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const results = await locationProvider.saveGeofences(validGeofences);
@@ -692,13 +672,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('saveGeofences calls batchPutGeofences in batches of 10 from input', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const numberOfGeofences = 44;
@@ -731,13 +707,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('saveGeofences properly handles errors with bad network calls', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const input = createGeofenceInputArray(44);
@@ -790,17 +762,13 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should error if a geofence is wound clockwise', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
 			LocationClient.prototype.send = jest
 				.fn()
 				.mockImplementation(mockBatchPutGeofenceCommand);
 
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			await expect(
@@ -811,17 +779,13 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should error if input is empty array', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
 			LocationClient.prototype.send = jest
 				.fn()
 				.mockImplementation(mockBatchPutGeofenceCommand);
 
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			await expect(locationProvider.saveGeofences([])).rejects.toThrow(
@@ -830,14 +794,16 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should error if there are no geofenceCollections in config', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
+			const emptyCtx = createMockAmplifyContext({
+				Geo: { LocationService: { region: 'us-east-1' } },
 			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue({
-				Geo: { LocationService: {} },
+			(emptyCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
 			});
-			const locationProvider = new AmazonLocationServiceProvider();
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				emptyCtx,
+			);
 
 			await expect(
 				locationProvider.saveGeofences(validGeofences),
@@ -849,17 +815,13 @@ describe('AmazonLocationServiceProvider', () => {
 
 	describe('getGeofence', () => {
 		test('getGeofence returns the right geofence', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
 			LocationClient.prototype.send = jest
 				.fn()
 				.mockImplementation(mockGetGeofenceCommand);
 
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const results: AmazonLocationServiceGeofence =
@@ -877,17 +839,13 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('getGeofence errors when a bad geofenceId is given', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
 			LocationClient.prototype.send = jest
 				.fn()
 				.mockImplementationOnce(mockGetGeofenceCommand);
 
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const badGeofenceId = 't|-|!$ !$ N()T V@|_!D';
@@ -897,14 +855,16 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should error if there are no geofenceCollections in config', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
+			const emptyCtx = createMockAmplifyContext({
+				Geo: { LocationService: { region: 'us-east-1' } },
 			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue({
-				Geo: { LocationService: {} },
+			(emptyCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
 			});
-			const locationProvider = new AmazonLocationServiceProvider();
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				emptyCtx,
+			);
 
 			await expect(locationProvider.getGeofence('geofenceId')).rejects.toThrow(
 				'No Geofence Collections found, please run `amplify add geo` to create one and run `amplify push` after.',
@@ -914,17 +874,13 @@ describe('AmazonLocationServiceProvider', () => {
 
 	describe('listGeofences', () => {
 		test('listGeofences gets the first 100 geofences when no arguments are given', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
 			LocationClient.prototype.send = jest
 				.fn()
 				.mockImplementation(mockListGeofencesCommand);
 
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const geofences = await locationProvider.listGeofences();
@@ -933,17 +889,13 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('listGeofences gets the second 100 geofences when nextToken is passed', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
 			LocationClient.prototype.send = jest
 				.fn()
 				.mockImplementation(mockListGeofencesCommand);
 
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const first100Geofences = await locationProvider.listGeofences();
@@ -962,14 +914,16 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should error if there are no geofenceCollections in config', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
+			const emptyCtx = createMockAmplifyContext({
+				Geo: { LocationService: { region: 'us-east-1' } },
 			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue({
-				Geo: { LocationService: {} },
+			(emptyCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
 			});
-			const locationProvider = new AmazonLocationServiceProvider();
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				emptyCtx,
+			);
 
 			await expect(locationProvider.listGeofences()).rejects.toThrow(
 				'No Geofence Collections found, please run `amplify add geo` to create one and run `amplify push` after.',
@@ -979,17 +933,13 @@ describe('AmazonLocationServiceProvider', () => {
 
 	describe('deleteGeofences', () => {
 		test('deleteGeofences deletes given geofences successfully', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
 			LocationClient.prototype.send = jest
 				.fn()
 				.mockImplementation(mockDeleteGeofencesCommand);
 
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const geofenceIds = validGeofences.map(({ geofenceId }) => geofenceId);
@@ -1005,13 +955,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('deleteGeofences calls batchDeleteGeofences in batches of 10 from input', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const geofenceIds = validGeofences.map(({ geofenceId }) => geofenceId);
@@ -1038,13 +984,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('deleteGeofences properly handles errors with bad network calls', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 
 			const input = createGeofenceInputArray(44).map(
@@ -1094,12 +1036,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should error if there is a bad geofence in the input', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 			await expect(
 				locationProvider.deleteGeofences([
@@ -1113,12 +1052,9 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should error if input array is empty', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
-			});
-			(Amplify.getConfig as jest.Mock).mockReturnValue(awsConfigGeoV4);
 			const locationProvider = new AmazonLocationServiceProvider(
-				awsConfigGeoV4,
+				awsConfigGeoV4.Geo,
+				mockCtx,
 			);
 			await expect(locationProvider.deleteGeofences([])).rejects.toThrow(
 				`GeofenceId input array is empty`,
@@ -1126,14 +1062,16 @@ describe('AmazonLocationServiceProvider', () => {
 		});
 
 		test('should error if there are no geofenceCollections in config', async () => {
-			(fetchAuthSession as jest.Mock).mockImplementationOnce(() => {
-				return Promise.resolve({ credentials });
+			const emptyCtx = createMockAmplifyContext({
+				Geo: { LocationService: { region: 'us-east-1' } },
 			});
-
-			(Amplify.getConfig as jest.Mock).mockReturnValue({
-				Geo: { LocationService: {} },
+			(emptyCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
 			});
-			const locationProvider = new AmazonLocationServiceProvider();
+			const locationProvider = new AmazonLocationServiceProvider(
+				undefined,
+				emptyCtx,
+			);
 
 			const geofenceIds = validGeofences.map(({ geofenceId }) => geofenceId);
 

--- a/packages/geo/__tests__/Providers/AmazonLocationServiceProvider.test.ts
+++ b/packages/geo/__tests__/Providers/AmazonLocationServiceProvider.test.ts
@@ -8,6 +8,10 @@ import {
 	SearchPlaceIndexForTextCommand,
 } from '@aws-sdk/client-location';
 import { AmplifyContext, GeoConfig } from '@aws-amplify/core';
+import {
+	clearGlobalContext,
+	setGlobalContext,
+} from '@aws-amplify/core/internals/utils';
 import camelcaseKeys from 'camelcase-keys';
 
 import { AmazonLocationServiceProvider } from '../../src/providers/location-service/AmazonLocationServiceProvider';
@@ -1079,6 +1083,121 @@ describe('AmazonLocationServiceProvider', () => {
 				locationProvider.deleteGeofences(geofenceIds),
 			).rejects.toThrow(
 				'No Geofence Collections found, please run `amplify add geo` to create one and run `amplify push` after.',
+			);
+		});
+	});
+
+	describe('lazy context resolution', () => {
+		afterEach(() => {
+			clearGlobalContext();
+		});
+
+		test('reconfigure honored: provider without explicit ctx picks up new global context', async () => {
+			// Re-set the LocationClient mock for search operations
+			const sendMock = jest.fn(async command => {
+				if (command instanceof SearchPlaceIndexForTextCommand) {
+					return {
+						Results: [{ Place: TestPlacePascalCase }],
+					};
+				}
+			});
+			LocationClient.prototype.send = sendMock;
+
+			const ctxA = createMockAmplifyContext(awsConfigGeoV4);
+			(ctxA.fetchAuthSession as jest.Mock).mockResolvedValue({ credentials });
+
+			setGlobalContext(ctxA);
+
+			// Create provider without explicit ctx (global fallback)
+			const provider = new AmazonLocationServiceProvider();
+
+			// First operation uses ctxA
+			await provider.searchByText('test');
+			expect(ctxA.fetchAuthSession).toHaveBeenCalled();
+
+			// Reconfigure with a different context
+			const altConfig = {
+				...awsConfigGeoV4,
+				Geo: {
+					LocationService: {
+						...awsConfigGeoV4.Geo!.LocationService,
+						searchIndices: {
+							items: ['altSearchIndex'],
+							default: 'altSearchIndex',
+						},
+					},
+				},
+			};
+			const ctxB = createMockAmplifyContext(altConfig);
+			(ctxB.fetchAuthSession as jest.Mock).mockResolvedValue({ credentials });
+
+			setGlobalContext(ctxB);
+
+			// Same provider instance's next operation should use ctxB
+			await provider.searchByText('test2');
+			expect(ctxB.fetchAuthSession).toHaveBeenCalled();
+
+			// Second call (index 1) should use ctxB's search index
+			const { input } = sendMock.mock.calls[1][0];
+			expect(input).toHaveProperty('IndexName', 'altSearchIndex');
+		});
+
+		test('explicit ctx pinned: provider with explicit ctx ignores global changes', async () => {
+			// Re-set the LocationClient mock for search operations
+			LocationClient.prototype.send = jest.fn(async command => {
+				if (command instanceof SearchPlaceIndexForTextCommand) {
+					return {
+						Results: [{ Place: TestPlacePascalCase }],
+					};
+				}
+			});
+
+			const explicitCtx = createMockAmplifyContext(awsConfigGeoV4);
+			(explicitCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+			});
+
+			const provider = new AmazonLocationServiceProvider(
+				undefined,
+				explicitCtx,
+			);
+
+			// Change global context
+			const altConfig = {
+				...awsConfigGeoV4,
+				Geo: {
+					LocationService: {
+						...awsConfigGeoV4.Geo!.LocationService,
+						searchIndices: {
+							items: ['globalSearchIndex'],
+							default: 'globalSearchIndex',
+						},
+					},
+				},
+			};
+			const globalCtx = createMockAmplifyContext(altConfig);
+			(globalCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+			});
+			setGlobalContext(globalCtx);
+
+			// Provider should still use explicit ctx
+			await provider.searchByText('test');
+			expect(explicitCtx.fetchAuthSession).toHaveBeenCalled();
+			expect(globalCtx.fetchAuthSession).not.toHaveBeenCalled();
+		});
+
+		test('no eager throw: constructing provider without global context does not throw', () => {
+			clearGlobalContext();
+			expect(() => new AmazonLocationServiceProvider()).not.toThrow();
+		});
+
+		test('no eager throw: operation throws when global context is not set', async () => {
+			clearGlobalContext();
+			const provider = new AmazonLocationServiceProvider();
+
+			await expect(provider.searchByText('test')).rejects.toThrow(
+				'No AmplifyContext available',
 			);
 		});
 	});

--- a/packages/geo/__tests__/testData.ts
+++ b/packages/geo/__tests__/testData.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import camelcaseKeys from 'camelcase-keys';
-import { GeoConfig } from '@aws-amplify/core';
+import { ResourcesConfig } from '@aws-amplify/core';
 import { parseAWSExports } from '@aws-amplify/core/internals/utils';
 
 import {
@@ -50,7 +50,7 @@ export const awsConfig = {
 	credentials,
 };
 
-export const awsConfigGeoV4 = parseAWSExports(awsConfig) as GeoConfig;
+export const awsConfigGeoV4 = parseAWSExports(awsConfig) as ResourcesConfig;
 
 export const TestPlacePascalCase = {
 	AddressNumber: '123',

--- a/packages/geo/__tests__/testUtils/mockAmplifyContext.ts
+++ b/packages/geo/__tests__/testUtils/mockAmplifyContext.ts
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AMPLIFY_CONTEXT_BRAND,
+	AmplifyContext,
+	ResourcesConfig,
+} from '@aws-amplify/core';
+
+/**
+ * Creates a mock AmplifyContext for testing.
+ * Accepts partial/incomplete configs to test error paths.
+ */
+export function createMockAmplifyContext(
+	resourcesConfig?: ResourcesConfig | object,
+): AmplifyContext {
+	const ctx: AmplifyContext = {
+		resourcesConfig: (resourcesConfig || {}) as ResourcesConfig,
+		libraryOptions: {},
+		fetchAuthSession: jest.fn().mockResolvedValue({}),
+		clearCredentials: jest.fn().mockResolvedValue(undefined),
+		getTokens: jest.fn().mockResolvedValue(undefined),
+	};
+
+	Object.defineProperty(ctx, AMPLIFY_CONTEXT_BRAND, {
+		value: true,
+		enumerable: false,
+	});
+
+	return ctx;
+}

--- a/packages/geo/src/Geo.ts
+++ b/packages/geo/src/Geo.ts
@@ -1,6 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Amplify, ConsoleLogger } from '@aws-amplify/core';
+import {
+	AmplifyContext,
+	ConsoleLogger,
+	getGlobalContext,
+	isAmplifyContext,
+} from '@aws-amplify/core';
 
 import { AmazonLocationServiceProvider } from './providers/location-service/AmazonLocationServiceProvider';
 import { validateCoordinates } from './util';
@@ -33,17 +38,62 @@ export class GeoClass {
 	 * @private
 	 */
 	private _config?: GeoConfig;
-	private _pluggables: GeoProvider[];
+	private _pluggables: GeoProvider[] | undefined;
+	private _ctx: AmplifyContext | undefined;
 
-	constructor() {
+	constructor(ctx?: AmplifyContext) {
 		this._config = undefined;
-		this._pluggables = [];
+		this._pluggables = undefined;
 
-		const amplifyConfig = Amplify.getConfig() ?? {};
+		if (isAmplifyContext(ctx)) {
+			this._ctx = ctx;
+			this._initialize();
+		}
+		// When no ctx is passed, initialization is deferred until first use
+		// so the module-level singleton can be created without a global context.
+	}
+
+	/**
+	 * Resolve the AmplifyContext — uses the provided ctx or falls back to global.
+	 * @private
+	 */
+	private _getCtx(): AmplifyContext {
+		if (this._ctx) {
+			return this._ctx;
+		}
+
+		return getGlobalContext();
+	}
+
+	/**
+	 * Ensure the class is initialized (pluggables created, config read).
+	 * Called eagerly when ctx is provided, lazily otherwise.
+	 * @private
+	 */
+	private _ensureInitialized(): void {
+		if (this._pluggables) {
+			return;
+		}
+		this._initialize();
+	}
+
+	/**
+	 * Perform initialization: read config and create default provider.
+	 *
+	 * Note: The provider captures the resolved context at first use.
+	 * A full reconfiguration with a NEW context object requires constructing
+	 * a new GeoClass instance (matches previous singleton behavior).
+	 * @private
+	 */
+	private _initialize(): void {
+		this._pluggables = [];
+		const ctx = this._getCtx();
+		const amplifyConfig = ctx.resourcesConfig ?? {};
 		this._config = Object.assign({}, this._config, amplifyConfig.Geo);
 
 		const locationProvider = new AmazonLocationServiceProvider(
 			amplifyConfig.Geo,
+			ctx,
 		);
 		this._pluggables.push(locationProvider);
 
@@ -63,8 +113,9 @@ export class GeoClass {
 	 * @param {Object} pluggable an instance of the plugin
 	 */
 	public addPluggable(pluggable: GeoProvider) {
+		this._ensureInitialized();
 		if (pluggable && pluggable.getCategory() === 'Geo') {
-			this._pluggables.push(pluggable);
+			this._pluggables!.push(pluggable);
 		}
 	}
 
@@ -73,7 +124,8 @@ export class GeoClass {
 	 * @param providerName the name of the plugin
 	 */
 	public getPluggable(providerName: string) {
-		const targetPluggable = this._pluggables.find(
+		this._ensureInitialized();
+		const targetPluggable = this._pluggables!.find(
 			pluggable => pluggable.getProviderName() === providerName,
 		);
 		if (targetPluggable === undefined) {
@@ -87,7 +139,8 @@ export class GeoClass {
 	 * @param providerName the name of the plugin
 	 */
 	public removePluggable(providerName: string) {
-		this._pluggables = this._pluggables.filter(
+		this._ensureInitialized();
+		this._pluggables = this._pluggables!.filter(
 			pluggable => pluggable.getProviderName() !== providerName,
 		);
 	}

--- a/packages/geo/src/Geo.ts
+++ b/packages/geo/src/Geo.ts
@@ -3,7 +3,6 @@
 import {
 	AmplifyContext,
 	ConsoleLogger,
-	getGlobalContext,
 	isAmplifyContext,
 } from '@aws-amplify/core';
 
@@ -54,18 +53,6 @@ export class GeoClass {
 	}
 
 	/**
-	 * Resolve the AmplifyContext — uses the provided ctx or falls back to global.
-	 * @private
-	 */
-	private _getCtx(): AmplifyContext {
-		if (this._ctx) {
-			return this._ctx;
-		}
-
-		return getGlobalContext();
-	}
-
-	/**
 	 * Ensure the class is initialized (pluggables created, config read).
 	 * Called eagerly when ctx is provided, lazily otherwise.
 	 * @private
@@ -80,22 +67,31 @@ export class GeoClass {
 	/**
 	 * Perform initialization: read config and create default provider.
 	 *
-	 * Note: The provider captures the resolved context at first use.
-	 * A full reconfiguration with a NEW context object requires constructing
-	 * a new GeoClass instance (matches previous singleton behavior).
+	 * When GeoClass was constructed with an explicit ctx, the provider is pinned
+	 * to that context (fixed context by design). When using the global fallback,
+	 * no ctx is passed to the provider so it resolves the global context lazily
+	 * per operation — reconfiguration via setGlobalContext is honored.
 	 * @private
 	 */
 	private _initialize(): void {
 		this._pluggables = [];
-		const ctx = this._getCtx();
-		const amplifyConfig = ctx.resourcesConfig ?? {};
-		this._config = Object.assign({}, this._config, amplifyConfig.Geo);
 
-		const locationProvider = new AmazonLocationServiceProvider(
-			amplifyConfig.Geo,
-			ctx,
-		);
-		this._pluggables.push(locationProvider);
+		if (this._ctx) {
+			// Explicit ctx path: read config eagerly and pin provider to this ctx
+			const amplifyConfig = this._ctx.resourcesConfig ?? {};
+			this._config = Object.assign({}, this._config, amplifyConfig.Geo);
+
+			const locationProvider = new AmazonLocationServiceProvider(
+				amplifyConfig.Geo,
+				this._ctx,
+			);
+			this._pluggables.push(locationProvider);
+		} else {
+			// Global fallback path: provider resolves ctx lazily per operation.
+			// Config is read lazily via _refreshConfig() inside the provider.
+			const locationProvider = new AmazonLocationServiceProvider();
+			this._pluggables.push(locationProvider);
+		}
 
 		logger.debug('Geo Options', this._config);
 	}

--- a/packages/geo/src/index.ts
+++ b/packages/geo/src/index.ts
@@ -1,4 +1,4 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-export { Geo } from './Geo';
+export { Geo, GeoClass } from './Geo';
 export * from './types';

--- a/packages/geo/src/providers/location-service/AmazonLocationServiceProvider.ts
+++ b/packages/geo/src/providers/location-service/AmazonLocationServiceProvider.ts
@@ -1,7 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import camelcaseKeys from 'camelcase-keys';
-import { Amplify, ConsoleLogger, fetchAuthSession } from '@aws-amplify/core';
+import {
+	AmplifyContext,
+	ConsoleLogger,
+	getGlobalContext,
+	isAmplifyContext,
+} from '@aws-amplify/core';
 import { GeoAction } from '@aws-amplify/core/internals/utils';
 import {
 	BatchDeleteGeofenceCommand,
@@ -70,13 +75,20 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 	 */
 	private _config;
 	private _credentials;
+	private _ctx: AmplifyContext;
 
 	/**
 	 * Initialize Geo with AWS configurations
 	 * @param {Object} config - Configuration object for Geo
+	 * @param {AmplifyContext} ctx - The AmplifyContext to use for auth and config
 	 */
-	constructor(config?: GeoConfig) {
+	constructor(config?: GeoConfig, ctx?: AmplifyContext) {
 		this._config = config || {};
+		if (isAmplifyContext(ctx)) {
+			this._ctx = ctx;
+		} else {
+			this._ctx = getGlobalContext();
+		}
 		logger.debug('Geo Options', this._config);
 	}
 
@@ -713,7 +725,7 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 	 */
 	private async _ensureCredentials(): Promise<boolean> {
 		try {
-			const { credentials } = await fetchAuthSession();
+			const { credentials } = await this._ctx.fetchAuthSession();
 			if (!credentials) return false;
 			logger.debug(
 				'Set credentials for storage. Credentials are:',
@@ -730,7 +742,7 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 	}
 
 	private _refreshConfig() {
-		this._config = Amplify.getConfig().Geo?.LocationService;
+		this._config = this._ctx.resourcesConfig.Geo?.LocationService;
 		if (!this._config) {
 			const errorString =
 				"No Geo configuration found in amplify config, run 'amplify add geo' to create one and run `amplify push` after";

--- a/packages/geo/src/providers/location-service/AmazonLocationServiceProvider.ts
+++ b/packages/geo/src/providers/location-service/AmazonLocationServiceProvider.ts
@@ -75,19 +75,34 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 	 */
 	private _config;
 	private _credentials;
-	private _ctx: AmplifyContext;
+	private _explicitCtx: AmplifyContext | undefined;
+
+	/**
+	 * Resolve the AmplifyContext for this provider.
+	 * - If an explicit ctx was passed at construction, it is pinned (fixed context by design).
+	 * - Otherwise, the global context is resolved fresh per access so that reconfiguration
+	 *   (setGlobalContext with a new AmplifyContext) is honored across operations.
+	 * @private
+	 */
+	private get _ctx(): AmplifyContext {
+		if (this._explicitCtx) {
+			return this._explicitCtx;
+		}
+
+		return getGlobalContext();
+	}
 
 	/**
 	 * Initialize Geo with AWS configurations
 	 * @param {Object} config - Configuration object for Geo
-	 * @param {AmplifyContext} ctx - The AmplifyContext to use for auth and config
+	 * @param {AmplifyContext} ctx - The AmplifyContext to use for auth and config.
+	 *   When provided, the provider is pinned to this context.
+	 *   When omitted, the provider resolves the global context lazily per operation.
 	 */
 	constructor(config?: GeoConfig, ctx?: AmplifyContext) {
 		this._config = config || {};
 		if (isAmplifyContext(ctx)) {
-			this._ctx = ctx;
-		} else {
-			this._ctx = getGlobalContext();
+			this._explicitCtx = ctx;
 		}
 		logger.debug('Geo Options', this._config);
 	}
@@ -724,8 +739,10 @@ export class AmazonLocationServiceProvider implements GeoProvider {
 	 * @private
 	 */
 	private async _ensureCredentials(): Promise<boolean> {
+		// Resolve ctx outside try/catch so 'No AmplifyContext available' propagates
+		const ctx = this._ctx;
 		try {
-			const { credentials } = await this._ctx.fetchAuthSession();
+			const { credentials } = await ctx.fetchAuthSession();
 			if (!credentials) return false;
 			logger.debug(
 				'Set credentials for storage. Credentials are:',


### PR DESCRIPTION
## Description

B-geo split (Task 4) of the v6 context migration. Migrates `@aws-amplify/geo` from the Amplify singleton to the explicit `AmplifyContext` pattern (Pattern 7, class-based):

- `GeoClass` stores the context; constructor accepts an optional `AmplifyContext` and the module-level `Geo` singleton lazily falls back to the global context on first use (`isAmplifyContext`/`getGlobalContext`) — fully backward compatible.
- `AmazonLocationServiceProvider` accepts a context; config is read from `ctx.resourcesConfig.Geo` and credentials via `ctx.fetchAuthSession()` (direct `fetchAuthSession` import removed).
- `index.ts` additionally exports `GeoClass`.
- Tests rewritten to use a branded `createMockAmplifyContext` factory + `setGlobalContext`/`clearGlobalContext` with cleanup — no `Amplify.getConfig` mocking.

No server wrappers (geo has none). No changeset (feature-branch target).

## Validation

- `yarn turbo run build --filter=@aws-amplify/geo` — pass
- `eslint '**/*.{ts,tsx}'` in packages/geo — pass
- `yarn turbo run test --filter=@aws-amplify/geo` — 113 tests / 3 suites pass, ts-coverage threshold met
- `yarn turbo run test:size --filter=@aws-amplify/geo` — 40.75 kB vs 46 kB limit

## Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit tests are changed or added