### PR TITLE
fix: mark v5 public APIs as deprecated for maintenance mode

### DIFF
--- a/packages/amazon-cognito-identity-js/index.d.ts
+++ b/packages/amazon-cognito-identity-js/index.d.ts
@@ -1,24 +1,54 @@
 declare module 'amazon-cognito-identity-js' {
 	//import * as AWS from "aws-sdk";
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export type NodeCallback<E, T> = (err?: E, result?: T) => void;
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export type UpdateAttributesNodeCallback<E, T, K> = (
 		err?: E,
 		result?: T,
 		details?: K
 	) => void;
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export namespace NodeCallback {
 		export type Any = NodeCallback<Error | undefined, any>;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface CodeDeliveryDetails {
 		AttributeName: string;
 		DeliveryMedium: string;
 		Destination: string;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export type ClientMetadata = { [key: string]: string } | undefined;
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface IAuthenticationCallback {
 		onSuccess: (
 			session: CognitoUserSession,
@@ -45,10 +75,20 @@ declare module 'amazon-cognito-identity-js' {
 		) => void;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface IMfaSettings {
 		PreferredMfa: boolean;
 		Enabled: boolean;
 	}
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface IAuthenticationDetailsData {
 		Username: string;
 		Password?: string;
@@ -56,6 +96,11 @@ declare module 'amazon-cognito-identity-js' {
 		ClientMetadata?: ClientMetadata;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export class AuthenticationDetails {
 		constructor(data: IAuthenticationDetailsData);
 
@@ -64,6 +109,11 @@ declare module 'amazon-cognito-identity-js' {
 		public getValidationData(): any[];
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface ICognitoStorage {
 		setItem(key: string, value: string): void;
 		getItem(key: string): string | null;
@@ -71,16 +121,31 @@ declare module 'amazon-cognito-identity-js' {
 		clear(): void;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface ICognitoUserData {
 		Username: string;
 		Pool: CognitoUserPool;
 		Storage?: ICognitoStorage;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface GetSessionOptions {
 		clientMetadata: Record<string, string>;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export type ChallengeName =
 		| 'CUSTOM_CHALLENGE'
 		| 'MFA_SETUP'
@@ -89,6 +154,11 @@ declare module 'amazon-cognito-identity-js' {
 		| 'SMS_MFA'
 		| 'SOFTWARE_TOKEN_MFA';
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export class CognitoUser {
 		constructor(data: ICognitoUserData);
 
@@ -284,11 +354,21 @@ declare module 'amazon-cognito-identity-js' {
 		): void;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface MFAOption {
 		DeliveryMedium: 'SMS' | 'EMAIL';
 		AttributeName: string;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface UserData {
 		MFAOptions: MFAOption[];
 		PreferredMfaSetting: string;
@@ -297,11 +377,21 @@ declare module 'amazon-cognito-identity-js' {
 		Username: string;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface ICognitoUserAttributeData {
 		Name: string;
 		Value: string;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export class CognitoUserAttribute implements ICognitoUserAttributeData {
 		constructor(data: ICognitoUserAttributeData);
 
@@ -316,6 +406,11 @@ declare module 'amazon-cognito-identity-js' {
 		public toJSON(): Object;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface ISignUpResult {
 		user: CognitoUser;
 		userConfirmed: boolean;
@@ -323,6 +418,11 @@ declare module 'amazon-cognito-identity-js' {
 		codeDeliveryDetails: CodeDeliveryDetails;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface ICognitoUserPoolData {
 		UserPoolId: string;
 		ClientId: string;
@@ -331,6 +431,11 @@ declare module 'amazon-cognito-identity-js' {
 		AdvancedSecurityDataCollectionFlag?: boolean;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export class CognitoUserPool {
 		constructor(
 			data: ICognitoUserPoolData,
@@ -355,12 +460,22 @@ declare module 'amazon-cognito-identity-js' {
 		public getCurrentUser(): CognitoUser | null;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface ICognitoUserSessionData {
 		IdToken: CognitoIdToken;
 		AccessToken: CognitoAccessToken;
 		RefreshToken?: CognitoRefreshToken;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export class CognitoUserSession {
 		constructor(data: ICognitoUserSessionData);
 
@@ -374,6 +489,11 @@ declare module 'amazon-cognito-identity-js' {
         public config: AWS.CognitoIdentityServiceProvider.Types.ClientConfiguration;
     }
     */
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export class CognitoAccessToken {
 		payload: { [key: string]: any };
 
@@ -385,6 +505,11 @@ declare module 'amazon-cognito-identity-js' {
 		public decodePayload(): { [id: string]: any };
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export class CognitoIdToken {
 		payload: { [key: string]: any };
 
@@ -396,12 +521,22 @@ declare module 'amazon-cognito-identity-js' {
 		public decodePayload(): { [id: string]: any };
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export class CognitoRefreshToken {
 		constructor({ RefreshToken }: { RefreshToken: string });
 
 		public getToken(): string;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export interface ICookieStorageData {
 		domain?: string;
 		path?: string;
@@ -409,6 +544,11 @@ declare module 'amazon-cognito-identity-js' {
 		secure?: boolean;
 		sameSite?: 'strict' | 'lax' | 'none';
 	}
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export class CookieStorage implements ICognitoStorage {
 		constructor(data?: ICookieStorageData);
 		setItem(key: string, value: string): void;
@@ -417,12 +557,27 @@ declare module 'amazon-cognito-identity-js' {
 		clear(): void;
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export class UserAgent {
 		constructor();
 	}
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export const appendToCognitoUserAgent: (content: string) => void;
 
+	/**
+	 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+	 * See the migration guide:
+	 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+	 */
 	export class WordArray {
 		constructor(words?: string[], sigBytes?: number);
 		random(nBytes: number): WordArray;

--- a/packages/analytics/src/Analytics.ts
+++ b/packages/analytics/src/Analytics.ts
@@ -448,5 +448,10 @@ const sendEvents = () => {
 	});
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Analytics = new AnalyticsClass();
 Amplify.register(Analytics);

--- a/packages/analytics/src/Providers/AWSKinesisFirehoseProvider.ts
+++ b/packages/analytics/src/Providers/AWSKinesisFirehoseProvider.ts
@@ -12,6 +12,11 @@ import { getAnalyticsUserAgent } from '../utils/UserAgent';
 
 const logger = new Logger('AWSKineisFirehoseProvider');
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class AWSKinesisFirehoseProvider extends AWSKinesisProvider {
 	private _kinesisFirehose: FirehoseClient;
 

--- a/packages/analytics/src/Providers/AWSKinesisProvider.ts
+++ b/packages/analytics/src/Providers/AWSKinesisProvider.ts
@@ -19,6 +19,11 @@ const FLUSH_SIZE = 100;
 const FLUSH_INTERVAL = 5 * 1000; // 5s
 const RESEND_LIMIT = 5;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class AWSKinesisProvider implements AnalyticsProvider {
 	protected _config;
 	private _kinesis;

--- a/packages/analytics/src/Providers/AWSPinpointProvider.ts
+++ b/packages/analytics/src/Providers/AWSPinpointProvider.ts
@@ -67,6 +67,9 @@ const RESEND_LIMIT = 5;
 // params: { event: {name: , .... }, timeStamp, config, resendLimits }
 /**
  * @deprecated AWS will end support for Amazon Pinpoint on October 30, 2026.
+ * Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class AWSPinpointProvider implements AnalyticsProvider {
 	static category = 'Analytics';

--- a/packages/analytics/src/Providers/AmazonPersonalizeProvider.ts
+++ b/packages/analytics/src/Providers/AmazonPersonalizeProvider.ts
@@ -34,6 +34,11 @@ const FLUSH_INTERVAL = 5 * 1000; // 5s
 
 const IDENTIFY_EVENT = 'Identify';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class AmazonPersonalizeProvider implements AnalyticsProvider {
 	private _config;
 	private _personalize;

--- a/packages/analytics/src/types/Provider.ts
+++ b/packages/analytics/src/types/Provider.ts
@@ -9,6 +9,11 @@ export interface PromiseHandlers {
 // CAUTION: The AnalyticsProvider interface is publicly available and allows customers to implement their own custom
 // analytics providers. Exercise caution when modifying this class as additive changes to this interface can break
 // customers when not marked as optional.
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface AnalyticsProvider {
 	// you need to implement those methods
 

--- a/packages/api-graphql/src/GraphQLAPI.ts
+++ b/packages/api-graphql/src/GraphQLAPI.ts
@@ -5,6 +5,11 @@ import { GraphQLOptions, GraphQLResult } from './types';
 import { InternalGraphQLAPIClass } from './internals';
 import Observable from 'zen-observable-ts';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const graphqlOperation = (
 	query,
 	variables = {},
@@ -17,6 +22,9 @@ export const graphqlOperation = (
 
 /**
  * Export Cloud Logic APIs
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class GraphQLAPIClass extends InternalGraphQLAPIClass {
 	public getModuleName() {
@@ -38,5 +46,10 @@ export class GraphQLAPIClass extends InternalGraphQLAPIClass {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const GraphQLAPI = new GraphQLAPIClass(null);
 Amplify.register(GraphQLAPI);

--- a/packages/api-graphql/src/types/index.ts
+++ b/packages/api-graphql/src/types/index.ts
@@ -6,6 +6,11 @@ import { GRAPHQL_AUTH_MODE } from '@aws-amplify/auth';
 export { GRAPHQL_AUTH_MODE };
 import { CustomUserAgentDetails } from '@aws-amplify/core';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface GraphQLOptions {
 	query: string | DocumentNode;
 	variables?: object;
@@ -17,6 +22,11 @@ export interface GraphQLOptions {
 	userAgentSuffix?: string; // TODO: remove in v6
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface GraphQLResult<T = object> {
 	data?: T;
 	errors?: GraphQLError[];
@@ -25,6 +35,11 @@ export interface GraphQLResult<T = object> {
 	};
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum GraphQLAuthError {
 	NO_API_KEY = 'No api-key configured',
 	NO_CURRENT_USER = 'No current user',
@@ -36,5 +51,8 @@ export enum GraphQLAuthError {
 /**
  * GraphQLSource or string, the type of the parameter for calling graphql.parse
  * @see: https://graphql.org/graphql-js/language/#parse
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export type GraphQLOperation = Source | string;

--- a/packages/api-rest/src/RestAPI.ts
+++ b/packages/api-rest/src/RestAPI.ts
@@ -12,6 +12,9 @@ const logger = new Logger('RestAPI');
 
 /**
  * Export Cloud Logic APIs
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class RestAPIClass {
 	/**
@@ -334,5 +337,10 @@ export class RestAPIClass {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const RestAPI = new RestAPIClass(null);
 Amplify.register(RestAPI);

--- a/packages/api-rest/src/RestClient.ts
+++ b/packages/api-rest/src/RestClient.ts
@@ -26,6 +26,9 @@ restClient.get('...')
     })
     .catch(err => console.log(err));
 </pre>
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
 */
 export class RestClient {
 	private _options;

--- a/packages/api/src/API.ts
+++ b/packages/api/src/API.ts
@@ -12,6 +12,9 @@ const logger = new Logger('API');
  * @deprecated
  * Use RestApi or GraphQLAPI to reduce your application bundle size
  * Export Cloud Logic APIs
+ * Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class APIClass extends InternalAPIClass {
 	public getModuleName() {
@@ -44,5 +47,10 @@ export class APIClass extends InternalAPIClass {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const API = new APIClass(null);
 Amplify.register(API);

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -16,7 +16,17 @@ export {
 // Opaque type used for determining the graphql query type
 declare const queryType: unique symbol;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type GraphQLQuery<T> = T & { readonly [queryType]: 'query' };
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type GraphQLSubscription<T> = T & {
 	readonly [queryType]: 'subscription';
 };

--- a/packages/auth/src/Auth.ts
+++ b/packages/auth/src/Auth.ts
@@ -2807,6 +2807,11 @@ export class AuthClass {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Auth = new AuthClass(null);
 
 Amplify.register(Auth);

--- a/packages/auth/src/common/AuthErrorStrings.ts
+++ b/packages/auth/src/common/AuthErrorStrings.ts
@@ -1,5 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum AuthErrorStrings {
 	DEFAULT_MSG = 'Authentication Error',
 	EMPTY_EMAIL = 'Email cannot be empty',

--- a/packages/auth/src/types/Auth.ts
+++ b/packages/auth/src/types/Auth.ts
@@ -8,6 +8,9 @@ import {
 
 /**
  * Parameters for user sign up
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export interface SignUpParams {
 	username: string;
@@ -44,6 +47,11 @@ export interface AuthOptions {
 	signUpVerificationMethod?: 'code' | 'link';
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum CognitoHostedUIIdentityProvider {
 	Cognito = 'COGNITO',
 	Google = 'Google',
@@ -227,6 +235,11 @@ export interface AutoSignInOptions {
 	validationData?: { [key: string]: any };
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum GRAPHQL_AUTH_MODE {
 	API_KEY = 'API_KEY',
 	AWS_IAM = 'AWS_IAM',

--- a/packages/aws-amplify-react-native/src/API/GraphQL/Connect.tsx
+++ b/packages/aws-amplify-react-native/src/API/GraphQL/Connect.tsx
@@ -27,6 +27,11 @@ interface IConnectState {
 	mutation: any;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class Connect extends Component<IConnectProps, IConnectState> {
 	subSubscription: any;
 

--- a/packages/aws-amplify-react-native/src/AmplifyMessageMap.ts
+++ b/packages/aws-amplify-react-native/src/AmplifyMessageMap.ts
@@ -5,6 +5,11 @@ import { I18n } from 'aws-amplify';
 
 type MapEntry = [string, RegExp, string?];
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const MapEntries: MapEntry[] = [
 	['User does not exist', /user.*not.*exist/i],
 	['User already exists', /user.*already.*exist/i],

--- a/packages/aws-amplify-react-native/src/AmplifyTheme.ts
+++ b/packages/aws-amplify-react-native/src/AmplifyTheme.ts
@@ -16,6 +16,11 @@ export const buttonColor = '#ff9900';
 export const disabledButtonColor = '#ff990080';
 
 // Theme
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default StyleSheet.create({
 	container: {
 		flex: 1,

--- a/packages/aws-amplify-react-native/src/AmplifyUI.tsx
+++ b/packages/aws-amplify-react-native/src/AmplifyUI.tsx
@@ -38,6 +38,11 @@ interface IContainerProps {
 	theme?: AmplifyThemeType;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Container: FC<IContainerProps> = (props) => {
 	const theme = props.theme || AmplifyTheme;
 	return <SafeAreaView style={theme.container}>{props.children}</SafeAreaView>;
@@ -49,6 +54,11 @@ interface IFormFieldProps extends TextInputProperties {
 	theme?: AmplifyThemeType;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const FormField: FC<IFormFieldProps> = (props) => {
 	const theme = props.theme || AmplifyTheme;
 	return (
@@ -83,6 +93,11 @@ interface IPhoneState {
 
 const minWidth = { minWidth: Platform.OS === 'android' ? 16 : 0 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class PhoneField extends Component<IPhoneProps, IPhoneState> {
 	constructor(props: IPhoneProps) {
 		super(props);
@@ -153,6 +168,11 @@ interface ILinkCellProps {
 	theme?: AmplifyThemeType;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const LinkCell: FC<ILinkCellProps> = (props) => {
 	const { disabled } = props;
 	const theme = props.theme || AmplifyTheme;
@@ -175,6 +195,11 @@ interface IHeaderProps {
 	theme?: AmplifyThemeType;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Header: FC<IHeaderProps> = (props) => {
 	const theme = props.theme || AmplifyTheme;
 	return (
@@ -190,6 +215,11 @@ interface IErrorRowProps {
 	theme?: AmplifyThemeType;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const ErrorRow: FC<IErrorRowProps> = (props) => {
 	const theme = props.theme || AmplifyTheme;
 	if (!props.children) return null;
@@ -210,6 +240,11 @@ interface IAmplifyButtonProps extends TouchableOpacityProps {
 	theme?: AmplifyThemeType;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const AmplifyButton: FC<IAmplifyButtonProps> = (props) => {
 	const theme = props.theme || AmplifyTheme;
 	let style = theme.button;
@@ -234,6 +269,11 @@ interface IWrapperProps {
 	onPress?: Function;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Wrapper: FC<IWrapperProps> = (props) => {
 	const isWeb = Platform.OS === 'web';
 	const WrapperComponent: React.ElementType = isWeb ? View : TouchableWithoutFeedback;
@@ -250,6 +290,11 @@ export const Wrapper: FC<IWrapperProps> = (props) => {
 	return <WrapperComponent {...wrapperProps}>{props.children}</WrapperComponent>;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const SignedOutMessage = (props) => {
 	const theme = props.theme || AmplifyTheme;
 	const message = props.signedOutMessage || I18n.get('Please Sign In / Sign Up');

--- a/packages/aws-amplify-react-native/src/Auth/AuthPiece.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/AuthPiece.tsx
@@ -49,6 +49,11 @@ export interface IAuthPieceState {
 	username?: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class AuthPiece<Props extends IAuthPieceProps, State extends IAuthPieceState> extends React.Component<
 	Props,
 	State

--- a/packages/aws-amplify-react-native/src/Auth/Authenticator.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/Authenticator.tsx
@@ -74,6 +74,11 @@ interface IAuthenticatorState {
 	error?: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class Authenticator extends React.Component<IAuthenticatorProps, IAuthenticatorState> {
 	_initialAuthState: string;
 	_isMounted: boolean;

--- a/packages/aws-amplify-react-native/src/Auth/ConfirmSignIn.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/ConfirmSignIn.tsx
@@ -36,6 +36,11 @@ interface IConfirmSignInState extends IAuthPieceState {
 	code?: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class ConfirmSignIn extends AuthPiece<
 	IConfirmSignInProps,
 	IConfirmSignInState

--- a/packages/aws-amplify-react-native/src/Auth/ConfirmSignUp.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/ConfirmSignUp.tsx
@@ -27,6 +27,11 @@ interface IConfirmSignUpState extends IAuthPieceState {
 	code: string | null;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class ConfirmSignUp extends AuthPiece<IConfirmSignUpProps, IConfirmSignUpState> {
 	constructor(props: IConfirmSignUpProps) {
 		super(props);

--- a/packages/aws-amplify-react-native/src/Auth/ForgotPassword.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/ForgotPassword.tsx
@@ -38,6 +38,11 @@ interface IForgotPasswordState extends IAuthPieceState {
 	password?: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class ForgotPassword extends AuthPiece<
 	IForgotPasswordProps,
 	IForgotPasswordState

--- a/packages/aws-amplify-react-native/src/Auth/Greetings.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/Greetings.tsx
@@ -27,6 +27,11 @@ interface IGreetingsProps extends IAuthPieceProps {
 
 interface IGreetingsState extends IAuthPieceState {}
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class Greetings extends AuthPiece<
 	IGreetingsProps,
 	IGreetingsState

--- a/packages/aws-amplify-react-native/src/Auth/Loading.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/Loading.tsx
@@ -19,6 +19,11 @@ import { Header } from '../AmplifyUI';
 import { AmplifyThemeType } from '../AmplifyTheme';
 import TEST_ID from '../AmplifyTestIDs';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class Loading extends AuthPiece<
 	IAuthPieceProps,
 	IAuthPieceState

--- a/packages/aws-amplify-react-native/src/Auth/RequireNewPassword.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/RequireNewPassword.tsx
@@ -38,6 +38,11 @@ interface IRequireNewPasswordState extends IAuthPieceState {
 	requiredAttributes: Record<string, any>;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class RequireNewPassword extends AuthPiece<
 	IRequireNewPasswordProps,
 	IRequireNewPasswordState

--- a/packages/aws-amplify-react-native/src/Auth/SignIn.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/SignIn.tsx
@@ -37,6 +37,11 @@ interface ISignInState extends IAuthPieceState {
 	hasPendingSignIn: boolean;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class SignIn extends AuthPiece<ISignInProps, ISignInState> {
 	constructor(props: ISignInProps) {
 		super(props);

--- a/packages/aws-amplify-react-native/src/Auth/SignUp.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/SignUp.tsx
@@ -52,6 +52,11 @@ interface ISignUpState extends IAuthPieceState {
 	password?: string | null;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class SignUp extends AuthPiece<ISignUpProps, ISignUpState> {
 	header: string;
 	defaultSignUpFields: ISignUpField[];

--- a/packages/aws-amplify-react-native/src/Auth/VerifyContact.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/VerifyContact.tsx
@@ -31,6 +31,11 @@ interface IVerifyContactState extends IAuthPieceState {
 	verifyAttr?: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class VerifyContact extends AuthPiece<IVerifyContactProps, IVerifyContactState> {
 	constructor(props: IVerifyContactProps) {
 		super(props);

--- a/packages/aws-amplify-react-native/src/Auth/index.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/index.tsx
@@ -56,6 +56,11 @@ interface IWithAuthenticatorState {
 	authState: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function withAuthenticator<Props extends object>(
 	Comp: React.ComponentType<Props>,
 	includeGreetings: boolean | { [index: string]: any } = false,

--- a/packages/aws-amplify-react-native/src/Auth/withOAuth.tsx
+++ b/packages/aws-amplify-react-native/src/Auth/withOAuth.tsx
@@ -44,6 +44,11 @@ interface IWithOAuthState {
 	user?: any;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default function withOAuth<Props extends object>(
 	Comp: React.ComponentType<IWithOAuthProps & IOAuthProps>
 ) {

--- a/packages/aws-amplify-react-native/src/Interactions/ChatBot.tsx
+++ b/packages/aws-amplify-react-native/src/Interactions/ChatBot.tsx
@@ -96,6 +96,11 @@ interface IChatBotState {
 	voice: boolean;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class ChatBot extends Component<IChatBotProps, IChatBotState> {
 	listItemsRef: React.RefObject<any>;
 

--- a/packages/aws-amplify-react-native/src/Storage/S3Album.tsx
+++ b/packages/aws-amplify-react-native/src/Storage/S3Album.tsx
@@ -30,6 +30,11 @@ interface IS3AlbumState {
 	images: any[];
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class S3Album extends Component<IS3AlbumProps, IS3AlbumState> {
 	constructor(props: IS3AlbumProps) {
 		super(props);

--- a/packages/aws-amplify-react-native/src/Storage/S3Image.tsx
+++ b/packages/aws-amplify-react-native/src/Storage/S3Image.tsx
@@ -32,6 +32,11 @@ interface IS3ImageState {
 	src?: any;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class S3Image extends Component<IS3ImageProps, IS3ImageState> {
 	constructor(props: IS3ImageProps) {
 		super(props);

--- a/packages/aws-amplify-react-native/src/index.ts
+++ b/packages/aws-amplify-react-native/src/index.ts
@@ -54,6 +54,11 @@ const configure = function (config) {
 	AmplifyCore.configure(config);
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 const Amplify = {
 	configure: configure,
 };

--- a/packages/aws-amplify/src/withSSRContext.ts
+++ b/packages/aws-amplify/src/withSSRContext.ts
@@ -24,6 +24,11 @@ type Context = {
 	modules?: any[];
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function withSSRContext(context: Context = {}) {
 	const { modules = defaultModules, req } = context;
 	if (modules.includes(DataStore) && !modules.includes(InternalAPI)) {

--- a/packages/cache/src/BrowserStorageCache.ts
+++ b/packages/cache/src/BrowserStorageCache.ts
@@ -486,6 +486,11 @@ export class BrowserStorageCacheClass extends StorageCache implements ICache {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const BrowserStorageCache: ICache = new BrowserStorageCacheClass();
 
 Amplify.register(BrowserStorageCache);

--- a/packages/cache/src/InMemoryCache.ts
+++ b/packages/cache/src/InMemoryCache.ts
@@ -345,4 +345,9 @@ export class InMemoryCacheClass extends StorageCache implements ICache {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const InMemoryCache: ICache = new InMemoryCacheClass();

--- a/packages/cache/src/types/Cache.ts
+++ b/packages/cache/src/types/Cache.ts
@@ -32,6 +32,9 @@ export interface ICache {
 
 /**
  * Cache instance options
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export interface CacheConfig {
 	/** Prepend to key to avoid conflicts */

--- a/packages/core/src/Amplify.ts
+++ b/packages/core/src/Amplify.ts
@@ -4,6 +4,11 @@ import { ConsoleLogger as LoggerClass } from './Logger';
 
 const logger = new LoggerClass('Amplify');
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class AmplifyClass {
 	// Everything that is `register`ed is tracked here
 	private _components = [];
@@ -113,4 +118,9 @@ export class AmplifyClass {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Amplify = new AmplifyClass();

--- a/packages/core/src/ClientDevice/index.ts
+++ b/packages/core/src/ClientDevice/index.ts
@@ -3,6 +3,11 @@
 
 import { clientInfo, dimension } from './browser';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class ClientDevice {
 	static clientInfo() {
 		return clientInfo();

--- a/packages/core/src/Credentials.ts
+++ b/packages/core/src/Credentials.ts
@@ -31,6 +31,11 @@ const dispatchCredentialsEvent = (
 	Hub.dispatch('core', { event, data, message }, 'Credentials', AMPLIFY_SYMBOL);
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class CredentialsClass {
 	private _config;
 	private _credentials;
@@ -629,6 +634,11 @@ export class CredentialsClass {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Credentials = new CredentialsClass(null);
 
 Amplify.register(Credentials);

--- a/packages/core/src/Errors.ts
+++ b/packages/core/src/Errors.ts
@@ -1,9 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function missingConfig(name: string) {
 	return new Error('Missing config value of ' + name);
 }
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function invalidParameter(name: string) {
 	return new Error('Invalid parameter value of ' + name);
 }

--- a/packages/core/src/Hub.ts
+++ b/packages/core/src/Hub.ts
@@ -20,6 +20,11 @@ interface IListener {
 	callback: HubCallback;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type HubCapsule = {
 	channel: string;
 	payload: HubPayload;
@@ -27,12 +32,22 @@ export type HubCapsule = {
 	patternInfo?: string[];
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type HubPayload = {
 	event: string;
 	data?: any;
 	message?: string;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type HubCallback = (capsule: HubCapsule) => void;
 
 export type LegacyCallback = { onHubCapsule: HubCallback };
@@ -232,4 +247,9 @@ export class HubClass {
 /*We export a __default__ instance of HubClass to use it as a 
 pseudo Singleton for the main messaging bus, however you can still create
 your own instance of HubClass() for a separate "private bus" of events.*/
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Hub = new HubClass('__default__');

--- a/packages/core/src/I18n/index.ts
+++ b/packages/core/src/I18n/index.ts
@@ -13,6 +13,9 @@ let _i18n = null;
 
 /**
  * Export I18n APIs
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class I18n {
 	/**

--- a/packages/core/src/JS.ts
+++ b/packages/core/src/JS.ts
@@ -45,8 +45,18 @@ const MIME_MAP = [
 	{ type: 'message/rfc822', ext: 'eml' },
 ];
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const isEmpty = (obj = {}) => Object.keys(obj).length === 0;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const sortByField = (list, field, dir) => {
 	if (!list || !list.sort) {
 		return false;
@@ -78,6 +88,11 @@ export const sortByField = (list, field, dir) => {
 	return true;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const objectLessAttributes = (obj, less) => {
 	const ret = Object.assign({}, obj);
 	if (less) {
@@ -93,6 +108,11 @@ export const objectLessAttributes = (obj, less) => {
 	return ret;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const filenameToContentType = (
 	filename,
 	defVal = 'application/octet-stream'
@@ -103,6 +123,11 @@ export const filenameToContentType = (
 	return filtered.length > 0 ? filtered[0].type : defVal;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const isTextFile = contentType => {
 	const type = contentType.toLowerCase();
 	if (type.startsWith('text/')) {
@@ -115,6 +140,11 @@ export const isTextFile = contentType => {
 	);
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const generateRandomString = () => {
 	let result = '';
 	const chars =
@@ -125,6 +155,11 @@ export const generateRandomString = () => {
 	return result;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const makeQuerablePromise = promise => {
 	if (promise.isResolved) return promise;
 
@@ -152,6 +187,11 @@ export const makeQuerablePromise = promise => {
 	return result;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const isWebWorker = () => {
 	if (typeof self === 'undefined') {
 		return false;
@@ -163,6 +203,11 @@ export const isWebWorker = () => {
 	);
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const browserOrNode = () => {
 	const isBrowser =
 		typeof window !== 'undefined' && typeof window.document !== 'undefined';
@@ -182,6 +227,9 @@ export const browserOrNode = () => {
  * @param {Object} obj - the object need to be transferred
  * @param {Array} whiteListForItself - whitelist itself from being transferred
  * @param {Array} whiteListForChildren - whitelist its children keys from being transferred
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export const transferKeyToLowerCase = (
 	obj,
@@ -215,6 +263,9 @@ export const transferKeyToLowerCase = (
  * @param {Object} obj - the object need to be transferred
  * @param {Array} whiteListForItself - whitelist itself from being transferred
  * @param {Array} whiteListForChildren - whitelist its children keys from being transferred
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export const transferKeyToUpperCase = (
 	obj,
@@ -246,6 +297,9 @@ export const transferKeyToUpperCase = (
  * Return true if the object is a strict object
  * which means it's not Array, Function, Number, String, Boolean or Null
  * @param obj the Object
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export const isStrictObject = obj => {
 	return (

--- a/packages/core/src/Logger/ConsoleLogger.ts
+++ b/packages/core/src/Logger/ConsoleLogger.ts
@@ -25,6 +25,9 @@ export enum LOG_TYPE {
 /**
  * Write logs
  * @class Logger
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class ConsoleLogger implements Logger {
 	name: string;

--- a/packages/core/src/OAuthHelper/index.ts
+++ b/packages/core/src/OAuthHelper/index.ts
@@ -3,5 +3,15 @@
 import { GoogleOAuth as GoogleOAuthClass } from './GoogleOAuth';
 import { FacebookOAuth as FacebookOAuthClass } from './FacebookOAuth';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const GoogleOAuth = new GoogleOAuthClass();
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const FacebookOAuth = new FacebookOAuthClass();

--- a/packages/core/src/Platform/index.ts
+++ b/packages/core/src/Platform/index.ts
@@ -26,8 +26,18 @@ class PlatformBuilder {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Platform = new PlatformBuilder();
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const getAmplifyUserAgentObject = ({
 	category,
 	action,
@@ -42,6 +52,11 @@ export const getAmplifyUserAgentObject = ({
 	return userAgent;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const getAmplifyUserAgent = (
 	customUserAgentDetails?: CustomUserAgentDetails
 ): string => {

--- a/packages/core/src/Platform/types.ts
+++ b/packages/core/src/Platform/types.ts
@@ -1,6 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum Framework {
 	// < 100 - Web frameworks
 	WebUnknown = '0',
@@ -25,6 +30,11 @@ export enum Framework {
 	Expo = '202',
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum Category {
 	API = 'api',
 	Auth = 'auth',
@@ -39,10 +49,20 @@ export enum Category {
 	Storage = 'storage',
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum AnalyticsAction {
 	Record = '1',
 	UpdateEndpoint = '2',
 }
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum ApiAction {
 	GraphQl = '1',
 	Get = '2',
@@ -52,6 +72,11 @@ export enum ApiAction {
 	Del = '6',
 	Head = '7',
 }
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum AuthAction {
 	// SignUp = '1',
 	// ConfirmSignUp = '2',
@@ -88,30 +113,70 @@ export enum AuthAction {
 	// ForgetDevice = '33',
 	// FetchDevices = '34',
 }
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum DataStoreAction {
 	Subscribe = '1',
 	GraphQl = '2',
 }
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum GeoAction {
 	None = '0',
 }
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum InAppMessagingAction {
 	None = '0',
 }
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum InteractionsAction {
 	None = '0',
 }
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum PredictionsAction {
 	Convert = '1',
 	Identify = '2',
 	Interpret = '3',
 }
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum PubSubAction {
 	Subscribe = '1',
 }
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum PushNotificationAction {
 	None = '0',
 }
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum StorageAction {
 	Put = '1',
 	Get = '2',
@@ -145,6 +210,11 @@ type CustomUserAgentDetailsBase = {
 	framework?: Framework;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type CustomUserAgentDetails =
 	| (CustomUserAgentDetailsBase & { category?: never; action?: never })
 	| UserAgentDetailsWithCategory<Category.API>

--- a/packages/core/src/Providers/AWSCloudWatchProvider.ts
+++ b/packages/core/src/Providers/AWSCloudWatchProvider.ts
@@ -46,6 +46,11 @@ import {
 
 const logger = new Logger('AWSCloudWatch');
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 class AWSCloudWatchProvider implements LoggingProvider {
 	static readonly PROVIDER_NAME = AWS_CLOUDWATCH_PROVIDER_NAME;
 	static readonly CATEGORY = AWS_CLOUDWATCH_CATEGORY;

--- a/packages/core/src/RNComponents/index.ts
+++ b/packages/core/src/RNComponents/index.ts
@@ -4,12 +4,27 @@
 import { browserOrNode } from '../JS';
 import { StorageHelper } from '../StorageHelper';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Linking = {};
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const AppState = {
 	addEventListener: (action, handler) => undefined,
 };
 
 // if not in react native, just use local storage
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const AsyncStorage = browserOrNode().isBrowser
 	? new StorageHelper().getStorage()
 	: undefined;

--- a/packages/core/src/ServiceWorker/ServiceWorker.ts
+++ b/packages/core/src/ServiceWorker/ServiceWorker.ts
@@ -26,6 +26,9 @@ import { Amplify } from '../Amplify';
  * At the minmum this class will register the service worker and listen
  * and attempt to dispatch messages on state change and record analytics
  * events based on the service worker lifecycle.
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class ServiceWorkerClass {
 	// The active service worker will be set once it is registered

--- a/packages/core/src/Signer.ts
+++ b/packages/core/src/Signer.ts
@@ -12,6 +12,11 @@ const IOT_SERVICE_NAME = 'iotdevicegateway';
 // Best practice regex to parse the service and region from an AWS endpoint
 const AWS_ENDPOINT_REGEX = /([^\.]+)\.(?:([^\.]*)\.)?amazonaws\.com(.cn)?$/;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class Signer {
 	/**
     * Sign a HTTP request, add 'Authorization' header to request param

--- a/packages/core/src/StorageHelper/index.ts
+++ b/packages/core/src/StorageHelper/index.ts
@@ -3,7 +3,12 @@
 
 let dataMemory = {};
 
-/** @class */
+/**
+ * @class
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class MemoryStorage {
 	/**
 	 * This is used to set a specific item in storage
@@ -47,6 +52,11 @@ export class MemoryStorage {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class StorageHelper {
 	private storageWindow: any;
 	/**

--- a/packages/core/src/UniversalStorage/index.ts
+++ b/packages/core/src/UniversalStorage/index.ts
@@ -12,6 +12,11 @@ type Context = { req?: any };
 
 const ONE_YEAR_IN_MS = 365 * 24 * 60 * 60 * 1000;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class UniversalStorage implements Storage {
 	cookies = new Cookies();
 	store: Store = isBrowser ? window.localStorage : Object.create(null);

--- a/packages/core/src/Util/BackgroundProcessManager.ts
+++ b/packages/core/src/Util/BackgroundProcessManager.ts
@@ -9,6 +9,9 @@
  *
  * As work completes on its own prior to close, the manager removes them
  * from the registry to avoid holding references to completed jobs.
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class BackgroundProcessManager {
 	/**
@@ -396,6 +399,9 @@ export class BackgroundProcessManager {
 
 /**
  *
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class BackgroundManagerNotOpenError extends Error {
 	constructor(message: string) {
@@ -405,6 +411,9 @@ export class BackgroundManagerNotOpenError extends Error {
 
 /**
  * All possible states a `BackgroundProcessManager` instance can be in.
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export enum BackgroundProcessManagerState {
 	/**

--- a/packages/core/src/Util/Constants.ts
+++ b/packages/core/src/Util/Constants.ts
@@ -2,12 +2,47 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Logging constants
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 const AWS_CLOUDWATCH_BASE_BUFFER_SIZE = 26;
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 const AWS_CLOUDWATCH_MAX_BATCH_EVENT_SIZE = 1048576;
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 const AWS_CLOUDWATCH_MAX_EVENT_SIZE = 256000;
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 const AWS_CLOUDWATCH_CATEGORY = 'Logging';
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 const AWS_CLOUDWATCH_PROVIDER_NAME = 'AWSCloudWatch';
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 const NO_CREDS_ERROR_STRING = 'No credentials';
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 const RETRY_ERROR_CODES = [
 	'ResourceNotFoundException',
 	'InvalidSequenceTokenException',

--- a/packages/core/src/Util/DateUtils.ts
+++ b/packages/core/src/Util/DateUtils.ts
@@ -11,6 +11,11 @@
 
 const FIVE_MINUTES_IN_MS = 1000 * 60 * 5;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const DateUtils = {
 	/**
 	 * Milliseconds to offset the date to compensate for clock skew between device & services

--- a/packages/core/src/Util/Mutex.ts
+++ b/packages/core/src/Util/Mutex.ts
@@ -42,6 +42,11 @@ namespace MutexInterface {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 class Mutex implements MutexInterface {
 	isLocked(): boolean {
 		return this._pending;

--- a/packages/core/src/Util/Reachability.ts
+++ b/packages/core/src/Util/Reachability.ts
@@ -7,6 +7,11 @@ type NetworkStatus = {
 	online: boolean;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export default class ReachabilityNavigator implements Reachability {
 	private static _observers: Array<
 		ZenObservable.SubscriptionObserver<NetworkStatus>

--- a/packages/core/src/Util/Retry.ts
+++ b/packages/core/src/Util/Retry.ts
@@ -4,6 +4,11 @@ import { DelayFunction } from '../types';
 import { ConsoleLogger as Logger } from '../Logger/ConsoleLogger';
 const logger = new Logger('Util');
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class NonRetryableError extends Error {
 	public readonly nonRetryable = true;
 	constructor(message: string) {
@@ -11,6 +16,11 @@ export class NonRetryableError extends Error {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const isNonRetryableError = (obj: any): obj is NonRetryableError => {
 	const key: keyof NonRetryableError = 'nonRetryable';
 	return obj && obj[key];
@@ -19,6 +29,9 @@ export const isNonRetryableError = (obj: any): obj is NonRetryableError => {
 /**
  * @private
  * Internal use of Amplify only
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export async function retry<T>(
 	functionToRetry: (...args: any[]) => T,
@@ -95,6 +108,9 @@ const MAX_DELAY_MS = 5 * 60 * 1000;
 /**
  * @private
  * Internal use of Amplify only
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export function jitteredBackoff(
 	maxDelayMs: number = MAX_DELAY_MS
@@ -111,6 +127,9 @@ export function jitteredBackoff(
 /**
  * @private
  * Internal use of Amplify only
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export const jitteredExponentialRetry = <T>(
 	functionToRetry: (...args: any[]) => T,

--- a/packages/core/src/Util/StringUtils.ts
+++ b/packages/core/src/Util/StringUtils.ts
@@ -1,5 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function urlSafeEncode(str: string) {
 	return str
 		.split('')
@@ -12,6 +17,11 @@ export function urlSafeEncode(str: string) {
 		.join('');
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function urlSafeDecode(hex: string) {
 	return hex
 		.match(/.{2}/g)

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -8,8 +8,18 @@
 const hasSymbol =
 	typeof Symbol !== 'undefined' && typeof Symbol.for === 'function';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const INTERNAL_AWS_APPSYNC_REALTIME_PUBSUB_PROVIDER = hasSymbol
 	? Symbol.for('INTERNAL_AWS_APPSYNC_REALTIME_PUBSUB_PROVIDER')
 	: '@@INTERNAL_AWS_APPSYNC_REALTIME_PUBSUB_PROVIDER';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const USER_AGENT_HEADER = 'x-amz-user-agent';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,6 +61,11 @@ export {
 	USER_AGENT_HEADER,
 } from './constants';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Constants = {
 	userAgent: Platform.userAgent,
 };

--- a/packages/core/src/parseAWSExports.ts
+++ b/packages/core/src/parseAWSExports.ts
@@ -5,6 +5,11 @@ import { ConsoleLogger as Logger } from './Logger';
 
 const logger = new Logger('Parser');
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const parseAWSExports = (config): AmplifyConfig => {
 	const amplifyConfig: AmplifyConfig = {};
 	// Analytics

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -17,6 +17,11 @@ export interface AmplifyConfig {
 	ssr?: boolean;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface ICredentials {
 	accessKeyId: string;
 	sessionToken: string;

--- a/packages/datastore-storage-adapter/src/SQLiteAdapter/SQLiteAdapter.ts
+++ b/packages/datastore-storage-adapter/src/SQLiteAdapter/SQLiteAdapter.ts
@@ -3,6 +3,11 @@
 import { CommonSQLiteAdapter } from '../common/CommonSQLiteAdapter';
 import SQLiteDatabase from './SQLiteDatabase';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 const SQLiteAdapter: CommonSQLiteAdapter = new CommonSQLiteAdapter(
 	new SQLiteDatabase()
 );

--- a/packages/datastore/src/datastore/datastore.ts
+++ b/packages/datastore/src/datastore/datastore.ts
@@ -310,6 +310,11 @@ export const getAttachment = (instance: PersistentModel) => {
 		: ModelAttachment.Detached;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 const initSchema = (userSchema: Schema) => {
 	if (schema !== undefined) {
 		console.warn('The schema has already been initialized');
@@ -548,6 +553,9 @@ const createTypeClasses: (
  * @param modelConstructor The model constructor.
  * @param init Init data that would normally be passed to the constructor.
  * @returns The initialized model.
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export declare type ModelInstanceCreator = typeof modelInstanceCreator;
 
@@ -1112,6 +1120,9 @@ const createModelClass = <T extends PersistentModel>(
 
 /**
  * An eventually loaded related model instance.
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class AsyncItem<T> extends Promise<T> {}
 
@@ -1119,6 +1130,9 @@ export class AsyncItem<T> extends Promise<T> {}
  * A collection of related model instances.
  *
  * This collection can be async-iterated or turned directly into an array using `toArray()`.
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class AsyncCollection<T> implements AsyncIterable<T> {
 	private values: Array<any> | Promise<Array<any>>;
@@ -1387,6 +1401,11 @@ enum DataStoreState {
 
 // TODO: How can we get rid of the non-null assertions?
 // https://github.com/aws-amplify/amplify-js/pull/10477/files#r1007363485
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 class DataStore {
 	// reference to configured category instances. Used for preserving SSR context
 	private Auth = Auth;
@@ -2757,6 +2776,11 @@ class DataStore {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 const instance = new DataStore();
 Amplify.register(instance);
 

--- a/packages/datastore/src/index.ts
+++ b/packages/datastore/src/index.ts
@@ -26,6 +26,11 @@ import {
 
 export { NAMESPACES } from './util';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const utils = {
 	USER,
 	traverseModel,

--- a/packages/datastore/src/predicates/index.ts
+++ b/packages/datastore/src/predicates/index.ts
@@ -96,6 +96,11 @@ const isValid = o => {
 // This symbol is not used at runtime, only its type (unique symbol)
 export const PredicateAll = Symbol('A predicate that matches all records');
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class Predicates {
 	public static get ALL(): typeof PredicateAll {
 		const predicate = <ProducerModelPredicate<any>>(c => c);
@@ -106,6 +111,11 @@ export class Predicates {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class ModelPredicateCreator {
 	/**
 	 * Map of storage predicates (key objects) to storage predicate AST's.

--- a/packages/datastore/src/predicates/sort.ts
+++ b/packages/datastore/src/predicates/sort.ts
@@ -9,6 +9,11 @@ import {
 	SortPredicatesGroup,
 } from '../types';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class ModelSortPredicateCreator {
 	private static sortPredicateGroupsMap = new WeakMap<
 		SortPredicate<any>,

--- a/packages/datastore/src/storage/adapter/index.ts
+++ b/packages/datastore/src/storage/adapter/index.ts
@@ -11,6 +11,11 @@ import {
 	SystemComponent,
 } from '../../types';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface Adapter extends SystemComponent {
 	clear(): Promise<void>;
 	save<T extends PersistentModel>(

--- a/packages/datastore/src/types.ts
+++ b/packages/datastore/src/types.ts
@@ -21,13 +21,28 @@ import { InternalAPI } from '@aws-amplify/api/internals';
 import { Cache } from '@aws-amplify/cache';
 import { Adapter } from './storage/adapter';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type Scalar<T> = T extends Array<infer InnerType> ? InnerType : T;
 
 //#region Schema types
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type Schema = UserSchema & {
 	version: string;
 	codegenVersion: string;
 };
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type UserSchema = {
 	models: SchemaModels;
 	nonModels?: SchemaNonModels;
@@ -36,16 +51,41 @@ export type UserSchema = {
 	enums: SchemaEnums;
 	modelTopologicalOrdering?: Map<string, string[]>;
 };
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type InternalSchema = {
 	namespaces: SchemaNamespaces;
 	version: string;
 	codegenVersion: string;
 };
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SchemaNamespaces = Record<string, SchemaNamespace>;
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SchemaNamespace = UserSchema & {
 	name: string;
 };
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SchemaModels = Record<string, SchemaModel>;
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SchemaModel = {
 	name: string;
 	pluralName: string;
@@ -64,17 +104,37 @@ export type SchemaModel = {
 	syncable?: boolean;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isSchemaModel(obj: any): obj is SchemaModel {
 	return obj && (<SchemaModel>obj).pluralName !== undefined;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isSchemaModelWithAttributes(
 	m: SchemaModel | SchemaNonModel
 ): m is SchemaModel {
 	return isSchemaModel(m) && (m as SchemaModel).attributes !== undefined;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SchemaNonModels = Record<string, SchemaNonModel>;
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SchemaNonModel = {
 	name: string;
 	fields: ModelFields;
@@ -84,11 +144,21 @@ type SchemaEnum = {
 	name: string;
 	values: string[];
 };
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelMeta<T extends PersistentModel> = {
 	builder: PersistentModelConstructor<T>;
 	schema: SchemaModel;
 	pkField: string[];
 };
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelAssociation = AssociatedWith | TargetNameAssociation;
 type AssociatedWith = {
 	connectionType: 'HAS_MANY' | 'HAS_ONE';
@@ -97,6 +167,11 @@ type AssociatedWith = {
 	targetNames?: string[];
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isAssociatedWith(obj: any): obj is AssociatedWith {
 	return obj && obj.associatedWith;
 }
@@ -107,6 +182,11 @@ type TargetNameAssociation = {
 	targetNames?: string[];
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isTargetNameAssociation(
 	obj: any
 ): obj is TargetNameAssociation {
@@ -116,6 +196,11 @@ export function isTargetNameAssociation(
 type FieldAssociation = {
 	connectionType: 'HAS_ONE' | 'BELONGS_TO' | 'HAS_MANY';
 };
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isFieldAssociation(
 	obj: any,
 	fieldName: string
@@ -123,9 +208,24 @@ export function isFieldAssociation(
 	return obj?.fields[fieldName]?.association?.connectionType;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelAttributes = ModelAttribute[];
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelAttribute = { type: string; properties?: Record<string, any> };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelAuthRule = {
 	allow: string;
 	provider?: string;
@@ -137,6 +237,11 @@ export type ModelAuthRule = {
 	groupsField?: string;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelAttributeAuth = {
 	type: 'auth';
 	properties: {
@@ -144,6 +249,11 @@ export type ModelAttributeAuth = {
 	};
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isModelAttributeAuth(
 	attr: ModelAttribute
 ): attr is ModelAttributeAuth {
@@ -179,6 +289,11 @@ type ModelAttributeCompositeKey = {
 	};
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isModelAttributeKey(
 	attr: ModelAttribute
 ): attr is ModelAttributeKey {
@@ -190,12 +305,22 @@ export function isModelAttributeKey(
 	);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isModelAttributePrimaryKey(
 	attr: ModelAttribute
 ): attr is ModelAttributePrimaryKey {
 	return isModelAttributeKey(attr) && attr.properties.name === undefined;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isModelAttributeCompositeKey(
 	attr: ModelAttribute
 ): attr is ModelAttributeCompositeKey {
@@ -206,6 +331,11 @@ export function isModelAttributeCompositeKey(
 	);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelAttributeAuthProperty = {
 	allow: ModelAttributeAuthAllow;
 	identityClaim?: string;
@@ -216,6 +346,11 @@ export type ModelAttributeAuthProperty = {
 	provider?: ModelAttributeAuthProvider;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum ModelAttributeAuthAllow {
 	CUSTOM = 'custom',
 	OWNER = 'owner',
@@ -224,6 +359,11 @@ export enum ModelAttributeAuthAllow {
 	PUBLIC = 'public',
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum ModelAttributeAuthProvider {
 	FUNCTION = 'function',
 	USER_POOLS = 'userPools',
@@ -232,7 +372,17 @@ export enum ModelAttributeAuthProvider {
 	API_KEY = 'apiKey',
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelFields = Record<string, ModelField>;
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum GraphQLScalarType {
 	ID,
 	String,
@@ -250,6 +400,11 @@ export enum GraphQLScalarType {
 	AWSIPAddress,
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export namespace GraphQLScalarType {
 	export function getJSType(
 		scalar: keyof Omit<
@@ -312,6 +467,11 @@ export namespace GraphQLScalarType {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AuthorizationRule = {
 	identityClaim: string;
 	ownerField: string;
@@ -323,6 +483,11 @@ export type AuthorizationRule = {
 	areSubscriptionsPublic: boolean;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isGraphQLScalarType(
 	obj: any
 ): obj is keyof Omit<
@@ -332,10 +497,20 @@ export function isGraphQLScalarType(
 	return obj && GraphQLScalarType[obj] !== undefined;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelFieldType = {
 	model: string;
 	modelConstructor?: ModelMeta<PersistentModel>;
 };
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isModelFieldType<T extends PersistentModel>(
 	obj: any
 ): obj is ModelFieldType {
@@ -345,7 +520,17 @@ export function isModelFieldType<T extends PersistentModel>(
 	return false;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type NonModelFieldType = { nonModel: string };
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isNonModelFieldType(obj: any): obj is NonModelFieldType {
 	const typeField: keyof NonModelFieldType = 'nonModel';
 	if (obj && obj[typeField]) return true;
@@ -354,6 +539,11 @@ export function isNonModelFieldType(obj: any): obj is NonModelFieldType {
 }
 
 type EnumFieldType = { enum: string };
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isEnumFieldType(obj: any): obj is EnumFieldType {
 	const modelField: keyof EnumFieldType = 'enum';
 	if (obj && obj[modelField]) return true;
@@ -361,6 +551,11 @@ export function isEnumFieldType(obj: any): obj is EnumFieldType {
 	return false;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelField = {
 	name: string;
 	type:
@@ -381,11 +576,21 @@ export type ModelField = {
 //#endregion
 
 //#region Model definition
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type NonModelTypeConstructor<T> = {
 	new (init: T): T;
 };
 
 // Class for model
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type PersistentModelConstructor<T extends PersistentModel> = {
 	new (init: ModelInit<T, PersistentModelMetaData<T>>): T;
 	copyOf(
@@ -399,6 +604,9 @@ export type PersistentModelConstructor<T extends PersistentModel> = {
  * Internal use of Amplify only.
  *
  * Indicates to use lazy models or eager models.
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export declare class LazyLoadingDisabled {
 	disabled: true;
@@ -409,9 +617,17 @@ export declare class LazyLoadingDisabled {
  * Internal use of Amplify only.
  *
  * Indicates to use lazy models or eager models.
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export declare class LazyLoading {}
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type TypeConstructorMap = Record<
 	string,
 	PersistentModelConstructor<any> | NonModelTypeConstructor<unknown>
@@ -420,40 +636,78 @@ export type TypeConstructorMap = Record<
 /**
  * Each identifier type is represented using nominal types, see:
  * https://basarat.gitbook.io/typescript/main-1/nominaltyping
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export declare const __identifierBrand__: unique symbol;
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type IdentifierBrand<T, K> = T & { [__identifierBrand__]: K };
 
 // datastore generates a uuid for you
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ManagedIdentifier<T, F extends keyof T> = IdentifierBrand<
 	{ field: F extends string ? F : never; type: T },
 	'ManagedIdentifier'
 >;
 
 // you can provide a value, if not, datastore generates a uuid for you
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type OptionallyManagedIdentifier<T, F extends keyof T> = IdentifierBrand<
 	{ field: F extends string ? F : never; type: T },
 	'OptionallyManagedIdentifier'
 >;
 
 // You provide the values
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type CompositeIdentifier<T, K extends Array<keyof T>> = IdentifierBrand<
 	{ fields: K; type: T },
 	'CompositeIdentifier'
 >;
 
 // You provide the value
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type CustomIdentifier<T, K extends keyof T> = CompositeIdentifier<
 	T,
 	[K]
 >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type Identifier<T> =
 	| ManagedIdentifier<T, any>
 	| OptionallyManagedIdentifier<T, any>
 	| CompositeIdentifier<T, any>
 	| CustomIdentifier<T, any>;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type IdentifierFields<
 	T extends PersistentModel,
 	M extends PersistentModelMetaData<T> = never
@@ -469,6 +723,11 @@ export type IdentifierFields<
 	: Extract<MetadataOrDefault<T, M>['identifier'], { field: any }>['field']) &
 	string;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type IdentifierFieldsForInit<
 	T extends PersistentModel,
 	M extends PersistentModelMetaData<T>
@@ -486,8 +745,18 @@ export type IdentifierFieldsForInit<
 	: never;
 
 // Instance of model
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export declare const __modelMeta__: unique symbol;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type PersistentModelMetaData<T> = {
 	identifier?: Identifier<T>;
 	readOnlyFields?: string;
@@ -497,6 +766,11 @@ export interface AsyncCollection<T> extends AsyncIterable<T> {
 	toArray(options?: { max?: number }): Promise<T[]>;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SettableFieldType<T> = T extends Promise<infer InnerPromiseType>
 	? undefined extends InnerPromiseType
 		? InnerPromiseType | null
@@ -507,6 +781,11 @@ export type SettableFieldType<T> = T extends Promise<infer InnerPromiseType>
 	? T | null
 	: T;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type PredicateFieldType<T> = NonNullable<
 	Scalar<
 		T extends Promise<infer InnerPromiseType>
@@ -540,11 +819,21 @@ type PickOptionalFields<T> = Pick<
 	KeysOfSuperType<T, undefined> | OptionalRelativesOf<T>
 >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type DefaultPersistentModelMetaData = {
 	identifier: ManagedIdentifier<{ id: string }, 'id'>;
 	readOnlyFields: never;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type MetadataOrDefault<
 	T extends PersistentModel,
 	_ extends PersistentModelMetaData<T> = never
@@ -554,8 +843,18 @@ export type MetadataOrDefault<
 	? T[typeof __modelMeta__]
 	: DefaultPersistentModelMetaData;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type PersistentModel = Readonly<Record<string, any>>;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type MetadataReadOnlyFields<
 	T extends PersistentModel,
 	M extends PersistentModelMetaData<T>
@@ -569,6 +868,11 @@ export type MetadataReadOnlyFields<
 // This type omits readOnlyFields in the constructor init object
 // This type requires some identifiers in the constructor init object (e.g. CustomIdentifier)
 // This type makes optional some identifiers in the constructor init object (e.g. OptionallyManagedIdentifier)
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelInitBase<
 	T extends PersistentModel,
 	M extends PersistentModelMetaData<T> = {}
@@ -583,6 +887,11 @@ export type ModelInitBase<
 		? Partial<Pick<T, IdentifierFieldsForInit<T, M>>>
 		: Required<Pick<T, IdentifierFieldsForInit<T, M>>>);
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelInit<
 	T extends PersistentModel,
 	M extends PersistentModelMetaData<T> = {}
@@ -608,6 +917,11 @@ type DeepWritable<T> = {
 		: DeepWritable<T[P]>;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type MutableModel<
 	T extends PersistentModel,
 	M extends PersistentModelMetaData<T> = {}
@@ -618,12 +932,22 @@ export type MutableModel<
 > &
 	Readonly<Pick<T, IdentifierFields<T, M> | MetadataReadOnlyFields<T, M>>>;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelInstanceMetadata = {
 	_version: number;
 	_lastChangedAt: number;
 	_deleted: boolean;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type IdentifierFieldValue<
 	T extends PersistentModel,
 	M extends PersistentModelMetaData<T>
@@ -633,11 +957,21 @@ export type IdentifierFieldValue<
 		: never
 	: T[Extract<MetadataOrDefault<T, M>['identifier'], { field: any }>['field']];
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type IdentifierFieldOrIdentifierObject<
 	T extends PersistentModel,
 	M extends PersistentModelMetaData<T>
 > = Pick<T, IdentifierFields<T, M>> | IdentifierFieldValue<T, M>;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isIdentifierObject<T extends PersistentModel>(
 	obj: any,
 	modelDefinition: SchemaModel
@@ -651,17 +985,32 @@ export function isIdentifierObject<T extends PersistentModel>(
 //#endregion
 
 //#region Subscription messages
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum OpType {
 	INSERT = 'INSERT',
 	UPDATE = 'UPDATE',
 	DELETE = 'DELETE',
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SubscriptionMessage<T extends PersistentModel> = Pick<
 	InternalSubscriptionMessage<T>,
 	'opType' | 'element' | 'model' | 'condition'
 >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type InternalSubscriptionMessage<T extends PersistentModel> = {
 	opType: OpType;
 	element: T;
@@ -670,6 +1019,11 @@ export type InternalSubscriptionMessage<T extends PersistentModel> = {
 	savedElement?: T;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type DataStoreSnapshot<T extends PersistentModel> = {
 	items: T[];
 	isSynced: boolean;
@@ -678,6 +1032,11 @@ export type DataStoreSnapshot<T extends PersistentModel> = {
 
 //#region Predicates
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type PredicateExpression<
 	M extends PersistentModel,
 	FT
@@ -712,6 +1071,11 @@ type ArrayOperators<T> = {
 	contains: T;
 	notContains: T;
 };
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AllOperators = NumberOperators<any> &
 	StringOperators<any> &
 	ArrayOperators<any>;
@@ -739,6 +1103,11 @@ type TypeName<T> = T extends string
 	? 'boolean[]'
 	: never;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type PredicateGroups<T extends PersistentModel> = {
 	and: (
 		predicate: (predicate: ModelPredicate<T>) => ModelPredicate<T>
@@ -751,47 +1120,92 @@ export type PredicateGroups<T extends PersistentModel> = {
 	) => ModelPredicate<T>;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelPredicate<M extends PersistentModel> = {
 	[K in keyof M]-?: PredicateExpression<M, NonNullable<M[K]>>;
 } & PredicateGroups<M>;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ProducerModelPredicate<M extends PersistentModel> = (
 	condition: ModelPredicate<M>
 ) => ModelPredicate<M>;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type PredicatesGroup<T extends PersistentModel> = {
 	type: keyof PredicateGroups<T>;
 	predicates: (PredicateObject<T> | PredicatesGroup<T>)[];
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isPredicateObj<T extends PersistentModel>(
 	obj: any
 ): obj is PredicateObject<T> {
 	return obj && (<PredicateObject<T>>obj).field !== undefined;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isPredicateGroup<T extends PersistentModel>(
 	obj: any
 ): obj is PredicatesGroup<T> {
 	return obj && (<PredicatesGroup<T>>obj).type !== undefined;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type PredicateObject<T extends PersistentModel> = {
 	field: keyof T;
 	operator: keyof AllOperators;
 	operand: any;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum QueryOne {
 	FIRST,
 	LAST,
 }
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type GraphQLField = {
 	[field: string]: {
 		[operator: string]: string | number | [number, number];
 	};
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type GraphQLCondition = Partial<
 	| GraphQLField
 	| {
@@ -801,6 +1215,11 @@ export type GraphQLCondition = Partial<
 	  }
 >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type GraphQLFilter = Partial<
 	| GraphQLField
 	| {
@@ -818,31 +1237,61 @@ export type GraphQLFilter = Partial<
 
 //#region Pagination
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ProducerPaginationInput<T extends PersistentModel> = {
 	sort?: ProducerSortPredicate<T>;
 	limit?: number;
 	page?: number;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ObserveQueryOptions<T extends PersistentModel> = Pick<
 	ProducerPaginationInput<T>,
 	'sort'
 >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type PaginationInput<T extends PersistentModel> = {
 	sort?: SortPredicate<T>;
 	limit?: number;
 	page?: number;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ProducerSortPredicate<M extends PersistentModel> = (
 	condition: SortPredicate<M>
 ) => SortPredicate<M>;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SortPredicate<T extends PersistentModel> = {
 	[K in keyof T]-?: SortPredicateExpression<T, NonNullable<T[K]>>;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SortPredicateExpression<
 	M extends PersistentModel,
 	FT
@@ -850,14 +1299,29 @@ export type SortPredicateExpression<
 	? (sortDirection: keyof typeof SortDirection) => SortPredicate<M>
 	: never;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum SortDirection {
 	ASCENDING = 'ASCENDING',
 	DESCENDING = 'DESCENDING',
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SortPredicatesGroup<T extends PersistentModel> =
 	SortPredicateObject<T>[];
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SortPredicateObject<T extends PersistentModel> = {
 	field: keyof T;
 	sortDirection: keyof typeof SortDirection;
@@ -867,6 +1331,11 @@ export type SortPredicateObject<T extends PersistentModel> = {
 
 //#region System Components
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SystemComponent = {
 	setUp(
 		schema: InternalSchema,
@@ -880,10 +1349,20 @@ export type SystemComponent = {
 	): Promise<void>;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type NamespaceResolver = (
 	modelConstructor: PersistentModelConstructor<any>
 ) => string;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ControlMessageType<T> = {
 	type: T;
 	data?: any;
@@ -892,6 +1371,11 @@ export type ControlMessageType<T> = {
 //#endregion
 
 //#region Relationship types
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type RelationType = {
 	fieldName: string;
 	modelName: string;
@@ -905,8 +1389,18 @@ type IndexOptions = {
 	unique?: boolean;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type IndexesType = Array<[string, string[], IndexOptions?]>;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type RelationshipType = {
 	[modelName: string]: {
 		indexes: IndexesType;
@@ -917,11 +1411,21 @@ export type RelationshipType = {
 //#endregion
 
 //#region Key type
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type KeyType = {
 	primaryKey?: string[];
 	compositeKeys?: Set<string>[];
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelKeys = {
 	[modelName: string]: KeyType;
 };
@@ -929,6 +1433,11 @@ export type ModelKeys = {
 //#endregion
 
 //#region DataStore config types
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type DataStoreConfig = {
 	DataStore?: {
 		authModeStrategyType?: AuthModeStrategyType;
@@ -952,31 +1461,61 @@ export type DataStoreConfig = {
 	storageAdapter?: Adapter;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AuthProviders = {
 	functionAuthProvider: () => { token: string } | Promise<{ token: string }>;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum AuthModeStrategyType {
 	DEFAULT = 'DEFAULT',
 	MULTI_AUTH = 'MULTI_AUTH',
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AuthModeStrategyReturn =
 	| GRAPHQL_AUTH_MODE
 	| GRAPHQL_AUTH_MODE[]
 	| undefined
 	| null;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AuthModeStrategyParams = {
 	schema: InternalSchema;
 	modelName: string;
 	operation: ModelOperation;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AuthModeStrategy = (
 	authModeStrategyParams: AuthModeStrategyParams
 ) => AuthModeStrategyReturn | Promise<AuthModeStrategyReturn>;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum ModelOperation {
 	CREATE = 'CREATE',
 	READ = 'READ',
@@ -984,6 +1523,11 @@ export enum ModelOperation {
 	DELETE = 'DELETE',
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelAuthModes = Record<
 	string,
 	{
@@ -991,6 +1535,11 @@ export type ModelAuthModes = Record<
 	}
 >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SyncExpression = Promise<{
 	modelConstructor: any;
 	conditionProducer: (c?: any) => any;
@@ -1028,6 +1577,11 @@ type ConditionProducer<T extends PersistentModel, A extends Option<T>> = (
 	...args: A
 ) => A['length'] extends keyof Lookup<T> ? Lookup<T>[A['length']] : never;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export async function syncExpression<
 	T extends PersistentModel,
 	A extends Option<T>
@@ -1044,6 +1598,11 @@ export async function syncExpression<
 	};
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SyncConflict = {
 	modelConstructor: PersistentModelConstructor<any>;
 	localModel: PersistentModel;
@@ -1052,6 +1611,11 @@ export type SyncConflict = {
 	attempts: number;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SyncError<T extends PersistentModel> = {
 	message: string;
 	errorType: ErrorType;
@@ -1065,6 +1629,11 @@ export type SyncError<T extends PersistentModel> = {
 	cause?: Error;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ErrorType =
 	| 'ConfigError'
 	| 'BadModel'
@@ -1073,34 +1642,69 @@ export type ErrorType =
 	| 'Transient'
 	| 'Unknown';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum ProcessName {
 	'sync' = 'sync',
 	'mutate' = 'mutate',
 	'subscribe' = 'subscribe',
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const DISCARD = Symbol('DISCARD');
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ConflictHandler = (
 	conflict: SyncConflict
 ) =>
 	| Promise<PersistentModel | typeof DISCARD>
 	| PersistentModel
 	| typeof DISCARD;
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ErrorHandler = (error: SyncError<PersistentModel>) => void;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type DeferredCallbackResolverOptions = {
 	callback: () => void;
 	maxInterval?: number;
 	errorHandler?: (error: string) => void;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum LimitTimerRaceResolvedValues {
 	LIMIT = 'LIMIT',
 	TIMER = 'TIMER',
 }
 //#endregion
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AmplifyContext = {
 	Auth: typeof Auth;
 	InternalAPI: typeof InternalAPI;
@@ -1109,6 +1713,11 @@ export type AmplifyContext = {
 
 // #region V5 predicate types
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type MatchableTypes =
 	| string
 	| string[]
@@ -1117,12 +1726,27 @@ export type MatchableTypes =
 	| boolean
 	| boolean[];
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AllFieldOperators = keyof AllOperators;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type NonNeverKeys<T> = {
 	[K in keyof T]: T[K] extends never ? never : K;
 }[keyof T];
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type WithoutNevers<T> = Pick<T, NonNeverKeys<T>>;
 
 /**
@@ -1147,23 +1771,46 @@ export type WithoutNevers<T> = Pick<T, NonNeverKeys<T>>;
  *   m.myModelField.ne('something')
  * ]))
  * ```
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export type RecursiveModelPredicateExtender<RT extends PersistentModel> = (
 	lambda: RecursiveModelPredicate<RT>
 ) => PredicateInternalsKey;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type RecursiveModelPredicateAggregateExtender<
 	RT extends PersistentModel
 > = (lambda: RecursiveModelPredicate<RT>) => PredicateInternalsKey[];
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type RecursiveModelPredicateOperator<RT extends PersistentModel> = (
 	predicates: RecursiveModelPredicateAggregateExtender<RT>
 ) => PredicateInternalsKey;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type RecursiveModelPredicateNegation<RT extends PersistentModel> = (
 	predicate: RecursiveModelPredicateExtender<RT>
 ) => PredicateInternalsKey;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type RecursiveModelPredicate<RT extends PersistentModel> = {
 	[K in keyof RT]-?: PredicateFieldType<RT[K]> extends PersistentModel
 		? RecursiveModelPredicate<PredicateFieldType<RT[K]>>
@@ -1194,15 +1841,28 @@ export type RecursiveModelPredicate<RT extends PersistentModel> = {
  * 	m.field.eq('whatever else')
  * ]))
  * ```
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export type ModelPredicateExtender<RT extends PersistentModel> = (
 	lambda: V5ModelPredicate<RT>
 ) => PredicateInternalsKey;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelPredicateAggregateExtender<RT extends PersistentModel> = (
 	lambda: V5ModelPredicate<RT>
 ) => PredicateInternalsKey[];
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ValuePredicate<
 	RT extends PersistentModel,
 	MT extends MatchableTypes
@@ -1215,6 +1875,11 @@ export type ValuePredicate<
 		: (operand: Scalar<MT>) => PredicateInternalsKey;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type V5ModelPredicate<RT extends PersistentModel> = WithoutNevers<{
 	[K in keyof RT]-?: PredicateFieldType<RT[K]> extends PersistentModel
 		? never
@@ -1225,10 +1890,20 @@ export type V5ModelPredicate<RT extends PersistentModel> = WithoutNevers<{
 	not: ModelPredicateNegation<RT>;
 } & PredicateInternalsKey;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelPredicateOperator<RT extends PersistentModel> = (
 	predicates: ModelPredicateAggregateExtender<RT>
 ) => PredicateInternalsKey;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ModelPredicateNegation<RT extends PersistentModel> = (
 	predicate: ModelPredicateExtender<RT>
 ) => PredicateInternalsKey;
@@ -1236,6 +1911,9 @@ export type ModelPredicateNegation<RT extends PersistentModel> = (
 /**
  * A pointer used by DataStore internally to lookup predicate details
  * that should not be exposed on public customer interfaces.
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class PredicateInternalsKey {
 	private __isPredicateInternalsKeySentinel: boolean = true;

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -64,6 +64,11 @@ export const errorMessages = {
 		'Object literal syntax cannot be used with observe. Use a predicate instead: https://docs.amplify.aws/lib/datastore/data-access/q/platform/js/#predicates',
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum NAMESPACES {
 	DATASTORE = 'datastore',
 	USER = 'user',

--- a/packages/geo/src/Geo.ts
+++ b/packages/geo/src/Geo.ts
@@ -330,5 +330,10 @@ export class GeoClass {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Geo = new GeoClass();
 Amplify.register(Geo);

--- a/packages/geo/src/types/AmazonLocationServiceProvider.ts
+++ b/packages/geo/src/types/AmazonLocationServiceProvider.ts
@@ -10,16 +10,31 @@ import {
 } from './Geo';
 
 // Maps
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface AmazonLocationServiceMapStyle extends MapStyle {
 	region: string;
 }
 
 // Geofences
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AmazonLocationServiceGeofenceOptions = GeofenceOptions & {
 	collectionName?: string;
 };
 
 // Status types for Geofences
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AmazonLocationServiceGeofenceStatus =
 	| 'ACTIVE'
 	| 'PENDING'
@@ -27,16 +42,31 @@ export type AmazonLocationServiceGeofenceStatus =
 	| 'DELETED'
 	| 'DELETING';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AmazonLocationServiceGeofence = Omit<Geofence, 'status'> & {
 	status: AmazonLocationServiceGeofenceStatus;
 };
 
 // List Geofences
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AmazonLocationServiceListGeofenceOptions = ListGeofenceOptions & {
 	collectionName?: string;
 };
 
 // Delete Geofences
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AmazonLocationServiceBatchGeofenceErrorMessages =
 	| 'AccessDeniedException'
 	| 'InternalServerException'
@@ -44,6 +74,11 @@ export type AmazonLocationServiceBatchGeofenceErrorMessages =
 	| 'ThrottlingException'
 	| 'ValidationException';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AmazonLocationServiceBatchGeofenceError = Omit<
 	GeofenceError,
 	'error'
@@ -54,6 +89,11 @@ export type AmazonLocationServiceBatchGeofenceError = Omit<
 	};
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type AmazonLocationServiceDeleteGeofencesResults = Omit<
 	DeleteGeofencesResults,
 	'errors'

--- a/packages/geo/src/types/Geo.ts
+++ b/packages/geo/src/types/Geo.ts
@@ -1,6 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 // configuration shape for the Geo class
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface GeoConfig {
 	region?: string;
 	AmazonLocationService?: {
@@ -20,29 +25,79 @@ export interface GeoConfig {
 }
 
 // Data held about maps in aws-exports
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface MapStyle {
 	mapName: string;
 	style: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type Longitude = number;
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type Latitude = number;
 
 // Coordinates are a tuple of longitude and latitude
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type Coordinates = [Longitude, Latitude];
 
 // SW Longitude point for bounding box
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SWLongitude = Longitude;
 // SW Latitude point for bounding box
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SWLatitude = Latitude;
 // SW Longitude point for bounding box
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type NELongitude = Longitude;
 // SW Latitude point for bounding box
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type NELatitude = Latitude;
 // Full Bounding Box point array
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type BoundingBox = [SWLongitude, SWLatitude, NELongitude, NELatitude];
 
 // Base items for SearchByText options
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface SearchByTextOptionsBase {
 	countries?: string[];
 	maxResults?: number;
@@ -51,39 +106,74 @@ export interface SearchByTextOptionsBase {
 }
 
 // SearchByText options with a bias position
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface SearchByTextOptionsWithBiasPosition
 	extends SearchByTextOptionsBase {
 	biasPosition?: Coordinates;
 }
 
 // SearchByText options with search area constraints (such as a bounding box)
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface SearchByTextOptionsWithSearchAreaConstraints
 	extends SearchByTextOptionsBase {
 	searchAreaConstraints?: BoundingBox;
 }
 
 // Union type for searchByText options
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SearchByTextOptions =
 	| SearchByTextOptionsWithBiasPosition
 	| SearchByTextOptionsWithSearchAreaConstraints;
 
 // Options object for searchByCoordinates
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SearchByCoordinatesOptions = {
 	maxResults?: number;
 	searchIndexName?: string;
 	providerName?: string;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type searchByPlaceIdOptions = {
 	searchIndexName?: string;
 };
 
 // Geometry object for Place points
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type PlaceGeometry = {
 	point: Coordinates;
 };
 
 // Place object with locality information
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface Place {
 	addressNumber?: string;
 	country?: string;
@@ -97,30 +187,65 @@ export interface Place {
 	subRegion?: string;
 }
 // Array of 4 or more coordinates, where the first and last coordinate are the same to form a closed boundary
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type LinearRing = Coordinates[];
 
 // An array of one linear ring
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type GeofencePolygon = LinearRing[];
 
 // Geometry object for Polygon
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type PolygonGeometry = {
 	polygon: GeofencePolygon;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type GeofenceId = string;
 
 // Geofence object used as input for saveGeofences
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type GeofenceInput = {
 	geofenceId: GeofenceId;
 	geometry: PolygonGeometry;
 };
 
 // Options object for saveGeofences
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type GeofenceOptions = {
 	providerName?: string;
 };
 
 // Error type for errors related to Geofence API calls
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type GeofenceError = {
 	error: {
 		code: string;
@@ -137,36 +262,71 @@ type GeofenceBase = {
 };
 
 // Results object for getGeofence
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type Geofence = GeofenceBase & {
 	geometry: PolygonGeometry;
 };
 
 // Results object for saveGeofences
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SaveGeofencesResults = {
 	successes: GeofenceBase[];
 	errors: GeofenceError[];
 };
 
 // Options object for listGeofence
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ListGeofenceOptions = GeofenceOptions & {
 	nextToken?: string;
 };
 
 // Results options for listGeofence
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ListGeofenceResults = {
 	entries: Geofence[];
 	nextToken: string | undefined;
 };
 
 // Results object for deleteGeofence
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type DeleteGeofencesResults = {
 	successes: GeofenceId[];
 	errors: GeofenceError[];
 };
 
 // Return type for searchForSuggestions
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SearchForSuggestionsResults = SearchForSuggestionsResult[];
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type SearchForSuggestionsResult = {
 	text: string;
 	placeId?: string;

--- a/packages/geo/src/types/Provider.ts
+++ b/packages/geo/src/types/Provider.ts
@@ -18,6 +18,11 @@ import {
 	searchByPlaceIdOptions,
 } from './Geo';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface GeoProvider {
 	// get the category name for the provider
 	getCategory(): string;

--- a/packages/interactions/src/Interactions.ts
+++ b/packages/interactions/src/Interactions.ts
@@ -158,5 +158,10 @@ export class InteractionsClass {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Interactions = new InteractionsClass();
 Amplify.register(Interactions);

--- a/packages/interactions/src/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/Providers/AWSLexProvider.ts
@@ -34,6 +34,11 @@ type AWSLexProviderSendResponse =
 	| PostTextCommandOutput
 	| PostContentCommandOutputFormatted;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class AWSLexProvider extends AbstractInteractionsProvider {
 	private lexRuntimeServiceClient: LexRuntimeServiceClient;
 	private _botsCompleteCallback: object;

--- a/packages/interactions/src/Providers/AWSLexV2Provider.ts
+++ b/packages/interactions/src/Providers/AWSLexV2Provider.ts
@@ -53,6 +53,11 @@ type lexV2BaseReqParams = {
 	sessionId: string;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class AWSLexV2Provider extends AbstractInteractionsProvider {
 	private _lexRuntimeServiceV2Client: LexRuntimeV2Client;
 	private _botsCompleteCallback: object;

--- a/packages/interactions/src/Providers/InteractionsProvider.ts
+++ b/packages/interactions/src/Providers/InteractionsProvider.ts
@@ -11,6 +11,11 @@ import { ConsoleLogger as Logger } from '@aws-amplify/core';
 
 const logger = new Logger('AbstractInteractionsProvider');
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export abstract class AbstractInteractionsProvider
 	implements InteractionsProvider {
 	protected _config: InteractionsOptions;

--- a/packages/interactions/src/types/Interactions.ts
+++ b/packages/interactions/src/types/Interactions.ts
@@ -1,9 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InteractionsOptions {
 	[key: string]: any;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type InteractionsTextMessage = {
 	content: string;
 	options: {
@@ -11,6 +21,11 @@ export type InteractionsTextMessage = {
 	};
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type InteractionsVoiceMessage = {
 	content: object;
 	options: {
@@ -18,6 +33,11 @@ export type InteractionsVoiceMessage = {
 	};
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type InteractionsMessage =
 	| InteractionsTextMessage
 	| InteractionsVoiceMessage;

--- a/packages/interactions/src/types/Provider.ts
+++ b/packages/interactions/src/types/Provider.ts
@@ -3,6 +3,11 @@
 import { InteractionsOptions } from './Interactions';
 import { InteractionsResponse } from './Response';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InteractionsProvider {
 	// configure your provider
 	configure(config: InteractionsOptions): InteractionsOptions;
@@ -21,6 +26,11 @@ export interface InteractionsProvider {
 	);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InteractionsProviders {
 	[key: string]: InteractionsProvider;
 }

--- a/packages/interactions/src/types/Providers/AWSLexProvider.ts
+++ b/packages/interactions/src/types/Providers/AWSLexProvider.ts
@@ -1,5 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface AWSLexProviderOption {
 	name: string;
 	alias: string;
@@ -8,6 +13,11 @@ export interface AWSLexProviderOption {
 	onComplete?(botname: string, callback: (err, confirmation) => void): void;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface AWSLexProviderOptions {
 	[key: string]: AWSLexProviderOption;
 }

--- a/packages/interactions/src/types/Providers/AWSLexV2Provider.ts
+++ b/packages/interactions/src/types/Providers/AWSLexV2Provider.ts
@@ -1,5 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface AWSLexV2ProviderOption {
 	name: string;
 	botId: string;
@@ -10,6 +15,11 @@ export interface AWSLexV2ProviderOption {
 	onComplete?(botname: string, callback: (err, confirmation) => void): void;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface AWSLexV2ProviderOptions {
 	[key: string]: AWSLexV2ProviderOption;
 }

--- a/packages/interactions/src/types/Response.ts
+++ b/packages/interactions/src/types/Response.ts
@@ -1,6 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type InteractionsResponse = {
 	[key: string]: any;
 };

--- a/packages/notifications/src/InAppMessaging/types.ts
+++ b/packages/notifications/src/InAppMessaging/types.ts
@@ -57,17 +57,32 @@ export interface InAppMessagingProvider extends NotificationsProvider {
 	): Promise<InAppMessage[]>;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InAppMessagingConfig {
 	listenForAnalyticsEvents?: boolean;
 	AWSPinpoint?: AWSPinpointProviderConfig;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type InAppMessagingEvent = {
 	name: string;
 	attributes?: Record<string, string>;
 	metrics?: Record<string, number>;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type InAppMessageLayout =
 	| 'BOTTOM_BANNER'
 	| 'CAROUSEL'
@@ -76,8 +91,18 @@ export type InAppMessageLayout =
 	| 'MODAL'
 	| 'TOP_BANNER';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type InAppMessageAction = 'CLOSE' | 'DEEP_LINK' | 'LINK';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type InAppMessageTextAlign = 'center' | 'left' | 'right';
 
 interface InAppMessageContainer {
@@ -94,10 +119,20 @@ interface InAppMessageBody {
 	style?: InAppMessageStyle;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InAppMessageImage {
 	src: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InAppMessageButton {
 	title: string;
 	action: InAppMessageAction;
@@ -105,6 +140,11 @@ export interface InAppMessageButton {
 	style?: InAppMessageStyle;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InAppMessageStyle {
 	backgroundColor?: string;
 	borderRadius?: number;
@@ -112,6 +152,11 @@ export interface InAppMessageStyle {
 	textAlign?: InAppMessageTextAlign;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InAppMessageContent {
 	container?: InAppMessageContainer;
 	header?: InAppMessageHeader;
@@ -121,6 +166,11 @@ export interface InAppMessageContent {
 	secondaryButton?: InAppMessageButton;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InAppMessage {
 	id: string;
 	layout: InAppMessageLayout;
@@ -130,6 +180,11 @@ export interface InAppMessage {
 
 export type OnMessageInteractionEventHandler = (message: InAppMessage) => any;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum InAppMessageInteractionEvent {
 	MESSAGE_RECEIVED = 'MESSAGE_RECEIVED_EVENT',
 	MESSAGE_DISPLAYED = 'MESSAGE_DISPLAYED_EVENT',

--- a/packages/notifications/src/Notifications.ts
+++ b/packages/notifications/src/Notifications.ts
@@ -84,6 +84,11 @@ class NotificationsClass {
 	};
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 const Notifications = new NotificationsClass();
 
 export default Notifications;

--- a/packages/notifications/src/PushNotification/types.ts
+++ b/packages/notifications/src/PushNotification/types.ts
@@ -55,6 +55,11 @@ export interface PushNotificationConfig {
 	AWSPinpoint?: AWSPinpointProviderConfig;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface PushNotificationMessage {
 	title?: string;
 	body?: string;
@@ -77,6 +82,11 @@ interface ApnsPlatformOptions {
 	subtitle?: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface PushNotificationPermissions
 	extends Partial<Record<string, boolean>> {
 	alert?: boolean;
@@ -84,6 +94,11 @@ export interface PushNotificationPermissions
 	sound?: boolean;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum PushNotificationPermissionStatus {
 	DENIED = 'DENIED',
 	GRANTED = 'GRANTED',

--- a/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
+++ b/packages/notifications/src/common/AWSPinpointProviderCommon/index.ts
@@ -33,6 +33,9 @@ import { AWSPinpointUserInfo } from './types';
 
 /**
  * @deprecated AWS will end support for Amazon Pinpoint on October 30, 2026.
+ * Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export default abstract class AWSPinpointProviderCommon
 	implements NotificationsProvider

--- a/packages/notifications/src/common/AWSPinpointProviderCommon/types.ts
+++ b/packages/notifications/src/common/AWSPinpointProviderCommon/types.ts
@@ -13,6 +13,9 @@ export interface AWSPinpointProviderConfig {
 
 /**
  * @deprecated AWS will end support for Amazon Pinpoint on October 30, 2026.
+ * Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export interface AWSPinpointUserInfo extends UserInfo {
 	address?: string;

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -25,6 +25,11 @@ export interface NotificationsProvider {
 	identifyUser(userId: string, userInfo: UserInfo): Promise<void>;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface NotificationsConfig {
 	Notifications?: {
 		InAppMessaging?: InAppMessagingConfig;
@@ -32,6 +37,11 @@ export interface NotificationsConfig {
 	};
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type UserInfo = {
 	attributes?: Record<string, string[]>;
 	demographic?: {

--- a/packages/predictions/src/Predictions.ts
+++ b/packages/predictions/src/Predictions.ts
@@ -247,5 +247,10 @@ export class PredictionsClass {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const Predictions = new PredictionsClass({});
 Amplify.register(Predictions);

--- a/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIConvertPredictionsProvider.ts
@@ -35,6 +35,11 @@ const eventBuilder = new EventStreamMarshaller(toUtf8, fromUtf8);
 
 const LANGUAGES_CODE_IN_8KHZ = ['fr-FR', 'en-AU', 'en-GB', 'fr-CA'];
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class AmazonAIConvertPredictionsProvider extends AbstractConvertPredictionsProvider {
 	private translateClient: TranslateClient;
 	private pollyClient: PollyClient;

--- a/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIIdentifyPredictionsProvider.ts
@@ -57,6 +57,11 @@ import {
 	categorizeTextractBlocks,
 } from './IdentifyTextUtils';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class AmazonAIIdentifyPredictionsProvider extends AbstractIdentifyPredictionsProvider {
 	private rekognitionClient: RekognitionClient;
 	private textractClient: TextractClient;

--- a/packages/predictions/src/Providers/AmazonAIInterpretPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIInterpretPredictionsProvider.ts
@@ -26,6 +26,11 @@ import {
 	DetectSentimentCommand,
 } from '@aws-sdk/client-comprehend';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class AmazonAIInterpretPredictionsProvider extends AbstractInterpretPredictionsProvider {
 	private comprehendClient: ComprehendClient;
 

--- a/packages/predictions/src/Providers/AmazonAIPredictionsProvider.ts
+++ b/packages/predictions/src/Providers/AmazonAIPredictionsProvider.ts
@@ -22,6 +22,11 @@ import {
 	InterpretTextOutput,
 } from '../types';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class AmazonAIPredictionsProvider extends AbstractPredictionsProvider {
 	private convertProvider: AmazonAIConvertPredictionsProvider;
 	private identifyProvider: AmazonAIIdentifyPredictionsProvider;

--- a/packages/predictions/src/types/Predictions.ts
+++ b/packages/predictions/src/types/Predictions.ts
@@ -4,17 +4,28 @@
 
 /**
  * Base types
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export interface PredictionsOptions {
 	[key: string]: any;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface ProviderOptions {
 	providerName?: string;
 }
 
 /**
  * Convert types
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 
 export enum InterpretTextCategories {
@@ -26,10 +37,20 @@ export enum InterpretTextCategories {
 	KEY_PHRASES = 'KEY_PHRASES',
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InterpretTextInput {
 	text: InterpretTextInputLanguage | InterpretTextOthers | InterpretTextAll;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InterpretTextInputLanguage {
 	source: {
 		text: string;
@@ -37,6 +58,11 @@ export interface InterpretTextInputLanguage {
 	type: InterpretTextCategories.LANGUAGE;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InterpretTextOthers {
 	source: {
 		text: string;
@@ -49,6 +75,11 @@ export interface InterpretTextOthers {
 		| InterpretTextCategories.KEY_PHRASES;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InterpretTextAll {
 	source: {
 		text: string;
@@ -56,20 +87,40 @@ export interface InterpretTextAll {
 	type: InterpretTextCategories.ALL;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface TextEntities {
 	type: string;
 	text: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface KeyPhrases {
 	text: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface TextSyntax {
 	text: string;
 	syntax: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface TextSentiment {
 	predominant: string;
 	positive: number;
@@ -78,6 +129,11 @@ export interface TextSentiment {
 	mixed: number;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface InterpretTextOutput {
 	textInterpretation: {
 		language?: string;
@@ -88,6 +144,11 @@ export interface InterpretTextOutput {
 	};
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface TranslateTextInput {
 	translateText: {
 		source: {
@@ -98,11 +159,21 @@ export interface TranslateTextInput {
 	};
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface TranslateTextOutput {
 	text: string;
 	language: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface TextToSpeechInput {
 	textToSpeech: {
 		source: {
@@ -113,26 +184,51 @@ export interface TextToSpeechInput {
 	};
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface TextToSpeechOutput {
 	speech: { url: string };
 	audioStream: Buffer;
 	text: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface StorageSource {
 	key: string;
 	level?: 'public' | 'private' | 'protected';
 	identityId?: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface FileSource {
 	file: File;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface BytesSource {
 	bytes: Buffer | ArrayBuffer | Blob | string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface SpeechToTextInput {
 	transcription: {
 		source: BytesSource;
@@ -140,14 +236,29 @@ export interface SpeechToTextInput {
 	};
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface SpeechToTextOutput {
 	transcription: {
 		fullText: string;
 	};
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type IdentifySource = StorageSource | FileSource | BytesSource;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface IdentifyTextInput {
 	text: {
 		source: IdentifySource;
@@ -155,12 +266,22 @@ export interface IdentifyTextInput {
 	};
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface Word {
 	text?: string;
 	polygon?: Polygon;
 	boundingBox?: BoundingBox;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface LineDetailed {
 	text?: string;
 	polygon?: Polygon;
@@ -168,11 +289,21 @@ export interface LineDetailed {
 	page?: number;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface Content {
 	text?: string;
 	selected?: boolean;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface TableCell extends Content {
 	boundingBox?: BoundingBox;
 	polygon?: Polygon;
@@ -180,6 +311,11 @@ export interface TableCell extends Content {
 	columnSpan?: Number;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface Table {
 	size: {
 		rows: number;
@@ -190,6 +326,11 @@ export interface Table {
 	boundingBox: BoundingBox;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface KeyValue {
 	key: string;
 	value: Content;
@@ -197,6 +338,11 @@ export interface KeyValue {
 	boundingBox: BoundingBox;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface IdentifyTextOutput {
 	text: {
 		fullText: string;
@@ -213,6 +359,11 @@ export interface IdentifyTextOutput {
 	};
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface IdentifyLabelsInput {
 	labels: {
 		source: IdentifySource;
@@ -220,13 +371,28 @@ export interface IdentifyLabelsInput {
 	};
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface Point {
 	x?: Number;
 	y?: Number;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type Polygon = Array<Point> | Iterable<Point>;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface BoundingBox {
 	width?: Number;
 	height?: Number;
@@ -234,6 +400,11 @@ export interface BoundingBox {
 	top?: Number;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface IdentifyLabelsOutput {
 	labels?: {
 		name: string;
@@ -243,10 +414,20 @@ export interface IdentifyLabelsOutput {
 	unsafe?: 'YES' | 'NO' | 'UNKNOWN';
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface IdentifyEntitiesInput {
 	entities: IdentifyFromCollection | IdentifyCelebrities | IdentifyEntities;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface IdentifyFromCollection {
 	source: IdentifySource;
 	collection: true;
@@ -254,15 +435,30 @@ export interface IdentifyFromCollection {
 	maxEntities?: number;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface IdentifyCelebrities {
 	source: IdentifySource;
 	celebrityDetection: true;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface IdentifyEntities {
 	source: IdentifySource;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface FaceAttributes {
 	smile?: boolean;
 	eyeglasses?: boolean;
@@ -275,6 +471,11 @@ export interface FaceAttributes {
 	emotions?: string[];
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface IdentifyEntitiesOutput {
 	entities: {
 		boundingBox?: BoundingBox;
@@ -292,6 +493,11 @@ export interface IdentifyEntitiesOutput {
 	}[];
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isIdentifyFromCollection(
 	obj: any
 ): obj is IdentifyFromCollection {
@@ -300,51 +506,101 @@ export function isIdentifyFromCollection(
 	return obj && (obj.hasOwnProperty(key) || obj.hasOwnProperty(keyId));
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isIdentifyCelebrities(obj: any): obj is IdentifyCelebrities {
 	const key: keyof IdentifyCelebrities = 'celebrityDetection';
 	return obj && obj.hasOwnProperty(key);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isTranslateTextInput(obj: any): obj is TranslateTextInput {
 	const key: keyof TranslateTextInput = 'translateText';
 	return obj && obj.hasOwnProperty(key);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isTextToSpeechInput(obj: any): obj is TextToSpeechInput {
 	const key: keyof TextToSpeechInput = 'textToSpeech';
 	return obj && obj.hasOwnProperty(key);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isSpeechToTextInput(obj: any): obj is SpeechToTextInput {
 	const key: keyof SpeechToTextInput = 'transcription';
 	return obj && obj.hasOwnProperty(key);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isStorageSource(obj: any): obj is StorageSource {
 	const key: keyof StorageSource = 'key';
 	return obj && obj.hasOwnProperty(key);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isFileSource(obj: any): obj is FileSource {
 	const key: keyof FileSource = 'file';
 	return obj && obj.hasOwnProperty(key);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isBytesSource(obj: any): obj is BytesSource {
 	const key: keyof BytesSource = 'bytes';
 	return obj && obj.hasOwnProperty(key);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isIdentifyTextInput(obj: any): obj is IdentifyTextInput {
 	const key: keyof IdentifyTextInput = 'text';
 	return obj && obj.hasOwnProperty(key);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isIdentifyLabelsInput(obj: any): obj is IdentifyLabelsInput {
 	const key: keyof IdentifyLabelsInput = 'labels';
 	return obj && obj.hasOwnProperty(key);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isIdentifyEntitiesInput(
 	obj: any
 ): obj is IdentifyEntitiesInput {
@@ -352,11 +608,21 @@ export function isIdentifyEntitiesInput(
 	return obj && obj.hasOwnProperty(key);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function isInterpretTextInput(obj: any): obj is InterpretTextInput {
 	const key: keyof InterpretTextInput = 'text';
 	return obj && obj.hasOwnProperty(key);
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface Geometry {
 	/**
 	 * <p>An axis-aligned coarse representation of the detected text's location on the image.</p>
@@ -369,6 +635,11 @@ export interface Geometry {
 	Polygon?: Array<Point> | Iterable<Point>;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface Relationship {
 	/**
 	 * <p>The type of relationship that the blocks in the IDs array have with the current block. The relationship can be <code>VALUE</code> or <code>CHILD</code>.</p>
@@ -381,5 +652,15 @@ export interface Relationship {
 	Ids?: Array<string> | Iterable<string>;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type FeatureType = 'TABLES' | 'FORMS' | string;
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type FeatureTypes = FeatureType[];

--- a/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider/index.ts
+++ b/packages/pubsub/src/Providers/AWSAppSyncRealTimeProvider/index.ts
@@ -77,6 +77,11 @@ const base64urlEncode = (str: string): string => {
 	return base64UrlStr;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ObserverQuery = {
 	observer: PubSubContentObserver;
 	query: string;
@@ -112,6 +117,11 @@ type ParsedMessagePayload = {
 	};
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface AWSAppSyncRealTimeProviderOptions extends ProviderOptions {
 	appSyncGraphqlEndpoint?: string;
 	authenticationType?: GraphqlAuthModes;
@@ -130,6 +140,11 @@ type AWSAppSyncRealTimeAuthInput =
 		host?: string | undefined;
 	};
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class AWSAppSyncRealTimeProvider extends AbstractPubSubProvider<AWSAppSyncRealTimeProviderOptions> {
 	private awsRealTimeSocket?: WebSocket;
 	private socketStatus: SOCKET_STATUS = SOCKET_STATUS.CLOSED;

--- a/packages/pubsub/src/Providers/AWSIotProvider.ts
+++ b/packages/pubsub/src/Providers/AWSIotProvider.ts
@@ -5,11 +5,21 @@ import { Signer, Credentials } from '@aws-amplify/core';
 
 const SERVICE_NAME = 'iotdevicegateway';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface AWSIoTProviderOptions extends MqttProviderOptions {
 	aws_pubsub_region?: string;
 	aws_pubsub_endpoint?: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class AWSIoTProvider extends MqttOverWSProvider {
 	constructor(options: AWSIoTProviderOptions = {}) {
 		super(options);

--- a/packages/pubsub/src/Providers/MqttOverWSProvider.ts
+++ b/packages/pubsub/src/Providers/MqttOverWSProvider.ts
@@ -24,6 +24,11 @@ import { AMPLIFY_SYMBOL, CONNECTION_STATE_CHANGE } from './constants';
 
 const logger = new Logger('MqttOverWSProvider');
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export function mqttTopicMatch(filter: string, topic: string) {
 	const filterArray = filter.split('/');
 	const length = filterArray.length;
@@ -38,6 +43,11 @@ export function mqttTopicMatch(filter: string, topic: string) {
 	return length === topicArray.length;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface MqttProviderOptions extends ProviderOptions {
 	clientId?: string;
 	url?: string;
@@ -99,6 +109,11 @@ const dispatchPubSubEvent = (
 
 const topicSymbol = typeof Symbol !== 'undefined' ? Symbol('topic') : '@@topic';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export class MqttOverWSProvider extends AbstractPubSubProvider<MqttProviderOptions> {
 	private _clientsQueue = new ClientsQueue();
 	private connectionState: ConnectionState;

--- a/packages/pubsub/src/Providers/PubSubProvider.ts
+++ b/packages/pubsub/src/Providers/PubSubProvider.ts
@@ -10,6 +10,11 @@ import { PubSubContent } from '../types/PubSub';
 
 const logger = new Logger('AbstractPubSubProvider');
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export abstract class AbstractPubSubProvider<T extends ProviderOptions>
 	implements PubSubProvider
 {

--- a/packages/pubsub/src/Providers/constants.ts
+++ b/packages/pubsub/src/Providers/constants.ts
@@ -4,6 +4,11 @@ export const MAX_DELAY_MS = 5000;
 
 export const NON_RETRYABLE_CODES = [400, 401, 403];
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const CONNECTION_STATE_CHANGE = 'ConnectionStateChange';
 
 export enum MESSAGE_TYPES {

--- a/packages/pubsub/src/PubSub.ts
+++ b/packages/pubsub/src/PubSub.ts
@@ -29,5 +29,10 @@ export class PubSubClass extends InternalPubSubClass {
 	}
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const PubSub = new PubSubClass();
 Amplify.register(PubSub);

--- a/packages/pubsub/src/types/PubSub.ts
+++ b/packages/pubsub/src/types/PubSub.ts
@@ -9,6 +9,11 @@ export interface SubscriptionObserver<T> {
 	complete(): void;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum CONTROL_MSG {
 	CONNECTION_CLOSED = 'Connection closed',
 	CONNECTION_FAILED = 'Connection failed',
@@ -17,7 +22,12 @@ export enum CONTROL_MSG {
 	TIMEOUT_DISCONNECT = 'Timeout disconnect',
 }
 
-/** @enum {string} */
+/**
+ * @enum {string}
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export enum ConnectionState {
 	/*
 	 * The connection is alive and healthy

--- a/packages/pushnotification/src/index.ts
+++ b/packages/pushnotification/src/index.ts
@@ -4,6 +4,11 @@ import { Amplify } from '@aws-amplify/core';
 import NotificationClass from './PushNotification';
 
 const _instance = new NotificationClass(null);
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const PushNotification = _instance;
 Amplify.register(PushNotification);
 

--- a/packages/rtn-push-notification/src/index.ts
+++ b/packages/rtn-push-notification/src/index.ts
@@ -4,6 +4,11 @@
 import { NativeModules } from 'react-native';
 import { PushNotificationNativeModule } from './types';
 export { PushNotificationNativeModule } from './types';
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const {
 	AmplifyRTNPushNotification,
 }: { AmplifyRTNPushNotification?: PushNotificationNativeModule } =

--- a/packages/rtn-push-notification/src/types.ts
+++ b/packages/rtn-push-notification/src/types.ts
@@ -1,6 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface PushNotificationNativeModule {
 	completeNotification?: (completionHandlerId: string) => void;
 	getConstants: () => {

--- a/packages/storage/src/Storage.ts
+++ b/packages/storage/src/Storage.ts
@@ -36,6 +36,9 @@ const loggerStorageInstance = new Logger('Storage'); // Logging relating to Stor
 const DEFAULT_PROVIDER = 'AWSS3';
 /**
  * Provide storage methods to use AWS S3
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class Storage {
 	/**
@@ -463,5 +466,10 @@ const getInstance = () => {
 	return _instance;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export const StorageInstance: Storage = getInstance();
 Amplify.register(StorageInstance);

--- a/packages/storage/src/providers/AWSS3Provider.ts
+++ b/packages/storage/src/providers/AWSS3Provider.ts
@@ -81,6 +81,9 @@ interface AddTaskInput {
 
 /**
  * Provide storage methods to use AWS S3
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export class AWSS3Provider implements StorageProvider {
 	static readonly CATEGORY = 'Storage';

--- a/packages/storage/src/types/AWSS3Provider.ts
+++ b/packages/storage/src/types/AWSS3Provider.ts
@@ -19,6 +19,11 @@ import { UploadTask } from './Provider';
 
 type ListObjectsCommandOutputContent = _Object;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface FileMetadata {
 	bucket: string;
 	fileName: string;
@@ -28,6 +33,11 @@ export interface FileMetadata {
 	uploadId: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type CommonStorageOptions = Omit<
 	StorageOptions,
 	| 'credentials'
@@ -36,6 +46,11 @@ export type CommonStorageOptions = Omit<
 	| 'dangerouslyConnectToHttpEndpointForTesting'
 >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type S3ProviderGetConfig = CommonStorageOptions & {
 	download?: boolean;
 	track?: boolean;
@@ -55,6 +70,11 @@ export type S3ProviderGetConfig = CommonStorageOptions & {
 	validateObjectExistence?: boolean;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type S3ProviderGetPropertiesConfig = CommonStorageOptions & {
 	SSECustomerAlgorithm?: HeadObjectInput['SSECustomerAlgorithm'];
 	SSECustomerKey?: HeadObjectInput['SSECustomerKey'];
@@ -62,6 +82,11 @@ export type S3ProviderGetPropertiesConfig = CommonStorageOptions & {
 	SSECustomerKeyMD5?: HeadObjectInput['SSECustomerKeyMD5'];
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type S3ProviderGetOuput<T> = T extends { download: true }
 	? GetObjectOutput
 	: string;
@@ -89,6 +114,11 @@ type _S3ProviderPutConfig = {
 	resumable?: boolean;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type ResumableUploadConfig = {
 	resumable: true;
 	progressCallback?: (progress: UploadTaskProgressEvent) => any;
@@ -104,6 +134,9 @@ export type ResumableUploadConfig = {
  * Usage of this parameter is not considered a recommended practice:
  *  {@link https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html}
  *
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export type S3ProviderPutConfig = CommonStorageOptions &
 	(
@@ -112,19 +145,39 @@ export type S3ProviderPutConfig = CommonStorageOptions &
 		| (_S3ProviderPutConfig & ResumableUploadConfig)
 	);
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type S3ProviderRemoveConfig = CommonStorageOptions & {
 	bucket?: string;
 	provider?: 'AWSS3';
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type S3ProviderListOutput = {
 	results: S3ProviderListOutputItem[];
 	nextToken?: string;
 	hasNextToken: boolean;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type S3ProviderRemoveOutput = DeleteObjectOutput;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type S3ProviderListConfig = CommonStorageOptions & {
 	bucket?: string;
 	pageSize?: number | 'ALL';
@@ -133,10 +186,20 @@ export type S3ProviderListConfig = CommonStorageOptions & {
 	nextToken?: string;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type S3ClientOptions = StorageOptions & {
 	credentials: ICredentials;
 } & S3ProviderListConfig;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface S3ProviderListOutputItem {
 	key: ListObjectsCommandOutputContent['Key'];
 	eTag: ListObjectsCommandOutputContent['ETag'];
@@ -144,14 +207,29 @@ export interface S3ProviderListOutputItem {
 	size: ListObjectsCommandOutputContent['Size'];
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface S3CopyTarget {
 	key: string;
 	level?: StorageAccessLevel;
 	identityId?: string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type S3CopySource = S3CopyTarget;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type S3CopyDestination = Omit<S3CopyTarget, 'identityId'>;
 
 /**
@@ -162,6 +240,9 @@ export type S3CopyDestination = Omit<S3CopyTarget, 'identityId'>;
  * Usage of this parameter is not considered a recommended practice:
  *  {@link https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html}
  *
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export type S3ProviderCopyConfig = Omit<CommonStorageOptions, 'level'> & {
 	provider?: 'AWSS3';
@@ -182,10 +263,20 @@ export type S3ProviderCopyConfig = Omit<CommonStorageOptions, 'level'> & {
 	SSEKMSKeyId?: CopyObjectInput['SSEKMSKeyId'];
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type S3ProviderCopyOutput = {
 	key: string;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type S3ProviderGetPropertiesOutput = {
 	contentType: string;
 	contentLength: number;
@@ -194,10 +285,20 @@ export type S3ProviderGetPropertiesOutput = {
 	metadata: Record<string, string>;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type PutResult = {
 	key: string;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type S3ProviderPutOutput<T> = T extends { resumable: true }
 	? UploadTask
 	: Promise<PutResult>;

--- a/packages/storage/src/types/Provider.ts
+++ b/packages/storage/src/types/Provider.ts
@@ -10,6 +10,11 @@ import {
 // CAUTION: The StorageProvider interface is publicly available and allows customers to implement their own custom
 // storage providers. Exercise caution when modifying this class as additive changes to this interface can break
 // customers when not marked as optional.
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface StorageProvider {
 	// you need to implement those methods
 
@@ -48,6 +53,11 @@ export interface StorageProvider {
 	getProviderName(): string;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface UploadTask {
 	resume(): any;
 	pause(): any;
@@ -55,6 +65,11 @@ export interface UploadTask {
 	isInProgress: boolean;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface StorageProviderWithCopy extends StorageProvider {
 	// copy object from src to dest
 	copy(
@@ -64,10 +79,20 @@ export interface StorageProviderWithCopy extends StorageProvider {
 	): Promise<any>;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface StorageProviderWithGetProperties extends StorageProvider {
 	getProperties(key: string, options?): Promise<Object>;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageProviderApi =
 	| 'copy'
 	| 'get'

--- a/packages/storage/src/types/Storage.ts
+++ b/packages/storage/src/types/Storage.ts
@@ -31,6 +31,11 @@ type Last<T extends any[]> = T[Exclude<keyof T, keyof Tail<T>>];
 // Utility type to extract the last parameter type of a function
 type LastParameter<F extends (...args: any) => any> = Last<Parameters<F>>;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export interface StorageOptions {
 	credentials?: ICredentials;
 	region?: string;
@@ -50,20 +55,45 @@ export interface StorageOptions {
 	dangerouslyConnectToHttpEndpointForTesting?: boolean;
 }
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageAccessLevel = 'public' | 'protected' | 'private';
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type CustomPrefix = {
 	[key in StorageAccessLevel]?: string;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageCopyTarget = {
 	key: string;
 	level?: string;
 	identityId?: string;
 };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageCopySource = StorageCopyTarget;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageCopyDestination = Omit<StorageCopyTarget, 'identityId'>;
 
 /**
@@ -94,6 +124,11 @@ type StorageOperationConfig<
 			provider: ReturnType<T['getProviderName']>;
 	  };
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageGetConfig<T extends Record<string, any>> =
 	T extends StorageProvider
 		? StorageOperationConfig<T, 'get'>
@@ -102,6 +137,11 @@ export type StorageGetConfig<T extends Record<string, any>> =
 				T
 		  >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageGetPropertiesConfig<T extends Record<string, any>> =
 	T extends StorageProviderWithGetProperties
 		? StorageOperationConfig<T, 'getProperties'>
@@ -110,6 +150,11 @@ export type StorageGetPropertiesConfig<T extends Record<string, any>> =
 				T
 		  >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StoragePutConfig<T extends Record<string, any>> =
 	T extends StorageProvider
 		? StorageOperationConfig<T, 'put'>
@@ -118,6 +163,11 @@ export type StoragePutConfig<T extends Record<string, any>> =
 				T
 		  >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageRemoveConfig<T extends Record<string, any>> =
 	T extends StorageProvider
 		? StorageOperationConfig<T, 'remove'>
@@ -126,6 +176,11 @@ export type StorageRemoveConfig<T extends Record<string, any>> =
 				T
 		  >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageListConfig<T extends Record<string, any>> =
 	T extends StorageProvider
 		? StorageOperationConfig<T, 'list'>
@@ -134,6 +189,11 @@ export type StorageListConfig<T extends Record<string, any>> =
 				T
 		  >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageCopyConfig<T extends Record<string, any>> =
 	T extends StorageProviderWithCopy
 		? StorageOperationConfig<T, 'copy'>
@@ -168,33 +228,63 @@ type PickProviderOutput<
 		: Promise<any>
 	: DefaultOutput;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageGetOutput<T extends StorageProvider | Record<string, any>> =
 	PickProviderOutput<Promise<S3ProviderGetOuput<T>>, T, 'get'>;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StoragePutOutput<T> = PickProviderOutput<
 	S3ProviderPutOutput<T>,
 	T,
 	'put'
 >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageRemoveOutput<T> = PickProviderOutput<
 	Promise<S3ProviderRemoveOutput>,
 	T,
 	'remove'
 >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageListOutput<T> = PickProviderOutput<
 	Promise<S3ProviderListOutput>,
 	T,
 	'list'
 >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageCopyOutput<T> = PickProviderOutput<
 	Promise<S3ProviderCopyOutput>,
 	T,
 	'copy'
 >;
 
+/**
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
+ */
 export type StorageGetPropertiesOutput<T> = PickProviderOutput<
 	Promise<S3ProviderGetPropertiesOutput>,
 	T,
@@ -204,6 +294,9 @@ export type StorageGetPropertiesOutput<T> = PickProviderOutput<
 /**
  * Utility type to allow custom provider to use any config keys, if provider is set to AWSS3 then it should use
  * AWSS3Provider's config.
+ * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
+ * See the migration guide:
+ * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
  */
 export type StorageOperationConfigMap<
 	Default,


### PR DESCRIPTION
## What

Amplify JavaScript **v5 is in maintenance mode**. This PR annotates the **public API surface of every publishable package** with a TSDoc `@deprecated` tag pointing users to the v5 → v6 migration guide:

> https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/

The notice surfaces directly in users' editors (IDE strikethrough + hover text) and in the generated `.d.ts` files, so consumers learn about the upgrade path at the point of use rather than having to find a release note.

Every tag uses the same wording, applied consistently:

```ts
/**
 * @deprecated Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
 * See the migration guide:
 * https://docs.amplify.aws/gen1/javascript/build-a-backend/troubleshooting/migrate-from-javascript-v5-to-v6/
 */
export class StorageHelper { ... }
```

## Scope of the change

**Comment-only. No runtime behavior, signatures, or logic are modified.**

- `117 files changed, 2526 insertions(+), 2 deletions(-)`
- **520 annotations** — 516 new `@deprecated` tags, plus 4 merged into pre-existing `@deprecated` tags
- The only two non-additive edits expand single-line JSDoc blocks (`/** @class */`, `/** @enum {string} */`) into multi-line blocks so a tag could be added without corrupting them.

Where a symbol already had an `@deprecated` tag (e.g. the Amazon Pinpoint end-of-support notices), the migration pointer was **appended to the existing tag** rather than added as a second tag — a duplicate tag would have been ignored by TypeScript and would have hidden the original note:

```ts
/**
 * @deprecated AWS will end support for Amazon Pinpoint on October 30, 2026.
 * Amplify JavaScript v5 is in maintenance mode. Upgrade to v6.
 * See the migration guide:
 * https://docs.amplify.aws/...
 */
```

## How the public API surface was determined

None of the packages declare an `exports` map, so for each package the public surface is the set of symbols re-exported from its public entry point (`main`/`module`/`typings` all resolve to `src/index.ts`). That set was resolved with the TypeScript compiler API rather than by grepping, then each symbol was annotated **at its original declaration site** so the tag flows through re-export chains. Internal modules that are not reachable from an entry point were deliberately left alone.

Two packages needed special handling:

- **`amazon-cognito-identity-js`** ships JavaScript sources with a hand-written `index.d.ts` that wraps its whole surface in `declare module 'amazon-cognito-identity-js' { ... }`. That ambient declaration file *is* the consumer-facing type surface, so the tags were added there.
- **`aws-amplify`** (the umbrella package) is almost entirely re-exports of its siblings. Only its own `withSSRContext` is annotated locally; the other 31 symbols inherit the tag from the sibling declarations. This was verified, not assumed (see below).

## Coverage

| Package | Public exports | Annotated |
|---|---|---|
| `amazon-cognito-identity-js` | 30 | 30 |
| `@aws-amplify/analytics` | 6 | 6 |
| `@aws-amplify/api` | 8 | 8 |
| `@aws-amplify/api-graphql` | 10 | 9 ¹ |
| `@aws-amplify/api-rest` | 3 | 3 |
| `@aws-amplify/auth` | 9 | 9 |
| `aws-amplify` | 32 | 32 (inherited) |
| `aws-amplify-react-native` | 29 | 29 ² |
| `@aws-amplify/cache` | 4 | 4 |
| `@aws-amplify/core` | 80 | 80 |
| `@aws-amplify/datastore` | 149 | 149 |
| `@aws-amplify/datastore-storage-adapter` | 1 | 1 |
| `@aws-amplify/geo` | 42 | 42 |
| `@aws-amplify/interactions` | 15 | 15 |
| `@aws-amplify/notifications` | 19 | 19 |
| `@aws-amplify/predictions` | 62 | 62 |
| `@aws-amplify/pubsub` | 13 | 13 |
| `@aws-amplify/pushnotification` | 1 | 1 |
| `@aws-amplify/rtn-push-notification` | 2 | 2 |
| `@aws-amplify/storage` | 48 | 48 |

All 20 publishable packages are covered; **no package was skipped.**

¹ `OperationTypeNode` is re-exported straight from the third-party `graphql` package. It is intentionally **not** annotated, since that would mean editing `node_modules`.

² `aws-amplify-react-native` is Babel-built and publishes no type declarations (no `typings` field), so its tags are verified at the source level rather than through emitted `.d.ts`.

## Verification

Run with Node 24 (matching CI) and driven through the `yarn` scripts:

- **`yarn build`** — exit 0, all 20 packages built, "No duplicated Amplify dependencies detected."
- **`lerna run test`** — exit 0, all 20 packages, **2212 tests passed, 0 failures**.
- **`lerna run lint`** — exit 0, clean in all 19 linted packages.
- **Consumer-perspective type check** — a synthetic consumer (`import * as ns from '<pkg>'`) was compiled against each package's **built** declarations and every resolved export was asserted to carry a `@deprecated` tag containing the migration URL: **533/534**, the single exception being the third-party `OperationTypeNode` above. This is what confirms the `aws-amplify` umbrella re-exports genuinely inherit the tag after a real build.

Two things worth calling out, both checked against a clean baseline and **pre-existing, not caused by this PR**:

- `yarn test:license` reports failures only for files inside gitignored local build/tooling directories (`.turbo/`, `.husky/_/`); the count is identical before and after this change. No source file changed here is missing its license header.
- `prettier --check` flags 20 of the touched files — the identical set and count fails on `v5-stable` before this change. The lines added by this PR are Prettier-clean; formatting those files would have added unrelated churn, so it was left out.

All added lines were also kept within the 120-character `max-line-length` that the packages' `tslint.json` enforces, which is why the message is wrapped across three comment lines.

## Release type

The commit is typed `fix:`, so Lerna will cut a **patch version bump** for the affected packages on the next `v5-stable` release — meaning **these deprecation notices will publish to npm and reach consumers**, rather than sitting unreleased.

`AGENTS.md` forbids `feat:` on this maintenance branch; `fix:` is permitted, and is the correct type here given the intent is for users to actually receive the upgrade notice. The change itself remains comment-only — no runtime behavior, signatures, or logic are modified.

## Deferred scope

- **`OperationTypeNode`** (`@aws-amplify/api-graphql`) — owned by the third-party `graphql` package; cannot be annotated from this repo.
- Only **public entry-point exports** are annotated. Internal/private modules and individual class *members* are not tagged; the deprecation is applied at the level of each exported symbol, which is what consumers import.
- Generated API docs under `docs/api` were not regenerated, as that is produced by the release pipeline.
