### PR TITLE
fix(auth): prevent fetchAuthSession from hanging on cross-tab/abandoned OAuth flows

### DIFF
--- a/.changeset/cross-tab-oauth-hang.md
+++ b/.changeset/cross-tab-oauth-hang.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/auth': patch
+---
+
+fix(auth): prevent `fetchAuthSession`/`getCurrentUser` from hanging after a cross-tab or abandoned `signInWithRedirect` OAuth flow. A tab that did not itself process the OAuth redirect response no longer blocks indefinitely on the shared `inflightOAuth` flag; it releases when another tab clears the flag or, for an abandoned flow, after a bounded timeout, while a tab actively completing its own redirect keeps waiting.

--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -556,6 +556,13 @@ tests:
     sample_name: [sign-in-with-oauth]
     spec: sign-in-with-oauth
     browser: [chrome]
+  - test_name: integ_next_sign_in_with_oauth_cross_tab
+    desc: 'OAuth cross-tab fetchAuthSession does not hang'
+    framework: next
+    category: auth
+    sample_name: [sign-in-with-oauth]
+    spec: sign-in-with-oauth-cross-tab
+    browser: [chrome]
   - test_name: integ_vue_sign_out_of_oidc_provider
     desc: 'Sign-out of OIDC provider'
     framework: vue

--- a/.github/workflows/push-integ-test.yml
+++ b/.github/workflows/push-integ-test.yml
@@ -8,7 +8,7 @@ concurrency:
 on:
   push:
     branches:
-      - replace-with-your-branch
+      - fix/cross-tab-oauth-fetchauthsession-hang
 
 jobs:
   e2e:

--- a/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
@@ -5,7 +5,10 @@ import { Hub, ResourcesConfig } from '@aws-amplify/core';
 import { AMPLIFY_SYMBOL } from '@aws-amplify/core/internals/utils';
 
 import { TokenOrchestrator } from '../../../src/providers/cognito/tokenProvider';
-import { addInflightPromise } from '../../../src/providers/cognito/utils/oauth/inflightPromise';
+import {
+	addInflightPromise,
+	isOAuthInProgress,
+} from '../../../src/providers/cognito/utils/oauth/inflightPromise';
 import { oAuthStore } from '../../../src/providers/cognito/utils/oauth';
 
 jest.mock('../../../src/providers/cognito/utils/oauth/oAuthStore');
@@ -41,7 +44,9 @@ const validAuthConfig: ResourcesConfig = {
 };
 
 jest.mock('../../../src/providers/cognito/utils/oauth/inflightPromise', () => ({
-	addInflightPromise: jest.fn(),
+	// `addInflightPromise` returns an unregister handle in the real module.
+	addInflightPromise: jest.fn(() => jest.fn()),
+	isOAuthInProgress: jest.fn(() => false),
 }));
 
 const currentDate = new Date();
@@ -101,6 +106,15 @@ const validAuthTokens = {
 };
 
 const mockAddInflightPromise = addInflightPromise as jest.Mock;
+const mockIsOAuthInProgress = isOAuthInProgress as jest.Mock;
+
+const INFLIGHT_OAUTH_KEY =
+	'CognitoIdentityServiceProvider.test-id.inflightOAuth';
+// Flush pending microtasks and the current (real-timer) macrotask queue.
+const flushAsyncWork = () =>
+	new Promise<void>(resolve => {
+		setTimeout(resolve, 0);
+	});
 
 describe('TokenOrchestrator', () => {
 	const tokenOrchestrator = new TokenOrchestrator();
@@ -108,6 +122,8 @@ describe('TokenOrchestrator', () => {
 		beforeAll(() => {
 			mockAddInflightPromise.mockImplementation(resolver => {
 				resolver();
+
+				return jest.fn();
 			});
 			tokenOrchestrator.setAuthConfig(validAuthConfig.Auth!);
 			tokenOrchestrator.setAuthTokenStore(mockAuthTokenStore);
@@ -149,6 +165,266 @@ describe('TokenOrchestrator', () => {
 
 			expect(addInflightPromise).toHaveBeenCalledWith(expect.any(Function));
 			expect(tokens?.accessToken).toEqual(validAuthTokens.accessToken);
+		});
+
+		it('Should not block indefinitely when the inflight OAuth flow is never resolved by this tab (e.g. started or abandoned in another tab), resolving after a bounded timeout', async () => {
+			jest.useFakeTimers();
+			try {
+				mockAuthTokenStore.loadTokens.mockResolvedValue(validAuthTokens);
+				(oAuthStore.loadOAuthInFlight as jest.Mock).mockResolvedValue(true);
+				mockIsOAuthInProgress.mockReturnValue(false);
+				// Simulate a tab that never processes the OAuth redirect response, so
+				// the registered resolver is never invoked in-process. The listener and
+				// timeout are wired before addInflightPromise is called, so resolving
+				// here signals setup is complete without releasing the wait.
+				const readyToAdvance = new Promise<void>(resolve => {
+					mockAddInflightPromise.mockImplementationOnce(() => {
+						resolve();
+
+						return jest.fn();
+					});
+				});
+
+				const tokensPromise = tokenOrchestrator.getTokens();
+				await readyToAdvance;
+				await jest.advanceTimersByTimeAsync(5_000);
+
+				const tokens = await tokensPromise;
+				expect(tokens?.accessToken).toEqual(validAuthTokens.accessToken);
+			} finally {
+				jest.useRealTimers();
+			}
+		});
+
+		it('Should keep waiting past the timeout while this tab is completing its own OAuth redirect, then resolve once completion finishes', async () => {
+			jest.useFakeTimers();
+			try {
+				mockAuthTokenStore.loadTokens.mockResolvedValue(validAuthTokens);
+				(oAuthStore.loadOAuthInFlight as jest.Mock).mockResolvedValue(true);
+				// This tab owns the flow (running completeOAuthFlow), so it must not
+				// give up on the safety timeout.
+				mockIsOAuthInProgress.mockReturnValue(true);
+				const ready = new Promise<void>(resolve => {
+					mockAddInflightPromise.mockImplementationOnce(() => {
+						resolve();
+
+						return jest.fn();
+					});
+				});
+
+				let resolved = false;
+				const tokensPromise = tokenOrchestrator.getTokens().then(tokens => {
+					resolved = true;
+
+					return tokens;
+				});
+				await ready;
+
+				// First timeout fires but re-arms because completion is in progress.
+				await jest.advanceTimersByTimeAsync(5_000);
+				expect(resolved).toBe(false);
+
+				// Completion finishes; the next timeout releases the wait.
+				mockIsOAuthInProgress.mockReturnValue(false);
+				await jest.advanceTimersByTimeAsync(5_000);
+
+				const tokens = await tokensPromise;
+				expect(resolved).toBe(true);
+				expect(tokens?.accessToken).toEqual(validAuthTokens.accessToken);
+			} finally {
+				mockIsOAuthInProgress.mockReturnValue(false);
+				jest.useRealTimers();
+			}
+		});
+
+		it('Should stop blocking as soon as another tab clears the shared inflight OAuth flag', async () => {
+			mockAuthTokenStore.loadTokens.mockResolvedValue(validAuthTokens);
+			(oAuthStore.loadOAuthInFlight as jest.Mock).mockResolvedValue(true);
+			mockIsOAuthInProgress.mockReturnValue(false);
+			// Do not resolve the wait in-process; rely on the cross-tab storage event.
+			const listenerReady = new Promise<void>(resolve => {
+				mockAddInflightPromise.mockImplementationOnce(() => {
+					resolve();
+
+					return jest.fn();
+				});
+			});
+
+			const tokensPromise = tokenOrchestrator.getTokens();
+			await listenerReady;
+
+			window.dispatchEvent(
+				new StorageEvent('storage', {
+					key: INFLIGHT_OAUTH_KEY,
+					oldValue: 'true',
+					newValue: null,
+				}),
+			);
+
+			const tokens = await tokensPromise;
+			expect(tokens?.accessToken).toEqual(validAuthTokens.accessToken);
+		});
+
+		it('Should ignore a storage event that sets the flag to "true" and only release when it is cleared', async () => {
+			mockAuthTokenStore.loadTokens.mockResolvedValue(validAuthTokens);
+			(oAuthStore.loadOAuthInFlight as jest.Mock).mockResolvedValue(true);
+			mockIsOAuthInProgress.mockReturnValue(false);
+			const ready = new Promise<void>(resolve => {
+				mockAddInflightPromise.mockImplementationOnce(() => {
+					resolve();
+
+					return jest.fn();
+				});
+			});
+
+			let resolved = false;
+			const tokensPromise = tokenOrchestrator.getTokens().then(tokens => {
+				resolved = true;
+
+				return tokens;
+			});
+			await ready;
+
+			// Another tab STARTING a flow (newValue 'true') must not release the wait.
+			window.dispatchEvent(
+				new StorageEvent('storage', {
+					key: INFLIGHT_OAUTH_KEY,
+					oldValue: null,
+					newValue: 'true',
+				}),
+			);
+			await flushAsyncWork();
+			expect(resolved).toBe(false);
+
+			// Clearing it does release the wait.
+			window.dispatchEvent(
+				new StorageEvent('storage', {
+					key: INFLIGHT_OAUTH_KEY,
+					oldValue: 'true',
+					newValue: null,
+				}),
+			);
+			await tokensPromise;
+			expect(resolved).toBe(true);
+		});
+
+		it('Should ignore inflightOAuth changes for a different user pool client', async () => {
+			mockAuthTokenStore.loadTokens.mockResolvedValue(validAuthTokens);
+			(oAuthStore.loadOAuthInFlight as jest.Mock).mockResolvedValue(true);
+			mockIsOAuthInProgress.mockReturnValue(false);
+			const ready = new Promise<void>(resolve => {
+				mockAddInflightPromise.mockImplementationOnce(() => {
+					resolve();
+
+					return jest.fn();
+				});
+			});
+
+			let resolved = false;
+			const tokensPromise = tokenOrchestrator.getTokens().then(tokens => {
+				resolved = true;
+
+				return tokens;
+			});
+			await ready;
+
+			window.dispatchEvent(
+				new StorageEvent('storage', {
+					key: 'CognitoIdentityServiceProvider.another-client-id.inflightOAuth',
+					oldValue: 'true',
+					newValue: null,
+				}),
+			);
+			await flushAsyncWork();
+			expect(resolved).toBe(false);
+
+			window.dispatchEvent(
+				new StorageEvent('storage', {
+					key: INFLIGHT_OAUTH_KEY,
+					oldValue: 'true',
+					newValue: null,
+				}),
+			);
+			await tokensPromise;
+			expect(resolved).toBe(true);
+		});
+
+		it('Should ignore storage events with a null key (e.g. localStorage.clear())', async () => {
+			mockAuthTokenStore.loadTokens.mockResolvedValue(validAuthTokens);
+			(oAuthStore.loadOAuthInFlight as jest.Mock).mockResolvedValue(true);
+			mockIsOAuthInProgress.mockReturnValue(false);
+			const ready = new Promise<void>(resolve => {
+				mockAddInflightPromise.mockImplementationOnce(() => {
+					resolve();
+
+					return jest.fn();
+				});
+			});
+
+			let resolved = false;
+			const tokensPromise = tokenOrchestrator.getTokens().then(tokens => {
+				resolved = true;
+
+				return tokens;
+			});
+			await ready;
+
+			window.dispatchEvent(
+				new StorageEvent('storage', {
+					key: null,
+					oldValue: null,
+					newValue: null,
+				}),
+			);
+			await flushAsyncWork();
+			expect(resolved).toBe(false);
+
+			window.dispatchEvent(
+				new StorageEvent('storage', {
+					key: INFLIGHT_OAUTH_KEY,
+					oldValue: 'true',
+					newValue: null,
+				}),
+			);
+			await tokensPromise;
+			expect(resolved).toBe(true);
+		});
+
+		it('Should remove the storage listener and clear the timeout when the wait is resolved in-process', async () => {
+			mockAuthTokenStore.loadTokens.mockResolvedValue(validAuthTokens);
+			(oAuthStore.loadOAuthInFlight as jest.Mock).mockResolvedValue(true);
+			mockIsOAuthInProgress.mockReturnValue(false);
+			const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+			const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+			let capturedResolver: (() => void) | undefined;
+			const ready = new Promise<void>(resolve => {
+				mockAddInflightPromise.mockImplementationOnce(
+					(resolver: () => void) => {
+						capturedResolver = resolver;
+						resolve();
+
+						return jest.fn();
+					},
+				);
+			});
+
+			const tokensPromise = tokenOrchestrator.getTokens();
+			await ready;
+
+			// Simulate resolveAndClearInflightPromises invoking the registered resolver.
+			capturedResolver?.();
+
+			const tokens = await tokensPromise;
+			expect(removeEventListenerSpy).toHaveBeenCalledWith(
+				'storage',
+				expect.any(Function),
+			);
+			expect(clearTimeoutSpy).toHaveBeenCalled();
+			expect(tokens?.accessToken).toEqual(validAuthTokens.accessToken);
+
+			removeEventListenerSpy.mockRestore();
+			clearTimeoutSpy.mockRestore();
 		});
 	});
 

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/attemptCompleteOAuthFlow.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/attemptCompleteOAuthFlow.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@aws-amplify/core/internals/utils';
 
 import { attemptCompleteOAuthFlow } from '../../../../../src/providers/cognito/utils/oauth/attemptCompleteOAuthFlow';
+import { setOAuthInProgress } from '../../../../../src/providers/cognito/utils/oauth/inflightPromise';
 import { completeOAuthFlow } from '../../../../../src/providers/cognito/utils/oauth/completeOAuthFlow';
 import { getRedirectUrl } from '../../../../../src/providers/cognito/utils/oauth/getRedirectUrl';
 import { oAuthStore } from '../../../../../src/providers/cognito/utils/oauth/oAuthStore';
@@ -39,6 +40,8 @@ jest.mock(
 	'../../../../../src/providers/cognito/utils/oauth/inflightPromise',
 	() => ({
 		addInflightPromise: jest.fn(),
+		setOAuthInProgress: jest.fn(),
+		isOAuthInProgress: jest.fn(() => false),
 	}),
 );
 
@@ -107,6 +110,9 @@ describe('attemptCompleteOAuthFlow', () => {
 				redirectUri: 'http://localhost:3000/',
 			}),
 		);
+		// marks this tab as owning the inflight OAuth completion, then clears it
+		expect(setOAuthInProgress).toHaveBeenCalledWith(true);
+		expect(setOAuthInProgress).toHaveBeenLastCalledWith(false);
 	});
 
 	test.each([

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -18,7 +18,11 @@ import {
 import { assertServiceError } from '../../../errors/utils/assertServiceError';
 import { AuthError } from '../../../errors/AuthError';
 import { oAuthStore } from '../utils/oauth/oAuthStore';
-import { addInflightPromise } from '../utils/oauth/inflightPromise';
+import {
+	addInflightPromise,
+	isOAuthInProgress,
+} from '../utils/oauth/inflightPromise';
+import { OAuthStorageKeys } from '../utils/types';
 import { ClientMetadata, CognitoAuthSignInDetails } from '../types';
 
 import {
@@ -29,6 +33,20 @@ import {
 	OAuthMetadata,
 	TokenRefresher,
 } from './types';
+
+// Upper bound for how long a tab that does NOT own the inflight OAuth flow will
+// block token-fetching calls (fetchAuthSession, getCurrentUser, ...) before it
+// gives up waiting. The `inflightOAuth` flag lives in cross-tab shared storage,
+// but the resolver that clears the wait is only invoked in the tab that
+// actually processes the OAuth redirect response. This bound guarantees a tab
+// that did not initiate the flow (or where the flow was abandoned) can never
+// block indefinitely, while a tab that IS completing its own redirect keeps
+// waiting (see the `isOAuthInProgress` re-check in `waitForInflightOAuth`).
+const INFLIGHT_OAUTH_WAIT_TIMEOUT_MS = 5_000;
+
+// Storage-key prefix used by `DefaultOAuthStore` (see `signInWithRedirectStore`).
+// Must stay in sync with that store's provider name.
+const OAUTH_STORAGE_KEY_PREFIX = 'CognitoIdentityServiceProvider';
 
 export class TokenOrchestrator implements AuthTokenOrchestrator {
 	private authConfig?: AuthConfig;
@@ -50,8 +68,76 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 				// to block async calls that require fetching tokens before the oauth flow completes
 				// e.g. getCurrentUser, fetchAuthSession etc.
 
-				this.inflightPromise = new Promise<void>((resolve, _reject) => {
-					addInflightPromise(resolve);
+				const inflightOAuthKey = `${OAUTH_STORAGE_KEY_PREFIX}.${this.authConfig?.Cognito?.userPoolClientId}.${OAuthStorageKeys.inflightOAuth}`;
+
+				this.inflightPromise = new Promise<void>(resolve => {
+					let settled = false;
+					const cleanups: (() => void)[] = [];
+
+					// Releases only this tab's local waiter. It intentionally does NOT
+					// clear the shared `inflightOAuth`/PKCE/state, so an OAuth flow that
+					// is genuinely inflight in another tab is left untouched.
+					const settle = () => {
+						if (settled) {
+							return;
+						}
+						settled = true;
+						cleanups.forEach(cleanup => {
+							cleanup();
+						});
+						resolve();
+					};
+
+					// The `inflightOAuth` flag is persisted in shared (cross-tab)
+					// storage, but the resolver registered below is only invoked (via
+					// `resolveAndClearInflightPromises`) in the tab that processes the
+					// OAuth redirect response. Without an escape hatch, a tab that did
+					// not initiate the flow — the flow was started in another tab, or
+					// abandoned before completion — would block forever. Resolve the
+					// local waiter as soon as another tab clears this pool's shared flag
+					// (e.g. sign-out, completion, or failure). An exact-key match avoids
+					// reacting to other user-pool clients / tenants in the same origin.
+					if (
+						typeof window !== 'undefined' &&
+						typeof window.addEventListener === 'function'
+					) {
+						const onStorage = (event: StorageEvent) => {
+							if (event.key === inflightOAuthKey && event.newValue !== 'true') {
+								settle();
+							}
+						};
+						window.addEventListener('storage', onStorage);
+						cleanups.push(() => {
+							window.removeEventListener('storage', onStorage);
+						});
+					}
+
+					// ...and, as a safety net for an abandoned flow that is never
+					// cleared, after a bounded timeout. A tab that is actively
+					// completing its OWN redirect (`isOAuthInProgress()`) must not give
+					// up here — its `completeOAuthFlow` may legitimately take longer than
+					// the bound (slow network, cold Cognito) and will settle the wait via
+					// `resolveAndClearInflightPromises`. Only bystander/abandoned tabs
+					// release on timeout; owning tabs re-arm and keep waiting.
+					const scheduleTimeout = () => {
+						const timeoutId = setTimeout(() => {
+							if (isOAuthInProgress()) {
+								scheduleTimeout();
+							} else {
+								settle();
+							}
+						}, INFLIGHT_OAUTH_WAIT_TIMEOUT_MS);
+						cleanups.push(() => {
+							clearTimeout(timeoutId);
+						});
+					};
+					scheduleTimeout();
+
+					// Registered last so a resolver that fires synchronously can still
+					// tear down the listener and timeout created above. The returned
+					// handle removes `settle` from the shared list when we resolve via
+					// the timeout / storage paths, so no dead resolver is left behind.
+					cleanups.push(addInflightPromise(settle));
 				});
 
 				return this.inflightPromise;

--- a/packages/auth/src/providers/cognito/utils/oauth/attemptCompleteOAuthFlow.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/attemptCompleteOAuthFlow.ts
@@ -14,6 +14,7 @@ import { oAuthStore } from './oAuthStore';
 import { completeOAuthFlow } from './completeOAuthFlow';
 import { getRedirectUrl } from './getRedirectUrl';
 import { handleFailure } from './handleFailure';
+import { setOAuthInProgress } from './inflightPromise';
 
 export const attemptCompleteOAuthFlow = async (
 	authConfig: AuthConfig['Cognito'],
@@ -34,6 +35,11 @@ export const attemptCompleteOAuthFlow = async (
 		return;
 	}
 
+	// Mark that this tab owns the inflight OAuth flow so that concurrent
+	// token-fetching calls in this tab wait for completion instead of releasing
+	// early on the bystander/abandoned-flow safety timeout in
+	// `TokenOrchestrator.waitForInflightOAuth`.
+	setOAuthInProgress(true);
 	try {
 		const currentUrl = window.location.href;
 		const { loginWith, userPoolClientId } = authConfig;
@@ -50,5 +56,7 @@ export const attemptCompleteOAuthFlow = async (
 		});
 	} catch (err) {
 		await handleFailure(err);
+	} finally {
+		setOAuthInProgress(false);
 	}
 };

--- a/packages/auth/src/providers/cognito/utils/oauth/inflightPromise.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/inflightPromise.ts
@@ -3,8 +3,23 @@
 
 const inflightPromises: ((value: void | PromiseLike<void>) => void)[] = [];
 
-export const addInflightPromise = (resolver: () => void) => {
+/**
+ * Registers a resolver to be invoked when the inflight OAuth flow completes.
+ *
+ * Returns an `unregister` handle that removes the resolver from the internal
+ * list. Callers that resolve their wait through another path (e.g. a bounded
+ * timeout or a cross-tab `storage` event) MUST call it to avoid leaving a dead
+ * resolver in the list.
+ */
+export const addInflightPromise = (resolver: () => void): (() => void) => {
 	inflightPromises.push(resolver);
+
+	return () => {
+		const index = inflightPromises.indexOf(resolver);
+		if (index > -1) {
+			inflightPromises.splice(index, 1);
+		}
+	};
 };
 
 export const resolveAndClearInflightPromises = () => {
@@ -12,3 +27,17 @@ export const resolveAndClearInflightPromises = () => {
 		inflightPromises.pop()?.();
 	}
 };
+
+// Tracks whether *this* tab is actively processing an OAuth redirect response
+// (i.e. running `attemptCompleteOAuthFlow` -> `completeOAuthFlow`). It is an
+// in-memory, per-tab signal used to distinguish a tab that legitimately owns
+// the inflight OAuth flow — and should keep waiting for it to complete — from a
+// bystander tab that merely observes the shared `inflightOAuth` flag another
+// tab set (or a flag left behind by an abandoned flow).
+let oauthInProgress = false;
+
+export const setOAuthInProgress = (inProgress: boolean) => {
+	oauthInProgress = inProgress;
+};
+
+export const isOAuthInProgress = (): boolean => oauthInProgress;


### PR DESCRIPTION
## Description of changes

`fetchAuthSession()` (and `getCurrentUser()`) can hang forever after a cross-tab OAuth flow.

`TokenOrchestrator.waitForInflightOAuth()` blocks token-fetching calls whenever the `inflightOAuth` flag is set. That flag is persisted in **cross-tab shared** storage (`defaultStorage` → `localStorage`), but the resolver that releases the wait (`resolveAndClearInflightPromises`) lives in an **in-memory, per-tab** array (`inflightPromise.ts`) and is only invoked in the tab that actually processes the OAuth redirect response — `completeOAuthFlow` on success, `handleFailure` on error.

So any tab that did **not** itself complete the redirect blocks indefinitely:

- **Cross-tab (the reported case):** Tab A is signed in. Tab B calls `signInWithRedirect()` and is parked on the Cognito Managed Login page without finishing. Tab B has written `inflightOAuth=true` to shared localStorage. Tab A now calls `fetchAuthSession()` → `waitForInflightOAuth()` reads the shared `true` flag, registers an in-memory promise **its own runtime will never resolve**, and never settles.
- **Abandoned flow:** any flow that sets `inflightOAuth=true` and is never completed leaves the flag in localStorage permanently, so subsequent `fetchAuthSession()` calls in that origin hang.

### Fix

Bound the wait with an escape hatch inside `waitForInflightOAuth()`. It only ever releases **this tab's local waiter** and never mutates the shared `inflightOAuth`/PKCE/state, so a flow that is genuinely inflight in another tab is left untouched:

1. Resolve as soon as **another tab clears** the shared `inflightOAuth` flag (`storage` event) — covers cross-tab sign-out / completion / failure immediately.
2. Resolve after a **bounded timeout** (5s) as a safety net for abandoned flows that are never cleared.

The listener and timeout are wired up before `addInflightPromise` is registered so a synchronously-firing resolver still tears them down.

## Issue #, if available

Fixes #14344 (also matches an internal customer report of the same behavior with a Vue SPA + Amplify v6 + Cognito Managed Login).

## Description of how you validated your changes

- Added unit tests in `tokenOrchestrator.test.ts` covering both escape paths (timeout release, and cross-tab `storage`-event release).
- Reproduced end-to-end with a minimal Vite app on `aws-amplify@6.20.0` driven via Playwright across two tabs:
  - **Before:** with `inflightOAuth="true"` set by another tab, `fetchAuthSession()` never settled (hung the full 6s probe window). Baseline (no flag) resolved in <1s.
  - **After (patched build):** the abandoned/cross-tab case resolved at the 5s safety timeout; when another tab cleared the flag, it resolved immediately (~200ms).

## Checklist

- [x] PR description included
- [x] `yarn test` passes _(new unit tests added; monorepo suite not run in this environment)_
- [x] Tests are [changed or added]
- [x] Relevant documentation is changed or added (n/a — internal behavior)
- [x] No breaking changes: the fix is additive and only affects the previously-unbounded wait
