### PR TITLE
fix(datastore): apply pagination when only one record matches

### DIFF
--- a/.changeset/fix-datastore-single-record-pagination.md
+++ b/.changeset/fix-datastore-single-record-pagination.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/datastore': patch
+---
+
+fix(datastore): apply pagination when only one record matches a query

--- a/packages/datastore/__tests__/util.test.ts
+++ b/packages/datastore/__tests__/util.test.ts
@@ -20,6 +20,7 @@ import {
 	isIdOptionallyManaged,
 	indexNameFromKeys,
 	keysEqual,
+	inMemoryPagination,
 } from '../src/util';
 
 import { testSchema } from './helpers';
@@ -839,6 +840,61 @@ describe('datastore util', () => {
 				const result = keysEqual(keys1, keys2);
 				expect(result).toBeFalsy();
 			});
+		});
+	});
+
+	// See https://github.com/aws-amplify/amplify-js/issues/12049
+	describe('inMemoryPagination', () => {
+		const buildRecords = (count: number) =>
+			Array.from({ length: count }, (_, index) => ({ id: `id-${index}` }));
+
+		test('should return an empty page when there are no records', () => {
+			expect(
+				inMemoryPagination(buildRecords(0), { page: 1, limit: 20 }),
+			).toEqual([]);
+		});
+
+		test('should return the only record on the first page', () => {
+			expect(
+				inMemoryPagination(buildRecords(1), { page: 0, limit: 20 }),
+			).toEqual([{ id: 'id-0' }]);
+		});
+
+		test('should return an empty page for the page after a single record', () => {
+			expect(
+				inMemoryPagination(buildRecords(1), { page: 1, limit: 20 }),
+			).toEqual([]);
+		});
+
+		test('should return an empty page for any page past a single record', () => {
+			expect(
+				inMemoryPagination(buildRecords(1), { page: 2, limit: 1 }),
+			).toEqual([]);
+		});
+
+		test('should page through multiple records', () => {
+			expect(
+				inMemoryPagination(buildRecords(3), { page: 0, limit: 2 }),
+			).toEqual([{ id: 'id-0' }, { id: 'id-1' }]);
+			expect(
+				inMemoryPagination(buildRecords(3), { page: 1, limit: 2 }),
+			).toEqual([{ id: 'id-2' }]);
+		});
+
+		test('should return an empty page past the end of multiple records', () => {
+			expect(
+				inMemoryPagination(buildRecords(3), { page: 2, limit: 2 }),
+			).toEqual([]);
+		});
+
+		test('should not require a sort predicate', () => {
+			expect(
+				inMemoryPagination(buildRecords(3), {
+					page: 1,
+					limit: 2,
+					sort: undefined,
+				}),
+			).toEqual([{ id: 'id-2' }]);
 		});
 	});
 });

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -621,7 +621,9 @@ export function inMemoryPagination<T extends PersistentModel>(
 	records: T[],
 	pagination?: PaginationInput<T>,
 ): T[] {
-	if (pagination && records.length > 1) {
+	// Only an empty set is unaffected by pagination: with one record a page
+	// beyond the first must still resolve to no records.
+	if (pagination && records.length > 0) {
 		if (pagination.sort) {
 			const sortPredicates = ModelSortPredicateCreator.getPredicates(
 				pagination.sort,


### PR DESCRIPTION
#### Description of changes

`DataStore` pagination returned the same record on every page when a query
matched exactly one record.

**Root cause.** `inMemoryPagination` in `packages/datastore/src/util.ts` guarded
its entire pagination branch on the result-set size:

```ts
if (pagination && records.length > 1) {
```

With exactly one record that branch is skipped and `records` is returned
verbatim, so `page` and `limit` are never applied. Querying page 0 and then
page 1 of a single-record table yields the same item twice instead of an empty
second page — precisely the report in #12049.

**Fix.** Only an *empty* result set is genuinely unaffected by pagination, so the
guard now checks `records.length > 0`:

```ts
if (pagination && records.length > 0) {
```

This removes a size-dependent special case rather than adding one: a single
record now follows exactly the same slicing path as any larger set. Pagination
semantics are not widened — the arithmetic (`page`, `limit`, the no-limit and
negative-`page` paths) is untouched, and the 0-record and multi-record paths are
byte-for-byte unchanged.

Behaviour delta is confined to the single-record case, where three things now
match the `n >= 2` path that was already correct:

1. a page past the first resolves to `[]` (the bug being fixed);
2. the return value is a fresh `slice()` rather than the source array — no call
   site relies on identity, and `n >= 2` already returned a fresh array;
3. the `sort` predicate is evaluated. `Array.prototype.sort` on one element is a
   no-op, so ordering is unaffected; the only visible consequence is that an
   invalid hand-built predicate now throws consistently instead of throwing only
   when 2+ records happened to match.

`inMemoryPagination` is a pure exported function with three consumers —
`datastore.ts`, `IndexedDBAdapter`, and `AsyncStorageAdapter` — all of which
either reassign or directly return its result.

#### Issue #, if available

Fixes #12049

#### Description of how you validated changes

Added unit coverage to the existing `packages/datastore/__tests__/util.test.ts`,
written **before** the fix and confirmed RED against unmodified production code:

```
✕ should return an empty page for the page after a single record
✕ should return an empty page for any page past a single record

expect(received).toEqual(expected)
- Array []
+ Array [ Object { "id": "id-0" } ]
```

Both pass with the fix, and the other five cases in the block (0 records,
single record on page 0, multi-record paging, a page past the end of a
multi-record set, and an absent `sort` predicate) pass both before and after —
so they pin the unchanged paths rather than the fix.

Locally, on Node 24 / Yarn 1.22.22:

| Check | Result |
|---|---|
| `inMemoryPagination` block | 7 passed (was 2 failed / 5 passed) |
| `__tests__/util.test.ts` in full | 37 passed |
| `IndexedDBAdapter` + `AsyncStorageAdapter` (direct consumers) | 322 passed |
| `@aws-amplify/datastore` package `test` (lint + ts-coverage + jest + coverage thresholds) | 33 suites, 1167 passed, 0 failed |

`yarn test` is left unchecked below because I ran the `@aws-amplify/datastore`
package gate rather than the whole monorepo suite; `yarn test:tsc-compliance`
cannot run here without a prior full `yarn build` (it fails only with
`Cannot find module 'aws-amplify/...'` for unbuilt packages, naming no file in
this diff). CI covers both.

No screenshots: this is a library behaviour fix with no user-visible UI surface.

#### Checklist

- [x] PR description included
- [ ] `yarn test` passes
- [x] Unit Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

Documentation is unchecked because the fix brings behaviour into line with the
documented pagination contract; no documented behaviour changes.

#### Checklist for repo maintainers

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows
- [ ] New source file paths included in this PR have been added to CODEOWNERS, if appropriate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
