### PR TITLE
feat(pubsub): migrate PubSub AWSIoT provider to AmplifyContext

### DIFF
--- a/packages/pubsub/__tests__/PubSub.test.ts
+++ b/packages/pubsub/__tests__/PubSub.test.ts
@@ -18,13 +18,34 @@ jest.mock('@aws-amplify/core', () => ({
 			},
 		};
 	},
+	// Provides the global-ctx fallback for tests that construct providers
+	// without an explicit AmplifyContext (lazy ctx resolution path).
+	// References mockGlobalCtxFetchAuthSession lazily (at call time) so
+	// explicit-ctx tests can assert it is NOT called.
+	getGlobalContext() {
+		return {
+			fetchAuthSession: mockGlobalCtxFetchAuthSession,
+		};
+	},
+}));
+
+const mockGlobalCtxFetchAuthSession = jest.fn(() => ({
+	credentials: {
+		accessKeyId: 'accessKeyId',
+		sessionToken: 'sessionToken',
+		secretAccessKey: 'secretAccessKey',
+		identityId: 'identityId',
+		authenticated: true,
+	},
 }));
 
 import { Reachability } from '@aws-amplify/core/internals/utils';
 import * as Paho from '../src/vendor/paho-mqtt';
 import { ConnectionState, PubSub as IotPubSub, mqttTopicMatch } from '../src';
 import { PubSub as MqttPubSub } from '../src/clients/mqtt';
+import { AWSIoT } from '../src/Providers/AWSIot';
 import { HubConnectionListener } from './helpers';
+import { createMockAmplifyContext } from './testUtils/mockAmplifyContext';
 import { Observable, Observer } from 'rxjs';
 import * as constants from '../src/Providers/constants';
 
@@ -568,5 +589,68 @@ describe('PubSub', () => {
 				spyDisconnect.mockClear();
 			},
 		);
+	});
+
+	describe('AWSIoT with explicit AmplifyContext', () => {
+		test('uses ctx.fetchAuthSession() for URL signing when constructed with explicit ctx', async () => {
+			const mockCtx = createMockAmplifyContext();
+			(mockCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials: {
+					accessKeyId: 'ctxAccessKeyId',
+					secretAccessKey: 'ctxSecretAccessKey',
+					sessionToken: 'ctxSessionToken',
+				},
+			});
+
+			const provider = new AWSIoT(mockCtx, {
+				region: 'us-east-1',
+				endpoint: 'wss://iot.test.org:443/mqtt',
+			});
+
+			// Access the protected endpoint getter via bracket notation
+			await provider['endpoint'];
+
+			expect(mockCtx.fetchAuthSession).toHaveBeenCalledTimes(1);
+		});
+
+		test('throws when explicit ctx returns no credentials', async () => {
+			const mockCtx = createMockAmplifyContext();
+			(mockCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials: undefined,
+			});
+
+			const provider = new AWSIoT(mockCtx, {
+				region: 'us-east-1',
+				endpoint: 'wss://iot.test.org:443/mqtt',
+			});
+
+			await expect(provider['endpoint']).rejects.toThrow(
+				'No auth session credentials',
+			);
+		});
+
+		test('does not fall back to global fetchAuthSession when explicit ctx is provided', async () => {
+			mockGlobalCtxFetchAuthSession.mockClear();
+			const mockCtx = createMockAmplifyContext();
+			(mockCtx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials: {
+					accessKeyId: 'ctxAccessKeyId',
+					secretAccessKey: 'ctxSecretAccessKey',
+					sessionToken: 'ctxSessionToken',
+				},
+			});
+
+			const provider = new AWSIoT(mockCtx, {
+				region: 'us-east-1',
+				endpoint: 'wss://iot.test.org:443/mqtt',
+			});
+
+			await provider['endpoint'];
+
+			// The global-ctx fetchAuthSession must NOT have been called because
+			// the explicit ctx path is used instead
+			expect(mockCtx.fetchAuthSession).toHaveBeenCalled();
+			expect(mockGlobalCtxFetchAuthSession).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/pubsub/__tests__/PubSub.test.ts
+++ b/packages/pubsub/__tests__/PubSub.test.ts
@@ -649,7 +649,7 @@ describe('PubSub', () => {
 
 			// The global-ctx fetchAuthSession must NOT have been called because
 			// the explicit ctx path is used instead
-			expect(mockCtx.fetchAuthSession).toHaveBeenCalled();
+			expect(mockCtx.fetchAuthSession).toHaveBeenCalledTimes(1);
 			expect(mockGlobalCtxFetchAuthSession).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/pubsub/__tests__/PubSub.test.ts
+++ b/packages/pubsub/__tests__/PubSub.test.ts
@@ -39,7 +39,7 @@ const mockGlobalCtxFetchAuthSession = jest.fn(() => ({
 	},
 }));
 
-import { Reachability } from '@aws-amplify/core/internals/utils';
+import { Reachability, Signer } from '@aws-amplify/core/internals/utils';
 import * as Paho from '../src/vendor/paho-mqtt';
 import { ConnectionState, PubSub as IotPubSub, mqttTopicMatch } from '../src';
 import { PubSub as MqttPubSub } from '../src/clients/mqtt';
@@ -607,10 +607,28 @@ describe('PubSub', () => {
 				endpoint: 'wss://iot.test.org:443/mqtt',
 			});
 
-			// Access the protected endpoint getter via bracket notation
-			await provider['endpoint'];
+			const signUrlSpy = jest.spyOn(Signer, 'signUrl');
 
-			expect(mockCtx.fetchAuthSession).toHaveBeenCalledTimes(1);
+			try {
+				// Access the protected endpoint getter via bracket notation
+				await provider['endpoint'];
+
+				expect(mockCtx.fetchAuthSession).toHaveBeenCalledTimes(1);
+				// The ctx credentials must be the ones used for URL signing —
+				// asserting the full chain from ctx.fetchAuthSession() to Signer.signUrl
+				expect(signUrlSpy).toHaveBeenCalledTimes(1);
+				expect(signUrlSpy).toHaveBeenCalledWith(
+					'wss://iot.test.org:443/mqtt',
+					{
+						access_key: 'ctxAccessKeyId',
+						secret_key: 'ctxSecretAccessKey',
+						session_token: 'ctxSessionToken',
+					},
+					{ service: 'iotdevicegateway', region: 'us-east-1' },
+				);
+			} finally {
+				signUrlSpy.mockRestore();
+			}
 		});
 
 		test('throws when explicit ctx returns no credentials', async () => {

--- a/packages/pubsub/__tests__/testUtils/mockAmplifyContext.ts
+++ b/packages/pubsub/__tests__/testUtils/mockAmplifyContext.ts
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AMPLIFY_CONTEXT_BRAND,
+	AmplifyContext,
+	ResourcesConfig,
+} from '@aws-amplify/core';
+
+/**
+ * Creates a mock AmplifyContext for testing.
+ * Accepts partial/incomplete configs to test error paths.
+ */
+export function createMockAmplifyContext(
+	resourcesConfig?: ResourcesConfig | object,
+): AmplifyContext {
+	const ctx: AmplifyContext = {
+		resourcesConfig: (resourcesConfig || {}) as ResourcesConfig,
+		libraryOptions: {},
+		fetchAuthSession: jest.fn().mockResolvedValue({}),
+		clearCredentials: jest.fn().mockResolvedValue(undefined),
+		getTokens: jest.fn().mockResolvedValue(undefined),
+	};
+
+	Object.defineProperty(ctx, AMPLIFY_CONTEXT_BRAND, {
+		value: true,
+		enumerable: false,
+	});
+
+	return ctx;
+}

--- a/packages/pubsub/src/Providers/AWSIot.ts
+++ b/packages/pubsub/src/Providers/AWSIot.ts
@@ -21,14 +21,15 @@ export class AWSIoT extends MqttOverWS {
 
 	constructor(options?: AWSIoTOptions);
 	constructor(ctx: AmplifyContext, options?: AWSIoTOptions);
-	constructor(...args: unknown[]) {
-		const hasCtx = isAmplifyContext(args[0]);
-		const options: AWSIoTOptions = hasCtx
-			? ((args[1] as AWSIoTOptions) ?? {})
-			: ((args[0] as AWSIoTOptions) ?? {});
-		super(options);
-		if (hasCtx) {
-			this._explicitCtx = args[0] as AmplifyContext;
+	constructor(
+		ctxOrOptions?: AmplifyContext | AWSIoTOptions,
+		maybeOptions?: AWSIoTOptions,
+	) {
+		if (isAmplifyContext(ctxOrOptions)) {
+			super(maybeOptions ?? {});
+			this._explicitCtx = ctxOrOptions;
+		} else {
+			super(ctxOrOptions ?? {});
 		}
 	}
 

--- a/packages/pubsub/src/Providers/AWSIot.ts
+++ b/packages/pubsub/src/Providers/AWSIot.ts
@@ -17,7 +17,7 @@ export interface AWSIoTOptions extends MqttOptions {
 }
 
 export class AWSIoT extends MqttOverWS {
-	private _explicitCtx: AmplifyContext | undefined;
+	private readonly _explicitCtx: AmplifyContext | undefined;
 
 	constructor(options?: AWSIoTOptions);
 	constructor(ctx: AmplifyContext, options?: AWSIoTOptions);

--- a/packages/pubsub/src/Providers/AWSIot.ts
+++ b/packages/pubsub/src/Providers/AWSIot.ts
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { Signer } from '@aws-amplify/core/internals/utils';
-import { fetchAuthSession } from '@aws-amplify/core';
+import {
+	AmplifyContext,
+	getGlobalContext,
+	isAmplifyContext,
+} from '@aws-amplify/core';
 
 import { MqttOptions, MqttOverWS } from './MqttOverWS';
 
@@ -13,8 +17,34 @@ export interface AWSIoTOptions extends MqttOptions {
 }
 
 export class AWSIoT extends MqttOverWS {
-	constructor(options: AWSIoTOptions = {}) {
+	private _explicitCtx: AmplifyContext | undefined;
+
+	constructor(options?: AWSIoTOptions);
+	constructor(ctx: AmplifyContext, options?: AWSIoTOptions);
+	constructor(...args: unknown[]) {
+		const hasCtx = isAmplifyContext(args[0]);
+		const options: AWSIoTOptions = hasCtx
+			? ((args[1] as AWSIoTOptions) ?? {})
+			: ((args[0] as AWSIoTOptions) ?? {});
 		super(options);
+		if (hasCtx) {
+			this._explicitCtx = args[0] as AmplifyContext;
+		}
+	}
+
+	/**
+	 * Resolve the AmplifyContext for this provider.
+	 * - If an explicit ctx was passed at construction, it is pinned (fixed context by design).
+	 * - Otherwise, the global context is resolved fresh per access so that reconfiguration
+	 *   (setGlobalContext with a new AmplifyContext) is honored across operations.
+	 * @private
+	 */
+	private get _ctx(): AmplifyContext {
+		if (this._explicitCtx) {
+			return this._explicitCtx;
+		}
+
+		return getGlobalContext();
 	}
 
 	protected get region(): string | undefined {
@@ -29,7 +59,7 @@ export class AWSIoT extends MqttOverWS {
 				service: SERVICE_NAME,
 				region: this.region,
 			};
-			const session = await fetchAuthSession();
+			const session = await this._ctx.fetchAuthSession();
 
 			if (!session.credentials) {
 				throw new Error('No auth session credentials');


### PR DESCRIPTION
## Description

B-pubsub split (Task 7, Phase 2) of the v6 context migration. Migrates `@aws-amplify/pubsub`'s `AWSIoT` provider from the module-level `fetchAuthSession` import to the explicit `AmplifyContext` pattern (Pattern 7, class-based):

- `AWSIoT` constructor gains an overload accepting an optional `AmplifyContext` as first argument (`new AWSIoT(ctx, options)`), discriminated via `isAmplifyContext` — plain options objects are never mistaken for a context, so existing `new AWSIoT(options)` callers are fully backward compatible.
- The explicit context is stored only when branded; a private `_ctx` getter lazily resolves `explicitCtx ?? getGlobalContext()` fresh per operation (no constructor-time global-context snapshot, per the correction that landed in #14916).
- WebSocket URL signing in `get endpoint` now uses `this._ctx.fetchAuthSession()`; the direct `fetchAuthSession` import from `@aws-amplify/core` is removed.
- Adds `__tests__/testUtils/mockAmplifyContext.ts` (branded mock factory, same as sibling packages) and explicit-ctx tests: ctx-based signing, missing-credentials error path, and a negative assertion that the global context is not consulted when an explicit ctx is provided. No `Amplify.getConfig` mocking.

Config (region/endpoint) remains constructor-options-based — pubsub reads no `resourcesConfig` category; only the auth call migrates to ctx. No server wrappers (pubsub has none). No changeset (feature-branch target).

Depends on B-auth (#14836) — already merged into the base branch.

## Validation

- `yarn turbo run build --filter=@aws-amplify/pubsub` — pass
- `yarn turbo run test --filter=@aws-amplify/pubsub` — 20 tests / 1 suite pass
- `yarn turbo run lint --filter=@aws-amplify/pubsub` — pass
- `yarn test:size` (packages/pubsub) — IoT 88 B vs 1.2 kB limit, Mqtt 89 B vs 1.07 kB limit

## Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit tests are changed or added
