### PR TITLE
fix: UnauthorizedException from client.graphql().subscribe() when using 'oidc...

### DIFF
--- a/packages/api-graphql/src/Providers/AWSWebSocketProvider/authHeaders.ts
+++ b/packages/api-graphql/src/Providers/AWSWebSocketProvider/authHeaders.ts
@@ -26,6 +26,16 @@ const awsAuthTokenHeader = async ({ host }: AWSAppSyncRealTimeAuthInput) => {
 	};
 };
 
+const oidcAuthTokenHeader = async ({ host }: AWSAppSyncRealTimeAuthInput) => {
+	const session = await fetchAuthSession();
+	const tokens = session?.tokens;
+
+	return {
+		Authorization: (tokens?.idToken ?? tokens?.accessToken)?.toString(),
+		host,
+	};
+};
+
 const awsRealTimeApiKeyHeader = async ({
 	apiKey,
 	host,
@@ -110,7 +120,7 @@ export const awsRealTimeHeaderBasedAuth = async ({
 	const headerHandler = {
 		apiKey: awsRealTimeApiKeyHeader,
 		iam: awsRealTimeIAMHeader,
-		oidc: awsAuthTokenHeader,
+		oidc: oidcAuthTokenHeader,
 		userPool: awsAuthTokenHeader,
 		lambda: customAuthHeader,
 		none: customAuthHeader,


### PR DESCRIPTION
Fixes #14812

## Root cause

AppSync WebSocket auth header sends access token for 'oidc' auth mode

## Changes

- Added a dedicated OIDC handler in the AppSync WebSocket auth header resolver that sends tokens.idToken (falling back to tokens.accessToken when the token provider supplies no ID token), leaving userPool on the access token. Added unit tests for the oidc/userPool header resolution and a changeset.