### PR TITLE
feat(api-graphql): migrate GraphQL API, realtime providers, and events to AmplifyContext

### DIFF
--- a/packages/api-graphql/__tests__/AWSAppSyncEventProvider.test.ts
+++ b/packages/api-graphql/__tests__/AWSAppSyncEventProvider.test.ts
@@ -11,6 +11,8 @@ import { delay, FakeWebSocketInterface } from './helpers';
 import { ConnectionState as CS } from '../src/types/PubSub';
 
 import { AWSAppSyncEventProvider } from '../src/Providers/AWSAppSyncEventsProvider';
+import * as authHeadersModule from '../src/Providers/AWSWebSocketProvider/authHeaders';
+import { createMockAmplifyContext } from './testUtils/mockAmplifyContext';
 
 // Mock all calls to signRequest
 jest.mock('@aws-amplify/core/internals/aws-client-utils', () => {
@@ -48,6 +50,14 @@ jest.mock('@aws-amplify/core', () => {
 		fetchAuthSession: (_request: any, _options: any) => {
 			return Promise.resolve(session);
 		},
+		getGlobalContext: () => ({
+			resourcesConfig: {},
+			libraryOptions: {},
+			fetchAuthSession: async () => session,
+			clearCredentials: async () => undefined,
+			getTokens: async () => undefined,
+			[original.AMPLIFY_CONTEXT_BRAND]: true,
+		}),
 		Amplify: {
 			Auth: {
 				fetchAuthSession: async () => session,
@@ -599,6 +609,88 @@ describe('AppSyncEventProvider', () => {
 					},
 				}),
 			).rejects.toThrow('No auth token specified');
+		});
+	});
+
+	describe('ctx propagation', () => {
+		let fakeWebSocketInterface: FakeWebSocketInterface;
+		let provider: AWSAppSyncEventProvider;
+		let authSpy: jest.SpyInstance;
+
+		beforeEach(() => {
+			fakeWebSocketInterface = new FakeWebSocketInterface();
+			provider = new AWSAppSyncEventProvider();
+
+			Object.defineProperty(provider, 'socketStatus', {
+				value: constants.SOCKET_STATUS.CLOSED,
+			});
+
+			jest.spyOn(provider as any, '_getNewWebSocket').mockImplementation(() => {
+				fakeWebSocketInterface.newWebSocket();
+				return fakeWebSocketInterface.webSocket as WebSocket;
+			});
+
+			authSpy = jest.spyOn(authHeadersModule, 'awsRealTimeHeaderBasedAuth');
+		});
+
+		afterEach(async () => {
+			provider?.close();
+			await fakeWebSocketInterface?.closeInterface();
+			fakeWebSocketInterface?.teardown();
+			authSpy.mockRestore();
+		});
+
+		test('when ctx is supplied to connect, awsRealTimeHeaderBasedAuth uses that ctx', async () => {
+			const mockSession = {
+				tokens: { accessToken: { toString: () => 'per-request-token' } },
+				credentials: {
+					accessKeyId: 'per-request-key',
+					secretAccessKey: 'per-request-secret',
+				},
+			};
+			const explicitCtx = createMockAmplifyContext(
+				{},
+				{ fetchAuthSession: jest.fn().mockResolvedValue(mockSession) },
+			);
+
+			const connectPromise = provider.connect({
+				appSyncGraphqlEndpoint: 'ws://localhost:8080',
+				authenticationType: 'apiKey',
+				apiKey: 'da2-test',
+				region: 'us-east-1',
+				ctx: explicitCtx,
+			});
+
+			await fakeWebSocketInterface?.readyForUse;
+			await fakeWebSocketInterface?.triggerOpen();
+			await fakeWebSocketInterface?.sendDataMessage({
+				type: MESSAGE_TYPES.GQL_CONNECTION_ACK,
+			});
+			await connectPromise;
+
+			// awsRealTimeHeaderBasedAuth is called for the connection handshake
+			expect(authSpy).toHaveBeenCalled();
+			expect(authSpy.mock.calls[0][1]).toBe(explicitCtx);
+		});
+
+		test('when ctx is undefined, awsRealTimeHeaderBasedAuth falls back to global context', async () => {
+			const connectPromise = provider.connect({
+				appSyncGraphqlEndpoint: 'ws://localhost:8080',
+				authenticationType: 'apiKey',
+				apiKey: 'da2-test',
+				region: 'us-east-1',
+			});
+
+			await fakeWebSocketInterface?.readyForUse;
+			await fakeWebSocketInterface?.triggerOpen();
+			await fakeWebSocketInterface?.sendDataMessage({
+				type: MESSAGE_TYPES.GQL_CONNECTION_ACK,
+			});
+			await connectPromise;
+
+			expect(authSpy).toHaveBeenCalled();
+			// ctx should be undefined — authHeaders.ts falls back to getGlobalContext()
+			expect(authSpy.mock.calls[0][1]).toBeUndefined();
 		});
 	});
 });

--- a/packages/api-graphql/__tests__/AWSAppSyncRealTimeProvider.test.ts
+++ b/packages/api-graphql/__tests__/AWSAppSyncRealTimeProvider.test.ts
@@ -13,6 +13,8 @@ import { ConnectionState as CS } from '../src/types/PubSub';
 
 import { AWSAppSyncRealTimeProvider } from '../src/Providers/AWSAppSyncRealTimeProvider';
 import { isCustomDomain } from '../src/Providers/AWSWebSocketProvider/appsyncUrl';
+import * as authHeadersModule from '../src/Providers/AWSWebSocketProvider/authHeaders';
+import { createMockAmplifyContext } from './testUtils/mockAmplifyContext';
 
 // Mock all calls to signRequest
 jest.mock('@aws-amplify/core/internals/aws-client-utils', () => {
@@ -50,6 +52,14 @@ jest.mock('@aws-amplify/core', () => {
 		fetchAuthSession: (_request: any, _options: any) => {
 			return Promise.resolve(session);
 		},
+		getGlobalContext: () => ({
+			resourcesConfig: {},
+			libraryOptions: {},
+			fetchAuthSession: async () => session,
+			clearCredentials: async () => undefined,
+			getTokens: async () => undefined,
+			[original.AMPLIFY_CONTEXT_BRAND]: true,
+		}),
 		Amplify: {
 			Auth: {
 				fetchAuthSession: async () => session,
@@ -1304,6 +1314,93 @@ describe('AWSAppSyncRealTimeProvider', () => {
 					});
 				});
 			});
+		});
+	});
+
+	describe('ctx propagation', () => {
+		let fakeWebSocketInterface: FakeWebSocketInterface;
+		let provider: AWSAppSyncRealTimeProvider;
+		let authSpy: jest.SpyInstance;
+
+		beforeEach(() => {
+			fakeWebSocketInterface = new FakeWebSocketInterface();
+			provider = new AWSAppSyncRealTimeProvider();
+
+			jest.spyOn(provider as any, '_getNewWebSocket').mockImplementation(() => {
+				fakeWebSocketInterface.newWebSocket();
+				return fakeWebSocketInterface.webSocket as WebSocket;
+			});
+
+			authSpy = jest.spyOn(authHeadersModule, 'awsRealTimeHeaderBasedAuth');
+		});
+
+		afterEach(async () => {
+			provider?.close();
+			await fakeWebSocketInterface?.closeInterface();
+			fakeWebSocketInterface?.teardown();
+			authSpy.mockRestore();
+		});
+
+		test('when ctx is supplied to subscribe, awsRealTimeHeaderBasedAuth uses that ctx (not the global one)', async () => {
+			const mockSession = {
+				tokens: { accessToken: { toString: () => 'per-request-token' } },
+				credentials: {
+					accessKeyId: 'per-request-key',
+					secretAccessKey: 'per-request-secret',
+				},
+			};
+			const explicitCtx = createMockAmplifyContext(
+				{},
+				{ fetchAuthSession: jest.fn().mockResolvedValue(mockSession) },
+			);
+
+			provider
+				.subscribe({
+					appSyncGraphqlEndpoint: 'ws://localhost:8080',
+					authenticationType: 'apiKey',
+					apiKey: 'da2-test',
+					region: 'us-east-1',
+					ctx: explicitCtx,
+				})
+				.subscribe({ error: () => {} });
+
+			await fakeWebSocketInterface?.readyForUse;
+			await fakeWebSocketInterface?.triggerOpen();
+			await fakeWebSocketInterface?.sendDataMessage({
+				type: MESSAGE_TYPES.GQL_CONNECTION_ACK,
+			});
+
+			// awsRealTimeHeaderBasedAuth is called:
+			// 1) for the connection handshake (in _initializeWebSocketConnection)
+			// 2) for the subscription payload (in _prepareSubscriptionPayload)
+			// Both should receive the explicit ctx
+			expect(authSpy).toHaveBeenCalled();
+			for (const call of authSpy.mock.calls) {
+				expect(call[1]).toBe(explicitCtx);
+			}
+		});
+
+		test('when ctx is undefined, awsRealTimeHeaderBasedAuth falls back to global context', async () => {
+			provider
+				.subscribe({
+					appSyncGraphqlEndpoint: 'ws://localhost:8080',
+					authenticationType: 'apiKey',
+					apiKey: 'da2-test',
+					region: 'us-east-1',
+				})
+				.subscribe({ error: () => {} });
+
+			await fakeWebSocketInterface?.readyForUse;
+			await fakeWebSocketInterface?.triggerOpen();
+			await fakeWebSocketInterface?.sendDataMessage({
+				type: MESSAGE_TYPES.GQL_CONNECTION_ACK,
+			});
+
+			expect(authSpy).toHaveBeenCalled();
+			for (const call of authSpy.mock.calls) {
+				// ctx should be undefined — authHeaders.ts falls back to getGlobalContext()
+				expect(call[1]).toBeUndefined();
+			}
 		});
 	});
 });

--- a/packages/api-graphql/__tests__/GraphQLAPI.test.ts
+++ b/packages/api-graphql/__tests__/GraphQLAPI.test.ts
@@ -305,9 +305,8 @@ describe('API test', () => {
 
 			expect(spy).toHaveBeenCalledWith(
 				expect.objectContaining({
-					Auth: expect.any(Object),
-					configure: expect.any(Function),
-					getConfig: expect.any(Function),
+					resourcesConfig: expect.any(Object),
+					fetchAuthSession: expect.any(Function),
 				}),
 				{
 					abortController: expect.any(AbortController),
@@ -374,9 +373,8 @@ describe('API test', () => {
 			expect(thread).toEqual(graphqlResponse.data.getThread);
 			expect(spy).toHaveBeenCalledWith(
 				expect.objectContaining({
-					Auth: expect.any(Object),
-					configure: expect.any(Function),
-					getConfig: expect.any(Function),
+					resourcesConfig: expect.any(Object),
+					fetchAuthSession: expect.any(Function),
 				}),
 				{
 					abortController: expect.any(AbortController),
@@ -444,9 +442,8 @@ describe('API test', () => {
 			expect(thread).toEqual(graphqlResponse.data.getThread);
 			expect(spy).toHaveBeenCalledWith(
 				expect.objectContaining({
-					Auth: expect.any(Object),
-					configure: expect.any(Function),
-					getConfig: expect.any(Function),
+					resourcesConfig: expect.any(Object),
+					fetchAuthSession: expect.any(Function),
 				}),
 				{
 					abortController: expect.any(AbortController),
@@ -518,9 +515,8 @@ describe('API test', () => {
 			expect(thread).toEqual(graphqlResponse.data.getThread);
 			expect(spy).toHaveBeenCalledWith(
 				expect.objectContaining({
-					Auth: expect.any(Object),
-					configure: expect.any(Function),
-					getConfig: expect.any(Function),
+					resourcesConfig: expect.any(Object),
+					fetchAuthSession: expect.any(Function),
 				}),
 				{
 					abortController: expect.any(AbortController),
@@ -588,9 +584,8 @@ describe('API test', () => {
 			expect(thread).toEqual(graphqlResponse.data.getThread);
 			expect(spy).toHaveBeenCalledWith(
 				expect.objectContaining({
-					Auth: expect.any(Object),
-					configure: expect.any(Function),
-					getConfig: expect.any(Function),
+					resourcesConfig: expect.any(Object),
+					fetchAuthSession: expect.any(Function),
 				}),
 				{
 					abortController: expect.any(AbortController),
@@ -654,9 +649,8 @@ describe('API test', () => {
 
 			expect(spy).toHaveBeenCalledWith(
 				expect.objectContaining({
-					Auth: expect.any(Object),
-					configure: expect.any(Function),
-					getConfig: expect.any(Function),
+					resourcesConfig: expect.any(Object),
+					fetchAuthSession: expect.any(Function),
 				}),
 				{
 					abortController: expect.any(AbortController),
@@ -723,9 +717,8 @@ describe('API test', () => {
 
 			expect(spy).toHaveBeenCalledWith(
 				expect.objectContaining({
-					Auth: expect.any(Object),
-					configure: expect.any(Function),
-					getConfig: expect.any(Function),
+					resourcesConfig: expect.any(Object),
+					fetchAuthSession: expect.any(Function),
 				}),
 				{
 					abortController: expect.any(AbortController),
@@ -793,9 +786,8 @@ describe('API test', () => {
 
 			expect(spy).toHaveBeenCalledWith(
 				expect.objectContaining({
-					Auth: expect.any(Object),
-					configure: expect.any(Function),
-					getConfig: expect.any(Function),
+					resourcesConfig: expect.any(Object),
+					fetchAuthSession: expect.any(Function),
 				}),
 				{
 					abortController: expect.any(AbortController),
@@ -1036,9 +1028,8 @@ describe('API test', () => {
 			expect(thread).toEqual(graphqlResponse.data.getThread);
 			expect(spy).toHaveBeenCalledWith(
 				expect.objectContaining({
-					Auth: expect.any(Object),
-					configure: expect.any(Function),
-					getConfig: expect.any(Function),
+					resourcesConfig: expect.any(Object),
+					fetchAuthSession: expect.any(Function),
 				}),
 				{
 					abortController: expect.any(AbortController),
@@ -1286,9 +1277,8 @@ describe('API test', () => {
 			expect(thread).toEqual(graphqlResponse.data.getThread);
 			expect(spy).toHaveBeenCalledWith(
 				expect.objectContaining({
-					Auth: expect.any(Object),
-					configure: expect.any(Function),
-					getConfig: expect.any(Function),
+					resourcesConfig: expect.any(Object),
+					fetchAuthSession: expect.any(Function),
 				}),
 				{
 					abortController: expect.any(AbortController),
@@ -1377,9 +1367,8 @@ describe('API test', () => {
 			expect(thread).toEqual(graphqlResponse.data.getThread);
 			expect(spy).toHaveBeenCalledWith(
 				expect.objectContaining({
-					Auth: expect.any(Object),
-					configure: expect.any(Function),
-					getConfig: expect.any(Function),
+					resourcesConfig: expect.any(Object),
+					fetchAuthSession: expect.any(Function),
 				}),
 				{
 					abortController: expect.any(AbortController),
@@ -1507,9 +1496,8 @@ describe('API test', () => {
 
 			expect(spy).toHaveBeenCalledWith(
 				expect.objectContaining({
-					Auth: expect.any(Object),
-					configure: expect.any(Function),
-					getConfig: expect.any(Function),
+					resourcesConfig: expect.any(Object),
+					fetchAuthSession: expect.any(Function),
 				}),
 				'iam',
 				'FAKE-KEY',

--- a/packages/api-graphql/__tests__/authHeaders.test.ts
+++ b/packages/api-graphql/__tests__/authHeaders.test.ts
@@ -1,0 +1,120 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as core from '@aws-amplify/core';
+import { clearGlobalContext } from '@aws-amplify/core/internals/utils';
+
+import { awsRealTimeHeaderBasedAuth } from '../src/Providers/AWSWebSocketProvider/authHeaders';
+
+import { createMockAmplifyContext } from './testUtils/mockAmplifyContext';
+
+// Signing is a crypto boundary — mock it so the IAM path is deterministic in
+// jsdom. All other internals (context resolution, handler dispatch) run for real.
+jest.mock('@aws-amplify/core/internals/aws-client-utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/aws-client-utils'),
+	signRequest: jest.fn(() => ({ headers: { Authorization: 'AWS4-signed' } })),
+}));
+
+const appSyncGraphqlEndpoint = 'https://example.appsync-api.us-east-1.amazonaws.com/graphql';
+
+describe('awsRealTimeHeaderBasedAuth context resolution', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		// No global context — this is the scenario the fix targets.
+		clearGlobalContext();
+	});
+
+	it('apiKey auth works with no explicit ctx AND no global context (never resolves ctx)', async () => {
+		const getGlobalContextSpy = jest.spyOn(core, 'getGlobalContext');
+
+		const result = await awsRealTimeHeaderBasedAuth({
+			authenticationType: 'apiKey',
+			apiKey: 'da2-test',
+			appSyncGraphqlEndpoint,
+			region: 'us-east-1',
+			canonicalUri: '',
+			payload: '',
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({ 'x-api-key': 'da2-test' }),
+		);
+		// The apiKey handler must never touch the (missing) context.
+		expect(getGlobalContextSpy).not.toHaveBeenCalled();
+	});
+
+	it('none/lambda auth works with no ctx when an Authorization header is provided', async () => {
+		const getGlobalContextSpy = jest.spyOn(core, 'getGlobalContext');
+
+		const result = await awsRealTimeHeaderBasedAuth({
+			authenticationType: 'none',
+			appSyncGraphqlEndpoint,
+			region: 'us-east-1',
+			canonicalUri: '',
+			payload: '',
+			additionalCustomHeaders: { Authorization: 'custom-token' },
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({ Authorization: 'custom-token' }),
+		);
+		expect(getGlobalContextSpy).not.toHaveBeenCalled();
+	});
+
+	it('userPool auth uses the explicitly provided ctx', async () => {
+		const explicitCtx = createMockAmplifyContext(
+			{},
+			{
+				fetchAuthSession: jest.fn().mockResolvedValue({
+					tokens: { accessToken: { toString: () => 'per-request-token' } },
+				}),
+			},
+		);
+
+		const result = await awsRealTimeHeaderBasedAuth(
+			{
+				authenticationType: 'userPool',
+				appSyncGraphqlEndpoint,
+				region: 'us-east-1',
+				canonicalUri: '',
+				payload: '',
+			},
+			explicitCtx,
+		);
+
+		expect(explicitCtx.fetchAuthSession).toHaveBeenCalledTimes(1);
+		expect(result).toEqual(
+			expect.objectContaining({ Authorization: 'per-request-token' }),
+		);
+	});
+
+	it('iam auth uses the explicitly provided ctx', async () => {
+		const explicitCtx = createMockAmplifyContext(
+			{},
+			{
+				fetchAuthSession: jest.fn().mockResolvedValue({
+					credentials: {
+						accessKeyId: 'AKID',
+						secretAccessKey: 'secret',
+						sessionToken: 'session',
+					},
+				}),
+			},
+		);
+
+		const result = await awsRealTimeHeaderBasedAuth(
+			{
+				authenticationType: 'iam',
+				appSyncGraphqlEndpoint,
+				region: 'us-east-1',
+				canonicalUri: '/graphql/connect',
+				payload: '{}',
+			},
+			explicitCtx,
+		);
+
+		expect(explicitCtx.fetchAuthSession).toHaveBeenCalledTimes(1);
+		expect(result).toEqual(
+			expect.objectContaining({ Authorization: 'AWS4-signed' }),
+		);
+	});
+});

--- a/packages/api-graphql/__tests__/events.test.ts
+++ b/packages/api-graphql/__tests__/events.test.ts
@@ -48,7 +48,7 @@ describe('Events client', () => {
 	describe('config', () => {
 		test('no configure()', async () => {
 			await expect(events.connect('/')).rejects.toThrow(
-				'Amplify configuration is missing. Have you called Amplify.configure()?',
+				'No AmplifyContext available. Call Amplify.configure() to set a global context, or pass a context as the first argument.',
 			);
 		});
 
@@ -235,7 +235,10 @@ describe('Events client', () => {
 				await events.post('/', { test: 'data' });
 
 				expect(mockReq).toHaveBeenCalledWith(
-					Amplify,
+					expect.objectContaining({
+						resourcesConfig: expect.any(Object),
+						fetchAuthSession: expect.any(Function),
+					}),
 					expect.objectContaining({
 						query: '/',
 						variables: ['{"test":"data"}'],
@@ -252,7 +255,10 @@ describe('Events client', () => {
 					await events.post('/', { test: 'data' }, authConfig);
 
 					expect(mockReq).toHaveBeenCalledWith(
-						Amplify,
+						expect.objectContaining({
+							resourcesConfig: expect.any(Object),
+							fetchAuthSession: expect.any(Function),
+						}),
 						expect.objectContaining({
 							query: '/',
 							variables: ['{"test":"data"}'],

--- a/packages/api-graphql/__tests__/internals/generateClient.test.ts
+++ b/packages/api-graphql/__tests__/internals/generateClient.test.ts
@@ -419,7 +419,10 @@ describe('generateClient', () => {
 
 				// Request headers should overwrite client headers:
 				expect(spy).toHaveBeenCalledWith(
-					expect.any(AmplifyClassV6),
+					expect.objectContaining({
+						resourcesConfig: expect.any(Object),
+						fetchAuthSession: expect.any(Function),
+					}),
 					expect.objectContaining({
 						options: expect.objectContaining({
 							headers: expect.not.objectContaining({

--- a/packages/api-graphql/__tests__/resolveConfig.test.ts
+++ b/packages/api-graphql/__tests__/resolveConfig.test.ts
@@ -3,27 +3,20 @@
 
 import { resolveConfig } from '../src/utils';
 import { GraphQLAuthMode } from '@aws-amplify/core/internals/utils';
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { createMockAmplifyContext } from './testUtils/mockAmplifyContext';
 
 describe('GraphQL API Util: resolveConfig', () => {
 	const GraphQLConfig = {
 		endpoint: 'https://test.us-west-2.amazonaws.com/graphql',
 		region: 'us-west-2',
 		apiKey: 'mock-api-key',
-		defaultAuthMode: {
-			type: 'apiKey' as GraphQLAuthMode,
-			apiKey: '0123456789',
-		},
+		defaultAuthMode: 'apiKey' as GraphQLAuthMode,
 	};
 
 	it('returns required config', () => {
-		const amplify = {
-			getConfig: jest.fn(() => {
-				return {
-					API: { GraphQL: GraphQLConfig },
-				};
-			}),
-		} as unknown as AmplifyClassV6;
+		const amplify = createMockAmplifyContext({
+			API: { GraphQL: GraphQLConfig },
+		});
 
 		const expected = {
 			...GraphQLConfig,
@@ -35,19 +28,15 @@ describe('GraphQL API Util: resolveConfig', () => {
 	});
 
 	it('throws if custom endpoint region exists without custom endpoint:', () => {
-		const amplify = {
-			getConfig: jest.fn(() => {
-				return {
-					API: {
-						GraphQL: {
-							...GraphQLConfig,
-							customEndpoint: undefined,
-							customEndpointRegion: 'some-region',
-						},
-					},
-				};
-			}),
-		} as unknown as AmplifyClassV6;
+		const amplify = createMockAmplifyContext({
+			API: {
+				GraphQL: {
+					...GraphQLConfig,
+					customEndpoint: undefined,
+					customEndpointRegion: 'some-region',
+				},
+			},
+		});
 
 		expect(() => resolveConfig(amplify)).toThrow();
 	});

--- a/packages/api-graphql/__tests__/testUtils/mockAmplifyContext.ts
+++ b/packages/api-graphql/__tests__/testUtils/mockAmplifyContext.ts
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AMPLIFY_CONTEXT_BRAND,
+	AmplifyContext,
+	ResourcesConfig,
+} from '@aws-amplify/core';
+
+/**
+ * Creates a mock AmplifyContext for testing.
+ */
+export function createMockAmplifyContext(
+	resourcesConfig: ResourcesConfig = {},
+	overrides: Partial<
+		Pick<AmplifyContext, 'fetchAuthSession' | 'libraryOptions'>
+	> = {},
+): AmplifyContext {
+	const ctx: AmplifyContext = {
+		resourcesConfig,
+		libraryOptions: {},
+		fetchAuthSession: jest.fn().mockResolvedValue({}),
+		clearCredentials: jest.fn().mockResolvedValue(undefined),
+		getTokens: jest.fn().mockResolvedValue(undefined),
+		...overrides,
+	};
+
+	Object.defineProperty(ctx, AMPLIFY_CONTEXT_BRAND, {
+		value: true,
+		enumerable: false,
+	});
+
+	return ctx;
+}

--- a/packages/api-graphql/__tests__/utils/bridgeAmplifyClass.test.ts
+++ b/packages/api-graphql/__tests__/utils/bridgeAmplifyClass.test.ts
@@ -1,0 +1,117 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import {
+	AMPLIFY_CONTEXT_BRAND,
+	AmplifyClassV6,
+	isAmplifyContext,
+} from '@aws-amplify/core';
+
+import { bridgeAmplifyClass } from '../../src/utils/bridgeAmplifyClass';
+
+/**
+ * Builds a bare `AmplifyClass`-shaped object exposing ONLY the surface the
+ * bridge relies on: `getConfig()`, `libraryOptions`, and the cross-category
+ * `Auth.{fetchAuthSession,clearCredentials,getTokens}` methods. This is the
+ * exact shape that flows through the server wrapper / legacy internals, and it
+ * acts as the regression guard against the bridge reading top-level context
+ * methods that `AmplifyClass` does not surface.
+ */
+const buildBareAmplifyClass = () => {
+	const auth = {
+		fetchAuthSession: jest.fn().mockResolvedValue({}),
+		clearCredentials: jest.fn().mockResolvedValue(undefined),
+		getTokens: jest.fn().mockResolvedValue(undefined),
+	};
+
+	const raw = {
+		getConfig: jest.fn().mockReturnValue({ API: { GraphQL: { endpoint: 'e1' } } }),
+		libraryOptions: { ssr: false },
+		Auth: auth,
+	};
+
+	return { raw, auth };
+};
+
+describe('bridgeAmplifyClass', () => {
+	describe('auth delegation (regression guard)', () => {
+		it('routes fetchAuthSession through Auth.fetchAuthSession with the `{}` default arg', async () => {
+			const { raw, auth } = buildBareAmplifyClass();
+			const ctx = bridgeAmplifyClass(raw as unknown as AmplifyClassV6);
+
+			await ctx.fetchAuthSession();
+
+			expect(auth.fetchAuthSession).toHaveBeenCalledWith({});
+		});
+
+		it('forwards explicit fetchAuthSession options untouched', async () => {
+			const { raw, auth } = buildBareAmplifyClass();
+			const ctx = bridgeAmplifyClass(raw as unknown as AmplifyClassV6);
+
+			await ctx.fetchAuthSession({ forceRefresh: true });
+
+			expect(auth.fetchAuthSession).toHaveBeenCalledWith({ forceRefresh: true });
+		});
+
+		it('routes clearCredentials through Auth.clearCredentials', async () => {
+			const { raw, auth } = buildBareAmplifyClass();
+			const ctx = bridgeAmplifyClass(raw as unknown as AmplifyClassV6);
+
+			await ctx.clearCredentials();
+
+			expect(auth.clearCredentials).toHaveBeenCalledTimes(1);
+		});
+
+		it('routes getTokens through Auth.getTokens with the provided options', async () => {
+			const { raw, auth } = buildBareAmplifyClass();
+			const ctx = bridgeAmplifyClass(raw as unknown as AmplifyClassV6);
+
+			await ctx.getTokens({ forceRefresh: true });
+
+			expect(auth.getTokens).toHaveBeenCalledWith({ forceRefresh: true });
+		});
+	});
+
+	describe('live config getters', () => {
+		it('reflects a mutated resourcesConfig (getConfig is called per access)', () => {
+			const { raw } = buildBareAmplifyClass();
+			const ctx = bridgeAmplifyClass(raw as unknown as AmplifyClassV6);
+
+			const updatedConfig = { API: { GraphQL: { endpoint: 'e2' } } };
+			raw.getConfig.mockReturnValue(updatedConfig);
+
+			expect(ctx.resourcesConfig).toBe(updatedConfig);
+		});
+
+		it('reflects a wholesale-reassigned libraryOptions', () => {
+			const { raw } = buildBareAmplifyClass();
+			const ctx = bridgeAmplifyClass(raw as unknown as AmplifyClassV6);
+
+			const updatedLibraryOptions = { ssr: true };
+			raw.libraryOptions = updatedLibraryOptions;
+
+			expect(ctx.libraryOptions).toBe(updatedLibraryOptions);
+		});
+	});
+
+	describe('branding', () => {
+		it('produces a value recognized by isAmplifyContext', () => {
+			const { raw } = buildBareAmplifyClass();
+			const ctx = bridgeAmplifyClass(raw as unknown as AmplifyClassV6);
+
+			expect(isAmplifyContext(ctx)).toBe(true);
+		});
+
+		it('defines a non-enumerable AMPLIFY_CONTEXT_BRAND', () => {
+			const { raw } = buildBareAmplifyClass();
+			const ctx = bridgeAmplifyClass(raw as unknown as AmplifyClassV6);
+
+			expect(AMPLIFY_CONTEXT_BRAND in ctx).toBe(true);
+			const descriptor = Object.getOwnPropertyDescriptor(
+				ctx,
+				AMPLIFY_CONTEXT_BRAND,
+			);
+			expect(descriptor?.value).toBe(true);
+			expect(descriptor?.enumerable).toBe(false);
+		});
+	});
+});

--- a/packages/api-graphql/__tests__/utils/expects.ts
+++ b/packages/api-graphql/__tests__/utils/expects.ts
@@ -47,9 +47,8 @@ export function expectGet(
 ) {
 	expect(spy).toHaveBeenCalledWith(
 		expect.objectContaining({
-			Auth: expect.any(Object),
-			configure: expect.any(Function),
-			getConfig: expect.any(Function),
+			resourcesConfig: expect.any(Object),
+			fetchAuthSession: expect.any(Function),
 		}),
 		{
 			abortController: expect.any(AbortController),

--- a/packages/api-graphql/__tests__/utils/resolveServerContext.test.ts
+++ b/packages/api-graphql/__tests__/utils/resolveServerContext.test.ts
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { AMPLIFY_CONTEXT_BRAND, isAmplifyContext } from '@aws-amplify/core';
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+
+import { resolveServerContext } from '../../src/utils/resolveServerContext';
+
+import { createMockAmplifyContext } from '../testUtils/mockAmplifyContext';
+
+// Mock only the adapter-core boundary (same pattern as the api-rest server
+// tests). `isAmplifyContext` / branding come from the real core module and the
+// bridge runs for real.
+jest.mock('@aws-amplify/core/internals/adapter-core');
+
+const mockGetAmplifyServerContext = getAmplifyServerContext as jest.Mock;
+
+describe('resolveServerContext', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('returns an already-branded AmplifyContext unchanged (same reference)', () => {
+		const ctx = createMockAmplifyContext();
+
+		const result = resolveServerContext(ctx);
+
+		expect(result).toBe(ctx);
+		expect(isAmplifyContext(result)).toBe(true);
+		// Brand-check branch short-circuits before touching adapter-core.
+		expect(mockGetAmplifyServerContext).not.toHaveBeenCalled();
+	});
+
+	it('resolves a legacy ContextSpec via getAmplifyServerContext and brands the result', async () => {
+		const auth = {
+			fetchAuthSession: jest.fn().mockResolvedValue({}),
+			clearCredentials: jest.fn().mockResolvedValue(undefined),
+			getTokens: jest.fn().mockResolvedValue(undefined),
+		};
+		const mockAmplify = {
+			getConfig: jest.fn().mockReturnValue({ API: { GraphQL: {} } }),
+			libraryOptions: {},
+			Auth: auth,
+		};
+		mockGetAmplifyServerContext.mockReturnValue({ amplify: mockAmplify });
+
+		const contextSpec = {
+			token: { value: Symbol('test') },
+		} as unknown as AmplifyServer.ContextSpec;
+
+		const result = resolveServerContext(contextSpec);
+
+		expect(mockGetAmplifyServerContext).toHaveBeenCalledWith(contextSpec);
+		expect(isAmplifyContext(result)).toBe(true);
+		expect(AMPLIFY_CONTEXT_BRAND in result).toBe(true);
+
+		// The bridged context delegates through the underlying AmplifyClass.Auth.
+		await result.fetchAuthSession();
+		expect(auth.fetchAuthSession).toHaveBeenCalledWith({});
+	});
+});

--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AmplifyClassV6, AmplifyContext } from '@aws-amplify/core';
 import {
 	ApiAction,
 	Category,
@@ -49,7 +49,7 @@ export class GraphQLAPIClass extends InternalGraphQLAPIClass {
 	 * @returns An Observable if the query is a subscription query, else a promise of the graphql result.
 	 */
 	graphql<T = any>(
-		amplify: AmplifyClassV6 | (() => Promise<AmplifyClassV6>),
+		amplify: AmplifyContext | AmplifyClassV6 | (() => Promise<AmplifyContext>),
 		options: GraphQLOptions,
 		additionalHeaders?: CustomHeaders,
 	): Observable<GraphQLResult<T>> | Promise<GraphQLResult<T>> {

--- a/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSAppSyncEventsProvider/index.ts
@@ -7,6 +7,7 @@ import {
 	USER_AGENT_HEADER,
 	getAmplifyUserAgent,
 } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext } from '@aws-amplify/core';
 import { CustomHeaders } from '@aws-amplify/data-schema/runtime';
 
 import { DEFAULT_KEEP_ALIVE_TIMEOUT, MESSAGE_TYPES } from '../constants';
@@ -28,6 +29,13 @@ interface AWSAppSyncEventProviderOptions {
 	additionalHeaders?: CustomHeaders;
 	additionalCustomHeaders?: Record<string, string>;
 	authToken?: string;
+	/**
+	 * Optional AmplifyContext for per-request credential resolution.
+	 * When provided, this ctx is used for WebSocket auth header generation
+	 * instead of the global context. Scoped to the connection/subscription
+	 * lifecycle, NOT stored on the provider instance (providers are singletons).
+	 */
+	ctx?: AmplifyContext;
 }
 
 interface DataPayload {
@@ -104,6 +112,7 @@ export class AWSAppSyncEventProvider extends AWSWebSocketProvider {
 			apiKey,
 			region,
 			variables,
+			ctx,
 		} = options;
 
 		const data = {
@@ -113,15 +122,18 @@ export class AWSAppSyncEventProvider extends AWSWebSocketProvider {
 		const serializedData = JSON.stringify(data);
 
 		const headers = {
-			...(await awsRealTimeHeaderBasedAuth({
-				apiKey,
-				appSyncGraphqlEndpoint,
-				authenticationType,
-				payload: serializedData,
-				canonicalUri: '',
-				region,
-				additionalCustomHeaders,
-			})),
+			...(await awsRealTimeHeaderBasedAuth(
+				{
+					apiKey,
+					appSyncGraphqlEndpoint,
+					authenticationType,
+					payload: serializedData,
+					canonicalUri: '',
+					region,
+					additionalCustomHeaders,
+				},
+				ctx,
+			)),
 			...libraryConfigHeaders,
 			...additionalCustomHeaders,
 			[USER_AGENT_HEADER]: getAmplifyUserAgent(customUserAgentDetails),

--- a/packages/api-graphql/src/Providers/AWSAppSyncRealTimeProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSAppSyncRealTimeProvider/index.ts
@@ -8,6 +8,7 @@ import {
 	USER_AGENT_HEADER,
 	getAmplifyUserAgent,
 } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext } from '@aws-amplify/core';
 import { CustomHeaders } from '@aws-amplify/data-schema/runtime';
 
 import { DEFAULT_KEEP_ALIVE_TIMEOUT, MESSAGE_TYPES } from '../constants';
@@ -28,6 +29,13 @@ export interface AWSAppSyncRealTimeProviderOptions {
 	additionalHeaders?: CustomHeaders;
 	additionalCustomHeaders?: Record<string, string>;
 	authToken?: string;
+	/**
+	 * Optional AmplifyContext for per-request credential resolution.
+	 * When provided, this ctx is used for WebSocket auth header generation
+	 * instead of the global context. Scoped to the connection/subscription
+	 * lifecycle, NOT stored on the provider instance (providers are singletons).
+	 */
+	ctx?: AmplifyContext;
 }
 
 interface DataObject extends Record<string, unknown> {
@@ -84,6 +92,7 @@ export class AWSAppSyncRealTimeProvider extends AWSWebSocketProvider {
 			variables,
 			apiKey,
 			region,
+			ctx,
 		} = options;
 		const data = {
 			query,
@@ -92,15 +101,18 @@ export class AWSAppSyncRealTimeProvider extends AWSWebSocketProvider {
 		const serializedData = JSON.stringify(data);
 
 		const headers = {
-			...(await awsRealTimeHeaderBasedAuth({
-				apiKey,
-				appSyncGraphqlEndpoint,
-				authenticationType,
-				payload: serializedData,
-				canonicalUri: '',
-				region,
-				additionalCustomHeaders,
-			})),
+			...(await awsRealTimeHeaderBasedAuth(
+				{
+					apiKey,
+					appSyncGraphqlEndpoint,
+					authenticationType,
+					payload: serializedData,
+					canonicalUri: '',
+					region,
+					additionalCustomHeaders,
+				},
+				ctx,
+			)),
 			...libraryConfigHeaders,
 			...additionalCustomHeaders,
 			[USER_AGENT_HEADER]: getAmplifyUserAgent(customUserAgentDetails),

--- a/packages/api-graphql/src/Providers/AWSWebSocketProvider/authHeaders.ts
+++ b/packages/api-graphql/src/Providers/AWSWebSocketProvider/authHeaders.ts
@@ -22,10 +22,10 @@ type AWSAppSyncRealTimeAuthInput =
 	};
 
 const awsAuthTokenHeader = async (
-	ctx: AmplifyContext,
+	resolveCtx: () => AmplifyContext,
 	{ host }: AWSAppSyncRealTimeAuthInput,
 ) => {
-	const session = await ctx.fetchAuthSession();
+	const session = await resolveCtx().fetchAuthSession();
 
 	return {
 		Authorization: session?.tokens?.accessToken?.toString(),
@@ -34,7 +34,7 @@ const awsAuthTokenHeader = async (
 };
 
 const awsRealTimeApiKeyHeader = async (
-	_ctx: AmplifyContext,
+	_resolveCtx: () => AmplifyContext,
 	{ apiKey, host }: AWSAppSyncRealTimeAuthInput,
 ) => {
 	const dt = new Date();
@@ -48,7 +48,7 @@ const awsRealTimeApiKeyHeader = async (
 };
 
 const awsRealTimeIAMHeader = async (
-	ctx: AmplifyContext,
+	resolveCtx: () => AmplifyContext,
 	{
 		payload,
 		canonicalUri,
@@ -61,7 +61,7 @@ const awsRealTimeIAMHeader = async (
 		service: 'appsync',
 	};
 
-	const creds = (await ctx.fetchAuthSession()).credentials;
+	const creds = (await resolveCtx().fetchAuthSession()).credentials;
 
 	const request = {
 		url: `${appSyncGraphqlEndpoint}${canonicalUri}`,
@@ -88,7 +88,7 @@ const awsRealTimeIAMHeader = async (
 };
 
 const customAuthHeader = async (
-	_ctx: AmplifyContext,
+	_resolveCtx: () => AmplifyContext,
 	{ host, additionalCustomHeaders }: AWSAppSyncRealTimeAuthInput,
 ) => {
 	/**
@@ -120,9 +120,13 @@ export const awsRealTimeHeaderBasedAuth = async (
 		payload,
 	} = authInput;
 
-	// Resolve context: use the explicitly provided ctx, or fall back to global context.
-	// NOTE: we do NOT capture getGlobalContext() eagerly — it's resolved fresh per call.
-	const resolvedCtx = ctx ?? getGlobalContext();
+	// Resolve context LAZILY. Only the auth handlers that actually consume the
+	// context (iam / oidc / userPool) invoke this thunk. apiKey / none / lambda
+	// ignore it, so they must keep working with no explicit ctx AND no global
+	// context — resolving (and potentially throwing) here would break them.
+	// NOTE: we also do NOT capture getGlobalContext() eagerly — it's resolved
+	// fresh, per invocation of the thunk.
+	const resolveCtx = (): AmplifyContext => ctx ?? getGlobalContext();
 
 	const headerHandler = {
 		apiKey: awsRealTimeApiKeyHeader,
@@ -148,7 +152,7 @@ export const awsRealTimeHeaderBasedAuth = async (
 
 		logger.debug(`Authenticating with ${JSON.stringify(authenticationType)}`);
 
-		const result = await handler(resolvedCtx, {
+		const result = await handler(resolveCtx, {
 			payload,
 			canonicalUri,
 			appSyncGraphqlEndpoint,

--- a/packages/api-graphql/src/Providers/AWSWebSocketProvider/authHeaders.ts
+++ b/packages/api-graphql/src/Providers/AWSWebSocketProvider/authHeaders.ts
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ConsoleLogger, fetchAuthSession } from '@aws-amplify/core';
+import {
+	AmplifyContext,
+	ConsoleLogger,
+	getGlobalContext,
+} from '@aws-amplify/core';
 import { signRequest } from '@aws-amplify/core/internals/aws-client-utils';
 import { AmplifyUrl } from '@aws-amplify/core/internals/utils';
 
@@ -17,8 +21,11 @@ type AWSAppSyncRealTimeAuthInput =
 		host?: string | undefined;
 	};
 
-const awsAuthTokenHeader = async ({ host }: AWSAppSyncRealTimeAuthInput) => {
-	const session = await fetchAuthSession();
+const awsAuthTokenHeader = async (
+	ctx: AmplifyContext,
+	{ host }: AWSAppSyncRealTimeAuthInput,
+) => {
+	const session = await ctx.fetchAuthSession();
 
 	return {
 		Authorization: session?.tokens?.accessToken?.toString(),
@@ -26,10 +33,10 @@ const awsAuthTokenHeader = async ({ host }: AWSAppSyncRealTimeAuthInput) => {
 	};
 };
 
-const awsRealTimeApiKeyHeader = async ({
-	apiKey,
-	host,
-}: AWSAppSyncRealTimeAuthInput) => {
+const awsRealTimeApiKeyHeader = async (
+	_ctx: AmplifyContext,
+	{ apiKey, host }: AWSAppSyncRealTimeAuthInput,
+) => {
 	const dt = new Date();
 	const dtStr = dt.toISOString().replace(/[:-]|\.\d{3}/g, '');
 
@@ -40,18 +47,21 @@ const awsRealTimeApiKeyHeader = async ({
 	};
 };
 
-const awsRealTimeIAMHeader = async ({
-	payload,
-	canonicalUri,
-	appSyncGraphqlEndpoint,
-	region,
-}: AWSAppSyncRealTimeAuthInput) => {
+const awsRealTimeIAMHeader = async (
+	ctx: AmplifyContext,
+	{
+		payload,
+		canonicalUri,
+		appSyncGraphqlEndpoint,
+		region,
+	}: AWSAppSyncRealTimeAuthInput,
+) => {
 	const endpointInfo = {
 		region,
 		service: 'appsync',
 	};
 
-	const creds = (await fetchAuthSession()).credentials;
+	const creds = (await ctx.fetchAuthSession()).credentials;
 
 	const request = {
 		url: `${appSyncGraphqlEndpoint}${canonicalUri}`,
@@ -77,10 +87,10 @@ const awsRealTimeIAMHeader = async ({
 	return signedParams.headers;
 };
 
-const customAuthHeader = async ({
-	host,
-	additionalCustomHeaders,
-}: AWSAppSyncRealTimeAuthInput) => {
+const customAuthHeader = async (
+	_ctx: AmplifyContext,
+	{ host, additionalCustomHeaders }: AWSAppSyncRealTimeAuthInput,
+) => {
 	/**
 	 * If `additionalHeaders` was provided to the subscription as a function,
 	 * the headers that are returned by that function will already have been
@@ -96,17 +106,24 @@ const customAuthHeader = async ({
 	};
 };
 
-export const awsRealTimeHeaderBasedAuth = async ({
-	apiKey,
-	authenticationType,
-	canonicalUri,
-	appSyncGraphqlEndpoint,
-	region,
-	additionalCustomHeaders,
-	payload,
-}: AWSAppSyncRealTimeAuthInput): Promise<
-	Record<string, string | undefined> | undefined
-> => {
+export const awsRealTimeHeaderBasedAuth = async (
+	authInput: AWSAppSyncRealTimeAuthInput,
+	ctx?: AmplifyContext,
+): Promise<Record<string, string | undefined> | undefined> => {
+	const {
+		apiKey,
+		authenticationType,
+		canonicalUri,
+		appSyncGraphqlEndpoint,
+		region,
+		additionalCustomHeaders,
+		payload,
+	} = authInput;
+
+	// Resolve context: use the explicitly provided ctx, or fall back to global context.
+	// NOTE: we do NOT capture getGlobalContext() eagerly — it's resolved fresh per call.
+	const resolvedCtx = ctx ?? getGlobalContext();
+
 	const headerHandler = {
 		apiKey: awsRealTimeApiKeyHeader,
 		iam: awsRealTimeIAMHeader,
@@ -131,7 +148,7 @@ export const awsRealTimeHeaderBasedAuth = async ({
 
 		logger.debug(`Authenticating with ${JSON.stringify(authenticationType)}`);
 
-		const result = await handler({
+		const result = await handler(resolvedCtx, {
 			payload,
 			canonicalUri,
 			appSyncGraphqlEndpoint,

--- a/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
+++ b/packages/api-graphql/src/Providers/AWSWebSocketProvider/index.ts
@@ -220,7 +220,7 @@ export abstract class AWSWebSocketProvider {
 	}
 
 	private async _connectWebSocket(options: AWSAppSyncRealTimeProviderOptions) {
-		const { apiKey, appSyncGraphqlEndpoint, authenticationType, region } =
+		const { apiKey, appSyncGraphqlEndpoint, authenticationType, region, ctx } =
 			options;
 
 		const { additionalCustomHeaders } =
@@ -233,6 +233,7 @@ export abstract class AWSWebSocketProvider {
 			authenticationType,
 			region,
 			additionalCustomHeaders,
+			ctx,
 		});
 	}
 
@@ -812,6 +813,7 @@ export abstract class AWSWebSocketProvider {
 		apiKey,
 		region,
 		additionalCustomHeaders,
+		ctx,
 	}: AWSAppSyncRealTimeProviderOptions) {
 		if (this.socketStatus === SOCKET_STATUS.READY) {
 			return;
@@ -829,15 +831,18 @@ export abstract class AWSWebSocketProvider {
 					// Empty payload on connect
 					const payloadString = '{}';
 
-					const authHeader = await awsRealTimeHeaderBasedAuth({
-						authenticationType,
-						payload: payloadString,
-						canonicalUri: this.wsConnectUri,
-						apiKey,
-						appSyncGraphqlEndpoint,
-						region,
-						additionalCustomHeaders,
-					});
+					const authHeader = await awsRealTimeHeaderBasedAuth(
+						{
+							authenticationType,
+							payload: payloadString,
+							canonicalUri: this.wsConnectUri,
+							apiKey,
+							appSyncGraphqlEndpoint,
+							region,
+							additionalCustomHeaders,
+						},
+						ctx,
+					);
 
 					const headerString = authHeader ? JSON.stringify(authHeader) : '';
 					// base64url-encoded string

--- a/packages/api-graphql/src/internals/InternalGraphQLAPI.ts
+++ b/packages/api-graphql/src/internals/InternalGraphQLAPI.ts
@@ -8,7 +8,11 @@ import {
 	print,
 } from 'graphql';
 import { Observable, catchError } from 'rxjs';
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import {
+	AmplifyClassV6,
+	AmplifyContext,
+	isAmplifyContext,
+} from '@aws-amplify/core';
 import {
 	AmplifyUrl,
 	CustomUserAgentDetails,
@@ -27,7 +31,11 @@ import {
 
 import { AWSAppSyncRealTimeProvider } from '../Providers/AWSAppSyncRealTimeProvider';
 import { GraphQLOperation, GraphQLOptions, GraphQLResult } from '../types';
-import { resolveConfig, resolveLibraryOptions } from '../utils';
+import {
+	bridgeAmplifyClass,
+	resolveConfig,
+	resolveLibraryOptions,
+} from '../utils';
 import { repackageUnauthorizedError } from '../utils/errors/repackageAuthError';
 import { NO_ENDPOINT } from '../utils/errors/constants';
 import { GraphQLApiError, createGraphQLResultWithError } from '../utils/errors';
@@ -39,10 +47,25 @@ const USER_AGENT_HEADER = 'x-amz-user-agent';
 
 const isAmplifyInstance = (
 	amplify:
+		| AmplifyContext
 		| AmplifyClassV6
-		| ((fn: (amplify: any) => Promise<any>) => Promise<AmplifyClassV6>),
-): amplify is AmplifyClassV6 => {
+		| ((fn: (amplify: any) => Promise<any>) => Promise<AmplifyContext>),
+): amplify is AmplifyContext | AmplifyClassV6 => {
 	return typeof amplify !== 'function';
+};
+
+/**
+ * Ensures the given amplify argument is an AmplifyContext.
+ * Bridges AmplifyClassV6 (legacy singleton) if needed.
+ */
+const ensureContext = (
+	amplify: AmplifyContext | AmplifyClassV6,
+): AmplifyContext => {
+	if (isAmplifyContext(amplify)) {
+		return amplify;
+	}
+
+	return bridgeAmplifyClass(amplify as AmplifyClassV6);
 };
 
 /**
@@ -86,8 +109,9 @@ export class InternalGraphQLAPIClass {
 	 */
 	graphql<T = any>(
 		amplify:
+			| AmplifyContext
 			| AmplifyClassV6
-			| ((fn: (amplify: any) => Promise<any>) => Promise<AmplifyClassV6>),
+			| ((fn: (amplify: any) => Promise<any>) => Promise<AmplifyContext>),
 		{
 			query: paramQuery,
 			variables = {},
@@ -120,8 +144,9 @@ export class InternalGraphQLAPIClass {
 				let responsePromise: Promise<GraphQLResult<T>>;
 
 				if (isAmplifyInstance(amplify)) {
+					const ctx = ensureContext(amplify);
 					responsePromise = this._graphql<T>(
-						amplify,
+						ctx,
 						{ query, variables, authMode, apiKey, endpoint },
 						headers,
 						abortController,
@@ -131,7 +156,7 @@ export class InternalGraphQLAPIClass {
 				} else {
 					// NOTE: this wrapper function must be await-able so the Amplify server context manager can
 					// destroy the context only after it completes
-					const wrapper = async (amplifyInstance: AmplifyClassV6) => {
+					const wrapper = async (amplifyInstance: AmplifyContext) => {
 						const result = await this._graphql<T>(
 							amplifyInstance,
 							{ query, variables, authMode, apiKey, endpoint },
@@ -158,7 +183,7 @@ export class InternalGraphQLAPIClass {
 			}
 			case 'subscription':
 				return this._graphqlSubscribe(
-					amplify as AmplifyClassV6,
+					ensureContext(amplify as AmplifyContext | AmplifyClassV6),
 					{ query, variables, authMode, apiKey, endpoint },
 					headers,
 					customUserAgentDetails,
@@ -170,7 +195,7 @@ export class InternalGraphQLAPIClass {
 	}
 
 	private async _graphql<T = any>(
-		amplify: AmplifyClassV6,
+		amplify: AmplifyContext,
 		{
 			query,
 			variables,
@@ -354,7 +379,7 @@ export class InternalGraphQLAPIClass {
 	}
 
 	private _graphqlSubscribe(
-		amplify: AmplifyClassV6,
+		amplify: AmplifyContext,
 		{
 			query,
 			variables,
@@ -407,6 +432,7 @@ export class InternalGraphQLAPIClass {
 					additionalHeaders,
 					authToken,
 					libraryConfigHeaders,
+					ctx: amplify,
 				},
 				customUserAgentDetails,
 			)

--- a/packages/api-graphql/src/internals/events/appsyncRequest.ts
+++ b/packages/api-graphql/src/internals/events/appsyncRequest.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 import {
 	AmplifyUrl,
 	CustomUserAgentDetails,
@@ -35,7 +35,7 @@ interface GqlRequestOptions {
 // and extend _graphql() without having to change a bunch of tests as well... which in turn reduces confidence
 // that this feature will _not affect_ GQL behavior.
 export async function appsyncRequest<T = any>(
-	amplify: AmplifyClassV6,
+	amplify: AmplifyContext,
 	options: GqlRequestOptions,
 	additionalHeaders: CustomHeaders = {},
 	abortController: AbortController,
@@ -103,7 +103,7 @@ export async function appsyncRequest<T = any>(
  * @returns HTTP request headers key/value
  */
 async function requestHeaders(
-	amplify: AmplifyClassV6,
+	amplify: AmplifyContext,
 	options: GqlRequestOptions,
 	additionalHeaders: CustomHeaders,
 	customUserAgentDetails?: CustomUserAgentDetails,

--- a/packages/api-graphql/src/internals/events/index.ts
+++ b/packages/api-graphql/src/internals/events/index.ts
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Subscription } from 'rxjs';
-import { Amplify } from '@aws-amplify/core';
-import { DocumentType, amplifyUuid } from '@aws-amplify/core/internals/utils';
+import { AmplifyContext } from '@aws-amplify/core';
+import {
+	DocumentType,
+	amplifyUuid,
+	resolveCtxArgs,
+} from '@aws-amplify/core/internals/utils';
 
 import { AppSyncEventProvider as eventProvider } from '../../Providers/AWSAppSyncEventsProvider';
 
@@ -37,6 +41,9 @@ const openChannels = new Set<string>();
  * @example // authMode override
  * const channel = await events.connect("default/channel", { authMode: "userPool" })
  *
+ * @example // with explicit context
+ * const channel = await events.connect(ctx, "default/channel")
+ *
  * @param channel - channel path; `<namespace>/<channel>`
  * @param options - request overrides: `authMode`, `authToken`
  *
@@ -44,8 +51,17 @@ const openChannels = new Set<string>();
 async function connect(
 	channel: string,
 	options?: EventsOptions,
-): Promise<EventsChannel> {
-	const providerOptions: ProviderOptions = configure();
+): Promise<EventsChannel>;
+async function connect(
+	ctx: AmplifyContext,
+	channel: string,
+	options?: EventsOptions,
+): Promise<EventsChannel>;
+async function connect(...args: any[]): Promise<EventsChannel> {
+	const [ctx, channel, options] =
+		resolveCtxArgs<[string, EventsOptions?]>(args);
+
+	const providerOptions: ProviderOptions = configure(ctx);
 
 	providerOptions.authenticationType = normalizeAuth(
 		options?.authMode,
@@ -54,7 +70,8 @@ async function connect(
 	providerOptions.apiKey = options?.apiKey || providerOptions.apiKey;
 	providerOptions.authToken = options?.authToken || providerOptions.authToken;
 
-	await eventProvider.connect(providerOptions);
+	// Pass ctx to the provider so WebSocket auth uses the correct credentials
+	await eventProvider.connect({ ...providerOptions, ctx });
 
 	const channelId = amplifyUuid();
 	openChannels.add(channelId);
@@ -78,7 +95,7 @@ async function connect(
 			subOptions?.authToken || subscribeOptions.authToken;
 
 		_subscription = eventProvider
-			.subscribe(subscribeOptions)
+			.subscribe({ ...subscribeOptions, ctx })
 			.subscribe(observer);
 
 		return _subscription;
@@ -104,7 +121,7 @@ async function connect(
 		publishOptions.authToken =
 			pubOptions?.authToken || publishOptions.authToken;
 
-		return eventProvider.publish(publishOptions);
+		return eventProvider.publish({ ...publishOptions, ctx });
 	};
 
 	const close = async () => {
@@ -138,6 +155,9 @@ async function connect(
  * @example // authMode override
  * await events.post("default/channel", { some: "event" }, { authMode: "userPool" })
  *
+ * @example // with explicit context
+ * await events.post(ctx, "default/channel", { some: "event" })
+ *
  * @param channel - channel path; `<namespace>/<channel>`
  * @param event - JSON-serializable value or an array of values
  * @param options - request overrides: `authMode`, `authToken`
@@ -149,8 +169,20 @@ async function post(
 	channel: string,
 	event: DocumentType | DocumentType[],
 	options?: EventsOptions,
-): Promise<void | PublishedEvent[]> {
-	const providerOptions: ProviderOptions = configure();
+): Promise<void | PublishedEvent[]>;
+async function post(
+	ctx: AmplifyContext,
+	channel: string,
+	event: DocumentType | DocumentType[],
+	options?: EventsOptions,
+): Promise<void | PublishedEvent[]>;
+async function post(...args: any[]): Promise<void | PublishedEvent[]> {
+	const [ctx, channel, event, options] =
+		resolveCtxArgs<[string, DocumentType | DocumentType[], EventsOptions?]>(
+			args,
+		);
+
+	const providerOptions: ProviderOptions = configure(ctx);
 	providerOptions.authenticationType = normalizeAuth(
 		options?.authMode,
 		providerOptions.authenticationType,
@@ -170,7 +202,7 @@ async function post(
 	const abortController = new AbortController();
 
 	const res = await appsyncRequest<PublishResponse>(
-		Amplify,
+		ctx,
 		publishOptions,
 		{},
 		abortController,

--- a/packages/api-graphql/src/internals/events/utils.ts
+++ b/packages/api-graphql/src/internals/events/utils.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Amplify } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 import {
 	DocumentType,
 	GraphQLAuthMode,
@@ -23,8 +23,8 @@ export const normalizeAuth = (
 	return explicitAuthMode;
 };
 
-export const configure = () => {
-	const config = Amplify.getConfig();
+export const configure = (ctx: AmplifyContext) => {
+	const config = ctx.resourcesConfig;
 
 	const eventsConfig = config.API?.Events;
 

--- a/packages/api-graphql/src/internals/generateClient.ts
+++ b/packages/api-graphql/src/internals/generateClient.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Hub } from '@aws-amplify/core';
+import { Hub, isAmplifyContext } from '@aws-amplify/core';
 import {
 	CustomMutations,
 	CustomQueries,
@@ -20,6 +20,7 @@ import {
 	__headers,
 	getInternals,
 } from '../types';
+import { bridgeAmplifyClass } from '../utils/bridgeAmplifyClass';
 
 import { isApiGraphQLConfig } from './utils/runtimeTypeGuards/isApiGraphQLProviderConfig';
 import { isConfigureEventWithResourceConfig } from './utils/runtimeTypeGuards/isConfigureEventWithResourceConfig';
@@ -39,8 +40,13 @@ export function generateClient<
 	T extends Record<any, any> = never,
 	Options extends ClientGenerationParams = ClientGenerationParams,
 >(params: Options): V6Client<T, Options> {
+	// Bridge AmplifyClassV6 to AmplifyContext if needed
+	const amplifyCtx = isAmplifyContext(params.amplify)
+		? params.amplify
+		: bridgeAmplifyClass(params.amplify);
+
 	const client = {
-		[__amplify]: params.amplify,
+		[__amplify]: amplifyCtx,
 		[__authMode]: params.authMode,
 		[__authToken]: params.authToken,
 		[__apiKey]: 'apiKey' in params ? params.apiKey : undefined,
@@ -56,7 +62,7 @@ export function generateClient<
 		subscriptions: emptyProperty as CustomSubscriptions<never>,
 	} as any;
 
-	const apiGraphqlConfig = params.amplify.getConfig().API?.GraphQL;
+	const apiGraphqlConfig = amplifyCtx.resourcesConfig.API?.GraphQL;
 
 	if (client[__endpoint]) {
 		if (!client[__authMode]) {

--- a/packages/api-graphql/src/internals/graphqlAuth.ts
+++ b/packages/api-graphql/src/internals/graphqlAuth.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { GraphQLAuthMode } from '@aws-amplify/core/internals/utils';
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 import { GraphQLApiError } from '../utils/errors';
 import {
@@ -14,7 +14,7 @@ import {
 } from '../utils/errors/constants';
 
 export async function headerBasedAuth(
-	amplify: AmplifyClassV6,
+	amplify: AmplifyContext,
 	authMode: GraphQLAuthMode,
 	apiKey: string | undefined,
 	additionalHeaders: Record<string, string> = {},
@@ -31,7 +31,7 @@ export async function headerBasedAuth(
 			};
 			break;
 		case 'iam': {
-			const session = await amplify.Auth.fetchAuthSession();
+			const session = await amplify.fetchAuthSession();
 			if (session.credentials === undefined) {
 				throw new GraphQLApiError(NO_VALID_CREDENTIALS);
 			}
@@ -43,7 +43,7 @@ export async function headerBasedAuth(
 
 			try {
 				token = (
-					await amplify.Auth.fetchAuthSession()
+					await amplify.fetchAuthSession()
 				).tokens?.accessToken.toString();
 			} catch (e) {
 				// fetchAuthSession failed

--- a/packages/api-graphql/src/internals/graphqlRequest.ts
+++ b/packages/api-graphql/src/internals/graphqlRequest.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AmplifyUrl } from '@aws-amplify/core/internals/utils';
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 import {
 	// cancel as cancelREST,
 	post,
@@ -10,7 +10,7 @@ import {
 } from '@aws-amplify/api-rest/internals';
 
 export async function graphqlRequest(
-	amplify: AmplifyClassV6,
+	amplify: AmplifyContext,
 	url: string,
 	options: any,
 	abortController: AbortController,

--- a/packages/api-graphql/src/internals/types.ts
+++ b/packages/api-graphql/src/internals/types.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AmplifyClassV6, AmplifyContext } from '@aws-amplify/core';
 import { GraphQLAuthMode } from '@aws-amplify/core/internals/utils';
 import { CustomHeaders } from '@aws-amplify/data-schema/runtime';
 
@@ -10,7 +10,7 @@ import { CustomHeaders } from '@aws-amplify/data-schema/runtime';
  * The knobs available for configuring `generateClient` internally.
  */
 export type ClientGenerationParams = {
-	amplify: AmplifyClassV6;
+	amplify: AmplifyContext | AmplifyClassV6;
 } & CommonPublicClientOptions;
 
 export interface DefaultCommonClientOptions {

--- a/packages/api-graphql/src/server/generateClient.ts
+++ b/packages/api-graphql/src/server/generateClient.ts
@@ -1,11 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-	AmplifyServer,
-	getAmplifyServerContext,
-} from '@aws-amplify/core/internals/adapter-core';
-import { ResourcesConfig } from '@aws-amplify/core';
+import { AmplifyServer } from '@aws-amplify/core/internals/adapter-core';
+import { AmplifyContext, ResourcesConfig } from '@aws-amplify/core';
 import { CustomHeaders } from '@aws-amplify/data-schema/runtime';
 
 import { generateClientWithAmplifyInstance } from '../internals/server';
@@ -17,6 +14,7 @@ import {
 	V6ClientSSRRequest,
 	__amplify,
 } from '../types';
+import { resolveServerContext } from '../utils/resolveServerContext';
 
 /**
  * Generates an GraphQL API client that works with Amplify server context.
@@ -49,11 +47,11 @@ export function generateClient<
 	const prevGraphql = client.graphql as unknown as GraphQLMethod<Options>;
 
 	const wrappedGraphql = (
-		contextSpec: AmplifyServer.ContextSpec,
+		contextSpec: AmplifyContext | AmplifyServer.ContextSpec,
 		innerOptions: GraphQLOptionsV6<unknown, string, Options>,
 		additionalHeaders?: CustomHeaders,
 	) => {
-		const amplifyInstance = getAmplifyServerContext(contextSpec).amplify;
+		const amplifyInstance = resolveServerContext(contextSpec);
 
 		return prevGraphql.call(
 			{ [__amplify]: amplifyInstance },

--- a/packages/api-graphql/src/utils/bridgeAmplifyClass.ts
+++ b/packages/api-graphql/src/utils/bridgeAmplifyClass.ts
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+	AMPLIFY_CONTEXT_BRAND,
+	AmplifyClassV6,
+	AmplifyContext,
+} from '@aws-amplify/core';
+
+/**
+ * Bridges an {@link AmplifyClassV6} instance to the {@link AmplifyContext} shape.
+ *
+ * `AmplifyClassV6` (a.k.a. `AmplifyClass`) exposes `resourcesConfig` / `libraryOptions`
+ * directly but does NOT surface the top-level context methods
+ * (`fetchAuthSession` / `clearCredentials` / `getTokens`). Those live under its
+ * cross-category `Auth` utility, so this helper maps them through.
+ *
+ * This is used:
+ * - In the server wrapper where a legacy `ContextSpec` provides an `AmplifyClass` instance.
+ * - In the internals where dependents still pass an `AmplifyClassV6` until they migrate.
+ *
+ * @internal
+ */
+export const bridgeAmplifyClass = (amplify: AmplifyClassV6): AmplifyContext => {
+	const resolved: AmplifyContext = {
+		get resourcesConfig() {
+			return amplify.getConfig();
+		},
+		// Live getter: AmplifyClass.libraryOptions is REASSIGNED wholesale on
+		// configure(), so a snapshot would go stale.
+		get libraryOptions() {
+			return amplify.libraryOptions;
+		},
+		// AmplifyContext.fetchAuthSession has OPTIONAL options while
+		// AuthClass.Auth.fetchAuthSession requires it, hence the `?? {}` default.
+		fetchAuthSession: options => amplify.Auth.fetchAuthSession(options ?? {}),
+		clearCredentials: () => amplify.Auth.clearCredentials(),
+		// getTokens needs no default — options is required on both interfaces.
+		getTokens: options => amplify.Auth.getTokens(options),
+	};
+
+	// Branding makes downstream isAmplifyContext checks (e.g. internalPost)
+	// recognize an already-bridged context, preventing double-bridging which
+	// would break the Auth.* closures.
+	Object.defineProperty(resolved, AMPLIFY_CONTEXT_BRAND, {
+		value: true,
+		enumerable: false,
+	});
+
+	return resolved;
+};

--- a/packages/api-graphql/src/utils/index.ts
+++ b/packages/api-graphql/src/utils/index.ts
@@ -3,3 +3,5 @@
 
 export { resolveConfig } from './resolveConfig';
 export { resolveLibraryOptions } from './resolveLibraryOptions';
+export { bridgeAmplifyClass } from './bridgeAmplifyClass';
+export { resolveServerContext } from './resolveServerContext';

--- a/packages/api-graphql/src/utils/resolveConfig.ts
+++ b/packages/api-graphql/src/utils/resolveConfig.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6, ConsoleLogger } from '@aws-amplify/core';
+import { AmplifyContext, ConsoleLogger } from '@aws-amplify/core';
 
 import { APIValidationErrorCode, assertValidationError } from './errors';
 
@@ -10,8 +10,8 @@ const logger = new ConsoleLogger('GraphQLAPI resolveConfig');
 /**
  * @internal
  */
-export const resolveConfig = (amplify: AmplifyClassV6) => {
-	const config = amplify.getConfig();
+export const resolveConfig = (amplify: AmplifyContext) => {
+	const config = amplify.resourcesConfig;
 
 	if (!config.API?.GraphQL) {
 		logger.warn(

--- a/packages/api-graphql/src/utils/resolveLibraryOptions.ts
+++ b/packages/api-graphql/src/utils/resolveLibraryOptions.ts
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AmplifyClassV6 } from '@aws-amplify/core';
+import { AmplifyContext } from '@aws-amplify/core';
 
 /**
  * @internal
  */
-export const resolveLibraryOptions = (amplify: AmplifyClassV6) => {
+export const resolveLibraryOptions = (amplify: AmplifyContext) => {
 	const headers = amplify.libraryOptions?.API?.GraphQL?.headers;
 	const withCredentials = amplify.libraryOptions?.API?.GraphQL?.withCredentials;
 

--- a/packages/api-graphql/src/utils/resolveServerContext.ts
+++ b/packages/api-graphql/src/utils/resolveServerContext.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AmplifyContext, isAmplifyContext } from '@aws-amplify/core';
+import {
+	AmplifyServer,
+	getAmplifyServerContext,
+} from '@aws-amplify/core/internals/adapter-core';
+
+import { bridgeAmplifyClass } from './bridgeAmplifyClass';
+
+/**
+ * Resolves a server-side argument that may be either the new {@link AmplifyContext}
+ * or a legacy {@link AmplifyServer.ContextSpec}, into a concrete `AmplifyContext`.
+ */
+export const resolveServerContext = (
+	ctxOrContextSpec: AmplifyContext | AmplifyServer.ContextSpec,
+): AmplifyContext => {
+	// Already a branded AmplifyContext (e.g. a directly-supplied context) — use as-is.
+	if (isAmplifyContext(ctxOrContextSpec)) {
+		return ctxOrContextSpec;
+	}
+
+	// Legacy server ContextSpec: unwrap the `AmplifyClass` and adapt it to the
+	// `AmplifyContext` shape via the shared bridge helper.
+	const { amplify } = getAmplifyServerContext(ctxOrContextSpec);
+
+	return bridgeAmplifyClass(amplify);
+};

--- a/packages/api/__tests__/internals/InternalAPI.test.ts
+++ b/packages/api/__tests__/internals/InternalAPI.test.ts
@@ -1,0 +1,120 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { Observable } from 'rxjs';
+import { InternalAPI } from '@aws-amplify/api/internals';
+import { clearGlobalContext } from '@aws-amplify/core/internals/utils';
+import type { GraphQLOptions } from '@aws-amplify/api-graphql';
+
+/**
+ * These tests lock in the contract that `InternalAPI.graphql()` must NEVER
+ * throw synchronously when no global Amplify context is set. `InternalAPI` is
+ * consumed exclusively by DataStore, whose processors expect setup errors to
+ * arrive on the async boundary:
+ *   - query / mutation -> a rejected Promise
+ *   - subscription      -> the Observable's error channel
+ *
+ * We only manipulate the GLOBAL context here (via `clearGlobalContext`) and
+ * exercise the real `InternalAPI` internals — nothing internal is mocked.
+ */
+describe('InternalAPI (DataStore-only shim)', () => {
+	const MISSING_CONTEXT_ERROR = 'No AmplifyContext available';
+
+	beforeEach(() => {
+		// Ensure there is NO global context for these assertions.
+		clearGlobalContext();
+	});
+
+	it('exposes the expected module name', () => {
+		expect(InternalAPI.getModuleName()).toBe('InternalAPI');
+	});
+
+	it('delegates getGraphqlOperationType to the underlying GraphQL API', () => {
+		expect(
+			InternalAPI.getGraphqlOperationType('query Q { field }'),
+		).toBe('query');
+	});
+
+	describe('query / mutation with no global context', () => {
+		it.each(['query Q { field }', 'mutation M { field }'])(
+			'does not throw synchronously and rejects for %p',
+			async operation => {
+				// The call expression itself MUST NOT throw.
+				expect(() => {
+					void (
+						InternalAPI.graphql({ query: operation }) as Promise<unknown>
+					).catch(() => {
+						// swallow — asserted below
+					});
+				}).not.toThrow();
+
+				await expect(
+					InternalAPI.graphql({ query: operation }) as Promise<unknown>,
+				).rejects.toThrow(MISSING_CONTEXT_ERROR);
+			},
+		);
+	});
+
+	describe('subscription with no global context', () => {
+		it('returns an Observable and does not throw synchronously', () => {
+			expect(() =>
+				InternalAPI.graphql({
+					query: 'subscription S { onCreate { id } }',
+				}),
+			).not.toThrow();
+
+			expect(
+				InternalAPI.graphql({
+					query: 'subscription S { onCreate { id } }',
+				}),
+			).toBeInstanceOf(Observable);
+		});
+
+		it('surfaces the missing-context error on the Observable error channel', async () => {
+			const observable = InternalAPI.graphql({
+				query: 'subscription S { onCreate { id } }',
+			}) as Observable<object>;
+
+			const error = await new Promise<Error>((resolve, reject) => {
+				observable.subscribe({
+					next: () => reject(new Error('unexpected next emission')),
+					error: resolve,
+					complete: () => reject(new Error('unexpected completion')),
+				});
+			});
+
+			expect(error.message).toContain(MISSING_CONTEXT_ERROR);
+		});
+	});
+
+	describe('DocumentNode queries', () => {
+		it('resolves the operation type from a DocumentNode and still defers context', async () => {
+			// Hand-built AST fixture (DataStore passes strings, but the option type
+			// also permits a DocumentNode).
+			const documentNodeQuery = {
+				kind: 'Document',
+				definitions: [
+					{
+						kind: 'OperationDefinition',
+						operation: 'query',
+						selectionSet: { kind: 'SelectionSet', selections: [] },
+					},
+				],
+			} as unknown as GraphQLOptions['query'];
+
+			await expect(
+				InternalAPI.graphql({ query: documentNodeQuery }) as Promise<unknown>,
+			).rejects.toThrow(MISSING_CONTEXT_ERROR);
+		});
+
+		it('throws for a DocumentNode without an operation definition', () => {
+			const documentNodeWithoutOperation = {
+				kind: 'Document',
+				definitions: [{ kind: 'FragmentDefinition' }],
+			} as unknown as GraphQLOptions['query'];
+
+			expect(() =>
+				InternalAPI.graphql({ query: documentNodeWithoutOperation }),
+			).toThrow('invalid operation: no operation definition found');
+		});
+	});
+});

--- a/packages/api/src/internals/InternalAPI.ts
+++ b/packages/api/src/internals/InternalAPI.ts
@@ -16,7 +16,7 @@ import {
 	Category,
 	CustomUserAgentDetails,
 } from '@aws-amplify/core/internals/utils';
-import { Observable } from 'rxjs';
+import { Observable, defer } from 'rxjs';
 import { CustomHeaders } from '@aws-amplify/data-schema/runtime';
 
 /**
@@ -88,12 +88,75 @@ export class InternalAPIClass {
 			...customUserAgentDetails,
 		};
 
-		return this._graphqlApi.graphql(
-			getGlobalContext(),
-			options,
-			additionalHeaders,
-			apiUserAgentDetails,
+		/**
+		 * IMPORTANT: do NOT resolve the global context eagerly (e.g. by passing
+		 * `getGlobalContext()` directly as an argument). Because this method is
+		 * synchronous, an eager call would throw SYNCHRONOUSLY out of `graphql()`
+		 * when no global context has been set — breaking callers that expect
+		 * setup errors on their async boundary. Most notably, DataStore's
+		 * subscription processor expects an Observable whose errors arrive via
+		 * `subscribe({ error })`, and query/mutation callers expect a rejected
+		 * Promise.
+		 *
+		 * Instead we determine the operation type first (which does not touch the
+		 * context) and defer context resolution to the appropriate boundary:
+		 *   - subscription -> resolved lazily inside `defer()` so a missing context
+		 *     surfaces on the Observable's error channel.
+		 *   - query/mutation -> resolved inside a try/catch so a missing context
+		 *     surfaces as a rejected Promise.
+		 */
+		const operationType = this.getGraphqlOperationTypeFromOptions(
+			options.query,
 		);
+
+		switch (operationType) {
+			case 'subscription':
+				return defer(() =>
+					this._graphqlApi.graphql(
+						getGlobalContext(),
+						options,
+						additionalHeaders,
+						apiUserAgentDetails,
+					),
+				);
+			default:
+				// `query` | `mutation`
+				try {
+					return this._graphqlApi.graphql(
+						getGlobalContext(),
+						options,
+						additionalHeaders,
+						apiUserAgentDetails,
+					);
+				} catch (error) {
+					return Promise.reject(error);
+				}
+		}
+	}
+
+	/**
+	 * Resolves the GraphQL operation type from the request options WITHOUT
+	 * touching the Amplify context. This lets {@link graphql} pick the correct
+	 * lazy-resolution strategy (rejected Promise vs. Observable error channel)
+	 * before any context is resolved.
+	 */
+	private getGraphqlOperationTypeFromOptions(
+		query: GraphQLOptions['query'],
+	): OperationTypeNode {
+		if (typeof query === 'string') {
+			return this._graphqlApi.getGraphqlOperationType(query);
+		}
+
+		// `query` is a `DocumentNode`. Read the operation type off its first
+		// operation definition directly, avoiding a `graphql` runtime dependency
+		// in this package.
+		for (const definition of query.definitions) {
+			if (definition.kind === 'OperationDefinition') {
+				return definition.operation;
+			}
+		}
+
+		throw new Error('invalid operation: no operation definition found');
 	}
 }
 

--- a/packages/api/src/internals/InternalAPI.ts
+++ b/packages/api/src/internals/InternalAPI.ts
@@ -10,7 +10,7 @@ import {
 	OperationTypeNode,
 } from '@aws-amplify/api-graphql';
 import { InternalGraphQLAPIClass } from '@aws-amplify/api-graphql/internals';
-import { Amplify, Cache } from '@aws-amplify/core';
+import { Cache, getGlobalContext } from '@aws-amplify/core';
 import {
 	ApiAction,
 	Category,
@@ -89,7 +89,7 @@ export class InternalAPIClass {
 		};
 
 		return this._graphqlApi.graphql(
-			Amplify,
+			getGlobalContext(),
 			options,
 			additionalHeaders,
 			apiUserAgentDetails,

--- a/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
+++ b/packages/datastore-storage-adapter/__tests__/SQLiteAdapter.test.ts
@@ -7,6 +7,8 @@ import {
 	PersistentModelConstructor,
 	initSchema as initSchemaType,
 } from '@aws-amplify/datastore';
+import { Amplify } from '@aws-amplify/core';
+import { clearGlobalContext, setGlobalContext } from '@aws-amplify/core/internals/utils';
 import {
 	Model,
 	Post,
@@ -99,6 +101,39 @@ describe('SQLiteAdapter', () => {
 			});
 			await DataStore.clear();
 
+			// Establish a global context so InternalAPI.graphql() → getGlobalContext()
+			// succeeds when the sync engine starts subscriptions.
+			const testCtx = {
+				resourcesConfig: {
+					API: {
+						GraphQL: {
+							endpoint:
+								'https://0.0.0.0/does/not/exist/graphql',
+							region: 'us-west-2',
+							defaultAuthMode: 'apiKey' as const,
+							apiKey: 'da2-fakeApiId123456',
+						},
+					},
+				},
+				libraryOptions: {},
+				fetchAuthSession: () => Promise.resolve({}),
+				clearCredentials: () => Promise.resolve(),
+				getTokens: () => Promise.resolve(undefined),
+			};
+			Object.defineProperty(testCtx, Symbol.for('amplify.context'), {
+				value: true,
+				enumerable: false,
+			});
+			setGlobalContext(testCtx);
+
+			// Prevent the subscription processor from making real network
+			// requests. Inject a no-op InternalAPI that returns empty observables.
+			const { NEVER } = require('rxjs');
+			(DataStore as any).amplifyContext.InternalAPI = {
+				graphql: () => NEVER,
+				getGraphqlOperationType: () => 'subscription',
+			};
+
 			// start() ensures storageAdapter is set
 			await DataStore.start();
 
@@ -110,6 +145,11 @@ describe('SQLiteAdapter', () => {
 			// prevents the mutation process from clearing the mutation queue, which
 			// allows us to observe the state of mutations.
 			(syncEngine as any).mutationsProcessor.isReady = () => false;
+		});
+
+		afterEach(async () => {
+			await DataStore.clear();
+			clearGlobalContext();
 		});
 
 		describe('sanity checks', () => {

--- a/packages/datastore/__tests__/DataStore/observeQuery.test.ts
+++ b/packages/datastore/__tests__/DataStore/observeQuery.test.ts
@@ -118,6 +118,41 @@ describe('DataStore observeQuery, with fake-indexeddb and fake sync', () => {
 			Profile: PersistentModelConstructor<Profile>;
 		});
 
+		// After resetModules the fresh core module has no global context.
+		// Establish one so that InternalAPI.graphql() → getGlobalContext() succeeds
+		// when the sync engine starts subscriptions.
+		const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+		const testCtx = {
+			resourcesConfig: {
+				API: {
+					GraphQL: {
+						endpoint: 'https://0.0.0.0/graphql',
+						region: 'us-west-2',
+						defaultAuthMode: 'apiKey' as const,
+						apiKey: 'da2-fakeApiId123456',
+					},
+				},
+			},
+			libraryOptions: {},
+			fetchAuthSession: () => Promise.resolve({}),
+			clearCredentials: () => Promise.resolve(),
+			getTokens: () => Promise.resolve(undefined),
+		};
+		Object.defineProperty(testCtx, Symbol.for('amplify.context'), {
+			value: true,
+			enumerable: false,
+		});
+		setGlobalContext(testCtx);
+
+		// Prevent the subscription processor from making real network requests
+		// (which hang in the test environment). Inject a fake InternalAPI that
+		// returns empty observables for subscriptions.
+		const { NEVER } = require('rxjs');
+		(DataStore as any).amplifyContext.InternalAPI = {
+			graphql: () => NEVER,
+			getGraphqlOperationType: () => 'subscription',
+		};
+
 		jest.useFakeTimers();
 		await configureSync(DataStore);
 	});
@@ -126,6 +161,11 @@ describe('DataStore observeQuery, with fake-indexeddb and fake sync', () => {
 		await DataStore.clear();
 		await unconfigureSync(DataStore);
 		jest.useRealTimers();
+		// symmetric cleanup: the fresh module graph set a global ctx in beforeEach
+		const {
+			clearGlobalContext,
+		} = require('@aws-amplify/core/internals/utils');
+		clearGlobalContext();
 	});
 
 	test('publishes preexisting local data immediately', async () => {

--- a/packages/datastore/__tests__/commonAdapterTests.ts
+++ b/packages/datastore/__tests__/commonAdapterTests.ts
@@ -7,6 +7,7 @@ import {
 	initSchema as initSchemaType,
 } from '../src';
 
+import { setGlobalContext, clearGlobalContext } from '@aws-amplify/core/internals/utils';
 import { ModelRelationship } from '../src/storage/relationship';
 import {
 	extractPrimaryKeyFieldNames,
@@ -110,6 +111,39 @@ export function addCommonQueryTests({
 				ModelWithIndexes: PersistentModelConstructor<ModelWithIndexes>;
 			});
 
+			// Establish a global context so that InternalAPI.graphql() →
+			// getGlobalContext() succeeds when the sync engine starts.
+			const testCtx = {
+				resourcesConfig: {
+					API: {
+						GraphQL: {
+							endpoint:
+								'https://0.0.0.0/does/not/exist/graphql',
+							region: 'us-west-2',
+							defaultAuthMode: 'apiKey' as const,
+							apiKey: 'da2-fakeApiId123456',
+						},
+					},
+				},
+				libraryOptions: {},
+				fetchAuthSession: () => Promise.resolve({}),
+				clearCredentials: () => Promise.resolve(),
+				getTokens: () => Promise.resolve(undefined),
+			};
+			Object.defineProperty(testCtx, Symbol.for('amplify.context'), {
+				value: true,
+				enumerable: false,
+			});
+			setGlobalContext(testCtx);
+
+			// Prevent the subscription processor from making real network
+			// requests. Inject a no-op InternalAPI that returns empty observables.
+			const { NEVER } = require('rxjs');
+			(DataStore as any).amplifyContext.InternalAPI = {
+				graphql: () => NEVER,
+				getGraphqlOperationType: () => 'subscription',
+			};
+
 			// start() ensures storageAdapter is set
 			await DataStore.start();
 
@@ -131,6 +165,7 @@ export function addCommonQueryTests({
 			// prevent cross-contamination with other test suites which are using
 			// the same instance.
 			(DataStore as any).amplifyConfig.aws_appsync_graphqlEndpoint = '';
+			clearGlobalContext();
 		});
 
 		it('should match fields of any non-empty value for `("ne", undefined)`', async () => {
@@ -320,6 +355,36 @@ export function addCommonQueryTests({
 				User: PersistentModelConstructor<User>;
 			});
 
+			// Establish a global context and fake InternalAPI for sync engine.
+			const testCtx = {
+				resourcesConfig: {
+					API: {
+						GraphQL: {
+							endpoint:
+								'https://0.0.0.0/does/not/exist/graphql',
+							region: 'us-west-2',
+							defaultAuthMode: 'apiKey' as const,
+							apiKey: 'da2-fakeApiId123456',
+						},
+					},
+				},
+				libraryOptions: {},
+				fetchAuthSession: () => Promise.resolve({}),
+				clearCredentials: () => Promise.resolve(),
+				getTokens: () => Promise.resolve(undefined),
+			};
+			Object.defineProperty(testCtx, Symbol.for('amplify.context'), {
+				value: true,
+				enumerable: false,
+			});
+			setGlobalContext(testCtx);
+
+			const { NEVER } = require('rxjs');
+			(DataStore as any).amplifyContext.InternalAPI = {
+				graphql: () => NEVER,
+				getGraphqlOperationType: () => 'subscription',
+			};
+
 			// start() ensures storageAdapter is set
 			await DataStore.start();
 
@@ -336,6 +401,7 @@ export function addCommonQueryTests({
 		afterEach(async () => {
 			await DataStore.clear();
 			(DataStore as any).amplifyConfig.aws_appsync_graphqlEndpoint = '';
+			clearGlobalContext();
 		});
 
 		it('should allow linking model via model field', async () => {

--- a/packages/datastore/__tests__/helpers/datastoreFactory.ts
+++ b/packages/datastore/__tests__/helpers/datastoreFactory.ts
@@ -204,6 +204,34 @@ export function getDataStore({
 		DataStore: DataStoreType;
 	} = require('../../src/datastore/datastore');
 
+	// After jest.resetModules(), the fresh module graph has no global context.
+	// InternalAPI.graphql() now calls getGlobalContext() which throws unless
+	// a context exists. Establish one via setGlobalContext() on the FRESH core
+	// module (not Amplify.configure — that dispatches Hub events which can
+	// auto-start DataStore before its storage adapter is configured).
+	const { setGlobalContext } = require('@aws-amplify/core/internals/utils');
+	const testCtx = {
+		resourcesConfig: {
+			API: {
+				GraphQL: {
+					endpoint: 'https://0.0.0.0/graphql',
+					region: 'us-west-2',
+					defaultAuthMode: 'apiKey' as const,
+					apiKey: 'da2-fakeApiId123456',
+				},
+			},
+		},
+		libraryOptions: {},
+		fetchAuthSession: () => Promise.resolve({}),
+		clearCredentials: () => Promise.resolve(),
+		getTokens: () => Promise.resolve(undefined),
+	};
+	Object.defineProperty(testCtx, Symbol.for('amplify.context'), {
+		value: true,
+		enumerable: false,
+	});
+	setGlobalContext(testCtx);
+
 	let errorHandlerSubscriber: Observer<SyncError<any>> | null = null;
 
 	const errorHandler = new Observable<SyncError<any>>(subscriber => {
@@ -222,8 +250,10 @@ export function getDataStore({
 	});
 
 	// private, test-only DI's.
+	// Always inject the fake graphqlService so that subscription/mutation
+	// processors never attempt real network I/O (which hangs in test env).
+	(DataStore as any).amplifyContext.InternalAPI = graphqlService;
 	if (online) {
-		(DataStore as any).amplifyContext.InternalAPI = graphqlService;
 		(DataStore as any).connectivityMonitor = connectivityMonitor;
 		(DataStore as any).amplifyConfig.aws_appsync_graphqlEndpoint =
 			'https://0.0.0.0/graphql';

--- a/packages/datastore/__tests__/mutation.test.ts
+++ b/packages/datastore/__tests__/mutation.test.ts
@@ -199,9 +199,8 @@ describe('MutationProcessor', () => {
 			await mutationProcessor.resume();
 			expect(mockRestPost).toHaveBeenCalledWith(
 				expect.objectContaining({
-					Auth: expect.any(Object),
-					configure: expect.any(Function),
-					getConfig: expect.any(Function),
+					resourcesConfig: expect.any(Object),
+					fetchAuthSession: expect.any(Function),
 				}),
 				expect.objectContaining({
 					url: new URL(


### PR DESCRIPTION
#### Description of changes

B-api-graphql split of the v6 context migration (Task 9 of the migration plan): migrates `@aws-amplify/api-graphql` and the `@aws-amplify/api` umbrella from the `Amplify.getConfig()` / singleton `fetchAuthSession` pattern to explicit `AmplifyContext`, with backward-compatible overloads.

- **GraphQL core**: `InternalGraphQLAPI` / `GraphQLAPI` accept `AmplifyContext | AmplifyClassV6` at the entry point and bridge legacy instances via a branded `bridgeAmplifyClass` (mirroring the corrected storage #14874 bridge pattern — not api-rest's original bare-cast version); all internals (`graphqlAuth`, `graphqlRequest`, `resolveConfig`, `resolveLibraryOptions`) take `ctx: AmplifyContext` first and read `ctx.resourcesConfig` / call `ctx.fetchAuthSession()` (Patterns 3/4).
- **Realtime / WebSocket auth**: `awsRealTimeHeaderBasedAuth` takes an optional `ctx`, and the explicit context is threaded per-call (never stored on the long-lived provider singletons) from `_graphqlSubscribe` and the events APIs through `AWSAppSyncRealTimeProvider`, `AWSAppSyncEventsProvider`, and `AWSWebSocketProvider` to **both** auth points — the subscription registration payload and the WebSocket connection handshake. Falls back to `getGlobalContext()` when no ctx is supplied (unchanged singleton behavior).
- **Events**: `events.connect()` / `events.post()` gain `fn(...)` / `fn(ctx, ...)` overloads via the shared `resolveCtxArgs` helper (inherits the mis-ordered-ctx guard from #14912); `appsyncRequest` and `events/utils` take ctx.
- **generateClient**: `ClientGenerationParams.amplify` widened to `AmplifyContext | AmplifyClassV6`; `internals/generateClient.ts` bridges legacy singleton callers (so `packages/api` `API.ts` keeps its call shape). The SSR closure path in `internals/server/generateClientWithAmplifyInstance.ts` is intentionally unchanged (`null | closure`).
- **Server (Pattern 5)**: `server/generateClient.ts` kept as a dedicated wrapper accepting `AmplifyContext | AmplifyServer.ContextSpec`, normalizing via a new `resolveServerContext` (bridged + branded, matching the corrected storage #14874 pattern). Full legacy server-path auth alignment remains deferred to Phase C.
- **api umbrella**: `internals/InternalAPI.ts` migrated; `API.ts` unchanged by design (bridging happens inside api-graphql).
- **Tests**: new branded `__tests__/testUtils/mockAmplifyContext.ts`; 7 test files migrated off singleton-shape assertions; new non-tautological tests prove an explicitly-passed ctx (not the global one) reaches the realtime auth layer on both the RealTime and Events provider paths.

No changeset (feature-branch target).

#### Issue #, if available

Part of the v6 context migration (base: Split A #14805; dependency: B-api-rest #14914).

#### Description of how you validated changes

- `yarn turbo run build test lint --filter=@aws-amplify/api-graphql --filter=@aws-amplify/api --force` — exit 0; api-graphql 8/8 suites, 153/153 tests; api 2/2 suites, 86/86 tests; lint clean
- `yarn turbo run build --filter=aws-amplify` — exit 0 (dependent umbrella build, cross-package type check)

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

