### PR TITLE
fix: DataStore: failed Create followed by Update in outbox can leave records ...

### DIFF
--- a/packages/datastore/__tests__/outbox.test.ts
+++ b/packages/datastore/__tests__/outbox.test.ts
@@ -348,7 +348,64 @@ describe('Outbox tests', () => {
 			expect(headData.optionalField1).toEqual(optionalField1);
 		});
 	});
+
+	it('Should promote the next enqueued update to a create when an in progress create is discarded', async () => {
+		await drainOutbox();
+
+		const field1 = 'Some value';
+		const currentTimestamp = new Date().toISOString();
+		const optionalField1 = 'Optional value';
+
+		const newModel = new Model({
+			field1,
+			dateCreated: currentTimestamp,
+		});
+
+		await outbox.enqueue(Storage, await createMutationEvent(newModel));
+
+		await Storage.runExclusive(async s => {
+			const inProgressCreate = await outbox.peek(s);
+
+			expect(inProgressCreate.operation).toEqual(
+				TransformerMutationType.CREATE,
+			);
+		});
+
+		const updatedModel = Model.copyOf(newModel, updated => {
+			updated.optionalField1 = optionalField1;
+		});
+
+		await outbox.enqueue(Storage, await createMutationEvent(updatedModel));
+
+		await Storage.runExclusive(async s => {
+			const [_inProgress, nextMutation] = await outbox.getForModel(
+				s,
+				newModel as any,
+				getModelDefinition(Model),
+			);
+
+			expect(nextMutation.operation).toEqual(TransformerMutationType.UPDATE);
+
+			await outbox.dequeue(s);
+
+			const head = await outbox.peek(s);
+			const headData = JSON.parse(head.data);
+
+			expect(head.operation).toEqual(TransformerMutationType.CREATE);
+			expect(headData.field1).toEqual(field1);
+			expect(headData.dateCreated).toEqual(currentTimestamp);
+			expect(headData.optionalField1).toEqual(optionalField1);
+		});
+	});
 });
+
+async function drainOutbox(): Promise<void> {
+	await Storage.runExclusive(async s => {
+		while (await outbox.peek(s)) {
+			await outbox.dequeue(s);
+		}
+	});
+}
 
 // performs all the required dependency injection
 // in order to have a functional Outbox without the Sync Engine

--- a/packages/datastore/src/sync/outbox.ts
+++ b/packages/datastore/src/sync/outbox.ts
@@ -112,6 +112,8 @@ class MutationEventOutbox {
 
 		if (record) {
 			await this.syncOutboxVersionsOnDequeue(storage, record, head, recordOp!);
+		} else if (head?.operation === TransformerMutationType.CREATE) {
+			await this.promoteNextUpdateToCreate(storage, head);
 		}
 
 		if (head) {
@@ -249,6 +251,42 @@ class MutationEventOutbox {
 			reconciledMutations.map(async m =>
 				storage.save(m, undefined, this.ownSymbol),
 			),
+		);
+	}
+
+	private async promoteNextUpdateToCreate(
+		storage: StorageClass,
+		discardedCreate: MutationEvent,
+	): Promise<void> {
+		const mutationEventModelDefinition =
+			this.schema.namespaces[SYNC].models.MutationEvent;
+
+		const predicate = ModelPredicateCreator.createFromAST<MutationEvent>(
+			mutationEventModelDefinition,
+			{
+				and: [
+					{ modelId: { eq: discardedCreate.modelId } },
+					{ id: { ne: discardedCreate.id } },
+				],
+			},
+		);
+
+		const [next] = await storage.query(this._MutationEvent, predicate);
+
+		if (next?.operation !== TransformerMutationType.UPDATE) {
+			return;
+		}
+
+		const merged = this.mergeUserFields(discardedCreate, next);
+
+		await storage.save(
+			this._MutationEvent.copyOf(next, draft => {
+				draft.data = merged.data;
+				draft.operation = TransformerMutationType.CREATE;
+				draft.condition = JSON.stringify({});
+			}),
+			undefined,
+			this.ownSymbol,
 		);
 	}
 


### PR DESCRIPTION
Fixes #14766

## Root cause

Discarded in-flight CREATE leaves a queued UPDATE targeting a non-existent server record

## Changes

- In MutationEventOutbox.dequeue, when a CREATE mutation event is dequeued without a server record (i.e. it was discarded rather than acknowledged), the next pending mutation for the same modelId is promoted from UPDATE to CREATE with the create's and the update's fields merged, so the record is created in the cloud with its latest local state. Added a regression test in the outbox suite plus a changeset.