### PR TITLE
feat(predictions): migrate Predictions to AmplifyContext

### DIFF
--- a/packages/predictions/__tests__/Predictions.test.ts
+++ b/packages/predictions/__tests__/Predictions.test.ts
@@ -96,6 +96,23 @@ describe('Predictions test', () => {
 		afterEach(() => {
 			jest.restoreAllMocks();
 		});
+
+		test('all three providers receive the same ctx instance', () => {
+			const ctx = createMockAmplifyContext();
+
+			const predictions = new PredictionsClass(ctx);
+
+			// Access the private providers and verify each received the exact same ctx (identity check)
+			type ProviderWithCtx = { _explicitCtx: unknown };
+			const convertProvider = (predictions as unknown as { convertProvider: ProviderWithCtx }).convertProvider;
+			const identifyProvider = (predictions as unknown as { identifyProvider: ProviderWithCtx }).identifyProvider;
+			const interpretProvider = (predictions as unknown as { interpretProvider: ProviderWithCtx }).interpretProvider;
+
+			expect(convertProvider._explicitCtx).toBe(ctx);
+			expect(identifyProvider._explicitCtx).toBe(ctx);
+			expect(interpretProvider._explicitCtx).toBe(ctx);
+		});
+
 		test('convert delegates to provider constructed with ctx', async () => {
 			const ctx = createMockAmplifyContext();
 			const input: TranslateTextInput = {

--- a/packages/predictions/__tests__/Predictions.test.ts
+++ b/packages/predictions/__tests__/Predictions.test.ts
@@ -113,7 +113,7 @@ describe('Predictions test', () => {
 			expect(interpretProvider._explicitCtx).toBe(ctx);
 		});
 
-		test('convert delegates to provider constructed with ctx', async () => {
+		test('convert delegates to the convert provider', async () => {
 			const ctx = createMockAmplifyContext();
 			const input: TranslateTextInput = {
 				translateText: { source: { text: 'sourceText' } },
@@ -133,7 +133,7 @@ describe('Predictions test', () => {
 			expect(convertSpy).toHaveBeenCalledTimes(1);
 		});
 
-		test('identify delegates to provider constructed with ctx', async () => {
+		test('identify delegates to the identify provider', async () => {
 			const ctx = createMockAmplifyContext();
 			const input: IdentifyTextInput = {
 				text: { source: { key: 'key' }, format: 'PLAIN' },
@@ -157,7 +157,7 @@ describe('Predictions test', () => {
 			expect(identifySpy).toHaveBeenCalledTimes(1);
 		});
 
-		test('interpret delegates to provider constructed with ctx', async () => {
+		test('interpret delegates to the interpret provider', async () => {
 			const ctx = createMockAmplifyContext();
 			const input: InterpretTextInput = {
 				text: {

--- a/packages/predictions/__tests__/Predictions.test.ts
+++ b/packages/predictions/__tests__/Predictions.test.ts
@@ -13,6 +13,8 @@ import {
 	TranslateTextOutput,
 } from '../src/types';
 
+import { createMockAmplifyContext } from './testUtils';
+
 describe('Predictions test', () => {
 	describe('getModuleName tests', () => {
 		test('happy and the only case', () => {
@@ -20,68 +22,146 @@ describe('Predictions test', () => {
 		});
 	});
 
-	test('convert test', async () => {
-		const predictions = new PredictionsClass();
-		const input: TranslateTextInput = {
-			translateText: { source: { text: 'sourceText' } },
-		};
-		const result: TranslateTextOutput = {
-			text: 'translatedText',
-			language: 'en',
-		};
-		const convertSpy = jest
-			.spyOn(AmazonAIConvertPredictionsProvider.prototype, 'convert')
-			.mockImplementation(() => {
-				return Promise.resolve(result);
-			});
-		const data = await predictions.convert(input);
-		expect(data).toEqual(result);
-		expect(convertSpy).toHaveBeenCalledTimes(1);
-	});
+	describe('global-ctx fallback (no explicit ctx)', () => {
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+		test('convert test', async () => {
+			const predictions = new PredictionsClass();
+			const input: TranslateTextInput = {
+				translateText: { source: { text: 'sourceText' } },
+			};
+			const result: TranslateTextOutput = {
+				text: 'translatedText',
+				language: 'en',
+			};
+			const convertSpy = jest
+				.spyOn(AmazonAIConvertPredictionsProvider.prototype, 'convert')
+				.mockImplementation(() => {
+					return Promise.resolve(result);
+				});
+			const data = await predictions.convert(input);
+			expect(data).toEqual(result);
+			expect(convertSpy).toHaveBeenCalledTimes(1);
+		});
 
-	test('identify test', async () => {
-		const predictions = new PredictionsClass();
-		const input: IdentifyTextInput = {
-			text: { source: { key: 'key' }, format: 'PLAIN' },
-		};
-		const result: IdentifyTextOutput = {
-			text: {
-				fullText: 'Hello world',
-				lines: ['Hello world'],
-				linesDetailed: [{ text: 'Hello world' }],
-				words: [{ text: 'Hello' }, { text: 'world' }],
-			},
-		};
-		const identifySpy = jest
-			.spyOn(AmazonAIIdentifyPredictionsProvider.prototype, 'identify')
-			.mockImplementation(() => {
-				return Promise.resolve(result);
-			});
-		const data = await predictions.identify(input);
-		expect(data).toEqual(result);
-		expect(identifySpy).toHaveBeenCalledTimes(1);
-	});
-
-	test('interpret test', async () => {
-		const predictions = new PredictionsClass();
-		const input: InterpretTextInput = {
-			text: {
-				source: {
-					text: 'Test text',
+		test('identify test', async () => {
+			const predictions = new PredictionsClass();
+			const input: IdentifyTextInput = {
+				text: { source: { key: 'key' }, format: 'PLAIN' },
+			};
+			const result: IdentifyTextOutput = {
+				text: {
+					fullText: 'Hello world',
+					lines: ['Hello world'],
+					linesDetailed: [{ text: 'Hello world' }],
+					words: [{ text: 'Hello' }, { text: 'world' }],
 				},
-				type: 'language',
-			},
-		};
-		const result: InterpretTextOutput = {
-			textInterpretation: { language: 'en-US' },
-		};
-		const interpretSpy = jest
-			.spyOn(AmazonAIInterpretPredictionsProvider.prototype, 'interpret')
-			.mockImplementation(() => {
-				return Promise.resolve(result);
-			});
-		const data = await predictions.interpret(input);
-		expect(data).toEqual(result);
-		expect(interpretSpy).toHaveBeenCalledTimes(1);
+			};
+			const identifySpy = jest
+				.spyOn(AmazonAIIdentifyPredictionsProvider.prototype, 'identify')
+				.mockImplementation(() => {
+					return Promise.resolve(result);
+				});
+			const data = await predictions.identify(input);
+			expect(data).toEqual(result);
+			expect(identifySpy).toHaveBeenCalledTimes(1);
+		});
+
+		test('interpret test', async () => {
+			const predictions = new PredictionsClass();
+			const input: InterpretTextInput = {
+				text: {
+					source: {
+						text: 'Test text',
+					},
+					type: 'language',
+				},
+			};
+			const result: InterpretTextOutput = {
+				textInterpretation: { language: 'en-US' },
+			};
+			const interpretSpy = jest
+				.spyOn(AmazonAIInterpretPredictionsProvider.prototype, 'interpret')
+				.mockImplementation(() => {
+					return Promise.resolve(result);
+				});
+			const data = await predictions.interpret(input);
+			expect(data).toEqual(result);
+			expect(interpretSpy).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('explicit-ctx construction', () => {
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+		test('convert delegates to provider constructed with ctx', async () => {
+			const ctx = createMockAmplifyContext();
+			const input: TranslateTextInput = {
+				translateText: { source: { text: 'sourceText' } },
+			};
+			const result: TranslateTextOutput = {
+				text: 'translatedText',
+				language: 'en',
+			};
+			const convertSpy = jest
+				.spyOn(AmazonAIConvertPredictionsProvider.prototype, 'convert')
+				.mockImplementation(() => {
+					return Promise.resolve(result);
+				});
+			const predictions = new PredictionsClass(ctx);
+			const data = await predictions.convert(input);
+			expect(data).toEqual(result);
+			expect(convertSpy).toHaveBeenCalledTimes(1);
+		});
+
+		test('identify delegates to provider constructed with ctx', async () => {
+			const ctx = createMockAmplifyContext();
+			const input: IdentifyTextInput = {
+				text: { source: { key: 'key' }, format: 'PLAIN' },
+			};
+			const result: IdentifyTextOutput = {
+				text: {
+					fullText: 'Hello world',
+					lines: ['Hello world'],
+					linesDetailed: [{ text: 'Hello world' }],
+					words: [{ text: 'Hello' }, { text: 'world' }],
+				},
+			};
+			const identifySpy = jest
+				.spyOn(AmazonAIIdentifyPredictionsProvider.prototype, 'identify')
+				.mockImplementation(() => {
+					return Promise.resolve(result);
+				});
+			const predictions = new PredictionsClass(ctx);
+			const data = await predictions.identify(input);
+			expect(data).toEqual(result);
+			expect(identifySpy).toHaveBeenCalledTimes(1);
+		});
+
+		test('interpret delegates to provider constructed with ctx', async () => {
+			const ctx = createMockAmplifyContext();
+			const input: InterpretTextInput = {
+				text: {
+					source: {
+						text: 'Test text',
+					},
+					type: 'language',
+				},
+			};
+			const result: InterpretTextOutput = {
+				textInterpretation: { language: 'en-US' },
+			};
+			const interpretSpy = jest
+				.spyOn(AmazonAIInterpretPredictionsProvider.prototype, 'interpret')
+				.mockImplementation(() => {
+					return Promise.resolve(result);
+				});
+			const predictions = new PredictionsClass(ctx);
+			const data = await predictions.interpret(input);
+			expect(data).toEqual(result);
+			expect(interpretSpy).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/packages/predictions/__tests__/providers/AWSAIConvertPredictionsProvider.test.ts
+++ b/packages/predictions/__tests__/providers/AWSAIConvertPredictionsProvider.test.ts
@@ -1,4 +1,3 @@
-import { Amplify, fetchAuthSession } from '@aws-amplify/core';
 import {
 	Category,
 	PredictionsAction,
@@ -21,18 +20,7 @@ import {
 	TranslateTextInput,
 } from '../../src/types';
 
-const mockFetchAuthSession = fetchAuthSession as jest.Mock;
-const mockGetConfig = Amplify.getConfig as jest.Mock;
-
-jest.mock('@aws-amplify/core', () => ({
-	fetchAuthSession: jest.fn(),
-	Amplify: {
-		getConfig: jest.fn(),
-	},
-	ConsoleLogger: jest.fn(() => ({
-		debug: jest.fn(),
-	})),
-}));
+import { createMockAmplifyContext } from '../testUtils';
 
 const result = { TranslatedText: 'translatedText', TargetLanguageCode: 'es' };
 const resetTranslateMock = () => {
@@ -162,28 +150,24 @@ describe('Predictions convert provider test', () => {
 			jest.clearAllMocks();
 		});
 		test('happy case credentials exist', () => {
-			mockFetchAuthSession.mockResolvedValue({
+			const ctx = createMockAmplifyContext({
+				Predictions: { convert: options },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
 				credentials,
 				identityId,
 			});
-			mockGetConfig.mockReturnValue({
-				Predictions: {
-					convert: options,
-				},
-			});
-			const predictionsProvider = new AmazonAIConvertPredictionsProvider();
+			const predictionsProvider = new AmazonAIConvertPredictionsProvider(ctx);
 			expect(
 				predictionsProvider.convert(validTranslateTextInput),
 			).resolves.toMatchObject({ language: 'es', text: 'translatedText' });
 		});
 		test('error case credentials do not exist', () => {
-			mockFetchAuthSession.mockResolvedValue({});
-			mockGetConfig.mockReturnValue({
-				Predictions: {
-					convert: options,
-				},
+			const ctx = createMockAmplifyContext({
+				Predictions: { convert: options },
 			});
-			const predictionsProvider = new AmazonAIConvertPredictionsProvider();
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({});
+			const predictionsProvider = new AmazonAIConvertPredictionsProvider(ctx);
 
 			expect(
 				predictionsProvider.convert(validTranslateTextInput),
@@ -194,16 +178,14 @@ describe('Predictions convert provider test', () => {
 			);
 		});
 		test('error case credentials exist but service fails', () => {
-			mockFetchAuthSession.mockResolvedValue({
+			const ctx = createMockAmplifyContext({
+				Predictions: { convert: options },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
 				credentials,
 				identityId,
 			});
-			mockGetConfig.mockReturnValue({
-				Predictions: {
-					convert: options,
-				},
-			});
-			const predictionsProvider = new AmazonAIConvertPredictionsProvider();
+			const predictionsProvider = new AmazonAIConvertPredictionsProvider(ctx);
 			jest.spyOn(TranslateClient.prototype, 'send').mockImplementation(() => {
 				return Promise.reject('error');
 			});
@@ -218,16 +200,14 @@ describe('Predictions convert provider test', () => {
 			jest.clearAllMocks();
 		});
 		test('happy case credentials exist', () => {
-			mockFetchAuthSession.mockResolvedValue({
+			const ctx = createMockAmplifyContext({
+				Predictions: { convert: options },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
 				credentials,
 				identityId,
 			});
-			mockGetConfig.mockReturnValue({
-				Predictions: {
-					convert: options,
-				},
-			});
-			const predictionsProvider = new AmazonAIConvertPredictionsProvider();
+			const predictionsProvider = new AmazonAIConvertPredictionsProvider(ctx);
 			window.URL.createObjectURL = jest.fn();
 			jest.spyOn(URL, 'createObjectURL').mockImplementation(blob => {
 				return 'dummyURL';
@@ -243,13 +223,11 @@ describe('Predictions convert provider test', () => {
 			});
 		});
 		test('error case credentials do not exist', () => {
-			mockFetchAuthSession.mockResolvedValue({});
-			mockGetConfig.mockReturnValue({
-				Predictions: {
-					convert: options,
-				},
+			const ctx = createMockAmplifyContext({
+				Predictions: { convert: options },
 			});
-			const predictionsProvider = new AmazonAIConvertPredictionsProvider();
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({});
+			const predictionsProvider = new AmazonAIConvertPredictionsProvider(ctx);
 			expect(
 				predictionsProvider.convert(validTextToSpeechInput),
 			).rejects.toThrow(
@@ -259,16 +237,14 @@ describe('Predictions convert provider test', () => {
 			);
 		});
 		test('error case credentials exist but service fails', () => {
-			mockFetchAuthSession.mockResolvedValue({
+			const ctx = createMockAmplifyContext({
+				Predictions: { convert: options },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
 				credentials,
 				identityId,
 			});
-			mockGetConfig.mockReturnValue({
-				Predictions: {
-					convert: options,
-				},
-			});
-			const predictionsProvider = new AmazonAIConvertPredictionsProvider();
+			const predictionsProvider = new AmazonAIConvertPredictionsProvider(ctx);
 			jest.spyOn(PollyClient.prototype, 'send').mockImplementation(() => {
 				return Promise.reject('error');
 			});
@@ -283,11 +259,7 @@ describe('Predictions convert provider test', () => {
 			jest.clearAllMocks();
 		});
 		test('Error region not configured', () => {
-			mockFetchAuthSession.mockResolvedValue({
-				credentials,
-				identityId,
-			});
-			mockGetConfig.mockReturnValue({
+			const ctx = createMockAmplifyContext({
 				Predictions: {
 					convert: {
 						transcription: {
@@ -299,13 +271,17 @@ describe('Predictions convert provider test', () => {
 					},
 				},
 			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+				identityId,
+			});
 			AmazonAIConvertPredictionsProvider.serializeDataFromTranscribe = jest.fn(
 				() => {
 					return 'Hello how are you';
 				},
 			);
 
-			const predictionsProvider = new AmazonAIConvertPredictionsProvider();
+			const predictionsProvider = new AmazonAIConvertPredictionsProvider(ctx);
 
 			return expect(
 				predictionsProvider.convert(validSpeechToTextInput),
@@ -316,11 +292,7 @@ describe('Predictions convert provider test', () => {
 			);
 		});
 		test('Error languageCode not configured ', () => {
-			mockFetchAuthSession.mockResolvedValue({
-				credentials,
-				identityId,
-			});
-			mockGetConfig.mockReturnValue({
+			const ctx = createMockAmplifyContext({
 				Predictions: {
 					convert: {
 						transcription: {
@@ -330,13 +302,17 @@ describe('Predictions convert provider test', () => {
 					},
 				},
 			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+				identityId,
+			});
 			AmazonAIConvertPredictionsProvider.serializeDataFromTranscribe = jest.fn(
 				() => {
 					return 'Hello how are you';
 				},
 			);
 
-			const predictionsProvider = new AmazonAIConvertPredictionsProvider();
+			const predictionsProvider = new AmazonAIConvertPredictionsProvider(ctx);
 
 			expect(
 				predictionsProvider.convert(validSpeechToTextInput),
@@ -347,14 +323,12 @@ describe('Predictions convert provider test', () => {
 			);
 		});
 		test('Happy case ', () => {
-			mockFetchAuthSession.mockResolvedValue({
+			const ctx = createMockAmplifyContext({
+				Predictions: { convert: options },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
 				credentials,
 				identityId,
-			});
-			mockGetConfig.mockReturnValue({
-				Predictions: {
-					convert: options,
-				},
 			});
 			AmazonAIConvertPredictionsProvider.serializeDataFromTranscribe = jest.fn(
 				() => {
@@ -362,7 +336,7 @@ describe('Predictions convert provider test', () => {
 				},
 			);
 
-			const predictionsProvider = new AmazonAIConvertPredictionsProvider();
+			const predictionsProvider = new AmazonAIConvertPredictionsProvider(ctx);
 
 			expect(
 				predictionsProvider.convert(validSpeechToTextInput),
@@ -373,11 +347,7 @@ describe('Predictions convert provider test', () => {
 			} as SpeechToTextOutput);
 		});
 		test('Downsized Happy case ', async () => {
-			mockFetchAuthSession.mockResolvedValue({
-				credentials,
-				identityId,
-			});
-			mockGetConfig.mockReturnValue({
+			const ctx = createMockAmplifyContext({
 				Predictions: {
 					convert: {
 						transcription: {
@@ -390,6 +360,10 @@ describe('Predictions convert provider test', () => {
 					},
 				},
 			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+				identityId,
+			});
 			AmazonAIConvertPredictionsProvider.serializeDataFromTranscribe = jest.fn(
 				() => {
 					return 'Bonjour, comment vas tu?';
@@ -400,7 +374,7 @@ describe('Predictions convert provider test', () => {
 				'downsampleBuffer',
 			);
 
-			const predictionsProvider = new AmazonAIConvertPredictionsProvider();
+			const predictionsProvider = new AmazonAIConvertPredictionsProvider(ctx);
 
 			await predictionsProvider.convert(validSpeechToTextInput);
 			expect(downsampleBufferSpyon).toHaveBeenCalledWith(
@@ -415,16 +389,14 @@ describe('Predictions convert provider test', () => {
 			jest.clearAllMocks();
 		});
 		test('convert text to speech initializes a client with the correct custom user agent', async () => {
-			mockFetchAuthSession.mockResolvedValue({
+			const ctx = createMockAmplifyContext({
+				Predictions: { convert: options },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
 				credentials,
 				identityId,
 			});
-			mockGetConfig.mockReturnValue({
-				Predictions: {
-					convert: options,
-				},
-			});
-			const predictionsProvider = new AmazonAIConvertPredictionsProvider();
+			const predictionsProvider = new AmazonAIConvertPredictionsProvider(ctx);
 			window.URL.createObjectURL = jest.fn();
 			jest.spyOn(URL, 'createObjectURL').mockImplementation(blob => {
 				return 'dummyURL';
@@ -444,16 +416,14 @@ describe('Predictions convert provider test', () => {
 			);
 		});
 		test('convert translate text initializes a client with the correct custom user agent', async () => {
-			mockFetchAuthSession.mockResolvedValue({
+			const ctx = createMockAmplifyContext({
+				Predictions: { convert: options },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
 				credentials,
 				identityId,
 			});
-			mockGetConfig.mockReturnValue({
-				Predictions: {
-					convert: options,
-				},
-			});
-			const predictionsProvider = new AmazonAIConvertPredictionsProvider();
+			const predictionsProvider = new AmazonAIConvertPredictionsProvider(ctx);
 
 			await predictionsProvider.convert(validTranslateTextInput);
 			// translateClient is a private property

--- a/packages/predictions/__tests__/providers/AWSAIIdentifyPredictionsProvider.test.ts
+++ b/packages/predictions/__tests__/providers/AWSAIIdentifyPredictionsProvider.test.ts
@@ -1,4 +1,3 @@
-import { Amplify, fetchAuthSession } from '@aws-amplify/core';
 import {
 	Category,
 	PredictionsAction,
@@ -40,23 +39,13 @@ import {
 } from '../../src/types';
 import { BlockList } from '../../src/types/AWSTypes';
 
-const mockFetchAuthSession = fetchAuthSession as jest.Mock;
-const mockGetConfig = Amplify.getConfig as jest.Mock;
-const mockGetUrl = getUrl as jest.Mock;
-
-jest.mock('@aws-amplify/core', () => ({
-	fetchAuthSession: jest.fn(),
-	Amplify: {
-		getConfig: jest.fn(),
-	},
-	ConsoleLogger: jest.fn(() => ({
-		debug: jest.fn(),
-	})),
-}));
+import { createMockAmplifyContext } from '../testUtils';
 
 jest.mock('@aws-amplify/storage', () => ({
 	getUrl: jest.fn(),
 }));
+
+const mockGetUrl = getUrl as jest.Mock;
 
 // valid response
 RekognitionClient.prototype.send = jest.fn(command => {
@@ -272,37 +261,38 @@ const options = {
 	},
 };
 
-mockFetchAuthSession.mockResolvedValue({
-	credentials,
-	identityId,
-});
-mockGetConfig.mockReturnValue({
-	Predictions: {
-		identify: options,
-	},
-});
-mockGetUrl.mockImplementation(({ key, options }) => {
-	console.log(key, options);
-	const level = options?.accessLevel || 'guest';
+mockGetUrl.mockImplementation((...args: any[]) => {
+	// Handle ctx-aware overload: getUrl(ctx, { key, options })
+	const input = args.length === 2 ? args[1] : args[0];
+	const { key, options: storageOptions } = input;
+	const level = storageOptions?.accessLevel || 'guest';
 	let url: URL;
 	if (level === 'guest') {
 		url = new URL(
 			`https://bucket-name.s3.us-west-2.amazonaws.com/public/${key}?X-Amz-Algorithm=AWS4-HMAC-SHA256`,
 		);
 	} else {
-		const identityId = options?.targetIdentityId || 'identityId';
+		const targetIdentityId = storageOptions?.targetIdentityId || 'identityId';
 		url = new URL(
-			`https://bucket-name.s3.us-west-2.amazonaws.com/${level}/${identityId}/key.png?X-Amz-Algorithm=AWS4-HMAC-SHA256`,
+			`https://bucket-name.s3.us-west-2.amazonaws.com/${level}/${targetIdentityId}/key.png?X-Amz-Algorithm=AWS4-HMAC-SHA256`,
 		);
 	}
 	return Promise.resolve({ url });
 });
 
 describe('Predictions identify provider test', () => {
-	let predictionsProvider;
+	let predictionsProvider: AmazonAIIdentifyPredictionsProvider;
+	let ctx: ReturnType<typeof createMockAmplifyContext>;
 
 	beforeAll(() => {
-		predictionsProvider = new AmazonAIIdentifyPredictionsProvider();
+		ctx = createMockAmplifyContext({
+			Predictions: { identify: options },
+		});
+		(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
+			credentials,
+			identityId,
+		});
+		predictionsProvider = new AmazonAIIdentifyPredictionsProvider(ctx);
 	});
 	describe('identifyText tests', () => {
 		describe('identifyText::PLAIN tests', () => {
@@ -324,7 +314,7 @@ describe('Predictions identify provider test', () => {
 			});
 
 			test('error case no credentials', () => {
-				mockFetchAuthSession.mockResolvedValueOnce({});
+				(ctx.fetchAuthSession as jest.Mock).mockResolvedValueOnce({});
 
 				expect(predictionsProvider.identify(detectTextInput)).rejects.toThrow(
 					expect.objectContaining(
@@ -411,7 +401,7 @@ describe('Predictions identify provider test', () => {
 				).resolves.toMatchObject(expected);
 			});
 			test('error case credentials do not exist', () => {
-				mockFetchAuthSession.mockResolvedValueOnce({});
+				(ctx.fetchAuthSession as jest.Mock).mockResolvedValueOnce({});
 
 				expect(predictionsProvider.identify(detectLabelInput)).rejects.toThrow(
 					expect.objectContaining(
@@ -518,7 +508,7 @@ describe('Predictions identify provider test', () => {
 			});
 
 			test('error case credentials do not exist', () => {
-				mockFetchAuthSession.mockResolvedValueOnce({});
+				(ctx.fetchAuthSession as jest.Mock).mockResolvedValueOnce({});
 
 				expect(predictionsProvider.identify(detectFacesInput)).rejects.toThrow(
 					expect.objectContaining(
@@ -716,7 +706,7 @@ describe('Predictions identify provider test', () => {
 		test('error case invalid input source', () => {
 			const detectLabelInput = {
 				labels: { source: null, type: 'LABELS' },
-			};
+			} as unknown as IdentifyLabelsInput;
 			expect(predictionsProvider.identify(detectLabelInput)).rejects.toThrow(
 				'not configured correctly',
 			);
@@ -725,7 +715,7 @@ describe('Predictions identify provider test', () => {
 
 	describe('custom user agent', () => {
 		test('identify for label initializes a client with the correct custom user agent', async () => {
-			predictionsProvider = new AmazonAIIdentifyPredictionsProvider();
+			predictionsProvider = new AmazonAIIdentifyPredictionsProvider(ctx);
 			jest.spyOn(TextractClient.prototype, 'send');
 			jest.spyOn(RekognitionClient.prototype, 'send');
 			const fileInput = new File([Buffer.from('file')], 'file');
@@ -735,7 +725,7 @@ describe('Predictions identify provider test', () => {
 			await predictionsProvider.identify(detectLabelInput);
 
 			expect(
-				predictionsProvider.rekognitionClient.config.customUserAgent,
+				(predictionsProvider as any).rekognitionClient.config.customUserAgent,
 			).toEqual(
 				getAmplifyUserAgentObject({
 					category: Category.Predictions,
@@ -744,7 +734,7 @@ describe('Predictions identify provider test', () => {
 			);
 		});
 		test('identify for entities initializes a client with the correct custom user agent', async () => {
-			predictionsProvider = new AmazonAIIdentifyPredictionsProvider();
+			predictionsProvider = new AmazonAIIdentifyPredictionsProvider(ctx);
 			jest.spyOn(TextractClient.prototype, 'send');
 			jest.spyOn(RekognitionClient.prototype, 'send');
 			const detectFacesInput: IdentifyEntitiesInput = {
@@ -758,7 +748,7 @@ describe('Predictions identify provider test', () => {
 			await predictionsProvider.identify(detectFacesInput);
 
 			expect(
-				predictionsProvider.rekognitionClient.config.customUserAgent,
+				(predictionsProvider as any).rekognitionClient.config.customUserAgent,
 			).toEqual(
 				getAmplifyUserAgentObject({
 					category: Category.Predictions,
@@ -767,7 +757,7 @@ describe('Predictions identify provider test', () => {
 			);
 		});
 		test('identify for text initializes a client with the correct custom user agent', async () => {
-			predictionsProvider = new AmazonAIIdentifyPredictionsProvider();
+			predictionsProvider = new AmazonAIIdentifyPredictionsProvider(ctx);
 			jest.spyOn(TextractClient.prototype, 'send');
 			jest.spyOn(RekognitionClient.prototype, 'send');
 			const detectTextInput: IdentifyTextInput = {
@@ -776,7 +766,7 @@ describe('Predictions identify provider test', () => {
 			await predictionsProvider.identify(detectTextInput);
 
 			expect(
-				predictionsProvider.rekognitionClient.config.customUserAgent,
+				(predictionsProvider as any).rekognitionClient.config.customUserAgent,
 			).toEqual(
 				getAmplifyUserAgentObject({
 					category: Category.Predictions,
@@ -784,7 +774,9 @@ describe('Predictions identify provider test', () => {
 				}),
 			);
 
-			expect(predictionsProvider.textractClient.config.customUserAgent).toEqual(
+			expect(
+				(predictionsProvider as any).textractClient.config.customUserAgent,
+			).toEqual(
 				getAmplifyUserAgentObject({
 					category: Category.Predictions,
 					action: PredictionsAction.Identify,

--- a/packages/predictions/__tests__/providers/AWSAIIdentifyPredictionsProvider.test.ts
+++ b/packages/predictions/__tests__/providers/AWSAIIdentifyPredictionsProvider.test.ts
@@ -294,6 +294,17 @@ describe('Predictions identify provider test', () => {
 		});
 		predictionsProvider = new AmazonAIIdentifyPredictionsProvider(ctx);
 	});
+
+	test('explicit ctx is forwarded to storage getUrl (identity check)', async () => {
+		mockGetUrl.mockClear();
+		const input: IdentifyLabelsInput = {
+			labels: { source: { key: 'key' }, type: 'LABELS' },
+		};
+		await predictionsProvider.identify(input);
+		// Assert the ctx-aware overload was used and the SAME ctx instance was passed
+		expect(mockGetUrl.mock.calls[0][0]).toBe(ctx);
+	});
+
 	describe('identifyText tests', () => {
 		describe('identifyText::PLAIN tests', () => {
 			const detectTextInput: IdentifyTextInput = {
@@ -704,6 +715,7 @@ describe('Predictions identify provider test', () => {
 		});
 
 		test('error case invalid input source', () => {
+			// Intentionally bypasses compile-time checks to exercise the provider's runtime input validation
 			const detectLabelInput = {
 				labels: { source: null, type: 'LABELS' },
 			} as unknown as IdentifyLabelsInput;

--- a/packages/predictions/__tests__/providers/AWSAIInterpretPredictionsProvider.test.ts
+++ b/packages/predictions/__tests__/providers/AWSAIInterpretPredictionsProvider.test.ts
@@ -1,4 +1,3 @@
-import { Amplify, fetchAuthSession } from '@aws-amplify/core';
 import {
 	Category,
 	PredictionsAction,
@@ -13,18 +12,8 @@ import {
 	DetectSyntaxCommand,
 } from '@aws-sdk/client-comprehend';
 
-const mockFetchAuthSession = fetchAuthSession as jest.Mock;
-const mockGetConfig = Amplify.getConfig as jest.Mock;
-
-jest.mock('@aws-amplify/core', () => ({
-	fetchAuthSession: jest.fn(),
-	Amplify: {
-		getConfig: jest.fn(),
-	},
-	ConsoleLogger: jest.fn(() => ({
-		debug: jest.fn(),
-	})),
-}));
+import { AmazonAIInterpretPredictionsProvider } from '../../src/providers';
+import { createMockAmplifyContext } from '../testUtils';
 
 ComprehendClient.prototype.send = jest.fn((command, callback) => {
 	if (command instanceof DetectEntitiesCommand) {
@@ -205,23 +194,12 @@ const happyConfig = {
 	},
 };
 
-// Mocks before importing provider to avoid race condition with provider instantiation
-import { AmazonAIInterpretPredictionsProvider } from '../../src/providers';
-
 const credentials = {
 	accessKeyId: 'accessKeyId',
 	sessionToken: 'sessionToken',
 	secretAccessKey: 'secretAccessKey',
 };
 const identityId = 'identityId';
-
-mockFetchAuthSession.mockResolvedValue({
-	credentials,
-	identityId,
-});
-mockGetConfig.mockReturnValue({
-	Predictions: { interpret: happyConfig },
-});
 
 const textToTest =
 	'Well this is the end, William what do you think about global warming?';
@@ -232,7 +210,16 @@ describe('Predictions interpret provider test', () => {
 	});
 	describe('interpretText tests', () => {
 		test('happy case credentials exist detectEntities', async () => {
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider();
+			const ctx = createMockAmplifyContext({
+				Predictions: { interpret: happyConfig },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+				identityId,
+			});
+			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
+				ctx,
+			);
 			const detectEntitiesSpy = jest.spyOn(ComprehendClient.prototype, 'send');
 			expect.assertions(2);
 
@@ -261,7 +248,16 @@ describe('Predictions interpret provider test', () => {
 		});
 
 		test('happy case credentials exists detectDominantLanguage', async () => {
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider();
+			const ctx = createMockAmplifyContext({
+				Predictions: { interpret: happyConfig },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+				identityId,
+			});
+			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
+				ctx,
+			);
 			const dominantLanguageSpy = jest.spyOn(
 				ComprehendClient.prototype,
 				'send',
@@ -292,7 +288,16 @@ describe('Predictions interpret provider test', () => {
 		});
 
 		test('happy case credentials exists detect sentiment', async () => {
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider();
+			const ctx = createMockAmplifyContext({
+				Predictions: { interpret: happyConfig },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+				identityId,
+			});
+			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
+				ctx,
+			);
 			const sentimentSpy = jest.spyOn(ComprehendClient.prototype, 'send');
 
 			expect.assertions(2);
@@ -328,7 +333,16 @@ describe('Predictions interpret provider test', () => {
 		});
 
 		test('happy case credentials exists detect syntax', async () => {
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider();
+			const ctx = createMockAmplifyContext({
+				Predictions: { interpret: happyConfig },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+				identityId,
+			});
+			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
+				ctx,
+			);
 			const syntaxSpy = jest.spyOn(ComprehendClient.prototype, 'send');
 
 			expect.assertions(2);
@@ -374,7 +388,16 @@ describe('Predictions interpret provider test', () => {
 		});
 
 		test('happy case credentials exists detect key phrases', async () => {
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider();
+			const ctx = createMockAmplifyContext({
+				Predictions: { interpret: happyConfig },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+				identityId,
+			});
+			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
+				ctx,
+			);
 			const keyPhrasesSpy = jest.spyOn(ComprehendClient.prototype, 'send');
 
 			expect.assertions(2);
@@ -408,7 +431,16 @@ describe('Predictions interpret provider test', () => {
 		});
 
 		test("happy case credentials type: 'all'", async () => {
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider();
+			const ctx = createMockAmplifyContext({
+				Predictions: { interpret: happyConfig },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+				identityId,
+			});
+			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
+				ctx,
+			);
 			await expect(
 				predictionsProvider.interpret({
 					text: {
@@ -482,8 +514,17 @@ describe('Predictions interpret provider test', () => {
 
 	describe('custom user agent', () => {
 		test('interpret initializes a client with the correct custom user agent', async () => {
+			const ctx = createMockAmplifyContext({
+				Predictions: { interpret: happyConfig },
+			});
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
+				credentials,
+				identityId,
+			});
 			jest.spyOn(ComprehendClient.prototype, 'send');
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider();
+			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
+				ctx,
+			);
 			await predictionsProvider.interpret({
 				text: {
 					source: {

--- a/packages/predictions/__tests__/providers/AWSAIInterpretPredictionsProvider.test.ts
+++ b/packages/predictions/__tests__/providers/AWSAIInterpretPredictionsProvider.test.ts
@@ -12,6 +12,10 @@ import {
 	DetectSyntaxCommand,
 } from '@aws-sdk/client-comprehend';
 
+import {
+	PredictionsValidationErrorCode,
+	validationErrorMap,
+} from '../../src/errors/types/validation';
 import { AmazonAIInterpretPredictionsProvider } from '../../src/providers';
 import { createMockAmplifyContext } from '../testUtils';
 
@@ -205,21 +209,25 @@ const textToTest =
 	'Well this is the end, William what do you think about global warming?';
 
 describe('Predictions interpret provider test', () => {
+	let predictionsProvider: AmazonAIInterpretPredictionsProvider;
+	let ctx: ReturnType<typeof createMockAmplifyContext>;
+
+	beforeAll(() => {
+		ctx = createMockAmplifyContext({
+			Predictions: { interpret: happyConfig },
+		});
+		(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
+			credentials,
+			identityId,
+		});
+		predictionsProvider = new AmazonAIInterpretPredictionsProvider(ctx);
+	});
+
 	afterEach(() => {
 		jest.clearAllMocks();
 	});
 	describe('interpretText tests', () => {
 		test('happy case credentials exist detectEntities', async () => {
-			const ctx = createMockAmplifyContext({
-				Predictions: { interpret: happyConfig },
-			});
-			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
-				credentials,
-				identityId,
-			});
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
-				ctx,
-			);
 			const detectEntitiesSpy = jest.spyOn(ComprehendClient.prototype, 'send');
 			expect.assertions(2);
 
@@ -248,16 +256,6 @@ describe('Predictions interpret provider test', () => {
 		});
 
 		test('happy case credentials exists detectDominantLanguage', async () => {
-			const ctx = createMockAmplifyContext({
-				Predictions: { interpret: happyConfig },
-			});
-			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
-				credentials,
-				identityId,
-			});
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
-				ctx,
-			);
 			const dominantLanguageSpy = jest.spyOn(
 				ComprehendClient.prototype,
 				'send',
@@ -288,16 +286,6 @@ describe('Predictions interpret provider test', () => {
 		});
 
 		test('happy case credentials exists detect sentiment', async () => {
-			const ctx = createMockAmplifyContext({
-				Predictions: { interpret: happyConfig },
-			});
-			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
-				credentials,
-				identityId,
-			});
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
-				ctx,
-			);
 			const sentimentSpy = jest.spyOn(ComprehendClient.prototype, 'send');
 
 			expect.assertions(2);
@@ -333,16 +321,6 @@ describe('Predictions interpret provider test', () => {
 		});
 
 		test('happy case credentials exists detect syntax', async () => {
-			const ctx = createMockAmplifyContext({
-				Predictions: { interpret: happyConfig },
-			});
-			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
-				credentials,
-				identityId,
-			});
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
-				ctx,
-			);
 			const syntaxSpy = jest.spyOn(ComprehendClient.prototype, 'send');
 
 			expect.assertions(2);
@@ -388,16 +366,6 @@ describe('Predictions interpret provider test', () => {
 		});
 
 		test('happy case credentials exists detect key phrases', async () => {
-			const ctx = createMockAmplifyContext({
-				Predictions: { interpret: happyConfig },
-			});
-			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
-				credentials,
-				identityId,
-			});
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
-				ctx,
-			);
 			const keyPhrasesSpy = jest.spyOn(ComprehendClient.prototype, 'send');
 
 			expect.assertions(2);
@@ -431,16 +399,6 @@ describe('Predictions interpret provider test', () => {
 		});
 
 		test("happy case credentials type: 'all'", async () => {
-			const ctx = createMockAmplifyContext({
-				Predictions: { interpret: happyConfig },
-			});
-			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
-				credentials,
-				identityId,
-			});
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
-				ctx,
-			);
 			await expect(
 				predictionsProvider.interpret({
 					text: {
@@ -510,21 +468,30 @@ describe('Predictions interpret provider test', () => {
 				Text: textToTest,
 			});
 		});
+
+		test('error case credentials do not exist', async () => {
+			(ctx.fetchAuthSession as jest.Mock).mockResolvedValueOnce({});
+
+			await expect(
+				predictionsProvider.interpret({
+					text: {
+						source: {
+							text: textToTest,
+						},
+						type: 'all',
+					},
+				}),
+			).rejects.toThrow(
+				expect.objectContaining(
+					validationErrorMap[PredictionsValidationErrorCode.NoCredentials],
+				),
+			);
+		});
 	});
 
 	describe('custom user agent', () => {
 		test('interpret initializes a client with the correct custom user agent', async () => {
-			const ctx = createMockAmplifyContext({
-				Predictions: { interpret: happyConfig },
-			});
-			(ctx.fetchAuthSession as jest.Mock).mockResolvedValue({
-				credentials,
-				identityId,
-			});
 			jest.spyOn(ComprehendClient.prototype, 'send');
-			const predictionsProvider = new AmazonAIInterpretPredictionsProvider(
-				ctx,
-			);
 			await predictionsProvider.interpret({
 				text: {
 					source: {

--- a/packages/predictions/__tests__/testUtils/index.ts
+++ b/packages/predictions/__tests__/testUtils/index.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { createMockAmplifyContext } from './mockAmplifyContext';

--- a/packages/predictions/__tests__/testUtils/mockAmplifyContext.ts
+++ b/packages/predictions/__tests__/testUtils/mockAmplifyContext.ts
@@ -12,7 +12,7 @@ import {
  * Accepts partial/incomplete configs to test error paths.
  */
 export function createMockAmplifyContext(
-	resourcesConfig?: Partial<ResourcesConfig> | object,
+	resourcesConfig?: Partial<ResourcesConfig>,
 ): AmplifyContext {
 	const ctx: AmplifyContext = {
 		resourcesConfig: (resourcesConfig || {}) as ResourcesConfig,

--- a/packages/predictions/__tests__/testUtils/mockAmplifyContext.ts
+++ b/packages/predictions/__tests__/testUtils/mockAmplifyContext.ts
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AMPLIFY_CONTEXT_BRAND,
+	AmplifyContext,
+	ResourcesConfig,
+} from '@aws-amplify/core';
+
+/**
+ * Creates a mock AmplifyContext for testing.
+ * Accepts partial/incomplete configs to test error paths.
+ */
+export function createMockAmplifyContext(
+	resourcesConfig?: Partial<ResourcesConfig> | object,
+): AmplifyContext {
+	const ctx: AmplifyContext = {
+		resourcesConfig: (resourcesConfig || {}) as ResourcesConfig,
+		libraryOptions: {},
+		fetchAuthSession: jest.fn().mockResolvedValue({}),
+		clearCredentials: jest.fn().mockResolvedValue(undefined),
+		getTokens: jest.fn().mockResolvedValue(undefined),
+	};
+
+	Object.defineProperty(ctx, AMPLIFY_CONTEXT_BRAND, {
+		value: true,
+		enumerable: false,
+	});
+
+	return ctx;
+}

--- a/packages/predictions/src/Predictions.ts
+++ b/packages/predictions/src/Predictions.ts
@@ -38,15 +38,14 @@ export class PredictionsClass {
 	private interpretProvider: AmazonAIInterpretPredictionsProvider;
 
 	constructor(ctx?: AmplifyContext) {
-		if (isAmplifyContext(ctx)) {
-			this.convertProvider = new AmazonAIConvertPredictionsProvider(ctx);
-			this.identifyProvider = new AmazonAIIdentifyPredictionsProvider(ctx);
-			this.interpretProvider = new AmazonAIInterpretPredictionsProvider(ctx);
-		} else {
-			this.convertProvider = new AmazonAIConvertPredictionsProvider();
-			this.identifyProvider = new AmazonAIIdentifyPredictionsProvider();
-			this.interpretProvider = new AmazonAIInterpretPredictionsProvider();
-		}
+		const resolvedCtx = isAmplifyContext(ctx) ? ctx : undefined;
+		this.convertProvider = new AmazonAIConvertPredictionsProvider(resolvedCtx);
+		this.identifyProvider = new AmazonAIIdentifyPredictionsProvider(
+			resolvedCtx,
+		);
+		this.interpretProvider = new AmazonAIInterpretPredictionsProvider(
+			resolvedCtx,
+		);
 	}
 
 	public getModuleName() {

--- a/packages/predictions/src/Predictions.ts
+++ b/packages/predictions/src/Predictions.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { AmplifyContext, isAmplifyContext } from '@aws-amplify/core';
+
 import {
 	AmazonAIConvertPredictionsProvider,
 	AmazonAIIdentifyPredictionsProvider,
@@ -23,10 +25,29 @@ import {
 	TranslateTextOutput,
 } from './types';
 
+/**
+ * Facade class that delegates predictions operations to sub-providers.
+ *
+ * Exported publicly (alongside the default `Predictions` singleton) so consumers
+ * can construct an instance with an explicit `AmplifyContext` — enabling
+ * per-request context injection in server-side / multi-tenant scenarios.
+ */
 export class PredictionsClass {
-	private convertProvider = new AmazonAIConvertPredictionsProvider();
-	private identifyProvider = new AmazonAIIdentifyPredictionsProvider();
-	private interpretProvider = new AmazonAIInterpretPredictionsProvider();
+	private convertProvider: AmazonAIConvertPredictionsProvider;
+	private identifyProvider: AmazonAIIdentifyPredictionsProvider;
+	private interpretProvider: AmazonAIInterpretPredictionsProvider;
+
+	constructor(ctx?: AmplifyContext) {
+		if (isAmplifyContext(ctx)) {
+			this.convertProvider = new AmazonAIConvertPredictionsProvider(ctx);
+			this.identifyProvider = new AmazonAIIdentifyPredictionsProvider(ctx);
+			this.interpretProvider = new AmazonAIInterpretPredictionsProvider(ctx);
+		} else {
+			this.convertProvider = new AmazonAIConvertPredictionsProvider();
+			this.identifyProvider = new AmazonAIIdentifyPredictionsProvider();
+			this.interpretProvider = new AmazonAIInterpretPredictionsProvider();
+		}
+	}
 
 	public getModuleName() {
 		return 'Predictions';

--- a/packages/predictions/src/index.ts
+++ b/packages/predictions/src/index.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-export { Predictions } from './Predictions';
+export { Predictions, PredictionsClass } from './Predictions';
 
 export {
 	IdentifyEntitiesInput,

--- a/packages/predictions/src/providers/AmazonAIConvertPredictionsProvider.ts
+++ b/packages/predictions/src/providers/AmazonAIConvertPredictionsProvider.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Buffer } from 'buffer';
 
-import { Amplify, ConsoleLogger, fetchAuthSession } from '@aws-amplify/core';
+import {
+	AmplifyContext,
+	ConsoleLogger,
+	getGlobalContext,
+	isAmplifyContext,
+} from '@aws-amplify/core';
 import {
 	AWSCredentials,
 	Category,
@@ -50,6 +55,33 @@ const LANGUAGES_CODE_IN_8KHZ = ['fr-FR', 'en-AU', 'en-GB', 'fr-CA'];
 export class AmazonAIConvertPredictionsProvider {
 	private translateClient?: TranslateClient;
 	private pollyClient?: PollyClient;
+	private _explicitCtx: AmplifyContext | undefined;
+
+	/**
+	 * Resolve the AmplifyContext for this provider.
+	 * - If an explicit ctx was passed at construction, it is pinned (fixed context by design).
+	 * - Otherwise, the global context is resolved fresh per access so that reconfiguration
+	 *   (setGlobalContext with a new AmplifyContext) is honored across operations.
+	 * @private
+	 */
+	private get _ctx(): AmplifyContext {
+		if (this._explicitCtx) {
+			return this._explicitCtx;
+		}
+
+		return getGlobalContext();
+	}
+
+	/**
+	 * @param ctx - The AmplifyContext to use for auth and config.
+	 *   When provided, the provider is pinned to this context.
+	 *   When omitted, the provider resolves the global context lazily per operation.
+	 */
+	constructor(ctx?: AmplifyContext) {
+		if (isAmplifyContext(ctx)) {
+			this._explicitCtx = ctx;
+		}
+	}
 
 	getProviderName() {
 		return 'AmazonAIConvertPredictionsProvider';
@@ -84,14 +116,14 @@ export class AmazonAIConvertPredictionsProvider {
 		logger.debug('Starting translation');
 
 		const { translateText = {} } =
-			Amplify.getConfig().Predictions?.convert ?? {};
+			this._ctx.resourcesConfig.Predictions?.convert ?? {};
 		assertValidationError(
 			!!translateText.region,
 			PredictionsValidationErrorCode.NoRegion,
 		);
 		const { defaults = {}, region } = translateText;
 
-		const { credentials } = await fetchAuthSession();
+		const { credentials } = await this._ctx.fetchAuthSession();
 		assertValidationError(
 			!!credentials,
 			PredictionsValidationErrorCode.NoCredentials,
@@ -135,7 +167,7 @@ export class AmazonAIConvertPredictionsProvider {
 	protected async convertTextToSpeech(
 		input: TextToSpeechInput,
 	): Promise<TextToSpeechOutput> {
-		const { credentials } = await fetchAuthSession();
+		const { credentials } = await this._ctx.fetchAuthSession();
 		assertValidationError(
 			!!credentials,
 			PredictionsValidationErrorCode.NoCredentials,
@@ -145,7 +177,8 @@ export class AmazonAIConvertPredictionsProvider {
 			PredictionsValidationErrorCode.NoSource,
 		);
 
-		const { speechGenerator } = Amplify.getConfig().Predictions?.convert ?? {};
+		const { speechGenerator } =
+			this._ctx.resourcesConfig.Predictions?.convert ?? {};
 		assertValidationError(
 			!!speechGenerator?.region,
 			PredictionsValidationErrorCode.NoRegion,
@@ -191,13 +224,14 @@ export class AmazonAIConvertPredictionsProvider {
 		input: SpeechToTextInput,
 	): Promise<SpeechToTextOutput> {
 		logger.debug('starting transcription..');
-		const { credentials } = await fetchAuthSession();
+		const { credentials } = await this._ctx.fetchAuthSession();
 		assertValidationError(
 			!!credentials,
 			PredictionsValidationErrorCode.NoCredentials,
 		);
 
-		const { transcription } = Amplify.getConfig().Predictions?.convert ?? {};
+		const { transcription } =
+			this._ctx.resourcesConfig.Predictions?.convert ?? {};
 		assertValidationError(
 			!!transcription?.region,
 			PredictionsValidationErrorCode.NoRegion,

--- a/packages/predictions/src/providers/AmazonAIIdentifyPredictionsProvider.ts
+++ b/packages/predictions/src/providers/AmazonAIIdentifyPredictionsProvider.ts
@@ -1,6 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Amplify, ConsoleLogger, fetchAuthSession } from '@aws-amplify/core';
+import {
+	AmplifyContext,
+	ConsoleLogger,
+	getGlobalContext,
+	isAmplifyContext,
+} from '@aws-amplify/core';
 import {
 	Category,
 	PredictionsAction,
@@ -65,6 +70,33 @@ const logger = new ConsoleLogger('AmazonAIIdentifyPredictionsProvider');
 export class AmazonAIIdentifyPredictionsProvider {
 	private rekognitionClient?: RekognitionClient;
 	private textractClient?: TextractClient;
+	private _explicitCtx: AmplifyContext | undefined;
+
+	/**
+	 * Resolve the AmplifyContext for this provider.
+	 * - If an explicit ctx was passed at construction, it is pinned (fixed context by design).
+	 * - Otherwise, the global context is resolved fresh per access so that reconfiguration
+	 *   (setGlobalContext with a new AmplifyContext) is honored across operations.
+	 * @private
+	 */
+	private get _ctx(): AmplifyContext {
+		if (this._explicitCtx) {
+			return this._explicitCtx;
+		}
+
+		return getGlobalContext();
+	}
+
+	/**
+	 * @param ctx - The AmplifyContext to use for auth and config.
+	 *   When provided, the provider is pinned to this context.
+	 *   When omitted, the provider resolves the global context lazily per operation.
+	 */
+	constructor(ctx?: AmplifyContext) {
+		if (isAmplifyContext(ctx)) {
+			this._explicitCtx = ctx;
+		}
+	}
 
 	getProviderName() {
 		return 'AmazonAIIdentifyPredictionsProvider';
@@ -110,7 +142,7 @@ export class AmazonAIIdentifyPredictionsProvider {
 					targetIdentityId: source.identityId,
 				};
 
-				getUrl({ key: source.key, options: storageConfig })
+				getUrl(this._ctx, { key: source.key, options: storageConfig })
 					.then(value => {
 						const parser =
 							/https:\/\/([a-zA-Z0-9%\-_.]+)\.s3\.[A-Za-z0-9%\-._~]+\/([a-zA-Z0-9%\-._~/]+)\?/;
@@ -166,14 +198,14 @@ export class AmazonAIIdentifyPredictionsProvider {
 	protected async identifyText(
 		input: IdentifyTextInput,
 	): Promise<IdentifyTextOutput> {
-		const { credentials } = await fetchAuthSession();
+		const { credentials } = await this._ctx.fetchAuthSession();
 		assertValidationError(
 			!!credentials,
 			PredictionsValidationErrorCode.NoCredentials,
 		);
 
 		const { identifyText = {} } =
-			Amplify.getConfig().Predictions?.identify ?? {};
+			this._ctx.resourcesConfig.Predictions?.identify ?? {};
 		const { region = '', defaults = {} } = identifyText;
 		const { format: configFormat = 'PLAIN' } = defaults;
 
@@ -258,14 +290,14 @@ export class AmazonAIIdentifyPredictionsProvider {
 	protected async identifyLabels(
 		input: IdentifyLabelsInput,
 	): Promise<IdentifyLabelsOutput> {
-		const { credentials } = await fetchAuthSession();
+		const { credentials } = await this._ctx.fetchAuthSession();
 		assertValidationError(
 			!!credentials,
 			PredictionsValidationErrorCode.NoCredentials,
 		);
 
 		const { identifyLabels = {} } =
-			Amplify.getConfig().Predictions?.identify ?? {};
+			this._ctx.resourcesConfig.Predictions?.identify ?? {};
 		const { region = '', defaults = {} } = identifyLabels;
 		const { type = 'LABELS' } = defaults;
 
@@ -360,14 +392,14 @@ export class AmazonAIIdentifyPredictionsProvider {
 	protected async identifyEntities(
 		input: IdentifyEntitiesInput,
 	): Promise<IdentifyEntitiesOutput> {
-		const { credentials } = await fetchAuthSession();
+		const { credentials } = await this._ctx.fetchAuthSession();
 		assertValidationError(
 			!!credentials,
 			PredictionsValidationErrorCode.NoCredentials,
 		);
 
 		const { identifyEntities = {} } =
-			Amplify.getConfig().Predictions?.identify ?? {};
+			this._ctx.resourcesConfig.Predictions?.identify ?? {};
 		const {
 			region = '',
 			celebrityDetectionEnabled = false,

--- a/packages/predictions/src/providers/AmazonAIInterpretPredictionsProvider.ts
+++ b/packages/predictions/src/providers/AmazonAIInterpretPredictionsProvider.ts
@@ -1,6 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Amplify, fetchAuthSession } from '@aws-amplify/core';
+import {
+	AmplifyContext,
+	getGlobalContext,
+	isAmplifyContext,
+} from '@aws-amplify/core';
 import {
 	Category,
 	PredictionsAction,
@@ -38,6 +42,33 @@ import {
 
 export class AmazonAIInterpretPredictionsProvider {
 	private comprehendClient?: ComprehendClient;
+	private _explicitCtx: AmplifyContext | undefined;
+
+	/**
+	 * Resolve the AmplifyContext for this provider.
+	 * - If an explicit ctx was passed at construction, it is pinned (fixed context by design).
+	 * - Otherwise, the global context is resolved fresh per access so that reconfiguration
+	 *   (setGlobalContext with a new AmplifyContext) is honored across operations.
+	 * @private
+	 */
+	private get _ctx(): AmplifyContext {
+		if (this._explicitCtx) {
+			return this._explicitCtx;
+		}
+
+		return getGlobalContext();
+	}
+
+	/**
+	 * @param ctx - The AmplifyContext to use for auth and config.
+	 *   When provided, the provider is pinned to this context.
+	 *   When omitted, the provider resolves the global context lazily per operation.
+	 */
+	constructor(ctx?: AmplifyContext) {
+		if (isAmplifyContext(ctx)) {
+			this._explicitCtx = ctx;
+		}
+	}
 
 	getProviderName() {
 		return 'AmazonAIInterpretPredictionsProvider';
@@ -53,14 +84,14 @@ export class AmazonAIInterpretPredictionsProvider {
 	}
 
 	async interpretText(input: InterpretTextInput): Promise<InterpretTextOutput> {
-		const { credentials } = await fetchAuthSession();
+		const { credentials } = await this._ctx.fetchAuthSession();
 		assertValidationError(
 			!!credentials,
 			PredictionsValidationErrorCode.NoCredentials,
 		);
 
 		const { interpretText = {} } =
-			Amplify.getConfig().Predictions?.interpret ?? {};
+			this._ctx.resourcesConfig.Predictions?.interpret ?? {};
 		const { region = '', defaults = {} } = interpretText;
 		const { type: defaultType = '' } = defaults;
 


### PR DESCRIPTION
## Description

Task 8 / B-predictions split of the v6 AmplifyContext migration: PredictionsClass + 3 providers accept optional explicit AmplifyContext via `isAmplifyContext`-guarded constructor, lazy private `ctx` getter falling back to `getGlobalContext()` per operation — no constructor snapshot; config via `ctx.resourcesConfig`, credentials via `ctx.fetchAuthSession()`, storage `getUrl(ctx, ...)` threading in Identify provider; branded `createMockAmplifyContext` testUtil replaces core-module mocks.

## Related

- Depends on storage #14874 (merged)
- Follows geo #14916 pattern incl. lazy-ctx fix

## Validation

- [x] `yarn turbo run build --filter=@aws-amplify/predictions` — green
- [x] `yarn turbo run test --filter=@aws-amplify/predictions` — 4 suites, 53 passed
- [x] lint-staged (eslint) green on commit
- [x] aws-amplify dependent build green

> No changeset — PR targets feature branch `feat/bobbor/v6-context`

---

- [x] Tests added/updated
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.