### PR TITLE
fix(auth): bound waiting on inflight OAuth flow with read-time deadline

### DIFF
--- a/.changeset/oauth-inflight-deadline.md
+++ b/.changeset/oauth-inflight-deadline.md
@@ -1,0 +1,19 @@
+---
+'@aws-amplify/auth': patch
+---
+
+fix(auth): bound waiting on an inflight OAuth flow with a read-time deadline
+
+`fetchAuthSession` / `getCurrentUser` could previously hang forever when another
+tab started `signInWithRedirect` and abandoned the Hosted UI page: the shared
+`inflightOAuth` flag has no expiry and the parked promise was only released by
+the tab completing the flow.
+
+The flow now records a blocking deadline next to the flag (`inflightOAuthDeadline`,
+5 minutes). Token consumers evaluate it at read time and park with a backstop
+timer, and a cross-tab storage listener releases waiters as soon as the owning
+tab settles the flow. The deadline bounds only how long other work may block —
+the completion path deliberately ignores it, and no tab ever mutates another
+tab's flow state, so a slow-but-successful login still completes. Flags written
+by older library versions are handled by persisting a default deadline on first
+observation.

--- a/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenOrchestrator.test.ts
@@ -42,6 +42,7 @@ const validAuthConfig: ResourcesConfig = {
 
 jest.mock('../../../src/providers/cognito/utils/oauth/inflightPromise', () => ({
 	addInflightPromise: jest.fn(),
+	armInflightDeadline: jest.fn(),
 }));
 
 const currentDate = new Date();
@@ -143,11 +144,27 @@ describe('TokenOrchestrator', () => {
 
 		it('Should call addInflightPromise when OAuth is inflight', async () => {
 			mockAuthTokenStore.loadTokens.mockResolvedValue(validAuthTokens);
-			(oAuthStore.loadOAuthInFlight as jest.Mock).mockResolvedValue(true);
+			(oAuthStore.loadOAuthInFlightDeadline as jest.Mock).mockResolvedValue(
+				Date.now() + 60_000,
+			);
 
 			const tokens = await tokenOrchestrator.getTokens();
 
 			expect(addInflightPromise).toHaveBeenCalledWith(expect.any(Function));
+			expect(tokens?.accessToken).toEqual(validAuthTokens.accessToken);
+		});
+
+		it('Should not block when the inflight OAuth blocking deadline has passed', async () => {
+			mockAuthTokenStore.loadTokens.mockResolvedValue(validAuthTokens);
+			// An absent or expired deadline is reported as `undefined` by the store.
+			(oAuthStore.loadOAuthInFlightDeadline as jest.Mock).mockResolvedValue(
+				undefined,
+			);
+			mockAddInflightPromise.mockClear();
+
+			const tokens = await tokenOrchestrator.getTokens();
+
+			expect(addInflightPromise).not.toHaveBeenCalled();
 			expect(tokens?.accessToken).toEqual(validAuthTokens.accessToken);
 		});
 	});

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/inflightOAuthDeadline.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/inflightOAuthDeadline.test.ts
@@ -39,10 +39,16 @@ const deadlineKey = `${AUTH_KEY_PREFIX}.${userPoolClientId}.inflightOAuthDeadlin
 const pkceKey = `${AUTH_KEY_PREFIX}.${userPoolClientId}.oauthPKCE`;
 const stateKey = `${AUTH_KEY_PREFIX}.${userPoolClientId}.oauthState`;
 
-const flushMicrotasks = async () => {
-	// Enough passes to drain the deepest async chain under test
-	// (waitForInflightOAuth → store reads → waiter continuations).
-	for (let i = 0; i < 10; i++) {
+// Bounded microtask drain, used ONLY ahead of NEGATIVE (`isSettled() === false`)
+// assertions, where it is safe by construction: draining too little can only
+// make the assertion weaker, never flaky-pass a regression, and extra passes
+// only strengthen it. POSITIVE assertions never rely on this — they `await`
+// the parked promise itself, which is deterministic at any async-chain depth
+// and turns a regression into a hard jest timeout instead of a silent
+// under-drain (jest's jsdom provides neither setImmediate nor MessageChannel
+// for a true macrotask boundary).
+const drainMicrotasks = async () => {
+	for (let i = 0; i < 25; i++) {
 		await Promise.resolve();
 	}
 };
@@ -73,7 +79,7 @@ describe('inflight OAuth blocking deadline', () => {
 		// Drain any parked waiters and clear the singleton backstop timer so
 		// module-level state never leaks between tests.
 		resolveAndClearInflightPromises();
-		await flushMicrotasks();
+		await drainMicrotasks();
 		jest.clearAllTimers();
 		jest.useRealTimers();
 	});
@@ -81,10 +87,9 @@ describe('inflight OAuth blocking deadline', () => {
 	it('does not block when no OAuth flow is in flight', async () => {
 		const orchestrator = createOrchestrator();
 
-		const waiter = park(orchestrator);
-		await flushMicrotasks();
-
-		expect(waiter.isSettled()).toBe(true);
+		// Deterministic positive assertion: resolves without any timer advance,
+		// or times out the test on regression.
+		await park(orchestrator).promise;
 	});
 
 	it('parks while a flow is in flight and releases once the deadline passes, without mutating shared state', async () => {
@@ -94,17 +99,17 @@ describe('inflight OAuth blocking deadline', () => {
 
 		const orchestrator = createOrchestrator();
 		const waiter = park(orchestrator);
-		await flushMicrotasks();
+		await drainMicrotasks();
 		expect(waiter.isSettled()).toBe(false);
 
 		// One millisecond before the deadline: still parked.
 		await jest.advanceTimersByTimeAsync(OAUTH_INFLIGHT_TTL_MS - 1);
+		await drainMicrotasks();
 		expect(waiter.isSettled()).toBe(false);
 
 		// Deadline passes: the backstop timer releases the waiter locally...
 		await jest.advanceTimersByTimeAsync(2);
-		await flushMicrotasks();
-		expect(waiter.isSettled()).toBe(true);
+		await waiter.promise;
 
 		// ...while the (possibly still running) flow's shared state is intact:
 		// only the flow-owner tab may mutate it.
@@ -119,7 +124,7 @@ describe('inflight OAuth blocking deadline', () => {
 
 		const orchestrator = createOrchestrator();
 		const waiter = park(orchestrator);
-		await flushMicrotasks();
+		await drainMicrotasks();
 		expect(waiter.isSettled()).toBe(false);
 
 		// Simulate the owner tab settling the flow (success/failure both remove
@@ -133,9 +138,8 @@ describe('inflight OAuth blocking deadline', () => {
 				storageArea: window.localStorage,
 			}),
 		);
-		await flushMicrotasks();
 
-		expect(waiter.isSettled()).toBe(true);
+		await waiter.promise;
 	});
 
 	it('ignores unrelated cross-tab storage events', async () => {
@@ -143,7 +147,7 @@ describe('inflight OAuth blocking deadline', () => {
 
 		const orchestrator = createOrchestrator();
 		const waiter = park(orchestrator);
-		await flushMicrotasks();
+		await drainMicrotasks();
 
 		window.dispatchEvent(
 			new StorageEvent('storage', {
@@ -162,7 +166,7 @@ describe('inflight OAuth blocking deadline', () => {
 				storageArea: window.localStorage,
 			}),
 		);
-		await flushMicrotasks();
+		await drainMicrotasks();
 
 		expect(waiter.isSettled()).toBe(false);
 	});
@@ -172,7 +176,7 @@ describe('inflight OAuth blocking deadline', () => {
 
 		const orchestrator = createOrchestrator();
 		const waiter = park(orchestrator);
-		await flushMicrotasks();
+		await drainMicrotasks();
 
 		// One minute in, a fresh signInWithRedirect renews the deadline.
 		await jest.advanceTimersByTimeAsync(60_000);
@@ -181,12 +185,12 @@ describe('inflight OAuth blocking deadline', () => {
 		// Original deadline passes: the backstop re-checks, finds the renewed
 		// deadline, and re-arms instead of releasing.
 		await jest.advanceTimersByTimeAsync(OAUTH_INFLIGHT_TTL_MS - 60_000 + 1);
+		await drainMicrotasks();
 		expect(waiter.isSettled()).toBe(false);
 
 		// Renewed deadline passes: released.
 		await jest.advanceTimersByTimeAsync(60_000 + 1);
-		await flushMicrotasks();
-		expect(waiter.isSettled()).toBe(true);
+		await waiter.promise;
 	});
 
 	it('does not block on an expired flow, while the completion gate still sees it', async () => {
@@ -195,11 +199,9 @@ describe('inflight OAuth blocking deadline', () => {
 		resolveAndClearInflightPromises();
 
 		const orchestrator = createOrchestrator();
-		const waiter = park(orchestrator);
-		await flushMicrotasks();
 
 		// Read-time evaluation: nothing to block on.
-		expect(waiter.isSettled()).toBe(true);
+		await park(orchestrator).promise;
 		// The completion path deliberately ignores the deadline so a
 		// slow-but-successful login still completes.
 		await expect(oAuthStore.loadOAuthInFlight()).resolves.toBe(true);
@@ -230,22 +232,45 @@ describe('inflight OAuth blocking deadline', () => {
 		await oAuthStore.storeOAuthInFlight(true);
 
 		const first = park(createOrchestrator());
-		await flushMicrotasks();
+		await drainMicrotasks();
 
 		// An earlier release (e.g. a cross-tab event) drains waiters and clears
 		// the backstop timer ...
 		resolveAndClearInflightPromises();
-		await flushMicrotasks();
-		expect(first.isSettled()).toBe(true);
+		await first.promise;
 
 		// ... yet a subsequent park while the flag is still active must arm its
 		// own backstop rather than rely on a timer that no longer exists.
 		const second = park(createOrchestrator());
-		await flushMicrotasks();
+		await drainMicrotasks();
 		expect(second.isSettled()).toBe(false);
 
 		await jest.advanceTimersByTimeAsync(OAUTH_INFLIGHT_TTL_MS + 1);
-		await flushMicrotasks();
-		expect(second.isSettled()).toBe(true);
+		await second.promise;
+	});
+
+	it('blocks on a new flow parked on the SAME orchestrator right after a release', async () => {
+		// Pins the fix for the post-release hole: `this.inflightPromise` is reset
+		// by the resolver itself, so a caller arriving for a NEW flow immediately
+		// after a release must get a fresh park — not a stale, already-resolved
+		// promise that would let it skip blocking.
+		await oAuthStore.storeOAuthInFlight(true);
+		const orchestrator = createOrchestrator();
+
+		const first = park(orchestrator);
+		await drainMicrotasks();
+
+		// Flow 1 settles in another tab; waiters drain.
+		resolveAndClearInflightPromises();
+		await first.promise;
+
+		// Flow 2 starts; the SAME orchestrator is asked to wait again.
+		await oAuthStore.storeOAuthInFlight(true);
+		const second = park(orchestrator);
+		await drainMicrotasks();
+		expect(second.isSettled()).toBe(false);
+
+		await jest.advanceTimersByTimeAsync(OAUTH_INFLIGHT_TTL_MS + 1);
+		await second.promise;
 	});
 });

--- a/packages/auth/__tests__/providers/cognito/utils/oauth/inflightOAuthDeadline.test.ts
+++ b/packages/auth/__tests__/providers/cognito/utils/oauth/inflightOAuthDeadline.test.ts
@@ -1,0 +1,251 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { defaultStorage } from '@aws-amplify/core';
+
+import { TokenOrchestrator } from '../../../../../src/providers/cognito/tokenProvider/TokenOrchestrator';
+import { AUTH_KEY_PREFIX } from '../../../../../src/providers/cognito/tokenProvider/constants';
+import {
+	DefaultOAuthStore,
+	OAUTH_INFLIGHT_TTL_MS,
+} from '../../../../../src/providers/cognito/utils/signInWithRedirectStore';
+import { oAuthStore } from '../../../../../src/providers/cognito/utils/oauth/oAuthStore';
+import { resolveAndClearInflightPromises } from '../../../../../src/providers/cognito/utils/oauth/inflightPromise';
+
+// Registers the browser-only side effects at module load — including the
+// cross-tab storage listener that releases parked token consumers when the
+// inflight flag is removed in another tab.
+import '../../../../../src/providers/cognito/utils/oauth/enableOAuthListener';
+
+// Per repo convention only the boundaries are mocked: `isBrowser` (so the
+// browser-only branches are taken deterministically). The real oAuthStore,
+// defaultStorage (jsdom localStorage), inflightPromise module, and
+// TokenOrchestrator internals are exercised.
+jest.mock('@aws-amplify/core/internals/utils', () => ({
+	...jest.requireActual('@aws-amplify/core/internals/utils'),
+	isBrowser: jest.fn(() => true),
+}));
+
+const userPoolClientId = 'test-client-id';
+const authConfig = {
+	Cognito: {
+		userPoolId: 'us-east-1_test-id',
+		userPoolClientId,
+	},
+};
+
+const inflightKey = `${AUTH_KEY_PREFIX}.${userPoolClientId}.inflightOAuth`;
+const deadlineKey = `${AUTH_KEY_PREFIX}.${userPoolClientId}.inflightOAuthDeadline`;
+const pkceKey = `${AUTH_KEY_PREFIX}.${userPoolClientId}.oauthPKCE`;
+const stateKey = `${AUTH_KEY_PREFIX}.${userPoolClientId}.oauthState`;
+
+const flushMicrotasks = async () => {
+	// Enough passes to drain the deepest async chain under test
+	// (waitForInflightOAuth → store reads → waiter continuations).
+	for (let i = 0; i < 10; i++) {
+		await Promise.resolve();
+	}
+};
+
+const createOrchestrator = () => {
+	const orchestrator = new TokenOrchestrator();
+	orchestrator.setAuthConfig(authConfig as any);
+
+	return orchestrator;
+};
+
+const park = (orchestrator: TokenOrchestrator) => {
+	let settled = false;
+	const promise = orchestrator.waitForInflightOAuth().then(() => {
+		settled = true;
+	});
+
+	return { promise, isSettled: () => settled };
+};
+
+describe('inflight OAuth blocking deadline', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+		window.localStorage.clear();
+	});
+
+	afterEach(async () => {
+		// Drain any parked waiters and clear the singleton backstop timer so
+		// module-level state never leaks between tests.
+		resolveAndClearInflightPromises();
+		await flushMicrotasks();
+		jest.clearAllTimers();
+		jest.useRealTimers();
+	});
+
+	it('does not block when no OAuth flow is in flight', async () => {
+		const orchestrator = createOrchestrator();
+
+		const waiter = park(orchestrator);
+		await flushMicrotasks();
+
+		expect(waiter.isSettled()).toBe(true);
+	});
+
+	it('parks while a flow is in flight and releases once the deadline passes, without mutating shared state', async () => {
+		await oAuthStore.storeOAuthInFlight(true);
+		await defaultStorage.setItem(pkceKey, 'test-pkce');
+		await defaultStorage.setItem(stateKey, 'test-state');
+
+		const orchestrator = createOrchestrator();
+		const waiter = park(orchestrator);
+		await flushMicrotasks();
+		expect(waiter.isSettled()).toBe(false);
+
+		// One millisecond before the deadline: still parked.
+		await jest.advanceTimersByTimeAsync(OAUTH_INFLIGHT_TTL_MS - 1);
+		expect(waiter.isSettled()).toBe(false);
+
+		// Deadline passes: the backstop timer releases the waiter locally...
+		await jest.advanceTimersByTimeAsync(2);
+		await flushMicrotasks();
+		expect(waiter.isSettled()).toBe(true);
+
+		// ...while the (possibly still running) flow's shared state is intact:
+		// only the flow-owner tab may mutate it.
+		expect(window.localStorage.getItem(inflightKey)).toBe('true');
+		expect(window.localStorage.getItem(deadlineKey)).not.toBeNull();
+		expect(window.localStorage.getItem(pkceKey)).toBe('test-pkce');
+		expect(window.localStorage.getItem(stateKey)).toBe('test-state');
+	});
+
+	it('releases parked waiters when another tab removes the inflight flag', async () => {
+		await oAuthStore.storeOAuthInFlight(true);
+
+		const orchestrator = createOrchestrator();
+		const waiter = park(orchestrator);
+		await flushMicrotasks();
+		expect(waiter.isSettled()).toBe(false);
+
+		// Simulate the owner tab settling the flow (success/failure both remove
+		// the flag). Storage events only fire in OTHER tabs, which is exactly
+		// what this simulates.
+		window.dispatchEvent(
+			new StorageEvent('storage', {
+				key: inflightKey,
+				oldValue: 'true',
+				newValue: null,
+				storageArea: window.localStorage,
+			}),
+		);
+		await flushMicrotasks();
+
+		expect(waiter.isSettled()).toBe(true);
+	});
+
+	it('ignores unrelated cross-tab storage events', async () => {
+		await oAuthStore.storeOAuthInFlight(true);
+
+		const orchestrator = createOrchestrator();
+		const waiter = park(orchestrator);
+		await flushMicrotasks();
+
+		window.dispatchEvent(
+			new StorageEvent('storage', {
+				key: `${AUTH_KEY_PREFIX}.${userPoolClientId}.oauthSignIn`,
+				oldValue: null,
+				newValue: 'true,false',
+				storageArea: window.localStorage,
+			}),
+		);
+		// A NEW flow (re-)writing the flag must not release waiters either.
+		window.dispatchEvent(
+			new StorageEvent('storage', {
+				key: inflightKey,
+				oldValue: null,
+				newValue: 'true',
+				storageArea: window.localStorage,
+			}),
+		);
+		await flushMicrotasks();
+
+		expect(waiter.isSettled()).toBe(false);
+	});
+
+	it('extends a parked wait when the deadline is renewed by a fresh flow', async () => {
+		await oAuthStore.storeOAuthInFlight(true);
+
+		const orchestrator = createOrchestrator();
+		const waiter = park(orchestrator);
+		await flushMicrotasks();
+
+		// One minute in, a fresh signInWithRedirect renews the deadline.
+		await jest.advanceTimersByTimeAsync(60_000);
+		await oAuthStore.storeOAuthInFlight(true);
+
+		// Original deadline passes: the backstop re-checks, finds the renewed
+		// deadline, and re-arms instead of releasing.
+		await jest.advanceTimersByTimeAsync(OAUTH_INFLIGHT_TTL_MS - 60_000 + 1);
+		expect(waiter.isSettled()).toBe(false);
+
+		// Renewed deadline passes: released.
+		await jest.advanceTimersByTimeAsync(60_000 + 1);
+		await flushMicrotasks();
+		expect(waiter.isSettled()).toBe(true);
+	});
+
+	it('does not block on an expired flow, while the completion gate still sees it', async () => {
+		await oAuthStore.storeOAuthInFlight(true);
+		await jest.advanceTimersByTimeAsync(OAUTH_INFLIGHT_TTL_MS + 1);
+		resolveAndClearInflightPromises();
+
+		const orchestrator = createOrchestrator();
+		const waiter = park(orchestrator);
+		await flushMicrotasks();
+
+		// Read-time evaluation: nothing to block on.
+		expect(waiter.isSettled()).toBe(true);
+		// The completion path deliberately ignores the deadline so a
+		// slow-but-successful login still completes.
+		await expect(oAuthStore.loadOAuthInFlight()).resolves.toBe(true);
+	});
+
+	it('persists a stable default deadline for a flag written by a legacy library version', async () => {
+		// A legacy writer sets the flag without a deadline key.
+		window.localStorage.setItem(inflightKey, 'true');
+
+		const firstObserved = await oAuthStore.loadOAuthInFlightDeadline();
+		expect(firstObserved).toBe(Date.now() + OAUTH_INFLIGHT_TTL_MS);
+		// The observed deadline is persisted (additively) ...
+		expect(window.localStorage.getItem(deadlineKey)).toBe(
+			String(firstObserved),
+		);
+
+		// ... so a later reader ("another tab", "after reload") sees the SAME
+		// deadline instead of restarting the TTL from its own observation.
+		await jest.advanceTimersByTimeAsync(60_000);
+		const otherTabStore = new DefaultOAuthStore(defaultStorage);
+		otherTabStore.setAuthConfig(authConfig.Cognito as any);
+		await expect(otherTabStore.loadOAuthInFlightDeadline()).resolves.toBe(
+			firstObserved,
+		);
+	});
+
+	it('arms a fresh backstop for a park that happens after an earlier release', async () => {
+		await oAuthStore.storeOAuthInFlight(true);
+
+		const first = park(createOrchestrator());
+		await flushMicrotasks();
+
+		// An earlier release (e.g. a cross-tab event) drains waiters and clears
+		// the backstop timer ...
+		resolveAndClearInflightPromises();
+		await flushMicrotasks();
+		expect(first.isSettled()).toBe(true);
+
+		// ... yet a subsequent park while the flag is still active must arm its
+		// own backstop rather than rely on a timer that no longer exists.
+		const second = park(createOrchestrator());
+		await flushMicrotasks();
+		expect(second.isSettled()).toBe(false);
+
+		await jest.advanceTimersByTimeAsync(OAUTH_INFLIGHT_TTL_MS + 1);
+		await flushMicrotasks();
+		expect(second.isSettled()).toBe(true);
+	});
+});

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -69,7 +69,16 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 				// e.g. getCurrentUser, fetchAuthSession etc.
 
 				this.inflightPromise = new Promise<void>(resolve => {
-					addInflightPromise(resolve);
+					// Invariant: `this.inflightPromise` is owned by the park lifecycle —
+					// created here and reset by the very resolver that releases it
+					// (drained by the backstop timer, the cross-tab listener, or
+					// in-process completion). Resetting BEFORE resolving closes the
+					// post-release hole where a caller for a NEW flow could observe a
+					// stale, already-resolved promise and skip blocking on it.
+					addInflightPromise(() => {
+						this.inflightPromise = undefined;
+						resolve();
+					});
 					// Arm the deadline backstop in the same synchronous step as the
 					// park: it releases this waiter even when the cross-tab release
 					// fired between the deadline read above and this park (that storage
@@ -142,7 +151,10 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 			return null;
 		}
 		await this.waitForInflightOAuth();
-		this.inflightPromise = undefined;
+		// NOTE: `this.inflightPromise` is reset by the resolver registered in
+		// `waitForInflightOAuth` (co-located with the release), NOT here — a reset
+		// here could clobber a newer flow's park created between the release and
+		// this line resuming.
 		tokens = await this.getTokenStore().loadTokens();
 		const username = await this.getTokenStore().getLastAuthUser();
 

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -18,7 +18,10 @@ import {
 import { assertServiceError } from '../../../errors/utils/assertServiceError';
 import { AuthError } from '../../../errors/AuthError';
 import { oAuthStore } from '../utils/oauth/oAuthStore';
-import { addInflightPromise } from '../utils/oauth/inflightPromise';
+import {
+	addInflightPromise,
+	armInflightDeadline,
+} from '../utils/oauth/inflightPromise';
 import { ClientMetadata, CognitoAuthSignInDetails } from '../types';
 
 import {
@@ -38,11 +41,26 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 	inflightPromise: Promise<void> | undefined;
 	waitForInflightOAuth: () => Promise<void> = isBrowser()
 		? async () => {
-				if (!(await oAuthStore.loadOAuthInFlight())) {
+				// Read-time evaluation of the blocking deadline: absent flag, an
+				// expired deadline, or a flag value other than 'true' all mean
+				// "do not block". An abandoned flow in another tab can therefore
+				// never park token consumers indefinitely.
+				// (`loadOAuthInFlightDeadline` is optional on the OAuthStore
+				// interface for custom-implementation compatibility, but this
+				// singleton is always the concrete DefaultOAuthStore, which
+				// implements it.)
+				const deadline = await oAuthStore.loadOAuthInFlightDeadline();
+				if (deadline === undefined) {
 					return;
 				}
 
 				if (this.inflightPromise) {
+					// Keep the backstop aligned with the current deadline for waiters
+					// piggybacking on the existing park.
+					armInflightDeadline(deadline, () =>
+						oAuthStore.loadOAuthInFlightDeadline(),
+					);
+
 					return this.inflightPromise;
 				}
 
@@ -50,8 +68,17 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 				// to block async calls that require fetching tokens before the oauth flow completes
 				// e.g. getCurrentUser, fetchAuthSession etc.
 
-				this.inflightPromise = new Promise<void>((resolve, _reject) => {
+				this.inflightPromise = new Promise<void>(resolve => {
 					addInflightPromise(resolve);
+					// Arm the deadline backstop in the same synchronous step as the
+					// park: it releases this waiter even when the cross-tab release
+					// fired between the deadline read above and this park (that storage
+					// event never re-fires), when storage events are unavailable
+					// (Safari private mode), or when the flow is simply never
+					// completed anywhere.
+					armInflightDeadline(deadline, () =>
+						oAuthStore.loadOAuthInFlightDeadline(),
+					);
 				});
 
 				return this.inflightPromise;

--- a/packages/auth/src/providers/cognito/utils/oauth/enableOAuthListener.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/enableOAuthListener.ts
@@ -3,13 +3,19 @@
 
 import {
 	Hub,
+	KeyValueStorageEvent,
 	ResourcesConfig,
+	defaultStorage,
 	getGlobalContext,
 	hasGlobalContext,
 } from '@aws-amplify/core';
 import { isBrowser } from '@aws-amplify/core/internals/utils';
 
+import { AUTH_KEY_PREFIX } from '../../tokenProvider/constants';
+import { OAuthStorageKeys } from '../types';
+
 import { attemptCompleteOAuthFlow } from './attemptCompleteOAuthFlow';
+import { resolveAndClearInflightPromises } from './inflightPromise';
 
 // Synchronous re-entry guard for the OAuth completion side effect (PR #14925).
 //
@@ -68,6 +74,30 @@ if (isBrowser()) {
 			if (cognitoConfig?.loginWith?.oauth) {
 				attemptCompleteOAuthFlowOnce(cognitoConfig);
 			}
+		}
+	});
+
+	// Cross-tab release of parked token consumers: when the tab owning an
+	// inflight OAuth flow settles it (success, failure, or cancellation), it
+	// removes the `inflightOAuth` flag from shared storage — `completeOAuthFlow`
+	// on success, `handleFailure` otherwise. Observing that transition here
+	// releases this tab's waiters (`fetchAuthSession`, `getCurrentUser`, ...)
+	// immediately instead of leaving them parked until the blocking-deadline
+	// backstop fires. The release is purely local; no shared state is mutated.
+	// Registered for the module (page) lifetime, mirroring the Hub subscription
+	// above — deliberately never unsubscribed.
+	defaultStorage.addListener?.(async (event: KeyValueStorageEvent) => {
+		const { key, newValue } = event;
+		// Match by prefix/suffix rather than positional `split('.')`, consistent
+		// with the cross-tab token listener (key shape:
+		// `${AUTH_KEY_PREFIX}.<clientId>.inflightOAuth`).
+		if (
+			!!key &&
+			key.startsWith(`${AUTH_KEY_PREFIX}.`) &&
+			key.endsWith(`.${OAuthStorageKeys.inflightOAuth}`) &&
+			newValue !== 'true'
+		) {
+			resolveAndClearInflightPromises();
 		}
 	});
 

--- a/packages/auth/src/providers/cognito/utils/oauth/inflightPromise.ts
+++ b/packages/auth/src/providers/cognito/utils/oauth/inflightPromise.ts
@@ -3,11 +3,66 @@
 
 const inflightPromises: ((value: void | PromiseLike<void>) => void)[] = [];
 
+// Module-level singleton backstop timer for the inflight OAuth blocking
+// deadline. A single timer (not one per waiter) is sufficient because all
+// parked waiters share one release (`resolveAndClearInflightPromises` drains
+// them all), and every park re-arms it with the current deadline.
+let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+
 export const addInflightPromise = (resolver: () => void) => {
 	inflightPromises.push(resolver);
 };
 
+/**
+ * Arms (or re-arms) the backstop timer that releases parked token consumers
+ * once the inflight OAuth blocking deadline passes.
+ *
+ * On fire it re-reads the deadline instead of trusting the armed one: a fresh
+ * `signInWithRedirect` may have renewed it (re-arm for the new deadline), or
+ * the flow may have been released through another path already (the re-check
+ * returns `undefined` and draining is a no-op). The release is purely local —
+ * it never mutates shared OAuth state, so another tab's still-running flow is
+ * left intact.
+ *
+ * Note: browsers throttle timers in background tabs, which may delay (never
+ * prevent) this release; the cross-tab storage listener remains the fast path.
+ */
+export const armInflightDeadline = (
+	deadline: number,
+	recheckDeadline: () => Promise<number | undefined>,
+) => {
+	if (deadlineTimer !== undefined) {
+		clearTimeout(deadlineTimer);
+	}
+	deadlineTimer = setTimeout(
+		() => {
+			deadlineTimer = undefined;
+			recheckDeadline()
+				.then(renewedDeadline => {
+					if (renewedDeadline !== undefined) {
+						armInflightDeadline(renewedDeadline, recheckDeadline);
+
+						return;
+					}
+					resolveAndClearInflightPromises();
+				})
+				// Fail open: an error while re-checking (e.g. auth config torn down)
+				// must release the waiters rather than leave them parked forever.
+				.catch(() => {
+					resolveAndClearInflightPromises();
+				});
+		},
+		Math.max(0, deadline - Date.now()),
+	);
+};
+
 export const resolveAndClearInflightPromises = () => {
+	// The waiters this timer guarded are being released through this very call
+	// (whatever triggered it) — clear it so no stale timer outlives its waiters.
+	if (deadlineTimer !== undefined) {
+		clearTimeout(deadlineTimer);
+		deadlineTimer = undefined;
+	}
 	while (inflightPromises.length) {
 		inflightPromises.pop()?.();
 	}

--- a/packages/auth/src/providers/cognito/utils/signInWithRedirectStore.ts
+++ b/packages/auth/src/providers/cognito/utils/signInWithRedirectStore.ts
@@ -14,6 +14,14 @@ import { OAuthStorageKeys, OAuthStore } from './types';
 
 const V5_HOSTED_UI_KEY = 'amplify-signin-with-hostedUI';
 
+// Bounds how long OTHER auth work (fetchAuthSession, getCurrentUser, ...) may
+// block on an inflight OAuth flow, aligned with the validity period of a
+// Cognito authorization code. It does NOT bound the flow itself: the
+// completion path (`attemptCompleteOAuthFlow`) deliberately keeps gating on
+// the raw `loadOAuthInFlight` flag and ignores this deadline, so a
+// slow-but-successful Hosted UI login still completes after it passes.
+export const OAUTH_INFLIGHT_TTL_MS = 5 * 60 * 1000;
+
 export class DefaultOAuthStore implements OAuthStore {
 	keyValueStorage: KeyValueStorageInterface;
 	cognitoConfig?: CognitoUserPoolConfig;
@@ -31,6 +39,7 @@ export class DefaultOAuthStore implements OAuthStore {
 		);
 		await Promise.all([
 			this.keyValueStorage.removeItem(authKeys.inflightOAuth),
+			this.keyValueStorage.removeItem(authKeys.inflightOAuthDeadline),
 			this.keyValueStorage.removeItem(authKeys.oauthPKCE),
 			this.keyValueStorage.removeItem(authKeys.oauthState),
 		]);
@@ -109,12 +118,64 @@ export class DefaultOAuthStore implements OAuthStore {
 		);
 	}
 
+	async loadOAuthInFlightDeadline(): Promise<number | undefined> {
+		assertTokenProviderConfig(this.cognitoConfig);
+		const { userPoolClientId } = this.cognitoConfig;
+
+		if (!(await this.loadOAuthInFlight())) {
+			return undefined;
+		}
+
+		const authKeys = createKeysForAuthStorage(
+			AUTH_KEY_PREFIX,
+			userPoolClientId,
+		);
+
+		const storedDeadline = await this.keyValueStorage.getItem(
+			authKeys.inflightOAuthDeadline,
+		);
+		let deadline = Number(storedDeadline);
+
+		if (storedDeadline === null || Number.isNaN(deadline)) {
+			// Legacy writer (an older library version set the flag without a
+			// deadline). Persist a default deadline counted from first observation
+			// so it stays stable across tabs and page reloads instead of resetting
+			// on every load. This write is purely additive — the legacy flow's own
+			// state (inflight flag, PKCE, state) is never touched, and legacy
+			// readers ignore the extra key. Concurrent first-observers may race
+			// this write (last writer wins); the resulting drift is a few
+			// milliseconds and harmless.
+			deadline = Date.now() + OAUTH_INFLIGHT_TTL_MS;
+			await this.keyValueStorage.setItem(
+				authKeys.inflightOAuthDeadline,
+				String(deadline),
+			);
+		}
+
+		// An expired deadline makes the flag inert for BLOCKING purposes only; it
+		// is evaluated at read time, never enforced by deleting the flow state
+		// (only the flow-owner tab mutates it), so a slow login can still finish.
+		return deadline > Date.now() ? deadline : undefined;
+	}
+
 	async storeOAuthInFlight(inflight: boolean): Promise<void> {
 		assertTokenProviderConfig(this.cognitoConfig);
 		const authKeys = createKeysForAuthStorage(
 			AUTH_KEY_PREFIX,
 			this.cognitoConfig.userPoolClientId,
 		);
+
+		if (inflight) {
+			// Write the deadline BEFORE the flag: a reader racing the two storage
+			// writes must never observe the flag without its deadline, or it would
+			// misclassify this writer as a legacy one and persist its own default.
+			await this.keyValueStorage.setItem(
+				authKeys.inflightOAuthDeadline,
+				String(Date.now() + OAUTH_INFLIGHT_TTL_MS),
+			);
+		} else {
+			await this.keyValueStorage.removeItem(authKeys.inflightOAuthDeadline);
+		}
 
 		await this.keyValueStorage.setItem(authKeys.inflightOAuth, `${inflight}`);
 	}

--- a/packages/auth/src/providers/cognito/utils/signInWithRedirectStore.ts
+++ b/packages/auth/src/providers/cognito/utils/signInWithRedirectStore.ts
@@ -142,9 +142,10 @@ export class DefaultOAuthStore implements OAuthStore {
 			// so it stays stable across tabs and page reloads instead of resetting
 			// on every load. This write is purely additive — the legacy flow's own
 			// state (inflight flag, PKCE, state) is never touched, and legacy
-			// readers ignore the extra key. Concurrent first-observers may race
-			// this write (last writer wins); the resulting drift is a few
-			// milliseconds and harmless.
+			// readers ignore the extra key. Independent first-observers race this
+			// write (last writer wins), so the persisted deadline can shift by the
+			// observation-time gap between tabs — harmless, as it stays bounded by
+			// observation time + OAUTH_INFLIGHT_TTL_MS.
 			deadline = Date.now() + OAUTH_INFLIGHT_TTL_MS;
 			await this.keyValueStorage.setItem(
 				authKeys.inflightOAuthDeadline,

--- a/packages/auth/src/providers/cognito/utils/types.ts
+++ b/packages/auth/src/providers/cognito/utils/types.ts
@@ -103,6 +103,7 @@ export function assertDeviceMetadata(
 
 export const OAuthStorageKeys = {
 	inflightOAuth: 'inflightOAuth',
+	inflightOAuthDeadline: 'inflightOAuthDeadline',
 	oauthSignIn: 'oauthSignIn',
 	oauthPKCE: 'oauthPKCE',
 	oauthState: 'oauthState',
@@ -111,6 +112,16 @@ export const OAuthStorageKeys = {
 export interface OAuthStore {
 	setAuthConfig(authConfigParam: CognitoUserPoolConfig): void;
 	loadOAuthInFlight(): Promise<boolean>;
+	/**
+	 * Returns the timestamp (epoch ms) until which token consumers should block
+	 * on the inflight OAuth flow, or `undefined` when there is nothing to block
+	 * on (no flow in flight, or its blocking deadline has passed).
+	 *
+	 * Optional so that custom {@link OAuthStore} implementations written before
+	 * this method existed keep compiling; callers must treat its absence as
+	 * "no deadline available".
+	 */
+	loadOAuthInFlightDeadline?(): Promise<number | undefined>;
 	storeOAuthInFlight(inflight: boolean): Promise<void>;
 	loadOAuthSignIn(): Promise<{
 		isOAuthSignIn: boolean;


### PR DESCRIPTION
#### Description of changes

`fetchAuthSession()` / `getCurrentUser()` can hang **forever** when another tab starts `signInWithRedirect()` and abandons the Hosted UI page: the shared `inflightOAuth` flag in localStorage has no expiry, and the promise parked in `TokenOrchestrator.waitForInflightOAuth()` is only ever resolved by the tab that completes or fails the redirect flow.

This bounds the wait with a **read-time blocking deadline** — expiry is evaluated, never enforced by deleting another tab's flow state:

- `signInWithRedirect()` records a deadline in a sibling storage key (`inflightOAuthDeadline`, 5 min, aligned with authorization-code validity), written **before** the flag so a racing reader never misclassifies the writer as a legacy one.
- `TokenOrchestrator.waitForInflightOAuth()` gates on the deadline (`loadOAuthInFlightDeadline()`: absent flag or passed deadline ⇒ don't block) and arms a singleton backstop timer on **every** park — covering the race where a cross-tab release fires between the deadline read and the park, environments without storage events, and flows that are never completed anywhere.
- A cross-tab storage listener (built on the #14465 machinery) releases parked waiters as soon as the owning tab settles the flow — success, failure, or cancellation all remove the flag.
- The completion gate (`attemptCompleteOAuthFlow` → `loadOAuthInFlight()`) deliberately **ignores** the deadline, and no tab ever mutates another tab's flow state (flag/PKCE/state), so a slow-but-successful Hosted UI login still completes.
- Flags written by older library versions (no deadline key) get a default deadline persisted on first observation, stable across tabs and reloads.

Backwards compatible in both version directions: old readers keep seeing `inflightOAuth: 'true'` unchanged; `OAuthStore.loadOAuthInFlightDeadline` is optional so custom store implementations keep compiling; waiters are still resolved (never rejected).

#### Issue #, if available

N/A (internal report: multi-tab `fetchAuthSession()` hang; cross-tab signIn/signOut events landed separately in #14465)

#### Description of how you validated changes

- New unit suite `inflightOAuthDeadline.test.ts` (8 tests, fake timers, real store/orchestrator internals over jsdom localStorage; only `isBrowser` mocked): parking + deadline release without mutating shared state, cross-tab release via storage event, unrelated-event immunity, deadline renewal by a fresh flow, expired-flow non-blocking while the completion gate still sees the flow, legacy-flag deadline stability across store instances, fresh backstop after an earlier release.
- Full `@aws-amplify/auth` suite: 103 suites / 1182 tests green (`--no-cache` after rebasing onto main).
- Full monorepo `yarn build` green.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Unit Tests are changed or added
- [ ] Relevant documentation is changed or added (behavior fix; no doc surface)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
