### PR TITLE
fix(interactions): bump fflate to 0.7.5 to fix unzipSync DoS (resolves #308/#309)

### DIFF
--- a/.changeset/fix-interactions-fflate-dos.md
+++ b/.changeset/fix-interactions-fflate-dos.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/interactions': patch
+---
+
+fix(interactions): bump fflate to 0.7.5 to address unzipSync infinite-loop DoS (GHSA)

--- a/packages/interactions/package.json
+++ b/packages/interactions/package.json
@@ -76,7 +76,7 @@
 		"@aws-sdk/client-lex-runtime-service": "^3.1012.0",
 		"@aws-sdk/client-lex-runtime-v2": "^3.1012.0",
 		"base-64": "1.0.0",
-		"fflate": "0.7.3",
+		"fflate": "0.7.5",
 		"pako": "2.0.4",
 		"tslib": "^2.5.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -7988,10 +7988,10 @@ fdir@^6.5.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
-fflate@0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.7.3.tgz#288b034ff0e9c380eaa2feff48c787b8371b7fa5"
-  integrity sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw==
+fflate@0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.7.5.tgz#1dfcb7189bc104d599da0436eace14ed26de879f"
+  integrity sha512-QieYf//cis6ywHNi5qW1+PXPQ4bC+XVJAtS4AXIML8P76GroEiOxm/oQtn1f02UkJY1+KsXMJcC+R2v/Eg4G3g==
 
 file-entry-cache@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
## Problem

Two Dependabot alerts for **fflate** — `unzipSync` can enter an infinite loop on crafted input (DoS), vulnerable `>= 0.7.0, < 0.7.5`, patched `0.7.5`:
- **#308** — `packages/interactions/package.json` (direct runtime dependency)
- **#309** — `yarn.lock`

**Issue number, if available:** Dependabot alerts #308, #309

## Changes

- `@aws-amplify/interactions`: `fflate` `0.7.3 → 0.7.5` (manifest + lockfile). Stays within the `0.7` minor — the fix is a patch release, so no API change.
- Added a `patch` changeset for `@aws-amplify/interactions` (fflate is a runtime dep of a published package).

## Validation

- `yarn install --frozen-lockfile` passes; `fflate` resolves to `0.7.5`, no `0.7.3` remains.
- fflate `0.7.5` has no dependencies; diff limited to the one manifest line, the `fflate` lockfile block, and the changeset.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
